### PR TITLE
Support MLflow tracing with OpenTelemetry auto-instrumentation

### DIFF
--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -394,11 +394,18 @@ def _initialize_tracer_provider(disabled=False):
                 "An existing TracerProvider is detected. Adding MLflow's span processors "
                 "to the existing provider for unified tracing."
             )
-            existing_processors = set(existing_provider._active_span_processor._span_processors)
-            for processor in processors:
-                if not any(isinstance(p, type(processor)) for p in existing_processors):
-                    existing_provider.add_span_processor(processor)
-            return
+            try:
+                existing_processors = set(existing_provider._active_span_processor._span_processors)
+                for processor in processors:
+                    if not any(isinstance(p, type(processor)) for p in existing_processors):
+                        existing_provider.add_span_processor(processor)
+                return
+            except Exception as e:
+                _logger.debug(
+                    f"An error occurred while adding span processors to the existing provider: {e}."
+                    " Overriding the existing provider with MLflow trace provider.",
+                    exc_info=True,
+                )
 
     # NB: If otel resource env vars are set explicitly, don't create an empty resource
     # so that they are propagated to otel spans.

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -383,8 +383,8 @@ def _initialize_tracer_provider(disabled=False):
     suppress_warning("opentelemetry.sdk.trace", "Calling end() on an ended span")
 
     # When using the global tracer provider mode (MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false),
-    # check if a TracerProvider is already set by an external library (e.g., auto-instrumentation
-    # from Uvicorn, FastAPI, etc.). If so, add MLflow's span processors to the existing provider
+    # check if a TracerProvider is already set (e.g., set with `set_tracer_provider` API for
+    # Uvicorn, FastAPI, etc.). If so, add MLflow's span processors to the existing provider
     # instead of replacing it. This enables unified tracing where both external and MLflow spans
     # are captured in the same trace.
     if not MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():

--- a/tests/tracing/opentelemetry/test_integration.py
+++ b/tests/tracing/opentelemetry/test_integration.py
@@ -1,14 +1,31 @@
 import pytest
 from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
 
 import mlflow
 from mlflow.entities.span import SpanStatusCode, encode_span_id
 from mlflow.entities.trace_location import MlflowExperimentLocation
 from mlflow.entities.trace_state import TraceState
 from mlflow.environment_variables import MLFLOW_USE_DEFAULT_TRACER_PROVIDER
+from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
+from mlflow.tracing.provider import _initialize_tracer_provider, provider
 from mlflow.utils.os import is_windows
 
 from tests.tracing.helper import get_traces
+
+
+@pytest.fixture(autouse=True)
+def reset_tracing():
+    yield
+    # Explicitly reset all tracing state to ensure test isolation when tests
+    # switch between MLFLOW_USE_DEFAULT_TRACER_PROVIDER modes. This is needed
+    # because mlflow.tracing.reset() only resets the state for the current mode,
+    # but this fixture runs when env var is at default.
+    otel_trace._TRACER_PROVIDER = None
+    otel_trace._TRACER_PROVIDER_SET_ONCE._done = False
+    # Also reset MLflow's internal once flags for both modes
+    provider._global_provider_init_once._done = False
+    provider._isolated_tracer_provider_once._done = False
 
 
 @pytest.mark.skipif(is_windows(), reason="Skipping as this is flaky on Windows")
@@ -157,3 +174,97 @@ def test_mlflow_and_opentelemetry_isolated_tracing(monkeypatch):
     assert spans[0].inputs == {"text": "hello"}
     assert spans[0].outputs == {"text": "world"}
     assert spans[0].status.status_code == SpanStatusCode.OK
+
+
+def test_mlflow_adds_processors_to_existing_tracer_provider(monkeypatch):
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "false")
+
+    external_provider = TracerProvider()
+    otel_trace.set_tracer_provider(external_provider)
+
+    # Trigger MLflow initialization - this adds MLflow's processors to the external provider
+    _initialize_tracer_provider()
+
+    # Verify the external provider was NOT replaced
+    assert otel_trace.get_tracer_provider() is external_provider
+
+    # Verify MLflow's processors were added to the external provider
+    processors = external_provider._active_span_processor._span_processors
+    assert any(isinstance(p, MlflowV3SpanProcessor) for p in processors)
+
+    otel_tracer = otel_trace.get_tracer("external_lib")
+    with otel_tracer.start_as_current_span("http_request_parent") as external_span:
+        external_span.set_attribute("http.method", "GET")
+
+        with mlflow.start_span("model_prediction") as mlflow_span:
+            mlflow_span.set_inputs({"query": "test"})
+            mlflow_span.set_outputs({"result": "success"})
+
+    traces = get_traces()
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.info.trace_id.startswith("tr-")
+    assert trace.info.status == TraceState.OK
+
+    spans = trace.data.spans
+    assert len(spans) == 2
+    assert spans[0].name == "http_request_parent"
+    assert spans[0].parent_id is None
+    assert spans[1].name == "model_prediction"
+    assert spans[1].parent_id == spans[0].span_id
+    assert spans[1].inputs == {"query": "test"}
+    assert spans[1].outputs == {"result": "success"}
+    assert spans[1].status.status_code == SpanStatusCode.OK
+
+
+def test_mlflow_does_not_add_duplicate_processors_global_mode(monkeypatch):
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "false")
+
+    external_provider = TracerProvider()
+    otel_trace.set_tracer_provider(external_provider)
+
+    # First call to initialize tracer provider - adds MLflow's processors
+    _initialize_tracer_provider()
+
+    processors = external_provider._active_span_processor._span_processors
+    assert len(processors) == 1
+    assert isinstance(processors[0], MlflowV3SpanProcessor)
+
+    # Second call to initialize tracer provider - should NOT add duplicate processors
+    _initialize_tracer_provider()
+
+    latest_processors = external_provider._active_span_processor._span_processors
+    assert latest_processors == processors
+
+
+def test_mlflow_does_not_add_duplicate_processors_isolated_mode(monkeypatch):
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+
+    with mlflow.start_span("mlflow_span"):
+        pass
+
+    current_provider = provider.get()
+    processors = current_provider._active_span_processor._span_processors
+    assert len(processors) == 1
+    assert isinstance(processors[0], MlflowV3SpanProcessor)
+
+    # Second call to initialize tracer provider - should NOT add duplicate processors
+    _initialize_tracer_provider()
+
+    latest_processors = current_provider._active_span_processor._span_processors
+    assert latest_processors == processors
+
+
+@pytest.mark.parametrize(
+    "use_default_tracer_provider",
+    [True, False],
+)
+def test_initialize_tracer_provider_without_otel_provider_set(
+    monkeypatch, use_default_tracer_provider
+):
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, str(use_default_tracer_provider))
+    _initialize_tracer_provider()
+    # no external provider set, we should always use mlflow own tracer provider
+    processors = provider.get()._active_span_processor._span_processors
+    assert len(processors) == 1
+    assert isinstance(processors[0], MlflowV3SpanProcessor)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/19501?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19501/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19501/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19501/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #19036 

### What changes are proposed in this pull request?
When `MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false`, MLflow now adds its span processors to an existing external TracerProvider (e.g., set by auto-instrumentation libraries like Uvicorn, FastAPI) instead of replacing it. This enables unified tracing where both external and MLflow spans are captured in the same trace.

**The trigger is an internal function `_initialize_tracer_provider`, which is invoked when `set_destination` is called. I'll resolve this confusion in a follow-up PR to decide when/where to add this trigger.**

With this PR, this workflow works:
1. set OpenTelemetry auto-instrumentation `trace.set_tracer_provider(tracer_provider)`
2. Invoke set_destination `mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id))`
3. Trace your agent

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
