### PR TITLE
[ Gateway 8/10 ] Add Auth config to endpoint creation

### DIFF
--- a/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
@@ -1,0 +1,122 @@
+import { useState, useMemo, useCallback, memo } from 'react';
+import { Input, useDesignSystemTheme, FormUI, Tag, ModelsIcon } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { ModelSelectorModal } from '../model-selector/ModelSelectorModal';
+import { useModelsQuery } from '../../hooks/useModelsQuery';
+import type { ProviderModel } from '../../types';
+
+interface ModelSelectProps {
+  provider: string;
+  value: string;
+  onChange: (model: string) => void;
+  disabled?: boolean;
+  error?: string;
+  /** Component ID prefix for telemetry (default: 'mlflow.gateway.model-select') */
+  componentIdPrefix?: string;
+}
+
+export const ModelSelect = ({
+  provider,
+  value,
+  onChange,
+  disabled,
+  error,
+  componentIdPrefix = 'mlflow.gateway.model-select',
+}: ModelSelectProps) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Fetch models to get the selected model's details
+  const { data: models } = useModelsQuery({ provider: provider || undefined });
+  const selectedModel = useMemo(() => models?.find((m) => m.model === value), [models, value]);
+
+  const handleClick = useCallback(() => {
+    if (!disabled && provider) {
+      setIsModalOpen(true);
+    }
+  }, [disabled, provider]);
+
+  const handleSelect = useCallback(
+    (model: ProviderModel) => {
+      onChange(model.model);
+    },
+    [onChange],
+  );
+
+  const handleClose = useCallback(() => {
+    setIsModalOpen(false);
+  }, []);
+
+  return (
+    <div>
+      <FormUI.Label htmlFor={componentIdPrefix}>
+        <FormattedMessage defaultMessage="Model" description="Label for model select field" />
+      </FormUI.Label>
+      <Input
+        id={componentIdPrefix}
+        componentId={componentIdPrefix}
+        placeholder={
+          !provider
+            ? intl.formatMessage({
+                defaultMessage: 'Select a provider first',
+                description: 'Placeholder when no provider selected',
+              })
+            : intl.formatMessage({
+                defaultMessage: 'Click to select a model',
+                description: 'Placeholder for model selection',
+              })
+        }
+        readOnly
+        disabled={disabled || !provider}
+        onClick={handleClick}
+        value={value || ''}
+        validationState={error ? 'error' : undefined}
+        prefix={value ? <ModelsIcon /> : undefined}
+        css={{
+          cursor: disabled || !provider ? 'not-allowed' : 'pointer',
+          '& input': {
+            cursor: disabled || !provider ? 'not-allowed' : 'pointer',
+          },
+        }}
+      />
+      {error && <FormUI.Message type="error" message={error} />}
+      {selectedModel && <ModelCapabilities model={selectedModel} />}
+      <ModelSelectorModal isOpen={isModalOpen} onClose={handleClose} onSelect={handleSelect} provider={provider} />
+    </div>
+  );
+};
+
+const ModelCapabilities = memo(({ model }: { model: ProviderModel }) => {
+  const { theme } = useDesignSystemTheme();
+
+  const capabilities = useMemo(() => {
+    const caps: string[] = [];
+    if (model.supports_function_calling) caps.push('Tools');
+    if (model.supports_reasoning) caps.push('Reasoning');
+    if (model.supports_prompt_caching) caps.push('Caching');
+    return caps;
+  }, [model.supports_function_calling, model.supports_reasoning, model.supports_prompt_caching]);
+
+  if (capabilities.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      css={{
+        marginTop: theme.spacing.xs,
+        display: 'flex',
+        alignItems: 'center',
+        gap: theme.spacing.xs,
+        flexWrap: 'wrap',
+      }}
+    >
+      {capabilities.map((cap) => (
+        <Tag key={cap} componentId={`mlflow.gateway.model-select.capability.${cap.toLowerCase()}`}>
+          {cap}
+        </Tag>
+      ))}
+    </div>
+  );
+});

--- a/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
@@ -1,39 +1,76 @@
-import { useState } from 'react';
+import { useMemo, useCallback } from 'react';
 import { Alert, Button, FormUI, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { GatewayInput } from '../common';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Controller, useFormContext } from 'react-hook-form';
 import { ProviderSelect } from '../create-endpoint/ProviderSelect';
-import { ModelSelectorModal } from '../model-selector';
+import { ModelSelect } from '../create-endpoint/ModelSelect';
+import { ApiKeyConfigurator } from '../model-configuration/components/ApiKeyConfigurator';
+import { useApiKeyConfiguration } from '../model-configuration/hooks/useApiKeyConfiguration';
+import type { ApiKeyConfiguration } from '../model-configuration/types';
+import { formatProviderName } from '../../utils/providerUtils';
 import { LongFormSection } from '../../../common/components/long-form/LongFormSection';
 import { LongFormSummary } from '../../../common/components/long-form/LongFormSummary';
-import { formatProviderName } from '../../utils/providerUtils';
+import type { ProviderModel, SecretInfo } from '../../types';
 import { formatTokens, formatCost } from '../../utils/formatters';
-import type { ProviderModel } from '../../types';
+import type { SecretMode } from '../secrets/SecretConfigSection';
 
 const LONG_FORM_TITLE_WIDTH = 200;
 
+/**
+ * Shared form data interface for both create and edit endpoint forms.
+ * Both use the same field structure.
+ */
 export interface EndpointFormData {
   name: string;
   provider: string;
   modelName: string;
+  secretMode: SecretMode;
+  existingSecretId: string;
+  newSecret: {
+    name: string;
+    authMode: string;
+    secretFields: Record<string, string>;
+    configFields: Record<string, string>;
+  };
 }
 
 export interface EndpointFormRendererProps {
+  /** Whether this is editing an existing endpoint (affects button labels, etc.) */
   mode: 'create' | 'edit';
+  /** Whether the form is submitting */
   isSubmitting: boolean;
+  /** Error to display */
   error: Error | null;
+  /** User-friendly error message */
   errorMessage: string | null;
+  /** Callback to reset errors when user makes changes */
   resetErrors: () => void;
+  /** The selected model's full metadata (for summary display) */
   selectedModel: ProviderModel | undefined;
+  /** Whether all required fields are filled */
   isFormComplete: boolean;
+  /** Whether any fields have changed from their initial values (edit mode only) */
   hasChanges?: boolean;
+  /** Form submission handler */
   onSubmit: (values: EndpointFormData) => Promise<void>;
+  /** Cancel handler */
   onCancel: () => void;
+  /** Handler for name field blur (for duplicate checking) */
   onNameBlur: () => void;
+  /** Component ID prefix for telemetry */
   componentIdPrefix?: string;
 }
 
+/**
+ * Unified presentational component for endpoint forms (create and edit).
+ * All business logic is handled by the parent hook (useCreateEndpointForm or useEditEndpointForm).
+ *
+ * This component expects to be wrapped in a FormProvider by the parent.
+ * Page-level concerns (breadcrumbs, page wrapper, loading/error states) should be
+ * handled by the parent to allow this form to be reused in different contexts
+ * (full page, modal, etc.).
+ */
 export const EndpointFormRenderer = ({
   mode,
   isSubmitting,
@@ -51,11 +88,44 @@ export const EndpointFormRenderer = ({
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const form = useFormContext<EndpointFormData>();
-  const [isModelSelectorOpen, setIsModelSelectorOpen] = useState(false);
 
   const provider = form.watch('provider');
   const modelName = form.watch('modelName');
+  const secretMode = form.watch('secretMode');
+  const existingSecretId = form.watch('existingSecretId');
+  const newSecret = form.watch('newSecret');
 
+  // Get API key configuration data for the selected provider
+  const { existingSecrets, isLoadingSecrets, authModes, defaultAuthMode, isLoadingProviderConfig } =
+    useApiKeyConfiguration({ provider });
+
+  // Convert form values to ApiKeyConfiguration format for the presentation component
+  const apiKeyConfig: ApiKeyConfiguration = useMemo(
+    () => ({
+      mode: secretMode,
+      existingSecretId: existingSecretId,
+      newSecret: newSecret,
+    }),
+    [secretMode, existingSecretId, newSecret],
+  );
+
+  // Handler to update form values when ApiKeyConfigurator changes
+  const handleApiKeyChange = useCallback(
+    (config: ApiKeyConfiguration) => {
+      if (config.mode !== secretMode) {
+        form.setValue('secretMode', config.mode);
+      }
+      if (config.existingSecretId !== existingSecretId) {
+        form.setValue('existingSecretId', config.existingSecretId);
+      }
+      if (config.newSecret !== newSecret) {
+        form.setValue('newSecret', config.newSecret);
+      }
+    },
+    [form, secretMode, existingSecretId, newSecret],
+  );
+
+  // Determine button disabled state and tooltip
   const isButtonDisabled = mode === 'edit' ? !isFormComplete || !hasChanges : !isFormComplete;
   const buttonTooltip = !isFormComplete
     ? intl.formatMessage({
@@ -90,6 +160,7 @@ export const EndpointFormRenderer = ({
           gap: theme.spacing.md,
           padding: `0 ${theme.spacing.md}px`,
           overflow: 'auto',
+          // Stack vertically on narrow screens
           '@media (max-width: 1023px)': {
             flexDirection: 'column',
           },
@@ -155,53 +226,66 @@ export const EndpointFormRenderer = ({
             hideDivider
           >
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
-              {/* Provider subsection */}
-              <div>
-                <Controller
-                  control={form.control}
-                  name="provider"
-                  rules={{ required: 'Provider is required' }}
-                  render={({ field, fieldState }) => (
-                    <ProviderSelect
-                      value={field.value}
-                      onChange={(value) => {
-                        field.onChange(value);
-                        form.setValue('modelName', '');
-                      }}
-                      error={fieldState.error?.message}
-                      componentIdPrefix={`${componentIdPrefix}.provider`}
-                    />
-                  )}
-                />
-              </div>
-
-              {/* Model subsection - only show when provider is selected */}
-              {provider && (
-                <div>
-                  <FormUI.Label htmlFor={`${componentIdPrefix}.model`}>
-                    <FormattedMessage defaultMessage="Model" description="Model label" />
-                  </FormUI.Label>
-                  <Button
-                    componentId={`${componentIdPrefix}.select-model`}
-                    onClick={() => setIsModelSelectorOpen(true)}
-                    css={{
-                      width: '100%',
-                      fontWeight: 'normal',
-                      '& > span': {
-                        width: '100%',
-                        justifyContent: 'flex-start',
-                      },
+              <Controller
+                control={form.control}
+                name="provider"
+                rules={{ required: 'Provider is required' }}
+                render={({ field, fieldState }) => (
+                  <ProviderSelect
+                    value={field.value}
+                    onChange={(value) => {
+                      field.onChange(value);
+                      // Reset all dependent fields when provider changes
+                      form.setValue('modelName', '');
+                      form.setValue('existingSecretId', '');
+                      form.setValue('secretMode', 'new');
+                      form.setValue('newSecret', {
+                        name: '',
+                        authMode: '',
+                        secretFields: {},
+                        configFields: {},
+                      });
                     }}
-                  >
-                    {modelName || (
-                      <span css={{ color: theme.colors.textSecondary }}>
-                        <FormattedMessage
-                          defaultMessage="Select a model..."
-                          description="Model selection placeholder"
-                        />
-                      </span>
-                    )}
-                  </Button>
+                    error={fieldState.error?.message}
+                    componentIdPrefix={`${componentIdPrefix}.provider`}
+                  />
+                )}
+              />
+              <Controller
+                control={form.control}
+                name="modelName"
+                rules={{ required: 'Model is required' }}
+                render={({ field, fieldState }) => (
+                  <ModelSelect
+                    provider={provider}
+                    value={field.value}
+                    onChange={field.onChange}
+                    error={fieldState.error?.message}
+                    componentIdPrefix={`${componentIdPrefix}.model`}
+                  />
+                )}
+              />
+
+              {/* Connections subsection - nested within Model */}
+              {provider && (
+                <div css={{ marginTop: theme.spacing.sm }}>
+                  <Typography.Text bold css={{ display: 'block', marginBottom: theme.spacing.sm }}>
+                    <FormattedMessage
+                      defaultMessage="Connections"
+                      description="Subsection header for API key configuration"
+                    />
+                  </Typography.Text>
+                  <ApiKeyConfigurator
+                    value={apiKeyConfig}
+                    onChange={handleApiKeyChange}
+                    provider={provider}
+                    existingSecrets={existingSecrets}
+                    isLoadingSecrets={isLoadingSecrets}
+                    authModes={authModes}
+                    defaultAuthMode={defaultAuthMode}
+                    isLoadingProviderConfig={isLoadingProviderConfig}
+                    componentIdPrefix={`${componentIdPrefix}.api-key`}
+                  />
                 </div>
               )}
             </div>
@@ -256,6 +340,19 @@ export const EndpointFormRenderer = ({
                   </Typography.Text>
                 )}
               </div>
+
+              {/* API Key */}
+              <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                <Typography.Text bold color="secondary">
+                  <FormattedMessage defaultMessage="API Key" description="Summary API key label" />
+                </Typography.Text>
+                <ApiKeySummary
+                  secretMode={secretMode}
+                  newSecretName={newSecret?.name}
+                  existingSecretId={existingSecretId}
+                  existingSecrets={existingSecrets}
+                />
+              </div>
             </div>
           </LongFormSummary>
         </div>
@@ -291,16 +388,6 @@ export const EndpointFormRenderer = ({
           </Button>
         </Tooltip>
       </div>
-
-      <ModelSelectorModal
-        isOpen={isModelSelectorOpen}
-        onClose={() => setIsModelSelectorOpen(false)}
-        onSelect={(model) => {
-          form.setValue('modelName', model.model);
-          setIsModelSelectorOpen(false);
-        }}
-        provider={provider}
-      />
     </>
   );
 };
@@ -374,4 +461,30 @@ const ModelSummary = ({ model, modelName }: { model: ProviderModel | undefined; 
       )}
     </div>
   );
+};
+
+/** Helper component to display API key info in the summary */
+const ApiKeySummary = ({
+  secretMode,
+  newSecretName,
+  existingSecretId,
+  existingSecrets,
+}: {
+  secretMode: SecretMode;
+  newSecretName?: string;
+  existingSecretId?: string;
+  existingSecrets?: SecretInfo[];
+}) => {
+  const apiKeyName =
+    secretMode === 'new' ? newSecretName : existingSecrets?.find((s) => s.secret_id === existingSecretId)?.secret_name;
+
+  if (!apiKeyName) {
+    return (
+      <Typography.Text color="secondary">
+        <FormattedMessage defaultMessage="Not configured" description="Summary not configured" />
+      </Typography.Text>
+    );
+  }
+
+  return <Typography.Text>{apiKeyName}</Typography.Text>;
 };

--- a/mlflow/server/js/src/gateway/components/model-configuration/components/ApiKeyConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/model-configuration/components/ApiKeyConfigurator.tsx
@@ -1,0 +1,345 @@
+import { useCallback, useMemo } from 'react';
+import { FormUI, Radio, Spinner, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { GatewayInput } from '../../common';
+import { SecretInput } from '../../secrets/SecretInput';
+import { SecretSelector } from '../../secrets/SecretSelector';
+import { formatCredentialFieldName, sortFieldsByProvider } from '../../../utils/providerUtils';
+import type { ApiKeyConfiguration, NewSecretData } from '../types';
+import type { SecretInfo, AuthMode, SecretField, ConfigField } from '../../../types';
+
+interface ApiKeyConfiguratorProps {
+  value: ApiKeyConfiguration;
+  onChange: (value: ApiKeyConfiguration) => void;
+  provider: string;
+  existingSecrets: SecretInfo[];
+  isLoadingSecrets: boolean;
+  authModes: AuthMode[];
+  defaultAuthMode: string | undefined;
+  isLoadingProviderConfig: boolean;
+  errors?: {
+    existingSecretId?: string;
+    newSecret?: {
+      name?: string;
+      secretFields?: Record<string, string>;
+      configFields?: Record<string, string>;
+    };
+  };
+  disabled?: boolean;
+  componentIdPrefix?: string;
+}
+
+export function ApiKeyConfigurator({
+  value,
+  onChange,
+  provider,
+  existingSecrets,
+  isLoadingSecrets,
+  authModes,
+  defaultAuthMode,
+  isLoadingProviderConfig,
+  errors,
+  disabled,
+  componentIdPrefix = 'mlflow.gateway.api-key-config',
+}: ApiKeyConfiguratorProps) {
+  const { theme } = useDesignSystemTheme();
+  const { formatMessage } = useIntl();
+
+  const hasExistingSecrets = existingSecrets.length > 0;
+  const hasMultipleAuthModes = authModes.length > 1;
+
+  const selectedAuthMode = useMemo((): AuthMode | undefined => {
+    if (!authModes.length) return undefined;
+    if (value.newSecret.authMode) {
+      const matched = authModes.find((m) => m.mode === value.newSecret.authMode);
+      if (matched) return matched;
+    }
+    return authModes.find((m) => m.mode === defaultAuthMode) ?? authModes[0];
+  }, [authModes, value.newSecret.authMode, defaultAuthMode]);
+
+  const handleModeChange = useCallback(
+    (mode: 'new' | 'existing') => {
+      onChange({ ...value, mode });
+    },
+    [onChange, value],
+  );
+
+  const handleExistingSecretSelect = useCallback(
+    (secretId: string) => {
+      onChange({ ...value, existingSecretId: secretId });
+    },
+    [onChange, value],
+  );
+
+  const handleNewSecretChange = useCallback(
+    (newSecret: NewSecretData) => {
+      onChange({ ...value, newSecret });
+    },
+    [onChange, value],
+  );
+
+  const handleNameChange = useCallback(
+    (name: string) => {
+      handleNewSecretChange({ ...value.newSecret, name });
+    },
+    [handleNewSecretChange, value.newSecret],
+  );
+
+  const handleAuthModeChange = useCallback(
+    (authMode: string) => {
+      handleNewSecretChange({
+        ...value.newSecret,
+        authMode,
+        secretFields: {},
+        configFields: {},
+      });
+    },
+    [handleNewSecretChange, value.newSecret],
+  );
+
+  const handleSecretFieldChange = useCallback(
+    (fieldName: string, fieldValue: string) => {
+      handleNewSecretChange({
+        ...value.newSecret,
+        secretFields: { ...value.newSecret.secretFields, [fieldName]: fieldValue },
+      });
+    },
+    [handleNewSecretChange, value.newSecret],
+  );
+
+  const handleConfigFieldChange = useCallback(
+    (fieldName: string, fieldValue: string) => {
+      handleNewSecretChange({
+        ...value.newSecret,
+        configFields: { ...value.newSecret.configFields, [fieldName]: fieldValue },
+      });
+    },
+    [handleNewSecretChange, value.newSecret],
+  );
+
+  if (!provider) {
+    return (
+      <Typography.Text color="secondary">
+        <FormattedMessage
+          defaultMessage="Select a provider and model to configure API key"
+          description="Message when no provider selected for API key form"
+        />
+      </Typography.Text>
+    );
+  }
+
+  if (isLoadingProviderConfig) {
+    return (
+      <div css={{ display: 'flex', justifyContent: 'center', padding: theme.spacing.md }}>
+        <Spinner size="small" />
+      </div>
+    );
+  }
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+      <Radio.Group
+        componentId={`${componentIdPrefix}.mode`}
+        name={`${componentIdPrefix}.mode`}
+        value={value.mode}
+        onChange={(e) => handleModeChange(e.target.value as 'new' | 'existing')}
+        layout="horizontal"
+        disabled={disabled}
+      >
+        <Radio value="new">
+          <FormattedMessage defaultMessage="Create new API key" description="Option to create new API key" />
+        </Radio>
+        <Radio value="existing" disabled={!hasExistingSecrets}>
+          <FormattedMessage defaultMessage="Use existing API key" description="Option to use existing API key" />
+        </Radio>
+      </Radio.Group>
+
+      {!hasExistingSecrets && (
+        <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+          <FormattedMessage
+            defaultMessage="No existing API keys for this provider."
+            description="Message when no existing API keys"
+          />
+        </Typography.Text>
+      )}
+
+      {value.mode === 'existing' ? (
+        <SecretSelector
+          provider={provider}
+          value={value.existingSecretId}
+          onChange={handleExistingSecretSelect}
+          disabled={disabled}
+          error={errors?.existingSecretId}
+        />
+      ) : (
+        <NewSecretForm
+          value={value.newSecret}
+          provider={provider}
+          selectedAuthMode={selectedAuthMode}
+          authModes={authModes}
+          hasMultipleAuthModes={hasMultipleAuthModes}
+          defaultAuthMode={defaultAuthMode}
+          errors={errors?.newSecret}
+          disabled={disabled}
+          componentIdPrefix={componentIdPrefix}
+          onNameChange={handleNameChange}
+          onAuthModeChange={handleAuthModeChange}
+          onSecretFieldChange={handleSecretFieldChange}
+          onConfigFieldChange={handleConfigFieldChange}
+        />
+      )}
+    </div>
+  );
+}
+
+interface NewSecretFormProps {
+  value: NewSecretData;
+  provider: string;
+  selectedAuthMode: AuthMode | undefined;
+  authModes: AuthMode[];
+  hasMultipleAuthModes: boolean;
+  defaultAuthMode: string | undefined;
+  errors?: {
+    name?: string;
+    secretFields?: Record<string, string>;
+    configFields?: Record<string, string>;
+  };
+  disabled?: boolean;
+  componentIdPrefix: string;
+  onNameChange: (name: string) => void;
+  onAuthModeChange: (mode: string) => void;
+  onSecretFieldChange: (fieldName: string, fieldValue: string) => void;
+  onConfigFieldChange: (fieldName: string, fieldValue: string) => void;
+}
+
+function NewSecretForm({
+  value,
+  provider,
+  selectedAuthMode,
+  authModes,
+  hasMultipleAuthModes,
+  defaultAuthMode,
+  errors,
+  disabled,
+  componentIdPrefix,
+  onNameChange,
+  onAuthModeChange,
+  onSecretFieldChange,
+  onConfigFieldChange,
+}: NewSecretFormProps) {
+  const { theme } = useDesignSystemTheme();
+  const { formatMessage } = useIntl();
+
+  // Combine secret and config fields into a single sorted list
+  const sortedFields = useMemo(() => {
+    const secretFields = (selectedAuthMode?.secret_fields ?? []).map((field) => ({
+      ...field,
+      fieldType: 'secret' as const,
+    }));
+    const configFields = (selectedAuthMode?.config_fields ?? []).map((field) => ({
+      ...field,
+      fieldType: 'config' as const,
+    }));
+    const allFields = [...secretFields, ...configFields];
+    return sortFieldsByProvider(allFields, provider);
+  }, [selectedAuthMode?.secret_fields, selectedAuthMode?.config_fields, provider]);
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+      <div>
+        <FormUI.Label htmlFor={`${componentIdPrefix}.name`}>
+          <FormattedMessage defaultMessage="API key name" description="Label for API key name input" />
+          <span css={{ color: theme.colors.textValidationDanger }}> *</span>
+        </FormUI.Label>
+        <GatewayInput
+          id={`${componentIdPrefix}.name`}
+          componentId={`${componentIdPrefix}.name`}
+          value={value.name}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder={formatMessage({
+            defaultMessage: 'my-api-key',
+            description: 'Placeholder for API key name input',
+          })}
+          validationState={errors?.name ? 'error' : undefined}
+          disabled={disabled}
+        />
+        {errors?.name ? (
+          <FormUI.Message type="error" message={errors.name} />
+        ) : (
+          <FormUI.Hint>
+            <FormattedMessage
+              defaultMessage="A unique name to identify this API key for reuse across endpoints"
+              description="Hint text explaining API key name field"
+            />
+          </FormUI.Hint>
+        )}
+      </div>
+
+      {hasMultipleAuthModes && (
+        <div>
+          <FormUI.Label>
+            <FormattedMessage defaultMessage="Authentication method" description="Label for auth mode selector" />
+          </FormUI.Label>
+          <Radio.Group
+            name={`${componentIdPrefix}.auth-mode`}
+            componentId={`${componentIdPrefix}.auth-mode`}
+            value={value.authMode || defaultAuthMode}
+            onChange={(e) => onAuthModeChange(e.target.value)}
+            disabled={disabled}
+          >
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+              {authModes.map((mode) => (
+                <Radio key={mode.mode} value={mode.mode}>
+                  <div>
+                    <div css={{ fontWeight: theme.typography.typographyBoldFontWeight }}>{mode.display_name}</div>
+                    {mode.description && (
+                      <div css={{ color: theme.colors.textSecondary, fontSize: theme.typography.fontSizeSm }}>
+                        {mode.description}
+                      </div>
+                    )}
+                  </div>
+                </Radio>
+              ))}
+            </div>
+          </Radio.Group>
+        </div>
+      )}
+
+      {sortedFields.map((field) => (
+        <div key={field.name}>
+          <FormUI.Label htmlFor={`${componentIdPrefix}.${field.fieldType}.${field.name}`}>
+            {formatCredentialFieldName(field.name)}
+            {field.required && <span css={{ color: theme.colors.textValidationDanger }}> *</span>}
+          </FormUI.Label>
+          {field.fieldType === 'secret' ? (
+            <SecretInput
+              id={`${componentIdPrefix}.secret.${field.name}`}
+              componentId={`${componentIdPrefix}.secret.${field.name}`}
+              value={value.secretFields[field.name] ?? ''}
+              onChange={(e) => onSecretFieldChange(field.name, e.target.value)}
+              placeholder={field.description}
+              validationState={errors?.secretFields?.[field.name] ? 'error' : undefined}
+              disabled={disabled}
+            />
+          ) : (
+            <GatewayInput
+              id={`${componentIdPrefix}.config.${field.name}`}
+              componentId={`${componentIdPrefix}.config.${field.name}`}
+              value={value.configFields[field.name] ?? ''}
+              onChange={(e) => onConfigFieldChange(field.name, e.target.value)}
+              placeholder={field.description}
+              validationState={errors?.configFields?.[field.name] ? 'error' : undefined}
+              disabled={disabled}
+            />
+          )}
+          {field.fieldType === 'secret' && errors?.secretFields?.[field.name] && (
+            <FormUI.Message type="error" message={errors.secretFields[field.name]} />
+          )}
+          {field.fieldType === 'config' && errors?.configFields?.[field.name] && (
+            <FormUI.Message type="error" message={errors.configFields[field.name]} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/mlflow/server/js/src/gateway/components/model-configuration/hooks/useApiKeyConfiguration.ts
+++ b/mlflow/server/js/src/gateway/components/model-configuration/hooks/useApiKeyConfiguration.ts
@@ -1,0 +1,58 @@
+import { useMemo, useCallback } from 'react';
+import { useSecretsQuery } from '../../../hooks/useSecretsQuery';
+import { useProviderConfigQuery } from '../../../hooks/useProviderConfigQuery';
+import type { ApiKeyConfiguration, NewSecretData } from '../types';
+import type { SecretInfo, AuthMode } from '../../../types';
+
+interface UseApiKeyConfigurationOptions {
+  provider: string;
+}
+
+interface UseApiKeyConfigurationResult {
+  existingSecrets: SecretInfo[];
+  isLoadingSecrets: boolean;
+  authModes: AuthMode[];
+  defaultAuthMode: string | undefined;
+  selectedAuthMode: AuthMode | undefined;
+  isLoadingProviderConfig: boolean;
+  hasExistingSecrets: boolean;
+}
+
+export function useApiKeyConfiguration({ provider }: UseApiKeyConfigurationOptions): UseApiKeyConfigurationResult {
+  const { data: allSecrets, isLoading: isLoadingSecrets } = useSecretsQuery();
+
+  const existingSecrets = useMemo(() => {
+    if (!allSecrets || !provider) return [];
+    return allSecrets.filter((secret) => secret.provider === provider);
+  }, [allSecrets, provider]);
+
+  const { data: providerConfig, isLoading: isLoadingProviderConfig } = useProviderConfigQuery({
+    provider,
+  });
+
+  const authModes = useMemo(() => providerConfig?.auth_modes ?? [], [providerConfig?.auth_modes]);
+
+  const defaultAuthMode = providerConfig?.default_mode;
+
+  const getSelectedAuthMode = useCallback(
+    (authModeKey: string | undefined): AuthMode | undefined => {
+      if (!authModes.length) return undefined;
+      if (authModeKey) {
+        const matched = authModes.find((m) => m.mode === authModeKey);
+        if (matched) return matched;
+      }
+      return authModes.find((m) => m.mode === defaultAuthMode) ?? authModes[0];
+    },
+    [authModes, defaultAuthMode],
+  );
+
+  return {
+    existingSecrets,
+    isLoadingSecrets,
+    authModes,
+    defaultAuthMode,
+    selectedAuthMode: getSelectedAuthMode(defaultAuthMode),
+    isLoadingProviderConfig,
+    hasExistingSecrets: existingSecrets.length > 0,
+  };
+}

--- a/mlflow/server/js/src/gateway/components/model-configuration/types.ts
+++ b/mlflow/server/js/src/gateway/components/model-configuration/types.ts
@@ -1,0 +1,12 @@
+export interface NewSecretData {
+  name: string;
+  authMode: string;
+  secretFields: Record<string, string>;
+  configFields: Record<string, string>;
+}
+
+export interface ApiKeyConfiguration {
+  mode: 'new' | 'existing';
+  existingSecretId: string;
+  newSecret: NewSecretData;
+}

--- a/mlflow/server/js/src/gateway/components/secrets/CreateSecretForm.tsx
+++ b/mlflow/server/js/src/gateway/components/secrets/CreateSecretForm.tsx
@@ -1,0 +1,74 @@
+import { useFormContext } from 'react-hook-form';
+import { SecretFormFields } from './SecretFormFields';
+import type { SecretFormData } from './types';
+
+interface CreateSecretFormProps {
+  provider: string;
+  fieldPrefix?: string;
+  componentIdPrefix?: string;
+}
+
+export const CreateSecretForm = ({
+  provider,
+  fieldPrefix = 'newSecret',
+  componentIdPrefix = 'mlflow.gateway.create-endpoint',
+}: CreateSecretFormProps) => {
+  const { watch, setValue, formState } = useFormContext();
+
+  const secretData: SecretFormData = {
+    name: watch(`${fieldPrefix}.name`) ?? '',
+    authMode: watch(`${fieldPrefix}.authMode`) ?? '',
+    secretFields: watch(`${fieldPrefix}.secretFields`) ?? {},
+    configFields: watch(`${fieldPrefix}.configFields`) ?? {},
+  };
+
+  const getErrors = () => {
+    const getNestedError = (path: string): string | undefined => {
+      const parts = path.split('.');
+      let current: any = formState.errors;
+      for (const part of parts) {
+        if (!current) return undefined;
+        current = current[part];
+      }
+      return current?.message as string | undefined;
+    };
+
+    const extractFieldErrors = (fieldType: 'secretFields' | 'configFields'): Record<string, string> | undefined => {
+      const errors: Record<string, string> = {};
+      const fieldPrefixErrors = formState.errors?.[fieldPrefix] as Record<string, any> | undefined;
+      const fieldsErrors = fieldPrefixErrors?.[fieldType];
+      if (fieldsErrors && typeof fieldsErrors === 'object') {
+        for (const [key, error] of Object.entries(fieldsErrors as Record<string, { message?: string }>)) {
+          if (error?.message) {
+            errors[key] = error.message;
+          }
+        }
+      }
+      return Object.keys(errors).length > 0 ? errors : undefined;
+    };
+
+    return {
+      name: getNestedError(`${fieldPrefix}.name`),
+      secretFields: extractFieldErrors('secretFields'),
+      configFields: extractFieldErrors('configFields'),
+    };
+  };
+
+  const handleChange = (newValue: SecretFormData) => {
+    setValue(`${fieldPrefix}.name`, newValue.name, { shouldValidate: true });
+    setValue(`${fieldPrefix}.authMode`, newValue.authMode, { shouldValidate: true });
+    setValue(`${fieldPrefix}.secretFields`, newValue.secretFields, { shouldValidate: true });
+    setValue(`${fieldPrefix}.configFields`, newValue.configFields, { shouldValidate: true });
+  };
+
+  return (
+    <SecretFormFields
+      provider={provider}
+      value={secretData}
+      onChange={handleChange}
+      errors={getErrors()}
+      componentIdPrefix={componentIdPrefix}
+      hideNameField
+    />
+  );
+};

--- a/mlflow/server/js/src/gateway/components/secrets/SecretConfigSection.tsx
+++ b/mlflow/server/js/src/gateway/components/secrets/SecretConfigSection.tsx
@@ -1,0 +1,113 @@
+import { Radio, useDesignSystemTheme, FormUI, Tooltip } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { SecretSelector } from './SecretSelector';
+import { CreateSecretForm } from './CreateSecretForm';
+import { useSecretsQuery } from '../../hooks/useSecretsQuery';
+
+export type SecretMode = 'existing' | 'new';
+
+interface SecretConfigSectionProps {
+  provider: string;
+  mode: SecretMode;
+  onModeChange: (mode: SecretMode) => void;
+  selectedSecretId?: string;
+  onSecretSelect: (secretId: string) => void;
+  newSecretFieldPrefix?: string;
+  error?: string;
+  showModeSelector?: boolean;
+  label?: string;
+  componentIdPrefix?: string;
+}
+
+export const SecretConfigSection = ({
+  provider,
+  mode,
+  onModeChange,
+  selectedSecretId,
+  onSecretSelect,
+  newSecretFieldPrefix = 'newSecret',
+  error,
+  showModeSelector = true,
+  label,
+  componentIdPrefix = 'mlflow.gateway.secret-config',
+}: SecretConfigSectionProps) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const { data: secrets } = useSecretsQuery({ provider });
+  const filteredSecrets = provider ? secrets?.filter((s) => s.provider === provider) : secrets;
+  const hasExistingSecrets = filteredSecrets && filteredSecrets.length > 0;
+
+  if (!provider) {
+    return (
+      <div>
+        {label !== '' && (
+          <FormUI.Label>
+            {label || <FormattedMessage defaultMessage="Connections" description="Label for connections section" />}
+          </FormUI.Label>
+        )}
+        <div css={{ color: theme.colors.textSecondary, marginTop: theme.spacing.xs }}>
+          <FormattedMessage
+            defaultMessage="Select a provider to configure authentication"
+            description="Message when no provider selected"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+      {showModeSelector && (
+        <div>
+          {label !== '' && (
+            <FormUI.Label>
+              {label || <FormattedMessage defaultMessage="Connections" description="Label for connections section" />}
+            </FormUI.Label>
+          )}
+          <Radio.Group
+            componentId={`${componentIdPrefix}.mode`}
+            name="secretMode"
+            value={mode}
+            onChange={(e) => onModeChange(e.target.value as SecretMode)}
+            layout="horizontal"
+            css={{ gap: theme.spacing.md }}
+          >
+            <Radio value="new">
+              <FormattedMessage defaultMessage="Create new API key" description="Option to create new API key" />
+            </Radio>
+            <Tooltip
+              componentId={`${componentIdPrefix}.mode.tooltip`}
+              content={
+                !hasExistingSecrets
+                  ? intl.formatMessage({
+                      defaultMessage: 'No existing API keys for this provider',
+                      description: 'Tooltip when no API keys exist for provider',
+                    })
+                  : undefined
+              }
+            >
+              <span>
+                <Radio value="existing" disabled={!hasExistingSecrets}>
+                  <FormattedMessage
+                    defaultMessage="Use existing API key"
+                    description="Option to use existing API key"
+                  />
+                </Radio>
+              </span>
+            </Tooltip>
+          </Radio.Group>
+        </div>
+      )}
+
+      {mode === 'existing' ? (
+        <SecretSelector provider={provider} value={selectedSecretId ?? ''} onChange={onSecretSelect} error={error} />
+      ) : (
+        <CreateSecretForm
+          provider={provider}
+          fieldPrefix={newSecretFieldPrefix}
+          componentIdPrefix={componentIdPrefix}
+        />
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/secrets/SecretSelector.tsx
+++ b/mlflow/server/js/src/gateway/components/secrets/SecretSelector.tsx
@@ -1,0 +1,173 @@
+import {
+  SimpleSelect,
+  SimpleSelectOption,
+  FormUI,
+  Spinner,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { useMemo } from 'react';
+import { useSecretsQuery } from '../../hooks/useSecretsQuery';
+import { formatAuthMethodName, formatCredentialFieldName } from '../../utils/providerUtils';
+import { parseAuthConfig } from '../../utils/secretUtils';
+import { TimeAgo } from '../../../shared/web-shared/browse/TimeAgo';
+import { MaskedValueDisplay } from './MaskedValueDisplay';
+import type { SecretInfo } from '../../types';
+
+interface SecretSelectorProps {
+  provider?: string;
+  value: string;
+  onChange: (secretId: string) => void;
+  disabled?: boolean;
+  error?: string;
+}
+
+const AuthConfigDisplay = ({ secret }: { secret: SecretInfo | undefined }) => {
+  const { theme } = useDesignSystemTheme();
+
+  const authConfig = useMemo(() => {
+    if (!secret) return null;
+    return secret.auth_config ?? null;
+  }, [secret]);
+
+  if (!authConfig) return null;
+  const configEntries = Object.entries(authConfig).filter(([key]) => key !== 'auth_mode');
+  if (configEntries.length === 0) return null;
+
+  return (
+    <>
+      <Typography.Text color="secondary">
+        <FormattedMessage defaultMessage="Config:" description="Auth config label" />
+      </Typography.Text>
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs / 2 }}>
+        {configEntries.map(([key, value]) => (
+          <div key={key} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+              {formatCredentialFieldName(key)}:
+            </Typography.Text>
+            <Typography.Text css={{ fontFamily: 'monospace', fontSize: theme.typography.fontSizeSm }}>
+              {String(value)}
+            </Typography.Text>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export const SecretSelector = ({ provider, value, onChange, disabled, error }: SecretSelectorProps) => {
+  const { theme } = useDesignSystemTheme();
+  const { data: secrets, isLoading } = useSecretsQuery({ provider });
+
+  const filteredSecrets = useMemo(
+    () => (provider ? secrets?.filter((s) => s.provider === provider) : secrets),
+    [provider, secrets],
+  );
+
+  const selectedSecret = useMemo(
+    () => (value ? filteredSecrets?.find((s) => s.secret_id === value) : undefined),
+    [value, filteredSecrets],
+  );
+
+  if (isLoading) {
+    return (
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+        <Spinner size="small" />
+        <FormattedMessage defaultMessage="Loading API keys..." description="Loading message for API keys" />
+      </div>
+    );
+  }
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm, width: '100%' }}>
+      <div>
+        <FormUI.Label htmlFor="mlflow.gateway.create-endpoint.secret-select">
+          <FormattedMessage defaultMessage="API key" description="Label for API key selector" />
+        </FormUI.Label>
+        <SimpleSelect
+          id="mlflow.gateway.create-endpoint.secret-select"
+          componentId="mlflow.gateway.create-endpoint.secret-select"
+          value={value}
+          onChange={({ target }) => onChange(target.value)}
+          disabled={disabled || !filteredSecrets?.length}
+          placeholder={filteredSecrets?.length ? 'Select an API key' : 'No API keys available for this provider'}
+          validationState={error ? 'error' : undefined}
+          contentProps={{
+            matchTriggerWidth: true,
+            maxHeight: 300,
+          }}
+          css={{ width: '100%' }}
+        >
+          {filteredSecrets?.map((secret) => (
+            <SimpleSelectOption key={secret.secret_id} value={secret.secret_id}>
+              {secret.secret_name}
+            </SimpleSelectOption>
+          ))}
+        </SimpleSelect>
+        {error && <FormUI.Message type="error" message={error} />}
+      </div>
+
+      {selectedSecret && (
+        <div
+          css={{
+            backgroundColor: theme.colors.backgroundSecondary,
+            borderRadius: theme.general.borderRadiusBase,
+            padding: theme.spacing.md,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <Typography.Text bold size="sm" color="secondary">
+            <FormattedMessage defaultMessage="API key details" description="Header for API key details section" />
+          </Typography.Text>
+          <div
+            css={{
+              display: 'grid',
+              gridTemplateColumns: 'auto 1fr',
+              gap: `${theme.spacing.xs}px ${theme.spacing.md}px`,
+              fontSize: theme.typography.fontSizeSm,
+              marginTop: theme.spacing.md,
+            }}
+          >
+            {parseAuthConfig(selectedSecret)?.['auth_mode'] && (
+              <>
+                <Typography.Text color="secondary">
+                  <FormattedMessage defaultMessage="Auth Type:" description="Auth type label" />
+                </Typography.Text>
+                <Typography.Text>
+                  {formatAuthMethodName(String(parseAuthConfig(selectedSecret)!['auth_mode']))}
+                </Typography.Text>
+              </>
+            )}
+            <Typography.Text color="secondary">
+              <FormattedMessage defaultMessage="Masked Key:" description="Masked API key label" />
+            </Typography.Text>
+            <MaskedValueDisplay maskedValue={selectedSecret.masked_values} />
+            <AuthConfigDisplay secret={selectedSecret} />
+            <Typography.Text color="secondary">
+              <FormattedMessage defaultMessage="Last Updated:" description="Label for last updated" />
+            </Typography.Text>
+            <Typography.Text>
+              <TimeAgo date={new Date(selectedSecret.last_updated_at)} />
+            </Typography.Text>
+            <Typography.Text color="secondary">
+              <FormattedMessage defaultMessage="Created:" description="Label for created date" />
+            </Typography.Text>
+            <Typography.Text>
+              <TimeAgo date={new Date(selectedSecret.created_at)} />
+            </Typography.Text>
+            {selectedSecret.created_by && (
+              <>
+                <Typography.Text color="secondary">
+                  <FormattedMessage defaultMessage="Created by:" description="Label for created by" />
+                </Typography.Text>
+                <Typography.Text>{selectedSecret.created_by}</Typography.Text>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/secrets/types.ts
+++ b/mlflow/server/js/src/gateway/components/secrets/types.ts
@@ -1,10 +1,7 @@
 export interface SecretFormData {
   name: string;
-  /** Selected authentication mode */
   authMode: string;
-  /** Secret field values (e.g., api_key, aws_access_key_id, aws_secret_access_key) */
   secretFields: Record<string, string>;
-  /** Additional config field values (e.g., aws_region_name) */
   configFields: Record<string, string>;
 }
 

--- a/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
+++ b/mlflow/server/js/src/gateway/hooks/useCreateEndpointForm.ts
@@ -1,66 +1,170 @@
 import { useForm } from 'react-hook-form';
-import { useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useNavigate } from '../../common/utils/RoutingUtils';
-import { useEndpointsQuery } from './useEndpointsQuery';
+import { useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { useCreateEndpointMutation } from './useCreateEndpointMutation';
+import { useCreateSecret } from './useCreateSecret';
+import { useCreateModelDefinitionMutation } from './useCreateModelDefinitionMutation';
 import { useModelsQuery } from './useModelsQuery';
+import { useEndpointsQuery } from './useEndpointsQuery';
 import GatewayRoutes from '../routes';
 import type { ProviderModel } from '../types';
+import type { SecretMode } from '../components/secrets/SecretConfigSection';
 
 export interface CreateEndpointFormData {
   name: string;
   provider: string;
   modelName: string;
+  secretMode: SecretMode;
+  existingSecretId: string;
+  newSecret: {
+    name: string;
+    authMode: string;
+    secretFields: Record<string, string>;
+    configFields: Record<string, string>;
+  };
 }
 
 export interface UseCreateEndpointFormResult {
   form: ReturnType<typeof useForm<CreateEndpointFormData>>;
+  // Mutations and state
   isLoading: boolean;
   error: Error | null;
   resetErrors: () => void;
+  // Data
   existingEndpoints: ReturnType<typeof useEndpointsQuery>['data'];
   selectedModel: ProviderModel | undefined;
+  // Computed state
   isFormComplete: boolean;
+  // Handlers
   handleSubmit: (values: CreateEndpointFormData) => Promise<void>;
   handleCancel: () => void;
   handleNameBlur: () => void;
 }
 
+/**
+ * Custom hook that contains all business logic for creating an endpoint.
+ * Separates concerns from the renderer component for easier testing and reuse.
+ */
 export function useCreateEndpointForm(): UseCreateEndpointFormResult {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const form = useForm<CreateEndpointFormData>({
     defaultValues: {
       name: '',
       provider: '',
       modelName: '',
+      secretMode: 'new',
+      existingSecretId: '',
+      newSecret: {
+        name: '',
+        authMode: '',
+        secretFields: {},
+        configFields: {},
+      },
     },
   });
 
-  const resetErrors = useCallback(() => {
-    // Will be expanded when we add actual mutations
-  }, []);
+  const {
+    mutateAsync: createEndpoint,
+    error: createEndpointError,
+    isLoading: isCreatingEndpoint,
+    reset: resetEndpointError,
+  } = useCreateEndpointMutation();
 
-  const handleSubmit = async (_values: CreateEndpointFormData) => {
-    // TODO: Implement actual endpoint creation in a future PR
-    // For now, this is a placeholder - we need model selection and API key config first
+  const {
+    mutateAsync: createSecret,
+    error: createSecretError,
+    isLoading: isCreatingSecret,
+    reset: resetSecretError,
+  } = useCreateSecret();
+
+  const {
+    mutateAsync: createModelDefinition,
+    error: createModelDefinitionError,
+    isLoading: isCreatingModelDefinition,
+    reset: resetModelDefinitionError,
+  } = useCreateModelDefinitionMutation();
+
+  // Custom error state for handling special cases like secret name conflicts
+  const [customError, setCustomError] = useState<Error | null>(null);
+
+  const resetErrors = useCallback(() => {
+    resetEndpointError();
+    resetSecretError();
+    resetModelDefinitionError();
+    setCustomError(null);
+  }, [resetEndpointError, resetSecretError, resetModelDefinitionError]);
+
+  const isLoading = isCreatingEndpoint || isCreatingSecret || isCreatingModelDefinition;
+  const error = (customError || createEndpointError || createSecretError || createModelDefinitionError) as Error | null;
+
+  const handleSubmit = async (values: CreateEndpointFormData) => {
+    try {
+      let secretId = values.existingSecretId;
+
+      if (values.secretMode === 'new') {
+        // Build auth_config with auth_mode included
+        const authConfig: Record<string, string> = { ...values.newSecret.configFields };
+        if (values.newSecret.authMode) {
+          authConfig['auth_mode'] = values.newSecret.authMode;
+        }
+
+        const secretResponse = await createSecret({
+          secret_name: values.newSecret.name,
+          secret_value: values.newSecret.secretFields,
+          provider: values.provider,
+          auth_config: Object.keys(authConfig).length > 0 ? authConfig : undefined,
+        });
+
+        secretId = secretResponse.secret.secret_id;
+      }
+
+      // Create a model definition (auto-generate name from endpoint name and model)
+      const modelDefinitionResponse = await createModelDefinition({
+        name: `${values.name || 'endpoint'}-${values.modelName}`,
+        secret_id: secretId,
+        provider: values.provider,
+        model_name: values.modelName,
+      });
+
+      const modelDefinitionId = modelDefinitionResponse.model_definition.model_definition_id;
+
+      // Create the endpoint with the model definition ID
+      const endpointResponse = await createEndpoint({
+        name: values.name || undefined,
+        model_definition_ids: [modelDefinitionId],
+      });
+
+      navigate(GatewayRoutes.getEndpointDetailsRoute(endpointResponse.endpoint.endpoint_id));
+    } catch {
+      // Error is captured by the mutation's error state and displayed via the Alert component
+    }
   };
 
   const handleCancel = () => {
     navigate(GatewayRoutes.gatewayPageRoute);
   };
 
+  // Watch form values
   const provider = form.watch('provider');
-  const name = form.watch('name');
   const modelName = form.watch('modelName');
+  const secretMode = form.watch('secretMode');
+  const existingSecretId = form.watch('existingSecretId');
+  const newSecretName = form.watch('newSecret.name');
+  const newSecretFields = form.watch('newSecret.secretFields');
 
-  const { data: existingEndpoints } = useEndpointsQuery();
-
+  // Get the selected model's full data for the summary
   const { data: models } = useModelsQuery({ provider: provider || undefined });
   const selectedModel = models?.find((m) => m.model === modelName);
 
+  // Fetch existing endpoints to check for name conflicts on blur
+  const { data: existingEndpoints } = useEndpointsQuery();
+
   const handleNameBlur = () => {
-    const currentName = form.getValues('name');
-    if (currentName && existingEndpoints?.some((e) => e.name === currentName)) {
+    const name = form.getValues('name');
+    if (name && existingEndpoints?.some((e) => e.name === name)) {
       form.setError('name', {
         type: 'manual',
         message: 'An endpoint with this name already exists',
@@ -68,12 +172,15 @@ export function useCreateEndpointForm(): UseCreateEndpointFormResult {
     }
   };
 
-  const isFormComplete = !!provider && !!modelName;
+  // Check if the form is complete enough to enable the Create button
+  const hasSecretFieldValues = Object.values(newSecretFields || {}).some((v) => !!v);
+  const isSecretConfigured = secretMode === 'existing' ? !!existingSecretId : !!newSecretName && hasSecretFieldValues;
+  const isFormComplete = !!provider && !!modelName && isSecretConfigured;
 
   return {
     form,
-    isLoading: false,
-    error: null,
+    isLoading,
+    error,
     resetErrors,
     existingEndpoints,
     selectedModel,

--- a/mlflow/server/js/src/gateway/hooks/useCreateEndpointMutation.ts
+++ b/mlflow/server/js/src/gateway/hooks/useCreateEndpointMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+import type { CreateEndpointRequest, CreateEndpointResponse } from '../types';
+
+export const useCreateEndpointMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateEndpointRequest) => GatewayApi.createEndpoint(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['gateway_endpoints']);
+    },
+  });
+};

--- a/mlflow/server/js/src/gateway/hooks/useCreateModelDefinitionMutation.ts
+++ b/mlflow/server/js/src/gateway/hooks/useCreateModelDefinitionMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+import type { CreateModelDefinitionRequest } from '../types';
+
+export const useCreateModelDefinitionMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateModelDefinitionRequest) => GatewayApi.createModelDefinition(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['gateway_model_definitions']);
+    },
+  });
+};

--- a/mlflow/server/js/src/gateway/utils/providerUtils.test.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from '@jest/globals';
-import { formatProviderName, formatAuthMethodName, formatCredentialFieldName } from './providerUtils';
+import {
+  formatProviderName,
+  formatAuthMethodName,
+  formatCredentialFieldName,
+  sortFieldsByProvider,
+} from './providerUtils';
 
 describe('providerUtils', () => {
   describe('formatProviderName', () => {
@@ -51,6 +56,54 @@ describe('providerUtils', () => {
 
     it('formats unknown credential fields with title case', () => {
       expect(formatCredentialFieldName('some_new_field')).toBe('Some New Field');
+    });
+  });
+
+  describe('sortFieldsByProvider', () => {
+    it('sorts Databricks fields in the defined order', () => {
+      const fields = [
+        { name: 'api_base', value: '' },
+        { name: 'client_id', value: '' },
+        { name: 'client_secret', value: '' },
+      ];
+      const sorted = sortFieldsByProvider(fields, 'databricks');
+      expect(sorted.map((f) => f.name)).toEqual(['client_id', 'client_secret', 'api_base']);
+    });
+
+    it('returns fields unchanged for providers without custom ordering', () => {
+      const fields = [
+        { name: 'api_key', value: '' },
+        { name: 'api_base', value: '' },
+      ];
+      const sorted = sortFieldsByProvider(fields, 'openai');
+      expect(sorted.map((f) => f.name)).toEqual(['api_key', 'api_base']);
+    });
+
+    it('puts unknown fields after known fields for Databricks', () => {
+      const fields = [
+        { name: 'unknown_field', value: '' },
+        { name: 'client_id', value: '' },
+        { name: 'api_base', value: '' },
+      ];
+      const sorted = sortFieldsByProvider(fields, 'databricks');
+      expect(sorted.map((f) => f.name)).toEqual(['client_id', 'api_base', 'unknown_field']);
+    });
+
+    it('handles empty fields array', () => {
+      const sorted = sortFieldsByProvider([], 'databricks');
+      expect(sorted).toEqual([]);
+    });
+
+    it('preserves additional properties on field objects', () => {
+      const fields = [
+        { name: 'client_secret', value: 'secret', extra: true },
+        { name: 'client_id', value: 'id', extra: false },
+      ];
+      const sorted = sortFieldsByProvider(fields, 'databricks');
+      expect(sorted).toEqual([
+        { name: 'client_id', value: 'id', extra: false },
+        { name: 'client_secret', value: 'secret', extra: true },
+      ]);
     });
   });
 });

--- a/mlflow/server/js/src/gateway/utils/providerUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.ts
@@ -198,3 +198,25 @@ export function formatCredentialFieldName(fieldName: string): string {
   };
   return formatMap[fieldName] ?? fieldName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
+
+const PROVIDER_FIELD_ORDER: Record<string, string[]> = {
+  databricks: ['client_id', 'client_secret', 'api_base'],
+};
+
+export function sortFieldsByProvider<T extends { name: string }>(fields: T[], provider: string): T[] {
+  const fieldOrder = PROVIDER_FIELD_ORDER[provider];
+  if (!fieldOrder) {
+    return fields;
+  }
+
+  return [...fields].sort((a, b) => {
+    const aIndex = fieldOrder.indexOf(a.name);
+    const bIndex = fieldOrder.indexOf(b.name);
+
+    if (aIndex === -1 && bIndex === -1) return 0;
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+
+    return aIndex - bIndex;
+  });
+}

--- a/mlflow/server/js/src/gateway/utils/secretUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/secretUtils.ts
@@ -4,7 +4,3 @@ export function parseAuthConfig(secret: SecretInfo | undefined | null): Record<s
   if (!secret) return null;
   return secret.auth_config ?? null;
 }
-
-export function isSingleMaskedValue(maskedValue: Record<string, string>): boolean {
-  return Object.keys(maskedValue).length === 1;
-}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -175,6 +175,10 @@
     "defaultMessage": "Output: {output}/1M tokens",
     "description": "Output cost per million tokens"
   },
+  "/NF6sl": {
+    "defaultMessage": "Use existing API key",
+    "description": "Option to use existing API key"
+  },
   "/Q7stq": {
     "defaultMessage": "Learn more",
     "description": "Model registry > OSS Promo modal for model version aliases > learn more link"
@@ -587,6 +591,10 @@
     "defaultMessage": "Share",
     "description": "Text for share button on experiment view page header"
   },
+  "2pSaCv": {
+    "defaultMessage": "Create new API key",
+    "description": "Option to create new API key"
+  },
   "2pj5gm": {
     "defaultMessage": "Discover new features",
     "description": "Home page news section title"
@@ -934,6 +942,10 @@
     "defaultMessage": "Key name",
     "description": "API key name column header"
   },
+  "6I8pKa": {
+    "defaultMessage": "Auth Type:",
+    "description": "Auth type label"
+  },
   "6JOLpj": {
     "defaultMessage": "Value",
     "description": "Label for the value field in the GenAI Traces Table Filter form"
@@ -1073,6 +1085,10 @@
   "79dD5F": {
     "defaultMessage": "There was an error submitting your note.",
     "description": "Error message text when saving an editable note in MLflow"
+  },
+  "7AbOaV": {
+    "defaultMessage": "A unique name to identify this API key for reuse across endpoints",
+    "description": "Hint text explaining API key name field"
   },
   "7BkVQ9": {
     "defaultMessage": "Run the following code to start an evaluation.",
@@ -1726,6 +1742,10 @@
     "defaultMessage": "-∞",
     "description": "Label displaying negative infinity symbol displayed on a plot UI element"
   },
+  "C5WOXw": {
+    "defaultMessage": "Click to select a model",
+    "description": "Placeholder for model selection"
+  },
   "C6ReUY": {
     "defaultMessage": "Save",
     "description": "Tag assignment modal > Save button"
@@ -1930,6 +1950,10 @@
     "defaultMessage": "Session",
     "description": "Label preceding a chat session ID"
   },
+  "EBJq8A": {
+    "defaultMessage": "No existing API keys for this provider.",
+    "description": "Message when no existing API keys"
+  },
   "EBwDIg": {
     "defaultMessage": "Delete",
     "description": "Delete evaluation runs modal button text"
@@ -2025,6 +2049,10 @@
   "F9Aau+": {
     "defaultMessage": "Table view",
     "description": "Label for the table view toggle button in the logged model list page"
+  },
+  "F9COCs": {
+    "defaultMessage": "No existing API keys for this provider",
+    "description": "Tooltip when no API keys exist for provider"
   },
   "FAfPOl": {
     "defaultMessage": "Stop Sequences",
@@ -2426,10 +2454,6 @@
     "defaultMessage": "Provider",
     "description": "Filter section label for provider"
   },
-  "J8yNZH": {
-    "defaultMessage": "Model",
-    "description": "Model label"
-  },
   "J961B2": {
     "defaultMessage": "Filters{numFilters}",
     "description": "Evaluation review > evaluations list > filter dropdown button"
@@ -2637,6 +2661,10 @@
   "KwAeyt": {
     "defaultMessage": "classification",
     "description": "A short label for experiments focused on classification modeling"
+  },
+  "KwJRcV": {
+    "defaultMessage": "API key details",
+    "description": "Header for API key details section"
   },
   "Kwz1fc": {
     "defaultMessage": "Artifacts",
@@ -3134,6 +3162,10 @@
     "defaultMessage": "None",
     "description": "Default text for no content in an editable note in MLflow"
   },
+  "PRwILA": {
+    "defaultMessage": "Connections",
+    "description": "Subsection header for API key configuration"
+  },
   "PRwcGm": {
     "defaultMessage": "Search",
     "description": "Placeholder for the search input in the logged model list page sort column selector"
@@ -3200,6 +3232,10 @@
   "QBYbF3": {
     "defaultMessage": "Prompts",
     "description": "Sidebar link for prompts tab"
+  },
+  "QC0Fmv": {
+    "defaultMessage": "Connections",
+    "description": "Label for connections section"
   },
   "QC5Vjq": {
     "defaultMessage": "Y-axis:",
@@ -3992,6 +4028,10 @@
     "defaultMessage": "Failed to override assessment. Error: {error}",
     "description": "Error message when overriding an assessment fails"
   },
+  "X1nbeT": {
+    "defaultMessage": "Last Updated:",
+    "description": "Label for last updated"
+  },
   "X3F7x3": {
     "defaultMessage": "No Artifacts Recorded",
     "description": "Empty state string when there are no artifacts record for the experiment"
@@ -4683,6 +4723,10 @@
     "defaultMessage": "Run evaluation",
     "description": "Label for a button that displays instructions for starting a new evaluation run"
   },
+  "cNkqxA": {
+    "defaultMessage": "API key",
+    "description": "Label for API key selector"
+  },
   "cQQnzX": {
     "defaultMessage": "Hide assessments",
     "description": "Tooltip for a button that closes the assessments pane"
@@ -4983,6 +5027,10 @@
     "defaultMessage": "Root Cause Analysis",
     "description": "Root cause analysis section title"
   },
+  "evVfYj": {
+    "defaultMessage": "Created:",
+    "description": "Label for created date"
+  },
   "ew8ReB": {
     "defaultMessage": "Max Input Tokens",
     "description": "Table header for max input tokens"
@@ -5243,6 +5291,10 @@
     "defaultMessage": "Assessment added by LLM-as-a-judge",
     "description": "Evaluation review > assessments > tooltip > assessment added by LLM-as-a-judge"
   },
+  "gqFQc3": {
+    "defaultMessage": "API Key",
+    "description": "Summary API key label"
+  },
   "gqfk5C": {
     "defaultMessage": "User is not authorized.",
     "description": "Unauthorized (HTTP STATUS 401) generic error message"
@@ -5354,6 +5406,10 @@
   "ho2T6B": {
     "defaultMessage": "Error",
     "description": "Model trace header > status label > error"
+  },
+  "hpAK1G": {
+    "defaultMessage": "Created by:",
+    "description": "Label for created by"
   },
   "hvImg5": {
     "defaultMessage": "No resources are using this key",
@@ -6491,6 +6547,10 @@
     "defaultMessage": "Relevant",
     "description": "Evaluation results > relevancy assessment > positive value label. Displayed if evaluation result is considered as irrelevant to the query."
   },
+  "rRaThb": {
+    "defaultMessage": "Select a provider first",
+    "description": "Placeholder when no provider selected"
+  },
   "rRhMQt": {
     "defaultMessage": "Execution time (ms)",
     "description": "Column label for execution time with the unit suffix"
@@ -6542,6 +6602,10 @@
   "rstugP": {
     "defaultMessage": "Max Tokens",
     "description": "Label for max tokens input"
+  },
+  "rvRhzv": {
+    "defaultMessage": "Masked Key:",
+    "description": "Masked API key label"
   },
   "rxMHgr": {
     "defaultMessage": "Stage transition",
@@ -6671,6 +6735,10 @@
     "defaultMessage": "Automatically log traces for OpenAI API calls by calling the {code} function. For example:",
     "description": "Description of how to log traces for the OpenAI package using MLflow autologging. This message is followed by a code example."
   },
+  "sptgX6": {
+    "defaultMessage": "Model",
+    "description": "Label for model select field"
+  },
   "srbhok": {
     "defaultMessage": "Use workspace settings",
     "description": "Label for a radio button that configures the x-axis on a line chart. This option is for using global workspace settings."
@@ -6739,6 +6807,10 @@
     "defaultMessage": "Global guideline adherence",
     "description": "Evaluation results > known type of evaluation result assessment > global guideline adherence assessment. Used to indicate if the result adheres to the global guidelines in context of LLMs evaluation. Label displayed if user provided custom value, e.g. \"Global guideline adherence: moderate\""
   },
+  "tatySQ": {
+    "defaultMessage": "my-api-key",
+    "description": "Placeholder for API key name input"
+  },
   "tbAlJg": {
     "defaultMessage": "Go to external location",
     "description": "Text for the external location link in the experiment run dataset drawer"
@@ -6746,6 +6818,10 @@
   "tdmVWN": {
     "defaultMessage": "While deleting an experiment run, an error occurred.",
     "description": "Experiment tracking > delete run modal > error message"
+  },
+  "tfN9sC": {
+    "defaultMessage": "Select a provider to configure authentication",
+    "description": "Message when no provider selected"
   },
   "tkAOSa": {
     "defaultMessage": "Custom expression",
@@ -6810,10 +6886,6 @@
   "uYkbr+": {
     "defaultMessage": "Default",
     "description": "Label for the default render mode selector in the model trace explorer summary view"
-  },
-  "uZHZPr": {
-    "defaultMessage": "Select a model...",
-    "description": "Model selection placeholder"
   },
   "ua6IVs": {
     "defaultMessage": "Error while loading compare runs page",
@@ -6967,6 +7039,10 @@
     "defaultMessage": "Search metrics",
     "description": "Run page > Overview > Metrics table > Filter input placeholder"
   },
+  "w2WWoM": {
+    "defaultMessage": "Config:",
+    "description": "Auth config label"
+  },
   "w39cZ4": {
     "defaultMessage": "Show first 10",
     "description": "Menu option for showing only 10 first runs in the experiment view runs compare mode"
@@ -7082,6 +7158,10 @@
   "wvskxE": {
     "defaultMessage": "Log traces",
     "description": "Home page quick action title for logging traces"
+  },
+  "wx0s66": {
+    "defaultMessage": "Select a provider and model to configure API key",
+    "description": "Message when no provider selected for API key form"
   },
   "wxq/qM": {
     "defaultMessage": "Set as baseline",
@@ -7402,6 +7482,10 @@
   "zfpA2q": {
     "defaultMessage": "Source run",
     "description": "Label for the group by runs option in the logged model list page"
+  },
+  "zgpnjD": {
+    "defaultMessage": "Loading API keys...",
+    "description": "Loading message for API keys"
   },
   "zhzZUu": {
     "defaultMessage": "An error occured while attempting to delete traces. Please refresh the page and try again.",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19494/files) to review incremental changes.
- [**stack/gateway-ui/endpoint-auth**](https://github.com/mlflow/mlflow/pull/19494) [[Files changed](https://github.com/mlflow/mlflow/pull/19494/files)]
  - [stack/gateway-ui/endpoint-edit](https://github.com/mlflow/mlflow/pull/19502) [[Files changed](https://github.com/mlflow/mlflow/pull/19502/files/6d5d4467a6748638b9b4f135cd11df53c9f87485..966419eb568f27378e5688b9622c25cdae928732)]
    - [stack/gateway-ui/provider-optimization](https://github.com/mlflow/mlflow/pull/19503) [[Files changed](https://github.com/mlflow/mlflow/pull/19503/files/966419eb568f27378e5688b9622c25cdae928732..b24ac74b791db0cf2091df618791af373a1a17c7)]
      - [stack/gateway-ui/endpoint-details](https://github.com/mlflow/mlflow/pull/19537) [[Files changed](https://github.com/mlflow/mlflow/pull/19537/files/b24ac74b791db0cf2091df618791af373a1a17c7..74e5cfc275df9b2494e426dd7bd9f039d8891dea)]
        - [stack/gateway-ui/refine](https://github.com/mlflow/mlflow/pull/19538) [[Files changed](https://github.com/mlflow/mlflow/pull/19538/files/74e5cfc275df9b2494e426dd7bd9f039d8891dea..31e16e189839b3c66744a734e8d5fb567d73ad6d)]
          - [stack/gateway-ui/complex-combobox](https://github.com/mlflow/mlflow/pull/19546) [[Files changed](https://github.com/mlflow/mlflow/pull/19546/files/31e16e189839b3c66744a734e8d5fb567d73ad6d..d9d9b5bc201e5926c13a5db4d64c450b8860a4f1)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds the auth configuration to endpoint creation page. 
Additional fixes from the prototype include: 
- Summary pane styling changes for consistency and a removal of the Tags style display (which creates visual background shading).
- Forced ordering of the configuration elements for logical grouping of auth keys (client -> secret -> base url, for instance, rather than natural sort ordering).
- Styling for icon links to use primary coloring instead of link coloring from the design system.
- Fix for the default placeholder text for secret reference to conform to other fields in the Summary view.
- Cleanup of 2 unneeded hooks and removal of redundant props on the rendering component for the page.

Empty Form State:
<img width="1951" height="1414" alt="Screenshot 2025-12-18 at 1 49 15 PM" src="https://github.com/user-attachments/assets/c752cc05-8e8f-4492-a6b2-15d2125484de" />

Populated Form State:
<img width="1944" height="1413" alt="Screenshot 2025-12-18 at 1 49 03 PM" src="https://github.com/user-attachments/assets/6d715178-365d-4930-b968-542624b28f6a" />


### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
