### PR TITLE
Cherry picking traces for testing new scorer [Part 1/x] Extract trace selector

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import {
   useDesignSystemTheme,
   Typography,
-  SimpleSelect,
-  SimpleSelectOption,
   Button,
   PlayCircleFillIcon,
   LoadingState,
@@ -15,7 +13,8 @@ import {
 import { FormattedMessage } from '@databricks/i18n';
 import { SimplifiedModelTraceExplorer } from '@databricks/web-shared/model-trace-explorer';
 import type { Assessment, ModelTrace } from '@databricks/web-shared/model-trace-explorer';
-import { COMPONENT_ID_PREFIX, BUTTON_VARIANT, type ButtonVariant } from './constants';
+import { COMPONENT_ID_PREFIX, BUTTON_VARIANT, type ButtonVariant, DEFAULT_TRACE_COUNT } from './constants';
+import { SampleScorerTracesToEvaluatePicker } from './SampleScorerTracesToEvaluatePicker';
 
 /**
  * Run scorer button component.
@@ -119,23 +118,10 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
           <FormattedMessage defaultMessage="Sample judge output" description="Title for sample judge output panel" />
         </Typography.Text>
         <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
-          <SimpleSelect
-            componentId={`${COMPONENT_ID_PREFIX}.sample-output-traces-select`}
-            id="sample-output-traces-select"
-            value={String(tracesCount)}
-            onChange={({ target }) => onTracesCountChange(Number(target.value))}
-            triggerSize="small"
-          >
-            <SimpleSelectOption value="1">
-              <FormattedMessage defaultMessage="Last trace" description="Option for last trace" />
-            </SimpleSelectOption>
-            <SimpleSelectOption value="5">
-              <FormattedMessage defaultMessage="Last 5 traces" description="Option for last 5 traces" />
-            </SimpleSelectOption>
-            <SimpleSelectOption value="10">
-              <FormattedMessage defaultMessage="Last 10 traces" description="Option for last 10 traces" />
-            </SimpleSelectOption>
-          </SimpleSelect>
+          <SampleScorerTracesToEvaluatePicker
+            tracesToEvaluate={{ traceCount: tracesCount }}
+            onTracesToEvaluateChange={({ traceCount }) => onTracesCountChange(traceCount)}
+          />
           {!isInitialScreen && (
             <Tooltip
               componentId={`${COMPONENT_ID_PREFIX}.rerun-scorer-button-tooltip`}
@@ -168,6 +154,7 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
               flexDirection: 'column',
               padding: theme.spacing.md,
               gap: theme.spacing.xs,
+              flex: 1,
             }}
           >
             {/* Carousel controls and trace info */}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
@@ -1,0 +1,102 @@
+import {
+  Button,
+  DialogComboboxOptionList,
+  DialogComboboxContent,
+  DialogComboboxOptionListSelectItem,
+} from '@databricks/design-system';
+
+import { ChevronDownIcon, DialogCombobox, DialogComboboxCustomButtonTriggerWrapper } from '@databricks/design-system';
+import { defineMessage, FormattedMessage } from 'react-intl';
+import { isEmpty } from 'lodash';
+import { useMemo, useState } from 'react';
+import { coerceToEnum } from '../../../shared/web-shared/utils';
+
+enum PickerOption {
+  'LAST_TRACE' = '1',
+  'LAST_5_TRACES' = '5',
+  'LAST_10_TRACES' = '10',
+  'CUSTOM' = 'custom',
+}
+
+const PickerOptionsLabels = {
+  [PickerOption.LAST_TRACE]: defineMessage({
+    defaultMessage: 'Last trace',
+    description: 'Option for last trace',
+  }),
+  [PickerOption.LAST_5_TRACES]: defineMessage({
+    defaultMessage: 'Last 5 traces',
+    description: 'Option for last 5 traces',
+  }),
+  [PickerOption.LAST_10_TRACES]: defineMessage({
+    defaultMessage: 'Last 10 traces',
+    description: 'Option for last 10 traces',
+  }),
+  [PickerOption.CUSTOM]: defineMessage({
+    defaultMessage: 'Select traces',
+    description: 'Option for selecting custom traces',
+  }),
+};
+
+export const SampleScorerTracesToEvaluatePicker = ({
+  onTracesToEvaluateChange,
+  tracesToEvaluate,
+}: {
+  tracesToEvaluate: { traceCount: number; traceIds?: string[] };
+  onTracesToEvaluateChange: (tracesToEvaluate: { traceCount: number; traceIds?: string[] }) => void;
+}) => {
+  const [displayPickCustomTracesModal, setDisplayPickCustomTracesModal] = useState(false);
+  const tracesToEvaluateDropdownValue = useMemo(() => {
+    if (!isEmpty(tracesToEvaluate.traceIds)) {
+      return PickerOption.CUSTOM;
+    }
+    return coerceToEnum(PickerOption, String(tracesToEvaluate.traceCount), PickerOption.LAST_10_TRACES);
+  }, [tracesToEvaluate]);
+
+  return (
+    <>
+      <DialogCombobox
+        componentId="mlflow.experiment-scorers.form.traces-picker"
+        id="TODO"
+        value={[tracesToEvaluateDropdownValue]}
+      >
+        <DialogComboboxCustomButtonTriggerWrapper>
+          <Button
+            componentId="mlflow.experiment-scorers.form.traces-picker.trigger"
+            size="small"
+            endIcon={<ChevronDownIcon />}
+          >
+            {tracesToEvaluateDropdownValue === PickerOption.CUSTOM ? (
+              <FormattedMessage
+                defaultMessage="{count, plural, one {1 trace selected} other {# traces selected}}"
+                description="Label for the number of traces selected"
+                values={{ count: tracesToEvaluate.traceIds?.length }}
+              />
+            ) : (
+              <FormattedMessage {...PickerOptionsLabels[tracesToEvaluateDropdownValue]} />
+            )}
+          </Button>
+        </DialogComboboxCustomButtonTriggerWrapper>
+        <DialogComboboxContent align="end">
+          <DialogComboboxOptionList>
+            {[PickerOption.LAST_TRACE, PickerOption.LAST_5_TRACES, PickerOption.LAST_10_TRACES].map((value) => (
+              <DialogComboboxOptionListSelectItem
+                value={value}
+                checked={tracesToEvaluateDropdownValue === value}
+                onChange={() => {
+                  onTracesToEvaluateChange({ traceCount: Number(value), traceIds: undefined });
+                }}
+              >
+                <FormattedMessage {...PickerOptionsLabels[value]} />
+              </DialogComboboxOptionListSelectItem>
+            ))}
+            {/* TODO(next PRs): Add custom trace selection option */}
+          </DialogComboboxOptionList>
+        </DialogComboboxContent>
+      </DialogCombobox>
+      {displayPickCustomTracesModal && (
+        // TODO(next PRs): Add custom trace selection modal
+        <div />
+      )}
+    </>
+  );
+};

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -359,6 +359,10 @@
     "defaultMessage": "Copy",
     "description": "Button text for copy button"
   },
+  "1NeHsz": {
+    "defaultMessage": "{count, plural, one {1 trace selected} other {# traces selected}}",
+    "description": "Label for the number of traces selected"
+  },
   "1RxxTj": {
     "defaultMessage": "(Version {sourceModelVersion})",
     "description": "Version number of the source model version"
@@ -5770,6 +5774,10 @@
   "pjlcSc": {
     "defaultMessage": "Metric",
     "description": "Run page > Overview > Metrics table > Key column header"
+  },
+  "pjluqu": {
+    "defaultMessage": "Select traces",
+    "description": "Option for selecting custom traces"
   },
   "pl1bdY": {
     "defaultMessage": "Registered Models",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19531/files) to review incremental changes.
- [**stack/select-traces-for-scorers-part1**](https://github.com/mlflow/mlflow/pull/19531) [[Files changed](https://github.com/mlflow/mlflow/pull/19531/files)]
  - [stack/select-traces-for-scorers-part2](https://github.com/mlflow/mlflow/pull/19532) [[Files changed](https://github.com/mlflow/mlflow/pull/19532/files/507dce07c2a17f934d572b4e2087536658bc893f..846b578cef71be687398030051616c2618190cae)]
    - [stack/select-traces-for-scorers-part3](https://github.com/mlflow/mlflow/pull/19533) [[Files changed](https://github.com/mlflow/mlflow/pull/19533/files/846b578cef71be687398030051616c2618190cae..a5107f7e8cf364dd6dddbc0432a14b582d8de9d1)]
      - [stack/select-traces-for-scorers-part4](https://github.com/mlflow/mlflow/pull/19534) [[Files changed](https://github.com/mlflow/mlflow/pull/19534/files/a5107f7e8cf364dd6dddbc0432a14b582d8de9d1..fbe96290b44bc33b6202973c1bcdb5c0aae7e0e7)]
        - [stack/select-traces-for-scorers-part5](https://github.com/mlflow/mlflow/pull/19568) [[Files changed](https://github.com/mlflow/mlflow/pull/19568/files/fbe96290b44bc33b6202973c1bcdb5c0aae7e0e7..30b1269ac8257715d34f23ba0c9e25db5320ebd5)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

This PR extracts the trace selector logic from `SampleScorerOutputPanelRenderer` into a new standalone component called `SampleScorerTracesToEvaluatePicker`. This refactoring improves code organization and modularity by separating the trace selection UI into its own reusable component. The changes include:
- Created new `SampleScorerTracesToEvaluatePicker` component with trace selection functionality
- Updated `SampleScorerOutputPanelRenderer` to use the new extracted component
- Added necessary i18n strings for the trace picker UI

#### Manual regression test

https://github.com/user-attachments/assets/47aec195-ac22-4e3c-a595-90a93dcd46c7

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
