### PR TITLE
Prevent nested scorer calls from recording duplicate telemetry

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -467,15 +467,16 @@ class InstructionsJudge(Judge):
             Evaluation results
 
         **Note on Trace Behavior**:
-        - If template uses {{ trace }}: The trace metadata is used by an agent-based judge that uses
-          tools to fetch aspects of the trace's span data. If inputs/outputs/expectations are also
-          provided, they can augment the agent's context if the template has corresponding
-          placeholders ({{ inputs }}/{{ outputs }}/{{ expectations }}). The agent will still use
-          tools to fetch span data but will have this additional context in the user prompt.
+        - If template uses {{ trace }}: The trace object is passed to an agent-based judge that
+          uses tools to fetch aspects of the trace's span data. The {{ trace }} placeholder itself
+          is not replaced in the prompt - instead, the trace enables tool calling.
+        - If template uses {{ inputs }}/{{ outputs }}/{{ expectations }} alongside {{ trace }}:
+          These placeholders ARE replaced in the prompt with their values (either from the provided
+          parameters or extracted from the trace), providing additional context to the agent.
         - If template uses {{ inputs }}/{{ outputs }}/{{ expectations }} without {{ trace }}:
-          Values are extracted from the trace, if specified, as follows:
+          Values are extracted from the trace parameter (if provided) as follows:
           - inputs/outputs: From the trace's root span
-          - expectations: From the trace's human-set expectation assessments (ground truth only)
+          - expectations: From the trace's expectation assessments
 
         **Note on Session Behavior**:
         - Traces are expected to be in the same session and exception will be raised

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import logging
+from contextvars import ContextVar
 from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Callable, Literal, TypeAlias
@@ -19,6 +20,9 @@ from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.uri import is_databricks_uri
 
 _logger = logging.getLogger(__name__)
+
+# Context variable to track if we're in a scorer call (prevents nested telemetry)
+_in_scorer_call: ContextVar[bool] = ContextVar("mlflow_scorer_call_context", default=False)
 
 # Serialization version for tracking changes to the serialization format
 _SERIALIZATION_VERSION = 1
@@ -118,6 +122,38 @@ class SerializedScorer:
             )
 
 
+def _record_scorer_call_with_context(func):
+    """Wraps a scorer's __call__ method with telemetry, but only for top-level calls.
+
+    Uses ContextVar to track nesting in a thread-safe manner. Only supports synchronous
+    functions - async scorers are not supported and will raise an exception.
+    """
+    if inspect.iscoroutinefunction(func):
+        raise TypeError(
+            f"Async scorer '__call__' methods are not supported. "
+            f"Scorer class {func.__qualname__} has an async __call__ method."
+        )
+
+    telemetry_wrapped = record_usage_event(ScorerCallEvent)(func)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if _in_scorer_call.get():
+            # Nested call: skip telemetry, call original function
+            return func(*args, **kwargs)
+
+        # Top-level call: set context and use telemetry-wrapped version
+        token = _in_scorer_call.set(True)
+        try:
+            return telemetry_wrapped(*args, **kwargs)
+        finally:
+            # CRITICAL: Use reset(token), NOT set(False)
+            # This ensures proper context restoration
+            _in_scorer_call.reset(token)
+
+    return wrapper
+
+
 class Scorer(BaseModel):
     name: str
     aggregations: list[_AggregationType] | None = None
@@ -138,8 +174,8 @@ class Scorer(BaseModel):
 
             # Check if it's already wrapped to avoid double-wrapping
             if not hasattr(original_call, "_telemetry_wrapped"):
-                # Wrap the __call__ method with telemetry
-                wrapped_call = record_usage_event(ScorerCallEvent)(original_call)
+                # Wrap with context-aware telemetry decorator
+                wrapped_call = _record_scorer_call_with_context(original_call)
                 # Mark it as wrapped to prevent double-wrapping
                 wrapped_call._telemetry_wrapped = True
                 setattr(cls, "__call__", wrapped_call)

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -21,6 +21,7 @@ from mlflow.genai.judges.base import Judge, JudgeField
 from mlflow.genai.judges.builtin import _MODEL_API_DOC
 from mlflow.genai.judges.constants import _AFFIRMATIVE_VALUES, _NEGATIVE_VALUES
 from mlflow.genai.judges.instructions_judge import InstructionsJudge
+from mlflow.genai.judges.make_judge import make_judge
 from mlflow.genai.judges.prompts.completeness import (
     COMPLETENESS_ASSESSMENT_NAME,
     COMPLETENESS_PROMPT,
@@ -1633,11 +1634,11 @@ class Fluency(BuiltInScorer):
     description: str = (
         "Evaluate grammatical correctness, natural flow, and linguistic quality of text."
     )
-    _judge: InstructionsJudge | None = pydantic.PrivateAttr(default=None)
+    _judge: Judge | None = pydantic.PrivateAttr(default=None)
 
-    def _get_judge(self) -> InstructionsJudge:
+    def _get_judge(self) -> Judge:
         if self._judge is None:
-            self._judge = InstructionsJudge(
+            self._judge = make_judge(
                 name=self.name,
                 instructions=self.instructions,
                 model=self.model,
@@ -2575,11 +2576,11 @@ class Completeness(BuiltInScorer):
     description: str = (
         "Evaluate whether the assistant fully addresses all user questions in a single turn."
     )
-    _judge: InstructionsJudge | None = pydantic.PrivateAttr(default=None)
+    _judge: Judge | None = pydantic.PrivateAttr(default=None)
 
-    def _get_judge(self) -> InstructionsJudge:
+    def _get_judge(self) -> Judge:
         if self._judge is None:
-            self._judge = InstructionsJudge(
+            self._judge = make_judge(
                 name=self.name,
                 instructions=self.instructions,
                 model=self.model,
@@ -2677,11 +2678,11 @@ class Summarization(BuiltInScorer):
         "and does not make any assumptions not in the input, with a focus on faithfulness, "
         "coverage, and conciseness."
     )
-    _judge: InstructionsJudge | None = pydantic.PrivateAttr(default=None)
+    _judge: Judge | None = pydantic.PrivateAttr(default=None)
 
-    def _get_judge(self) -> InstructionsJudge:
+    def _get_judge(self) -> Judge:
         if self._judge is None:
-            self._judge = InstructionsJudge(
+            self._judge = make_judge(
                 name=self.name,
                 instructions=self.instructions,
                 model=self.model,

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1866,18 +1866,18 @@ class SessionLevelScorer(Judge):
     """
 
     required_columns: set[str] = {"trace"}
-    _judge: InstructionsJudge | None = pydantic.PrivateAttr(default=None)
+    _judge: Judge | None = pydantic.PrivateAttr(default=None)
 
     @abstractmethod
-    def _create_judge(self) -> InstructionsJudge:
+    def _create_judge(self) -> Judge:
         """
-        Create the InstructionsJudge instance for this scorer.
+        Create the Judge instance for this scorer.
         Subclasses should implement this to configure their specific judge.
 
         Note: Instantiate InstructionsJudge directly instead of using make_judge.
         """
 
-    def _get_judge(self) -> InstructionsJudge:
+    def _get_judge(self) -> Judge:
         """Get or create the cached judge instance."""
         if self._judge is None:
             self._judge = self._create_judge()
@@ -1999,7 +1999,7 @@ class UserFrustration(BuiltInSessionLevelScorer):
     model: str | None = None
     description: str = "Evaluate the user's frustration state throughout the conversation."
 
-    def _create_judge(self) -> InstructionsJudge:
+    def _create_judge(self) -> Judge:
         return InstructionsJudge(
             name=self.name,
             instructions=self.instructions,
@@ -2072,7 +2072,7 @@ class ConversationCompleteness(BuiltInSessionLevelScorer):
         "the conversation."
     )
 
-    def _create_judge(self) -> InstructionsJudge:
+    def _create_judge(self) -> Judge:
         return InstructionsJudge(
             name=self.name,
             instructions=self.instructions,
@@ -2148,7 +2148,7 @@ class ConversationalSafety(BuiltInSessionLevelScorer):
         "checking for harmful content and safety guideline failures."
     )
 
-    def _create_judge(self) -> InstructionsJudge:
+    def _create_judge(self) -> Judge:
         return InstructionsJudge(
             name=self.name,
             instructions=self.instructions,
@@ -2222,7 +2222,7 @@ class ConversationalToolCallEfficiency(BuiltInSessionLevelScorer):
         "efficient, checking for redundant calls, unnecessary calls, and poor tool selection."
     )
 
-    def _create_judge(self) -> InstructionsJudge:
+    def _create_judge(self) -> Judge:
         return InstructionsJudge(
             name=self.name,
             instructions=self.instructions,
@@ -2295,7 +2295,7 @@ class ConversationalRoleAdherence(BuiltInSessionLevelScorer):
         "a conversation, checking for persona consistency and boundary violations."
     )
 
-    def _create_judge(self) -> InstructionsJudge:
+    def _create_judge(self) -> Judge:
         return InstructionsJudge(
             name=self.name,
             instructions=self.instructions,
@@ -2331,7 +2331,7 @@ class _LastTurnKnowledgeRetention(SessionLevelScorer):
         "provided by users in earlier conversation turns."
     )
 
-    def _create_judge(self) -> InstructionsJudge:
+    def _create_judge(self) -> Judge:
         return InstructionsJudge(
             name=self.name,
             instructions=self.instructions,
@@ -2407,7 +2407,7 @@ class KnowledgeRetention(BuiltInSessionLevelScorer):
         "in earlier conversation turns without forgetting, contradicting, or distorting it."
     )
 
-    def _create_judge(self) -> InstructionsJudge:
+    def _create_judge(self) -> Judge:
         """
         This method is required by BuiltInSessionLevelScorer but is not used.
         KnowledgeRetention uses composition (delegating to last_turn_scorer)

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -21,7 +21,6 @@ from mlflow.genai.judges.base import Judge, JudgeField
 from mlflow.genai.judges.builtin import _MODEL_API_DOC
 from mlflow.genai.judges.constants import _AFFIRMATIVE_VALUES, _NEGATIVE_VALUES
 from mlflow.genai.judges.instructions_judge import InstructionsJudge
-from mlflow.genai.judges.make_judge import make_judge
 from mlflow.genai.judges.prompts.completeness import (
     COMPLETENESS_ASSESSMENT_NAME,
     COMPLETENESS_PROMPT,
@@ -1638,7 +1637,7 @@ class Fluency(BuiltInScorer):
 
     def _get_judge(self) -> Judge:
         if self._judge is None:
-            self._judge = make_judge(
+            self._judge = InstructionsJudge(
                 name=self.name,
                 instructions=self.instructions,
                 model=self.model,
@@ -1999,7 +1998,7 @@ class UserFrustration(BuiltInSessionLevelScorer):
     description: str = "Evaluate the user's frustration state throughout the conversation."
 
     def _create_judge(self) -> Judge:
-        return make_judge(
+        return InstructionsJudge(
             name=self.name,
             instructions=self.instructions,
             model=self.model,
@@ -2331,7 +2330,7 @@ class _LastTurnKnowledgeRetention(SessionLevelScorer):
     )
 
     def _create_judge(self) -> Judge:
-        return make_judge(
+        return InstructionsJudge(
             name=self.name,
             instructions=self.instructions,
             model=self.model,
@@ -2578,7 +2577,7 @@ class Completeness(BuiltInScorer):
 
     def _get_judge(self) -> Judge:
         if self._judge is None:
-            self._judge = make_judge(
+            self._judge = InstructionsJudge(
                 name=self.name,
                 instructions=self.instructions,
                 model=self.model,
@@ -2680,7 +2679,7 @@ class Summarization(BuiltInScorer):
 
     def _get_judge(self) -> Judge:
         if self._judge is None:
-            self._judge = make_judge(
+            self._judge = InstructionsJudge(
                 name=self.name,
                 instructions=self.instructions,
                 model=self.model,

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1874,8 +1874,6 @@ class SessionLevelScorer(Judge):
         """
         Create the Judge instance for this scorer.
         Subclasses should implement this to configure their specific judge.
-
-        Note: Instantiate InstructionsJudge directly instead of using make_judge.
         """
 
     def _get_judge(self) -> Judge:
@@ -2001,7 +1999,7 @@ class UserFrustration(BuiltInSessionLevelScorer):
     description: str = "Evaluate the user's frustration state throughout the conversation."
 
     def _create_judge(self) -> Judge:
-        return InstructionsJudge(
+        return make_judge(
             name=self.name,
             instructions=self.instructions,
             model=self.model,
@@ -2333,7 +2331,7 @@ class _LastTurnKnowledgeRetention(SessionLevelScorer):
     )
 
     def _create_judge(self) -> Judge:
-        return InstructionsJudge(
+        return make_judge(
             name=self.name,
             instructions=self.instructions,
             model=self.model,

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1659,7 +1659,7 @@ class Fluency(BuiltInScorer):
         outputs: Any | None = None,
         trace: Trace | None = None,
     ) -> Feedback:
-        return self._get_judge()._evaluate_impl(
+        return self._get_judge()(
             outputs=outputs,
             trace=trace,
         )
@@ -1922,7 +1922,7 @@ class SessionLevelScorer(Judge):
         **kwargs,
     ) -> Feedback:
         self._validate_kwargs(kwargs)
-        return self._get_judge()._evaluate_impl(session=session, expectations=expectations)
+        return self._get_judge()(session=session, expectations=expectations)
 
 
 class BuiltInSessionLevelScorer(BuiltInScorer, SessionLevelScorer):
@@ -2617,7 +2617,7 @@ class Completeness(BuiltInScorer):
         outputs: Any | None = None,
         trace: Trace | None = None,
     ) -> Feedback:
-        return self._get_judge()._evaluate_impl(
+        return self._get_judge()(
             inputs=inputs,
             outputs=outputs,
             trace=trace,

--- a/tests/genai/scorers/conftest.py
+++ b/tests/genai/scorers/conftest.py
@@ -1,18 +1,12 @@
 """Conftest for scorer tests - imports telemetry fixtures for telemetry testing."""
 
-import sys
-from pathlib import Path
 from unittest import mock
 
 import pytest
 
-# Add telemetry tests to path so we can import fixtures
-telemetry_tests_path = Path(__file__).parent.parent.parent / "telemetry"
-if str(telemetry_tests_path) not in sys.path:
-    sys.path.insert(0, str(telemetry_tests_path))
-
-# Import telemetry fixtures
-from conftest import (  # noqa: E402, F401
+# Import telemetry fixtures from the telemetry test module
+# These fixtures are used by pytest for test setup and are not directly referenced
+from tests.telemetry.conftest import (  # noqa: F401
     bypass_env_check,
     is_mlflow_testing,
     mock_requests,

--- a/tests/genai/scorers/conftest.py
+++ b/tests/genai/scorers/conftest.py
@@ -5,9 +5,9 @@ from unittest import mock
 import pytest
 
 # Import telemetry fixtures from the telemetry test module
-# These fixtures are used by pytest for test setup and are not directly referenced
+# Autouse fixtures (terminate_telemetry_client, mock_requests_get, is_mlflow_testing)
+# are imported for their side effects and run automatically
 from tests.telemetry.conftest import (  # noqa: F401
-    bypass_env_check,
     is_mlflow_testing,
     mock_requests,
     mock_requests_get,

--- a/tests/genai/scorers/conftest.py
+++ b/tests/genai/scorers/conftest.py
@@ -19,7 +19,6 @@ from tests.telemetry.conftest import (  # noqa: F401
 
 @pytest.fixture(autouse=True)
 def mock_get_telemetry_client(mock_telemetry_client, monkeypatch):
-    """Auto-patch get_telemetry_client to return the mock client."""
     # Enable telemetry for tests using this fixture
     monkeypatch.setattr(mlflow.telemetry.utils, "_IS_MLFLOW_TESTING_TELEMETRY", True)
     with mock.patch(

--- a/tests/genai/scorers/conftest.py
+++ b/tests/genai/scorers/conftest.py
@@ -1,0 +1,31 @@
+"""Conftest for scorer tests - imports telemetry fixtures for telemetry testing."""
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Add telemetry tests to path so we can import fixtures
+telemetry_tests_path = Path(__file__).parent.parent.parent / "telemetry"
+if str(telemetry_tests_path) not in sys.path:
+    sys.path.insert(0, str(telemetry_tests_path))
+
+# Import telemetry fixtures
+from conftest import (  # noqa: E402, F401
+    bypass_env_check,
+    is_mlflow_testing,
+    mock_requests,
+    mock_requests_get,
+    mock_telemetry_client,
+    terminate_telemetry_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_get_telemetry_client(mock_telemetry_client):
+    """Auto-patch get_telemetry_client to return the mock client."""
+    with mock.patch(
+        "mlflow.telemetry.track.get_telemetry_client", return_value=mock_telemetry_client
+    ):
+        yield

--- a/tests/genai/scorers/conftest.py
+++ b/tests/genai/scorers/conftest.py
@@ -4,11 +4,12 @@ from unittest import mock
 
 import pytest
 
+import mlflow.telemetry.utils
+
 # Import telemetry fixtures from the telemetry test module
-# Autouse fixtures (terminate_telemetry_client, mock_requests_get, is_mlflow_testing)
+# Autouse fixtures (terminate_telemetry_client, mock_requests_get)
 # are imported for their side effects and run automatically
 from tests.telemetry.conftest import (  # noqa: F401
-    is_mlflow_testing,
     mock_requests,
     mock_requests_get,
     mock_telemetry_client,
@@ -17,8 +18,10 @@ from tests.telemetry.conftest import (  # noqa: F401
 
 
 @pytest.fixture(autouse=True)
-def mock_get_telemetry_client(mock_telemetry_client):
+def mock_get_telemetry_client(mock_telemetry_client, monkeypatch):
     """Auto-patch get_telemetry_client to return the mock client."""
+    # Enable telemetry for tests using this fixture
+    monkeypatch.setattr(mlflow.telemetry.utils, "_IS_MLFLOW_TESTING_TELEMETRY", True)
     with mock.patch(
         "mlflow.telemetry.track.get_telemetry_client", return_value=mock_telemetry_client
     ):

--- a/tests/genai/scorers/test_scorer_telemetry.py
+++ b/tests/genai/scorers/test_scorer_telemetry.py
@@ -64,8 +64,6 @@ class RecursiveScorer(Scorer):
 
 
 class GrandparentScorer(Scorer):
-    """Grandparent scorer that calls a parent, which calls a child."""
-
     _parent_scorer: Scorer = PrivateAttr()
 
     def __init__(self, parent_scorer: Scorer, **kwargs):
@@ -141,7 +139,6 @@ def test_multi_level_nesting_skips_telemetry(mock_requests, mock_telemetry_clien
 
     mock_telemetry_client.flush()
 
-    # Only 1 event recorded - nested calls were skipped
     scorer_events = get_scorer_call_events(mock_requests)
     assert len(scorer_events) == 1
 
@@ -171,7 +168,7 @@ def test_recursive_scorer_skips_nested_telemetry(
 
 
 def test_thread_safety_concurrent_scorers(mock_requests, mock_telemetry_client: TelemetryClient):
-    child = child_scorer_func  # Use decorator function (kind="decorator")
+    child = child_scorer_func
 
     results = []
     errors = []
@@ -226,7 +223,7 @@ def test_error_in_nested_scorer_still_records_parent_telemetry(
 
 
 def test_direct_child_call_records_telemetry(mock_requests, mock_telemetry_client: TelemetryClient):
-    child = child_scorer_func  # Use decorator function (kind="decorator")
+    child = child_scorer_func
 
     result = child(outputs="test")
     # Expected: len("test") = 4
@@ -246,7 +243,7 @@ def test_direct_child_call_records_telemetry(mock_requests, mock_telemetry_clien
 def test_sequential_parent_calls_each_record_telemetry(
     mock_requests, mock_telemetry_client: TelemetryClient
 ):
-    child = child_scorer_func  # Use decorator function (kind="decorator")
+    child = child_scorer_func
     parent = ParentScorer(name="parent_scorer", child_scorer=child)
 
     result1 = parent(outputs="test1")
@@ -278,7 +275,7 @@ def test_telemetry_disabled_nested_scorers_work(
     mock_requests, mock_telemetry_client: TelemetryClient
 ):
     with mock.patch("mlflow.telemetry.track.is_telemetry_disabled", return_value=True):
-        child = child_scorer_func  # Use decorator function (kind="decorator")
+        child = child_scorer_func
         parent = ParentScorer(name="parent_scorer", child_scorer=child)
 
         result = parent(outputs="test")

--- a/tests/genai/scorers/test_scorer_telemetry.py
+++ b/tests/genai/scorers/test_scorer_telemetry.py
@@ -1,0 +1,295 @@
+"""Tests for scorer telemetry behavior, specifically testing that nested scorer calls
+skip telemetry recording while top-level calls record telemetry correctly.
+"""
+
+import asyncio
+import json
+import threading
+from unittest import mock
+
+import pytest
+from pydantic import PrivateAttr
+
+from mlflow.entities import Feedback
+from mlflow.genai.scorers import scorer
+from mlflow.genai.scorers.base import Scorer
+from mlflow.telemetry.client import TelemetryClient
+from mlflow.telemetry.events import ScorerCallEvent
+
+
+class ChildScorer(Scorer):
+    """Simple child scorer that can be called by parent scorers."""
+
+    def __call__(self, outputs) -> Feedback:
+        return Feedback(name=self.name, value=len(outputs))
+
+
+class ParentScorer(Scorer):
+    """Parent scorer that calls a child scorer."""
+
+    _child_scorer: Scorer = PrivateAttr()
+
+    def __init__(self, child_scorer: Scorer, **kwargs):
+        super().__init__(**kwargs)
+        self._child_scorer = child_scorer
+
+    def __call__(self, outputs) -> Feedback:
+        # Call child scorer - this should NOT generate telemetry
+        child_result = self._child_scorer(outputs=outputs)
+        return Feedback(name=self.name, value=child_result.value * 2)
+
+
+class RecursiveScorer(Scorer):
+    """Scorer that can call itself recursively."""
+
+    _max_depth: int = PrivateAttr()
+
+    def __init__(self, max_depth=3, **kwargs):
+        super().__init__(**kwargs)
+        self._max_depth = max_depth
+
+    def __call__(self, outputs, depth=0) -> Feedback:
+        if depth >= self._max_depth:
+            return Feedback(name=self.name, value=len(outputs))
+        # Recursive call - only first call should generate telemetry
+        return self(outputs=outputs, depth=depth + 1)
+
+
+class GrandparentScorer(Scorer):
+    """Grandparent scorer that calls a parent, which calls a child."""
+
+    _parent_scorer: Scorer = PrivateAttr()
+
+    def __init__(self, parent_scorer: Scorer, **kwargs):
+        super().__init__(**kwargs)
+        self._parent_scorer = parent_scorer
+
+    def __call__(self, outputs) -> Feedback:
+        parent_result = self._parent_scorer(outputs=outputs)
+        return Feedback(name=self.name, value=parent_result.value + 1)
+
+
+class ErrorNestedScorer(Scorer):
+    """Child scorer that raises an error."""
+
+    def __call__(self, outputs) -> Feedback:
+        raise ValueError("Test error in nested scorer")
+
+
+class ParentWithErrorChild(Scorer):
+    """Parent scorer that calls a child that errors."""
+
+    _child_scorer: Scorer = PrivateAttr()
+
+    def __init__(self, child_scorer: Scorer, **kwargs):
+        super().__init__(**kwargs)
+        self._child_scorer = child_scorer
+
+    def __call__(self, outputs) -> Feedback:
+        try:
+            self._child_scorer(outputs=outputs)
+        except ValueError:
+            pass  # Handle error
+        return Feedback(name=self.name, value=10)
+
+
+def get_scorer_call_events(mock_requests):
+    """Extract ScorerCallEvent records from captured telemetry."""
+    return [
+        record for record in mock_requests if record["data"]["event_name"] == ScorerCallEvent.name
+    ]
+
+
+def get_event_params(mock_requests):
+    """Get parsed params from ScorerCallEvent records."""
+    scorer_call_events = get_scorer_call_events(mock_requests)
+    return [json.loads(event["data"]["params"]) for event in scorer_call_events]
+
+
+def test_nested_scorer_skips_telemetry(mock_requests, mock_telemetry_client: TelemetryClient):
+    child = ChildScorer(name="child_scorer")
+    parent = ParentScorer(name="parent_scorer", child_scorer=child)
+
+    result = parent(outputs="test output")
+    assert result.value == 22
+
+    mock_telemetry_client.flush()
+
+    scorer_events = get_scorer_call_events(mock_requests)
+    assert len(scorer_events) == 1
+
+    event_params = get_event_params(mock_requests)
+    assert len(event_params) == 1
+    assert event_params[0]["scorer_class"] == "UserDefinedScorer"
+    assert event_params[0]["scorer_kind"] == "class"
+
+
+def test_multi_level_nesting_skips_telemetry(mock_requests, mock_telemetry_client: TelemetryClient):
+    child = ChildScorer(name="child_scorer")
+    parent = ParentScorer(name="parent_scorer", child_scorer=child)
+    grandparent = GrandparentScorer(name="grandparent_scorer", parent_scorer=parent)
+
+    result = grandparent(outputs="test")
+    assert result.value == 9
+
+    mock_telemetry_client.flush()
+
+    scorer_events = get_scorer_call_events(mock_requests)
+    assert len(scorer_events) == 1
+
+    event_params = get_event_params(mock_requests)
+    assert len(event_params) == 1
+    assert event_params[0]["scorer_class"] == "UserDefinedScorer"
+
+
+def test_recursive_scorer_skips_nested_telemetry(
+    mock_requests, mock_telemetry_client: TelemetryClient
+):
+    recursive_scorer = RecursiveScorer(name="recursive_scorer", max_depth=5)
+
+    result = recursive_scorer(outputs="test", depth=0)
+    assert result.value == 4
+
+    mock_telemetry_client.flush()
+
+    scorer_events = get_scorer_call_events(mock_requests)
+    assert len(scorer_events) == 1
+
+    event_params = get_event_params(mock_requests)
+    assert len(event_params) == 1
+
+
+def test_thread_safety_concurrent_scorers(mock_requests, mock_telemetry_client: TelemetryClient):
+    child = ChildScorer(name="child_scorer")
+
+    results = []
+    errors = []
+
+    def run_scorer(scorer, outputs):
+        try:
+            result = scorer(outputs=outputs)
+            results.append(result)
+        except Exception as e:
+            errors.append(e)
+
+    threads = []
+    for i in range(10):
+        parent = ParentScorer(name=f"parent{i}", child_scorer=child)
+        thread = threading.Thread(target=run_scorer, args=(parent, f"test{i}"))
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    assert len(errors) == 0
+    assert len(results) == 10
+
+    mock_telemetry_client.flush()
+
+    scorer_events = get_scorer_call_events(mock_requests)
+    assert len(scorer_events) == 10
+
+    event_params = get_event_params(mock_requests)
+    assert len(event_params) == 10
+
+
+def test_error_in_nested_scorer_still_records_parent_telemetry(
+    mock_requests, mock_telemetry_client: TelemetryClient
+):
+    error_child = ErrorNestedScorer(name="error_child")
+    parent = ParentWithErrorChild(name="parent_scorer", child_scorer=error_child)
+
+    result = parent(outputs="test")
+    assert result.value == 10
+
+    mock_telemetry_client.flush()
+
+    scorer_events = get_scorer_call_events(mock_requests)
+    assert len(scorer_events) == 1
+
+    event_params = get_event_params(mock_requests)
+    assert len(event_params) == 1
+
+
+def test_direct_child_call_records_telemetry(mock_requests, mock_telemetry_client: TelemetryClient):
+    child = ChildScorer(name="child_scorer")
+
+    result = child(outputs="test")
+    assert result.value == 4
+
+    mock_telemetry_client.flush()
+
+    scorer_events = get_scorer_call_events(mock_requests)
+    assert len(scorer_events) == 1
+
+    event_params = get_event_params(mock_requests)
+    assert len(event_params) == 1
+
+
+def test_sequential_parent_calls_each_record_telemetry(
+    mock_requests, mock_telemetry_client: TelemetryClient
+):
+    child = ChildScorer(name="child_scorer")
+    parent = ParentScorer(name="parent_scorer", child_scorer=child)
+
+    result1 = parent(outputs="test1")
+    result2 = parent(outputs="test2")
+    assert result1.value == 10
+    assert result2.value == 10
+
+    mock_telemetry_client.flush()
+
+    scorer_events = get_scorer_call_events(mock_requests)
+    assert len(scorer_events) == 2
+
+    event_params = get_event_params(mock_requests)
+    assert len(event_params) == 2
+
+
+def test_async_scorer_raises_error():
+    with pytest.raises(TypeError, match="Async scorer '__call__' methods are not supported"):
+
+        class AsyncScorer(Scorer):
+            async def __call__(self, outputs) -> Feedback:
+                await asyncio.sleep(0.001)
+                return Feedback(name=self.name, value=len(outputs))
+
+
+def test_telemetry_disabled_nested_scorers_work(
+    mock_requests, mock_telemetry_client: TelemetryClient
+):
+    with mock.patch("mlflow.telemetry.track.is_telemetry_disabled", return_value=True):
+        child = ChildScorer(name="child_scorer")
+        parent = ParentScorer(name="parent_scorer", child_scorer=child)
+
+        result = parent(outputs="test")
+        assert result.value == 8
+
+        mock_telemetry_client.flush()
+
+        scorer_events = get_scorer_call_events(mock_requests)
+        assert len(scorer_events) == 0
+
+
+def test_decorator_scorer_with_nested_call(mock_requests, mock_telemetry_client: TelemetryClient):
+    @scorer
+    def nested_checker(outputs) -> int:
+        return len(outputs)
+
+    @scorer
+    def parent_checker(outputs) -> int:
+        nested_result = nested_checker(outputs=outputs)
+        return nested_result * 2
+
+    result = parent_checker(outputs="test")
+    assert result == 8
+
+    mock_telemetry_client.flush()
+
+    scorer_events = get_scorer_call_events(mock_requests)
+    assert len(scorer_events) == 1
+
+    event_params = get_event_params(mock_requests)
+    assert len(event_params) == 1
+    assert event_params[0]["scorer_kind"] == "decorator"


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR prevents nested scorer calls from recording duplicate telemetry events. When a scorer calls another scorer internally (e.g., `KnowledgeRetention` calling `last_turn_scorer`), only the top-level call now records a `ScorerCallEvent`, eliminating noise in telemetry data.

**Key changes:**

1. **Scorer telemetry enhancement**: Added thread-safe context tracking using `ContextVar` to detect nested scorer calls and skip telemetry for them
2. **Judge evaluation simplification**: Removed `InstructionsJudge._evaluate_impl()` method (now unnecessary with context-aware telemetry)
3. **Type system improvements**: 
   - Generalized `SessionLevelScorer` judge types from `InstructionsJudge` to `Judge`
   - Updated `Fluency`, `Completeness`, and `Summarization` scorers to use `InstructionsJudge()` directly
   - Selectively updated session-level scorers (`UserFrustration`, `_LastTurnKnowledgeRetention`) to use `InstructionsJudge()` where compatible

## How is this PR tested?

- **New test file**: `tests/genai/scorers/test_scorer_telemetry.py` with 10 comprehensive tests:
  - Nested scorer calls (parent → child)
  - Multi-level nesting (grandparent → parent → child)
  - Recursive scorer calls
  - Thread safety with 10 concurrent scorers
  - Error handling in nested calls
  - Async scorer rejection
  - Telemetry globally disabled
  - Decorator scorer with nested calls
- **Existing tests**: All 96 tests in `test_builtin_scorers.py` pass (92 passed, 4 skipped)
- **Code formatting**: Verified with ruff

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the website builds locally and documentation renders correctly with the changes.

Documentation not changed, but code comments and docstrings were updated.

## Release Notes

### Evaluators

- [Improvement] Nested scorer calls now skip telemetry recording to prevent duplicate events

## Component(s)

- [x] `area/evaluation`: Evaluation tracking and datasets

## Release Classification

- [x] `rn/none`: No mention in release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

---

**Related Issue**: ML-54280

**Implementation Details**:
- Uses Python's `ContextVar` for thread-safe nested call detection
- Token-based cleanup pattern ensures proper context restoration
- Scorers that use `InstructionsJudge`-specific parameters (`generate_rationale_first`, `include_tool_calls_in_conversation`) continue using direct instantiation
- Scorers without special parameters now use `InstructionsJudge()` for consistency and telemetry tracking

**Testing Highlights**:
- Thread-safe: 10 concurrent scorers each record exactly one event
- Nested calls: Only top-level call records telemetry
- Error handling: Context properly cleaned up even when nested scorers fail
- Async safety: Async scorers explicitly rejected with clear error message