### PR TITLE
Fix structured outputs for databricks serving endpoints

### DIFF
--- a/tests/genai/judges/adapters/test_databricks_adapter.py
+++ b/tests/genai/judges/adapters/test_databricks_adapter.py
@@ -35,6 +35,15 @@ def mock_trace():
     return Trace(info=trace_info, data=None)
 
 
+@pytest.fixture
+def mock_databricks_creds():
+    """Fixture for mocked Databricks credentials."""
+    creds = mock.Mock()
+    creds.host = "https://test.databricks.com"
+    creds.token = "test-token"
+    return creds
+
+
 def test_parse_databricks_model_response_valid_response() -> None:
     res_json = {
         "choices": [{"message": {"content": "This is the response"}}],
@@ -106,11 +115,9 @@ def test_parse_databricks_model_response_errors(
         _parse_databricks_model_response(res_json, headers)
 
 
-def test_invoke_databricks_serving_endpoint_successful_invocation() -> None:
-    mock_creds = mock.Mock()
-    mock_creds.host = "https://test.databricks.com"
-    mock_creds.token = "test-token"
-
+def test_invoke_databricks_serving_endpoint_successful_invocation(
+    mock_databricks_creds,
+) -> None:
     mock_response = mock.Mock()
     mock_response.status_code = 200
     mock_response.json.return_value = {
@@ -122,7 +129,7 @@ def test_invoke_databricks_serving_endpoint_successful_invocation() -> None:
     with (
         mock.patch(
             "mlflow.utils.databricks_utils.get_databricks_host_creds",
-            return_value=mock_creds,
+            return_value=mock_databricks_creds,
         ) as mock_get_creds,
         mock.patch(
             "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.requests.post",
@@ -147,11 +154,9 @@ def test_invoke_databricks_serving_endpoint_successful_invocation() -> None:
 
 
 @pytest.mark.parametrize("status_code", [400, 401, 403, 404])
-def test_invoke_databricks_serving_endpoint_bad_request_error_no_retry(status_code: int) -> None:
-    mock_creds = mock.Mock()
-    mock_creds.host = "https://test.databricks.com"
-    mock_creds.token = "test-token"
-
+def test_invoke_databricks_serving_endpoint_bad_request_error_no_retry(
+    mock_databricks_creds, status_code: int
+) -> None:
     mock_response = mock.Mock()
     mock_response.status_code = status_code
     mock_response.text = f"Error {status_code}"
@@ -159,7 +164,7 @@ def test_invoke_databricks_serving_endpoint_bad_request_error_no_retry(status_co
     with (
         mock.patch(
             "mlflow.utils.databricks_utils.get_databricks_host_creds",
-            return_value=mock_creds,
+            return_value=mock_databricks_creds,
         ) as mock_get_creds,
         mock.patch(
             "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.requests.post",
@@ -175,11 +180,9 @@ def test_invoke_databricks_serving_endpoint_bad_request_error_no_retry(status_co
         mock_get_creds.assert_called_once()
 
 
-def test_invoke_databricks_serving_endpoint_retry_logic_with_transient_errors() -> None:
-    mock_creds = mock.Mock()
-    mock_creds.host = "https://test.databricks.com"
-    mock_creds.token = "test-token"
-
+def test_invoke_databricks_serving_endpoint_retry_logic_with_transient_errors(
+    mock_databricks_creds,
+) -> None:
     # First call fails with 500, second succeeds
     error_response = mock.Mock()
     error_response.status_code = 500
@@ -193,7 +196,7 @@ def test_invoke_databricks_serving_endpoint_retry_logic_with_transient_errors() 
     with (
         mock.patch(
             "mlflow.utils.databricks_utils.get_databricks_host_creds",
-            return_value=mock_creds,
+            return_value=mock_databricks_creds,
         ) as mock_get_creds,
         mock.patch(
             "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.requests.post",
@@ -214,11 +217,7 @@ def test_invoke_databricks_serving_endpoint_retry_logic_with_transient_errors() 
     assert result.response == "Success"
 
 
-def test_invoke_databricks_serving_endpoint_json_decode_error() -> None:
-    mock_creds = mock.Mock()
-    mock_creds.host = "https://test.databricks.com"
-    mock_creds.token = "test-token"
-
+def test_invoke_databricks_serving_endpoint_json_decode_error(mock_databricks_creds) -> None:
     mock_response = mock.Mock()
     mock_response.status_code = 200
     mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
@@ -226,7 +225,7 @@ def test_invoke_databricks_serving_endpoint_json_decode_error() -> None:
     with (
         mock.patch(
             "mlflow.utils.databricks_utils.get_databricks_host_creds",
-            return_value=mock_creds,
+            return_value=mock_databricks_creds,
         ) as mock_get_creds,
         mock.patch(
             "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.requests.post",
@@ -242,13 +241,13 @@ def test_invoke_databricks_serving_endpoint_json_decode_error() -> None:
         mock_get_creds.assert_called_once()
 
 
-def test_invoke_databricks_serving_endpoint_connection_error_with_retries() -> None:
-    mock_creds = mock.Mock()
-
+def test_invoke_databricks_serving_endpoint_connection_error_with_retries(
+    mock_databricks_creds,
+) -> None:
     with (
         mock.patch(
             "mlflow.utils.databricks_utils.get_databricks_host_creds",
-            return_value=mock_creds,
+            return_value=mock_databricks_creds,
         ) as mock_get_creds,
         mock.patch(
             "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.requests.post",
@@ -270,7 +269,7 @@ def test_invoke_databricks_serving_endpoint_connection_error_with_retries() -> N
         mock_get_creds.assert_called_once()
 
 
-def test_invoke_databricks_serving_endpoint_with_response_schema():
+def test_invoke_databricks_serving_endpoint_with_response_format(mock_databricks_creds):
     class ResponseFormat(BaseModel):
         result: int
         rationale: str
@@ -291,18 +290,14 @@ def test_invoke_databricks_serving_endpoint_with_response_schema():
         }
         return mock_response
 
-    # Mock Databricks host creds
-    mock_creds = mock.Mock()
-    mock_creds.host = "https://test.databricks.com"
-    mock_creds.token = "test-token"
-
     with (
         mock.patch(
             "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.requests.post",
             side_effect=mock_post,
         ),
         mock.patch(
-            "mlflow.utils.databricks_utils.get_databricks_host_creds", return_value=mock_creds
+            "mlflow.utils.databricks_utils.get_databricks_host_creds",
+            return_value=mock_databricks_creds,
         ),
     ):
         output = _invoke_databricks_serving_endpoint(
@@ -312,16 +307,68 @@ def test_invoke_databricks_serving_endpoint_with_response_schema():
             response_format=ResponseFormat,
         )
 
-        # Verify response_schema was included in the payload
+        # Verify response_format was included in the payload
         assert captured_payload is not None
-        assert "response_schema" in captured_payload
-        assert captured_payload["response_schema"] == ResponseFormat.model_json_schema()
+        assert "response_format" in captured_payload
+        assert captured_payload["response_format"] == ResponseFormat.model_json_schema()
 
         # Verify the response was returned correctly
         assert output.response == '{"result": 8, "rationale": "Good quality"}'
 
 
-def test_invoke_databricks_serving_endpoint_with_inference_params() -> None:
+def test_invoke_databricks_serving_endpoint_response_format_fallback(mock_databricks_creds):
+    class ResponseFormat(BaseModel):
+        result: int
+        rationale: str
+
+    call_count = 0
+    captured_payloads = []
+
+    def mock_post(*args, **kwargs):
+        nonlocal call_count
+        captured_payloads.append(kwargs.get("json"))
+        call_count += 1
+
+        mock_response = mock.Mock()
+        if call_count == 1:
+            # First call with response_format fails
+            mock_response.status_code = 400
+            mock_response.text = '{"error": "Invalid parameter: response_format is not supported"}'
+        else:
+            # Second call without response_format succeeds
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "choices": [{"message": {"content": '{"result": 8, "rationale": "Good quality"}'}}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+                "id": "test-request-id",
+            }
+        return mock_response
+
+    with (
+        mock.patch(
+            "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.requests.post",
+            side_effect=mock_post,
+        ),
+        mock.patch(
+            "mlflow.utils.databricks_utils.get_databricks_host_creds",
+            return_value=mock_databricks_creds,
+        ),
+    ):
+        output = _invoke_databricks_serving_endpoint(
+            model_name="my-endpoint",
+            prompt="Rate this",
+            num_retries=1,
+            response_format=ResponseFormat,
+        )
+
+        # Verify we made 2 calls, the first with response_format, the second without
+        assert call_count == 2
+        assert "response_format" in captured_payloads[0]
+        assert "response_format" not in captured_payloads[1]
+        assert output.response == '{"result": 8, "rationale": "Good quality"}'
+
+
+def test_invoke_databricks_serving_endpoint_with_inference_params(mock_databricks_creds) -> None:
     captured_payload = None
 
     def mock_post(*args, **kwargs):
@@ -337,10 +384,6 @@ def test_invoke_databricks_serving_endpoint_with_inference_params() -> None:
         mock_response.headers = {"x-request-id": "test-id"}
         return mock_response
 
-    mock_creds = mock.Mock()
-    mock_creds.host = "https://test.databricks.com"
-    mock_creds.token = "test-token"
-
     inference_params = {"temperature": 0.5, "max_tokens": 100, "top_p": 0.9}
 
     with (
@@ -349,7 +392,8 @@ def test_invoke_databricks_serving_endpoint_with_inference_params() -> None:
             side_effect=mock_post,
         ),
         mock.patch(
-            "mlflow.utils.databricks_utils.get_databricks_host_creds", return_value=mock_creds
+            "mlflow.utils.databricks_utils.get_databricks_host_creds",
+            return_value=mock_databricks_creds,
         ),
     ):
         result = _invoke_databricks_serving_endpoint(
@@ -375,15 +419,13 @@ def test_invoke_databricks_serving_endpoint_with_inference_params() -> None:
         ["not a ChatMessage", "also invalid"],  # List but not ChatMessage instances
     ],
 )
-def test_invoke_databricks_serving_endpoint_invalid_prompt_type(invalid_prompt) -> None:
-    mock_creds = mock.Mock()
-    mock_creds.host = "https://test.databricks.com"
-    mock_creds.token = "test-token"
-
+def test_invoke_databricks_serving_endpoint_invalid_prompt_type(
+    mock_databricks_creds, invalid_prompt
+) -> None:
     with (
         mock.patch(
             "mlflow.utils.databricks_utils.get_databricks_host_creds",
-            return_value=mock_creds,
+            return_value=mock_databricks_creds,
         ),
     ):
         with pytest.raises(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/19572?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19572/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19572/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19572/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Previously, we were using `response_schema` to trigger structured outputs for DBX model serving endpoints. However, this is not a valid argument and would fall back to litellm. Due to the recent refactor, we no longer fallback to litellm, exposing this issue - as such, I've fixed it from `response_schema` to `response_format` and added the appropriate fallback logic.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
import mlflow
from mlflow.genai.judges import make_judge

mlflow.set_tracking_uri("databricks")
mlflow.set_experiment(experiment_id="2105341160121525")

eval_data = [
    {
        "inputs": {"query": "What is Databricks?"},
        "outputs": "Databricks is a unified data and AI platform."
    }
]
correctness_judge = make_judge(
    name="correctness_score",
    instructions=(
        "Evaluate if the response in {{ outputs }} is contains correct facts given the qualitative and quantitative information present in: {{ inputs }}. The response should be factual, Score it from 0-1, where 0 is a response with no correct information and 1 is a response with all information being in line (correct)."
    ),
    model="databricks:/databricks-gpt-5",
)
results = mlflow.genai.evaluate(
    data=eval_data,
    scorers=[correctness_judge]
)

print(results.tables["eval_results"]["assessments"][0])
```

output:
```
2025/12/22 14:54:11 INFO mlflow.models.evaluation.utils.trace: Auto tracing is temporarily enabled during the model evaluation for computing some metrics and debugging. To disable tracing, call `mlflow.autolog(disable=True)`.
Evaluating:   0%|                                                                                 | 0/1 [Elapsed: 00:00, Remaining: ?] 2025/12/22 14:54:12 WARNING mlflow.genai.judges.instructions_judge: The following parameters were provided but are not used by this judge's instructions: 'expectations'. The judge only uses template variables that appear in the instructions: {'outputs', 'inputs'}
Evaluating: 100%|█████████████████████████████████████████████████████████████████████████████| 1/1 [Elapsed: 00:04, Remaining: 00:00]

✨ Evaluation completed.

Metrics and evaluation results are logged to the MLflow run:
  Run name: shivering-seal-250
  Run ID: 45e9d9e52e59499f97c1088c5d8debd4
View the evaluation results at https://e2-dogfood.staging.cloud.databricks.com/ml/experiments/2105341160121525/evaluation-runs?selectedRunUuid=45e9d9e52e59499f97c1088c5d8debd4

[{'assessment_id': 'a-59f4002822cc4150886ca7c39f4844a7', 'assessment_name': 'correctness_score', 'trace_id': 'tr-1f0b0c851bace77d3e1e5f3988125121', 'span_id': 'a5b6343037f3cf88', 'source': {'source_type': 'LLM_JUDGE', 'source_id': 'databricks:/databricks-gpt-5'}, 'create_time': '2025-12-22T22:54:15.341Z', 'last_update_time': '2025-12-22T22:54:15.341Z', 'feedback': {'value': '1'}, 'rationale': 'The output accurately describes Databricks as a unified data and AI platform, which aligns with commonly accepted and official descriptions of Databricks. There are no contradictions or incorrect details relative to the input query.', 'metadata': {'mlflow.assessment.sourceRunId': '45e9d9e52e59499f97c1088c5d8debd4'}, 'valid': True}]
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fix structured outputs in `make_judge` for databricks model serving endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
