### PR TITLE
Fix type hint for `mlflow.genai.evaluate` and add a small doc

### DIFF
--- a/docs/docs/genai/eval-monitor/faq.mdx
+++ b/docs/docs/genai/eval-monitor/faq.mdx
@@ -186,7 +186,7 @@ To view the scorer trace, you can open the assessment pane of the trace details 
 
 ## How do I programmatically access evaluation results?
 
-The <APILink fn="mlflow.genai.evaluate" /> function returns an <APILink fn="mlflow.genai.EvaluationResult" /> object that contains all evaluation results. Here's how to access different parts of the results:
+The <APILink fn="mlflow.genai.evaluate" /> function returns an <APILink fn="mlflow.genai.evaluation.entities.EvaluationResult" /> object that contains all evaluation results. Here's how to access different parts of the results:
 
 ### Accessing Aggregated Metrics
 

--- a/docs/docs/genai/eval-monitor/faq.mdx
+++ b/docs/docs/genai/eval-monitor/faq.mdx
@@ -183,3 +183,51 @@ you to inspect the input, output, and internal steps during the scorer execution
 
 To view the scorer trace, you can open the assessment pane of the trace details page and click the
 "View trace" link.
+
+## How do I programmatically access evaluation results?
+
+The <APILink fn="mlflow.genai.evaluate" /> function returns an <APILink fn="mlflow.genai.EvaluationResult" /> object that contains all evaluation results. Here's how to access different parts of the results:
+
+### Accessing Aggregated Metrics
+
+The `metrics` property returns a dictionary of aggregated metric values across all evaluated rows:
+
+```python
+result = mlflow.genai.evaluate(
+    data=eval_dataset,
+    predict_fn=my_predict_fn,
+    scorers=[Correctness(), Safety()],
+)
+
+# Access aggregated metrics
+print(result.metrics)
+# Output: {'correctness/mean': 0.85, 'safety/mean': 0.95}
+
+# Access a specific metric
+correctness_score = result.metrics.get("correctness/mean")
+```
+
+To get metrics for an existing evaluation run, you can use <APILink fn="mlflow.get_run" /> API:
+
+```python
+run = mlflow.get_run(run_id="<run_id>")
+print(run.data.metrics)
+# Output: {'correctness/mean': 0.85, 'safety/mean': 0.95}
+```
+
+### Accessing the Results DataFrame
+
+The `result_df` property returns a pandas DataFrame containing detailed per-row evaluation results:
+
+```python
+# Export to CSV for further analysis
+result.result_df.to_csv("evaluation_results.csv", index=False)
+```
+
+### Accessing Traces from Results
+
+You can get the traces for the evaluation run by using <APILink fn="mlflow.search_traces" /> API:
+
+```python
+traces = mlflow.search_traces(run_id=result.run_id, return_type="list")
+```

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -13,6 +13,7 @@ from mlflow.environment_variables import MLFLOW_GENAI_EVAL_MAX_WORKERS
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets.evaluation_dataset import EvaluationDataset
 from mlflow.genai.evaluation.constant import InputDatasetColumn
+from mlflow.genai.evaluation.entities import EvaluationResult
 from mlflow.genai.evaluation.session_utils import validate_session_level_evaluation_inputs
 from mlflow.genai.evaluation.utils import (
     _convert_to_eval_set,
@@ -24,7 +25,6 @@ from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, vali
 from mlflow.genai.utils.display_utils import display_evaluation_output
 from mlflow.genai.utils.trace_utils import convert_predict_fn
 from mlflow.models.evaluation.base import (
-    EvaluationResult,
     _is_model_deployment_endpoint_uri,
     _start_run_or_reuse_active_run,
 )
@@ -234,7 +234,7 @@ def evaluate(
             :py:func:`mlflow.set_active_model` function.
 
     Returns:
-        An :py:class:`mlflow.models.EvaluationResult~` object.
+        An :py:class:`mlflow.genai.evaluation.entities.EvaluationResult` object.
 
     Note:
         Certain advanced features of this function are only supported on Databricks.

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -13,7 +13,6 @@ from mlflow.environment_variables import MLFLOW_GENAI_EVAL_MAX_WORKERS
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets.evaluation_dataset import EvaluationDataset
 from mlflow.genai.evaluation.constant import InputDatasetColumn
-from mlflow.genai.evaluation.entities import EvaluationResult
 from mlflow.genai.evaluation.session_utils import validate_session_level_evaluation_inputs
 from mlflow.genai.evaluation.utils import (
     _convert_to_eval_set,
@@ -43,6 +42,7 @@ from mlflow.tracking.fluent import _get_experiment_id, _set_active_model
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_IS_EVALUATION
 
 if TYPE_CHECKING:
+    from mlflow.genai.evaluation.entities import EvaluationResult
     from mlflow.genai.evaluation.utils import EvaluationDatasetTypes
 
 
@@ -54,7 +54,7 @@ def evaluate(
     scorers: list[Scorer],
     predict_fn: Callable[..., Any] | None = None,
     model_id: str | None = None,
-) -> EvaluationResult:
+) -> "EvaluationResult":
     """
     Evaluate the performance of a generative AI model/application using specified
     data and scorers.
@@ -250,7 +250,7 @@ def evaluate(
 
 
 @record_usage_event(GenAIEvaluateEvent)
-def _run_harness(data, scorers, predict_fn, model_id) -> tuple[EvaluationResult, dict[str, Any]]:
+def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult", dict[str, Any]]:
     """
     Internal harness for running evaluation.
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/19555?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19555/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19555/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19555/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The return type is incorrectly annotated as the legacy `EvaluationResult` class.

This PR fixes that and also adds a small guide in the FAQ for how to use it.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
