### PR TITLE
Add evaluation telemetry for third-party scorer frameworks (DeepEval/Ragas)

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -34,6 +34,7 @@ class ScorerKind(Enum):
     DECORATOR = "decorator"
     INSTRUCTIONS = "instructions"
     GUIDELINES = "guidelines"
+    THIRD_PARTY = "third_party"
 
 
 _ALLOWED_SCORERS_FOR_REGISTRATION = [

--- a/mlflow/genai/scorers/deepeval/__init__.py
+++ b/mlflow/genai/scorers/deepeval/__init__.py
@@ -28,7 +28,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.builtin import _MODEL_API_DOC
 from mlflow.genai.judges.utils import CategoricalRating, get_default_model
 from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
-from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.scorers.base import Scorer, ScorerKind
 from mlflow.genai.scorers.deepeval.models import create_deepeval_model
 from mlflow.genai.scorers.deepeval.registry import (
     get_metric_class,
@@ -89,6 +89,10 @@ class DeepEvalScorer(Scorer):
                 async_mode=False,
                 **metric_kwargs,
             )
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.THIRD_PARTY
 
     @property
     def is_session_level_scorer(self) -> bool:

--- a/mlflow/genai/scorers/ragas/__init__.py
+++ b/mlflow/genai/scorers/ragas/__init__.py
@@ -30,7 +30,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.builtin import _MODEL_API_DOC
 from mlflow.genai.judges.utils import CategoricalRating, get_default_model
 from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
-from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.scorers.base import Scorer, ScorerKind
 from mlflow.genai.scorers.ragas.models import create_ragas_model
 from mlflow.genai.scorers.ragas.registry import get_metric_class, is_deterministic_metric
 from mlflow.genai.scorers.ragas.utils import (
@@ -79,6 +79,10 @@ class RagasScorer(Scorer):
         else:
             ragas_llm = create_ragas_model(model)
             self._metric = metric_class(llm=ragas_llm, **metric_kwargs)
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.THIRD_PARTY
 
     def __call__(
         self,

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -1,10 +1,38 @@
 import inspect
 import sys
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mlflow.entities import Feedback
 from mlflow.telemetry.constant import GENAI_MODULES, MODULES_TO_CHECK_IMPORT
+
+if TYPE_CHECKING:
+    from mlflow.genai.scorers.base import Scorer
+
+
+def _get_scorer_class_name_for_tracking(scorer: "Scorer") -> str:
+    from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
+
+    if isinstance(scorer, BuiltInScorer):
+        return type(scorer).__name__
+
+    try:
+        from mlflow.genai.scorers.deepeval import DeepEvalScorer
+
+        if isinstance(scorer, DeepEvalScorer):
+            return f"DeepEval:{scorer.name}"
+    except ImportError:
+        pass
+
+    try:
+        from mlflow.genai.scorers.ragas import RagasScorer
+
+        if isinstance(scorer, RagasScorer):
+            return f"Ragas:{scorer.name}"
+    except ImportError:
+        pass
+
+    return "UserDefinedScorer"
 
 
 class Event:
@@ -79,7 +107,6 @@ class GenAIEvaluateEvent(Event):
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
         from mlflow.genai.scorers.base import Scorer
-        from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
 
         record_params = {}
 
@@ -97,11 +124,7 @@ class GenAIEvaluateEvent(Event):
         scorers = arguments.get("scorers") or []
         scorer_info = [
             {
-                "class": (
-                    type(scorer).__name__
-                    if isinstance(scorer, BuiltInScorer)
-                    else "UserDefinedScorer"
-                ),
+                "class": _get_scorer_class_name_for_tracking(scorer),
                 "kind": scorer.kind.value,
                 "scope": "session" if scorer.is_session_level_scorer else "response",
             }
@@ -383,7 +406,6 @@ class ScorerCallEvent(Event):
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
         from mlflow.genai.scorers.base import Scorer
-        from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
 
         scorer_instance = arguments.get("self")
         if not isinstance(scorer_instance, Scorer):
@@ -400,11 +422,7 @@ class ScorerCallEvent(Event):
                     break
 
         return {
-            "scorer_class": (
-                type(scorer_instance).__name__
-                if isinstance(scorer_instance, BuiltInScorer)
-                else "UserDefinedScorer"
-            ),
+            "scorer_class": _get_scorer_class_name_for_tracking(scorer_instance),
             "scorer_kind": scorer_instance.kind.value,
             "is_session_level_scorer": scorer_instance.is_session_level_scorer,
             "callsite": callsite,

--- a/tests/genai/conftest.py
+++ b/tests/genai/conftest.py
@@ -5,10 +5,29 @@ from unittest import mock
 import pytest
 
 import mlflow
+import mlflow.telemetry.utils
 from mlflow.entities.assessment import Expectation
 from mlflow.entities.document import Document
 from mlflow.entities.span import SpanType
 from mlflow.genai.scorers.validation import IS_DBX_AGENTS_INSTALLED
+
+# Import telemetry test fixtures from tests/telemetry/conftest.py
+# This allows genai tests to use the same telemetry testing infrastructure
+from tests.telemetry.conftest import (  # noqa: F401
+    mock_requests,
+    mock_requests_get,
+    mock_telemetry_client,
+    terminate_telemetry_client,
+)
+
+
+@pytest.fixture
+def enable_telemetry_in_tests(monkeypatch):
+    """
+    Enable telemetry for tests that need to verify telemetry tracking.
+    Use this fixture explicitly in tests that validate telemetry behavior.
+    """
+    monkeypatch.setattr(mlflow.telemetry.utils, "_IS_MLFLOW_TESTING_TELEMETRY", True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/genai/scorers/deepeval/test_deepeval_scorer.py
+++ b/tests/genai/scorers/deepeval/test_deepeval_scorer.py
@@ -2,11 +2,22 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+import mlflow
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSourceType
 from mlflow.genai.judges.utils import CategoricalRating
 from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
-from mlflow.genai.scorers.deepeval import AnswerRelevancy, KnowledgeRetention, get_scorer
+from mlflow.genai.scorers.base import ScorerKind
+from mlflow.genai.scorers.deepeval import (
+    AnswerRelevancy,
+    ExactMatch,
+    KnowledgeRetention,
+    get_scorer,
+)
+from mlflow.telemetry.client import TelemetryClient
+from mlflow.telemetry.events import GenAIEvaluateEvent, ScorerCallEvent
+
+from tests.telemetry.helper_functions import validate_telemetry_record
 
 
 @pytest.fixture
@@ -31,6 +42,12 @@ def mock_deepeval_model():
             return "mock-model"
 
     return MockDeepEvalModel()
+
+
+@pytest.fixture(autouse=True)
+def mock_get_telemetry_client(mock_telemetry_client: TelemetryClient):
+    with patch("mlflow.telemetry.track.get_telemetry_client", return_value=mock_telemetry_client):
+        yield
 
 
 def test_deepeval_scorer_with_exact_match_metric():
@@ -211,3 +228,104 @@ def test_single_turn_metric_ignores_session_parameter():
         # Verify result
         assert isinstance(result, Feedback)
         assert result.value == CategoricalRating.YES
+
+
+def test_deepeval_scorer_kind_property():
+    scorer = get_scorer("ExactMatch")
+    assert scorer.kind == ScorerKind.THIRD_PARTY
+
+
+def test_deepeval_scorer_kind_property_with_llm_metric(mock_deepeval_model):
+    with patch(
+        "mlflow.genai.scorers.deepeval.create_deepeval_model", return_value=mock_deepeval_model
+    ):
+        scorer = AnswerRelevancy()
+        assert scorer.kind == ScorerKind.THIRD_PARTY
+
+
+@pytest.mark.parametrize(
+    ("scorer_factory", "expected_class"),
+    [
+        (lambda: ExactMatch(), "DeepEval:ExactMatch"),
+        (lambda: get_scorer("ExactMatch"), "DeepEval:ExactMatch"),
+    ],
+    ids=["direct_instantiation", "get_scorer"],
+)
+def test_deepeval_scorer_telemetry_direct_call(
+    enable_telemetry_in_tests, mock_requests, mock_telemetry_client, scorer_factory, expected_class
+):
+    deepeval_scorer = scorer_factory()
+
+    with patch.object(deepeval_scorer._metric, "measure") as mock_measure:
+        mock_measure.return_value = None
+        deepeval_scorer._metric.score = 1.0
+        deepeval_scorer._metric.reason = "Match"
+        deepeval_scorer._metric.threshold = 0.5
+        deepeval_scorer._metric.is_successful = Mock(return_value=True)
+
+        deepeval_scorer(
+            inputs="What is MLflow?",
+            outputs="MLflow is a platform",
+            expectations={"expected_output": "MLflow is a platform"},
+        )
+
+    mock_telemetry_client.flush()
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": expected_class,
+            "scorer_kind": "third_party",
+            "is_session_level_scorer": False,
+            "callsite": "direct_scorer_call",
+            "has_feedback_error": False,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("scorer_factory", "expected_class"),
+    [
+        (lambda: ExactMatch(), "DeepEval:ExactMatch"),
+        (lambda: get_scorer("ExactMatch"), "DeepEval:ExactMatch"),
+    ],
+    ids=["direct_instantiation", "get_scorer"],
+)
+def test_deepeval_scorer_telemetry_in_genai_evaluate(
+    enable_telemetry_in_tests, mock_requests, mock_telemetry_client, scorer_factory, expected_class
+):
+    deepeval_scorer = scorer_factory()
+
+    data = [
+        {
+            "inputs": {"question": "What is MLflow?"},
+            "outputs": "MLflow is a platform",
+            "expectations": {"expected_output": "MLflow is a platform"},
+        }
+    ]
+
+    with patch.object(deepeval_scorer._metric, "measure") as mock_measure:
+        mock_measure.return_value = None
+        deepeval_scorer._metric.score = 1.0
+        deepeval_scorer._metric.reason = "Match"
+        deepeval_scorer._metric.threshold = 0.5
+        deepeval_scorer._metric.is_successful = Mock(return_value=True)
+
+        mlflow.genai.evaluate(data=data, scorers=[deepeval_scorer])
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        GenAIEvaluateEvent.name,
+        {
+            "predict_fn_provided": False,
+            "scorer_info": [
+                {"class": expected_class, "kind": "third_party", "scope": "response"},
+            ],
+            "eval_data_type": "list[dict]",
+            "eval_data_size": 1,
+            "eval_data_provided_fields": ["expectations", "inputs", "outputs"],
+        },
+    )

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -2,11 +2,13 @@ from unittest.mock import patch
 
 import pytest
 
+import mlflow
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSourceType
 from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.utils import CategoricalRating
 from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
+from mlflow.genai.scorers.base import ScorerKind
 from mlflow.genai.scorers.ragas import (
     AspectCritic,
     ContextEntityRecall,
@@ -24,6 +26,16 @@ from mlflow.genai.scorers.ragas import (
     SummarizationScore,
     get_scorer,
 )
+from mlflow.telemetry.client import TelemetryClient
+from mlflow.telemetry.events import GenAIEvaluateEvent, ScorerCallEvent
+
+from tests.telemetry.helper_functions import validate_telemetry_record
+
+
+@pytest.fixture(autouse=True)
+def mock_get_telemetry_client(mock_telemetry_client: TelemetryClient):
+    with patch("mlflow.telemetry.track.get_telemetry_client", return_value=mock_telemetry_client):
+        yield
 
 
 def test_ragas_scorer_with_exact_match_metric():
@@ -161,3 +173,92 @@ def test_namespaced_class_properly_instantiates(scorer_class, expected_metric_na
     scorer = scorer_class(**metric_kwargs)
     assert isinstance(scorer, RagasScorer)
     assert scorer.name == expected_metric_name
+
+
+def test_ragas_scorer_kind_property():
+    scorer = get_scorer("ExactMatch")
+    assert scorer.kind == ScorerKind.THIRD_PARTY
+
+
+def test_ragas_scorer_kind_property_with_llm_metric():
+    with patch("mlflow.genai.scorers.ragas.create_ragas_model"):
+        scorer = Faithfulness()
+        assert scorer.kind == ScorerKind.THIRD_PARTY
+
+
+@pytest.mark.parametrize(
+    ("scorer_factory", "expected_class"),
+    [
+        (lambda: ExactMatch(), "Ragas:ExactMatch"),
+        (lambda: get_scorer("ExactMatch"), "Ragas:ExactMatch"),
+    ],
+    ids=["direct_instantiation", "get_scorer"],
+)
+def test_ragas_scorer_telemetry_direct_call(
+    enable_telemetry_in_tests, mock_requests, mock_telemetry_client, scorer_factory, expected_class
+):
+    ragas_scorer = scorer_factory()
+
+    with patch.object(ragas_scorer._metric, "single_turn_score", return_value=1.0):
+        result = ragas_scorer(
+            inputs="What is MLflow?",
+            outputs="MLflow is a platform",
+            expectations={"expected_output": "MLflow is a platform"},
+        )
+
+    assert result.value == 1.0
+
+    mock_telemetry_client.flush()
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": expected_class,
+            "scorer_kind": "third_party",
+            "is_session_level_scorer": False,
+            "callsite": "direct_scorer_call",
+            "has_feedback_error": False,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("scorer_factory", "expected_class"),
+    [
+        (lambda: ExactMatch(), "Ragas:ExactMatch"),
+        (lambda: get_scorer("ExactMatch"), "Ragas:ExactMatch"),
+    ],
+    ids=["direct_instantiation", "get_scorer"],
+)
+def test_ragas_scorer_telemetry_in_genai_evaluate(
+    enable_telemetry_in_tests, mock_requests, mock_telemetry_client, scorer_factory, expected_class
+):
+    ragas_scorer = scorer_factory()
+
+    data = [
+        {
+            "inputs": {"question": "What is MLflow?"},
+            "outputs": "MLflow is a platform",
+            "expectations": {"expected_output": "MLflow is a platform"},
+        }
+    ]
+
+    with patch.object(ragas_scorer._metric, "single_turn_score", return_value=1.0):
+        mlflow.genai.evaluate(data=data, scorers=[ragas_scorer])
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        GenAIEvaluateEvent.name,
+        {
+            "predict_fn_provided": False,
+            "scorer_info": [
+                {"class": expected_class, "kind": "third_party", "scope": "response"},
+            ],
+            "eval_data_type": "list[dict]",
+            "eval_data_size": 1,
+            "eval_data_provided_fields": ["expectations", "inputs", "outputs"],
+        },
+    )


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19497/files) to review incremental changes.
- [**stack/wrapped-judges-add-telemetry-support-for-wrapped-judges-eval**](https://github.com/mlflow/mlflow/pull/19497) [[Files changed](https://github.com/mlflow/mlflow/pull/19497/files)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This commit adds telemetry tracking support for third-party scorer frameworks (DeepEval and Ragas) in MLflow's evaluation system. It introduces a new `THIRD_PARTY` kind to the ScorerKind enum and implements the kind property for both `DeepEvalScorer` and `RagasScorer` classes to properly classify these scorers in telemetry events. The implementation includes a refactored helper function `_get_scorer_class_name_for_tracking()` that identifies scorer types with framework-specific prefixes (e.g., "DeepEval:ExactMatch", "Ragas:Faithfulness") for better analytics on third-party scorer adoption and usage patterns.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
## Manual Testing
Running the following:
```
import os
os.environ["_MLFLOW_TESTING_TELEMETRY"] = "true"

import mlflow
from mlflow.genai.scorers.deepeval import ExactMatch

deepeval_scorer = ExactMatch()

data = [
    {
        "inputs": {"question": "What is MLflow?"},
        "outputs": "MLflow is a platform",
        "expectations": {"expected_output": "MLflow is a platform"},
    }
]

mlflow.genai.evaluate(data=data, scorers=[deepeval_scorer])
```

Logged the following event:
```
event: scorer_call, params: {'scorer_class': 'DeepEval:ExactMatch', 'scorer_kind': 'third_party', 'is_session_level_scorer': False, 'callsite': 'genai.evaluate', 'has_feedback_error': False}

event: genai_evaluate, params: {'predict_fn_provided': False, 'eval_data_type': 'list[dict]', 'scorer_info': [{'class': 'DeepEval:ExactMatch', 'kind': 'third_party', 'scope': 'response'}], 'eval_data_size': 1, 'eval_data_provided_fields': ['expectations', 'inputs', 'outputs']}

```





### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
