### PR TITLE
Implement `@pytest.mark.flaky` marker for test reruns

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -379,35 +379,21 @@ jobs:
           # files created during tests on Windows as it keeps the DB connection open until
           # it's explicitly disposed.
           MLFLOW_SQLALCHEMYSTORE_POOLCLASS: "NullPool"
-        run: |
           # Set Hadoop environment variables required for testing Spark integrations on Windows
-          export HADOOP_HOME=/tmp/winutils/hadoop-3.2.2
+          HADOOP_HOME: /tmp/winutils/hadoop-3.2.2
+        run: |
           export PATH=$PATH:$HADOOP_HOME/bin
-
-          # Define function to run pytest with common arguments
-          run_pytest() {
-            uv run --no-sync pytest "$@" \
-              --ignore-flavors \
-              --ignore=tests/projects \
-              --ignore=tests/examples \
-              --ignore=tests/evaluate \
-              --ignore=tests/optuna \
-              --ignore=tests/pyspark/optuna \
-              --ignore=tests/genai \
-              --ignore=tests/sagemaker \
-              --ignore=tests/gateway \
-              --ignore=tests/server/auth \
-              --ignore=tests/data/test_spark_dataset.py \
-              tests
-          }
-
-          # Run Windows tests
-          # Retry failed tests once to handle flaky tests on Windows
-          set +e
-          run_pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }}
-          status=$?
-          set -e
-          if [ $status -ne 0 ]; then
-            echo "Retrying failed tests..."
-            run_pytest --last-failed
-          fi
+          uv run --no-sync pytest tests \
+            --splits=${{ matrix.splits }} \
+            --group=${{ matrix.group }} \
+            --ignore-flavors \
+            --ignore=tests/projects \
+            --ignore=tests/examples \
+            --ignore=tests/evaluate \
+            --ignore=tests/optuna \
+            --ignore=tests/pyspark/optuna \
+            --ignore=tests/genai \
+            --ignore=tests/sagemaker \
+            --ignore=tests/gateway \
+            --ignore=tests/server/auth \
+            --ignore=tests/data/test_spark_dataset.py

--- a/tests/tracing/processor/test_otel_metrics.py
+++ b/tests/tracing/processor/test_otel_metrics.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import pytest
@@ -18,6 +19,7 @@ def metric_reader() -> InMemoryMetricReader:
     provider.shutdown()
 
 
+@pytest.mark.flaky(attempts=3, condition=os.name == "nt")
 def test_metrics_export(
     monkeypatch: pytest.MonkeyPatch, metric_reader: InMemoryMetricReader
 ) -> None:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/19505?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19505/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19505/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19505/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Replace the manual retry logic in Windows CI with a custom pytest hook that supports the `@pytest.mark.flaky` marker. This allows marking specific flaky tests for automatic reruns instead of retrying all failed tests.

The implementation is inspired by [pytest-rerunfailures](https://github.com/pytest-dev/pytest-rerunfailures/blob/v15.0/src/pytest_rerunfailures.py#L387-L454) but simplified to only support the features we need:
- `reruns`: number of times to retry (default: 1)
- `condition`: boolean to conditionally enable reruns (default: True)

Usage:
```python
@pytest.mark.flaky(reruns=3, condition=sys.platform == "win32")
def test_windows_flaky():
    ...
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified the flaky marker works by creating a test that fails on first run and passes on rerun.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name=\"release-note-category\"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the \"Small Bugfixes and Documentation Updates\" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the \"Breaking Changes\" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)