### PR TITLE
Fix type signature loss in `@trace_disabled` decorator

### DIFF
--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -13,7 +13,7 @@ import json
 import logging
 import os
 from contextlib import contextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, ParamSpec, TypeVar
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
@@ -51,6 +51,10 @@ from mlflow.utils.databricks_utils import (
 
 if TYPE_CHECKING:
     from mlflow.entities import Span
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 # A trace destination specified by the user via the `set_destination` function.
@@ -601,7 +605,7 @@ def enable():
     provider.once._done = True
 
 
-def trace_disabled(f):
+def trace_disabled(f: Callable[P, R]) -> Callable[P, R]:
     """
     A decorator that temporarily disables tracing for the duration of the decorated function.
 
@@ -622,7 +626,7 @@ def trace_disabled(f):
     """
 
     @functools.wraps(f)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         is_func_called = False
         result = None
         try:

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1,5 +1,4 @@
 from concurrent.futures import ThreadPoolExecutor
-from typing import get_type_hints
 from unittest import mock
 
 import pytest
@@ -312,29 +311,6 @@ def test_trace_disabled_decorator(enabled_initially):
         assert test_fn() == 0
         assert call_count == 4
         assert enable_mock.call_count == (1 if enabled_initially else 0)
-
-
-def test_trace_disabled_preserves_type_annotations():
-    # Test that @trace_disabled preserves type annotations for static type checkers.
-
-    def original_func(x: int, y: str) -> float:
-        return float(x)
-
-    @trace_disabled
-    def decorated_func(x: int, y: str) -> float:
-        return float(x)
-
-    # Verify that type hints are preserved
-    original_hints = get_type_hints(original_func)
-    decorated_hints = get_type_hints(decorated_func)
-
-    assert original_hints == decorated_hints
-    assert decorated_hints["x"] is int
-    assert decorated_hints["y"] is str
-    assert decorated_hints["return"] is float
-
-    # Verify the decorated function still works correctly
-    assert decorated_func(42, "hello") == 42.0
 
 
 def test_disable_enable_tracing_not_mutate_otel_provider(monkeypatch):

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -316,7 +316,6 @@ def test_trace_disabled_decorator(enabled_initially):
 
 def test_trace_disabled_preserves_type_annotations():
     # Test that @trace_disabled preserves type annotations for static type checkers.
-    # This validates the fix for https://github.com/mlflow/mlflow/issues/19566
 
     def original_func(x: int, y: str) -> float:
         return float(x)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mr-brobot/mlflow/pull/19569?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19569/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19569/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19569/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #19566

### What changes are proposed in this pull request?

Add PEP 612 type annotations to the `@trace_disabled` decorator to preserve type signatures for static type checkers.

**Changes:**
- Add `ParamSpec` and `TypeVar` type hints to `trace_disabled` decorator in `mlflow/tracing/provider.py`
- The wrapper function now correctly propagates parameter and return types

This follows the same pattern already used by the `@experimental` decorator in the codebase.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_trace_disabled_preserves_type_annotations` which verifies that `get_type_hints()` returns the same annotations for decorated and undecorated functions.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix type signature loss in `@trace_disabled` decorator. Static type checkers like pyright and mypy now correctly infer return types for decorated functions such as `mlflow.pyfunc.load_model()`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
