### PR TITLE
Cherry picking traces for testing new scorer [Part 4/x] Default selected columns, persist row selection

### DIFF
--- a/mlflow/server/js/src/common/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/common/utils/FeatureUtils.ts
@@ -57,6 +57,16 @@ export const isRunningScorersEnabled = () => {
 };
 
 /**
+ * Determines if running scorers feature is enabled (ability to run LLM scorers on sample traces)
+ */
+export const isEvaluatingSessionsInScorersEnabled = () => {
+  if (!enableScorersUI() || !isRunningScorersEnabled()) {
+    return false;
+  }
+  return false;
+};
+
+/**
  * Determines if experiment kind inference is enabled.
  */
 export const shouldEnableExperimentKindInference = () => true;

--- a/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
@@ -3,22 +3,45 @@ import { useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useParams } from '../../common/utils/RoutingUtils';
 import { TracesV3Logs } from './experiment-page/components/traces-v3/TracesV3Logs';
-import { GenAiTraceTableRowSelectionProvider } from '../../shared/web-shared/genai-traces-table/hooks/useGenAiTraceTableRowSelection';
-import { TracesTableColumn } from '../../shared/web-shared/genai-traces-table';
+import { GenAiTraceTableRowSelectionProvider } from '@databricks/web-shared/genai-traces-table/hooks/useGenAiTraceTableRowSelection';
+import {
+  TRACE_ID_COLUMN_ID,
+  TracesTableColumn,
+  TracesTableColumnType,
+} from '@databricks/web-shared/genai-traces-table';
+import { INPUTS_COLUMN_ID, RESPONSE_COLUMN_ID } from '@databricks/web-shared/genai-traces-table/hooks/useTableColumns';
+
+/**
+ * Default columns to be visible when selecting traces.
+ */
+const defaultCustomDefaultSelectedColumns = (column: TracesTableColumn) => {
+  if (column.type === TracesTableColumnType.ASSESSMENT || column.type === TracesTableColumnType.EXPECTATION) {
+    return true;
+  }
+  return [TRACE_ID_COLUMN_ID, INPUTS_COLUMN_ID, RESPONSE_COLUMN_ID].includes(column.id);
+};
 
 export const SelectTracesModal = ({
   onClose,
   onSuccess,
   maxTraceCount,
+  customDefaultSelectedColumns = defaultCustomDefaultSelectedColumns,
+  initialTraceIdsSelected = [],
 }: {
   onClose?: () => void;
   onSuccess?: (traceIds: string[]) => void;
   maxTraceCount?: number;
   customDefaultSelectedColumns?: (column: TracesTableColumn) => boolean;
+  initialTraceIdsSelected?: string[];
 }) => {
   const { experimentId } = useParams();
 
-  const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
+  const [rowSelection, setRowSelection] = useState<Record<string, boolean>>(
+    initialTraceIdsSelected.reduce((acc, traceId) => {
+      acc[traceId] = true;
+      return acc;
+    }, {} as Record<string, boolean>),
+  );
 
   const handleOk = async () => {
     const selectedTraceIds = Object.entries(rowSelection)
@@ -57,7 +80,11 @@ export const SelectTracesModal = ({
       cancelText={<FormattedMessage defaultMessage="Cancel" description="Cancel button in the select traces modal" />}
     >
       <GenAiTraceTableRowSelectionProvider rowSelection={rowSelection} setRowSelection={setRowSelection}>
-        <TracesV3Logs endpointName="" experimentId={experimentId} />
+        <TracesV3Logs
+          disableActions
+          experimentId={experimentId}
+          customDefaultSelectedColumns={customDefaultSelectedColumns}
+        />
       </GenAiTraceTableRowSelectionProvider>
     </Modal>
   );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -58,16 +58,20 @@ const ContextProviders = ({
 const TracesV3LogsImpl = React.memo(
   ({
     experimentId,
-    endpointName,
+    endpointName = '',
     timeRange,
     isLoadingExperiment,
     loggedModelId,
+    disableActions = false,
+    customDefaultSelectedColumns,
   }: {
     experimentId: string;
-    endpointName: string;
+    endpointName?: string;
     timeRange?: { startTime: string | undefined; endTime: string | undefined };
     isLoadingExperiment?: boolean;
     loggedModelId?: string;
+    disableActions?: boolean;
+    customDefaultSelectedColumns?: (column: TracesTableColumn) => boolean;
   }) => {
     const makeHtmlFromMarkdown = useMarkdownConverter();
     const intl = useIntl();
@@ -113,7 +117,9 @@ const TracesV3LogsImpl = React.memo(
     const defaultSelectedColumns = useCallback(
       (allColumns: TracesTableColumn[]) => {
         const { responseHasContent, inputHasContent, tokensHasContent } = checkColumnContents(evaluatedTraces);
-
+        if (customDefaultSelectedColumns) {
+          return allColumns.filter(customDefaultSelectedColumns);
+        }
         return allColumns.filter(
           (col) =>
             col.type === TracesTableColumnType.ASSESSMENT ||
@@ -128,7 +134,7 @@ const TracesV3LogsImpl = React.memo(
             col.type === TracesTableColumnType.INTERNAL_MONITOR_REQUEST_TIME,
         );
       },
-      [evaluatedTraces],
+      [evaluatedTraces, customDefaultSelectedColumns],
     );
 
     const { selectedColumns, toggleColumns, setSelectedColumns } = useSelectedColumns(
@@ -192,6 +198,13 @@ const TracesV3LogsImpl = React.memo(
       });
 
     const traceActions: TraceActions = useMemo(() => {
+      if (disableActions) {
+        return {
+          deleteTracesAction: undefined,
+          exportToEvals: undefined,
+          editTags: undefined,
+        };
+      }
       return {
         deleteTracesAction,
         exportToEvals: {
@@ -219,6 +232,7 @@ const TracesV3LogsImpl = React.memo(
       EditTagsModalUnified,
       showEditTagsModalForTrace,
       EditTagsModal,
+      disableActions,
     ]);
 
     const countInfo = useMemo(() => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
@@ -13,9 +13,12 @@ import {
 import { FormattedMessage } from '@databricks/i18n';
 import { SimplifiedModelTraceExplorer } from '@databricks/web-shared/model-trace-explorer';
 import type { Assessment, ModelTrace } from '@databricks/web-shared/model-trace-explorer';
-import { COMPONENT_ID_PREFIX, BUTTON_VARIANT, type ButtonVariant } from './constants';
+import { COMPONENT_ID_PREFIX, BUTTON_VARIANT, type ButtonVariant, ScorerEvaluationScope } from './constants';
 import { EvaluateTracesParams } from './types';
 import { SampleScorerTracesToEvaluatePicker } from './SampleScorerTracesToEvaluatePicker';
+import { useFormContext } from 'react-hook-form';
+import { ScorerFormData } from './utils/scorerTransformUtils';
+import { coerceToEnum } from '../../../shared/web-shared/utils';
 
 /**
  * Run scorer button component.
@@ -92,6 +95,9 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
 
   // Whether we are showing a trace or the initial screen
   const isInitialScreen = !currentTrace;
+
+  const { watch } = useFormContext<ScorerFormData>();
+  const evaluationScope = coerceToEnum(ScorerEvaluationScope, watch('evaluationScope'), ScorerEvaluationScope.TRACES);
 
   return (
     <div
@@ -248,12 +254,17 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
               </div>
             )}
             <Typography.Text size="lg" color="secondary" bold css={{ margin: 0, marginBottom: theme.spacing.xs }}>
-              <FormattedMessage defaultMessage="Run judge on traces" description="Title for running judge on traces" />
+              <FormattedMessage
+                defaultMessage="Run judge on {isTraces, select, true {traces} other {sessions}}"
+                description="Title for running judge on traces or sessions"
+                values={{ isTraces: evaluationScope === ScorerEvaluationScope.TRACES }}
+              />
             </Typography.Text>
             <Typography.Text color="secondary" css={{ margin: 0, marginBottom: theme.spacing.md }}>
               <FormattedMessage
-                defaultMessage="Run the judge on the selected group of traces"
-                description="Description for running judge on traces"
+                defaultMessage="Run the judge on the selected group of {isTraces, select, true {traces} other {sessions}}"
+                description="Description for running judge on traces or sessions"
+                values={{ isTraces: evaluationScope === ScorerEvaluationScope.TRACES }}
               />
             </Typography.Text>
             <Tooltip

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
@@ -167,6 +167,13 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
               }}
             >
               <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+                <Typography.Text size="sm" color="secondary">
+                  <FormattedMessage
+                    defaultMessage="Trace {index} of {total}"
+                    description="Index of the current trace and total number of traces"
+                    values={{ index: currentTraceIndex + 1, total: totalTraces }}
+                  />
+                </Typography.Text>
                 <Button
                   componentId={`${COMPONENT_ID_PREFIX}.previous-trace-button`}
                   size="small"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
@@ -115,6 +115,7 @@ export const SampleScorerTracesToEvaluatePicker = ({
             }
             setDisplayPickCustomTracesModal(false);
           }}
+          initialTraceIdsSelected={itemsToEvaluate.itemIds}
         />
       )}
     </>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
@@ -12,29 +12,51 @@ import { isEmpty } from 'lodash';
 import { useMemo, useState } from 'react';
 import { coerceToEnum } from '../../../shared/web-shared/utils';
 import { SelectTracesModal } from '../../components/SelectTracesModal';
+import { ScorerFormData } from './utils/scorerTransformUtils';
+import { useFormContext } from 'react-hook-form';
+import { ScorerEvaluationScope } from './constants';
 
 enum PickerOption {
-  'LAST_TRACE' = '1',
-  'LAST_5_TRACES' = '5',
-  'LAST_10_TRACES' = '10',
+  'LAST_TRACE_OR_SESSION' = '1',
+  'LAST_5_TRACES_OR_SESSIONS' = '5',
+  'LAST_10_TRACES_OR_SESSIONS' = '10',
   'CUSTOM' = 'custom',
 }
 
-const PickerOptionsLabels = {
-  [PickerOption.LAST_TRACE]: defineMessage({
+const PickerOptionsLabelsForTraces = {
+  [PickerOption.LAST_TRACE_OR_SESSION]: defineMessage({
     defaultMessage: 'Last trace',
     description: 'Option for last trace',
   }),
-  [PickerOption.LAST_5_TRACES]: defineMessage({
+  [PickerOption.LAST_5_TRACES_OR_SESSIONS]: defineMessage({
     defaultMessage: 'Last 5 traces',
     description: 'Option for last 5 traces',
   }),
-  [PickerOption.LAST_10_TRACES]: defineMessage({
+  [PickerOption.LAST_10_TRACES_OR_SESSIONS]: defineMessage({
     defaultMessage: 'Last 10 traces',
     description: 'Option for last 10 traces',
   }),
   [PickerOption.CUSTOM]: defineMessage({
     defaultMessage: 'Select traces',
+    description: 'Option for selecting custom traces',
+  }),
+};
+
+const PickerOptionsLabelsForSessions = {
+  [PickerOption.LAST_TRACE_OR_SESSION]: defineMessage({
+    defaultMessage: 'Last session',
+    description: 'Option for last session',
+  }),
+  [PickerOption.LAST_5_TRACES_OR_SESSIONS]: defineMessage({
+    defaultMessage: 'Last 5 sessions',
+    description: 'Option for last 5 sessions',
+  }),
+  [PickerOption.LAST_10_TRACES_OR_SESSIONS]: defineMessage({
+    defaultMessage: 'Last 10 sessions',
+    description: 'Option for last 10 sessions',
+  }),
+  [PickerOption.CUSTOM]: defineMessage({
+    defaultMessage: 'Select sessions',
     description: 'Option for selecting custom traces',
   }),
 };
@@ -46,12 +68,19 @@ export const SampleScorerTracesToEvaluatePicker = ({
   itemsToEvaluate: Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>;
   onItemsToEvaluateChange: (itemsToEvaluate: Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>) => void;
 }) => {
+  const { watch } = useFormContext<ScorerFormData>();
+
+  const evaluationScope = coerceToEnum(ScorerEvaluationScope, watch('evaluationScope'), ScorerEvaluationScope.TRACES);
+
+  const PickerOptionsLabels =
+    evaluationScope === ScorerEvaluationScope.TRACES ? PickerOptionsLabelsForTraces : PickerOptionsLabelsForSessions;
+
   const [displayPickCustomTracesModal, setDisplayPickCustomTracesModal] = useState(false);
   const itemsToEvaluateDropdownValue = useMemo(() => {
     if (!isEmpty(itemsToEvaluate.itemIds)) {
       return PickerOption.CUSTOM;
     }
-    return coerceToEnum(PickerOption, String(itemsToEvaluate.itemCount), PickerOption.LAST_10_TRACES);
+    return coerceToEnum(PickerOption, String(itemsToEvaluate.itemCount), PickerOption.LAST_10_TRACES_OR_SESSIONS);
   }, [itemsToEvaluate]);
 
   return (
@@ -80,7 +109,11 @@ export const SampleScorerTracesToEvaluatePicker = ({
         </DialogComboboxCustomButtonTriggerWrapper>
         <DialogComboboxContent align="end">
           <DialogComboboxOptionList>
-            {[PickerOption.LAST_TRACE, PickerOption.LAST_5_TRACES, PickerOption.LAST_10_TRACES].map((value) => (
+            {[
+              PickerOption.LAST_TRACE_OR_SESSION,
+              PickerOption.LAST_5_TRACES_OR_SESSIONS,
+              PickerOption.LAST_10_TRACES_OR_SESSIONS,
+            ].map((value) => (
               <DialogComboboxOptionListSelectItem
                 value={value}
                 checked={itemsToEvaluateDropdownValue === value}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerFormCreateContainer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerFormCreateContainer.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
-import { useForm, useWatch } from 'react-hook-form';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { isRunningScorersEnabled } from '../../../common/utils/FeatureUtils';
 import { useCreateScheduledScorerMutation } from './hooks/useCreateScheduledScorer';
 import { convertFormDataToScheduledScorer, type ScorerFormData } from './utils/scorerTransformUtils';
 import ScorerFormRenderer from './ScorerFormRenderer';
-import { SCORER_FORM_MODE } from './constants';
+import { SCORER_FORM_MODE, ScorerEvaluationScope } from './constants';
 
 interface ScorerFormCreateContainerProps {
   experimentId: string;
@@ -21,7 +21,7 @@ const ScorerFormCreateContainer: React.FC<ScorerFormCreateContainerProps> = ({ e
   // Hook for creating scorer
   const createScorerMutation = useCreateScheduledScorerMutation();
 
-  const { handleSubmit, control, reset, setValue, getValues } = useForm<ScorerFormData>({
+  const form = useForm<ScorerFormData>({
     mode: 'onChange', // Enable real-time validation
     defaultValues: {
       scorerType: 'llm',
@@ -32,8 +32,11 @@ const ScorerFormCreateContainer: React.FC<ScorerFormCreateContainerProps> = ({ e
       model: '',
       disableMonitoring: true,
       isInstructionsJudge: true, // Custom template is an instructions judge
+      evaluationScope: ScorerEvaluationScope.TRACES,
     },
   });
+
+  const { handleSubmit, control, reset, setValue, getValues } = form;
 
   // Watch the scorer type from form data
   const scorerType = useWatch({ control, name: 'scorerType' });
@@ -96,20 +99,22 @@ const ScorerFormCreateContainer: React.FC<ScorerFormCreateContainerProps> = ({ e
         flexDirection: 'column',
       }}
     >
-      <ScorerFormRenderer
-        mode={SCORER_FORM_MODE.CREATE}
-        handleSubmit={handleSubmit}
-        onFormSubmit={onFormSubmit}
-        control={control}
-        setValue={setValue}
-        getValues={getValues}
-        scorerType={scorerType}
-        mutation={createScorerMutation}
-        componentError={componentError}
-        handleCancel={handleCancel}
-        isSubmitButtonDisabled={isSubmitButtonDisabled}
-        experimentId={experimentId}
-      />
+      <FormProvider {...form}>
+        <ScorerFormRenderer
+          mode={SCORER_FORM_MODE.CREATE}
+          handleSubmit={handleSubmit}
+          onFormSubmit={onFormSubmit}
+          control={control}
+          setValue={setValue}
+          getValues={getValues}
+          scorerType={scorerType}
+          mutation={createScorerMutation}
+          componentError={componentError}
+          handleCancel={handleCancel}
+          isSubmitButtonDisabled={isSubmitButtonDisabled}
+          experimentId={experimentId}
+        />
+      </FormProvider>
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerFormEditContainer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerFormEditContainer.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
-import { useForm, useWatch } from 'react-hook-form';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { isRunningScorersEnabled } from '../../../common/utils/FeatureUtils';
 import { useUpdateScheduledScorerMutation } from './hooks/useUpdateScheduledScorer';
 import { convertFormDataToScheduledScorer, type ScorerFormData } from './utils/scorerTransformUtils';
 import { getFormValuesFromScorer } from './scorerCardUtils';
 import ScorerFormRenderer from './ScorerFormRenderer';
 import type { ScheduledScorer } from './types';
-import { SCORER_FORM_MODE } from './constants';
+import { SCORER_FORM_MODE, ScorerEvaluationScope } from './constants';
 
 interface ScorerFormEditContainerProps {
   experimentId: string;
@@ -24,10 +24,12 @@ const ScorerFormEditContainer: React.FC<ScorerFormEditContainerProps> = ({ exper
   // Hook for updating scorer
   const updateScorerMutation = useUpdateScheduledScorerMutation();
 
-  const { handleSubmit, control, reset, setValue, getValues, formState } = useForm<ScorerFormData>({
+  const form = useForm<ScorerFormData>({
     mode: 'onChange', // Enable real-time validation
     defaultValues: getFormValuesFromScorer(existingScorer),
   });
+
+  const { handleSubmit, control, reset, setValue, getValues, formState } = form;
 
   // Watch the scorer type from form data
   const scorerType = useWatch({ control, name: 'scorerType' });
@@ -95,20 +97,22 @@ const ScorerFormEditContainer: React.FC<ScorerFormEditContainerProps> = ({ exper
         flexDirection: 'column',
       }}
     >
-      <ScorerFormRenderer
-        mode={SCORER_FORM_MODE.EDIT}
-        handleSubmit={handleSubmit}
-        onFormSubmit={onFormSubmit}
-        control={control}
-        setValue={setValue}
-        getValues={getValues}
-        scorerType={scorerType}
-        mutation={updateScorerMutation}
-        componentError={componentError}
-        handleCancel={handleCancel}
-        isSubmitButtonDisabled={isSubmitButtonDisabled}
-        experimentId={experimentId}
-      />
+      <FormProvider {...form}>
+        <ScorerFormRenderer
+          mode={SCORER_FORM_MODE.EDIT}
+          handleSubmit={handleSubmit}
+          onFormSubmit={onFormSubmit}
+          control={control}
+          setValue={setValue}
+          getValues={getValues}
+          scorerType={scorerType}
+          mutation={updateScorerMutation}
+          componentError={componentError}
+          handleCancel={handleCancel}
+          isSubmitButtonDisabled={isSubmitButtonDisabled}
+          experimentId={experimentId}
+        />
+      </FormProvider>
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerFormEvaluationScopeSelect.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerFormEvaluationScopeSelect.tsx
@@ -1,0 +1,52 @@
+import { FormUI, Radio, RHFControlledComponents, Spacer } from '@databricks/design-system';
+import { useFormContext } from 'react-hook-form';
+import { ScorerFormData } from './utils/scorerTransformUtils';
+import { FormattedMessage } from 'react-intl';
+import { ScorerEvaluationScope } from './constants';
+
+export const ScorerFormEvaluationScopeSelect = () => {
+  const { control } = useFormContext<ScorerFormData>();
+
+  return (
+    <>
+      <FormUI.Label>
+        <FormattedMessage
+          defaultMessage="Select scope"
+          description="Label for the scorer evaluation scope/level selection (either traces or sessions)"
+        />
+      </FormUI.Label>
+      <FormUI.Hint>
+        <FormattedMessage
+          defaultMessage="What do you want the scorer to evaluate?"
+          description="Hint for the scorer evaluation scope selection"
+        />
+      </FormUI.Hint>
+      <RHFControlledComponents.RadioGroup
+        componentId="mlflow.experiment-scorers.form.scope-select"
+        id="mlflow.experiment-scorers.form.scope-select"
+        control={control}
+        name="evaluationScope"
+      >
+        <Radio value={ScorerEvaluationScope.TRACES}>
+          <FormattedMessage defaultMessage="Traces" description="Label for the scorer evaluation scope selection" />
+          <FormUI.Hint>
+            <FormattedMessage
+              defaultMessage="Use a large language model to automatically evaluate traces."
+              description="Hint for the scorer evaluation scope selection for traces"
+            />
+          </FormUI.Hint>
+        </Radio>
+        <Radio value={ScorerEvaluationScope.SESSIONS}>
+          <FormattedMessage defaultMessage="Sessions" description="Label for the scorer evaluation scope selection" />
+          <FormUI.Hint>
+            <FormattedMessage
+              defaultMessage="Evaluate entire sessions for conversation quality and outcomes."
+              description="Hint for the scorer evaluation scope selection for sessions"
+            />
+          </FormUI.Hint>
+        </Radio>
+      </RHFControlledComponents.RadioGroup>
+      <Spacer />
+    </>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerFormRenderer.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-hook-form';
 import { useDesignSystemTheme, Button, FormUI, Alert, Radio, Tag } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from '@databricks/i18n';
-import { isRunningScorersEnabled } from '../../../common/utils/FeatureUtils';
+import { isEvaluatingSessionsInScorersEnabled, isRunningScorersEnabled } from '../../../common/utils/FeatureUtils';
 import {
   ModelTraceExplorerResizablePane,
   type ModelTraceExplorerResizablePaneRef,
@@ -21,6 +21,7 @@ import type { ScheduledScorer } from './types';
 import { getTypeDisplayName, getTypeIcon } from './scorerCardUtils';
 import type { ScorerFormData } from './utils/scorerTransformUtils';
 import { COMPONENT_ID_PREFIX, SCORER_FORM_MODE, type ScorerFormMode } from './constants';
+import { ScorerFormEvaluationScopeSelect } from './ScorerFormEvaluationScopeSelect';
 
 interface ScorerFormRendererProps {
   mode: ScorerFormMode;
@@ -68,6 +69,11 @@ const ScorerFormContent: React.FC<ScorerFormContentProps> = ({
 
   return (
     <>
+      {isEvaluatingSessionsInScorersEnabled() && (
+        <div>
+          <ScorerFormEvaluationScopeSelect />
+        </div>
+      )}
       {/* Scorer Type Selection - only show in create mode */}
       {mode === SCORER_FORM_MODE.CREATE && (
         <div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/constants.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/constants.ts
@@ -6,6 +6,11 @@ export const SCORER_FORM_MODE = {
   DISPLAY: 'display',
 } as const;
 
+export enum ScorerEvaluationScope {
+  TRACES = 'traces',
+  SESSIONS = 'sessions',
+}
+
 export type ScorerFormMode = typeof SCORER_FORM_MODE[keyof typeof SCORER_FORM_MODE];
 
 export const DEFAULT_TRACE_COUNT = 10;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/scorerCardUtils.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/scorerCardUtils.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from '@jest/globals';
 import { getFormValuesFromScorer } from './scorerCardUtils';
 import type { LLMScorer, CustomCodeScorer } from './types';
 import { TEMPLATE_INSTRUCTIONS_MAP } from './prompts';
+import { ScorerEvaluationScope } from './constants';
 
 describe('scorerCardUtils', () => {
   describe('getFormValuesFromScorer', () => {
@@ -33,6 +34,7 @@ describe('scorerCardUtils', () => {
           model: '',
           disableMonitoring: undefined,
           isInstructionsJudge: undefined,
+          evaluationScope: ScorerEvaluationScope.TRACES,
         });
       });
 
@@ -62,6 +64,7 @@ describe('scorerCardUtils', () => {
           instructions: '',
           filterString: 'model_name == "gpt-4"',
           model: '',
+          evaluationScope: ScorerEvaluationScope.TRACES,
         });
       });
 
@@ -86,6 +89,7 @@ describe('scorerCardUtils', () => {
           instructions: '',
           filterString: '',
           model: '',
+          evaluationScope: ScorerEvaluationScope.TRACES,
         });
       });
 
@@ -113,6 +117,7 @@ describe('scorerCardUtils', () => {
           instructions: '',
           filterString: '',
           model: '',
+          evaluationScope: ScorerEvaluationScope.TRACES,
         });
       });
     });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/scorerCardUtils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/scorerCardUtils.tsx
@@ -8,6 +8,8 @@ import type { ScheduledScorer, LLMScorer, CustomCodeScorer } from './types';
 import type { LLMScorerFormData } from './LLMScorerFormRenderer';
 import type { CustomCodeScorerFormData } from './CustomCodeScorerFormRenderer';
 import { TEMPLATE_INSTRUCTIONS_MAP } from './prompts';
+import { ScorerFormData } from './utils/scorerTransformUtils';
+import { ScorerEvaluationScope } from './constants';
 
 export const getTypeDisplayName = (scorer: ScheduledScorer, intl: IntlShape): string => {
   if (scorer.type === 'custom-code') {
@@ -72,7 +74,7 @@ export const getStatusTag = (
  * @param scorer The ScheduledScorer to derive form values from
  * @returns Form values object suitable for react-hook-form
  */
-export const getFormValuesFromScorer = (scorer: ScheduledScorer): LLMScorerFormData | CustomCodeScorerFormData => {
+export const getFormValuesFromScorer = (scorer: ScheduledScorer): LLMScorerFormData | ScorerFormData => {
   // For LLM scorers, get instructions from the scorer or fall back to template defaults
   let instructions = '';
   if (scorer.type === 'llm') {
@@ -94,6 +96,7 @@ export const getFormValuesFromScorer = (scorer: ScheduledScorer): LLMScorerFormD
     model: scorer.type === 'llm' ? (scorer as LLMScorer).model || '' : '',
     disableMonitoring: scorer.disableMonitoring,
     isInstructionsJudge: scorer.type === 'llm' ? (scorer as LLMScorer).is_instructions_judge : undefined,
+    evaluationScope: scorer.isSessionLevelScorer ? ScorerEvaluationScope.SESSIONS : ScorerEvaluationScope.TRACES,
   };
 };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
@@ -12,6 +12,7 @@ interface ScheduledScorerBase {
   // Whether the UI disables monitoring for this scorer. If disabled, the UI
   // will not show the form fields for monitoring (sample rate, filter string, etc.)
   disableMonitoring?: boolean;
+  isSessionLevelScorer?: boolean;
 }
 
 // LLM Template Constants
@@ -66,6 +67,7 @@ export type ScorerConfig = {
   sample_rate?: number;
   filter_string?: string;
   scorer_version?: number;
+  is_session_level_scorer?: boolean;
 };
 
 interface EvaluateChatParamsBase {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/utils/scorerTransformUtils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/utils/scorerTransformUtils.test.ts
@@ -564,6 +564,7 @@ describe('convertFormDataToScheduledScorer', () => {
         instructions: 'Evaluate the response',
         model: 'openai:/gpt-4o-mini',
         is_instructions_judge: true,
+        isSessionLevelScorer: false,
       });
     });
 
@@ -589,6 +590,7 @@ describe('convertFormDataToScheduledScorer', () => {
         instructions: 'Evaluate the response',
         model: undefined,
         is_instructions_judge: true,
+        isSessionLevelScorer: false,
       });
     });
 
@@ -616,6 +618,7 @@ describe('convertFormDataToScheduledScorer', () => {
         instructions: 'Evaluate if the response is safe.',
         model: 'openai:/gpt-4o-mini',
         is_instructions_judge: true,
+        isSessionLevelScorer: false,
       });
     });
 
@@ -641,6 +644,7 @@ describe('convertFormDataToScheduledScorer', () => {
         instructions: 'Evaluate if the response is relevant.',
         model: undefined,
         is_instructions_judge: true,
+        isSessionLevelScorer: false,
       });
     });
 
@@ -666,6 +670,7 @@ describe('convertFormDataToScheduledScorer', () => {
         instructions: undefined,
         model: undefined,
         is_instructions_judge: false,
+        isSessionLevelScorer: false,
       });
     });
 
@@ -688,6 +693,7 @@ describe('convertFormDataToScheduledScorer', () => {
         type: 'llm',
         llmTemplate: 'Guidelines',
         guidelines: ['Line 1', 'Line 2', 'Line 3'],
+        isSessionLevelScorer: false,
       });
     });
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -11,10 +11,6 @@
     "defaultMessage": "Temperature",
     "description": "Label for temperature input"
   },
-  "+1d2x/": {
-    "defaultMessage": "Run judge on traces",
-    "description": "Title for running judge on traces"
-  },
   "+1i81u": {
     "defaultMessage": "Registered At",
     "description": "Label name for registered timestamp metadata in model version page"
@@ -258,6 +254,10 @@
   "/nPZbt": {
     "defaultMessage": "{totalTokens} total tokens",
     "description": "Experiment page > artifact compare view > results table > total number of evaluated tokens"
+  },
+  "/qIHh7": {
+    "defaultMessage": "Traces",
+    "description": "Label for the scorer evaluation scope selection"
   },
   "/sk75d": {
     "defaultMessage": "Experiment not found",
@@ -950,6 +950,10 @@
     "defaultMessage": "Go back to <link>the home page.</link>",
     "description": "Default error message for error views in MLflow"
   },
+  "6AUuoS": {
+    "defaultMessage": "Run judge on {isTraces, select, true {traces} other {sessions}}",
+    "description": "Title for running judge on traces or sessions"
+  },
   "6BRlPU": {
     "defaultMessage": "Rationale",
     "description": "Field label for assessment rationale in an edit form"
@@ -1337,6 +1341,10 @@
   "8kU9Sc": {
     "defaultMessage": "No API keys found",
     "description": "Empty state title when filter returns no results"
+  },
+  "8nHnwU": {
+    "defaultMessage": "Select sessions",
+    "description": "Option for selecting custom traces"
   },
   "8qJt7/": {
     "defaultMessage": "Experimental",
@@ -3565,6 +3573,10 @@
     "defaultMessage": "Description",
     "description": "Header for the description column in the experiments table"
   },
+  "SUmLKb": {
+    "defaultMessage": "Last session",
+    "description": "Option for last session"
+  },
   "SXKt8h": {
     "defaultMessage": "Must be unique in this experiment. Cannot be changed after creation.",
     "description": "Hint text for Name section"
@@ -3600,6 +3612,10 @@
   "SnPghu": {
     "defaultMessage": "Delete sessions",
     "description": "Delete sessions action"
+  },
+  "SojbzO": {
+    "defaultMessage": "Evaluate entire sessions for conversation quality and outcomes.",
+    "description": "Hint for the scorer evaluation scope selection for sessions"
   },
   "SrV58C": {
     "defaultMessage": "Settings",
@@ -4355,6 +4371,10 @@
     "defaultMessage": "Export traces to datasets",
     "description": "Export traces to dataset modal title"
   },
+  "ZF/84G": {
+    "defaultMessage": "Use a large language model to automatically evaluate traces.",
+    "description": "Hint for the scorer evaluation scope selection for traces"
+  },
   "ZGrkWk": {
     "defaultMessage": "Perform inference via model.transform()",
     "description": "Code comment which states how we can perform SparkML inference"
@@ -4886,6 +4906,10 @@
   "cy9EfG": {
     "defaultMessage": "Attributes",
     "description": "Experiment page > group by runs control > attributes section label"
+  },
+  "d+WXp2": {
+    "defaultMessage": "Last 5 sessions",
+    "description": "Option for last 5 sessions"
   },
   "d00egE": {
     "defaultMessage": "No span with type RETRIEVER found in trace.",
@@ -5423,10 +5447,6 @@
     "defaultMessage": "User is not authorized.",
     "description": "Unauthorized (HTTP STATUS 401) generic error message"
   },
-  "guCNzD": {
-    "defaultMessage": "Run the judge on the selected group of traces",
-    "description": "Description for running judge on traces"
-  },
   "gwS08B": {
     "defaultMessage": "Back to common providers",
     "description": "Navigation back to common providers list"
@@ -5607,6 +5627,10 @@
     "defaultMessage": "Retrieval",
     "description": "Evaluation review > Retrieval section > title"
   },
+  "iQJCx6": {
+    "defaultMessage": "Select scope",
+    "description": "Label for the scorer evaluation scope/level selection (either traces or sessions)"
+  },
   "iQzwqe": {
     "defaultMessage": "Min",
     "description": "Column title for the column displaying the minimum metric values for a metric"
@@ -5698,6 +5722,10 @@
   "j7cj5r": {
     "defaultMessage": "Please log at least one table artifact containing evaluation data. <link>Learn more</link>.",
     "description": "Experiment page > artifact compare view > empty state for no evaluation tables logged > subtitle"
+  },
+  "j9F8Nt": {
+    "defaultMessage": "Last 10 sessions",
+    "description": "Option for last 10 sessions"
   },
   "jA7Y1x": {
     "defaultMessage": "Edit API key",
@@ -6427,6 +6455,10 @@
     "defaultMessage": "Are you sure you want to delete this tag？",
     "description": "Title text for confirmation pop-up to delete a tag from table\n                     in MLflow"
   },
+  "pCaE4I": {
+    "defaultMessage": "Sessions",
+    "description": "Label for the scorer evaluation scope selection"
+  },
   "pDCDkJ": {
     "defaultMessage": "Showing {visibleCount} out of {totalCount} {groupName}. Select columns to view more.",
     "description": "Tooltip for the group column header"
@@ -6458,6 +6490,10 @@
   "pVF+2s": {
     "defaultMessage": "Show less",
     "description": "Label for a link that shows less tags when clicked"
+  },
+  "pYUr49": {
+    "defaultMessage": "What do you want the scorer to evaluate?",
+    "description": "Hint for the scorer evaluation scope selection"
   },
   "paQ2Wc": {
     "defaultMessage": "Stage (deprecated)",
@@ -7438,6 +7474,10 @@
   "y56Vz9": {
     "defaultMessage": "In progress",
     "description": "Experiment page > traces table > status label > in progress"
+  },
+  "y6KMoc": {
+    "defaultMessage": "Run the judge on the selected group of {isTraces, select, true {traces} other {sessions}}",
+    "description": "Description for running judge on traces or sessions"
   },
   "y8O4PM": {
     "defaultMessage": "Retrieval Groundedness",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -7303,6 +7303,10 @@
     "defaultMessage": "Set as baseline",
     "description": "In the run data difference comparison table, the label for an option to set particular experiment run as a baseline one - meaning other runs will be compared to it."
   },
+  "x/G0Ow": {
+    "defaultMessage": "Trace {index} of {total}",
+    "description": "Index of the current trace and total number of traces"
+  },
   "x/YJtF": {
     "defaultMessage": "MLflow MCP server",
     "description": "Home page news card title one"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19534/files) to review incremental changes.
- [**stack/select-traces-for-scorers-part4**](https://github.com/mlflow/mlflow/pull/19534) [[Files changed](https://github.com/mlflow/mlflow/pull/19534/files)]
  - [stack/select-traces-for-scorers-part6](https://github.com/mlflow/mlflow/pull/19640) [[Files changed](https://github.com/mlflow/mlflow/pull/19640/files/7bb5c20d15aa03a039d650c59ae519a90d2d5e4b..c09fe8e807d98600a34b63a7bc0d20da1356297c)]
    - [stack/select-traces-for-scorers-part7](https://github.com/mlflow/mlflow/pull/19641) [[Files changed](https://github.com/mlflow/mlflow/pull/19641/files/c09fe8e807d98600a34b63a7bc0d20da1356297c..bc6bc6a5eac3b2600a683db8110812db5baf51e1)]
      - [stack/select-traces-for-scorers-part8](https://github.com/mlflow/mlflow/pull/19642) [[Files changed](https://github.com/mlflow/mlflow/pull/19642/files/bc6bc6a5eac3b2600a683db8110812db5baf51e1..91ce08a750452a2f5ab1a57a513c46e5bc3aa707)]

---------
### What changes are proposed in this pull request?

This PR enhances the trace selection CUJ with some QoL features:
- Added default selected columns configuration to `SelectTracesModal` to show relevant columns by default
- Implemented persistent row selection that maintains user's trace selections across modal interactions
- Updated `SampleScorerOutputPanelRenderer` to display current trace index

### Demo

https://github.com/user-attachments/assets/716799c1-7525-4374-9df8-11f30aa70ed0

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
