### PR TITLE
Unify common pattern in charts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ChartCardWrapper.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ChartCardWrapper.tsx
@@ -4,6 +4,61 @@ import { FormattedMessage } from 'react-intl';
 
 const DEFAULT_CHART_HEIGHT = 280;
 
+interface ChartHeaderProps {
+  /** Icon component to display before the title */
+  icon: React.ReactNode;
+  /** Chart title */
+  title: React.ReactNode;
+  /** Main value to display (e.g., "1.2K", "150 ms") */
+  value?: React.ReactNode;
+  /** Optional subtitle shown after the value */
+  subtitle?: React.ReactNode;
+}
+
+/**
+ * Common header component for chart cards with icon, title, and value
+ */
+export const ChartHeader: React.FC<ChartHeaderProps> = ({ icon, title, value, subtitle }) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div css={{ marginBottom: theme.spacing.lg }}>
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+        <span css={{ color: theme.colors.textSecondary, display: 'flex' }}>{icon}</span>
+        <Typography.Text bold size="lg">
+          {title}
+        </Typography.Text>
+      </div>
+      {value !== undefined && (
+        <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm }}>
+          {value}
+          {subtitle && (
+            <>
+              {' '}
+              <Typography.Text color="secondary" css={{ fontWeight: 'normal' }}>
+                {subtitle}
+              </Typography.Text>
+            </>
+          )}
+        </Typography.Title>
+      )}
+    </div>
+  );
+};
+
+/**
+ * "Over time" label shown above time-series charts
+ */
+export const OverTimeLabel: React.FC = () => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <Typography.Text color="secondary" size="sm" css={{ textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+      <FormattedMessage defaultMessage="Over time" description="Label above time-series charts" />
+    </Typography.Text>
+  );
+};
+
 interface ChartCardWrapperProps {
   children: React.ReactNode;
   height?: number;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 const DEFAULT_CHART_HEIGHT = 280;
 
-interface ChartHeaderProps {
+interface OverviewChartHeaderProps {
   /** Icon component to display before the title */
   icon: React.ReactNode;
   /** Chart title */
@@ -16,9 +16,9 @@ interface ChartHeaderProps {
 }
 
 /**
- * Common header component for chart cards with icon, title, and value
+ * Common header component for overview chart cards with icon, title, and value
  */
-export const ChartHeader: React.FC<ChartHeaderProps> = ({ icon, title, value, subtitle }) => {
+export const OverviewChartHeader: React.FC<OverviewChartHeaderProps> = ({ icon, title, value, subtitle }) => {
   const { theme } = useDesignSystemTheme();
 
   return (
@@ -47,9 +47,9 @@ export const ChartHeader: React.FC<ChartHeaderProps> = ({ icon, title, value, su
 };
 
 /**
- * "Over time" label shown above time-series charts
+ * "Over time" label shown above time-series charts in overview
  */
-export const OverTimeLabel: React.FC = () => {
+export const OverviewChartTimeLabel: React.FC = () => {
   const { theme } = useDesignSystemTheme();
 
   return (
@@ -59,15 +59,15 @@ export const OverTimeLabel: React.FC = () => {
   );
 };
 
-interface ChartCardWrapperProps {
+interface OverviewChartCardProps {
   children: React.ReactNode;
   height?: number;
 }
 
 /**
- * Common wrapper for chart cards with consistent styling
+ * Common wrapper for overview chart cards with consistent styling
  */
-export const ChartCardWrapper: React.FC<ChartCardWrapperProps> = ({ children, height = DEFAULT_CHART_HEIGHT }) => {
+export const OverviewChartCard: React.FC<OverviewChartCardProps> = ({ children, height = DEFAULT_CHART_HEIGHT }) => {
   const { theme } = useDesignSystemTheme();
 
   return (
@@ -87,32 +87,32 @@ export const ChartCardWrapper: React.FC<ChartCardWrapperProps> = ({ children, he
   );
 };
 
-interface ChartLoadingStateProps {
+interface OverviewChartLoadingStateProps {
   height?: number;
 }
 
 /**
- * Loading state for chart cards
+ * Loading state for overview chart cards
  */
-export const ChartLoadingState: React.FC<ChartLoadingStateProps> = ({ height }) => {
+export const OverviewChartLoadingState: React.FC<OverviewChartLoadingStateProps> = ({ height }) => {
   return (
-    <ChartCardWrapper height={height}>
+    <OverviewChartCard height={height}>
       <Spinner />
-    </ChartCardWrapper>
+    </OverviewChartCard>
   );
 };
 
-interface ChartErrorStateProps {
+interface OverviewChartErrorStateProps {
   height?: number;
   message?: React.ReactNode;
 }
 
 /**
- * Error state for chart cards
+ * Error state for overview chart cards
  */
-export const ChartErrorState: React.FC<ChartErrorStateProps> = ({ height, message }) => {
+export const OverviewChartErrorState: React.FC<OverviewChartErrorStateProps> = ({ height, message }) => {
   return (
-    <ChartCardWrapper height={height}>
+    <OverviewChartCard height={height}>
       <Typography.Text color="error">
         {message || (
           <FormattedMessage
@@ -121,19 +121,19 @@ export const ChartErrorState: React.FC<ChartErrorStateProps> = ({ height, messag
           />
         )}
       </Typography.Text>
-    </ChartCardWrapper>
+    </OverviewChartCard>
   );
 };
 
-interface ChartEmptyStateProps {
+interface OverviewChartEmptyStateProps {
   height?: number;
   message?: React.ReactNode;
 }
 
 /**
- * Empty state for chart cards when no data is available
+ * Empty state for overview chart cards when no data is available
  */
-export const ChartEmptyState: React.FC<ChartEmptyStateProps> = ({ height, message }) => {
+export const OverviewChartEmptyState: React.FC<OverviewChartEmptyStateProps> = ({ height, message }) => {
   return (
     <div
       css={{

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
@@ -13,7 +13,13 @@ import {
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
-import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
+import {
+  OverviewChartLoadingState,
+  OverviewChartErrorState,
+  OverviewChartEmptyState,
+  OverviewChartHeader,
+  OverviewChartTimeLabel,
+} from './OverviewChartComponents';
 import type { OverviewChartProps } from '../types';
 
 // Filter to get only error traces
@@ -130,11 +136,11 @@ export const TraceErrorsChart: React.FC<OverviewChartProps> = ({
   };
 
   if (isLoading) {
-    return <ChartLoadingState />;
+    return <OverviewChartLoadingState />;
   }
 
   if (error) {
-    return <ChartErrorState />;
+    return <OverviewChartErrorState />;
   }
 
   return (
@@ -146,14 +152,14 @@ export const TraceErrorsChart: React.FC<OverviewChartProps> = ({
         backgroundColor: theme.colors.backgroundPrimary,
       }}
     >
-      <ChartHeader
+      <OverviewChartHeader
         icon={<DangerIcon />}
         title={<FormattedMessage defaultMessage="Errors" description="Title for the errors chart" />}
         value={totalErrors.toLocaleString()}
         subtitle={`(Overall error rate: ${overallErrorRate.toFixed(1)}%)`}
       />
 
-      <OverTimeLabel />
+      <OverviewChartTimeLabel />
 
       {/* Chart */}
       <div css={{ height: 200, marginTop: theme.spacing.sm }}>
@@ -238,7 +244,7 @@ export const TraceErrorsChart: React.FC<OverviewChartProps> = ({
             </ComposedChart>
           </ResponsiveContainer>
         ) : (
-          <ChartEmptyState />
+          <OverviewChartEmptyState />
         )}
       </div>
     </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useDesignSystemTheme, Typography, DangerIcon } from '@databricks/design-system';
+import { useDesignSystemTheme, DangerIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { ComposedChart, Bar, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, ReferenceLine } from 'recharts';
 import {
@@ -13,7 +13,7 @@ import {
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
-import { ChartLoadingState, ChartErrorState, ChartEmptyState } from './ChartCardWrapper';
+import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
 import type { OverviewChartProps } from '../types';
 
 // Filter to get only error traces
@@ -146,26 +146,14 @@ export const TraceErrorsChart: React.FC<OverviewChartProps> = ({
         backgroundColor: theme.colors.backgroundPrimary,
       }}
     >
-      {/* Chart header */}
-      <div css={{ marginBottom: theme.spacing.lg }}>
-        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
-          <DangerIcon css={{ color: theme.colors.textSecondary }} />
-          <Typography.Text bold size="lg">
-            <FormattedMessage defaultMessage="Errors" description="Title for the errors chart" />
-          </Typography.Text>
-        </div>
-        <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm }}>
-          {totalErrors.toLocaleString()}{' '}
-          <Typography.Text color="secondary" css={{ fontWeight: 'normal' }}>
-            (Overall error rate: {overallErrorRate.toFixed(1)}%)
-          </Typography.Text>
-        </Typography.Title>
-      </div>
+      <ChartHeader
+        icon={<DangerIcon />}
+        title={<FormattedMessage defaultMessage="Errors" description="Title for the errors chart" />}
+        value={totalErrors.toLocaleString()}
+        subtitle={`(Overall error rate: ${overallErrorRate.toFixed(1)}%)`}
+      />
 
-      {/* "Over time" label */}
-      <Typography.Text color="secondary" size="sm" css={{ textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-        <FormattedMessage defaultMessage="Over time" description="Label above the errors chart" />
-      </Typography.Text>
+      <OverTimeLabel />
 
       {/* Chart */}
       <div css={{ height: 200, marginTop: theme.spacing.sm }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
@@ -12,7 +12,13 @@ import {
   getPercentileKey,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
-import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
+import {
+  OverviewChartLoadingState,
+  OverviewChartErrorState,
+  OverviewChartEmptyState,
+  OverviewChartHeader,
+  OverviewChartTimeLabel,
+} from './OverviewChartComponents';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
 import type { OverviewChartProps } from '../types';
 
@@ -113,11 +119,11 @@ export const TraceLatencyChart: React.FC<OverviewChartProps> = ({
   };
 
   if (isLoading) {
-    return <ChartLoadingState />;
+    return <OverviewChartLoadingState />;
   }
 
   if (error) {
-    return <ChartErrorState />;
+    return <OverviewChartErrorState />;
   }
 
   return (
@@ -129,13 +135,13 @@ export const TraceLatencyChart: React.FC<OverviewChartProps> = ({
         backgroundColor: theme.colors.backgroundPrimary,
       }}
     >
-      <ChartHeader
+      <OverviewChartHeader
         icon={<ClockIcon />}
         title={<FormattedMessage defaultMessage="Latency" description="Title for the latency chart" />}
         value={avgLatency !== undefined ? formatLatency(avgLatency) : undefined}
       />
 
-      <OverTimeLabel />
+      <OverviewChartTimeLabel />
 
       {/* Chart */}
       <div css={{ height: 200, marginTop: theme.spacing.sm }}>
@@ -221,7 +227,7 @@ export const TraceLatencyChart: React.FC<OverviewChartProps> = ({
             </LineChart>
           </ResponsiveContainer>
         ) : (
-          <ChartEmptyState />
+          <OverviewChartEmptyState />
         )}
       </div>
     </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useDesignSystemTheme, Typography, ClockIcon } from '@databricks/design-system';
+import { useDesignSystemTheme, ClockIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, ReferenceLine } from 'recharts';
 import {
@@ -12,7 +12,7 @@ import {
   getPercentileKey,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
-import { ChartLoadingState, ChartErrorState, ChartEmptyState } from './ChartCardWrapper';
+import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
 import type { OverviewChartProps } from '../types';
 
@@ -129,25 +129,13 @@ export const TraceLatencyChart: React.FC<OverviewChartProps> = ({
         backgroundColor: theme.colors.backgroundPrimary,
       }}
     >
-      {/* Chart header */}
-      <div css={{ marginBottom: theme.spacing.lg }}>
-        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
-          <ClockIcon css={{ color: theme.colors.textSecondary }} />
-          <Typography.Text bold size="lg">
-            <FormattedMessage defaultMessage="Latency" description="Title for the latency chart" />
-          </Typography.Text>
-        </div>
-        {avgLatency !== undefined && (
-          <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm }}>
-            {formatLatency(avgLatency)}
-          </Typography.Title>
-        )}
-      </div>
+      <ChartHeader
+        icon={<ClockIcon />}
+        title={<FormattedMessage defaultMessage="Latency" description="Title for the latency chart" />}
+        value={avgLatency !== undefined ? formatLatency(avgLatency) : undefined}
+      />
 
-      {/* "Over time" label */}
-      <Typography.Text color="secondary" size="sm" css={{ textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-        <FormattedMessage defaultMessage="Over time" description="Label above the latency chart" />
-      </Typography.Text>
+      <OverTimeLabel />
 
       {/* Chart */}
       <div css={{ height: 200, marginTop: theme.spacing.sm }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
@@ -5,7 +5,13 @@ import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recha
 import { MetricViewType, AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
-import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
+import {
+  OverviewChartLoadingState,
+  OverviewChartErrorState,
+  OverviewChartEmptyState,
+  OverviewChartHeader,
+  OverviewChartTimeLabel,
+} from './OverviewChartComponents';
 import type { OverviewChartProps } from '../types';
 
 export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
@@ -51,11 +57,11 @@ export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
   }, [traceCountDataPoints, timeIntervalSeconds]);
 
   if (isLoading) {
-    return <ChartLoadingState />;
+    return <OverviewChartLoadingState />;
   }
 
   if (error) {
-    return <ChartErrorState />;
+    return <OverviewChartErrorState />;
   }
 
   return (
@@ -67,12 +73,12 @@ export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
         backgroundColor: theme.colors.backgroundPrimary,
       }}
     >
-      <ChartHeader
+      <OverviewChartHeader
         icon={<ChartLineIcon />}
         title={<FormattedMessage defaultMessage="Requests" description="Title for the trace requests chart" />}
         value={totalRequests.toLocaleString()}
       />
-      <OverTimeLabel />
+      <OverviewChartTimeLabel />
 
       {/* Chart */}
       <div css={{ height: 200 }}>
@@ -100,7 +106,7 @@ export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
             </BarChart>
           </ResponsiveContainer>
         ) : (
-          <ChartEmptyState />
+          <OverviewChartEmptyState />
         )}
       </div>
     </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo } from 'react';
-import { useDesignSystemTheme, Typography, ChartLineIcon } from '@databricks/design-system';
+import { useDesignSystemTheme, ChartLineIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import { MetricViewType, AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
 import { formatTimestampForTraceMetrics, getTimestampFromDataPoint } from '../utils/chartUtils';
-import { ChartLoadingState, ChartErrorState, ChartEmptyState } from './ChartCardWrapper';
+import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
 import type { OverviewChartProps } from '../types';
 
 export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
@@ -67,18 +67,12 @@ export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
         backgroundColor: theme.colors.backgroundPrimary,
       }}
     >
-      {/* Chart header */}
-      <div css={{ marginBottom: theme.spacing.lg }}>
-        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
-          <ChartLineIcon css={{ color: theme.colors.textSecondary }} />
-          <Typography.Text bold size="lg">
-            <FormattedMessage defaultMessage="Requests" description="Title for the trace requests chart" />
-          </Typography.Text>
-        </div>
-        <Typography.Title level={3} css={{ margin: 0, marginTop: theme.spacing.sm, marginBottom: theme.spacing.sm }}>
-          {totalRequests.toLocaleString()}
-        </Typography.Title>
-      </div>
+      <ChartHeader
+        icon={<ChartLineIcon />}
+        title={<FormattedMessage defaultMessage="Requests" description="Title for the trace requests chart" />}
+        value={totalRequests.toLocaleString()}
+      />
+      <OverTimeLabel />
 
       {/* Chart */}
       <div css={{ height: 200 }}>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -123,10 +123,6 @@
     "defaultMessage": "No traces found. Try clearing your active filters to see more traces.",
     "description": "Text displayed when no traces are found in the trace review page"
   },
-  "+pJvL0": {
-    "defaultMessage": "Over time",
-    "description": "Label above the latency chart"
-  },
   "+w9a+1": {
     "defaultMessage": "Open runs in this group in the new tab",
     "description": "Experiment page > grouped runs table > tooltip for a button that opens runs in a group in a new tab"
@@ -1389,6 +1385,10 @@
   "8wnmuq": {
     "defaultMessage": "2. Trace your code",
     "description": "Section title introducing the tracing quickstart example"
+  },
+  "8xKF+v": {
+    "defaultMessage": "Over time",
+    "description": "Label above time-series charts"
   },
   "8xji5J": {
     "defaultMessage": "X-axis:",
@@ -3097,10 +3097,6 @@
   "Nj6Ez5": {
     "defaultMessage": "Name",
     "description": "Text for name column in schema table in model version page"
-  },
-  "NkyJeV": {
-    "defaultMessage": "Over time",
-    "description": "Label above the errors chart"
   },
   "Nlm9bK": {
     "defaultMessage": "Add tags",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19601/files) to review incremental changes.
- [**stack/chart_common_parts**](https://github.com/mlflow/mlflow/pull/19601) [[Files changed](https://github.com/mlflow/mlflow/pull/19601/files)]
  - [stack/charts_time_buckets_fix](https://github.com/mlflow/mlflow/pull/19602) [[Files changed](https://github.com/mlflow/mlflow/pull/19602/files/a3408c58c6eb6cb30931c9e49dee4023ee3dbfd9..04dae3b722c9759ced88f95c26896e586fa00da1)]
    - [stack/latency_time_fix](https://github.com/mlflow/mlflow/pull/19603) [[Files changed](https://github.com/mlflow/mlflow/pull/19603/files/04dae3b722c9759ced88f95c26896e586fa00da1..d00bf3d0cd39aeffaa1b294517cbc389831610ff)]
      - [stack/error_chart_time_fix](https://github.com/mlflow/mlflow/pull/19604) [[Files changed](https://github.com/mlflow/mlflow/pull/19604/files/d00bf3d0cd39aeffaa1b294517cbc389831610ff..f2f0a6d9b3db543c7efc7409e96ff15805ef618a)]
        - [stack/token_usage_chart](https://github.com/mlflow/mlflow/pull/19606) [[Files changed](https://github.com/mlflow/mlflow/pull/19606/files/f2f0a6d9b3db543c7efc7409e96ff15805ef618a..338df7dfe9b8e0e25f786781389a21ae083cd99a)]
          - [stack/empty_data_fix](https://github.com/mlflow/mlflow/pull/19607) [[Files changed](https://github.com/mlflow/mlflow/pull/19607/files/338df7dfe9b8e0e25f786781389a21ae083cd99a..18d37765e1b492ba3f6916ad5aaa30fbe79fba39)]
            - [stack/simplify_charts_components](https://github.com/mlflow/mlflow/pull/19608) [[Files changed](https://github.com/mlflow/mlflow/pull/19608/files/18d37765e1b492ba3f6916ad5aaa30fbe79fba39..8fb07e645da3454e624514d3dd9973b769a1341d)]
              - [stack/token_statistics_chart](https://github.com/mlflow/mlflow/pull/19609) [[Files changed](https://github.com/mlflow/mlflow/pull/19609/files/8fb07e645da3454e624514d3dd9973b769a1341d..9b70f1681ab25c84bfb3daea7ddaa56bf2c73546)]
                - [stack/quality_tab](https://github.com/mlflow/mlflow/pull/19619) [[Files changed](https://github.com/mlflow/mlflow/pull/19619/files/9b70f1681ab25c84bfb3daea7ddaa56bf2c73546..76ca58d8a1103d8ae7407eedbaabaa8c344ba971)]
                  - [stack/query_assessment_metrics](https://github.com/mlflow/mlflow/pull/19620) [[Files changed](https://github.com/mlflow/mlflow/pull/19620/files/76ca58d8a1103d8ae7407eedbaabaa8c344ba971..d0396b9822cf0db50142934fc1cbaae451da19de)]
                    - [stack/assessment_chart](https://github.com/mlflow/mlflow/pull/19621) [[Files changed](https://github.com/mlflow/mlflow/pull/19621/files/d0396b9822cf0db50142934fc1cbaae451da19de..825a6f5d4d233c67e6b1d24b9bf4dda1f4c8e481)]
                      - [stack/render_scorer_charts](https://github.com/mlflow/mlflow/pull/19622) [[Files changed](https://github.com/mlflow/mlflow/pull/19622/files/825a6f5d4d233c67e6b1d24b9bf4dda1f4c8e481..527ee716111239a64b4a15cc9c0423453638d793)]
                        - [stack/scorer_counts](https://github.com/mlflow/mlflow/pull/19624) [[Files changed](https://github.com/mlflow/mlflow/pull/19624/files/527ee716111239a64b4a15cc9c0423453638d793..e31dee8ac1999d2887fd391f968d3b79c79f079c)]
                          - [stack/tools_tab](https://github.com/mlflow/mlflow/pull/19632) [[Files changed](https://github.com/mlflow/mlflow/pull/19632/files/e31dee8ac1999d2887fd391f968d3b79c79f079c..86ab78eea73b6457a7c62b4fb3290581aecf298d)]
                            - [stack/query_span_metrics](https://github.com/mlflow/mlflow/pull/19633) [[Files changed](https://github.com/mlflow/mlflow/pull/19633/files/86ab78eea73b6457a7c62b4fb3290581aecf298d..ca66134719ba82764639cf7b92ff2643305b15d2)]
                              - [stack/tool_calls_statistics](https://github.com/mlflow/mlflow/pull/19634) [[Files changed](https://github.com/mlflow/mlflow/pull/19634/files/ca66134719ba82764639cf7b92ff2643305b15d2..04584143aaecdc98a860df4a4f9e178c6222f254)]
                                - [stack/tool_error_rate_charts](https://github.com/mlflow/mlflow/pull/19635) [[Files changed](https://github.com/mlflow/mlflow/pull/19635/files/04584143aaecdc98a860df4a4f9e178c6222f254..9101fcd786d7369b131d90798d53cbd75df4938b)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
As title, the chart header, text and overtime label are similar across different charts. So I move them into the chart card file so we can reuse later without specifying the same formatting over again.
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
