### PR TITLE
Unify common pattern in charts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -8,6 +8,7 @@ import { TracesV3DateSelector } from '../../components/experiment-page/component
 import { useMonitoringFilters, getAbsoluteStartEndTime } from '../../hooks/useMonitoringFilters';
 import { MonitoringConfigProvider, useMonitoringConfig } from '../../hooks/useMonitoringConfig';
 import { LazyTraceRequestsChart } from './components/LazyTraceRequestsChart';
+import { calculateTimeInterval } from './hooks/useTraceMetricsQuery';
 
 enum OverviewTab {
   Usage = 'usage',
@@ -35,6 +36,12 @@ const ExperimentGenAIOverviewPageImpl = () => {
   // Convert ISO strings to milliseconds for the API
   const startTimeMs = startTime ? new Date(startTime).getTime() : undefined;
   const endTimeMs = endTime ? new Date(endTime).getTime() : undefined;
+
+  // Calculate time interval once for all charts
+  const timeIntervalSeconds = calculateTimeInterval(startTimeMs, endTimeMs);
+
+  // Common props for all chart components
+  const chartProps = { experimentId, startTimeMs, endTimeMs, timeIntervalSeconds };
 
   return (
     <div
@@ -87,8 +94,16 @@ const ExperimentGenAIOverviewPageImpl = () => {
         </div>
 
         <Tabs.Content value={OverviewTab.Usage} css={{ flex: 1, overflowY: 'auto' }}>
-          <div css={{ padding: `${theme.spacing.sm}px 0` }}>
-            <LazyTraceRequestsChart experimentId={experimentId} startTimeMs={startTimeMs} endTimeMs={endTimeMs} />
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: theme.spacing.lg,
+              padding: `${theme.spacing.sm}px 0`,
+            }}
+          >
+            {/* Requests chart - full width */}
+            <LazyTraceRequestsChart {...chartProps} />
           </div>
         </Tabs.Content>
       </Tabs.Root>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -9,6 +9,7 @@ import { useMonitoringFilters, getAbsoluteStartEndTime } from '../../hooks/useMo
 import { MonitoringConfigProvider, useMonitoringConfig } from '../../hooks/useMonitoringConfig';
 import { LazyTraceRequestsChart } from './components/LazyTraceRequestsChart';
 import { LazyTraceLatencyChart } from './components/LazyTraceLatencyChart';
+import { LazyTraceErrorsChart } from './components/LazyTraceErrorsChart';
 import { calculateTimeInterval } from './hooks/useTraceMetricsQuery';
 
 enum OverviewTab {
@@ -106,7 +107,7 @@ const ExperimentGenAIOverviewPageImpl = () => {
             {/* Requests chart - full width */}
             <LazyTraceRequestsChart {...chartProps} />
 
-            {/* Latency chart*/}
+            {/* Latency and Errors charts - side by side */}
             <div
               css={{
                 display: 'grid',
@@ -115,6 +116,7 @@ const ExperimentGenAIOverviewPageImpl = () => {
               }}
             >
               <LazyTraceLatencyChart {...chartProps} />
+              <LazyTraceErrorsChart {...chartProps} />
             </div>
           </div>
         </Tabs.Content>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -8,6 +8,7 @@ import { TracesV3DateSelector } from '../../components/experiment-page/component
 import { useMonitoringFilters, getAbsoluteStartEndTime } from '../../hooks/useMonitoringFilters';
 import { MonitoringConfigProvider, useMonitoringConfig } from '../../hooks/useMonitoringConfig';
 import { LazyTraceRequestsChart } from './components/LazyTraceRequestsChart';
+import { LazyTraceLatencyChart } from './components/LazyTraceLatencyChart';
 import { calculateTimeInterval } from './hooks/useTraceMetricsQuery';
 
 enum OverviewTab {
@@ -104,6 +105,17 @@ const ExperimentGenAIOverviewPageImpl = () => {
           >
             {/* Requests chart - full width */}
             <LazyTraceRequestsChart {...chartProps} />
+
+            {/* Latency chart*/}
+            <div
+              css={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(400px, 1fr))',
+                gap: theme.spacing.lg,
+              }}
+            >
+              <LazyTraceLatencyChart {...chartProps} />
+            </div>
           </div>
         </Tabs.Content>
       </Tabs.Root>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ChartCardWrapper.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ChartCardWrapper.tsx
@@ -4,6 +4,61 @@ import { FormattedMessage } from 'react-intl';
 
 const DEFAULT_CHART_HEIGHT = 280;
 
+interface ChartHeaderProps {
+  /** Icon component to display before the title */
+  icon: React.ReactNode;
+  /** Chart title */
+  title: React.ReactNode;
+  /** Main value to display (e.g., "1.2K", "150 ms") */
+  value?: React.ReactNode;
+  /** Optional subtitle shown after the value */
+  subtitle?: React.ReactNode;
+}
+
+/**
+ * Common header component for chart cards with icon, title, and value
+ */
+export const ChartHeader: React.FC<ChartHeaderProps> = ({ icon, title, value, subtitle }) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div css={{ marginBottom: theme.spacing.lg }}>
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+        <span css={{ color: theme.colors.textSecondary, display: 'flex' }}>{icon}</span>
+        <Typography.Text bold size="lg">
+          {title}
+        </Typography.Text>
+      </div>
+      {value !== undefined && (
+        <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm }}>
+          {value}
+          {subtitle && (
+            <>
+              {' '}
+              <Typography.Text color="secondary" css={{ fontWeight: 'normal' }}>
+                {subtitle}
+              </Typography.Text>
+            </>
+          )}
+        </Typography.Title>
+      )}
+    </div>
+  );
+};
+
+/**
+ * "Over time" label shown above time-series charts
+ */
+export const OverTimeLabel: React.FC = () => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <Typography.Text color="secondary" size="sm" css={{ textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+      <FormattedMessage defaultMessage="Over time" description="Label above time-series charts" />
+    </Typography.Text>
+  );
+};
+
 interface ChartCardWrapperProps {
   children: React.ReactNode;
   height?: number;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceErrorsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceErrorsChart.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { LegacySkeleton } from '@databricks/design-system';
+import type { OverviewChartProps } from '../types';
+
+const TraceErrorsChart = React.lazy(() =>
+  import('./TraceErrorsChart').then((module) => ({ default: module.TraceErrorsChart })),
+);
+
+export const LazyTraceErrorsChart: React.FC<OverviewChartProps> = (props) => (
+  <React.Suspense fallback={<LegacySkeleton active />}>
+    <TraceErrorsChart {...props} />
+  </React.Suspense>
+);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceLatencyChart.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { LegacySkeleton } from '@databricks/design-system';
+import type { OverviewChartProps } from '../types';
+
+const TraceLatencyChart = React.lazy(() =>
+  import('./TraceLatencyChart').then((module) => ({ default: module.TraceLatencyChart })),
+);
+
+export const LazyTraceLatencyChart: React.FC<OverviewChartProps> = (props) => (
+  <React.Suspense fallback={<LegacySkeleton active />}>
+    <TraceLatencyChart {...props} />
+  </React.Suspense>
+);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceRequestsChart.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { LegacySkeleton } from '@databricks/design-system';
-import type { TraceRequestsChartProps } from './TraceRequestsChart';
+import type { OverviewChartProps } from '../types';
 
 const TraceRequestsChart = React.lazy(() =>
   import('./TraceRequestsChart').then((module) => ({ default: module.TraceRequestsChart })),
 );
 
-export const LazyTraceRequestsChart: React.FC<TraceRequestsChartProps> = (props) => (
+export const LazyTraceRequestsChart: React.FC<OverviewChartProps> = (props) => (
   <React.Suspense fallback={<LegacySkeleton active />}>
     <TraceRequestsChart {...props} />
   </React.Suspense>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.test.tsx
@@ -1,0 +1,312 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithIntl } from '../../../../common/utils/TestUtils.react18';
+import { TraceErrorsChart } from './TraceErrorsChart';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
+
+// Mock FetchUtils
+jest.mock('../../../../common/utils/FetchUtils', () => ({
+  fetchOrFail: jest.fn(),
+  getAjaxUrl: (url: string) => url,
+}));
+
+import { fetchOrFail } from '../../../../common/utils/FetchUtils';
+const mockFetchOrFail = fetchOrFail as jest.MockedFunction<typeof fetchOrFail>;
+
+// Helper to create mock API response
+const mockApiResponse = (dataPoints: any[] | undefined) => {
+  mockFetchOrFail.mockResolvedValue({
+    json: () => Promise.resolve({ data_points: dataPoints }),
+  } as Response);
+};
+
+// Helper to chain mock API responses (for error count + total count calls)
+const mockApiResponses = (errorDataPoints: any[], totalDataPoints: any[]) => {
+  mockFetchOrFail
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ data_points: errorDataPoints }),
+    } as Response)
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ data_points: totalDataPoints }),
+    } as Response);
+};
+
+// Helper to create an error count data point
+const createErrorCountDataPoint = (timeBucket: string, count: number) => ({
+  metric_name: TraceMetricKey.TRACE_COUNT,
+  dimensions: { time_bucket: timeBucket },
+  values: { [AggregationType.COUNT]: count },
+});
+
+// Helper to create a total count data point
+const createTotalCountDataPoint = (timeBucket: string, count: number) => ({
+  metric_name: TraceMetricKey.TRACE_COUNT,
+  dimensions: { time_bucket: timeBucket },
+  values: { [AggregationType.COUNT]: count },
+});
+
+// Mock recharts components to avoid rendering issues in tests
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  ComposedChart: ({ children, data }: { children: React.ReactNode; data: any[] }) => (
+    <div data-testid="composed-chart" data-count={data?.length || 0}>
+      {children}
+    </div>
+  ),
+  Bar: ({ name }: { name: string }) => <div data-testid={`bar-${name}`} />,
+  Line: ({ name }: { name: string }) => <div data-testid={`line-${name}`} />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Legend: () => <div data-testid="legend" />,
+  ReferenceLine: ({ label }: { label?: { value: string } }) => (
+    <div data-testid="reference-line" data-label={label?.value} />
+  ),
+}));
+
+describe('TraceErrorsChart', () => {
+  const testExperimentId = 'test-experiment-123';
+  const now = Date.now();
+  const oneHourAgo = now - 60 * 60 * 1000;
+
+  // Default props reused across tests
+  const defaultProps = {
+    experimentId: testExperimentId,
+    startTimeMs: oneHourAgo,
+    endTimeMs: now,
+    timeIntervalSeconds: 3600, // 1 hour
+  };
+
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+  const renderComponent = (props: Partial<typeof defaultProps> = {}) => {
+    const queryClient = createQueryClient();
+    return renderWithIntl(
+      <QueryClientProvider client={queryClient}>
+        <DesignSystemProvider>
+          <TraceErrorsChart {...defaultProps} {...props} />
+        </DesignSystemProvider>
+      </QueryClientProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiResponse([]);
+  });
+
+  describe('loading state', () => {
+    it('should render loading spinner while data is being fetched', async () => {
+      mockFetchOrFail.mockReturnValue(new Promise(() => {}));
+
+      renderComponent();
+
+      expect(screen.getByRole('img')).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('should render error message when API call fails', async () => {
+      mockFetchOrFail.mockRejectedValue(new Error('API Error'));
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load chart data')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('empty data state', () => {
+    it('should render empty state message when no data points are returned', async () => {
+      mockApiResponse([]);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
+      });
+    });
+
+    it('should render empty state when data_points is undefined', async () => {
+      mockApiResponse(undefined);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('with data', () => {
+    const mockErrorDataPoints = [
+      createErrorCountDataPoint('2025-12-22T10:00:00Z', 5),
+      createErrorCountDataPoint('2025-12-22T11:00:00Z', 10),
+    ];
+
+    const mockTotalDataPoints = [
+      createTotalCountDataPoint('2025-12-22T10:00:00Z', 100),
+      createTotalCountDataPoint('2025-12-22T11:00:00Z', 200),
+    ];
+
+    it('should render chart with data points', async () => {
+      mockApiResponses(mockErrorDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('composed-chart')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('composed-chart')).toHaveAttribute('data-count', '2');
+    });
+
+    it('should display the "Errors" title', async () => {
+      mockApiResponses(mockErrorDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Errors')).toBeInTheDocument();
+      });
+    });
+
+    it('should display the total error count', async () => {
+      mockApiResponses(mockErrorDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      // Total errors should be 5 + 10 = 15
+      await waitFor(() => {
+        expect(screen.getByText(/15/)).toBeInTheDocument();
+      });
+    });
+
+    it('should display the overall error rate', async () => {
+      mockApiResponses(mockErrorDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      // Error rate: (5 + 10) / (100 + 200) = 15/300 = 5%
+      await waitFor(() => {
+        expect(screen.getByText(/5\.0% error rate/)).toBeInTheDocument();
+      });
+    });
+
+    it('should display "Over time" label', async () => {
+      mockApiResponses(mockErrorDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Over time')).toBeInTheDocument();
+      });
+    });
+
+    it('should render both bar and line series', async () => {
+      mockApiResponses(mockErrorDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('bar-Error Count')).toBeInTheDocument();
+        expect(screen.getByTestId('line-Error Rate')).toBeInTheDocument();
+      });
+    });
+
+    it('should render reference line with AVG label', async () => {
+      mockApiResponses(mockErrorDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        const referenceLine = screen.getByTestId('reference-line');
+        expect(referenceLine).toBeInTheDocument();
+        // AVG error rate: (5% + 5%) / 2 = 5%
+        expect(referenceLine).toHaveAttribute('data-label', expect.stringContaining('AVG'));
+      });
+    });
+  });
+
+  describe('API call parameters', () => {
+    it('should call fetchOrFail with error filter for first call', async () => {
+      renderComponent();
+
+      await waitFor(() => {
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
+        expect(callBody.filters).toContain('trace.status = "ERROR"');
+      });
+    });
+
+    it('should call fetchOrFail without filter for total count call', async () => {
+      renderComponent();
+
+      await waitFor(() => {
+        // Second call is for total count (no error filter)
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[1]?.[1] as any)?.body || '{}');
+        expect(callBody.filters).toBeUndefined();
+      });
+    });
+
+    it('should use provided time interval', async () => {
+      renderComponent({ timeIntervalSeconds: 60 });
+
+      await waitFor(() => {
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
+        expect(callBody.time_interval_seconds).toBe(60);
+      });
+    });
+  });
+
+  describe('data transformation', () => {
+    it('should handle data points with missing values gracefully', async () => {
+      mockApiResponses(
+        [
+          {
+            metric_name: TraceMetricKey.TRACE_COUNT,
+            dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
+            values: {}, // Missing COUNT value
+          },
+          createErrorCountDataPoint('2025-12-22T11:00:00Z', 10),
+        ],
+        [
+          createTotalCountDataPoint('2025-12-22T10:00:00Z', 100),
+          createTotalCountDataPoint('2025-12-22T11:00:00Z', 200),
+        ],
+      );
+
+      renderComponent();
+
+      // Should still render and show total of 10 (0 + 10)
+      await waitFor(() => {
+        expect(screen.getByText(/10/)).toBeInTheDocument();
+      });
+    });
+
+    it('should handle zero total count gracefully (no division by zero)', async () => {
+      mockApiResponses(
+        [createErrorCountDataPoint('2025-12-22T10:00:00Z', 0)],
+        [createTotalCountDataPoint('2025-12-22T10:00:00Z', 0)],
+      );
+
+      renderComponent();
+
+      // Should render without crashing, error rate should be 0%
+      await waitFor(() => {
+        expect(screen.getByText(/0\.0% error rate/)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.test.tsx
@@ -201,7 +201,7 @@ describe('TraceErrorsChart', () => {
 
       // Error rate: (5 + 10) / (100 + 200) = 15/300 = 5%
       await waitFor(() => {
-        expect(screen.getByText(/5\.0% error rate/)).toBeInTheDocument();
+        expect(screen.getByText(/Overall error rate: 5\.0%/)).toBeInTheDocument();
       });
     });
 
@@ -305,7 +305,7 @@ describe('TraceErrorsChart', () => {
 
       // Should render without crashing, error rate should be 0%
       await waitFor(() => {
-        expect(screen.getByText(/0\.0% error rate/)).toBeInTheDocument();
+        expect(screen.getByText(/Overall error rate: 0\.0%/)).toBeInTheDocument();
       });
     });
   });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
@@ -179,26 +179,8 @@ export const TraceErrorsChart: React.FC<OverviewChartProps> = ({
                 tickLine={false}
                 interval="preserveStartEnd"
               />
-              <YAxis
-                yAxisId="left"
-                orientation="left"
-                tick={{ fontSize: 10, fill: theme.colors.textSecondary }}
-                axisLine={false}
-                tickLine={false}
-                width={40}
-                hide={true}
-              />
-              <YAxis
-                yAxisId="right"
-                orientation="right"
-                tick={{ fontSize: 10, fill: theme.colors.textSecondary }}
-                axisLine={false}
-                tickLine={false}
-                tickFormatter={(value) => `${value}%`}
-                width={45}
-                domain={[0, 'auto']}
-                hide={true}
-              />
+              <YAxis yAxisId="left" hide />
+              <YAxis yAxisId="right" hide />
               <Tooltip
                 contentStyle={{
                   backgroundColor: theme.colors.backgroundPrimary,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useDesignSystemTheme, Typography, DangerIcon } from '@databricks/design-system';
+import { useDesignSystemTheme, DangerIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { ComposedChart, Bar, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, ReferenceLine } from 'recharts';
 import {
@@ -13,7 +13,7 @@ import {
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
-import { ChartLoadingState, ChartErrorState, ChartEmptyState } from './ChartCardWrapper';
+import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
 import type { OverviewChartProps } from '../types';
 
 // Filter to get only error traces
@@ -146,26 +146,14 @@ export const TraceErrorsChart: React.FC<OverviewChartProps> = ({
         backgroundColor: theme.colors.backgroundPrimary,
       }}
     >
-      {/* Chart header */}
-      <div css={{ marginBottom: theme.spacing.lg }}>
-        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
-          <DangerIcon css={{ color: theme.colors.textSecondary }} />
-          <Typography.Text bold size="lg">
-            <FormattedMessage defaultMessage="Errors" description="Title for the errors chart" />
-          </Typography.Text>
-        </div>
-        <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm }}>
-          {totalErrors.toLocaleString()}{' '}
-          <Typography.Text color="secondary" css={{ fontWeight: 'normal' }}>
-            (Overall error rate: {overallErrorRate.toFixed(1)}%)
-          </Typography.Text>
-        </Typography.Title>
-      </div>
+      <ChartHeader
+        icon={<DangerIcon />}
+        title={<FormattedMessage defaultMessage="Errors" description="Title for the errors chart" />}
+        value={totalErrors.toLocaleString()}
+        subtitle={`(Overall error rate: ${overallErrorRate.toFixed(1)}%)`}
+      />
 
-      {/* "Over time" label */}
-      <Typography.Text color="secondary" size="sm" css={{ textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-        <FormattedMessage defaultMessage="Over time" description="Label above the errors chart" />
-      </Typography.Text>
+      <OverTimeLabel />
 
       {/* Chart */}
       <div css={{ height: 200, marginTop: theme.spacing.sm }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
@@ -157,7 +157,7 @@ export const TraceErrorsChart: React.FC<OverviewChartProps> = ({
         <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm }}>
           {totalErrors.toLocaleString()}{' '}
           <Typography.Text color="secondary" css={{ fontWeight: 'normal' }}>
-            ({overallErrorRate.toFixed(1)}% error rate)
+            (Overall error rate: {overallErrorRate.toFixed(1)}%)
           </Typography.Text>
         </Typography.Title>
       </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
@@ -1,0 +1,276 @@
+import React, { useMemo, useState } from 'react';
+import { useDesignSystemTheme, Typography, DangerIcon } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { ComposedChart, Bar, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, ReferenceLine } from 'recharts';
+import {
+  MetricViewType,
+  AggregationType,
+  TraceMetricKey,
+  TIME_BUCKET_DIMENSION_KEY,
+  TraceFilterKey,
+  TraceStatus,
+  createTraceFilter,
+} from '@databricks/web-shared/model-trace-explorer';
+import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
+import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
+import { ChartLoadingState, ChartErrorState, ChartEmptyState } from './ChartCardWrapper';
+import type { OverviewChartProps } from '../types';
+
+// Filter to get only error traces
+const ERROR_FILTER = createTraceFilter(TraceFilterKey.STATUS, TraceStatus.ERROR);
+
+export const TraceErrorsChart: React.FC<OverviewChartProps> = ({
+  experimentId,
+  startTimeMs,
+  endTimeMs,
+  timeIntervalSeconds,
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  // Fetch error count metrics grouped by time bucket
+  const {
+    data: errorCountData,
+    isLoading: isLoadingErrors,
+    error: errorCountError,
+  } = useTraceMetricsQuery({
+    experimentId,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.TRACE_COUNT,
+    aggregations: [{ aggregation_type: AggregationType.COUNT }],
+    timeIntervalSeconds,
+    filters: [ERROR_FILTER],
+  });
+
+  // Fetch total trace count metrics grouped by time bucket (for calculating error rate)
+  // This query is also used by TraceRequestsChart, so React Query will dedupe it
+  const {
+    data: totalCountData,
+    isLoading: isLoadingTotal,
+    error: totalCountError,
+  } = useTraceMetricsQuery({
+    experimentId,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.TRACE_COUNT,
+    aggregations: [{ aggregation_type: AggregationType.COUNT }],
+    timeIntervalSeconds,
+  });
+
+  const errorDataPoints = useMemo(() => errorCountData?.data_points || [], [errorCountData?.data_points]);
+  const totalDataPoints = useMemo(() => totalCountData?.data_points || [], [totalCountData?.data_points]);
+  const isLoading = isLoadingErrors || isLoadingTotal;
+  const error = errorCountError || totalCountError;
+
+  // Calculate totals by summing time-bucketed data
+  const totalErrors = useMemo(
+    () => errorDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.COUNT] || 0), 0),
+    [errorDataPoints],
+  );
+  const totalTraces = useMemo(
+    () => totalDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.COUNT] || 0), 0),
+    [totalDataPoints],
+  );
+  const overallErrorRate = totalTraces > 0 ? (totalErrors / totalTraces) * 100 : 0;
+
+  // Create a map of time bucket -> total count for easy lookup
+  const totalCountMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const dp of totalDataPoints) {
+      const timeBucket = dp.dimensions?.[TIME_BUCKET_DIMENSION_KEY];
+      if (timeBucket) {
+        map.set(timeBucket, dp.values?.[AggregationType.COUNT] || 0);
+      }
+    }
+    return map;
+  }, [totalDataPoints]);
+
+  // Prepare chart data for recharts - combine error count and error rate
+  const chartData = useMemo(() => {
+    return errorDataPoints.map((dp) => {
+      const timestampMs = getTimestampFromDataPoint(dp);
+      const timeBucket = dp.dimensions?.[TIME_BUCKET_DIMENSION_KEY] || '';
+      const errorCount = dp.values?.[AggregationType.COUNT] || 0;
+      const totalCount = totalCountMap.get(timeBucket) || 0;
+      const errorRate = totalCount > 0 ? (errorCount / totalCount) * 100 : 0;
+
+      return {
+        name: timestampMs ? formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds) : '',
+        errorCount,
+        errorRate: Math.round(errorRate * 100) / 100, // Round to 2 decimal places
+      };
+    });
+  }, [errorDataPoints, totalCountMap, timeIntervalSeconds]);
+
+  // Calculate average error rate across time buckets for the reference line
+  const avgErrorRate = useMemo(() => {
+    if (chartData.length === 0) return 0;
+    const sum = chartData.reduce((acc, dp) => acc + dp.errorRate, 0);
+    return sum / chartData.length;
+  }, [chartData]);
+
+  // Track hovered legend item
+  const [hoveredSeries, setHoveredSeries] = useState<string | null>(null);
+
+  // Get opacity based on hover state
+  const getOpacity = (seriesKey: string) => {
+    if (hoveredSeries === null) return 1;
+    return hoveredSeries === seriesKey ? 1 : 0.2;
+  };
+
+  // Handle legend hover
+  const handleLegendMouseEnter = (data: { value: string }) => {
+    setHoveredSeries(data.value);
+  };
+
+  const handleLegendMouseLeave = () => {
+    setHoveredSeries(null);
+  };
+
+  if (isLoading) {
+    return <ChartLoadingState />;
+  }
+
+  if (error) {
+    return <ChartErrorState />;
+  }
+
+  return (
+    <div
+      css={{
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        padding: theme.spacing.lg,
+        backgroundColor: theme.colors.backgroundPrimary,
+      }}
+    >
+      {/* Chart header */}
+      <div css={{ marginBottom: theme.spacing.lg }}>
+        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+          <DangerIcon css={{ color: theme.colors.textSecondary }} />
+          <Typography.Text bold size="lg">
+            <FormattedMessage defaultMessage="Errors" description="Title for the errors chart" />
+          </Typography.Text>
+        </div>
+        <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm }}>
+          {totalErrors.toLocaleString()}{' '}
+          <Typography.Text color="secondary" css={{ fontWeight: 'normal' }}>
+            ({overallErrorRate.toFixed(1)}% error rate)
+          </Typography.Text>
+        </Typography.Title>
+      </div>
+
+      {/* "Over time" label */}
+      <Typography.Text color="secondary" size="sm" css={{ textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+        <FormattedMessage defaultMessage="Over time" description="Label above the errors chart" />
+      </Typography.Text>
+
+      {/* Chart */}
+      <div css={{ height: 200, marginTop: theme.spacing.sm }}>
+        {chartData.length > 0 ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={chartData} margin={{ top: 10, right: 10, left: 10, bottom: 0 }}>
+              <XAxis
+                dataKey="name"
+                tick={{ fontSize: 10, fill: theme.colors.textSecondary, dy: theme.spacing.sm }}
+                axisLine={false}
+                tickLine={false}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                yAxisId="left"
+                orientation="left"
+                tick={{ fontSize: 10, fill: theme.colors.textSecondary }}
+                axisLine={false}
+                tickLine={false}
+                width={40}
+                hide={true}
+              />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tick={{ fontSize: 10, fill: theme.colors.textSecondary }}
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={(value) => `${value}%`}
+                width={45}
+                domain={[0, 'auto']}
+                hide={true}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: theme.colors.backgroundPrimary,
+                  border: `1px solid ${theme.colors.border}`,
+                  borderRadius: theme.borders.borderRadiusMd,
+                  fontSize: 12,
+                }}
+                cursor={{ fill: theme.colors.actionTertiaryBackgroundHover }}
+                formatter={(value: number, name: string) => {
+                  if (name === 'Error Count') {
+                    return [value.toLocaleString(), name];
+                  }
+                  return [`${value.toFixed(1)}%`, name];
+                }}
+              />
+              <Bar
+                yAxisId="left"
+                dataKey="errorCount"
+                fill={theme.colors.red400}
+                radius={[4, 4, 0, 0]}
+                name="Error Count"
+                fillOpacity={getOpacity('Error Count')}
+                legendType="square"
+              />
+              {avgErrorRate > 0 && (
+                <ReferenceLine
+                  yAxisId="right"
+                  y={avgErrorRate}
+                  stroke={theme.colors.textSecondary}
+                  strokeDasharray="4 4"
+                  label={{
+                    value: `AVG (${avgErrorRate.toFixed(1)}%)`,
+                    position: 'insideTopRight',
+                    fill: theme.colors.textSecondary,
+                    fontSize: 10,
+                  }}
+                />
+              )}
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="errorRate"
+                stroke={theme.colors.yellow500}
+                strokeWidth={2}
+                dot={false}
+                name="Error Rate"
+                strokeOpacity={getOpacity('Error Rate')}
+                legendType="plainline"
+              />
+              <Legend
+                verticalAlign="bottom"
+                height={36}
+                onMouseEnter={handleLegendMouseEnter}
+                onMouseLeave={handleLegendMouseLeave}
+                formatter={(value) => (
+                  <span
+                    style={{
+                      color: theme.colors.textPrimary,
+                      fontSize: theme.typography.fontSizeSm,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {value}
+                  </span>
+                )}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        ) : (
+          <ChartEmptyState />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.test.tsx
@@ -1,0 +1,375 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithIntl } from '../../../../common/utils/TestUtils.react18';
+import { TraceLatencyChart } from './TraceLatencyChart';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import {
+  MetricViewType,
+  AggregationType,
+  TraceMetricKey,
+  P50,
+  P90,
+  P99,
+  getPercentileKey,
+} from '@databricks/web-shared/model-trace-explorer';
+
+// Mock FetchUtils
+jest.mock('../../../../common/utils/FetchUtils', () => ({
+  fetchOrFail: jest.fn(),
+  getAjaxUrl: (url: string) => url,
+}));
+
+import { fetchOrFail } from '../../../../common/utils/FetchUtils';
+const mockFetchOrFail = fetchOrFail as jest.MockedFunction<typeof fetchOrFail>;
+
+// Helper to create mock API response
+const mockApiResponse = (dataPoints: any[] | undefined) => {
+  mockFetchOrFail.mockResolvedValue({
+    json: () => Promise.resolve({ data_points: dataPoints }),
+  } as Response);
+};
+
+// Helper to chain mock API responses (for percentiles + AVG calls)
+const mockApiResponses = (percentileDataPoints: any[], avgDataPoints: any[]) => {
+  mockFetchOrFail
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ data_points: percentileDataPoints }),
+    } as Response)
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ data_points: avgDataPoints }),
+    } as Response);
+};
+
+// Helper to create a latency percentile data point
+const createLatencyDataPoint = (timeBucket: string, p50: number, p90: number, p99: number) => ({
+  metric_name: TraceMetricKey.LATENCY,
+  dimensions: { time_bucket: timeBucket },
+  values: {
+    [getPercentileKey(P50)]: p50,
+    [getPercentileKey(P90)]: p90,
+    [getPercentileKey(P99)]: p99,
+  },
+});
+
+// Helper to create an AVG latency data point
+const createAvgLatencyDataPoint = (avg: number) => ({
+  metric_name: TraceMetricKey.LATENCY,
+  dimensions: {},
+  values: { [AggregationType.AVG]: avg },
+});
+
+// Mock recharts components to avoid rendering issues in tests
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  LineChart: ({ children, data }: { children: React.ReactNode; data: any[] }) => (
+    <div data-testid="line-chart" data-count={data?.length || 0}>
+      {children}
+    </div>
+  ),
+  Line: ({ name }: { name: string }) => <div data-testid={`line-${name}`} />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Legend: () => <div data-testid="legend" />,
+  ReferenceLine: ({ label }: { label?: { value: string } }) => (
+    <div data-testid="reference-line" data-label={label?.value} />
+  ),
+}));
+
+describe('TraceLatencyChart', () => {
+  const testExperimentId = 'test-experiment-123';
+  const now = Date.now();
+  const oneHourAgo = now - 60 * 60 * 1000;
+
+  // Default props reused across tests
+  const defaultProps = {
+    experimentId: testExperimentId,
+    startTimeMs: oneHourAgo,
+    endTimeMs: now,
+    timeIntervalSeconds: 3600, // 1 hour
+  };
+
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+  const renderComponent = (props: Partial<typeof defaultProps> = {}) => {
+    const queryClient = createQueryClient();
+    return renderWithIntl(
+      <QueryClientProvider client={queryClient}>
+        <DesignSystemProvider>
+          <TraceLatencyChart {...defaultProps} {...props} />
+        </DesignSystemProvider>
+      </QueryClientProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiResponse([]);
+  });
+
+  describe('loading state', () => {
+    it('should render loading spinner while data is being fetched', async () => {
+      // Create a promise that never resolves to keep the component in loading state
+      mockFetchOrFail.mockReturnValue(new Promise(() => {}));
+
+      renderComponent();
+
+      // Check for spinner (loading state)
+      expect(screen.getByRole('img')).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('should render error message when time series API call fails', async () => {
+      mockFetchOrFail.mockRejectedValue(new Error('API Error'));
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load chart data')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('empty data state', () => {
+    it('should render empty state message when no data points are returned', async () => {
+      mockApiResponse([]);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
+      });
+    });
+
+    it('should render empty state when data_points is undefined', async () => {
+      mockApiResponse(undefined);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('with data', () => {
+    const mockPercentileDataPoints = [
+      createLatencyDataPoint('2025-12-22T10:00:00Z', 150, 350, 800),
+      createLatencyDataPoint('2025-12-22T11:00:00Z', 180, 400, 950),
+    ];
+
+    const mockAvgDataPoints = [createAvgLatencyDataPoint(250)];
+
+    it('should render chart with data points', async () => {
+      mockApiResponses(mockPercentileDataPoints, mockAvgDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+      });
+
+      // Verify the line chart has the correct number of data points
+      expect(screen.getByTestId('line-chart')).toHaveAttribute('data-count', '2');
+    });
+
+    it('should display all three percentile lines', async () => {
+      mockApiResponses(mockPercentileDataPoints, mockAvgDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('line-p50')).toBeInTheDocument();
+        expect(screen.getByTestId('line-p90')).toBeInTheDocument();
+        expect(screen.getByTestId('line-p99')).toBeInTheDocument();
+      });
+    });
+
+    it('should display the average latency in header', async () => {
+      mockApiResponses(mockPercentileDataPoints, mockAvgDataPoints);
+
+      renderComponent();
+
+      // Average is 250ms
+      await waitFor(() => {
+        expect(screen.getByText('250 ms')).toBeInTheDocument();
+      });
+    });
+
+    it('should display the "Latency" title', async () => {
+      mockApiResponses(mockPercentileDataPoints, mockAvgDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Latency')).toBeInTheDocument();
+      });
+    });
+
+    it('should display "Over time" label', async () => {
+      mockApiResponses(mockPercentileDataPoints, mockAvgDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Over time')).toBeInTheDocument();
+      });
+    });
+
+    it('should format latency in seconds for values >= 1000ms', async () => {
+      mockApiResponses(mockPercentileDataPoints, [createAvgLatencyDataPoint(1500)]);
+
+      renderComponent();
+
+      // 1500ms should be displayed as 1.50 sec
+      await waitFor(() => {
+        expect(screen.getByText('1.50 sec')).toBeInTheDocument();
+      });
+    });
+
+    it('should render reference line with AVG label', async () => {
+      mockApiResponses(mockPercentileDataPoints, mockAvgDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        const referenceLine = screen.getByTestId('reference-line');
+        expect(referenceLine).toBeInTheDocument();
+        expect(referenceLine).toHaveAttribute('data-label', 'AVG (250 ms)');
+      });
+    });
+  });
+
+  describe('API call parameters', () => {
+    it('should call fetchOrFail for percentiles with correct parameters', async () => {
+      renderComponent();
+
+      await waitFor(() => {
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
+        expect(callBody).toMatchObject({
+          experiment_ids: [testExperimentId],
+          view_type: MetricViewType.TRACES,
+          metric_name: TraceMetricKey.LATENCY,
+          aggregations: [
+            { aggregation_type: AggregationType.PERCENTILE, percentile_value: P50 },
+            { aggregation_type: AggregationType.PERCENTILE, percentile_value: P90 },
+            { aggregation_type: AggregationType.PERCENTILE, percentile_value: P99 },
+          ],
+        });
+      });
+    });
+
+    it('should call fetchOrFail for AVG with correct parameters', async () => {
+      renderComponent();
+
+      await waitFor(() => {
+        // Second call is for AVG
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[1]?.[1] as any)?.body || '{}');
+        expect(callBody).toMatchObject({
+          experiment_ids: [testExperimentId],
+          view_type: MetricViewType.TRACES,
+          metric_name: TraceMetricKey.LATENCY,
+          aggregations: [{ aggregation_type: AggregationType.AVG }],
+        });
+      });
+    });
+
+    it('should use provided time interval', async () => {
+      renderComponent({ timeIntervalSeconds: 60 });
+
+      await waitFor(() => {
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
+        expect(callBody.time_interval_seconds).toBe(60);
+      });
+    });
+
+    it('should use provided time interval for hourly grouping', async () => {
+      renderComponent({ timeIntervalSeconds: 3600 });
+
+      await waitFor(() => {
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
+        expect(callBody.time_interval_seconds).toBe(3600);
+      });
+    });
+
+    it('should use provided time interval for daily grouping', async () => {
+      renderComponent({ timeIntervalSeconds: 86400 });
+
+      await waitFor(() => {
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
+        expect(callBody.time_interval_seconds).toBe(86400);
+      });
+    });
+  });
+
+  describe('data transformation', () => {
+    it('should handle data points with missing percentile values gracefully', async () => {
+      mockApiResponses(
+        [
+          {
+            metric_name: TraceMetricKey.LATENCY,
+            dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
+            values: {}, // Missing percentile values
+          },
+        ],
+        [createAvgLatencyDataPoint(100)],
+      );
+
+      renderComponent();
+
+      // Should still render without crashing
+      await waitFor(() => {
+        expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+      });
+    });
+
+    it('should handle missing AVG data gracefully', async () => {
+      mockApiResponses([createLatencyDataPoint('2025-12-22T10:00:00Z', 150, 350, 800)], []);
+
+      renderComponent();
+
+      // Should still render the chart without avg
+      await waitFor(() => {
+        expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+      });
+
+      // Should NOT display avg value or reference line when not available
+      expect(screen.queryByTestId('reference-line')).not.toBeInTheDocument();
+    });
+
+    it('should handle data points with missing time_bucket', async () => {
+      mockApiResponses(
+        [
+          {
+            metric_name: TraceMetricKey.LATENCY,
+            dimensions: {}, // Missing time_bucket
+            values: {
+              [getPercentileKey(P50)]: 100,
+              [getPercentileKey(P90)]: 200,
+              [getPercentileKey(P99)]: 300,
+            },
+          },
+        ],
+        [createAvgLatencyDataPoint(150)],
+      );
+
+      renderComponent();
+
+      // Should still render the chart
+      await waitFor(() => {
+        expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
@@ -1,0 +1,241 @@
+import React, { useMemo, useState } from 'react';
+import { useDesignSystemTheme, Typography, ClockIcon } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, ReferenceLine } from 'recharts';
+import {
+  MetricViewType,
+  AggregationType,
+  TraceMetricKey,
+  P50,
+  P90,
+  P99,
+  getPercentileKey,
+} from '@databricks/web-shared/model-trace-explorer';
+import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
+import { ChartLoadingState, ChartErrorState, ChartEmptyState } from './ChartCardWrapper';
+import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
+import type { OverviewChartProps } from '../types';
+
+/**
+ * Format latency value in human-readable format
+ */
+function formatLatency(ms: number): string {
+  if (ms >= 1000) {
+    return `${(ms / 1000).toFixed(2)} sec`;
+  }
+  return `${ms.toFixed(0)} ms`;
+}
+
+export const TraceLatencyChart: React.FC<OverviewChartProps> = ({
+  experimentId,
+  startTimeMs,
+  endTimeMs,
+  timeIntervalSeconds,
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  // Fetch latency metrics with p50, p90, p99 aggregations grouped by time
+  const {
+    data: latencyData,
+    isLoading: isLoadingTimeSeries,
+    error: timeSeriesError,
+  } = useTraceMetricsQuery({
+    experimentId,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.LATENCY,
+    aggregations: [
+      { aggregation_type: AggregationType.PERCENTILE, percentile_value: P50 },
+      { aggregation_type: AggregationType.PERCENTILE, percentile_value: P90 },
+      { aggregation_type: AggregationType.PERCENTILE, percentile_value: P99 },
+    ],
+    timeIntervalSeconds,
+  });
+
+  // Fetch overall average latency (without time bucketing) for the header
+  const {
+    data: avgLatencyData,
+    isLoading: isLoadingAvg,
+    error: avgError,
+  } = useTraceMetricsQuery({
+    experimentId,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.LATENCY,
+    aggregations: [{ aggregation_type: AggregationType.AVG }],
+  });
+
+  const latencyDataPoints = latencyData?.data_points || [];
+  const isLoading = isLoadingTimeSeries || isLoadingAvg;
+  const error = timeSeriesError || avgError;
+
+  // Extract overall average latency from the response (undefined if not available)
+  const avgLatency = avgLatencyData?.data_points?.[0]?.values?.[AggregationType.AVG];
+
+  // Prepare chart data for recharts
+  const chartData = useMemo(() => {
+    return latencyDataPoints.map((dp) => {
+      const timestampMs = getTimestampFromDataPoint(dp);
+      return {
+        name: timestampMs ? formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds) : '',
+        p50: dp.values?.[getPercentileKey(P50)] || 0,
+        p90: dp.values?.[getPercentileKey(P90)] || 0,
+        p99: dp.values?.[getPercentileKey(P99)] || 0,
+      };
+    });
+  }, [latencyDataPoints, timeIntervalSeconds]);
+
+  // Track hovered legend item (null means none hovered, show all)
+  const [hoveredLine, setHoveredLine] = useState<string | null>(null);
+
+  // Line colors
+  const lineColors = {
+    p50: theme.colors.blue300,
+    p90: theme.colors.blue500,
+    p99: theme.colors.yellow500,
+  };
+
+  // Get opacity for a line based on hover state
+  const getLineOpacity = (lineKey: string) => {
+    if (hoveredLine === null) return 1;
+    return hoveredLine === lineKey ? 1 : 0.2;
+  };
+
+  // Handle legend hover
+  const handleLegendMouseEnter = (data: { value: string }) => {
+    setHoveredLine(data.value);
+  };
+
+  const handleLegendMouseLeave = () => {
+    setHoveredLine(null);
+  };
+
+  if (isLoading) {
+    return <ChartLoadingState />;
+  }
+
+  if (error) {
+    return <ChartErrorState />;
+  }
+
+  return (
+    <div
+      css={{
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        padding: theme.spacing.lg,
+        backgroundColor: theme.colors.backgroundPrimary,
+      }}
+    >
+      {/* Chart header */}
+      <div css={{ marginBottom: theme.spacing.lg }}>
+        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+          <ClockIcon css={{ color: theme.colors.textSecondary }} />
+          <Typography.Text bold size="lg">
+            <FormattedMessage defaultMessage="Latency" description="Title for the latency chart" />
+          </Typography.Text>
+        </div>
+        {avgLatency !== undefined && (
+          <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm }}>
+            {formatLatency(avgLatency)}
+          </Typography.Title>
+        )}
+      </div>
+
+      {/* "Over time" label */}
+      <Typography.Text color="secondary" size="sm" css={{ textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+        <FormattedMessage defaultMessage="Over time" description="Label above the latency chart" />
+      </Typography.Text>
+
+      {/* Chart */}
+      <div css={{ height: 200, marginTop: theme.spacing.sm }}>
+        {chartData.length > 0 ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData} margin={{ top: 10, right: 30, left: 30, bottom: 0 }}>
+              <XAxis
+                dataKey="name"
+                tick={{ fontSize: 10, fill: theme.colors.textSecondary, dy: theme.spacing.sm }}
+                axisLine={false}
+                tickLine={false}
+                interval="preserveStartEnd"
+              />
+              <YAxis hide />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: theme.colors.backgroundPrimary,
+                  border: `1px solid ${theme.colors.border}`,
+                  borderRadius: theme.borders.borderRadiusMd,
+                  fontSize: 12,
+                }}
+                cursor={{ stroke: theme.colors.actionTertiaryBackgroundHover }}
+                formatter={(value: number, name: string) => [formatLatency(value), name]}
+              />
+              <Line
+                type="monotone"
+                dataKey="p50"
+                stroke={lineColors.p50}
+                strokeWidth={2}
+                dot={false}
+                name="p50"
+                strokeOpacity={getLineOpacity('p50')}
+              />
+              <Line
+                type="monotone"
+                dataKey="p90"
+                stroke={lineColors.p90}
+                strokeWidth={2}
+                dot={false}
+                name="p90"
+                strokeOpacity={getLineOpacity('p90')}
+              />
+              <Line
+                type="monotone"
+                dataKey="p99"
+                stroke={lineColors.p99}
+                strokeWidth={2}
+                dot={false}
+                name="p99"
+                strokeOpacity={getLineOpacity('p99')}
+              />
+              {avgLatency !== undefined && (
+                <ReferenceLine
+                  y={avgLatency}
+                  stroke={theme.colors.textSecondary}
+                  strokeDasharray="4 4"
+                  label={{
+                    value: `AVG (${formatLatency(avgLatency)})`,
+                    position: 'insideTopRight',
+                    fill: theme.colors.textSecondary,
+                    fontSize: 10,
+                  }}
+                />
+              )}
+              <Legend
+                verticalAlign="bottom"
+                iconType="plainline"
+                height={36}
+                onMouseEnter={handleLegendMouseEnter}
+                onMouseLeave={handleLegendMouseLeave}
+                formatter={(value) => (
+                  <span
+                    style={{
+                      color: theme.colors.textPrimary,
+                      fontSize: theme.typography.fontSizeSm,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {value}
+                  </span>
+                )}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        ) : (
+          <ChartEmptyState />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useDesignSystemTheme, Typography, ClockIcon } from '@databricks/design-system';
+import { useDesignSystemTheme, ClockIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, ReferenceLine } from 'recharts';
 import {
@@ -12,7 +12,7 @@ import {
   getPercentileKey,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
-import { ChartLoadingState, ChartErrorState, ChartEmptyState } from './ChartCardWrapper';
+import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
 import type { OverviewChartProps } from '../types';
 
@@ -129,25 +129,13 @@ export const TraceLatencyChart: React.FC<OverviewChartProps> = ({
         backgroundColor: theme.colors.backgroundPrimary,
       }}
     >
-      {/* Chart header */}
-      <div css={{ marginBottom: theme.spacing.lg }}>
-        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
-          <ClockIcon css={{ color: theme.colors.textSecondary }} />
-          <Typography.Text bold size="lg">
-            <FormattedMessage defaultMessage="Latency" description="Title for the latency chart" />
-          </Typography.Text>
-        </div>
-        {avgLatency !== undefined && (
-          <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm }}>
-            {formatLatency(avgLatency)}
-          </Typography.Title>
-        )}
-      </div>
+      <ChartHeader
+        icon={<ClockIcon />}
+        title={<FormattedMessage defaultMessage="Latency" description="Title for the latency chart" />}
+        value={avgLatency !== undefined ? formatLatency(avgLatency) : undefined}
+      />
 
-      {/* "Over time" label */}
-      <Typography.Text color="secondary" size="sm" css={{ textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-        <FormattedMessage defaultMessage="Over time" description="Label above the latency chart" />
-      </Typography.Text>
+      <OverTimeLabel />
 
       {/* Chart */}
       <div css={{ height: 200, marginTop: theme.spacing.sm }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
@@ -67,7 +67,7 @@ export const TraceLatencyChart: React.FC<OverviewChartProps> = ({
     aggregations: [{ aggregation_type: AggregationType.AVG }],
   });
 
-  const latencyDataPoints = latencyData?.data_points || [];
+  const latencyDataPoints = useMemo(() => latencyData?.data_points || [], [latencyData?.data_points]);
   const isLoading = isLoadingTimeSeries || isLoadingAvg;
   const error = timeSeriesError || avgError;
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
@@ -15,6 +15,20 @@ jest.mock('../../../../common/utils/FetchUtils', () => ({
 import { fetchOrFail } from '../../../../common/utils/FetchUtils';
 const mockFetchOrFail = fetchOrFail as jest.MockedFunction<typeof fetchOrFail>;
 
+// Helper to create mock API response
+const mockApiResponse = (dataPoints: any[] | undefined) => {
+  mockFetchOrFail.mockResolvedValue({
+    json: () => Promise.resolve({ data_points: dataPoints }),
+  } as Response);
+};
+
+// Helper to create a single data point
+const createTraceCountDataPoint = (timeBucket: string, count: number) => ({
+  metric_name: TraceMetricKey.TRACE_COUNT,
+  dimensions: { time_bucket: timeBucket },
+  values: { [AggregationType.COUNT]: count },
+});
+
 // Mock recharts components to avoid rendering issues in tests
 jest.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
@@ -36,6 +50,14 @@ describe('TraceRequestsChart', () => {
   const now = Date.now();
   const oneHourAgo = now - 60 * 60 * 1000;
 
+  // Default props reused across tests
+  const defaultProps = {
+    experimentId: testExperimentId,
+    startTimeMs: oneHourAgo,
+    endTimeMs: now,
+    timeIntervalSeconds: 3600, // 1 hour
+  };
+
   const createQueryClient = () =>
     new QueryClient({
       defaultOptions: {
@@ -45,12 +67,12 @@ describe('TraceRequestsChart', () => {
       },
     });
 
-  const renderComponent = (props: { experimentId: string; startTimeMs?: number; endTimeMs?: number }) => {
+  const renderComponent = (props: Partial<typeof defaultProps> = {}) => {
     const queryClient = createQueryClient();
     return renderWithIntl(
       <QueryClientProvider client={queryClient}>
         <DesignSystemProvider>
-          <TraceRequestsChart {...props} />
+          <TraceRequestsChart {...defaultProps} {...props} />
         </DesignSystemProvider>
       </QueryClientProvider>,
     );
@@ -58,10 +80,7 @@ describe('TraceRequestsChart', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Mock fetchOrFail to return a response with json() method
-    mockFetchOrFail.mockResolvedValue({
-      json: () => Promise.resolve({ data_points: [] }),
-    } as Response);
+    mockApiResponse([]);
   });
 
   describe('loading state', () => {
@@ -69,11 +88,7 @@ describe('TraceRequestsChart', () => {
       // Create a promise that never resolves to keep the component in loading state
       mockFetchOrFail.mockReturnValue(new Promise(() => {}));
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       // Check for spinner (loading state)
       expect(screen.getByRole('img')).toBeInTheDocument();
@@ -84,11 +99,7 @@ describe('TraceRequestsChart', () => {
     it('should render error message when API call fails', async () => {
       mockFetchOrFail.mockRejectedValue(new Error('API Error'));
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(screen.getByText('Failed to load chart data')).toBeInTheDocument();
@@ -98,15 +109,9 @@ describe('TraceRequestsChart', () => {
 
   describe('empty data state', () => {
     it('should render empty state message when no data points are returned', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () => Promise.resolve({ data_points: [] }),
-      } as Response);
+      mockApiResponse([]);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
@@ -114,16 +119,9 @@ describe('TraceRequestsChart', () => {
     });
 
     it('should render empty state when data_points is undefined', async () => {
-      // Cast to simulate edge case where API might return malformed response
-      mockFetchOrFail.mockResolvedValue({
-        json: () => Promise.resolve({ data_points: undefined }),
-      } as Response);
+      mockApiResponse(undefined);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
@@ -133,33 +131,15 @@ describe('TraceRequestsChart', () => {
 
   describe('with data', () => {
     const mockDataPoints = [
-      {
-        metric_name: TraceMetricKey.TRACE_COUNT,
-        dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
-        values: { [AggregationType.COUNT]: 42 },
-      },
-      {
-        metric_name: TraceMetricKey.TRACE_COUNT,
-        dimensions: { time_bucket: '2025-12-22T11:00:00Z' },
-        values: { [AggregationType.COUNT]: 58 },
-      },
-      {
-        metric_name: TraceMetricKey.TRACE_COUNT,
-        dimensions: { time_bucket: '2025-12-22T12:00:00Z' },
-        values: { [AggregationType.COUNT]: 100 },
-      },
+      createTraceCountDataPoint('2025-12-22T10:00:00Z', 42),
+      createTraceCountDataPoint('2025-12-22T11:00:00Z', 58),
+      createTraceCountDataPoint('2025-12-22T12:00:00Z', 100),
     ];
 
     it('should render chart with data points', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () => Promise.resolve({ data_points: mockDataPoints }),
-      } as Response);
+      mockApiResponse(mockDataPoints);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
@@ -170,15 +150,9 @@ describe('TraceRequestsChart', () => {
     });
 
     it('should display the total request count', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () => Promise.resolve({ data_points: mockDataPoints }),
-      } as Response);
+      mockApiResponse(mockDataPoints);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       // Total should be 42 + 58 + 100 = 200
       await waitFor(() => {
@@ -187,15 +161,9 @@ describe('TraceRequestsChart', () => {
     });
 
     it('should display the "Requests" title', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () => Promise.resolve({ data_points: mockDataPoints }),
-      } as Response);
+      mockApiResponse(mockDataPoints);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(screen.getByText('Requests')).toBeInTheDocument();
@@ -203,24 +171,9 @@ describe('TraceRequestsChart', () => {
     });
 
     it('should format large numbers with locale formatting', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () =>
-          Promise.resolve({
-            data_points: [
-              {
-                metric_name: TraceMetricKey.TRACE_COUNT,
-                dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
-                values: { [AggregationType.COUNT]: 1234567 },
-              },
-            ],
-          }),
-      } as Response);
+      mockApiResponse([createTraceCountDataPoint('2025-12-22T10:00:00Z', 1234567)]);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       await waitFor(() => {
         // Check for locale-formatted number (1,234,567 in US locale)
@@ -231,14 +184,7 @@ describe('TraceRequestsChart', () => {
 
   describe('API call parameters', () => {
     it('should call fetchOrFail with correct parameters', async () => {
-      const startTimeMs = oneHourAgo;
-      const endTimeMs = now;
-
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs,
-        endTimeMs,
-      });
+      renderComponent();
 
       await waitFor(() => {
         expect(mockFetchOrFail).toHaveBeenCalledWith(
@@ -254,80 +200,46 @@ describe('TraceRequestsChart', () => {
       });
     });
 
-    it('should calculate appropriate time interval for 1-hour range', async () => {
-      const endTimeMs = Date.now();
-      const startTimeMs = endTimeMs - 60 * 60 * 1000; // 1 hour
-
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs,
-        endTimeMs,
-      });
+    it('should use provided time interval', async () => {
+      renderComponent({ timeIntervalSeconds: 60 });
 
       await waitFor(() => {
         const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
-        expect(callBody.time_interval_seconds).toBe(60); // MINUTE_IN_SECONDS
+        expect(callBody.time_interval_seconds).toBe(60);
       });
     });
 
-    it('should calculate appropriate time interval for 24-hour range', async () => {
-      const endTimeMs = Date.now();
-      const startTimeMs = endTimeMs - 12 * 60 * 60 * 1000; // 12 hours
-
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs,
-        endTimeMs,
-      });
+    it('should use provided time interval for hourly grouping', async () => {
+      renderComponent({ timeIntervalSeconds: 3600 });
 
       await waitFor(() => {
         const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
-        expect(callBody.time_interval_seconds).toBe(3600); // HOUR_IN_SECONDS
+        expect(callBody.time_interval_seconds).toBe(3600);
       });
     });
 
-    it('should calculate appropriate time interval for 7-day range', async () => {
-      const endTimeMs = Date.now();
-      const startTimeMs = endTimeMs - 7 * 24 * 60 * 60 * 1000; // 7 days
-
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs,
-        endTimeMs,
-      });
+    it('should use provided time interval for daily grouping', async () => {
+      renderComponent({ timeIntervalSeconds: 86400 });
 
       await waitFor(() => {
         const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
-        expect(callBody.time_interval_seconds).toBe(86400); // DAY_IN_SECONDS
+        expect(callBody.time_interval_seconds).toBe(86400);
       });
     });
   });
 
   describe('data transformation', () => {
     it('should handle data points with missing values gracefully', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () =>
-          Promise.resolve({
-            data_points: [
-              {
-                metric_name: TraceMetricKey.TRACE_COUNT,
-                dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
-                values: {}, // Missing COUNT value
-              },
-              {
-                metric_name: TraceMetricKey.TRACE_COUNT,
-                dimensions: { time_bucket: '2025-12-22T11:00:00Z' },
-                values: { [AggregationType.COUNT]: 50 },
-              },
-            ],
-          }),
-      } as Response);
+      mockApiResponse([
+        {
+          metric_name: TraceMetricKey.TRACE_COUNT,
+          dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
+          values: {}, // Missing COUNT value
+        },
+        createTraceCountDataPoint('2025-12-22T11:00:00Z', 50),
+      ]);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       // Should still render and show total of 50 (0 + 50)
       await waitFor(() => {
@@ -336,24 +248,15 @@ describe('TraceRequestsChart', () => {
     });
 
     it('should handle data points with missing time_bucket', async () => {
-      mockFetchOrFail.mockResolvedValue({
-        json: () =>
-          Promise.resolve({
-            data_points: [
-              {
-                metric_name: TraceMetricKey.TRACE_COUNT,
-                dimensions: {}, // Missing time_bucket
-                values: { [AggregationType.COUNT]: 25 },
-              },
-            ],
-          }),
-      } as Response);
+      mockApiResponse([
+        {
+          metric_name: TraceMetricKey.TRACE_COUNT,
+          dimensions: {}, // Missing time_bucket
+          values: { [AggregationType.COUNT]: 25 },
+        },
+      ]);
 
-      renderComponent({
-        experimentId: testExperimentId,
-        startTimeMs: oneHourAgo,
-        endTimeMs: now,
-      });
+      renderComponent();
 
       // Should still render with the count
       await waitFor(() => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo } from 'react';
-import { useDesignSystemTheme, Typography, ChartLineIcon } from '@databricks/design-system';
+import { useDesignSystemTheme, ChartLineIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import { MetricViewType, AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
-import { ChartLoadingState, ChartErrorState, ChartEmptyState } from './ChartCardWrapper';
+import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
 import type { OverviewChartProps } from '../types';
 
 export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
@@ -67,18 +67,12 @@ export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
         backgroundColor: theme.colors.backgroundPrimary,
       }}
     >
-      {/* Chart header */}
-      <div css={{ marginBottom: theme.spacing.lg }}>
-        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
-          <ChartLineIcon css={{ color: theme.colors.textSecondary }} />
-          <Typography.Text bold size="lg">
-            <FormattedMessage defaultMessage="Requests" description="Title for the trace requests chart" />
-          </Typography.Text>
-        </div>
-        <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm, marginBottom: theme.spacing.sm }}>
-          {totalRequests.toLocaleString()}
-        </Typography.Title>
-      </div>
+      <ChartHeader
+        icon={<ChartLineIcon />}
+        title={<FormattedMessage defaultMessage="Requests" description="Title for the trace requests chart" />}
+        value={totalRequests.toLocaleString()}
+      />
+      <OverTimeLabel />
 
       {/* Chart */}
       <div css={{ height: 200 }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
@@ -3,21 +3,18 @@ import { useDesignSystemTheme, Typography, ChartLineIcon } from '@databricks/des
 import { FormattedMessage } from 'react-intl';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import { MetricViewType, AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
-import { useTraceMetricsQuery, calculateTimeInterval } from '../hooks/useTraceMetricsQuery';
+import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
 import { ChartLoadingState, ChartErrorState, ChartEmptyState } from './ChartCardWrapper';
+import type { OverviewChartProps } from '../types';
 
-export interface TraceRequestsChartProps {
-  experimentId: string;
-  startTimeMs?: number;
-  endTimeMs?: number;
-}
-
-export const TraceRequestsChart: React.FC<TraceRequestsChartProps> = ({ experimentId, startTimeMs, endTimeMs }) => {
+export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
+  experimentId,
+  startTimeMs,
+  endTimeMs,
+  timeIntervalSeconds,
+}) => {
   const { theme } = useDesignSystemTheme();
-
-  // Calculate time interval for grouping
-  const timeIntervalSeconds = calculateTimeInterval(startTimeMs, endTimeMs);
 
   // Fetch trace count metrics grouped by time bucket
   const {
@@ -74,7 +71,7 @@ export const TraceRequestsChart: React.FC<TraceRequestsChartProps> = ({ experime
       <div css={{ marginBottom: theme.spacing.lg }}>
         <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
           <ChartLineIcon css={{ color: theme.colors.textSecondary }} />
-          <Typography.Text bold>
+          <Typography.Text bold size="lg">
             <FormattedMessage defaultMessage="Requests" description="Title for the trace requests chart" />
           </Typography.Text>
         </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceMetricsQuery.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceMetricsQuery.ts
@@ -67,6 +67,8 @@ interface UseTraceMetricsQueryParams {
   aggregations: MetricAggregation[];
   /** Optional: Time interval for grouping. If not provided, no time grouping is applied. */
   timeIntervalSeconds?: number;
+  /** Optional: Filter expressions to apply (e.g. `trace.status="ERROR"`) */
+  filters?: string[];
 }
 
 export function useTraceMetricsQuery({
@@ -77,6 +79,7 @@ export function useTraceMetricsQuery({
   metricName,
   aggregations,
   timeIntervalSeconds,
+  filters,
 }: UseTraceMetricsQueryParams) {
   const queryParams: QueryTraceMetricsRequest = {
     experiment_ids: [experimentId],
@@ -86,6 +89,7 @@ export function useTraceMetricsQuery({
     time_interval_seconds: timeIntervalSeconds,
     start_time_ms: startTimeMs,
     end_time_ms: endTimeMs,
+    filters,
   };
 
   return useQuery({
@@ -98,6 +102,7 @@ export function useTraceMetricsQuery({
       metricName,
       JSON.stringify(aggregations),
       timeIntervalSeconds,
+      JSON.stringify(filters),
     ],
     queryFn: async () => {
       const response = await queryTraceMetrics(queryParams);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Common props for overview charts that query trace metrics
+ */
+export interface OverviewChartProps {
+  experimentId: string;
+  startTimeMs?: number;
+  endTimeMs?: number;
+  /** Time interval in seconds for grouping metrics by time bucket */
+  timeIntervalSeconds: number;
+}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -115,6 +115,10 @@
     "defaultMessage": "No traces found. Try clearing your active filters to see more traces.",
     "description": "Text displayed when no traces are found in the trace review page"
   },
+  "+pJvL0": {
+    "defaultMessage": "Over time",
+    "description": "Label above the latency chart"
+  },
   "+w9a+1": {
     "defaultMessage": "Open runs in this group in the new tab",
     "description": "Experiment page > grouped runs table > tooltip for a button that opens runs in a group in a new tab"
@@ -1729,6 +1733,10 @@
   "C6ReUY": {
     "defaultMessage": "Save",
     "description": "Tag assignment modal > Save button"
+  },
+  "C83vFj": {
+    "defaultMessage": "Latency",
+    "description": "Title for the latency chart"
   },
   "C8Jj/L": {
     "defaultMessage": "Name",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -115,10 +115,6 @@
     "defaultMessage": "No traces found. Try clearing your active filters to see more traces.",
     "description": "Text displayed when no traces are found in the trace review page"
   },
-  "+pJvL0": {
-    "defaultMessage": "Over time",
-    "description": "Label above the latency chart"
-  },
   "+w9a+1": {
     "defaultMessage": "Open runs in this group in the new tab",
     "description": "Experiment page > grouped runs table > tooltip for a button that opens runs in a group in a new tab"
@@ -1309,6 +1305,10 @@
   "8wnmuq": {
     "defaultMessage": "2. Trace your code",
     "description": "Section title introducing the tracing quickstart example"
+  },
+  "8xKF+v": {
+    "defaultMessage": "Over time",
+    "description": "Label above time-series charts"
   },
   "8xji5J": {
     "defaultMessage": "X-axis:",
@@ -2957,10 +2957,6 @@
   "Nj6Ez5": {
     "defaultMessage": "Name",
     "description": "Text for name column in schema table in model version page"
-  },
-  "NkyJeV": {
-    "defaultMessage": "Over time",
-    "description": "Label above the errors chart"
   },
   "Nlm9bK": {
     "defaultMessage": "Add tags",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2958,6 +2958,10 @@
     "defaultMessage": "Name",
     "description": "Text for name column in schema table in model version page"
   },
+  "NkyJeV": {
+    "defaultMessage": "Over time",
+    "description": "Label above the errors chart"
+  },
   "Nlm9bK": {
     "defaultMessage": "Add tags",
     "description": "Label for the add tags button on the registered prompt details page"
@@ -6702,6 +6706,10 @@
   "t0Qkuc": {
     "defaultMessage": "Value",
     "description": "Run page > Overview > Metrics table > Value column header"
+  },
+  "t3mHNt": {
+    "defaultMessage": "Errors",
+    "description": "Title for the errors chart"
   },
   "tCC/M3": {
     "defaultMessage": "Create a new key if a different provider is needed.",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/TraceMetrics.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/TraceMetrics.types.ts
@@ -17,6 +17,20 @@ export const TraceMetricKey = {
 export type TraceMetricKeyType = typeof TraceMetricKey[keyof typeof TraceMetricKey];
 
 /**
+ * Common percentile values for latency metrics
+ */
+export const P50 = 50;
+export const P90 = 90;
+export const P99 = 99;
+
+/**
+ * Get the key for accessing percentile values in the API response
+ * @param percentile - The percentile value (e.g., 50, 90, 99)
+ * @returns The key string in format "Pxx.0" (e.g., "P50.0", "P90.0", "P99.0")
+ */
+export const getPercentileKey = (percentile: number): string => `P${percentile.toFixed(1)}`;
+
+/**
  * Time bucket dimension key, included in results when time_interval_seconds is specified.
  * Applies to all view types (traces, spans, assessments).
  */

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/TraceMetrics.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/TraceMetrics.types.ts
@@ -37,6 +37,42 @@ export const getPercentileKey = (percentile: number): string => `P${percentile.t
 export const TIME_BUCKET_DIMENSION_KEY = 'time_bucket';
 
 /**
+ * View type prefix for trace-level filter expressions.
+ * Based on mlflow/tracing/constant.py TraceMetricSearchKey.VIEW_TYPE
+ */
+export const TRACE_FILTER_VIEW_TYPE = 'trace';
+
+/**
+ * Search key fields for trace metrics filter expressions.
+ * Based on mlflow/tracing/constant.py TraceMetricSearchKey
+ */
+export const TraceFilterKey = {
+  /** Status field key */
+  STATUS: 'status',
+  /** Tag field key */
+  TAG: 'tag',
+  /** Metadata field key */
+  METADATA: 'metadata',
+} as const;
+
+/**
+ * Trace status values for filter expressions.
+ */
+export const TraceStatus = {
+  OK: 'OK',
+  ERROR: 'ERROR',
+} as const;
+
+/**
+ * Creates a trace filter expression string.
+ * @param field - The field to filter on (e.g., TraceFilterKey.STATUS)
+ * @param value - The value to match (e.g., TraceStatus.ERROR)
+ * @returns Filter expression string (e.g., 'trace.status = "ERROR"')
+ */
+export const createTraceFilter = (field: string, value: string): string =>
+  `${TRACE_FILTER_VIEW_TYPE}.${field} = "${value}"`;
+
+/**
  * The level at which to aggregate metrics.
  */
 export enum MetricViewType {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/19589?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19589/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19589/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19589/merge
```

</p>
</details>

## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19589/files/1b1e6e5836c4f25fc1f99f7e228124b32325cfb2..ef1b053374ca2c60c0787d9d5e9a173e5d75067a) to review incremental changes.
- [stack/refactor_props](https://github.com/mlflow/mlflow/pull/19585) [[Files changed](https://github.com/mlflow/mlflow/pull/19585/files)]
  - [stack/latency_chart](https://github.com/mlflow/mlflow/pull/19581) [[Files changed](https://github.com/mlflow/mlflow/pull/19581/files/fa8d8447fad2622a1eb2227d4bd66159d3a15d11..2990299612522c887054dc8409908b4d55aa01e7)]
    - [stack/trace_metrics_filters](https://github.com/mlflow/mlflow/pull/19587) [[Files changed](https://github.com/mlflow/mlflow/pull/19587/files/2990299612522c887054dc8409908b4d55aa01e7..b7c446727485cef7872e70fac45579303a6b2d98)]
      - [stack/error_chart](https://github.com/mlflow/mlflow/pull/19588) [[Files changed](https://github.com/mlflow/mlflow/pull/19588/files/b7c446727485cef7872e70fac45579303a6b2d98..1b1e6e5836c4f25fc1f99f7e228124b32325cfb2)]
        - [**stack/chart_common_parts**](https://github.com/mlflow/mlflow/pull/19589) [[Files changed](https://github.com/mlflow/mlflow/pull/19589/files/1b1e6e5836c4f25fc1f99f7e228124b32325cfb2..ef1b053374ca2c60c0787d9d5e9a173e5d75067a)]
          - stack/token_usage_chart

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
As title, the chart header, text and overtime label are similar across different charts. So I move them into the chart card file so we can reuse later without specifying the same formatting over again.
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
