### PR TITLE
Set `--factory` flag for `uvicorn` if detected

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -281,7 +281,9 @@ def _build_gunicorn_command(gunicorn_opts, host, port, workers, app_name):
     ]
 
 
-def _build_uvicorn_command(uvicorn_opts, host, port, workers, app_name, env_file=None, is_factory=False):
+def _build_uvicorn_command(
+    uvicorn_opts, host, port, workers, app_name, env_file=None, is_factory=False
+):
     """Build command to run uvicorn server."""
     opts = shlex.split(uvicorn_opts) if uvicorn_opts else []
     cmd = [
@@ -391,7 +393,9 @@ def _run_server(
     # Determine which server to use
     if using_uvicorn:
         # Use uvicorn (default when no specific server options are provided)
-        full_command = _build_uvicorn_command(uvicorn_opts, host, port, workers or 4, app, env_file, is_factory)
+        full_command = _build_uvicorn_command(
+            uvicorn_opts, host, port, workers or 4, app, env_file, is_factory
+        )
     elif using_waitress:
         # Use waitress if explicitly requested
         warnings.warn(

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -281,7 +281,7 @@ def _build_gunicorn_command(gunicorn_opts, host, port, workers, app_name):
     ]
 
 
-def _build_uvicorn_command(uvicorn_opts, host, port, workers, app_name, env_file=None):
+def _build_uvicorn_command(uvicorn_opts, host, port, workers, app_name, env_file=None, is_factory=False):
     """Build command to run uvicorn server."""
     opts = shlex.split(uvicorn_opts) if uvicorn_opts else []
     cmd = [
@@ -298,6 +298,8 @@ def _build_uvicorn_command(uvicorn_opts, host, port, workers, app_name, env_file
     ]
     if env_file:
         cmd.extend(["--env-file", env_file])
+    if is_factory:
+        cmd.append("--factory")
     cmd.append(app_name)
     return cmd
 
@@ -389,7 +391,7 @@ def _run_server(
     # Determine which server to use
     if using_uvicorn:
         # Use uvicorn (default when no specific server options are provided)
-        full_command = _build_uvicorn_command(uvicorn_opts, host, port, workers or 4, app, env_file)
+        full_command = _build_uvicorn_command(uvicorn_opts, host, port, workers or 4, app, env_file, is_factory)
     elif using_waitress:
         # Use waitress if explicitly requested
         warnings.warn(

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -101,6 +101,22 @@ def test_build_uvicorn_command():
         "mlflow.server.fastapi_app:app",
     ]
 
+    assert server._build_uvicorn_command(
+        "", "localhost", "5000", "4", "mlflow.server.fastapi_app:app", None, is_factory=True
+    ) == [
+       sys.executable,
+       "-m",
+       "uvicorn",
+       "--host",
+       "localhost",
+       "--port",
+       "5000",
+       "--workers",
+       "4",
+       "--factory",
+       "mlflow.server.fastapi_app:app",
+   ]
+
 
 def test_build_uvicorn_command_with_env_file():
     cmd = server._build_uvicorn_command(

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -104,18 +104,18 @@ def test_build_uvicorn_command():
     assert server._build_uvicorn_command(
         "", "localhost", "5000", "4", "mlflow.server.fastapi_app:app", None, is_factory=True
     ) == [
-       sys.executable,
-       "-m",
-       "uvicorn",
-       "--host",
-       "localhost",
-       "--port",
-       "5000",
-       "--workers",
-       "4",
-       "--factory",
-       "mlflow.server.fastapi_app:app",
-   ]
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "--host",
+        "localhost",
+        "--port",
+        "5000",
+        "--workers",
+        "4",
+        "--factory",
+        "mlflow.server.fastapi_app:app",
+    ]
 
 
 def test_build_uvicorn_command_with_env_file():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/pmeier/mlflow/pull/19522?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19522/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19522/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19522/merge
```

</p>
</details>

### What changes are proposed in this pull request?

We are already detecting whether an app passed to `mlflow server` is actually an app factory

https://github.com/mlflow/mlflow/blob/f0157f9b6668c4e8d2867f468a26ca3d566ed444/mlflow/server/__init__.py#L381-L382

However, this value is currently only used by `waitress`

https://github.com/mlflow/mlflow/blob/f0157f9b6668c4e8d2867f468a26ca3d566ed444/mlflow/server/__init__.py#L402

`uvicorn` allows passing both an app instance or factory, but will emit a warning if you pass a factory without also passing the `--factory` flag:

```
WARNING:  ASGI app factory detected. Using it, but please consider setting the --factory flag explicitly.
```

This PR just adds this flag if we detect an app factory.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

(I don't think any of the categories fit well, but tracking IMO is the best)

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
