### PR TITLE
Bump TS SDK versions

### DIFF
--- a/libs/typescript/core/package.json
+++ b/libs/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlflow-tracing",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "TypeScript implementation of MLflow Tracing SDK for LLM observability",
   "repository": {
     "type": "git",

--- a/libs/typescript/integrations/anthropic/package.json
+++ b/libs/typescript/integrations/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlflow-anthropic",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Anthropic integration package for MLflow Tracing",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "format:check": "prettier --check ."
   },
   "peerDependencies": {
-    "mlflow-tracing": "^0.1.0-rc.0",
+    "mlflow-tracing": "^0.1.2",
     "@anthropic-ai/sdk": "^0.32.0"
   },
   "devDependencies": {

--- a/libs/typescript/integrations/gemini/package.json
+++ b/libs/typescript/integrations/gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlflow-gemini",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Gemini integration package for MLflow Tracing",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "format:check": "prettier --check ."
   },
   "peerDependencies": {
-    "mlflow-tracing": "^0.1.0-rc.0",
+    "mlflow-tracing": "^0.1.2",
     "@google/genai": "^1.22.0"
   },
   "devDependencies": {

--- a/libs/typescript/integrations/openai/package.json
+++ b/libs/typescript/integrations/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlflow-openai",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenAI integration package for MLflow Tracing",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "format:check": "prettier --check ."
   },
   "peerDependencies": {
-    "mlflow-tracing": "^0.1.1",
+    "mlflow-tracing": "^0.1.2",
     "openai": ">=4.0.0"
   },
   "devDependencies": {

--- a/libs/typescript/scripts/bump-ts-version.ts
+++ b/libs/typescript/scripts/bump-ts-version.ts
@@ -10,7 +10,7 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
 // list of packages that contain `mlflow-tracing` in peerDependencies
-const INTEGRATION_PACKAGES = ['openai', 'anthropic', 'vercel', 'gemini'];
+const INTEGRATION_PACKAGES = ['openai', 'anthropic', 'gemini'];
 
 interface PackageJson {
   name: string;


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/19600?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19600/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19600/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19600/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Bump TS SDK versions prior to the release. `yarn bump-version --version 0.1.2`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
