### PR TITLE
Cherry picking traces for testing new scorer [Part 3/x] Traces selector and table

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.test.tsx
@@ -1,0 +1,112 @@
+import { describe, jest, test, expect, beforeEach, beforeAll } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { SelectTracesModal } from './SelectTracesModal';
+import { useGenAiTraceTableRowSelection } from '../../shared/web-shared/genai-traces-table/hooks/useGenAiTraceTableRowSelection';
+import { TracesV3Logs } from './experiment-page/components/traces-v3/TracesV3Logs';
+import { TestRouter, testRoute } from '../../common/utils/RoutingTestUtils';
+
+// Mock TracesV3Logs to keep this test simple
+jest.mock('./experiment-page/components/traces-v3/TracesV3Logs', () => ({
+  TracesV3Logs: jest.fn(),
+}));
+
+const testExperimentId = 'test-experiment-123';
+
+describe('SelectTracesModal', () => {
+  beforeAll(() => {
+    // Mock the TracesV3Logs component to return a simple mock traces table
+    const MockTracesV3Logs = ({ experimentId }: { experimentId: string; endpointName: string }) => {
+      const { rowSelection, setRowSelection } = useGenAiTraceTableRowSelection();
+
+      // A few traces and checkboxes
+      const mockTraces = [
+        { id: 'trace-1', name: 'Trace 1' },
+        { id: 'trace-2', name: 'Trace 2' },
+        { id: 'trace-3', name: 'Trace 3' },
+      ];
+
+      return (
+        <div data-testid="mock-traces-table">
+          <div data-testid="experiment-id">{experimentId}</div>
+          {mockTraces.map((trace) => (
+            <label key={trace.id} data-testid={`trace-row-${trace.id}`}>
+              <input
+                type="checkbox"
+                checked={Boolean(rowSelection[trace.id])}
+                onChange={(e) => {
+                  setRowSelection((prev: Record<string, boolean>) => ({
+                    ...prev,
+                    [trace.id]: e.target.checked,
+                  }));
+                }}
+                data-testid={`checkbox-${trace.id}`}
+              />
+              {trace.name}
+            </label>
+          ))}
+        </div>
+      );
+    };
+    jest.mocked(TracesV3Logs).mockImplementation(MockTracesV3Logs as any);
+  });
+
+  const renderTestComponent = (props: { onClose?: () => void; onSuccess?: (traceIds: string[]) => void }) => {
+    return render(
+      <IntlProvider locale="en">
+        <TestRouter
+          routes={[
+            testRoute(
+              <DesignSystemProvider>
+                <SelectTracesModal {...props} />
+              </DesignSystemProvider>,
+              '/experiments/:experimentId',
+            ),
+          ]}
+          initialEntries={[`/experiments/${testExperimentId}`]}
+        />
+      </IntlProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should call onSuccess with selected trace IDs when OK is clicked', async () => {
+    const onSuccessMock = jest.fn();
+    renderTestComponent({ onSuccess: onSuccessMock });
+
+    // Select two traces
+    await userEvent.click(screen.getByTestId('checkbox-trace-1'));
+    await userEvent.click(screen.getByTestId('checkbox-trace-2'));
+
+    // Click the Select button
+    const selectButton = screen.getByRole('button', { name: /select/i });
+    await userEvent.click(selectButton);
+
+    // Verify onSuccess was called with the selected trace IDs
+    expect(onSuccessMock).toHaveBeenCalledTimes(1);
+    expect(onSuccessMock).toHaveBeenCalledWith(['trace-1', 'trace-2']);
+  });
+
+  test('should disable OK button if all traces are deselected', async () => {
+    renderTestComponent({});
+
+    // Select a trace
+    await userEvent.click(screen.getByTestId('checkbox-trace-1'));
+
+    // The Select button should be enabled
+    let selectButton = screen.getByRole('button', { name: /select/i });
+    expect(selectButton).toBeEnabled();
+
+    // Deselect the trace
+    await userEvent.click(screen.getByTestId('checkbox-trace-1'));
+
+    // The Select button should be disabled again
+    selectButton = screen.getByRole('button', { name: /select/i });
+    expect(selectButton).toBeDisabled();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
@@ -1,5 +1,5 @@
 import { Modal } from '@databricks/design-system';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useParams } from '../../common/utils/RoutingUtils';
 import { TracesV3Logs } from './experiment-page/components/traces-v3/TracesV3Logs';
@@ -9,9 +9,11 @@ import { TracesTableColumn } from '../../shared/web-shared/genai-traces-table';
 export const SelectTracesModal = ({
   onClose,
   onSuccess,
+  maxTraceCount,
 }: {
   onClose?: () => void;
   onSuccess?: (traceIds: string[]) => void;
+  maxTraceCount?: number;
   customDefaultSelectedColumns?: (column: TracesTableColumn) => boolean;
 }) => {
   const { experimentId } = useParams();
@@ -24,6 +26,14 @@ export const SelectTracesModal = ({
       .map(([traceId]) => traceId);
     onSuccess?.(selectedTraceIds);
   };
+
+  const isMaxTraceCountReached = useMemo(() => {
+    if (!maxTraceCount) {
+      return false;
+    }
+
+    return Object.values(rowSelection).filter((isSelected) => isSelected).length > maxTraceCount;
+  }, [maxTraceCount, rowSelection]);
 
   if (!experimentId) {
     return null;
@@ -41,7 +51,7 @@ export const SelectTracesModal = ({
       okText={<FormattedMessage defaultMessage="Select" description="Confirm button in the select traces modal" />}
       okButtonProps={{
         type: 'primary',
-        disabled: Object.values(rowSelection).every((isSelected) => !isSelected),
+        disabled: Object.values(rowSelection).every((isSelected) => !isSelected) || isMaxTraceCountReached,
       }}
       onOk={handleOk}
       cancelText={<FormattedMessage defaultMessage="Cancel" description="Cancel button in the select traces modal" />}

--- a/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
@@ -32,8 +32,8 @@ export const SelectTracesModal = ({
   return (
     <Modal
       visible
-      title="Select traces" // TODO
-      componentId="TODO"
+      title={<FormattedMessage defaultMessage="Select traces" description="Title for the select traces modal" />}
+      componentId="mlflow.experiment-scorers.form.select-traces-modal"
       onCancel={onClose}
       css={{ width: '90% !important' }}
       size="wide"

--- a/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
@@ -1,0 +1,54 @@
+import { Modal } from '@databricks/design-system';
+import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { useParams } from '../../common/utils/RoutingUtils';
+import { TracesV3Logs } from './experiment-page/components/traces-v3/TracesV3Logs';
+import { GenAiTraceTableRowSelectionProvider } from '../../shared/web-shared/genai-traces-table/hooks/useGenAiTraceTableRowSelection';
+import { TracesTableColumn } from '../../shared/web-shared/genai-traces-table';
+
+export const SelectTracesModal = ({
+  onClose,
+  onSuccess,
+}: {
+  onClose?: () => void;
+  onSuccess?: (traceIds: string[]) => void;
+  customDefaultSelectedColumns?: (column: TracesTableColumn) => boolean;
+}) => {
+  const { experimentId } = useParams();
+
+  const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
+
+  const handleOk = async () => {
+    const selectedTraceIds = Object.entries(rowSelection)
+      .filter(([_, isSelected]) => isSelected)
+      .map(([traceId]) => traceId);
+    onSuccess?.(selectedTraceIds);
+  };
+
+  if (!experimentId) {
+    return null;
+  }
+
+  return (
+    <Modal
+      visible
+      title="Select traces" // TODO
+      componentId="TODO"
+      onCancel={onClose}
+      css={{ width: '90% !important' }}
+      size="wide"
+      verticalSizing="maxed_out"
+      okText={<FormattedMessage defaultMessage="Select" description="Confirm button in the select traces modal" />}
+      okButtonProps={{
+        type: 'primary',
+        disabled: Object.values(rowSelection).every((isSelected) => !isSelected),
+      }}
+      onOk={handleOk}
+      cancelText={<FormattedMessage defaultMessage="Cancel" description="Cancel button in the select traces modal" />}
+    >
+      <GenAiTraceTableRowSelectionProvider rowSelection={rowSelection} setRowSelection={setRowSelection}>
+        <TracesV3Logs endpointName="" experimentId={experimentId} />
+      </GenAiTraceTableRowSelectionProvider>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
@@ -11,6 +11,7 @@ import { EvaluateTracesParams } from './types';
 import { isEmpty } from 'lodash';
 import { useMemo, useState } from 'react';
 import { coerceToEnum } from '../../../shared/web-shared/utils';
+import { SelectTracesModal } from '../../components/SelectTracesModal';
 
 enum PickerOption {
   'LAST_TRACE' = '1',
@@ -90,13 +91,31 @@ export const SampleScorerTracesToEvaluatePicker = ({
                 <FormattedMessage {...PickerOptionsLabels[value]} />
               </DialogComboboxOptionListSelectItem>
             ))}
-            {/* TODO(next PRs): Add custom trace selection option */}
+            <DialogComboboxOptionListSelectItem
+              value={PickerOption.CUSTOM}
+              checked={itemsToEvaluateDropdownValue === PickerOption.CUSTOM}
+              onChange={() => {
+                setDisplayPickCustomTracesModal(true);
+              }}
+            >
+              <FormattedMessage {...PickerOptionsLabels[PickerOption.CUSTOM]} />
+            </DialogComboboxOptionListSelectItem>
           </DialogComboboxOptionList>
         </DialogComboboxContent>
       </DialogCombobox>
       {displayPickCustomTracesModal && (
-        // TODO(next PRs): Add custom trace selection modal
-        <div />
+        <SelectTracesModal
+          onClose={() => {
+            onItemsToEvaluateChange({ ...itemsToEvaluate });
+            setDisplayPickCustomTracesModal(false);
+          }}
+          onSuccess={(traceIds) => {
+            if (!isEmpty(traceIds)) {
+              onItemsToEvaluateChange({ itemCount: undefined, itemIds: traceIds });
+            }
+            setDisplayPickCustomTracesModal(false);
+          }}
+        />
       )}
     </>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
@@ -58,7 +58,7 @@ export const SampleScorerTracesToEvaluatePicker = ({
     <>
       <DialogCombobox
         componentId="mlflow.experiment-scorers.form.traces-picker"
-        id="TODO"
+        id="mlflow.experiment-scorers.form.traces-picker"
         value={[itemsToEvaluateDropdownValue]}
       >
         <DialogComboboxCustomButtonTriggerWrapper>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3744,6 +3744,10 @@
     "defaultMessage": "<link>Version {versionNumber}</link>",
     "description": "Row entry for version columns in the registered model page"
   },
+  "U0joaT": {
+    "defaultMessage": "Select traces",
+    "description": "Title for the select traces modal"
+  },
   "U3btBc": {
     "defaultMessage": "Examples:",
     "description": "Text header for examples of mlflow search syntax"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -31,6 +31,10 @@
     "defaultMessage": "Follow these steps to enable the AI Gateway feature for managing AI provider credentials.",
     "description": "AI Gateway setup guide > Subtitle"
   },
+  "+9xfKv": {
+    "defaultMessage": "Select",
+    "description": "Confirm button in the select traces modal"
+  },
   "+CGMk6": {
     "defaultMessage": "On",
     "description": "Telemetry enabled label"
@@ -5242,6 +5246,10 @@
   "frPtD/": {
     "defaultMessage": "Metrics",
     "description": "Row group title for metrics of runs on the experiment compare runs page"
+  },
+  "fscXHt": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel button in the select traces modal"
   },
   "fsga0A": {
     "defaultMessage": "Connected resources ({count})",

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.tsx
@@ -1,4 +1,4 @@
-import type { RowSelectionState } from '@tanstack/react-table';
+import type { RowSelectionState, Updater } from '@tanstack/react-table';
 import React, { useState, useMemo, useCallback } from 'react';
 
 import { useDesignSystemTheme } from '@databricks/design-system';
@@ -21,6 +21,7 @@ import type {
 import { sortAssessmentInfos } from './utils/AggregationUtils';
 import { shouldEnableTagGrouping } from './utils/FeatureUtils';
 import { applyTraceInfoV3ToEvalEntry, DEFAULT_RUN_PLACEHOLDER_NAME } from './utils/TraceUtils';
+import { useGenAiTraceTableRowSelection } from './hooks/useGenAiTraceTableRowSelection';
 
 interface GenAITracesTableBodyContainerProps {
   // Experiment metadata
@@ -120,7 +121,7 @@ const GenAITracesTableBodyContainerImpl: React.FC<React.PropsWithChildren<GenAIT
       [compareToTraceInfoV3],
     );
 
-    const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+    const { rowSelection, setRowSelection } = useGenAiTraceTableRowSelection();
 
     // Handle assessment filter toggle
     const handleAssessmentFilterToggle = useCallback(

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useGenAiTraceTableRowSelection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useGenAiTraceTableRowSelection.tsx
@@ -1,0 +1,40 @@
+import { RowSelectionState } from '@tanstack/react-table';
+import { createContext, SetStateAction, useContext, useState } from 'react';
+
+export const useGenAiTraceTableRowSelection = () => {
+  const context = useContext(GenAiTraceTableRowSelectionContext);
+
+  // In a regular use case, we use the local state to manage the row selection.
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+  // However, if context is provided, we use the context to manage the row selection.
+  if (context) {
+    return context;
+  }
+  return { rowSelection, setRowSelection };
+};
+
+const GenAiTraceTableRowSelectionContext = createContext<{
+  rowSelection: RowSelectionState;
+  setRowSelection: (rowSelection: SetStateAction<RowSelectionState>) => void;
+} | null>(null);
+
+/**
+ * Use this provider to manage selected rows across the table using a context.
+ * If not used, the consumers of `useGenAiTraceTableRowSelection()` will use the local state to manage the row selection.
+ */
+export const GenAiTraceTableRowSelectionProvider = ({
+  children,
+  rowSelection,
+  setRowSelection,
+}: {
+  children: React.ReactNode;
+  rowSelection: RowSelectionState;
+  setRowSelection: (rowSelection: SetStateAction<RowSelectionState>) => void;
+}) => {
+  return (
+    <GenAiTraceTableRowSelectionContext.Provider value={{ rowSelection, setRowSelection }}>
+      {children}
+    </GenAiTraceTableRowSelectionContext.Provider>
+  );
+};


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19533/files) to review incremental changes.
- [**stack/select-traces-for-scorers-part3**](https://github.com/mlflow/mlflow/pull/19533) [[Files changed](https://github.com/mlflow/mlflow/pull/19533/files)]
  - [stack/select-traces-for-scorers-part4](https://github.com/mlflow/mlflow/pull/19534) [[Files changed](https://github.com/mlflow/mlflow/pull/19534/files/62f18c147366dfe335a24a76c5c9e144931d1313..3f62264a2e89a66c532f12e524bdeadb7f499b53)]
    - [stack/select-traces-for-scorers-part5](https://github.com/mlflow/mlflow/pull/19639) [[Files changed](https://github.com/mlflow/mlflow/pull/19639/files/3f62264a2e89a66c532f12e524bdeadb7f499b53..b80e0d4a71f3e576e4118bae824a2d15fc327cee)]
      - [stack/select-traces-for-scorers-part6](https://github.com/mlflow/mlflow/pull/19640) [[Files changed](https://github.com/mlflow/mlflow/pull/19640/files/b80e0d4a71f3e576e4118bae824a2d15fc327cee..4ef7daaca957437ec319f6b4345a3daa68dd0643)]
        - [stack/select-traces-for-scorers-part7](https://github.com/mlflow/mlflow/pull/19641) [[Files changed](https://github.com/mlflow/mlflow/pull/19641/files/4ef7daaca957437ec319f6b4345a3daa68dd0643..82bb484aa18f0ff3cf03cc1dbfc485db6bec768d)]
          - [stack/select-traces-for-scorers-part8](https://github.com/mlflow/mlflow/pull/19642) [[Files changed](https://github.com/mlflow/mlflow/pull/19642/files/82bb484aa18f0ff3cf03cc1dbfc485db6bec768d..988ea39f0c2e33f9e5844a0c9c69278b9825748c)]

---------
### What changes are proposed in this pull request?

This PR implements a modal-based trace selection interface for the scorer evaluation workflow. This feature allows users to manually select specific traces from a table view for evaluation. Key changes include:
- Created new `SelectTracesModal` component with full test coverage that provides a modal dialog for trace selection
- Added `useGenAiTraceTableRowSelection` hook to manage trace row selection state in the traces table
- Integrated the modal into `SampleScorerTracesToEvaluatePicker` to allow switching between count-based and manual selection modes
- Updated `GenAITracesTableBodyContainer` to support row selection functionality

### Demo video

https://github.com/user-attachments/assets/187ae3ea-f559-4291-a2b7-f4649abad75d

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
