### PR TITLE
Branch 3.8 patch: Fix GraphQL SearchRuns filter using invalid attribute key in trace comparison

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -402,7 +402,7 @@ const useGetCompareToData = (params: {
 
   const { data: runData, loading: runDetailsLoading } = useSearchRunsQuery({
     experimentIds: [experimentId],
-    filter: `attributes.runId = "${compareToRunUuid}"`,
+    filter: `attributes.run_id = "${compareToRunUuid}"`,
     disabled: isNil(compareToRunUuid),
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTabArtifacts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTabArtifacts.tsx
@@ -158,7 +158,7 @@ const useGetCompareToDataWithArtifacts = (
 
   const { data: runData, loading: runDetailsLoading } = useSearchRunsQuery({
     experimentIds: [experimentId],
-    filter: `attributes.runId = "${compareToRunUuid}"`,
+    filter: `attributes.run_id = "${compareToRunUuid}"`,
     disabled: isNil(compareToRunUuid),
   });
 


### PR DESCRIPTION
(cherry picked from commit 50c2e2cd9a4c721e3d60da9b80e90b22188ada7d)


<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/19526?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19526/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19526/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19526/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The trace comparison feature was sending GraphQL queries with `attributes.runId` (camelCase), but the backend expects `attributes.run_id` (snake_case), causing query failures with:
```
Invalid attribute key 'runId' specified. Valid keys are '{'run_id', 'start_time', ...}'
```

Changed two filter strings to use correct snake_case format:
- `RunViewEvaluationsTabArtifacts.tsx` (line 161)
- `RunViewEvaluationsTab.tsx` (line 405)

This aligns with backend expectations and existing codebase conventions.

![Trace comparison working](https://github.com/user-attachments/assets/5c13ea51-c271-43bf-a506-8790b91099cb)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual verification: Created two runs with traces, navigated to Traces tab, selected comparison run from dropdown. GraphQL query now succeeds without errors, and trace comparison displays correctly.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed trace comparison feature failing due to incorrect GraphQL query attribute name.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>


----

*This section details on the original issue you should resolve*

<issue_title>[BUG] Trace comparison GraphQL query sends wrong arguments</issue_title>
<issue_description>### MLflow version

feeb7d320f37da0f4d2c4cb927de8e210ed2b4cd

### System information

- **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**: MacOS Tahoe
- **Python version**: 3.10
- **yarn version, if running the dev UI**: 4.9.1


### Describe the problem

This bug is not necessarily breaking anything, since trace comparison still ends up working, and I'm not super in-the-know of the dataflow in the frontend parts of MLflow to diagnose the repercussions

The trace comparison table of the runs calls a `SearchRuns` GraphQL query on selecting a run to compare to, with the filter like `'attributes.runId = "<runId>"'`, but the backend responds with an error:

```
{"data":{"mlflowSearchRuns":null},"errors":["Invalid attribute key 'runId' specified. Valid keys are '{'start_time', 'run_id', 'artifact_uri', 'run_name', 'Run name', 'run name', 'Created', 'status', 'user_id', 'Run Name', 'created', 'end_time'}'"]}
```

### Steps to reproduce the bug

1) Create two runs with traces
2) Go to one of the logged runs
3) Go to the `Traces` tab
4) Open the dev console here to see the request, then select a run to compare to in the `compare to` dropdown:
<img width="605" height="429" alt="Image" src="https://github.com/user-attachments/assets/7862855f-4e9b-4fdd-8c31-9f33a3626ce5" />

5) Upon clicking, a call to the `/graphql` endpoint to do a `SearchRuns` query is done, and the error is returned.

The traces still show up to be compared, so the UI keeps working

I have changed the mentioned `runId` to `run_id` in following places, which fixed the broken GQL call:
https://github.com/mlflow/mlflow/blob/63303e7c978e5c3c481f30a7124d4d04abc54faa/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTabArtifacts.tsx#L161
https://github.com/mlflow/mlflow/blob/7d32fb44258518e8bcacf2bb68671c1bc268b690/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx#L405

As far as I can see, everything still works, the traces still show up, and I also don't see any change in functionality, or calls happening/not happening.
However, I am not sure if this was left intentionally broken, or not, so let me know if this is worthy of a fix PR


### Code to generate data required to reproduce the bug


```python
import mlflow
from mlflow.entities import SpanType


@mlflow.trace(span_type=SpanType.TOOL)
def calc_func(a, b):
    return a + b


def traced_function():
    with mlflow.start_span("calc_func", span_type="func") as span:
        sum = 0
        n = 5

        span.set_inputs({"sum": sum, "n": n})

        for i in range(n):
            sum = calc_func(sum, i)

        span.set_outputs({"res": sum})


def prepare_trace_comparison():
    with mlflow.start_run():
        traced_function()
    with mlflow.start_run():
        traced_function()


if __name__ == "__main__":
    mlflow.set_tracking_uri("http://localhost:5000")
    prepare_trace_comparison()
```

### Is the console panel in DevTools showing errors relevant to the bug?

Nothing about this call failing shows up in the console

### Does the network panel in DevTools contain failed requests relevant to the bug?

Request:
```json
{"operationName":"SearchRuns","variables":{"data":{"filter":"attributes.runId = \"378c02d3831a402da4de2e89a6f0ea88\"","experimentIds":["1184"]}},"query":"query SearchRuns($data: MlflowSearchRunsInput!) {\n  mlflowSearchRuns(input: $data) {\n    apiError {\n      helpUrl\n      code\n      message\n      __typename\n    }\n    runs {\n      info {\n        runName\n        status\n        runUuid\n        experimentId\n        artifactUri\n        endTime\n        lifecycleStage\n        startTime\n        userId\n        __typename\n      }\n      experiment {\n        experimentId\n        name\n        tags {\n          key\n          value\n          __typename\n        }\n        artifactLocation\n        lifecycleStage\n        lastUpdateTime\n        __typename\n      }\n      data {\n        metrics {\n          key\n          value\n          step\n          timestamp\n          __typename\n        }\n        params {\n          key\n          value\n          __typename\n        }\n        tags {\n          key\n          value\n          __typename\n        }\n        __typename\n      }\n      inputs {\n        datasetInputs {\n          dataset {\n            digest\n            name\n            profile\n            schema\n            source\n            sourceType\n            __typename\n          }\n          tags {\n            key\n            value\n            __typename\n          }\n          __typename\n        }\n        modelInputs {\n          modelId\n          __typename\n        }\n        __typename\n      }\n      outputs {\n        modelOutputs {\n          modelId\n          step\n   ...

</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes mlflow/mlflow#19488

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.
