### PR TITLE
Fix MLflow doc build failure

### DIFF
--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -4146,7 +4146,7 @@ message GatewaySecretInfo {
   optional string secret_name = 2;
   // Masked version of the secret values for display as key-value pairs.
   // For simple API keys: {"api_key": "sk-...xyz123"}
-  // For compound credentials: {"aws_access_key_id": "AKI...1234", "aws_secret_access_key": "***"}
+  // For compound credentials: ``{"aws_access_key_id": "AKI...1234", "aws_secret_access_key": "***"}``
   map<string, string> masked_values = 3;
   // Timestamp (milliseconds since epoch) when the secret was created
   optional int64 created_at = 4;


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/19542?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19542/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19542/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19542/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
The MLFlow 3.8.0 release doc building failed,
the root cause should be:
https://devportal.prod.databricks-corp.com/jobs/run-details/run-logs?run_id=14315860&runbot_instance=PROD&is_run_group=false&run_id_for_logs=14315860&lineNumber=3133

```
/ephemeral/home/ubuntu/mlflow-ec18427bcb6946f2/docs/api_reference/source/rest-api.rst:4224: WARNING: Inline strong start-string without end-string. 
/ephemeral/home/ubuntu/mlflow-ec18427bcb6946f2/docs/api_reference/source/rest-api.rst:4224: WARNING: Inline emphasis start-string without end-string. 
```

I manually ran `bazel build //ci/runbot/builds/ml-oss-ecosystem/scripts:api_docs` and uploaded the generated `mlflow.rst` file for debugging the issue, and we can see the related line has format issue:

https://github.com/databricks-eng/universe-dev/blob/b08832fc2a73d4c78298676a8edce40e8a3f9f09/mlflow/api/mlflow.rst?plain=1#L4225

```
+------------------+-------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
| masked_values    | An array of :ref:`mlflowgatewaysecretinfomaskedvaluesentry` | Masked version of the secret values for display as key-value pairs.                           |
|                  |                                                             | For simple API keys: {"api_key": "sk-...xyz123"}                                              |
|                  |                                                             | For compound credentials: {"aws_access_key_id": "AKI...1234", "aws_secret_access_key": "***"} |
+------------------+-------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
```

To fix the format issue, I updated the `service.proto` comments to be 
```
For compound credentials: ``{"aws_access_key_id": "AKI...1234", "aws_secret_access_key": "***"}``
```

Test run:
https://devportal.prod.databricks-corp.com/jobs/run-details/runs?run_id=14318358&runbot_instance=PROD


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
