### PR TITLE
Add Clint rule to forbid make_judge in builtin_scorers.py

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -648,6 +648,18 @@ class Linter(ast.NodeVisitor):
                 if alias.name.split(".")[-1] == "set_active_model":
                     self._check_forbidden_set_active_model_usage(node)
 
+        # Check for forbidden make_judge import in builtin_scorers.py
+        if self.path.name == "builtin_scorers.py" and node.module:
+            for alias in node.names:
+                if alias.name == "make_judge" and (
+                    node.module == "mlflow.genai.judges.make_judge"
+                    or node.module.endswith(".make_judge")
+                ):
+                    self._check(
+                        Range.from_node(node),
+                        rules.ForbiddenMakeJudgeInBuiltinScorers(),
+                    )
+
         self.generic_visit(node)
 
     def _check_forbidden_top_level_import(
@@ -693,6 +705,9 @@ class Linter(ast.NodeVisitor):
 
         if rules.ForbiddenSetActiveModelUsage.check(node, self.resolver):
             self._check(Location.from_node(node), rules.ForbiddenSetActiveModelUsage())
+
+        if rules.ForbiddenMakeJudgeInBuiltinScorers.check(node, self.resolver, self.path):
+            self._check(Range.from_node(node), rules.ForbiddenMakeJudgeInBuiltinScorers())
 
         if expr := rules.ForbiddenDeprecationWarning.check(node, self.resolver):
             self._check(Location.from_node(expr), rules.ForbiddenDeprecationWarning())

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -5,6 +5,9 @@ from clint.rules.empty_notebook_cell import EmptyNotebookCell
 from clint.rules.example_syntax_error import ExampleSyntaxError
 from clint.rules.extraneous_docstring_param import ExtraneousDocstringParam
 from clint.rules.forbidden_deprecation_warning import ForbiddenDeprecationWarning
+from clint.rules.forbidden_make_judge_in_builtin_scorers import (
+    ForbiddenMakeJudgeInBuiltinScorers,
+)
 from clint.rules.forbidden_set_active_model_usage import ForbiddenSetActiveModelUsage
 from clint.rules.forbidden_top_level_import import ForbiddenTopLevelImport
 from clint.rules.forbidden_trace_ui_in_notebook import ForbiddenTraceUIInNotebook
@@ -50,9 +53,10 @@ __all__ = [
     "ExampleSyntaxError",
     "ExtraneousDocstringParam",
     "ForbiddenDeprecationWarning",
-    "GetArtifactUri",
+    "ForbiddenMakeJudgeInBuiltinScorers",
     "ForbiddenSetActiveModelUsage",
     "ForbiddenTopLevelImport",
+    "GetArtifactUri",
     "ForbiddenTraceUIInNotebook",
     "ImplicitOptional",
     "IncorrectTypeAnnotation",

--- a/dev/clint/src/clint/rules/forbidden_make_judge_in_builtin_scorers.py
+++ b/dev/clint/src/clint/rules/forbidden_make_judge_in_builtin_scorers.py
@@ -1,0 +1,46 @@
+import ast
+from pathlib import Path
+
+from clint.resolver import Resolver
+from clint.rules.base import Rule
+
+
+class ForbiddenMakeJudgeInBuiltinScorers(Rule):
+    """Ensure make_judge is not used in builtin_scorers.py.
+
+    After switching to InstructionsJudge in builtin_scorers.py, this rule
+    prevents future regressions by detecting any usage of make_judge in that file.
+    """
+
+    def _message(self) -> str:
+        return (
+            "Usage of `make_judge` is forbidden in builtin_scorers.py. "
+            "Use `InstructionsJudge` directly instead."
+        )
+
+    @staticmethod
+    def check(node: ast.Call, resolver: Resolver, path: Path) -> bool:
+        """Check if this is a call to make_judge in builtin_scorers.py.
+
+        Args:
+            node: The AST Call node to check
+            resolver: Resolver instance to resolve fully qualified names
+            path: Path to the file being linted
+
+        Returns:
+            True if this is a forbidden make_judge call, False otherwise
+        """
+        if path.name != "builtin_scorers.py":
+            return False
+
+        if names := resolver.resolve(node):
+            match names:
+                case ["mlflow", "genai", "judges", "make_judge", *_]:
+                    return True
+                case ["mlflow", "genai", "make_judge", *_]:
+                    return True
+                case ["make_judge", *_]:
+                    return True
+                case _:
+                    return False
+        return False

--- a/dev/clint/tests/rules/test_forbidden_make_judge_in_builtin_scorers.py
+++ b/dev/clint/tests/rules/test_forbidden_make_judge_in_builtin_scorers.py
@@ -8,7 +8,6 @@ from clint.rules.forbidden_make_judge_in_builtin_scorers import (
 
 
 def test_forbidden_make_judge_in_builtin_scorers(index_path: Path) -> None:
-    """Test that make_judge usage is detected in builtin_scorers.py"""
     code = """
 from mlflow.genai.judges.make_judge import make_judge
 from mlflow.genai.judges import InstructionsJudge
@@ -32,7 +31,6 @@ judge3 = InstructionsJudge(name="test", instructions="test")
 
 
 def test_make_judge_allowed_in_other_files(index_path: Path) -> None:
-    """Test that make_judge is allowed in files other than builtin_scorers.py"""
     code = """
 from mlflow.genai.judges.make_judge import make_judge
 
@@ -47,7 +45,6 @@ judge = make_judge(name="test", instructions="test")
 
 
 def test_instructions_judge_not_flagged(index_path: Path) -> None:
-    """Test that InstructionsJudge usage is not flagged"""
     code = """
 from mlflow.genai.judges import InstructionsJudge
 
@@ -61,7 +58,6 @@ judge = InstructionsJudge(name="test", instructions="test")
 
 
 def test_nested_make_judge_call(index_path: Path) -> None:
-    """Test that nested make_judge calls are detected"""
     code = """
 from mlflow.genai.judges.make_judge import make_judge
 
@@ -77,7 +73,6 @@ result = some_function(make_judge(name="test", instructions="test"))
 
 
 def test_make_judge_in_comment_not_flagged(index_path: Path) -> None:
-    """Test that make_judge in comments is not flagged"""
     code = """
 from mlflow.genai.judges import InstructionsJudge
 

--- a/dev/clint/tests/rules/test_forbidden_make_judge_in_builtin_scorers.py
+++ b/dev/clint/tests/rules/test_forbidden_make_judge_in_builtin_scorers.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.linter import lint_file
+from clint.rules.forbidden_make_judge_in_builtin_scorers import (
+    ForbiddenMakeJudgeInBuiltinScorers,
+)
+
+
+def test_forbidden_make_judge_in_builtin_scorers(index_path: Path) -> None:
+    """Test that make_judge usage is detected in builtin_scorers.py"""
+    code = """
+from mlflow.genai.judges.make_judge import make_judge
+from mlflow.genai.judges import InstructionsJudge
+
+# BAD - direct call after import
+judge1 = make_judge(name="test", instructions="test")
+
+# BAD - module qualified call
+from mlflow.genai import judges
+judge2 = judges.make_judge(name="test", instructions="test")
+
+# GOOD - using InstructionsJudge instead
+judge3 = InstructionsJudge(name="test", instructions="test")
+"""
+    config = Config(select={ForbiddenMakeJudgeInBuiltinScorers.name})
+    violations = lint_file(Path("builtin_scorers.py"), code, config, index_path)
+
+    # Should detect: 1 import + 2 calls = 3 violations
+    assert len(violations) == 3
+    assert all(isinstance(v.rule, ForbiddenMakeJudgeInBuiltinScorers) for v in violations)
+
+
+def test_make_judge_allowed_in_other_files(index_path: Path) -> None:
+    """Test that make_judge is allowed in files other than builtin_scorers.py"""
+    code = """
+from mlflow.genai.judges.make_judge import make_judge
+
+# GOOD - allowed in other files
+judge = make_judge(name="test", instructions="test")
+"""
+    config = Config(select={ForbiddenMakeJudgeInBuiltinScorers.name})
+    violations = lint_file(Path("some_other_file.py"), code, config, index_path)
+
+    # Should NOT trigger in other files
+    assert len(violations) == 0
+
+
+def test_instructions_judge_not_flagged(index_path: Path) -> None:
+    """Test that InstructionsJudge usage is not flagged"""
+    code = """
+from mlflow.genai.judges import InstructionsJudge
+
+# GOOD - InstructionsJudge is the correct approach
+judge = InstructionsJudge(name="test", instructions="test")
+"""
+    config = Config(select={ForbiddenMakeJudgeInBuiltinScorers.name})
+    violations = lint_file(Path("builtin_scorers.py"), code, config, index_path)
+
+    assert len(violations) == 0
+
+
+def test_nested_make_judge_call(index_path: Path) -> None:
+    """Test that nested make_judge calls are detected"""
+    code = """
+from mlflow.genai.judges.make_judge import make_judge
+
+# BAD - nested call
+result = some_function(make_judge(name="test", instructions="test"))
+"""
+    config = Config(select={ForbiddenMakeJudgeInBuiltinScorers.name})
+    violations = lint_file(Path("builtin_scorers.py"), code, config, index_path)
+
+    # Should detect: 1 import + 1 call = 2 violations
+    assert len(violations) == 2
+    assert all(isinstance(v.rule, ForbiddenMakeJudgeInBuiltinScorers) for v in violations)
+
+
+def test_make_judge_in_comment_not_flagged(index_path: Path) -> None:
+    """Test that make_judge in comments is not flagged"""
+    code = """
+from mlflow.genai.judges import InstructionsJudge
+
+# This comment mentions make_judge but should not trigger
+judge = InstructionsJudge(name="test", instructions="test")
+"""
+    config = Config(select={ForbiddenMakeJudgeInBuiltinScorers.name})
+    violations = lint_file(Path("builtin_scorers.py"), code, config, index_path)
+
+    assert len(violations) == 0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/alkispoly-db/mlflow/pull/19495?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19495/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19495/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19495/merge
```

</p>
</details>

## What changes are proposed in this pull request?

This PR adds a custom Clint linting rule to prevent usage of `make_judge()` in `builtin_scorers.py`, enforcing the pattern of using `InstructionsJudge()` directly instead. This is recommended so that we avoid double-counting the use of make_judge() for custom scorers.

**Background:**
After switching all `make_judge()` calls to `InstructionsJudge()` in `builtin_scorers.py`, we want to prevent future regressions through automated linting.

**Implementation:**
- Created `ForbiddenMakeJudgeInBuiltinScorers` rule using AST parsing
- File-specific enforcement (only applies to `builtin_scorers.py`)
- Detects both imports and function calls
- Uses Resolver class to handle all import patterns (direct, module-qualified, aliased)
- Integrated with linter's `visit_Call()` and `visit_ImportFrom()` methods

**Key Features:**
- ✅ Detects `make_judge()` calls in `builtin_scorers.py`
- ✅ Detects `make_judge` imports in `builtin_scorers.py`
- ✅ Does NOT trigger in other files (make_judge is a valid public API)
- ✅ Provides clear error messages guiding developers to use `InstructionsJudge`

## How is this PR tested?

**New test file**: `dev/clint/tests/rules/test_forbidden_make_judge_in_builtin_scorers.py` with 5 comprehensive tests:
- Direct call detection after import
- Module-qualified calls (judges.make_judge)
- Import detection
- File-specific behavior (allowed in other files)
- False positive checks (InstructionsJudge, comments)
- Nested call detection

**Validation:**
- All 5 tests pass
- No violations in current `builtin_scorers.py`
- Follows the pattern of existing `ForbiddenSetActiveModelUsage` rule

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.

## Release Notes

### Development Tools

- [Improvement] Added Clint linting rule to prevent usage of `make_judge` in `builtin_scorers.py`

## Component(s)

- [x] `area/build`: Build and test infrastructure

## Release Classification

- [x] `rn/none`: No mention in release notes

## Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

**Next minor release target**

---

**Files Created:**
- `dev/clint/src/clint/rules/forbidden_make_judge_in_builtin_scorers.py` - Rule implementation
- `dev/clint/tests/rules/test_forbidden_make_judge_in_builtin_scorers.py` - Test suite

**Files Modified:**
- `dev/clint/src/clint/rules/__init__.py` - Rule registration
- `dev/clint/src/clint/linter.py` - Integration with linter

**Pattern Reference:**
- Follows the same pattern as `ForbiddenSetActiveModelUsage`
- Uses AST parsing with Resolver for fully qualified name resolution
- File-specific enforcement via path checking