### PR TITLE
[Workspace] Add workspace-aware auth backend and client coverage

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -132,6 +132,9 @@ jobs:
             ./tests/db/compose.sh run --rm --no-TTY $service pytest \
               tests/store/tracking/test_sqlalchemy_store.py \
               tests/store/model_registry/test_sqlalchemy_store.py \
+              tests/store/model_registry/test_sqlalchemy_workspace_store.py \
+              tests/store/workspace/test_sqlalchemy_store.py \
+              tests/store/tracking/test_sqlalchemy_workspace_store.py \
               tests/db
               RESULTS="$RESULTS\n$service: $(if [ $? -eq 0 ]; then echo "✅"; else echo "❌"; fi)"
           done

--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -1238,10 +1238,14 @@ mlflow.server.auth.client.AuthServiceClient.delete_experiment_permission
 mlflow.server.auth.client.AuthServiceClient.delete_registered_model_permission
 mlflow.server.auth.client.AuthServiceClient.delete_scorer_permission
 mlflow.server.auth.client.AuthServiceClient.delete_user
+mlflow.server.auth.client.AuthServiceClient.delete_workspace_permission
 mlflow.server.auth.client.AuthServiceClient.get_experiment_permission
 mlflow.server.auth.client.AuthServiceClient.get_registered_model_permission
 mlflow.server.auth.client.AuthServiceClient.get_scorer_permission
 mlflow.server.auth.client.AuthServiceClient.get_user
+mlflow.server.auth.client.AuthServiceClient.list_user_workspace_permissions
+mlflow.server.auth.client.AuthServiceClient.list_workspace_permissions
+mlflow.server.auth.client.AuthServiceClient.set_workspace_permission
 mlflow.server.auth.client.AuthServiceClient.update_experiment_permission
 mlflow.server.auth.client.AuthServiceClient.update_registered_model_permission
 mlflow.server.auth.client.AuthServiceClient.update_scorer_permission
@@ -1259,6 +1263,9 @@ mlflow.server.auth.entities.ScorerPermission.to_json
 mlflow.server.auth.entities.User
 mlflow.server.auth.entities.User.from_json
 mlflow.server.auth.entities.User.to_json
+mlflow.server.auth.entities.WorkspacePermission
+mlflow.server.auth.entities.WorkspacePermission.from_json
+mlflow.server.auth.entities.WorkspacePermission.to_json
 mlflow.server.get_app_client
 mlflow.set_active_model
 mlflow.set_experiment

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -14,6 +14,7 @@ import re
 from typing import Any, Callable
 
 import sqlalchemy
+from cachetools import TTLCache
 from flask import (
     Flask,
     Request,
@@ -30,7 +31,11 @@ from mlflow import MlflowException
 from mlflow.entities import Experiment
 from mlflow.entities.logged_model import LoggedModel
 from mlflow.entities.model_registry import RegisteredModel
-from mlflow.environment_variables import _MLFLOW_SGI_NAME, MLFLOW_FLASK_SERVER_SECRET_KEY
+from mlflow.environment_variables import (
+    _MLFLOW_SGI_NAME,
+    MLFLOW_ENABLE_WORKSPACES,
+    MLFLOW_FLASK_SERVER_SECRET_KEY,
+)
 from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
     INTERNAL_ERROR,
@@ -65,6 +70,7 @@ from mlflow.protos.service_pb2 import (
     # Routes for logged models
     CreateLoggedModel,
     CreateRun,
+    CreateWorkspace,
     DeleteExperiment,
     DeleteExperimentTag,
     DeleteLoggedModel,
@@ -72,6 +78,7 @@ from mlflow.protos.service_pb2 import (
     DeleteRun,
     DeleteScorer,
     DeleteTag,
+    DeleteWorkspace,
     FinalizeLoggedModel,
     GetExperiment,
     GetExperimentByName,
@@ -79,9 +86,11 @@ from mlflow.protos.service_pb2 import (
     GetMetricHistory,
     GetRun,
     GetScorer,
+    GetWorkspace,
     ListArtifacts,
     ListScorers,
     ListScorerVersions,
+    ListWorkspaces,
     LogBatch,
     LogLoggedModelParamsRequest,
     LogMetric,
@@ -97,11 +106,17 @@ from mlflow.protos.service_pb2 import (
     SetTag,
     UpdateExperiment,
     UpdateRun,
+    UpdateWorkspace,
 )
 from mlflow.server import app
 from mlflow.server.auth.config import read_auth_config
 from mlflow.server.auth.logo import MLFLOW_LOGO
-from mlflow.server.auth.permissions import MANAGE, Permission, get_permission
+from mlflow.server.auth.permissions import (
+    MANAGE,
+    NO_PERMISSIONS,
+    Permission,
+    get_permission,
+)
 from mlflow.server.auth.routes import (
     CREATE_EXPERIMENT_PERMISSION,
     CREATE_PROMPTLAB_RUN,
@@ -124,6 +139,8 @@ from mlflow.server.auth.routes import (
     GET_TRACE_ARTIFACT,
     GET_USER,
     HOME,
+    LIST_USER_WORKSPACE_PERMISSIONS,
+    LIST_WORKSPACE_PERMISSIONS,
     SEARCH_DATASETS,
     SIGNUP,
     UPDATE_EXPERIMENT_PERMISSION,
@@ -136,13 +153,17 @@ from mlflow.server.auth.routes import (
 from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
 from mlflow.server.fastapi_app import create_fastapi_app
 from mlflow.server.handlers import (
+    _disable_if_workspaces_disabled,
     _get_model_registry_store,
     _get_request_message,
     _get_tracking_store,
     catch_mlflow_exception,
     get_endpoints,
 )
+from mlflow.server.workspace_helpers import _get_workspace_store
 from mlflow.store.entities import PagedList
+from mlflow.store.workspace.utils import get_default_workspace_optional
+from mlflow.utils import workspace_context
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.rest_utils import _REST_API_PATH_PREFIX
 from mlflow.utils.search_utils import SearchUtils
@@ -159,6 +180,13 @@ _logger = logging.getLogger(__name__)
 
 auth_config = read_auth_config()
 store = SqlAlchemyStore()
+
+# Cache for resource_id -> workspace_name mapping. The relationship between a resource
+# (experiment, registered model) and its workspace is immutable.
+_RESOURCE_WORKSPACE_CACHE: TTLCache[str, str | None] = TTLCache(
+    maxsize=auth_config.workspace_cache_max_size,
+    ttl=auth_config.workspace_cache_ttl_seconds,
+)
 
 
 def is_unprotected_route(path: str) -> bool:
@@ -208,26 +236,244 @@ def _get_request_param(param: str) -> str:
     return args[param]
 
 
-def _get_permission_from_store_or_default(store_permission_func: Callable[[], str]) -> Permission:
+def _get_permission_from_store_or_default(
+    store_permission_func: Callable[[], str],
+    workspace_level_permission_func: Callable[[], Permission | None] | None = None,
+) -> Permission:
     """
-    Attempts to get permission from store,
-    and returns default permission if no record is found.
+    Resolve a permission from the auth store, with an optional workspace-aware fallback.
+
+    Behavior:
+    - If a direct (resource-level) permission exists, it is returned.
+    - If no direct permission exists and workspaces are enabled, callers provide
+      ``workspace_level_permission_func`` to check workspace-level permissions for the resource's
+      workspace. This fallback should default to ``NO_PERMISSIONS`` to preserve workspace isolation.
+    - If workspace permissions are not applicable (e.g. workspaces are disabled and the func
+      returns ``None``), fall back to ``auth_config.default_permission``.
+    - Unexpected errors are propagated rather than granting access.
     """
     try:
         perm = store_permission_func()
     except MlflowException as e:
         if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+            if workspace_level_permission_func is not None:
+                workspace_permission = workspace_level_permission_func()
+                # workspace_permission is only None when workspaces are not enabled.
+                # workspace_permission defaults to NO_PERMISSIONS. In effect, this means that
+                # auth_config.default_permission is not supported when workspaces are enabled
+                # to keep workspace isolation.
+                if workspace_permission is not None:
+                    return workspace_permission
             perm = auth_config.default_permission
         else:
             raise
     return get_permission(perm)
 
 
+def _workspace_permission(
+    username: str | None,
+    workspace_name: str,
+) -> Permission | None:
+    """
+    Determine the workspace-level permission for a user.
+
+    Returns:
+        - A `Permission` value from the auth store when workspaces are enabled.
+        - `auth_config.default_permission` (as a `Permission`) if the workspace is the default and
+          implicit access is granted via `grant_default_workspace_access`.
+        - `None` when workspaces are disabled.
+        - `NO_PERMISSIONS` when no permission is found and no implicit access applies.
+    """
+    if not MLFLOW_ENABLE_WORKSPACES.get():
+        return None
+
+    if not workspace_name:
+        raise ValueError("workspace_name must be provided when checking workspace permissions")
+
+    if username is None:
+        return NO_PERMISSIONS
+
+    try:
+        permission = store.get_workspace_permission(workspace_name, username)
+        if permission is not None:
+            return permission
+
+        if auth_config.grant_default_workspace_access and auth_config.default_permission:
+            default_workspace, _ = get_default_workspace_optional(_get_workspace_store())
+            if default_workspace and workspace_name == default_workspace.name:
+                return get_permission(auth_config.default_permission)
+
+        return NO_PERMISSIONS
+    except MlflowException as e:
+        _logger.warning(
+            "Error checking workspace permissions for user '%s' in workspace '%s': %s. "
+            "Denying access for security.",
+            username,
+            workspace_name,
+            e,
+        )
+        return NO_PERMISSIONS
+
+
+def _get_resource_workspace(
+    resource_id: str,
+    fetcher: Callable[[str], Any],
+    resource_label: str,
+) -> str | None:
+    """
+    Get the workspace name for a resource, using a cache to avoid repeated lookups.
+
+    The resource→workspace relationship is immutable, so caching is safe.
+    """
+    # Use a cache key that includes the resource_label to avoid collisions between
+    # experiments and registered models that might have the same ID/name.
+    cache_key = f"{resource_label}:{resource_id}"
+
+    if cache_key in _RESOURCE_WORKSPACE_CACHE:
+        return _RESOURCE_WORKSPACE_CACHE[cache_key]
+
+    try:
+        resource = fetcher(resource_id)
+        workspace_name = getattr(resource, "workspace", None)
+    except MlflowException as e:
+        _logger.warning(
+            "Failed to determine workspace for %s '%s': %s. Denying access for security.",
+            resource_label,
+            resource_id,
+            e,
+        )
+        workspace_name = None
+
+    _RESOURCE_WORKSPACE_CACHE[cache_key] = workspace_name
+    return workspace_name
+
+
+def _workspace_permission_for_resource(
+    username: str | None,
+    resource_id: str,
+    fetcher: Callable[[str], Any],
+    resource_label: str,
+) -> Permission | None:
+    """
+    Generic workspace permission checker for any resource type.
+
+    Args:
+        username: Username associated with the request (may be None)
+        resource_id: ID of the resource to check
+        fetcher: Function to fetch the resource (e.g., store.get_experiment)
+        resource_label: Human-readable label for error messages
+
+    Returns:
+        Permission object if workspace permissions apply, None if workspace permissions
+        are not supported. Returns NO_PERMISSIONS if the resource lookup fails
+        (security: deny on error).
+    """
+    if not MLFLOW_ENABLE_WORKSPACES.get():
+        return None
+
+    workspace_name = _get_resource_workspace(resource_id, fetcher, resource_label)
+    if workspace_name is None:
+        return NO_PERMISSIONS
+
+    return _workspace_permission(username, workspace_name)
+
+
+def _workspace_permission_for_experiment(
+    username: str | None, experiment_id: str
+) -> Permission | None:
+    """
+    Get workspace-level permission for accessing an experiment.
+
+    Returns:
+        Permission object if workspace permissions apply, None if workspace permissions
+        are not supported. Returns NO_PERMISSIONS if the experiment lookup fails
+        (security: deny on error).
+    """
+    return _workspace_permission_for_resource(
+        username,
+        experiment_id,
+        _get_tracking_store().get_experiment,
+        "experiment",
+    )
+
+
+def _workspace_permission_for_registered_model(
+    username: str | None, model_name: str
+) -> Permission | None:
+    """
+    Get workspace-level permission for accessing a registered model (including prompts).
+
+    Returns:
+        Permission object if workspace permissions apply, None to fall back to resource permissions.
+        Returns NO_PERMISSIONS if the model lookup fails (security: deny on error).
+    """
+    return _workspace_permission_for_resource(
+        username,
+        model_name,
+        _get_model_registry_store().get_registered_model,
+        "registered model",
+    )
+
+
+def _has_resource_read_access(
+    resource_id: str,
+    username: str | None,
+    workspace_permission_getter: Callable[[str | None, str], Permission | None],
+    explicit_can_read: dict[str, bool],
+    default_can_read: bool,
+) -> bool:
+    if resource_id in explicit_can_read:
+        return explicit_can_read[resource_id]
+
+    # If workspaces are enabled, the default is NO_PERMISSIONS.
+    if perm := workspace_permission_getter(username, resource_id):
+        return perm.can_read
+
+    # Use the default only when there is no explicit entry and no workspace permission.
+    # workspace_permission_getter returns None only when workspaces are disabled. In that
+    # mode, the stores refuse to start if any resource lives outside the default workspace,
+    # so this fallback cannot bypass workspace permissions.
+    return default_can_read
+
+
+def _has_experiment_read_access(
+    username: str | None,
+    experiment_id: str,
+    explicit_can_read: dict[str, bool],
+    default_can_read: bool,
+) -> bool:
+    return _has_resource_read_access(
+        experiment_id,
+        username,
+        _workspace_permission_for_experiment,
+        explicit_can_read,
+        default_can_read,
+    )
+
+
+def _has_registered_model_read_access(
+    username: str | None,
+    model_name: str,
+    explicit_can_read: dict[str, bool],
+    default_can_read: bool,
+) -> bool:
+    return _has_resource_read_access(
+        model_name,
+        username,
+        _workspace_permission_for_registered_model,
+        explicit_can_read,
+        default_can_read,
+    )
+
+
 def _get_permission_from_experiment_id() -> Permission:
     experiment_id = _get_request_param("experiment_id")
     username = authenticate_request().username
     return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission
+        lambda: store.get_experiment_permission(experiment_id, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+            username, experiment_id
+        ),
     )
 
 
@@ -242,11 +488,23 @@ def _get_experiment_id_from_view_args():
 
 
 def _get_permission_from_experiment_id_artifact_proxy() -> Permission:
+    username = authenticate_request().username
+
     if experiment_id := _get_experiment_id_from_view_args():
-        username = authenticate_request().username
         return _get_permission_from_store_or_default(
-            lambda: store.get_experiment_permission(experiment_id, username).permission
+            lambda: store.get_experiment_permission(experiment_id, username).permission,
+            workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+                username, experiment_id
+            ),
         )
+
+    if MLFLOW_ENABLE_WORKSPACES.get():
+        if workspace_name := workspace_context.get_request_workspace():
+            permission = _workspace_permission(username, workspace_name)
+            if permission is not None:
+                return permission
+        return NO_PERMISSIONS
+
     return get_permission(auth_config.default_permission)
 
 
@@ -259,8 +517,12 @@ def _get_permission_from_experiment_name() -> Permission:
             error_code=RESOURCE_DOES_NOT_EXIST,
         )
     username = authenticate_request().username
+
     return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(store_exp.experiment_id, username).permission
+        lambda: store.get_experiment_permission(store_exp.experiment_id, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+            username, store_exp.experiment_id
+        ),
     )
 
 
@@ -272,7 +534,10 @@ def _get_permission_from_run_id() -> Permission:
     experiment_id = run.info.experiment_id
     username = authenticate_request().username
     return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission
+        lambda: store.get_experiment_permission(experiment_id, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+            username, experiment_id
+        ),
     )
 
 
@@ -283,7 +548,10 @@ def _get_permission_from_model_id() -> Permission:
     experiment_id = model.experiment_id
     username = authenticate_request().username
     return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission
+        lambda: store.get_experiment_permission(experiment_id, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+            username, experiment_id
+        ),
     )
 
 
@@ -291,7 +559,10 @@ def _get_permission_from_registered_model_name() -> Permission:
     name = _get_request_param("name")
     username = authenticate_request().username
     return _get_permission_from_store_or_default(
-        lambda: store.get_registered_model_permission(name, username).permission
+        lambda: store.get_registered_model_permission(name, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_registered_model(
+            username, name
+        ),
     )
 
 
@@ -300,7 +571,10 @@ def _get_permission_from_scorer_name() -> Permission:
     name = _get_request_param("name")
     username = authenticate_request().username
     return _get_permission_from_store_or_default(
-        lambda: store.get_scorer_permission(experiment_id, name, username).permission
+        lambda: store.get_scorer_permission(experiment_id, name, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+            username, experiment_id
+        ),
     )
 
 
@@ -309,7 +583,10 @@ def _get_permission_from_scorer_permission_request() -> Permission:
     scorer_name = _get_request_param("scorer_name")
     username = authenticate_request().username
     return _get_permission_from_store_or_default(
-        lambda: store.get_scorer_permission(experiment_id, scorer_name, username).permission
+        lambda: store.get_scorer_permission(experiment_id, scorer_name, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+            username, experiment_id
+        ),
     )
 
 
@@ -396,6 +673,103 @@ def validate_can_manage_registered_model():
     return _get_permission_from_registered_model_name().can_manage
 
 
+def validate_can_create_experiment() -> bool:
+    # Historically, experiment creation has always been allowed when workspaces are
+    # disabled. We keep returning True here to preserve that behavior even if
+    # auth_config.default_permission is READ/NO_PERMISSIONS.
+    if not MLFLOW_ENABLE_WORKSPACES.get():
+        return True
+
+    workspace_name = workspace_context.get_request_workspace()
+    if workspace_name is None:
+        return False
+
+    perm = _workspace_permission(authenticate_request().username, workspace_name)
+    return perm is not None and perm.can_manage
+
+
+def validate_can_create_registered_model() -> bool:
+    # Historically, registered model creation has always been allowed when workspaces are
+    # disabled. We keep returning True here to preserve that behavior even if
+    # auth_config.default_permission is READ/NO_PERMISSIONS.
+    if not MLFLOW_ENABLE_WORKSPACES.get():
+        return True
+
+    workspace_name = workspace_context.get_request_workspace()
+    if workspace_name is None:
+        return False
+
+    perm = _workspace_permission(authenticate_request().username, workspace_name)
+    return perm is not None and perm.can_manage
+
+
+def validate_can_view_workspace() -> bool:
+    if not MLFLOW_ENABLE_WORKSPACES.get():
+        return True
+
+    username = authenticate_request().username
+
+    workspace_name = request.view_args.get("workspace_name") if request.view_args else None
+    if workspace_name is None:
+        return False
+
+    if username is None:
+        return False
+
+    if auth_config.grant_default_workspace_access:
+        default_workspace, _ = get_default_workspace_optional(_get_workspace_store())
+        if default_workspace and workspace_name == default_workspace.name:
+            return True
+
+    names = set(store.list_accessible_workspace_names(username))
+
+    return workspace_name in names
+
+
+def _get_workspace_name_from_request() -> str | None:
+    return request.view_args.get("workspace_name") if request.view_args else None
+
+
+def validate_can_list_workspace_permissions() -> bool:
+    username = authenticate_request().username
+    if not username:
+        return False
+
+    if store.get_user(username).is_admin:
+        return True
+
+    workspace_name = _get_workspace_name_from_request()
+    if not workspace_name:
+        return False
+
+    perm = _workspace_permission(username, workspace_name)
+    return perm is not None and perm.can_manage
+
+
+def validate_can_modify_workspace_permission() -> bool:
+    """
+    Validate if the user can create, update, or delete workspace permissions.
+
+    Permission delegation: Users with MANAGE permission on a workspace can grant
+    permissions to other users in that workspace. This allows workspace managers
+    to delegate access without requiring admin intervention, enabling self-service
+    team management within workspace boundaries.
+    """
+    username = authenticate_request().username
+    if not username:
+        return False
+
+    if store.get_user(username).is_admin:
+        return True
+
+    workspace_name = _get_workspace_name_from_request()
+    if not workspace_name:
+        return False
+
+    perm = _workspace_permission(username, workspace_name)
+    return perm is not None and perm.can_manage
+
+
 # Scorers
 def validate_can_read_scorer():
     return _get_permission_from_scorer_name().can_read
@@ -427,6 +801,12 @@ def filter_experiment_ids(experiment_ids: list[str]) -> list[str]:
     """
     Filter experiment IDs to only include those the user has read access to.
 
+    This function is called from search_runs_impl before the tracking store query.
+    When workspaces are enabled, the tracking store will subsequently filter results
+    to only experiments in the active workspace. Since experiments outside the active
+    workspace will be rejected anyway, we only need to check workspace permission once
+    for the active workspace, rather than fetching each experiment to determine its workspace.
+
     Args:
         experiment_ids: List of experiment IDs to filter
 
@@ -445,7 +825,20 @@ def filter_experiment_ids(experiment_ids: list[str]) -> list[str]:
         can_read = {p.experiment_id: get_permission(p.permission).can_read for p in perms}
         default_can_read = get_permission(auth_config.default_permission).can_read
 
-        return [exp_id for exp_id in experiment_ids if can_read.get(exp_id, default_can_read)]
+        if not MLFLOW_ENABLE_WORKSPACES.get():
+            return [exp_id for exp_id in experiment_ids if can_read.get(exp_id, default_can_read)]
+
+        # With workspaces enabled, the tracking store will filter to the active workspace
+        # after this function returns. Since experiments outside the active workspace
+        # will be excluded anyway, we only need ONE workspace permission check here.
+        workspace_name = workspace_context.get_request_workspace()
+        workspace_perm = (
+            _workspace_permission(username, workspace_name) if workspace_name else NO_PERMISSIONS
+        )
+
+        return [
+            exp_id for exp_id in experiment_ids if can_read.get(exp_id, workspace_perm.can_read)
+        ]
     except (RuntimeError, AttributeError):
         # Auth system not fully initialized, skip filtering
         return experiment_ids
@@ -495,7 +888,10 @@ def _get_permission_from_run_id_or_uuid() -> Permission:
     experiment_id = run.info.experiment_id
     username = authenticate_request().username
     return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission
+        lambda: store.get_experiment_permission(experiment_id, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+            username, experiment_id
+        ),
     )
 
 
@@ -522,7 +918,10 @@ def _get_permission_from_model_version() -> Permission:
         )
     username = authenticate_request().username
     return _get_permission_from_store_or_default(
-        lambda: store.get_registered_model_permission(name, username).permission
+        lambda: store.get_registered_model_permission(name, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_registered_model(
+            username, name
+        ),
     )
 
 
@@ -547,7 +946,10 @@ def _get_permission_from_trace_request_id() -> Permission:
     experiment_id = trace.experiment_id
     username = authenticate_request().username
     return _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission
+        lambda: store.get_experiment_permission(experiment_id, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+            username, experiment_id
+        ),
     )
 
 
@@ -572,8 +974,13 @@ def validate_can_read_metric_history_bulk():
     for run_id in run_ids:
         run = tracking_store.get_run(run_id)
         experiment_id = run.info.experiment_id
+
+        def get_workspace_perm(eid=experiment_id):
+            return _workspace_permission_for_experiment(username, eid)
+
         permission = _get_permission_from_store_or_default(
-            lambda eid=experiment_id: store.get_experiment_permission(eid, username).permission
+            lambda eid=experiment_id: store.get_experiment_permission(eid, username).permission,
+            workspace_level_permission_func=get_workspace_perm,
         )
         if not permission.can_read:
             return False
@@ -604,8 +1011,13 @@ def validate_can_search_datasets():
 
     # Check permission for each experiment
     for experiment_id in experiment_ids:
+
+        def get_workspace_perm(eid=experiment_id):
+            return _workspace_permission_for_experiment(username, eid)
+
         permission = _get_permission_from_store_or_default(
-            lambda eid=experiment_id: store.get_experiment_permission(eid, username).permission
+            lambda eid=experiment_id: store.get_experiment_permission(eid, username).permission,
+            workspace_level_permission_func=get_workspace_perm,
         )
         if not permission.can_read:
             return False
@@ -625,7 +1037,10 @@ def validate_can_create_promptlab_run():
 
     username = authenticate_request().username
     permission = _get_permission_from_store_or_default(
-        lambda: store.get_experiment_permission(experiment_id, username).permission
+        lambda: store.get_experiment_permission(experiment_id, username).permission,
+        workspace_level_permission_func=lambda: _workspace_permission_for_experiment(
+            username, experiment_id
+        ),
     )
     return permission.can_update
 
@@ -640,6 +1055,7 @@ def validate_gateway_proxy():
 
 BEFORE_REQUEST_HANDLERS = {
     # Routes for experiments
+    CreateExperiment: validate_can_create_experiment,
     GetExperiment: validate_can_read_experiment,
     GetExperimentByName: validate_can_read_experiment_by_name,
     DeleteExperiment: validate_can_delete_experiment,
@@ -662,6 +1078,7 @@ BEFORE_REQUEST_HANDLERS = {
     GetMetricHistory: validate_can_read_run,
     ListArtifacts: validate_can_read_run,
     # Routes for model registry
+    CreateRegisteredModel: validate_can_create_registered_model,
     GetRegisteredModel: validate_can_read_registered_model,
     DeleteRegisteredModel: validate_can_delete_registered_model,
     UpdateRegisteredModel: validate_can_update_registered_model,
@@ -686,6 +1103,12 @@ BEFORE_REQUEST_HANDLERS = {
     GetScorer: validate_can_read_scorer,
     DeleteScorer: validate_can_delete_scorer,
     ListScorerVersions: validate_can_read_scorer,
+    # Workspace routes
+    ListWorkspaces: None,
+    CreateWorkspace: sender_is_admin,
+    GetWorkspace: validate_can_view_workspace,
+    UpdateWorkspace: sender_is_admin,
+    DeleteWorkspace: sender_is_admin,
 }
 
 
@@ -693,6 +1116,7 @@ def get_before_request_handler(request_class):
     return BEFORE_REQUEST_HANDLERS.get(request_class)
 
 
+@functools.lru_cache(maxsize=None)
 def _re_compile_path(path: str) -> re.Pattern:
     """
     Convert a path with angle brackets to a regex pattern. For example,
@@ -744,9 +1168,19 @@ BEFORE_REQUEST_VALIDATORS.update(
         (CREATE_PROMPTLAB_RUN, "POST"): validate_can_create_promptlab_run,
         (GATEWAY_PROXY, "GET"): validate_gateway_proxy,
         (GATEWAY_PROXY, "POST"): validate_gateway_proxy,
+        (LIST_WORKSPACE_PERMISSIONS, "GET"): validate_can_list_workspace_permissions,
+        (LIST_WORKSPACE_PERMISSIONS, "POST"): validate_can_modify_workspace_permission,
+        (LIST_WORKSPACE_PERMISSIONS, "DELETE"): validate_can_modify_workspace_permission,
+        (LIST_USER_WORKSPACE_PERMISSIONS, "GET"): sender_is_admin,
     }
 )
 
+# Precompile workspace parameterized paths (e.g., workspace_name) for fast matching.
+WORKSPACE_PARAMETERIZED_BEFORE_REQUEST_VALIDATORS = {
+    (_re_compile_path(path), method): handler
+    for (path, method), handler in BEFORE_REQUEST_VALIDATORS.items()
+    if "<" in path and "/workspaces/" in path
+}
 
 LOGGED_MODEL_BEFORE_REQUEST_HANDLERS = {
     CreateLoggedModel: validate_can_update_experiment,
@@ -771,8 +1205,17 @@ LOGGED_MODEL_BEFORE_REQUEST_VALIDATORS = {
 }
 
 
+_AJAX_API_PATH_PREFIX = "/ajax-api/2.0"
+
+
 def _is_proxy_artifact_path(path: str) -> bool:
-    return path.startswith(f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/artifacts/")
+    # MlflowArtifactsService endpoints are registered at both /api/2.0/... and /ajax-api/2.0/...
+    # paths (see handlers._get_paths), so we need to check both prefixes for auth validation.
+    prefixes = [
+        f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/artifacts",
+        f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/artifacts",
+    ]
+    return any(path.startswith(prefix) for prefix in prefixes)
 
 
 def _get_proxy_artifact_validator(
@@ -836,8 +1279,26 @@ def _find_validator(req: Request) -> Callable[[], bool] | None:
             ),
             None,
         )
-    else:
-        return BEFORE_REQUEST_VALIDATORS.get((req.path, req.method))
+
+    if validator := BEFORE_REQUEST_VALIDATORS.get((req.path, req.method)):
+        return validator
+
+    # Workspace permission routes use parameterized path matching (e.g., workspace_name).
+    # Only check these when workspaces are enabled to avoid unnecessary regex matching.
+    if not MLFLOW_ENABLE_WORKSPACES.get():
+        return None
+
+    if "/workspaces/" not in req.path:
+        return None
+
+    # Regex matching for parameterized workspace paths.
+    for (path, method), candidate in WORKSPACE_PARAMETERIZED_BEFORE_REQUEST_VALIDATORS.items():
+        if method != req.method:
+            continue
+        if path.fullmatch(req.path):
+            return candidate
+
+    return None
 
 
 @catch_mlflow_exception
@@ -887,17 +1348,105 @@ def set_can_manage_registered_model_permission(resp: Response):
 
 def delete_can_manage_registered_model_permission(resp: Response):
     """
-    Delete registered model permission when the model is deleted.
+    Delete registered model permissions when the model is deleted.
 
     We need to do this because the primary key of the registered model is the name,
     unlike the experiment where the primary key is experiment_id (UUID). Therefore,
-    we have to delete the permission record when the model is deleted otherwise it
-    conflicts with the new model registered with the same name.
+    we have to delete existing permission records when the model is deleted; otherwise, they would
+    implicitly apply if a new model is later created with the same name.
     """
     # Get model name from request context because it's not available in the response
     name = request.get_json(force=True, silent=True)["name"]
+    store.delete_registered_model_permissions(name)
+
+
+def _validate_workspace_permission_payload(payload: dict[str, Any]) -> tuple[str, str]:
+    if missing := {"username", "permission"} - payload.keys():
+        raise MlflowException.invalid_parameter_value(
+            "Workspace permission payload missing keys: " + ", ".join(sorted(missing))
+        )
+    return payload["username"], payload["permission"]
+
+
+@catch_mlflow_exception
+@_disable_if_workspaces_disabled
+def list_workspace_permissions(workspace_name: str):
+    permissions = store.list_workspace_permissions(workspace_name)
+
+    if not sender_is_admin():
+        username = authenticate_request().username
+        perm = _workspace_permission(username, workspace_name)
+        if perm is None or not perm.can_manage:
+            return make_forbidden_response()
+
+    return jsonify({"permissions": [perm.to_json() for perm in permissions]})
+
+
+@catch_mlflow_exception
+@_disable_if_workspaces_disabled
+def set_workspace_permission(workspace_name: str):
+    payload = request.get_json(force=True, silent=True) or {}
+    username, permission = _validate_workspace_permission_payload(payload)
+    workspace_store = _get_workspace_store()
+    workspace_store.get_workspace(workspace_name)
+    perm = store.set_workspace_permission(workspace_name, username, permission)
+    return jsonify({"permission": perm.to_json()})
+
+
+@catch_mlflow_exception
+@_disable_if_workspaces_disabled
+def delete_workspace_permission(workspace_name: str):
+    username = _get_request_param("username")
+    store.delete_workspace_permission(workspace_name, username)
+    return Response(status=204)
+
+
+@catch_mlflow_exception
+@_disable_if_workspaces_disabled
+def list_user_workspace_permissions():
+    username = _get_request_param("username")
+    permissions = store.list_user_workspace_permissions(username)
+    return jsonify({"permissions": [perm.to_json() for perm in permissions]})
+
+
+def filter_list_workspaces(resp: Response) -> None:
+    if sender_is_admin():
+        return
+
     username = authenticate_request().username
-    store.delete_registered_model_permission(name, username)
+    response_message = ListWorkspaces.Response()
+    parse_dict(resp.json, response_message)
+
+    allowed: set[str] = set()
+    if username is not None:
+        allowed = set(store.list_accessible_workspace_names(username))
+        if auth_config.grant_default_workspace_access:
+            default_workspace, _ = get_default_workspace_optional(_get_workspace_store())
+            if default_workspace:
+                allowed.add(default_workspace.name)
+
+    filtered = [ws for ws in response_message.workspaces if ws.name in allowed]
+    response_message.ClearField("workspaces")
+    response_message.workspaces.extend(filtered)
+
+    resp.data = message_to_json(response_message)
+
+
+def _cleanup_workspace_permissions(resp: Response) -> None:
+    # This handler runs only on successful DELETE responses. Cleanup failures are logged
+    # instead of raised because the workspace deletion has already succeeded at this point.
+    workspace_name = request.view_args.get("workspace_name") if request.view_args else None
+    if not workspace_name:
+        return
+
+    try:
+        store.delete_workspace_permissions_for_workspace(workspace_name)
+    except MlflowException as e:
+        _logger.error(
+            "Failed to delete workspace permissions for workspace '%s': %s",
+            workspace_name,
+            e,
+        )
 
 
 def filter_search_experiments(resp: Response):
@@ -912,10 +1461,9 @@ def filter_search_experiments(resp: Response):
     perms = store.list_experiment_permissions(username)
     can_read = {p.experiment_id: get_permission(p.permission).can_read for p in perms}
     default_can_read = get_permission(auth_config.default_permission).can_read
-
     # filter out unreadable
     for e in list(response_message.experiments):
-        if not can_read.get(e.experiment_id, default_can_read):
+        if not _has_experiment_read_access(username, e.experiment_id, can_read, default_can_read):
             response_message.experiments.remove(e)
 
     # re-fetch to fill max results
@@ -937,7 +1485,9 @@ def filter_search_experiments(resp: Response):
             break
 
         refetched_readable_proto = [
-            e.to_proto() for e in refetched if can_read.get(e.experiment_id, default_can_read)
+            e.to_proto()
+            for e in refetched
+            if _has_experiment_read_access(username, e.experiment_id, can_read, default_can_read)
         ]
         response_message.experiments.extend(refetched_readable_proto)
 
@@ -968,10 +1518,11 @@ def filter_search_logged_models(resp: Response) -> None:
     perms = store.list_experiment_permissions(username)
     can_read = {p.experiment_id: get_permission(p.permission).can_read for p in perms}
     default_can_read = get_permission(auth_config.default_permission).can_read
-
     # Remove unreadable models
     for m in list(response_proto.models):
-        if not can_read.get(m.info.experiment_id, default_can_read):
+        if not _has_experiment_read_access(
+            username, m.info.experiment_id, can_read, default_can_read
+        ):
             response_proto.models.remove(m)
 
     request_proto = _get_request_message(SearchLoggedModels())
@@ -1004,7 +1555,9 @@ def filter_search_logged_models(resp: Response) -> None:
         offset = Token.decode(next_page_token).offset if next_page_token else 0
         last_index = len(batch) - 1
         for index, model in enumerate(batch):
-            if not can_read.get(model.experiment_id, default_can_read):
+            if not _has_experiment_read_access(
+                username, model.experiment_id, can_read, default_can_read
+            ):
                 continue
             response_proto.models.append(model.to_proto())
             if len(response_proto.models) >= max_results:
@@ -1037,10 +1590,9 @@ def filter_search_registered_models(resp: Response):
     perms = store.list_registered_model_permissions(username)
     can_read = {p.name: get_permission(p.permission).can_read for p in perms}
     default_can_read = get_permission(auth_config.default_permission).can_read
-
     # filter out unreadable
     for rm in list(response_message.registered_models):
-        if not can_read.get(rm.name, default_can_read):
+        if not _has_registered_model_read_access(username, rm.name, can_read, default_can_read):
             response_message.registered_models.remove(rm)
 
     # re-fetch to fill max results
@@ -1065,7 +1617,9 @@ def filter_search_registered_models(resp: Response):
             break
 
         refetched_readable_proto = [
-            rm.to_proto() for rm in refetched if can_read.get(rm.name, default_can_read)
+            rm.to_proto()
+            for rm in refetched
+            if _has_registered_model_read_access(username, rm.name, can_read, default_can_read)
         ]
         response_message.registered_models.extend(refetched_readable_proto)
 
@@ -1117,6 +1671,8 @@ AFTER_REQUEST_PATH_HANDLERS = {
     RenameRegisteredModel: rename_registered_model_permission,
     RegisterScorer: set_can_manage_scorer_permission,
     DeleteScorer: delete_scorer_permissions_cascade,
+    ListWorkspaces: filter_list_workspaces,
+    DeleteWorkspace: _cleanup_workspace_permissions,
 }
 
 
@@ -1128,7 +1684,14 @@ AFTER_REQUEST_HANDLERS = {
     (http_path, method): handler
     for http_path, handler, methods in get_endpoints(get_after_request_handler)
     for method in methods
-    if handler is not None and "/graphql" not in http_path
+    if handler is not None and "/graphql" not in http_path and "/server-features" not in http_path
+}
+
+# Precompile workspace parameterized paths for after-request handlers.
+WORKSPACE_PARAMETERIZED_AFTER_REQUEST_HANDLERS = {
+    (_re_compile_path(path), method): handler
+    for (path, method), handler in AFTER_REQUEST_HANDLERS.items()
+    if "<" in path and "/workspaces/" in path
 }
 
 
@@ -1137,7 +1700,17 @@ def _after_request(resp: Response):
     if 400 <= resp.status_code < 600:
         return resp
 
-    if handler := AFTER_REQUEST_HANDLERS.get((request.path, request.method)):
+    handler = AFTER_REQUEST_HANDLERS.get((request.path, request.method))
+    if handler is None and "/workspaces/" in request.path:
+        # Fallback to regex matching for workspace paths.
+        for (path, method), candidate in WORKSPACE_PARAMETERIZED_AFTER_REQUEST_HANDLERS.items():
+            if method != request.method:
+                continue
+            if path.fullmatch(request.path):
+                handler = candidate
+                break
+
+    if handler is not None:
         handler(resp)
     return resp
 
@@ -1565,6 +2138,26 @@ def create_app(app: Flask = app):
         rule=DELETE_SCORER_PERMISSION,
         view_func=delete_scorer_permission,
         methods=["DELETE"],
+    )
+    app.add_url_rule(
+        rule=LIST_WORKSPACE_PERMISSIONS,
+        view_func=list_workspace_permissions,
+        methods=["GET"],
+    )
+    app.add_url_rule(
+        rule=LIST_WORKSPACE_PERMISSIONS,
+        view_func=set_workspace_permission,
+        methods=["POST"],
+    )
+    app.add_url_rule(
+        rule=LIST_WORKSPACE_PERMISSIONS,
+        view_func=delete_workspace_permission,
+        methods=["DELETE"],
+    )
+    app.add_url_rule(
+        rule=LIST_USER_WORKSPACE_PERMISSIONS,
+        view_func=list_user_workspace_permissions,
+        methods=["GET"],
     )
 
     app.before_request(_before_request)

--- a/mlflow/server/auth/basic_auth.ini
+++ b/mlflow/server/auth/basic_auth.ini
@@ -4,3 +4,8 @@ database_uri = sqlite:///basic_auth.db
 admin_username = admin
 admin_password = password1234
 authorization_function = mlflow.server.auth:authenticate_request_basic_auth
+# When true, users inherit default_permission for the reserved 'default' workspace.
+grant_default_workspace_access = false
+# Cache settings for resource-to-workspace lookups (used for permission checks).
+# workspace_cache_max_size = 10000
+# workspace_cache_ttl_seconds = 3600

--- a/mlflow/server/auth/config.py
+++ b/mlflow/server/auth/config.py
@@ -11,6 +11,9 @@ class AuthConfig(NamedTuple):
     admin_username: str
     admin_password: str
     authorization_function: str
+    grant_default_workspace_access: bool
+    workspace_cache_max_size: int
+    workspace_cache_ttl_seconds: int
 
 
 def _get_auth_config_path() -> str:
@@ -30,5 +33,14 @@ def read_auth_config() -> AuthConfig:
         admin_password=config["mlflow"]["admin_password"],
         authorization_function=config["mlflow"].get(
             "authorization_function", "mlflow.server.auth:authenticate_request_basic_auth"
+        ),
+        grant_default_workspace_access=config.getboolean(
+            "mlflow", "grant_default_workspace_access", fallback=False
+        ),
+        workspace_cache_max_size=config.getint(
+            "mlflow", "workspace_cache_max_size", fallback=10000
+        ),
+        workspace_cache_ttl_seconds=config.getint(
+            "mlflow", "workspace_cache_ttl_seconds", fallback=3600
         ),
     )

--- a/mlflow/server/auth/db/migrations/versions/2ed73881770d_workspace_permissions.py
+++ b/mlflow/server/auth/db/migrations/versions/2ed73881770d_workspace_permissions.py
@@ -1,0 +1,90 @@
+"""Add workspace awareness to permissions
+
+Revision ID: 2ed73881770d
+Revises: 0965eb92f5f0
+Create Date: 2025-12-22 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+# revision identifiers, used by Alembic.
+revision = "2ed73881770d"
+down_revision = "0965eb92f5f0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workspace_permissions",
+        sa.Column("workspace", sa.String(length=63), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("permission", sa.String(length=32), nullable=False),
+        sa.PrimaryKeyConstraint("workspace", "user_id", name="workspace_permissions_pk"),
+    )
+    op.create_index(
+        "idx_workspace_permissions_user_id", "workspace_permissions", ["user_id"], unique=False
+    )
+    op.create_index(
+        "idx_workspace_permissions_workspace",
+        "workspace_permissions",
+        ["workspace"],
+        unique=False,
+    )
+
+    with op.batch_alter_table("registered_model_permissions", recreate="auto") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "workspace",
+                sa.String(length=63),
+                nullable=False,
+                server_default=sa.text(f"'{DEFAULT_WORKSPACE_NAME}'"),
+            )
+        )
+
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    unique_constraints = inspector.get_unique_constraints("registered_model_permissions")
+    has_unique_name_user = any(
+        constraint.get("name") == "unique_name_user" for constraint in unique_constraints
+    )
+
+    with op.batch_alter_table("registered_model_permissions", recreate="auto") as batch_op:
+        if has_unique_name_user:
+            batch_op.drop_constraint("unique_name_user", type_="unique")
+        batch_op.create_unique_constraint(
+            "unique_workspace_name_user", ["workspace", "name", "user_id"]
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conflicts = conn.execute(
+        sa.text(
+            """
+            SELECT name, user_id, COUNT(DISTINCT workspace) AS workspace_count
+            FROM registered_model_permissions
+            GROUP BY name, user_id
+            HAVING COUNT(DISTINCT workspace) > 1
+            """
+        )
+    ).fetchall()
+    if conflicts:
+        details = ", ".join(f"(name={row.name}, user_id={row.user_id})" for row in conflicts)
+        raise RuntimeError(
+            "Cannot downgrade workspace permissions migration because dropping the workspace "
+            + "column would create conflicts for the following registered_model_permissions rows: "
+            f"{details}. Please merge or delete the conflicting rows before retrying the downgrade."
+        )
+
+    op.drop_index("idx_workspace_permissions_workspace", table_name="workspace_permissions")
+    op.drop_index("idx_workspace_permissions_user_id", table_name="workspace_permissions")
+    op.drop_table("workspace_permissions")
+    with op.batch_alter_table("registered_model_permissions", recreate="auto") as batch_op:
+        batch_op.drop_constraint("unique_workspace_name_user", type_="unique")
+        batch_op.create_unique_constraint("unique_name_user", ["name", "user_id"])
+        batch_op.drop_column("workspace")

--- a/mlflow/server/auth/db/utils.py
+++ b/mlflow/server/auth/db/utils.py
@@ -59,7 +59,6 @@ def _stamp_legacy_database(engine: Engine, revision: str) -> None:
 def migrate(engine: Engine, revision: str) -> None:
     if _is_legacy_database(engine):
         _stamp_legacy_database(engine, INITIAL_REVISION)
-        return
 
     alembic_cfg = _get_alembic_config(engine.url.render_as_string(hide_password=False))
     with engine.begin() as conn:
@@ -70,7 +69,6 @@ def migrate(engine: Engine, revision: str) -> None:
 def migrate_if_needed(engine: Engine, revision: str) -> None:
     if _is_legacy_database(engine):
         _stamp_legacy_database(engine, INITIAL_REVISION)
-        return
 
     alembic_cfg = _get_alembic_config(engine.url.render_as_string(hide_password=False))
     script_dir = ScriptDirectory.from_config(alembic_cfg)

--- a/mlflow/server/auth/routes.py
+++ b/mlflow/server/auth/routes.py
@@ -20,6 +20,10 @@ CREATE_SCORER_PERMISSION = _get_rest_path("/mlflow/scorers/permissions/create", 
 GET_SCORER_PERMISSION = _get_rest_path("/mlflow/scorers/permissions/get", version=3)
 UPDATE_SCORER_PERMISSION = _get_rest_path("/mlflow/scorers/permissions/update", version=3)
 DELETE_SCORER_PERMISSION = _get_rest_path("/mlflow/scorers/permissions/delete", version=3)
+LIST_WORKSPACE_PERMISSIONS = _get_rest_path(
+    "/mlflow/workspaces/<workspace_name>/permissions", version=3
+)
+LIST_USER_WORKSPACE_PERMISSIONS = _get_rest_path("/mlflow/workspace-permissions", version=3)
 
 # Flask routes (not part of Protobuf API)
 GET_ARTIFACT = _add_static_prefix("/get-artifact")

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -584,7 +584,7 @@ def initialize_backend_stores(
 
 
 def _store_supports_workspaces(
-    store: AbstractTrackingStore | AbstractModelRegistryStore,
+    store: AbstractTrackingStore | AbstractModelRegistryStore | AbstractJobStore,
 ) -> bool:
     """Return whether the provided store reports workspace support."""
     return bool(getattr(store, "supports_workspaces", False))

--- a/mlflow/store/db_migrations/versions/1b5f0d9ad7c1_add_workspace_columns_and_catalog.py
+++ b/mlflow/store/db_migrations/versions/1b5f0d9ad7c1_add_workspace_columns_and_catalog.py
@@ -10,7 +10,7 @@ from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "1b5f0d9ad7c1"
-down_revision = "1b49d398cd23"
+down_revision = "1bd49d398cd23"
 branch_labels = None
 depends_on = None
 

--- a/mlflow/store/db_migrations/versions/1bd49d398cd23_add_secrets_tables.py
+++ b/mlflow/store/db_migrations/versions/1bd49d398cd23_add_secrets_tables.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "1b49d398cd23"
+revision = "1bd49d398cd23"
 down_revision = "bf29a5ff90ea"
 branch_labels = None
 depends_on = None

--- a/mlflow/store/workspace/utils.py
+++ b/mlflow/store/workspace/utils.py
@@ -9,9 +9,10 @@ _INVALID_PARAMETER_VALUE_CODE = databricks_pb2.INVALID_PARAMETER_VALUE
 _INVALID_PARAMETER_VALUE_NAME = databricks_pb2.ErrorCode.Name(_INVALID_PARAMETER_VALUE_CODE)
 
 
-def get_default_workspace_optional(
-    workspace_store, logger: logging.Logger | None = None
-) -> tuple[Workspace | None, bool]:
+_logger = logging.getLogger(__name__)
+
+
+def get_default_workspace_optional(workspace_store) -> tuple[Workspace | None, bool]:
     """
     Attempt to resolve a default workspace from the provider without bubbling opt-out errors.
 
@@ -21,7 +22,6 @@ def get_default_workspace_optional(
 
     Args:
         workspace_store: Workspace store exposing ``get_default_workspace``.
-        logger: Optional logger used for debug messaging.
 
     Returns:
         Tuple of (workspace or None, supports_default_workspace flag).
@@ -34,11 +34,10 @@ def get_default_workspace_optional(
     try:
         workspace = workspace_store.get_default_workspace()
     except NotImplementedError:
-        if logger:
-            logger.debug(
-                "Workspace provider %s does not implement default workspace resolution",
-                provider_name,
-            )
+        _logger.debug(
+            "Workspace provider %s does not implement default workspace resolution",
+            provider_name,
+        )
         return None, False
 
     return workspace, True

--- a/tests/db/compose.yml
+++ b/tests/db/compose.yml
@@ -40,6 +40,8 @@ services:
   mysql:
     image: mysql@sha256:569c4128dfa625ac2ac62cdd8af588a3a6a60a049d1a8d8f0fac95880ecdbbe5
     restart: always
+    # Allow non-SUPER users (our test user) to create triggers/functions when binlog is enabled.
+    command: --log-bin-trust-function-creators=1
     environment:
       MYSQL_ROOT_PASSWORD: root-password
       MYSQL_DATABASE: mlflowdb

--- a/tests/db/test_workspace_migration.py
+++ b/tests/db/test_workspace_migration.py
@@ -140,7 +140,7 @@ _EVALUATION_DATASETS = sa.table(
 )
 
 REVISION = "1b5f0d9ad7c1"
-PREVIOUS_REVISION = "1b49d398cd23"
+PREVIOUS_REVISION = "1bd49d398cd23"
 
 DB_URI = os.environ.get("MLFLOW_TRACKING_URI")
 USE_EXTERNAL_DB = DB_URI is not None and not DB_URI.startswith("sqlite")

--- a/tests/server/auth/db/test_cli.py
+++ b/tests/server/auth/db/test_cli.py
@@ -17,13 +17,16 @@ def test_upgrade(tmp_path: Path) -> None:
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
         tables = cursor.fetchall()
 
-    assert tables == [
-        ("alembic_version_auth",),
-        ("users",),
-        ("experiment_permissions",),
-        ("registered_model_permissions",),
-        ("scorer_permissions",),
-    ]
+    assert sorted(tables) == sorted(
+        [
+            ("alembic_version_auth",),
+            ("users",),
+            ("experiment_permissions",),
+            ("scorer_permissions",),
+            ("registered_model_permissions",),
+            ("workspace_permissions",),
+        ]
+    )
 
 
 def test_auth_and_tracking_store_coexist(tmp_path: Path) -> None:
@@ -48,8 +51,9 @@ def test_auth_and_tracking_store_coexist(tmp_path: Path) -> None:
     assert "alembic_version_auth" in tables
     assert "users" in tables
     assert "experiment_permissions" in tables
-    assert "registered_model_permissions" in tables
     assert "scorer_permissions" in tables
+    assert "registered_model_permissions" in tables
+    assert "workspace_permissions" in tables
     assert "experiments" in tables
     assert "runs" in tables
 
@@ -113,6 +117,8 @@ def test_upgrade_from_legacy_database(tmp_path: Path) -> None:
     assert "alembic_version_auth" in tables
     assert "users" in tables
     assert "experiment_permissions" in tables
+    assert "scorer_permissions" in tables
     assert "registered_model_permissions" in tables
-    assert version[0] == "8606fa83a998"
+    assert "workspace_permissions" in tables
+    assert version[0] == "2ed73881770d"
     assert user == ("testuser", 1)

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -1,0 +1,863 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from flask import Response, request
+
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+from mlflow.server import auth as auth_module
+from mlflow.server.auth.permissions import MANAGE, NO_PERMISSIONS, READ
+from mlflow.server.auth.routes import (
+    CREATE_PROMPTLAB_RUN,
+    GET_ARTIFACT,
+    GET_METRIC_HISTORY_BULK,
+    GET_METRIC_HISTORY_BULK_INTERVAL,
+    GET_MODEL_VERSION_ARTIFACT,
+    GET_TRACE_ARTIFACT,
+    SEARCH_DATASETS,
+    UPLOAD_ARTIFACT,
+)
+from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
+from mlflow.utils import workspace_context
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+from tests.helper_functions import random_str
+
+
+def test_cleanup_workspace_permissions_handler(monkeypatch):
+    mock_delete = Mock()
+
+    monkeypatch.setattr(
+        auth_module.store,
+        "delete_workspace_permissions_for_workspace",
+        mock_delete,
+        raising=True,
+    )
+
+    workspace_name = f"team-{random_str(10)}"
+    with auth_module.app.test_request_context(
+        f"/api/2.0/mlflow/workspaces/{workspace_name}", method="DELETE"
+    ):
+        request.view_args = {"workspace_name": workspace_name}
+        response = Response(status=204)
+        auth_module._after_request(response)
+
+    mock_delete.assert_called_once_with(workspace_name)
+
+
+class _TrackingStore:
+    def __init__(
+        self,
+        experiment_workspaces: dict[str, str],
+        run_experiments: dict[str, str],
+        trace_experiments: dict[str, str],
+        experiment_names: dict[str, str] | None = None,
+        logged_model_experiments: dict[str, str] | None = None,
+    ):
+        self._experiment_workspaces = experiment_workspaces
+        self._run_experiments = run_experiments
+        self._trace_experiments = trace_experiments
+        self._experiment_names = experiment_names or {}
+        self._logged_model_experiments = logged_model_experiments or {}
+
+    def get_experiment(self, experiment_id: str):
+        return SimpleNamespace(workspace=self._experiment_workspaces[experiment_id])
+
+    def get_experiment_by_name(self, experiment_name: str):
+        experiment_id = self._experiment_names.get(experiment_name)
+        if experiment_id is None:
+            return None
+        return SimpleNamespace(
+            experiment_id=experiment_id,
+            workspace=self._experiment_workspaces[experiment_id],
+        )
+
+    def get_run(self, run_id: str):
+        return SimpleNamespace(info=SimpleNamespace(experiment_id=self._run_experiments[run_id]))
+
+    def get_trace_info(self, request_id: str):
+        return SimpleNamespace(experiment_id=self._trace_experiments[request_id])
+
+    def get_logged_model(self, model_id: str):
+        experiment_id = self._logged_model_experiments[model_id]
+        return SimpleNamespace(experiment_id=experiment_id)
+
+
+class _RegistryStore:
+    def __init__(self, model_workspaces: dict[str, str]):
+        self._model_workspaces = model_workspaces
+
+    def get_registered_model(self, name: str):
+        return SimpleNamespace(workspace=self._model_workspaces[name])
+
+
+@pytest.fixture
+def workspace_permission_setup(tmp_path, monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(default_permission=NO_PERMISSIONS.name),
+    )
+
+    db_uri = f"sqlite:///{tmp_path / 'auth-store.db'}"
+    auth_store = SqlAlchemyStore()
+    auth_store.init_db(db_uri)
+    monkeypatch.setattr(auth_module, "store", auth_store, raising=False)
+
+    username = "alice"
+    auth_store.create_user(username, "supersecurepassword", is_admin=False)
+
+    tracking_store = _TrackingStore(
+        experiment_workspaces={"exp-1": "team-a", "exp-2": "team-a", "1": "team-a"},
+        run_experiments={"run-1": "exp-1", "run-2": "exp-2"},
+        trace_experiments={"trace-1": "exp-1"},
+        experiment_names={"Primary Experiment": "exp-1"},
+        logged_model_experiments={"model-1": "exp-1"},
+    )
+    monkeypatch.setattr(auth_module, "_get_tracking_store", lambda: tracking_store)
+
+    registry_store = _RegistryStore({"model-xyz": "team-a"})
+    monkeypatch.setattr(auth_module, "_get_model_registry_store", lambda: registry_store)
+
+    monkeypatch.setattr(
+        auth_module,
+        "authenticate_request",
+        lambda: SimpleNamespace(username=username),
+    )
+
+    auth_store.set_workspace_permission("team-a", username, MANAGE.name)
+
+    with workspace_context.WorkspaceContext("team-a"):
+        yield {"store": auth_store, "username": username}
+    auth_store.engine.dispose()
+
+
+def _set_workspace_permission(store: SqlAlchemyStore, username: str, permission: str):
+    store.set_workspace_permission("team-a", username, permission)
+
+
+def test_workspace_permission_grants_default_access(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+
+    default_permission = MANAGE.name
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(
+            default_permission=default_permission,
+            grant_default_workspace_access=True,
+        ),
+        raising=False,
+    )
+
+    class DummyStore:
+        def get_workspace_permission(self, workspace_name, username):
+            return None
+
+        def list_accessible_workspace_names(self, username):
+            return []
+
+    dummy_store = DummyStore()
+    monkeypatch.setattr(auth_module, "store", dummy_store, raising=False)
+
+    default_workspace = DEFAULT_WORKSPACE_NAME
+    monkeypatch.setattr(auth_module, "_get_workspace_store", lambda: None, raising=False)
+    monkeypatch.setattr(
+        auth_module,
+        "get_default_workspace_optional",
+        lambda *args, **kwargs: (SimpleNamespace(name=default_workspace), True),
+        raising=False,
+    )
+
+    auth = SimpleNamespace(username="alice")
+    permission = auth_module._workspace_permission(auth.username, default_workspace)
+    assert permission is not None
+    assert permission.can_manage
+
+    with workspace_context.WorkspaceContext(default_workspace):
+        monkeypatch.setattr(auth_module, "authenticate_request", lambda: auth)
+        assert auth_module.validate_can_create_experiment()
+
+
+def test_filter_list_workspaces_includes_default_when_autogrant(monkeypatch):
+    monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)
+    auth = SimpleNamespace(username="alice")
+    monkeypatch.setattr(auth_module, "authenticate_request", lambda: auth)
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(
+            grant_default_workspace_access=True,
+            default_permission=READ.name,
+        ),
+        raising=False,
+    )
+
+    default_workspace = "team-default"
+    monkeypatch.setattr(auth_module, "_get_workspace_store", lambda: None, raising=False)
+    monkeypatch.setattr(
+        auth_module,
+        "get_default_workspace_optional",
+        lambda *args, **kwargs: (SimpleNamespace(name=default_workspace), True),
+        raising=False,
+    )
+
+    class DummyStore:
+        def list_accessible_workspace_names(self, username):
+            return []
+
+    monkeypatch.setattr(auth_module, "store", DummyStore(), raising=False)
+
+    response = Response(
+        json.dumps(
+            {
+                "workspaces": [
+                    {"name": default_workspace},
+                    {"name": "other-workspace"},
+                ]
+            }
+        ),
+        mimetype="application/json",
+    )
+
+    auth_module.filter_list_workspaces(response)
+    payload = json.loads(response.get_data(as_text=True))
+    assert payload["workspaces"] == [{"name": default_workspace}]
+
+
+def test_filter_list_workspaces_filters_to_allowed(monkeypatch):
+    monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)
+    auth = SimpleNamespace(username="alice")
+    monkeypatch.setattr(auth_module, "authenticate_request", lambda: auth)
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(
+            grant_default_workspace_access=False,
+        ),
+        raising=False,
+    )
+
+    class DummyStore:
+        def list_accessible_workspace_names(self, username):
+            return ["team-a"]
+
+    monkeypatch.setattr(auth_module, "store", DummyStore(), raising=False)
+
+    response = Response(
+        json.dumps({"workspaces": [{"name": "team-a"}, {"name": "team-b"}]}),
+        mimetype="application/json",
+    )
+
+    auth_module.filter_list_workspaces(response)
+    payload = json.loads(response.get_data(as_text=True))
+    assert [ws["name"] for ws in payload["workspaces"]] == ["team-a"]
+
+
+def test_validate_can_view_workspace_allows_default_autogrant(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)
+    auth = SimpleNamespace(username="alice")
+    monkeypatch.setattr(auth_module, "authenticate_request", lambda: auth)
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(
+            grant_default_workspace_access=True,
+            default_permission=READ.name,
+        ),
+        raising=False,
+    )
+
+    default_workspace = "team-default"
+    monkeypatch.setattr(auth_module, "_get_workspace_store", lambda: None, raising=False)
+    monkeypatch.setattr(
+        auth_module,
+        "get_default_workspace_optional",
+        lambda *args, **kwargs: (SimpleNamespace(name=default_workspace), True),
+        raising=False,
+    )
+
+    class DummyStore:
+        def list_accessible_workspace_names(self, username):
+            return []
+
+    monkeypatch.setattr(auth_module, "store", DummyStore(), raising=False)
+
+    with auth_module.app.test_request_context(
+        f"/api/2.0/mlflow/workspaces/{default_workspace}", method="GET"
+    ):
+        request.view_args = {"workspace_name": default_workspace}
+        assert auth_module.validate_can_view_workspace()
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/workspaces/other-team", method="GET"
+    ):
+        request.view_args = {"workspace_name": "other-team"}
+        assert not auth_module.validate_can_view_workspace()
+
+
+def test_experiment_validators_allow_manage_permission(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, MANAGE.name)
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/experiments/get", method="GET", query_string={"experiment_id": "exp-1"}
+    ):
+        assert auth_module.validate_can_read_experiment()
+        assert auth_module.validate_can_update_experiment()
+        assert auth_module.validate_can_delete_experiment()
+        assert auth_module.validate_can_manage_experiment()
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/experiments/get-by-name",
+        method="GET",
+        query_string={"experiment_name": "Primary Experiment"},
+    ):
+        assert auth_module.validate_can_read_experiment_by_name()
+
+    with workspace_context.WorkspaceContext("team-a"):
+        assert auth_module.validate_can_create_experiment()
+
+
+def test_experiment_validators_read_permission_blocks_writes(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, READ.name)
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/experiments/get", method="GET", query_string={"experiment_id": "exp-1"}
+    ):
+        assert auth_module.validate_can_read_experiment()
+        assert not auth_module.validate_can_update_experiment()
+        assert not auth_module.validate_can_delete_experiment()
+        assert not auth_module.validate_can_manage_experiment()
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/experiments/get-by-name",
+        method="GET",
+        query_string={"experiment_name": "Primary Experiment"},
+    ):
+        assert auth_module.validate_can_read_experiment_by_name()
+
+    with workspace_context.WorkspaceContext("team-a"):
+        assert not auth_module.validate_can_create_experiment()
+
+
+def test_experiment_artifact_proxy_validators_respect_permissions(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, MANAGE.name)
+
+    with auth_module.app.test_request_context(
+        "/ajax-api/2.0/mlflow-artifacts/artifacts/1/path",
+        method="GET",
+    ):
+        request.view_args = {"artifact_path": "1/path"}
+        assert auth_module.validate_can_read_experiment_artifact_proxy()
+        assert auth_module.validate_can_update_experiment_artifact_proxy()
+        assert auth_module.validate_can_delete_experiment_artifact_proxy()
+
+    _set_workspace_permission(store, username, READ.name)
+
+    with auth_module.app.test_request_context(
+        "/ajax-api/2.0/mlflow-artifacts/artifacts/1/path",
+        method="GET",
+    ):
+        request.view_args = {"artifact_path": "1/path"}
+        assert auth_module.validate_can_read_experiment_artifact_proxy()
+        assert not auth_module.validate_can_update_experiment_artifact_proxy()
+        assert not auth_module.validate_can_delete_experiment_artifact_proxy()
+
+
+def test_experiment_artifact_proxy_without_experiment_id_uses_workspace_permissions(
+    workspace_permission_setup,
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, READ.name)
+
+    with auth_module.app.test_request_context(
+        "/ajax-api/2.0/mlflow-artifacts/artifacts/uploads/path",
+        method="GET",
+    ):
+        request.view_args = {"artifact_path": "uploads/path"}
+        assert auth_module.validate_can_read_experiment_artifact_proxy()
+        assert not auth_module.validate_can_update_experiment_artifact_proxy()
+
+
+def test_experiment_artifact_proxy_without_experiment_id_denied_without_workspace_permission(
+    workspace_permission_setup,
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, NO_PERMISSIONS.name)
+
+    with auth_module.app.test_request_context(
+        "/ajax-api/2.0/mlflow-artifacts/artifacts/uploads/path",
+        method="GET",
+    ):
+        request.view_args = {"artifact_path": "uploads/path"}
+        assert not auth_module.validate_can_read_experiment_artifact_proxy()
+
+
+def test_filter_experiment_ids_respects_workspace_permissions(
+    workspace_permission_setup, monkeypatch
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    monkeypatch.setattr(auth_module, "sender_is_admin", lambda: False)
+
+    experiment_ids = ["exp-1", "exp-2"]
+    assert auth_module.filter_experiment_ids(experiment_ids) == experiment_ids
+
+    _set_workspace_permission(store, username, NO_PERMISSIONS.name)
+    assert auth_module.filter_experiment_ids(experiment_ids) == []
+
+
+def test_run_validators_allow_manage_permission(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, MANAGE.name)
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/runs/get", method="GET", query_string={"run_id": "run-1"}
+    ):
+        assert auth_module.validate_can_read_run()
+        assert auth_module.validate_can_update_run()
+        assert auth_module.validate_can_delete_run()
+        assert auth_module.validate_can_manage_run()
+
+
+def test_run_validators_read_permission_blocks_writes(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, READ.name)
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/runs/get", method="GET", query_string={"run_id": "run-1"}
+    ):
+        assert auth_module.validate_can_read_run()
+        assert not auth_module.validate_can_update_run()
+        assert not auth_module.validate_can_delete_run()
+        assert not auth_module.validate_can_manage_run()
+
+
+def test_logged_model_validators_respect_permissions(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+
+    _set_workspace_permission(store, username, MANAGE.name)
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/logged-models/get",
+        method="GET",
+        query_string={"model_id": "model-1"},
+    ):
+        assert auth_module.validate_can_read_logged_model()
+        assert auth_module.validate_can_update_logged_model()
+        assert auth_module.validate_can_delete_logged_model()
+        assert auth_module.validate_can_manage_logged_model()
+
+    _set_workspace_permission(store, username, READ.name)
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/logged-models/get",
+        method="GET",
+        query_string={"model_id": "model-1"},
+    ):
+        assert auth_module.validate_can_read_logged_model()
+        assert not auth_module.validate_can_update_logged_model()
+        assert not auth_module.validate_can_delete_logged_model()
+        assert not auth_module.validate_can_manage_logged_model()
+
+
+def test_scorer_validators_use_workspace_permissions(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, MANAGE.name)
+
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/scorers/get",
+        method="GET",
+        query_string={"experiment_id": "exp-1", "name": "score-1"},
+    ):
+        assert auth_module.validate_can_read_scorer()
+        assert auth_module.validate_can_update_scorer()
+        assert auth_module.validate_can_delete_scorer()
+        assert auth_module.validate_can_manage_scorer()
+
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/scorers/permissions/create",
+        method="POST",
+        json={
+            "experiment_id": "exp-1",
+            "scorer_name": "score-1",
+            "username": "bob",
+            "permission": "READ",
+        },
+    ):
+        assert auth_module.validate_can_manage_scorer_permission()
+
+
+def test_scorer_validators_read_permission_blocks_writes(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, READ.name)
+
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/scorers/get",
+        method="GET",
+        query_string={"experiment_id": "exp-1", "name": "score-1"},
+    ):
+        assert auth_module.validate_can_read_scorer()
+        assert not auth_module.validate_can_update_scorer()
+        assert not auth_module.validate_can_delete_scorer()
+        assert not auth_module.validate_can_manage_scorer()
+
+    with auth_module.app.test_request_context(
+        "/api/3.0/mlflow/scorers/permissions/create",
+        method="POST",
+        json={
+            "experiment_id": "exp-1",
+            "scorer_name": "score-1",
+            "username": "bob",
+            "permission": "READ",
+        },
+    ):
+        assert not auth_module.validate_can_manage_scorer_permission()
+
+
+def test_registered_model_validators_require_manage_for_writes(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+
+    with workspace_context.WorkspaceContext("team-a"):
+        _set_workspace_permission(store, username, MANAGE.name)
+        with auth_module.app.test_request_context(
+            "/api/2.0/mlflow/registered-models/get",
+            method="GET",
+            query_string={"name": "model-xyz"},
+        ):
+            assert auth_module.validate_can_read_registered_model()
+            assert auth_module.validate_can_update_registered_model()
+            assert auth_module.validate_can_delete_registered_model()
+            assert auth_module.validate_can_manage_registered_model()
+        perm = auth_module._workspace_permission(
+            auth_module.authenticate_request().username, "team-a"
+        )
+        assert perm is not None
+        assert perm.can_manage
+        assert workspace_context.get_request_workspace() == "team-a"
+        assert auth_module.validate_can_create_registered_model()
+
+        _set_workspace_permission(store, username, READ.name)
+        with auth_module.app.test_request_context(
+            "/api/2.0/mlflow/registered-models/get",
+            method="GET",
+            query_string={"name": "model-xyz"},
+        ):
+            assert auth_module.validate_can_read_registered_model()
+            assert not auth_module.validate_can_update_registered_model()
+            assert not auth_module.validate_can_delete_registered_model()
+            assert not auth_module.validate_can_manage_registered_model()
+        assert not auth_module.validate_can_create_registered_model()
+
+
+def test_validate_can_view_workspace_requires_access(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/workspaces/team-a",
+        method="GET",
+    ):
+        request.view_args = {"workspace_name": "team-a"}
+        assert auth_module.validate_can_view_workspace()
+
+    store.delete_workspace_permission("team-a", username)
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/workspaces/team-a",
+        method="GET",
+    ):
+        request.view_args = {"workspace_name": "team-a"}
+        assert not auth_module.validate_can_view_workspace()
+
+
+def test_run_artifact_validators_use_workspace_permissions(workspace_permission_setup):
+    with auth_module.app.test_request_context(
+        GET_ARTIFACT,
+        method="GET",
+        query_string={"run_id": "run-1"},
+    ):
+        assert auth_module.validate_can_read_run_artifact()
+
+    with auth_module.app.test_request_context(
+        UPLOAD_ARTIFACT,
+        method="POST",
+        query_string={"run_id": "run-1"},
+    ):
+        assert auth_module.validate_can_update_run_artifact()
+
+
+def test_model_version_artifact_validator_uses_workspace_permissions(workspace_permission_setup):
+    with auth_module.app.test_request_context(
+        GET_MODEL_VERSION_ARTIFACT,
+        method="GET",
+        query_string={"name": "model-xyz"},
+    ):
+        assert auth_module.validate_can_read_model_version_artifact()
+
+
+def test_metric_history_bulk_validator_uses_workspace_permissions(workspace_permission_setup):
+    with auth_module.app.test_request_context(
+        GET_METRIC_HISTORY_BULK,
+        method="GET",
+        query_string=[("run_id", "run-1"), ("run_id", "run-2")],
+    ):
+        assert auth_module.validate_can_read_metric_history_bulk()
+
+
+def test_metric_history_bulk_interval_validator_uses_workspace_permissions(
+    workspace_permission_setup,
+):
+    with auth_module.app.test_request_context(
+        GET_METRIC_HISTORY_BULK_INTERVAL,
+        method="GET",
+        query_string=[
+            ("run_id", "run-1"),
+            ("run_id", "run-2"),
+            ("metric_key", "loss"),
+        ],
+    ):
+        assert auth_module.validate_can_read_metric_history_bulk_interval()
+
+
+def test_search_datasets_validator_uses_workspace_permissions(workspace_permission_setup):
+    with auth_module.app.test_request_context(
+        SEARCH_DATASETS,
+        method="POST",
+        json={"experiment_ids": ["exp-1", "exp-2"]},
+    ):
+        assert auth_module.validate_can_search_datasets()
+
+
+def test_create_promptlab_run_validator_uses_workspace_permissions(workspace_permission_setup):
+    with auth_module.app.test_request_context(
+        CREATE_PROMPTLAB_RUN,
+        method="POST",
+        json={"experiment_id": "exp-2"},
+    ):
+        assert auth_module.validate_can_create_promptlab_run()
+
+
+def test_trace_artifact_validator_uses_workspace_permissions(workspace_permission_setup):
+    with auth_module.app.test_request_context(
+        GET_TRACE_ARTIFACT,
+        method="GET",
+        query_string={"request_id": "trace-1"},
+    ):
+        assert auth_module.validate_can_read_trace_artifact()
+
+
+def test_experiment_artifact_proxy_without_workspaces_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(default_permission=READ.name),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        auth_module,
+        "authenticate_request",
+        lambda: SimpleNamespace(username="carol"),
+    )
+
+    with auth_module.app.test_request_context(
+        "/ajax-api/2.0/mlflow-artifacts/artifacts/uploads/path",
+        method="GET",
+    ):
+        request.view_args = {"artifact_path": "uploads/path"}
+        assert auth_module.validate_can_read_experiment_artifact_proxy()
+
+
+def test_run_artifact_validators_denied_without_workspace_permission(workspace_permission_setup):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    with auth_module.app.test_request_context(
+        GET_ARTIFACT,
+        method="GET",
+        query_string={"run_id": "run-1"},
+    ):
+        assert not auth_module.validate_can_read_run_artifact()
+
+    with auth_module.app.test_request_context(
+        UPLOAD_ARTIFACT,
+        method="POST",
+        query_string={"run_id": "run-1"},
+    ):
+        assert not auth_module.validate_can_update_run_artifact()
+
+
+def test_model_version_artifact_validator_denied_without_workspace_permission(
+    workspace_permission_setup,
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    with auth_module.app.test_request_context(
+        GET_MODEL_VERSION_ARTIFACT,
+        method="GET",
+        query_string={"name": "model-xyz"},
+    ):
+        assert not auth_module.validate_can_read_model_version_artifact()
+
+
+def test_metric_history_bulk_validator_denied_without_workspace_permission(
+    workspace_permission_setup,
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    with auth_module.app.test_request_context(
+        GET_METRIC_HISTORY_BULK,
+        method="GET",
+        query_string=[("run_id", "run-1"), ("run_id", "run-2")],
+    ):
+        assert not auth_module.validate_can_read_metric_history_bulk()
+
+
+def test_metric_history_bulk_interval_validator_denied_without_workspace_permission(
+    workspace_permission_setup,
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    with auth_module.app.test_request_context(
+        GET_METRIC_HISTORY_BULK_INTERVAL,
+        method="GET",
+        query_string=[
+            ("run_id", "run-1"),
+            ("run_id", "run-2"),
+            ("metric_key", "loss"),
+        ],
+    ):
+        assert not auth_module.validate_can_read_metric_history_bulk_interval()
+
+
+def test_search_datasets_validator_denied_without_workspace_permission(
+    workspace_permission_setup,
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    with auth_module.app.test_request_context(
+        SEARCH_DATASETS,
+        method="POST",
+        json={"experiment_ids": ["exp-1", "exp-2"]},
+    ):
+        assert not auth_module.validate_can_search_datasets()
+
+
+def test_create_promptlab_run_validator_denied_without_workspace_permission(
+    workspace_permission_setup,
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    with auth_module.app.test_request_context(
+        CREATE_PROMPTLAB_RUN,
+        method="POST",
+        json={"experiment_id": "exp-2"},
+    ):
+        assert not auth_module.validate_can_create_promptlab_run()
+
+
+def test_trace_artifact_validator_denied_without_workspace_permission(
+    workspace_permission_setup,
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+
+    with auth_module.app.test_request_context(
+        GET_TRACE_ARTIFACT,
+        method="GET",
+        query_string={"request_id": "trace-1"},
+    ):
+        assert not auth_module.validate_can_read_trace_artifact()
+
+
+def test_cross_workspace_access_denied(workspace_permission_setup, monkeypatch):
+    tracking_store = _TrackingStore(
+        experiment_workspaces={"exp-other-ws": "team-b"},
+        run_experiments={"run-other-ws": "exp-other-ws"},
+        trace_experiments={},
+    )
+    monkeypatch.setattr(auth_module, "_get_tracking_store", lambda: tracking_store)
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/experiments/get",
+        method="GET",
+        query_string={"experiment_id": "exp-other-ws"},
+    ):
+        assert not auth_module.validate_can_read_experiment()
+        assert not auth_module.validate_can_update_experiment()
+        assert not auth_module.validate_can_delete_experiment()
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/runs/get",
+        method="GET",
+        query_string={"run_id": "run-other-ws"},
+    ):
+        assert not auth_module.validate_can_read_run()
+        assert not auth_module.validate_can_update_run()
+
+
+def test_cross_workspace_registered_model_access_denied(workspace_permission_setup, monkeypatch):
+    registry_store = _RegistryStore({"model-other-ws": "team-b"})
+    monkeypatch.setattr(auth_module, "_get_model_registry_store", lambda: registry_store)
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/registered-models/get",
+        method="GET",
+        query_string={"name": "model-other-ws"},
+    ):
+        assert not auth_module.validate_can_read_registered_model()
+        assert not auth_module.validate_can_update_registered_model()
+        assert not auth_module.validate_can_delete_registered_model()
+
+
+def test_explicit_experiment_permission_overrides_workspace(
+    workspace_permission_setup,
+):
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+
+    store.set_workspace_permission("team-a", username, NO_PERMISSIONS.name)
+    store.create_experiment_permission("exp-1", username, READ.name)
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/experiments/get",
+        method="GET",
+        query_string={"experiment_id": "exp-1"},
+    ):
+        assert auth_module.validate_can_read_experiment()
+        assert not auth_module.validate_can_update_experiment()
+
+    with auth_module.app.test_request_context(
+        "/api/2.0/mlflow/experiments/get",
+        method="GET",
+        query_string={"experiment_id": "exp-2"},
+    ):
+        assert not auth_module.validate_can_read_experiment()

--- a/tests/server/auth/test_client.py
+++ b/tests/server/auth/test_client.py
@@ -19,6 +19,7 @@ from mlflow.protos.databricks_pb2 import (
 from mlflow.server.auth import auth_config
 from mlflow.server.auth.client import AuthServiceClient
 from mlflow.utils.os import is_windows
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 from tests.helper_functions import random_str
 from tests.server.auth.auth_test_utils import (
@@ -273,6 +274,7 @@ def test_client_create_registered_model_permission(client, monkeypatch):
         rmp = client.create_registered_model_permission(name, username, PERMISSION)
     assert rmp.name == name
     assert rmp.permission == PERMISSION
+    assert rmp.workspace == DEFAULT_WORKSPACE_NAME
 
     with assert_unauthenticated():
         client.create_registered_model_permission(name, username, PERMISSION)
@@ -290,6 +292,7 @@ def test_client_get_registered_model_permission(client, monkeypatch):
         rmp = client.get_registered_model_permission(name, username)
     assert rmp.name == name
     assert rmp.permission == PERMISSION
+    assert rmp.workspace == DEFAULT_WORKSPACE_NAME
 
     with assert_unauthenticated():
         client.get_registered_model_permission(name, username)
@@ -308,6 +311,7 @@ def test_client_update_registered_model_permission(client, monkeypatch):
         rmp = client.get_registered_model_permission(name, username)
     assert rmp.name == name
     assert rmp.permission == NEW_PERMISSION
+    assert rmp.workspace == DEFAULT_WORKSPACE_NAME
 
     with assert_unauthenticated():
         client.update_registered_model_permission(name, username, PERMISSION)
@@ -323,10 +327,14 @@ def test_client_delete_registered_model_permission(client, monkeypatch):
     with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
         client.create_registered_model_permission(name, username, PERMISSION)
         client.delete_registered_model_permission(name, username)
+        expected_message = (
+            "Registered model permission with "
+            f"workspace={DEFAULT_WORKSPACE_NAME}, name={name} "
+            f"and username={username} not found"
+        )
         with pytest.raises(
             MlflowException,
-            match=rf"Registered model permission with name={name} "
-            rf"and username={username} not found",
+            match=expected_message,
         ) as exception_context:
             client.get_registered_model_permission(name, username)
         assert exception_context.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)

--- a/tests/server/auth/test_client_workspace.py
+++ b/tests/server/auth/test_client_workspace.py
@@ -1,0 +1,374 @@
+from contextlib import contextmanager
+
+import pytest
+import requests
+
+from mlflow import MlflowException
+from mlflow.environment_variables import (
+    MLFLOW_ENABLE_WORKSPACES,
+    MLFLOW_FLASK_SERVER_SECRET_KEY,
+    MLFLOW_TRACKING_PASSWORD,
+    MLFLOW_TRACKING_USERNAME,
+    MLFLOW_WORKSPACE_STORE_URI,
+)
+from mlflow.protos.databricks_pb2 import PERMISSION_DENIED, UNAUTHENTICATED, ErrorCode
+from mlflow.server.auth.client import AuthServiceClient
+from mlflow.utils.os import is_windows
+from mlflow.utils.workspace_utils import WORKSPACE_HEADER_NAME
+
+from tests.helper_functions import random_str
+from tests.server.auth.auth_test_utils import (
+    ADMIN_PASSWORD,
+    ADMIN_USERNAME,
+    User,
+    create_user,
+)
+from tests.tracking.integration_test_utils import _init_server
+
+
+@pytest.fixture(autouse=True)
+def clear_credentials(monkeypatch):
+    monkeypatch.delenv(MLFLOW_TRACKING_USERNAME.name, raising=False)
+    monkeypatch.delenv(MLFLOW_TRACKING_PASSWORD.name, raising=False)
+
+
+@pytest.fixture
+def workspace_client(tmp_path):
+    path = tmp_path.joinpath("sqlalchemy.db").as_uri()
+    backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
+
+    with _init_server(
+        backend_uri=backend_uri,
+        root_artifact_uri=tmp_path.joinpath("artifacts").as_uri(),
+        app="mlflow.server.auth:create_app",
+        extra_env={
+            MLFLOW_FLASK_SERVER_SECRET_KEY.name: "my-secret-key",
+            MLFLOW_ENABLE_WORKSPACES.name: "true",
+            MLFLOW_WORKSPACE_STORE_URI.name: backend_uri,
+        },
+        server_type="flask",
+    ) as url:
+        yield AuthServiceClient(url), url
+
+
+@contextmanager
+def assert_unauthenticated():
+    with pytest.raises(MlflowException, match=r"You are not authenticated.") as exception_context:
+        yield
+    assert exception_context.value.error_code == ErrorCode.Name(UNAUTHENTICATED)
+
+
+@contextmanager
+def assert_unauthorized():
+    with pytest.raises(MlflowException, match=r"Permission denied.") as exception_context:
+        yield
+    assert exception_context.value.error_code == ErrorCode.Name(PERMISSION_DENIED)
+
+
+def _create_workspace(tracking_uri: str, workspace_name: str):
+    response = requests.post(
+        f"{tracking_uri}/api/2.0/mlflow/workspaces",
+        json={"name": workspace_name},
+        auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
+    )
+    response.raise_for_status()
+
+
+@pytest.fixture
+def workspace_setup(workspace_client):
+    client, tracking_uri = workspace_client
+    workspace_name = f"team-{random_str()}"
+    _create_workspace(tracking_uri, workspace_name)
+    username, password = create_user(tracking_uri)
+    return client, tracking_uri, workspace_name, username, password
+
+
+def _create_experiment(
+    tracking_uri: str, workspace_name: str, auth: tuple[str, str] = (ADMIN_USERNAME, ADMIN_PASSWORD)
+) -> str:
+    resp = requests.post(
+        f"{tracking_uri}/api/2.0/mlflow/experiments/create",
+        json={"name": f"exp-{random_str()}"},
+        auth=auth,
+        headers={WORKSPACE_HEADER_NAME: workspace_name},
+    )
+    assert resp.ok, f"create_experiment failed with {resp.status_code}: {resp.text}"
+    return resp.json()["experiment_id"]
+
+
+def _create_run(
+    tracking_uri: str,
+    workspace_name: str,
+    experiment_id: str,
+    auth: tuple[str, str] = (ADMIN_USERNAME, ADMIN_PASSWORD),
+) -> str:
+    resp = requests.post(
+        f"{tracking_uri}/api/2.0/mlflow/runs/create",
+        json={"experiment_id": experiment_id},
+        auth=auth,
+        headers={WORKSPACE_HEADER_NAME: workspace_name},
+    )
+    assert resp.ok, f"create_run failed with {resp.status_code}: {resp.text}"
+    return resp.json()["run"]["info"]["run_id"]
+
+
+def _create_registered_model(
+    tracking_uri: str,
+    workspace_name: str,
+    model_name: str,
+    auth: tuple[str, str] = (ADMIN_USERNAME, ADMIN_PASSWORD),
+):
+    resp = requests.post(
+        f"{tracking_uri}/api/2.0/mlflow/registered-models/create",
+        json={"name": model_name},
+        auth=auth,
+        headers={WORKSPACE_HEADER_NAME: workspace_name},
+    )
+    assert resp.ok, f"create_registered_model failed with {resp.status_code}: {resp.text}"
+
+
+def _create_model_version(
+    tracking_uri: str,
+    workspace_name: str,
+    model_name: str,
+    run_id: str,
+    auth: tuple[str, str] = (ADMIN_USERNAME, ADMIN_PASSWORD),
+) -> str:
+    resp = requests.post(
+        f"{tracking_uri}/api/2.0/mlflow/model-versions/create",
+        json={"name": model_name, "source": f"runs:/{run_id}/model", "run_id": run_id},
+        auth=auth,
+        headers={WORKSPACE_HEADER_NAME: workspace_name},
+    )
+    assert resp.ok, f"create_model_version failed with {resp.status_code}: {resp.text}"
+    return resp.json()["model_version"]["version"]
+
+
+def _graphql_search_runs(
+    tracking_uri: str, workspace_name: str, auth: tuple[str, str], experiment_ids: list[str]
+):
+    query = """
+    query SearchRuns($input: MlflowSearchRunsInput){
+      mlflowSearchRuns(input: $input){
+        runs { info { runId experimentId } }
+      }
+    }
+    """
+    variables = {"input": {"experimentIds": experiment_ids, "maxResults": 50}}
+    resp = requests.post(
+        f"{tracking_uri}/graphql",
+        json={"query": query, "variables": variables},
+        auth=auth,
+        headers={WORKSPACE_HEADER_NAME: workspace_name},
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    assert payload.get("errors") in (None, [])
+    return payload["data"]["mlflowSearchRuns"]["runs"]
+
+
+def _graphql_search_model_versions(
+    tracking_uri: str,
+    workspace_name: str,
+    auth: tuple[str, str],
+    filter_string: str | None = None,
+):
+    query = """
+    query SearchModelVersions($input: MlflowSearchModelVersionsInput){
+      mlflowSearchModelVersions(input: $input){
+        modelVersions { name version runId }
+      }
+    }
+    """
+    variables = {"input": {"filter": filter_string}}
+    resp = requests.post(
+        f"{tracking_uri}/graphql",
+        json={"query": query, "variables": variables},
+        auth=auth,
+        headers={WORKSPACE_HEADER_NAME: workspace_name},
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    assert payload.get("errors") in (None, [])
+    return payload["data"]["mlflowSearchModelVersions"]["modelVersions"]
+
+
+def test_workspace_permission_set_and_list(workspace_setup, monkeypatch):
+    client, _tracking_uri, workspace_name, username, _password = workspace_setup
+
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        perm = client.set_workspace_permission(workspace_name, username, "MANAGE")
+        user = client.get_user(username)
+    assert perm.workspace == workspace_name
+    assert perm.user_id == user.id
+    assert perm.permission == "MANAGE"
+
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        perms = client.list_workspace_permissions(workspace_name)
+        assert any(p.user_id == user.id for p in perms)
+
+        user_perms = client.list_user_workspace_permissions(username)
+        assert any(p.workspace == workspace_name for p in user_perms)
+
+        client.delete_workspace_permission(workspace_name, username)
+        assert client.list_workspace_permissions(workspace_name) == []
+
+
+def test_workspace_permission_list_requires_authentication(workspace_setup):
+    client, _tracking_uri, workspace_name, _username, _password = workspace_setup
+
+    with assert_unauthenticated():
+        client.list_workspace_permissions(workspace_name)
+
+
+def test_workspace_permission_list_requires_manage_permission(workspace_setup, monkeypatch):
+    client, tracking_uri, workspace_name, manager_username, manager_password = workspace_setup
+    target_username, _ = create_user(tracking_uri)
+    other_username, other_password = create_user(tracking_uri)
+
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.set_workspace_permission(workspace_name, manager_username, "MANAGE")
+        client.set_workspace_permission(workspace_name, target_username, "READ")
+
+    with User(other_username, other_password, monkeypatch), assert_unauthorized():
+        client.list_workspace_permissions(workspace_name)
+
+    with User(manager_username, manager_password, monkeypatch):
+        perms = client.list_workspace_permissions(workspace_name)
+
+    assert perms  # manager should see permissions they can manage
+    assert all(p.workspace == workspace_name for p in perms)
+
+
+def test_workspace_permission_set_requires_manage_permission(workspace_client, monkeypatch):
+    client, tracking_uri = workspace_client
+    workspace_name = "team-b"
+    _create_workspace(tracking_uri, workspace_name)
+    manager_username, manager_password = create_user(tracking_uri)
+    target_username, target_password = create_user(tracking_uri)
+
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.set_workspace_permission(workspace_name, manager_username, "MANAGE")
+
+    with User(manager_username, manager_password, monkeypatch):
+        perm = client.set_workspace_permission(workspace_name, target_username, "READ")
+        assert perm.permission == "READ"
+        client.delete_workspace_permission(workspace_name, target_username)
+
+    with User(manager_username, manager_password, monkeypatch):
+        perm = client.set_workspace_permission(workspace_name, target_username, "READ")
+        assert perm.permission == "READ"
+
+    with User(target_username, target_password, monkeypatch), assert_unauthorized():
+        client.set_workspace_permission(workspace_name, manager_username, "READ")
+
+    with User(target_username, target_password, monkeypatch), assert_unauthorized():
+        client.delete_workspace_permission(workspace_name, manager_username)
+
+
+def test_run_access_controls_across_workspaces(workspace_setup, monkeypatch):
+    client, tracking_uri, workspace_a, username, password = workspace_setup
+    workspace_b = f"team-{random_str()}"
+    _create_workspace(tracking_uri, workspace_b)
+
+    # Allow the regular user to create resources in both workspaces for setup.
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.set_workspace_permission(workspace_a, username, "MANAGE")
+        client.set_workspace_permission(workspace_b, username, "MANAGE")
+
+    exp_a = _create_experiment(tracking_uri, workspace_a, auth=(username, password))
+    run_a = _create_run(tracking_uri, workspace_a, exp_a, auth=(username, password))
+    exp_b = _create_experiment(tracking_uri, workspace_b, auth=(username, password))
+    run_b = _create_run(tracking_uri, workspace_b, exp_b, auth=(username, password))
+
+    # Use a separate limited user who only has access to workspace A.
+    limited_user, limited_password = create_user(tracking_uri)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.set_workspace_permission(workspace_a, limited_user, "READ")
+
+    # Positive: limited user can read run in workspace A.
+    resp_ok = requests.get(
+        f"{tracking_uri}/api/2.0/mlflow/runs/get",
+        params={"run_id": run_a},
+        auth=(limited_user, limited_password),
+        headers={WORKSPACE_HEADER_NAME: workspace_a},
+    )
+    assert resp_ok.status_code == 200
+
+    # REST: run in workspace B should be forbidden for limited user.
+    resp = requests.get(
+        f"{tracking_uri}/api/2.0/mlflow/runs/get",
+        params={"run_id": run_b},
+        auth=(limited_user, limited_password),
+        headers={WORKSPACE_HEADER_NAME: workspace_b},
+    )
+    assert resp.status_code == 403
+    assert "Permission denied" in resp.text
+
+    # GraphQL: only runs from authorized workspace should appear.
+    runs = _graphql_search_runs(
+        tracking_uri,
+        workspace_a,
+        auth=(limited_user, limited_password),
+        experiment_ids=[exp_a, exp_b],
+    )
+    returned_ids = {run["info"]["runId"] for run in runs}
+    assert returned_ids == {run_a}
+
+    # Switching to an unauthorized workspace should yield no readable runs.
+    runs_in_b = _graphql_search_runs(
+        tracking_uri, workspace_b, auth=(limited_user, limited_password), experiment_ids=[exp_b]
+    )
+    assert runs_in_b == []
+
+
+def test_registered_model_access_controls_across_workspaces(workspace_setup, monkeypatch):
+    client, tracking_uri, workspace_a, username, password = workspace_setup
+    workspace_b = f"team-{random_str()}"
+    _create_workspace(tracking_uri, workspace_b)
+
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.set_workspace_permission(workspace_a, username, "MANAGE")
+        client.set_workspace_permission(workspace_b, username, "MANAGE")
+
+    # Create resources in both workspaces as the regular user.
+    exp_a = _create_experiment(tracking_uri, workspace_a, auth=(username, password))
+    run_a = _create_run(tracking_uri, workspace_a, exp_a, auth=(username, password))
+    model_a = f"model-a-{random_str()}"
+    _create_registered_model(tracking_uri, workspace_a, model_a, auth=(username, password))
+    _create_model_version(tracking_uri, workspace_a, model_a, run_a, auth=(username, password))
+
+    exp_b = _create_experiment(tracking_uri, workspace_b, auth=(username, password))
+    run_b = _create_run(tracking_uri, workspace_b, exp_b, auth=(username, password))
+    model_b = f"model-b-{random_str()}"
+    _create_registered_model(tracking_uri, workspace_b, model_b, auth=(username, password))
+    _create_model_version(tracking_uri, workspace_b, model_b, run_b, auth=(username, password))
+
+    limited_user, limited_password = create_user(tracking_uri)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.set_workspace_permission(workspace_a, limited_user, "READ")
+
+    # Positive: limited user can read model in authorized workspace.
+    resp_ok = requests.get(
+        f"{tracking_uri}/api/2.0/mlflow/registered-models/get",
+        params={"name": model_a},
+        auth=(limited_user, limited_password),
+        headers={WORKSPACE_HEADER_NAME: workspace_a},
+    )
+    assert resp_ok.status_code == 200
+
+    # GraphQL: only model versions from the permitted workspace should appear.
+    versions = _graphql_search_model_versions(
+        tracking_uri, workspace_a, auth=(limited_user, limited_password), filter_string=None
+    )
+    assert {v["name"] for v in versions} == {model_a}
+
+    # REST: direct model get in another workspace should be forbidden.
+    resp = requests.get(
+        f"{tracking_uri}/api/2.0/mlflow/registered-models/get",
+        params={"name": model_b},
+        auth=(limited_user, limited_password),
+        headers={WORKSPACE_HEADER_NAME: workspace_b},
+    )
+    assert resp.status_code == 403
+    assert "Permission denied" in resp.text

--- a/tests/server/auth/test_sqlalchemy_store_workspace.py
+++ b/tests/server/auth/test_sqlalchemy_store_workspace.py
@@ -1,0 +1,235 @@
+import pytest
+
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+from mlflow.exceptions import MlflowException
+from mlflow.server.auth.entities import WorkspacePermission
+from mlflow.server.auth.permissions import EDIT, MANAGE, NO_PERMISSIONS, READ
+from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
+from mlflow.utils.workspace_context import WorkspaceContext
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+from tests.helper_functions import random_str
+from tests.server.auth.test_sqlalchemy_store import _rmp_maker, _user_maker
+
+pytest_plugins = ["tests.server.auth.test_sqlalchemy_store"]
+
+
+pytestmark = pytest.mark.notrackingurimock
+
+
+@pytest.fixture
+def store(tmp_sqlite_uri):
+    store = SqlAlchemyStore()
+    store.init_db(tmp_sqlite_uri)
+    return store
+
+
+def test_set_workspace_permission_creates_and_updates(store):
+    workspace = "team-alpha"
+    username = random_str()
+    user = store.create_user(username, random_str())
+
+    perm = store.set_workspace_permission(workspace, username, READ.name)
+    assert isinstance(perm, WorkspacePermission)
+    assert perm.workspace == workspace
+    assert perm.user_id == user.id
+    assert perm.permission == READ.name
+
+    updated = store.set_workspace_permission(workspace, username, MANAGE.name)
+    assert updated.permission == MANAGE.name
+
+
+def test_get_workspace_permission_precedence(store):
+    workspace = "team-beta"
+    username = random_str()
+    store.create_user(username, random_str())
+
+    assert store.get_workspace_permission(workspace, username) is None
+
+    store.set_workspace_permission(workspace, username, READ.name)
+    perm = store.get_workspace_permission(workspace, username)
+    assert perm == READ
+
+
+def test_list_workspace_permissions(store):
+    workspace = "team-gamma"
+    other_workspace = "team-delta"
+    username = random_str()
+    other_username = random_str()
+    user = store.create_user(username, random_str())
+    other_user = store.create_user(other_username, random_str())
+
+    p1 = store.set_workspace_permission(workspace, username, READ.name)
+    p2 = store.set_workspace_permission(workspace, other_username, EDIT.name)
+    p3 = store.set_workspace_permission(other_workspace, username, MANAGE.name)
+
+    perms = store.list_workspace_permissions(workspace)
+    actual = {(perm.workspace, perm.user_id, perm.permission) for perm in perms}
+    expected = {
+        (p1.workspace, user.id, p1.permission),
+        (p2.workspace, other_user.id, p2.permission),
+    }
+    assert actual == expected
+
+    perms_other = store.list_workspace_permissions(other_workspace)
+    assert {(perm.workspace, perm.user_id, perm.permission) for perm in perms_other} == {
+        (p3.workspace, user.id, p3.permission)
+    }
+
+
+def test_delete_workspace_permission(store):
+    workspace = "workspace-delete"
+    username = random_str()
+    store.create_user(username, random_str())
+
+    store.set_workspace_permission(workspace, username, READ.name)
+
+    store.delete_workspace_permission(workspace, username)
+    assert store.get_workspace_permission(workspace, username) is None
+
+    with pytest.raises(
+        MlflowException,
+        match=(
+            "Workspace permission does not exist for "
+            f"workspace='{workspace}', username='{username}'"
+        ),
+    ):
+        store.delete_workspace_permission(workspace, username)
+
+
+def test_delete_workspace_permissions_for_workspace(store):
+    workspace = "workspace-delete-all"
+    other_workspace = "workspace-keep"
+    username = random_str()
+    store.create_user(username, random_str())
+
+    store.set_workspace_permission(workspace, username, READ.name)
+    store.set_workspace_permission(other_workspace, username, EDIT.name)
+
+    store.delete_workspace_permissions_for_workspace(workspace)
+
+    assert store.list_workspace_permissions(workspace) == []
+    remaining = store.list_workspace_permissions(other_workspace)
+    assert len(remaining) == 1
+    assert remaining[0].workspace == other_workspace
+
+
+def test_list_accessible_workspace_names(store):
+    username = random_str()
+    other_user = random_str()
+    store.create_user(username, random_str())
+    store.create_user(other_user, random_str())
+
+    store.set_workspace_permission("workspace-read", username, READ.name)
+    store.set_workspace_permission("workspace-edit", username, EDIT.name)
+    store.set_workspace_permission("workspace-no-access", username, NO_PERMISSIONS.name)
+    store.set_workspace_permission("workspace-other", other_user, READ.name)
+
+    accessible = store.list_accessible_workspace_names(username)
+    assert accessible == {"workspace-read", "workspace-edit"}
+
+    assert store.list_accessible_workspace_names(other_user) == {
+        "workspace-other",
+    }
+    assert store.list_accessible_workspace_names(None) == set()
+
+
+def test_rename_registered_model_permissions_scoped_by_workspace(store, monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    username = random_str()
+    password = random_str()
+    _user_maker(store, username, password)
+
+    with WorkspaceContext("workspace-a"):
+        _rmp_maker(store, "model", username, READ.name)
+    with WorkspaceContext("workspace-b"):
+        _rmp_maker(store, "model", username, READ.name)
+
+    with WorkspaceContext("workspace-a"):
+        store.rename_registered_model_permissions("model", "model-renamed")
+        renamed = store.get_registered_model_permission("model-renamed", username)
+        assert renamed.name == "model-renamed"
+        assert renamed.workspace == "workspace-a"
+        with pytest.raises(
+            MlflowException,
+            match=(
+                "Registered model permission with workspace=workspace-a, name=model and username="
+            ),
+        ):
+            store.get_registered_model_permission("model", username)
+
+    with WorkspaceContext("workspace-b"):
+        still_original = store.get_registered_model_permission("model", username)
+        assert still_original.name == "model"
+        assert still_original.workspace == "workspace-b"
+
+
+def test_registered_model_permissions_are_workspace_scoped(store, monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    username = random_str()
+    password = random_str()
+    _user_maker(store, username, password)
+
+    model_name = random_str()
+    workspace_alt = f"workspace-{random_str()}"
+
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        store.create_registered_model_permission(model_name, username, READ.name)
+
+    with WorkspaceContext(workspace_alt):
+        perm_alt = store.create_registered_model_permission(model_name, username, EDIT.name)
+        assert perm_alt.workspace == workspace_alt
+
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        perm_default = store.get_registered_model_permission(model_name, username)
+        assert perm_default.permission == READ.name
+        assert perm_default.workspace == DEFAULT_WORKSPACE_NAME
+        perms_default = store.list_registered_model_permissions(username)
+        assert [p.permission for p in perms_default] == [READ.name]
+
+    with WorkspaceContext(workspace_alt):
+        perm_alt_lookup = store.get_registered_model_permission(model_name, username)
+        assert perm_alt_lookup.permission == EDIT.name
+        assert perm_alt_lookup.workspace == workspace_alt
+        perms_alt = store.list_registered_model_permissions(username)
+        assert [p.permission for p in perms_alt] == [EDIT.name]
+
+    # Switching back to default workspace should not affect alternate workspace permission
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        updated = store.update_registered_model_permission(model_name, username, MANAGE.name)
+        assert updated.permission == MANAGE.name
+        assert updated.workspace == DEFAULT_WORKSPACE_NAME
+
+    with WorkspaceContext(workspace_alt):
+        perm_alt_post_update = store.get_registered_model_permission(model_name, username)
+        assert perm_alt_post_update.permission == EDIT.name
+        assert perm_alt_post_update.workspace == workspace_alt
+
+
+def test_delete_registered_model_permissions_scoped_by_workspace(store, monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    username1 = random_str()
+    username2 = random_str()
+    _user_maker(store, username1, random_str())
+    _user_maker(store, username2, random_str())
+
+    model_name = random_str()
+
+    with WorkspaceContext("workspace-a"):
+        _rmp_maker(store, model_name, username1, READ.name)
+        _rmp_maker(store, model_name, username2, EDIT.name)
+
+    with WorkspaceContext("workspace-b"):
+        _rmp_maker(store, model_name, username1, MANAGE.name)
+
+    with WorkspaceContext("workspace-a"):
+        store.delete_registered_model_permissions(model_name)
+        with pytest.raises(MlflowException, match="Registered model permission .* not found"):
+            store.get_registered_model_permission(model_name, username1)
+        with pytest.raises(MlflowException, match="Registered model permission .* not found"):
+            store.get_registered_model_permission(model_name, username2)
+
+    with WorkspaceContext("workspace-b"):
+        remaining = store.get_registered_model_permission(model_name, username1)
+        assert remaining.permission == MANAGE.name
+        assert remaining.workspace == "workspace-b"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mprahl/mlflow/pull/19571?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19571/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19571/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19571/merge
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/issues/1464
https://github.com/mlflow/mlflow/issues/5844
Design document: https://docs.google.com/document/d/1IbFfceCmWV3knJfc0ninn58EXLVbHUh1meV_pknOM40/edit

### What changes are proposed in this pull request?

This adds workspace-level permission support to MLflow's authentication backend,
enabling fine-grained access control at the workspace scope.

**Key changes:**
- Add WorkspacePermission entity for workspace-level permission grants
- Add Alembic migration for workspace_permissions table
- Extend SQLAlchemy auth store with workspace permission CRUD operations
- Integrate workspace permission fallback into authorization checks
- Add AuthServiceClient methods: list_workspace_permissions(),
  set_workspace_permission(), delete_workspace_permission(),
  list_user_workspace_permissions()
- Add grant_default_workspace_access config option to control default
  workspace access inheritance

**Permission model:**
- Resource types: experiments, registered_models, or * (wildcard)
- Permission levels: READ, EDIT, MANAGE, NO_PERMISSIONS
- Workspace permissions are checked when resource-specific permissions
  are not found

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
