### PR TITLE
Refactor props and add percentile key

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -8,6 +8,7 @@ import { TracesV3DateSelector } from '../../components/experiment-page/component
 import { useMonitoringFilters, getAbsoluteStartEndTime } from '../../hooks/useMonitoringFilters';
 import { MonitoringConfigProvider, useMonitoringConfig } from '../../hooks/useMonitoringConfig';
 import { LazyTraceRequestsChart } from './components/LazyTraceRequestsChart';
+import { calculateTimeInterval } from './hooks/useTraceMetricsQuery';
 
 enum OverviewTab {
   Usage = 'usage',
@@ -35,6 +36,12 @@ const ExperimentGenAIOverviewPageImpl = () => {
   // Convert ISO strings to milliseconds for the API
   const startTimeMs = startTime ? new Date(startTime).getTime() : undefined;
   const endTimeMs = endTime ? new Date(endTime).getTime() : undefined;
+
+  // Calculate time interval once for all charts
+  const timeIntervalSeconds = calculateTimeInterval(startTimeMs, endTimeMs);
+
+  // Common props for all chart components
+  const chartProps = { experimentId, startTimeMs, endTimeMs, timeIntervalSeconds };
 
   return (
     <div
@@ -87,8 +94,16 @@ const ExperimentGenAIOverviewPageImpl = () => {
         </div>
 
         <Tabs.Content value={OverviewTab.Usage} css={{ flex: 1, overflowY: 'auto' }}>
-          <div css={{ padding: `${theme.spacing.sm}px 0` }}>
-            <LazyTraceRequestsChart experimentId={experimentId} startTimeMs={startTimeMs} endTimeMs={endTimeMs} />
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: theme.spacing.lg,
+              padding: `${theme.spacing.sm}px 0`,
+            }}
+          >
+            {/* Requests chart - full width */}
+            <LazyTraceRequestsChart {...chartProps} />
           </div>
         </Tabs.Content>
       </Tabs.Root>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceRequestsChart.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { LegacySkeleton } from '@databricks/design-system';
-import type { TraceRequestsChartProps } from './TraceRequestsChart';
+import type { OverviewChartProps } from '../types';
 
 const TraceRequestsChart = React.lazy(() =>
   import('./TraceRequestsChart').then((module) => ({ default: module.TraceRequestsChart })),
 );
 
-export const LazyTraceRequestsChart: React.FC<TraceRequestsChartProps> = (props) => (
+export const LazyTraceRequestsChart: React.FC<OverviewChartProps> = (props) => (
   <React.Suspense fallback={<LegacySkeleton active />}>
     <TraceRequestsChart {...props} />
   </React.Suspense>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
@@ -15,6 +15,20 @@ jest.mock('../../../../common/utils/FetchUtils', () => ({
 import { fetchOrFail } from '../../../../common/utils/FetchUtils';
 const mockFetchOrFail = fetchOrFail as jest.MockedFunction<typeof fetchOrFail>;
 
+// Helper to create mock API response
+const mockApiResponse = (dataPoints: any[] | undefined) => {
+  mockFetchOrFail.mockResolvedValue({
+    json: () => Promise.resolve({ data_points: dataPoints }),
+  } as Response);
+};
+
+// Helper to create a single data point
+const createTraceCountDataPoint = (timeBucket: string, count: number) => ({
+  metric_name: TraceMetricKey.TRACE_COUNT,
+  dimensions: { time_bucket: timeBucket },
+  values: { [AggregationType.COUNT]: count },
+});
+
 // Mock recharts components to avoid rendering issues in tests
 jest.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
@@ -36,6 +50,14 @@ describe('TraceRequestsChart', () => {
   const now = Date.now();
   const oneHourAgo = now - 60 * 60 * 1000;
 
+  // Default props reused across tests
+  const defaultProps = {
+    experimentId: testExperimentId,
+    startTimeMs: oneHourAgo,
+    endTimeMs: now,
+    timeIntervalSeconds: 3600, // 1 hour
+  };
+
   const createQueryClient = () =>
     new QueryClient({
       defaultOptions: {
@@ -45,12 +67,12 @@ describe('TraceRequestsChart', () => {
       },
     });
 
-  const renderComponent = (props: { experimentId: string; startTimeMs?: number; endTimeMs?: number }) => {
+  const renderComponent = (props: Partial<typeof defaultProps> = {}) => {
     const queryClient = createQueryClient();
     return renderWithIntl(
       <QueryClientProvider client={queryClient}>
         <DesignSystemProvider>
-          <TraceRequestsChart {...props} />
+          <TraceRequestsChart {...defaultProps} {...props} />
         </DesignSystemProvider>
       </QueryClientProvider>,
     );
@@ -58,10 +80,7 @@ describe('TraceRequestsChart', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Mock fetchOrFail to return a response with json() method
-    mockFetchOrFail.mockResolvedValue({
-      json: () => Promise.resolve({ data_points: [] }),
-    } as Response);
+    mockApiResponse([]);
   });
 
   describe('loading state', () => {
@@ -69,11 +88,7 @@ describe('TraceRequestsChart', () => {
       // Create a promise that never resolves to keep the component in loading state
       mockFetchOrFail.mockReturnValue(new Promise(() => {}));
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       // Check for spinner (loading state)
       expect(screen.getByRole('img')).toBeInTheDocument();
@@ -84,11 +99,7 @@ describe('TraceRequestsChart', () => {
     it('should render error message when API call fails', async () => {
       mockFetchOrFail.mockRejectedValue(new Error('API Error'));
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(screen.getByText('Failed to load chart data')).toBeInTheDocument();
@@ -98,15 +109,9 @@ describe('TraceRequestsChart', () => {
 
   describe('empty data state', () => {
     it('should render empty state message when no data points are returned', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () => Promise.resolve({ data_points: [] }),
-      } as Response);
+      mockApiResponse([]);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
@@ -114,16 +119,9 @@ describe('TraceRequestsChart', () => {
     });
 
     it('should render empty state when data_points is undefined', async () => {
-      // Cast to simulate edge case where API might return malformed response
-      mockFetchOrFail.mockResolvedValue({
-        json: () => Promise.resolve({ data_points: undefined }),
-      } as Response);
+      mockApiResponse(undefined);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
@@ -133,33 +131,15 @@ describe('TraceRequestsChart', () => {
 
   describe('with data', () => {
     const mockDataPoints = [
-      {
-        metric_name: TraceMetricKey.TRACE_COUNT,
-        dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
-        values: { [AggregationType.COUNT]: 42 },
-      },
-      {
-        metric_name: TraceMetricKey.TRACE_COUNT,
-        dimensions: { time_bucket: '2025-12-22T11:00:00Z' },
-        values: { [AggregationType.COUNT]: 58 },
-      },
-      {
-        metric_name: TraceMetricKey.TRACE_COUNT,
-        dimensions: { time_bucket: '2025-12-22T12:00:00Z' },
-        values: { [AggregationType.COUNT]: 100 },
-      },
+      createTraceCountDataPoint('2025-12-22T10:00:00Z', 42),
+      createTraceCountDataPoint('2025-12-22T11:00:00Z', 58),
+      createTraceCountDataPoint('2025-12-22T12:00:00Z', 100),
     ];
 
     it('should render chart with data points', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () => Promise.resolve({ data_points: mockDataPoints }),
-      } as Response);
+      mockApiResponse(mockDataPoints);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
@@ -170,15 +150,9 @@ describe('TraceRequestsChart', () => {
     });
 
     it('should display the total request count', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () => Promise.resolve({ data_points: mockDataPoints }),
-      } as Response);
+      mockApiResponse(mockDataPoints);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       // Total should be 42 + 58 + 100 = 200
       await waitFor(() => {
@@ -187,15 +161,9 @@ describe('TraceRequestsChart', () => {
     });
 
     it('should display the "Requests" title', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () => Promise.resolve({ data_points: mockDataPoints }),
-      } as Response);
+      mockApiResponse(mockDataPoints);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(screen.getByText('Requests')).toBeInTheDocument();
@@ -203,24 +171,9 @@ describe('TraceRequestsChart', () => {
     });
 
     it('should format large numbers with locale formatting', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () =>
-          Promise.resolve({
-            data_points: [
-              {
-                metric_name: TraceMetricKey.TRACE_COUNT,
-                dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
-                values: { [AggregationType.COUNT]: 1234567 },
-              },
-            ],
-          }),
-      } as Response);
+      mockApiResponse([createTraceCountDataPoint('2025-12-22T10:00:00Z', 1234567)]);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         // Check for locale-formatted number (1,234,567 in US locale)
@@ -231,14 +184,7 @@ describe('TraceRequestsChart', () => {
 
   describe('API call parameters', () => {
     it('should call fetchOrFail with correct parameters', async () => {
-      const startTimeMs = oneHourAgo;
-      const endTimeMs = now;
-
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs,
-        endTimeMs,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(mockFetchOrFail).toHaveBeenCalledWith(
@@ -254,80 +200,46 @@ describe('TraceRequestsChart', () => {
       });
     });
 
-    it('should calculate appropriate time interval for 1-hour range', async () => {
-      const endTimeMs = Date.now();
-      const startTimeMs = endTimeMs - 60 * 60 * 1000; // 1 hour
-
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs,
-        endTimeMs,
-      });
+    it('should use provided time interval', async () => {
+      renderComponent({ timeIntervalSeconds: 60 });
 
       await waitFor(() => {
         const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
-        expect(callBody.time_interval_seconds).toBe(60); // MINUTE_IN_SECONDS
+        expect(callBody.time_interval_seconds).toBe(60);
       });
     });
 
-    it('should calculate appropriate time interval for 24-hour range', async () => {
-      const endTimeMs = Date.now();
-      const startTimeMs = endTimeMs - 12 * 60 * 60 * 1000; // 12 hours
-
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs,
-        endTimeMs,
-      });
+    it('should use provided time interval for hourly grouping', async () => {
+      renderComponent({ timeIntervalSeconds: 3600 });
 
       await waitFor(() => {
         const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
-        expect(callBody.time_interval_seconds).toBe(3600); // HOUR_IN_SECONDS
+        expect(callBody.time_interval_seconds).toBe(3600);
       });
     });
 
-    it('should calculate appropriate time interval for 7-day range', async () => {
-      const endTimeMs = Date.now();
-      const startTimeMs = endTimeMs - 7 * 24 * 60 * 60 * 1000; // 7 days
-
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs,
-        endTimeMs,
-      });
+    it('should use provided time interval for daily grouping', async () => {
+      renderComponent({ timeIntervalSeconds: 86400 });
 
       await waitFor(() => {
         const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
-        expect(callBody.time_interval_seconds).toBe(86400); // DAY_IN_SECONDS
+        expect(callBody.time_interval_seconds).toBe(86400);
       });
     });
   });
 
   describe('data transformation', () => {
     it('should handle data points with missing values gracefully', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () =>
-          Promise.resolve({
-            data_points: [
-              {
-                metric_name: TraceMetricKey.TRACE_COUNT,
-                dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
-                values: {}, // Missing COUNT value
-              },
-              {
-                metric_name: TraceMetricKey.TRACE_COUNT,
-                dimensions: { time_bucket: '2025-12-22T11:00:00Z' },
-                values: { [AggregationType.COUNT]: 50 },
-              },
-            ],
-          }),
-      } as Response);
+      mockApiResponse([
+        {
+          metric_name: TraceMetricKey.TRACE_COUNT,
+          dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
+          values: {}, // Missing COUNT value
+        },
+        createTraceCountDataPoint('2025-12-22T11:00:00Z', 50),
+      ]);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       // Should still render and show total of 50 (0 + 50)
       await waitFor(() => {
@@ -336,24 +248,15 @@ describe('TraceRequestsChart', () => {
     });
 
     it('should handle data points with missing time_bucket', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () =>
-          Promise.resolve({
-            data_points: [
-              {
-                metric_name: TraceMetricKey.TRACE_COUNT,
-                dimensions: {}, // Missing time_bucket
-                values: { [AggregationType.COUNT]: 25 },
-              },
-            ],
-          }),
-      } as Response);
+      mockApiResponse([
+        {
+          metric_name: TraceMetricKey.TRACE_COUNT,
+          dimensions: {}, // Missing time_bucket
+          values: { [AggregationType.COUNT]: 25 },
+        },
+      ]);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       // Should still render with the count
       await waitFor(() => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
@@ -3,21 +3,18 @@ import { useDesignSystemTheme, Typography, ChartLineIcon } from '@databricks/des
 import { FormattedMessage } from 'react-intl';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import { MetricViewType, AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
-import { useTraceMetricsQuery, calculateTimeInterval } from '../hooks/useTraceMetricsQuery';
+import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
 import { ChartLoadingState, ChartErrorState, ChartEmptyState } from './ChartCardWrapper';
+import type { OverviewChartProps } from '../types';
 
-export interface TraceRequestsChartProps {
-  experimentId: string;
-  startTimeMs?: number;
-  endTimeMs?: number;
-}
-
-export const TraceRequestsChart: React.FC<TraceRequestsChartProps> = ({ experimentId, startTimeMs, endTimeMs }) => {
+export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
+  experimentId,
+  startTimeMs,
+  endTimeMs,
+  timeIntervalSeconds,
+}) => {
   const { theme } = useDesignSystemTheme();
-
-  // Calculate time interval for grouping
-  const timeIntervalSeconds = calculateTimeInterval(startTimeMs, endTimeMs);
 
   // Fetch trace count metrics grouped by time bucket
   const {
@@ -74,7 +71,7 @@ export const TraceRequestsChart: React.FC<TraceRequestsChartProps> = ({ experime
       <div css={{ marginBottom: theme.spacing.lg }}>
         <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
           <ChartLineIcon css={{ color: theme.colors.textSecondary }} />
-          <Typography.Text bold>
+          <Typography.Text bold size="lg">
             <FormattedMessage defaultMessage="Requests" description="Title for the trace requests chart" />
           </Typography.Text>
         </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Common props for overview charts that query trace metrics
+ */
+export interface OverviewChartProps {
+  experimentId: string;
+  startTimeMs?: number;
+  endTimeMs?: number;
+  /** Time interval in seconds for grouping metrics by time bucket */
+  timeIntervalSeconds: number;
+}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/TraceMetrics.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/TraceMetrics.types.ts
@@ -17,6 +17,20 @@ export const TraceMetricKey = {
 export type TraceMetricKeyType = typeof TraceMetricKey[keyof typeof TraceMetricKey];
 
 /**
+ * Common percentile values for latency metrics
+ */
+export const P50 = 50;
+export const P90 = 90;
+export const P99 = 99;
+
+/**
+ * Get the key for accessing percentile values in the API response
+ * @param percentile - The percentile value (e.g., 50, 90, 99)
+ * @returns The key string in format "Pxx.0" (e.g., "P50.0", "P90.0", "P99.0")
+ */
+export const getPercentileKey = (percentile: number): string => `P${percentile.toFixed(1)}`;
+
+/**
  * Time bucket dimension key, included in results when time_interval_seconds is specified.
  * Applies to all view types (traces, spans, assessments).
  */


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19585/files) to review incremental changes.
- [**stack/refactor_props**](https://github.com/mlflow/mlflow/pull/19585) [[Files changed](https://github.com/mlflow/mlflow/pull/19585/files)]
  - [stack/latency_chart](https://github.com/mlflow/mlflow/pull/19581) [[Files changed](https://github.com/mlflow/mlflow/pull/19581/files/dfdf42ad8225cae26b4712bb6d901a7a5a62966d..8edf8df62b797b069183777ee4080f0703966b3e)]
    - [stack/trace_metrics_filters](https://github.com/mlflow/mlflow/pull/19587) [[Files changed](https://github.com/mlflow/mlflow/pull/19587/files/8edf8df62b797b069183777ee4080f0703966b3e..3e4a35084cf8a455ede75dc5da62218ceb915f80)]
      - [stack/error_chart](https://github.com/mlflow/mlflow/pull/19588) [[Files changed](https://github.com/mlflow/mlflow/pull/19588/files/3e4a35084cf8a455ede75dc5da62218ceb915f80..f829a6e83f0e30a6068fda266c259a923fd19e8b)]
        - [stack/chart_common_parts](https://github.com/mlflow/mlflow/pull/19601) [[Files changed](https://github.com/mlflow/mlflow/pull/19601/files/f829a6e83f0e30a6068fda266c259a923fd19e8b..56281ccf1d6592652749eb31707d8133140631f9)]
          - [stack/charts_time_buckets_fix](https://github.com/mlflow/mlflow/pull/19602) [[Files changed](https://github.com/mlflow/mlflow/pull/19602/files/56281ccf1d6592652749eb31707d8133140631f9..1871e11b201ced713ffb97b19b63bd94cc48dcad)]
            - [stack/latency_time_fix](https://github.com/mlflow/mlflow/pull/19603) [[Files changed](https://github.com/mlflow/mlflow/pull/19603/files/1871e11b201ced713ffb97b19b63bd94cc48dcad..fa2a9eb7452d8fe486bd6d280e8c5c5bae99dfd5)]
              - [stack/error_chart_time_fix](https://github.com/mlflow/mlflow/pull/19604) [[Files changed](https://github.com/mlflow/mlflow/pull/19604/files/fa2a9eb7452d8fe486bd6d280e8c5c5bae99dfd5..52b39a7f05be238434a854a174c8a79de3813763)]
                - [stack/token_usage_chart](https://github.com/mlflow/mlflow/pull/19606) [[Files changed](https://github.com/mlflow/mlflow/pull/19606/files/52b39a7f05be238434a854a174c8a79de3813763..ae20253f463eda1efc8884cdc4dc5dd8bda5f224)]
                  - [stack/empty_data_fix](https://github.com/mlflow/mlflow/pull/19607) [[Files changed](https://github.com/mlflow/mlflow/pull/19607/files/ae20253f463eda1efc8884cdc4dc5dd8bda5f224..f8c077b582cbd3f19a8cdd280249204f4362b195)]
                    - [stack/simplify_charts_components](https://github.com/mlflow/mlflow/pull/19608) [[Files changed](https://github.com/mlflow/mlflow/pull/19608/files/f8c077b582cbd3f19a8cdd280249204f4362b195..4d4e4dedf542b8c9e9d3909fc734e173a1eb2f48)]
                      - [stack/token_statistics_chart](https://github.com/mlflow/mlflow/pull/19609) [[Files changed](https://github.com/mlflow/mlflow/pull/19609/files/4d4e4dedf542b8c9e9d3909fc734e173a1eb2f48..cecd62bf2b6b24e8fe4a372ef8d6cb6ddb4d0738)]
                        - [stack/quality_tab](https://github.com/mlflow/mlflow/pull/19619) [[Files changed](https://github.com/mlflow/mlflow/pull/19619/files/cecd62bf2b6b24e8fe4a372ef8d6cb6ddb4d0738..b120342fb9af2300f1628e31beb43ca1896f967f)]
                          - [stack/query_assessment_metrics](https://github.com/mlflow/mlflow/pull/19620) [[Files changed](https://github.com/mlflow/mlflow/pull/19620/files/b120342fb9af2300f1628e31beb43ca1896f967f..cbdf4b1784bac2bdf80b68e8b4baa800d9c9b705)]
                            - [stack/assessment_chart](https://github.com/mlflow/mlflow/pull/19621) [[Files changed](https://github.com/mlflow/mlflow/pull/19621/files/cbdf4b1784bac2bdf80b68e8b4baa800d9c9b705..6cd5b2cad908c851852b58356e4a369e92fac190)]
                              - [stack/render_scorer_charts](https://github.com/mlflow/mlflow/pull/19622) [[Files changed](https://github.com/mlflow/mlflow/pull/19622/files/6cd5b2cad908c851852b58356e4a369e92fac190..8f969a169d90a292a79e6603a724892add16a250)]
                                - [stack/scorer_counts](https://github.com/mlflow/mlflow/pull/19624) [[Files changed](https://github.com/mlflow/mlflow/pull/19624/files/8f969a169d90a292a79e6603a724892add16a250..3af5922def34591e8508c1801c42f61f1df4d1f8)]
                                  - [stack/tools_tab](https://github.com/mlflow/mlflow/pull/19632) [[Files changed](https://github.com/mlflow/mlflow/pull/19632/files/3af5922def34591e8508c1801c42f61f1df4d1f8..b4fa534928675f2e245616ef240f2d14263b391b)]
                                    - [stack/query_span_metrics](https://github.com/mlflow/mlflow/pull/19633) [[Files changed](https://github.com/mlflow/mlflow/pull/19633/files/b4fa534928675f2e245616ef240f2d14263b391b..65fd731b593b401bc50c92f0e082fad242079a6c)]
                                      - [stack/tool_calls_statistics](https://github.com/mlflow/mlflow/pull/19634) [[Files changed](https://github.com/mlflow/mlflow/pull/19634/files/65fd731b593b401bc50c92f0e082fad242079a6c..69fcb15418a740c7450985dd101890c3875dd99a)]
                                        - [stack/tool_error_rate_charts](https://github.com/mlflow/mlflow/pull/19635) [[Files changed](https://github.com/mlflow/mlflow/pull/19635/files/69fcb15418a740c7450985dd101890c3875dd99a..62213e588732e14cff2483e74560ba0be9409dc4)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
As title, the props will be passed to all charts.
Add percentile key for easier usage later, this corresponds to backend implementation that the percentile value is mapped to 'P{percentile_value}' key in result.
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
