### PR TITLE
Cherry picking traces for testing new scorer [Part 2/x] Refactor to support both trace count and IDs

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
@@ -2,11 +2,11 @@ import { render } from '@testing-library/react';
 import { IntlProvider } from '@databricks/i18n';
 import { useForm } from 'react-hook-form';
 import SampleScorerOutputPanelContainer from './SampleScorerOutputPanelContainer';
-import { useEvaluateTraces, type JudgeEvaluationResult, type EvaluateTracesParams } from './useEvaluateTraces';
+import { useEvaluateTraces, type JudgeEvaluationResult } from './useEvaluateTraces';
 import { type ModelTrace } from '@databricks/web-shared/model-trace-explorer';
 import SampleScorerOutputPanelRenderer from './SampleScorerOutputPanelRenderer';
 import type { ScorerFormData } from './utils/scorerTransformUtils';
-import { LLM_TEMPLATE } from './types';
+import { LLM_TEMPLATE, type EvaluateTracesParams } from './types';
 import { jest } from '@jest/globals';
 import { describe } from '@jest/globals';
 import { beforeEach } from '@jest/globals';
@@ -107,7 +107,7 @@ describe('SampleScorerOutputPanelContainer', () => {
           error: null,
           currentTraceIndex: 0,
           totalTraces: 0,
-          tracesCount: 10,
+          tracesToEvaluate: { traceCount: 10, traceIds: [] },
         }),
         expect.anything(),
       );
@@ -193,6 +193,7 @@ describe('SampleScorerOutputPanelContainer', () => {
 
       expect(mockEvaluateTraces).toHaveBeenCalledWith({
         traceCount: 10,
+        traceIds: [],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions: 'Test instructions',
         experimentId,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
@@ -107,7 +107,7 @@ describe('SampleScorerOutputPanelContainer', () => {
           error: null,
           currentTraceIndex: 0,
           totalTraces: 0,
-          tracesToEvaluate: { traceCount: 10, traceIds: [] },
+          itemsToEvaluate: { itemCount: 10, itemIds: [] },
         }),
         expect.anything(),
       );
@@ -192,8 +192,8 @@ describe('SampleScorerOutputPanelContainer', () => {
       rendererProps.handleRunScorer();
 
       expect(mockEvaluateTraces).toHaveBeenCalledWith({
-        traceCount: 10,
-        traceIds: [],
+        itemCount: 10,
+        itemIds: [],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions: 'Test instructions',
         experimentId,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
@@ -29,9 +29,9 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
   const scorerType = useWatch({ control, name: 'scorerType' });
   const { errors } = useFormState({ control });
 
-  const [tracesToEvaluate, setTracesToEvaluate] = useState<Pick<EvaluateTracesParams, 'traceCount' | 'traceIds'>>({
-    traceCount: DEFAULT_TRACE_COUNT,
-    traceIds: [],
+  const [itemsToEvaluate, setItemsToEvaluate] = useState<Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>>({
+    itemCount: DEFAULT_TRACE_COUNT,
+    itemIds: [],
   });
   const [evaluateTraces, { data, isLoading, error, reset }] = useEvaluateTraces();
 
@@ -68,15 +68,15 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
       // Prepare evaluation parameters based on mode
       const evaluationParams = isCustomMode
         ? {
-            traceCount: tracesToEvaluate.traceCount,
-            traceIds: tracesToEvaluate.traceIds,
+            itemCount: itemsToEvaluate.itemCount,
+            itemIds: itemsToEvaluate.itemIds,
             locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' as const }],
             judgeInstructions: judgeInstructions || '',
             experimentId,
           }
         : {
-            traceCount: tracesToEvaluate.traceCount,
-            traceIds: tracesToEvaluate.traceIds,
+            itemCount: itemsToEvaluate.itemCount,
+            itemIds: itemsToEvaluate.itemIds,
             locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' as const }],
             requestedAssessments: [
               {
@@ -105,7 +105,7 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
     judgeInstructions,
     llmTemplate,
     guidelines,
-    tracesToEvaluate,
+    itemsToEvaluate,
     evaluateTraces,
     experimentId,
     onScorerFinished,
@@ -229,8 +229,8 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
       handlePrevious={handlePrevious}
       handleNext={handleNext}
       totalTraces={data?.length ?? 0}
-      tracesToEvaluate={tracesToEvaluate}
-      onTracesToEvaluateChange={setTracesToEvaluate}
+      itemsToEvaluate={itemsToEvaluate}
+      onItemsToEvaluateChange={setItemsToEvaluate}
     />
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
@@ -8,7 +8,7 @@ import SampleScorerOutputPanelRenderer from './SampleScorerOutputPanelRenderer';
 import { convertEvaluationResultToAssessment } from './llmScorerUtils';
 import { extractTemplateVariables } from '../../utils/evaluationUtils';
 import { DEFAULT_TRACE_COUNT, ASSESSMENT_NAME_TEMPLATE_MAPPING } from './constants';
-import { LLM_TEMPLATE } from './types';
+import { EvaluateTracesParams, LLM_TEMPLATE } from './types';
 
 interface SampleScorerOutputPanelContainerProps {
   control: Control<ScorerFormData>;
@@ -29,7 +29,10 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
   const scorerType = useWatch({ control, name: 'scorerType' });
   const { errors } = useFormState({ control });
 
-  const [tracesCount, setTracesCount] = useState(DEFAULT_TRACE_COUNT);
+  const [tracesToEvaluate, setTracesToEvaluate] = useState<Pick<EvaluateTracesParams, 'traceCount' | 'traceIds'>>({
+    traceCount: DEFAULT_TRACE_COUNT,
+    traceIds: [],
+  });
   const [evaluateTraces, { data, isLoading, error, reset }] = useEvaluateTraces();
 
   // Carousel state for navigating through traces
@@ -65,13 +68,15 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
       // Prepare evaluation parameters based on mode
       const evaluationParams = isCustomMode
         ? {
-            traceCount: tracesCount,
+            traceCount: tracesToEvaluate.traceCount,
+            traceIds: tracesToEvaluate.traceIds,
             locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' as const }],
             judgeInstructions: judgeInstructions || '',
             experimentId,
           }
         : {
-            traceCount: tracesCount,
+            traceCount: tracesToEvaluate.traceCount,
+            traceIds: tracesToEvaluate.traceIds,
             locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' as const }],
             requestedAssessments: [
               {
@@ -100,7 +105,7 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
     judgeInstructions,
     llmTemplate,
     guidelines,
-    tracesCount,
+    tracesToEvaluate,
     evaluateTraces,
     experimentId,
     onScorerFinished,
@@ -224,8 +229,8 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
       handlePrevious={handlePrevious}
       handleNext={handleNext}
       totalTraces={data?.length ?? 0}
-      tracesCount={tracesCount}
-      onTracesCountChange={setTracesCount}
+      tracesToEvaluate={tracesToEvaluate}
+      onTracesToEvaluateChange={setTracesToEvaluate}
     />
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
@@ -13,7 +13,8 @@ import {
 import { FormattedMessage } from '@databricks/i18n';
 import { SimplifiedModelTraceExplorer } from '@databricks/web-shared/model-trace-explorer';
 import type { Assessment, ModelTrace } from '@databricks/web-shared/model-trace-explorer';
-import { COMPONENT_ID_PREFIX, BUTTON_VARIANT, type ButtonVariant, DEFAULT_TRACE_COUNT } from './constants';
+import { COMPONENT_ID_PREFIX, BUTTON_VARIANT, type ButtonVariant } from './constants';
+import { EvaluateTracesParams } from './types';
 import { SampleScorerTracesToEvaluatePicker } from './SampleScorerTracesToEvaluatePicker';
 
 /**
@@ -68,8 +69,8 @@ interface SampleScorerOutputPanelRendererProps {
   handlePrevious: () => void;
   handleNext: () => void;
   totalTraces: number;
-  tracesCount: number;
-  onTracesCountChange: (count: number) => void;
+  tracesToEvaluate: Pick<EvaluateTracesParams, 'traceCount' | 'traceIds'>;
+  onTracesToEvaluateChange: (tracesToEvaluate: Pick<EvaluateTracesParams, 'traceCount' | 'traceIds'>) => void;
 }
 
 const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererProps> = ({
@@ -84,8 +85,8 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
   handlePrevious,
   handleNext,
   totalTraces,
-  tracesCount,
-  onTracesCountChange,
+  tracesToEvaluate,
+  onTracesToEvaluateChange,
 }) => {
   const { theme } = useDesignSystemTheme();
 
@@ -119,8 +120,8 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
         </Typography.Text>
         <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
           <SampleScorerTracesToEvaluatePicker
-            tracesToEvaluate={{ traceCount: tracesCount }}
-            onTracesToEvaluateChange={({ traceCount }) => onTracesCountChange(traceCount)}
+            tracesToEvaluate={tracesToEvaluate}
+            onTracesToEvaluateChange={onTracesToEvaluateChange}
           />
           {!isInitialScreen && (
             <Tooltip

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
@@ -69,8 +69,8 @@ interface SampleScorerOutputPanelRendererProps {
   handlePrevious: () => void;
   handleNext: () => void;
   totalTraces: number;
-  tracesToEvaluate: Pick<EvaluateTracesParams, 'traceCount' | 'traceIds'>;
-  onTracesToEvaluateChange: (tracesToEvaluate: Pick<EvaluateTracesParams, 'traceCount' | 'traceIds'>) => void;
+  itemsToEvaluate: Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>;
+  onItemsToEvaluateChange: (itemsToEvaluate: Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>) => void;
 }
 
 const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererProps> = ({
@@ -85,8 +85,8 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
   handlePrevious,
   handleNext,
   totalTraces,
-  tracesToEvaluate,
-  onTracesToEvaluateChange,
+  itemsToEvaluate,
+  onItemsToEvaluateChange,
 }) => {
   const { theme } = useDesignSystemTheme();
 
@@ -120,8 +120,8 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
         </Typography.Text>
         <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
           <SampleScorerTracesToEvaluatePicker
-            tracesToEvaluate={tracesToEvaluate}
-            onTracesToEvaluateChange={onTracesToEvaluateChange}
+            itemsToEvaluate={itemsToEvaluate}
+            onItemsToEvaluateChange={onItemsToEvaluateChange}
           />
           {!isInitialScreen && (
             <Tooltip

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
@@ -39,26 +39,26 @@ const PickerOptionsLabels = {
 };
 
 export const SampleScorerTracesToEvaluatePicker = ({
-  onTracesToEvaluateChange,
-  tracesToEvaluate,
+  onItemsToEvaluateChange,
+  itemsToEvaluate,
 }: {
-  tracesToEvaluate: Pick<EvaluateTracesParams, 'traceCount' | 'traceIds'>;
-  onTracesToEvaluateChange: (tracesToEvaluate: Pick<EvaluateTracesParams, 'traceCount' | 'traceIds'>) => void;
+  itemsToEvaluate: Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>;
+  onItemsToEvaluateChange: (itemsToEvaluate: Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>) => void;
 }) => {
   const [displayPickCustomTracesModal, setDisplayPickCustomTracesModal] = useState(false);
-  const tracesToEvaluateDropdownValue = useMemo(() => {
-    if (!isEmpty(tracesToEvaluate.traceIds)) {
+  const itemsToEvaluateDropdownValue = useMemo(() => {
+    if (!isEmpty(itemsToEvaluate.itemIds)) {
       return PickerOption.CUSTOM;
     }
-    return coerceToEnum(PickerOption, String(tracesToEvaluate.traceCount), PickerOption.LAST_10_TRACES);
-  }, [tracesToEvaluate]);
+    return coerceToEnum(PickerOption, String(itemsToEvaluate.itemCount), PickerOption.LAST_10_TRACES);
+  }, [itemsToEvaluate]);
 
   return (
     <>
       <DialogCombobox
         componentId="mlflow.experiment-scorers.form.traces-picker"
         id="TODO"
-        value={[tracesToEvaluateDropdownValue]}
+        value={[itemsToEvaluateDropdownValue]}
       >
         <DialogComboboxCustomButtonTriggerWrapper>
           <Button
@@ -66,14 +66,14 @@ export const SampleScorerTracesToEvaluatePicker = ({
             size="small"
             endIcon={<ChevronDownIcon />}
           >
-            {tracesToEvaluateDropdownValue === PickerOption.CUSTOM ? (
+            {itemsToEvaluateDropdownValue === PickerOption.CUSTOM ? (
               <FormattedMessage
                 defaultMessage="{count, plural, one {1 trace selected} other {# traces selected}}"
                 description="Label for the number of traces selected"
-                values={{ count: tracesToEvaluate.traceIds?.length }}
+                values={{ count: itemsToEvaluate.itemIds?.length }}
               />
             ) : (
-              <FormattedMessage {...PickerOptionsLabels[tracesToEvaluateDropdownValue]} />
+              <FormattedMessage {...PickerOptionsLabels[itemsToEvaluateDropdownValue]} />
             )}
           </Button>
         </DialogComboboxCustomButtonTriggerWrapper>
@@ -82,9 +82,9 @@ export const SampleScorerTracesToEvaluatePicker = ({
             {[PickerOption.LAST_TRACE, PickerOption.LAST_5_TRACES, PickerOption.LAST_10_TRACES].map((value) => (
               <DialogComboboxOptionListSelectItem
                 value={value}
-                checked={tracesToEvaluateDropdownValue === value}
+                checked={itemsToEvaluateDropdownValue === value}
                 onChange={() => {
-                  onTracesToEvaluateChange({ traceCount: Number(value), traceIds: undefined });
+                  onItemsToEvaluateChange({ itemCount: Number(value), itemIds: undefined });
                 }}
               >
                 <FormattedMessage {...PickerOptionsLabels[value]} />

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
@@ -7,6 +7,7 @@ import {
 
 import { ChevronDownIcon, DialogCombobox, DialogComboboxCustomButtonTriggerWrapper } from '@databricks/design-system';
 import { defineMessage, FormattedMessage } from 'react-intl';
+import { EvaluateTracesParams } from './types';
 import { isEmpty } from 'lodash';
 import { useMemo, useState } from 'react';
 import { coerceToEnum } from '../../../shared/web-shared/utils';
@@ -41,8 +42,8 @@ export const SampleScorerTracesToEvaluatePicker = ({
   onTracesToEvaluateChange,
   tracesToEvaluate,
 }: {
-  tracesToEvaluate: { traceCount: number; traceIds?: string[] };
-  onTracesToEvaluateChange: (tracesToEvaluate: { traceCount: number; traceIds?: string[] }) => void;
+  tracesToEvaluate: Pick<EvaluateTracesParams, 'traceCount' | 'traceIds'>;
+  onTracesToEvaluateChange: (tracesToEvaluate: Pick<EvaluateTracesParams, 'traceCount' | 'traceIds'>) => void;
 }) => {
   const [displayPickCustomTracesModal, setDisplayPickCustomTracesModal] = useState(false);
   const tracesToEvaluateDropdownValue = useMemo(() => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
@@ -1,3 +1,8 @@
+import {
+  ModelTraceLocationMlflowExperiment,
+  ModelTraceLocationUcSchema,
+} from '@databricks/web-shared/model-trace-explorer';
+
 interface ScheduledScorerBase {
   name: string;
   sampleRate?: number; // Percentage between 0 and 100
@@ -62,3 +67,33 @@ export type ScorerConfig = {
   filter_string?: string;
   scorer_version?: number;
 };
+
+interface EvaluateChatParamsBase {
+  traceCount?: number;
+  traceIds?: string[];
+  locations: (ModelTraceLocationMlflowExperiment | ModelTraceLocationUcSchema)[];
+  experimentId: string;
+}
+
+/**
+ * Parameters for evaluating traces with custom LLM judges
+ */
+export interface EvaluateChatCompletionsParams extends EvaluateChatParamsBase {
+  judgeInstructions: string;
+}
+
+/**
+ * Parameters for evaluating traces with built-in judges
+ */
+export interface EvaluateChatAssessmentsParams extends EvaluateChatParamsBase {
+  requestedAssessments: Array<{
+    assessment_name: string;
+    assessment_examples?: any[];
+  }>;
+  guidelines?: string[];
+}
+
+/**
+ * Union type for all trace evaluation parameters
+ */
+export type EvaluateTracesParams = EvaluateChatCompletionsParams | EvaluateChatAssessmentsParams;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
@@ -69,8 +69,10 @@ export type ScorerConfig = {
 };
 
 interface EvaluateChatParamsBase {
-  traceCount?: number;
-  traceIds?: string[];
+  // Number of items to evaluate. This can be the number of traces or sessions.
+  itemCount?: number;
+  // Explicit list of item IDs to evaluate. Can be either trace IDs or session IDs. This is used to override the itemCount.
+  itemIds?: string[];
   locations: (ModelTraceLocationMlflowExperiment | ModelTraceLocationUcSchema)[];
   experimentId: string;
 }

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
@@ -181,7 +181,7 @@ describe('useEvaluateTraces', () => {
       expect(state.error).toBeNull();
 
       const evaluationResults = await evaluateTraces({
-        traceCount: 1,
+        itemCount: 1,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -276,7 +276,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: traceIds.length,
+        itemCount: traceIds.length,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -351,7 +351,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: 1,
+        itemCount: 1,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -404,7 +404,7 @@ describe('useEvaluateTraces', () => {
 
       // First call - should fetch from API
       await evaluateTraces({
-        traceCount: 1,
+        itemCount: 1,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -415,7 +415,7 @@ describe('useEvaluateTraces', () => {
       // Second call with same traceId - traces should use cache, so no additional trace API calls
       // but chat completions will be called again (not cached by design)
       await evaluateTraces({
-        traceCount: 1,
+        itemCount: 1,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -456,7 +456,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: 1,
+        itemCount: 1,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -490,7 +490,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: 0,
+        itemCount: 0,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -527,7 +527,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: 1,
+        itemCount: 1,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -583,7 +583,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: traceIds.length,
+        itemCount: traceIds.length,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -657,7 +657,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: 1,
+        itemCount: 1,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -696,7 +696,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: 1,
+        itemCount: 1,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -736,7 +736,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: 1,
+        itemCount: 1,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -770,7 +770,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: 1,
+        itemCount: 1,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -810,7 +810,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        traceCount: traceIds.length,
+        itemCount: traceIds.length,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -890,7 +890,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          traceCount: 1,
+          itemCount: 1,
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -980,7 +980,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          traceCount: traceIds.length,
+          itemCount: traceIds.length,
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1071,7 +1071,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         await evaluateTraces({
-          traceCount: 1,
+          itemCount: 1,
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1116,7 +1116,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          traceCount: 1,
+          itemCount: 1,
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1182,7 +1182,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          traceCount: 1,
+          itemCount: 1,
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1208,7 +1208,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          traceCount: 0,
+          itemCount: 0,
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1253,7 +1253,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          traceCount: 1,
+          itemCount: 1,
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1323,7 +1323,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          traceCount: traceIds.length,
+          itemCount: traceIds.length,
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useGetTracesForEvaluation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useGetTracesForEvaluation.tsx
@@ -7,9 +7,9 @@ import { isEmpty } from 'lodash';
 
 const fetchTracesAndGetIds = async (
   queryClient: QueryClient,
-  { traceCount, locations }: Required<Pick<EvaluateTracesParams, 'traceCount' | 'locations'>>,
+  { itemCount, locations }: Required<Pick<EvaluateTracesParams, 'itemCount' | 'locations'>>,
 ) => {
-  const modifiedTraceCount = Math.max(traceCount, DEFAULT_TRACE_COUNT);
+  const modifiedTraceCount = Math.max(itemCount, DEFAULT_TRACE_COUNT);
 
   const traces = await queryClient.fetchQuery({
     queryKey: [
@@ -36,7 +36,7 @@ const fetchTracesAndGetIds = async (
   const traceIds = traces
     .map((trace) => trace.trace_id)
     .filter((id): id is string => Boolean(id))
-    .slice(0, traceCount);
+    .slice(0, itemCount);
 
   return traceIds;
 };
@@ -46,13 +46,13 @@ export const useGetTraceIdsForEvaluation = () => {
 
   return useCallback(
     async (params: EvaluateTracesParams) => {
-      const { traceCount = 0, locations, traceIds } = params;
-      if (traceIds && !isEmpty(traceIds)) {
-        return traceIds;
+      const { itemCount: traceCount = 0, locations, itemIds } = params;
+      if (itemIds && !isEmpty(itemIds)) {
+        return itemIds;
       }
       const fetchedTraceIds = await fetchTracesAndGetIds(queryClient, {
         locations,
-        traceCount,
+        itemCount: traceCount,
       });
       return fetchedTraceIds;
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useGetTracesForEvaluation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useGetTracesForEvaluation.tsx
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+import { searchMlflowTracesQueryFn, SEARCH_MLFLOW_TRACES_QUERY_KEY } from '@databricks/web-shared/genai-traces-table';
+import { QueryClient, useQueryClient } from '@databricks/web-shared/query-client';
+import { EvaluateTracesParams } from './types';
+import { DEFAULT_TRACE_COUNT } from './constants';
+import { isEmpty } from 'lodash';
+
+const fetchTracesAndGetIds = async (
+  queryClient: QueryClient,
+  { traceCount, locations }: Required<Pick<EvaluateTracesParams, 'traceCount' | 'locations'>>,
+) => {
+  const modifiedTraceCount = Math.max(traceCount, DEFAULT_TRACE_COUNT);
+
+  const traces = await queryClient.fetchQuery({
+    queryKey: [
+      SEARCH_MLFLOW_TRACES_QUERY_KEY,
+      {
+        locations,
+        orderBy: ['timestamp DESC'],
+        pageSize: modifiedTraceCount,
+      },
+    ],
+    queryFn: ({ signal }) =>
+      searchMlflowTracesQueryFn({
+        signal,
+        locations,
+        pageSize: modifiedTraceCount,
+        limit: modifiedTraceCount,
+        orderBy: ['timestamp DESC'],
+      }),
+    staleTime: Infinity,
+    cacheTime: Infinity,
+  });
+
+  // Extract trace IDs from search results
+  const traceIds = traces
+    .map((trace) => trace.trace_id)
+    .filter((id): id is string => Boolean(id))
+    .slice(0, traceCount);
+
+  return traceIds;
+};
+
+export const useGetTraceIdsForEvaluation = () => {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (params: EvaluateTracesParams) => {
+      const { traceCount = 0, locations, traceIds } = params;
+      if (traceIds && !isEmpty(traceIds)) {
+        return traceIds;
+      }
+      const fetchedTraceIds = await fetchTracesAndGetIds(queryClient, {
+        locations,
+        traceCount,
+      });
+      return fetchedTraceIds;
+    },
+    [queryClient],
+  );
+};


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19532/files) to review incremental changes.
- [**stack/select-traces-for-scorers-part2**](https://github.com/mlflow/mlflow/pull/19532) [[Files changed](https://github.com/mlflow/mlflow/pull/19532/files)]
  - [stack/select-traces-for-scorers-part3](https://github.com/mlflow/mlflow/pull/19533) [[Files changed](https://github.com/mlflow/mlflow/pull/19533/files/03d548e5a5631a2b97fd7d28d559c3a91eb16a7b..760a0d614bdf11e0a14463912c7694ae8b345276)]
    - [stack/select-traces-for-scorers-part4](https://github.com/mlflow/mlflow/pull/19534) [[Files changed](https://github.com/mlflow/mlflow/pull/19534/files/760a0d614bdf11e0a14463912c7694ae8b345276..1bdba43feea5feafb25d0f30762329c03b682b3b)]
      - [stack/select-traces-for-scorers-part5](https://github.com/mlflow/mlflow/pull/19568) [[Files changed](https://github.com/mlflow/mlflow/pull/19568/files/1bdba43feea5feafb25d0f30762329c03b682b3b..535dfabd29e11607f794656190290b25661703d2)]

---------
### What changes are proposed in this pull request?

This PR refactors the trace evaluation system to support both trace count and explicit trace IDs. Key changes include:
- Added new TypeScript types for trace selection and evaluation in `types.ts`
- Created `useGetTracesForEvaluation` hook to fetch traces based on either count or explicit IDs
- Refactored `useEvaluateTraces` hook to work with the new trace selection approach
- Updated `SampleScorerOutputPanelContainer` and `SampleScorerOutputPanelRenderer` to use the new API
- Modified `SampleScorerTracesToEvaluatePicker` to support the new trace selection model
- Updated tests

#### Manual regression test

https://github.com/user-attachments/assets/7af72335-de68-4e42-b6b8-82a9998a03d9

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
