### PR TITLE
Include all timestamp in requests chart

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
@@ -31,14 +31,15 @@ const createTraceCountDataPoint = (timeBucket: string, count: number) => ({
 
 describe('TraceRequestsChart', () => {
   const testExperimentId = 'test-experiment-123';
-  const now = Date.now();
-  const oneHourAgo = now - 60 * 60 * 1000;
+  // Use fixed timestamps for predictable bucket generation
+  const startTimeMs = new Date('2025-12-22T10:00:00Z').getTime();
+  const endTimeMs = new Date('2025-12-22T12:00:00Z').getTime(); // 2 hours = 3 buckets with 1hr interval
 
   // Default props reused across tests
   const defaultProps = {
     experimentId: testExperimentId,
-    startTimeMs: oneHourAgo,
-    endTimeMs: now,
+    startTimeMs,
+    endTimeMs,
     timeIntervalSeconds: 3600, // 1 hour
   };
 
@@ -92,20 +93,24 @@ describe('TraceRequestsChart', () => {
   });
 
   describe('empty data state', () => {
-    it('should render empty state message when no data points are returned', async () => {
+    it('should render chart with zeros when no data points are returned', async () => {
       mockApiResponse([]);
 
       renderComponent();
 
+      // Chart should still render with all time buckets (filled with zeros)
       await waitFor(() => {
-        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
+        expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
       });
+
+      // Total should be 0
+      expect(screen.getByText('0')).toBeInTheDocument();
     });
 
-    it('should render empty state when data_points is undefined', async () => {
-      mockApiResponse(undefined);
+    it('should render empty state when time range is not provided', async () => {
+      mockApiResponse([]);
 
-      renderComponent();
+      renderComponent({ startTimeMs: undefined, endTimeMs: undefined });
 
       await waitFor(() => {
         expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
@@ -120,7 +125,7 @@ describe('TraceRequestsChart', () => {
       createTraceCountDataPoint('2025-12-22T12:00:00Z', 100),
     ];
 
-    it('should render chart with data points', async () => {
+    it('should render chart with all time buckets', async () => {
       mockApiResponse(mockDataPoints);
 
       renderComponent();
@@ -129,7 +134,7 @@ describe('TraceRequestsChart', () => {
         expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
       });
 
-      // Verify the bar chart has the correct number of data points
+      // Verify the bar chart has all 3 time buckets
       expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
     });
 
@@ -163,6 +168,21 @@ describe('TraceRequestsChart', () => {
         // Check for locale-formatted number (1,234,567 in US locale)
         expect(screen.getByText('1,234,567')).toBeInTheDocument();
       });
+    });
+
+    it('should fill missing time buckets with zeros', async () => {
+      // Only provide data for one time bucket
+      mockApiResponse([createTraceCountDataPoint('2025-12-22T10:00:00Z', 100)]);
+
+      renderComponent();
+
+      // Chart should still show all 3 time buckets
+      await waitFor(() => {
+        expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
+      });
+
+      // Total should only count the one data point
+      expect(screen.getByText('100')).toBeInTheDocument();
     });
   });
 
@@ -218,34 +238,37 @@ describe('TraceRequestsChart', () => {
         {
           metric_name: TraceMetricKey.TRACE_COUNT,
           dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
-          values: {}, // Missing COUNT value
+          values: {}, // Missing COUNT value - will be treated as 0
         },
         createTraceCountDataPoint('2025-12-22T11:00:00Z', 50),
       ]);
 
       renderComponent();
 
-      // Should still render and show total of 50 (0 + 50)
+      // Should still render with all time buckets and show total of 50 (0 + 50)
       await waitFor(() => {
-        expect(screen.getByText('50')).toBeInTheDocument();
+        expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
       });
+      expect(screen.getByText('50')).toBeInTheDocument();
     });
 
     it('should handle data points with missing time_bucket', async () => {
       mockApiResponse([
         {
           metric_name: TraceMetricKey.TRACE_COUNT,
-          dimensions: {}, // Missing time_bucket
+          dimensions: {}, // Missing time_bucket - won't be mapped to any bucket
           values: { [AggregationType.COUNT]: 25 },
         },
       ]);
 
       renderComponent();
 
-      // Should still render with the count
+      // Should still render with all time buckets (all with 0 values in chart, but total still counts)
       await waitFor(() => {
-        expect(screen.getByText('25')).toBeInTheDocument();
+        expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
       });
+      // Total count still includes the data point
+      expect(screen.getByText('25')).toBeInTheDocument();
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/chartUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/chartUtils.ts
@@ -39,3 +39,32 @@ export function getTimestampFromDataPoint(dp: MetricDataPoint): number {
   }
   return 0;
 }
+
+/**
+ * Generate all time bucket timestamps within a range
+ * @param startTimeMs - Start of time range in milliseconds
+ * @param endTimeMs - End of time range in milliseconds
+ * @param timeIntervalSeconds - Time interval in seconds for each bucket
+ * @returns Array of timestamps (in ms) for each bucket, aligned to interval boundaries
+ */
+export function generateTimeBuckets(
+  startTimeMs: number | undefined,
+  endTimeMs: number | undefined,
+  timeIntervalSeconds: number,
+): number[] {
+  if (!startTimeMs || !endTimeMs || timeIntervalSeconds <= 0) {
+    return [];
+  }
+
+  const intervalMs = timeIntervalSeconds * 1000;
+  const buckets: number[] = [];
+
+  // Align start time to the interval boundary (floor)
+  const alignedStart = Math.floor(startTimeMs / intervalMs) * intervalMs;
+
+  for (let ts = alignedStart; ts <= endTimeMs; ts += intervalMs) {
+    buckets.push(ts);
+  }
+
+  return buckets;
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19602/files) to review incremental changes.
- [**stack/charts_time_buckets_fix**](https://github.com/mlflow/mlflow/pull/19602) [[Files changed](https://github.com/mlflow/mlflow/pull/19602/files)]
  - [stack/latency_time_fix](https://github.com/mlflow/mlflow/pull/19603) [[Files changed](https://github.com/mlflow/mlflow/pull/19603/files/435920e458e7829847b3181d137a39a5146d42db..29c9fb86b7a862f2ec26381376832d18c797a532)]
    - [stack/error_chart_time_fix](https://github.com/mlflow/mlflow/pull/19604) [[Files changed](https://github.com/mlflow/mlflow/pull/19604/files/29c9fb86b7a862f2ec26381376832d18c797a532..73ba41d9e7bbc053451f6903daa74da71a6d7040)]
      - [stack/token_usage_chart](https://github.com/mlflow/mlflow/pull/19606) [[Files changed](https://github.com/mlflow/mlflow/pull/19606/files/73ba41d9e7bbc053451f6903daa74da71a6d7040..b4cd1d5373cfce4cd68da2b0d20610286b73e418)]
        - [stack/empty_data_fix](https://github.com/mlflow/mlflow/pull/19607) [[Files changed](https://github.com/mlflow/mlflow/pull/19607/files/b4cd1d5373cfce4cd68da2b0d20610286b73e418..0e90d42e3b9799a6892a4bf8f59def93159ab7d2)]
          - [stack/simplify_charts_components](https://github.com/mlflow/mlflow/pull/19608) [[Files changed](https://github.com/mlflow/mlflow/pull/19608/files/0e90d42e3b9799a6892a4bf8f59def93159ab7d2..96a8eea35f1d1e9b4c785dd2740ef658c2d00ff0)]
            - [stack/token_statistics_chart](https://github.com/mlflow/mlflow/pull/19609) [[Files changed](https://github.com/mlflow/mlflow/pull/19609/files/96a8eea35f1d1e9b4c785dd2740ef658c2d00ff0..bf175bae4cb492a4fc28f2cc30d7bd73e0367630)]
              - [stack/quality_tab](https://github.com/mlflow/mlflow/pull/19619) [[Files changed](https://github.com/mlflow/mlflow/pull/19619/files/bf175bae4cb492a4fc28f2cc30d7bd73e0367630..951ac26023e8c214eeb50fa84b3737e373228533)]
                - [stack/query_assessment_metrics](https://github.com/mlflow/mlflow/pull/19620) [[Files changed](https://github.com/mlflow/mlflow/pull/19620/files/951ac26023e8c214eeb50fa84b3737e373228533..89cff4e95558f38e49b28748ffd1917dc9993538)]
                  - [stack/assessment_chart](https://github.com/mlflow/mlflow/pull/19621) [[Files changed](https://github.com/mlflow/mlflow/pull/19621/files/89cff4e95558f38e49b28748ffd1917dc9993538..5be948ad22ca82075b165897dc7e7b530b1684c4)]
                    - [stack/render_scorer_charts](https://github.com/mlflow/mlflow/pull/19622) [[Files changed](https://github.com/mlflow/mlflow/pull/19622/files/5be948ad22ca82075b165897dc7e7b530b1684c4..fefc3f11457af3d7cba321855cfff132768d7221)]
                      - [stack/scorer_counts](https://github.com/mlflow/mlflow/pull/19624) [[Files changed](https://github.com/mlflow/mlflow/pull/19624/files/fefc3f11457af3d7cba321855cfff132768d7221..7aab15354504d02755258c47dd6ea7466e9b6615)]
                        - [stack/tools_tab](https://github.com/mlflow/mlflow/pull/19632) [[Files changed](https://github.com/mlflow/mlflow/pull/19632/files/7aab15354504d02755258c47dd6ea7466e9b6615..0fe4be8ecf36ba70100757949fb9c31596456c36)]
                          - [stack/query_span_metrics](https://github.com/mlflow/mlflow/pull/19633) [[Files changed](https://github.com/mlflow/mlflow/pull/19633/files/0fe4be8ecf36ba70100757949fb9c31596456c36..29afe2d199f3fc4c4a40f2771729047a720a0de2)]
                            - [stack/tool_calls_statistics](https://github.com/mlflow/mlflow/pull/19634) [[Files changed](https://github.com/mlflow/mlflow/pull/19634/files/29afe2d199f3fc4c4a40f2771729047a720a0de2..d72dd4590544595916ee918ce213759a932846f0)]
                              - [stack/tool_error_rate_charts](https://github.com/mlflow/mlflow/pull/19635) [[Files changed](https://github.com/mlflow/mlflow/pull/19635/files/d72dd4590544595916ee918ce213759a932846f0..94f3d70ea253ff6bbfd5aafe7965b0b21a5d6a6b)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Before:
<img width="1180" height="367" alt="Screenshot 2025-12-24 at 10 45 24 AM" src="https://github.com/user-attachments/assets/aa233107-e89f-4c38-b987-497187929aca" />

After:
<img width="1180" height="367" alt="Screenshot 2025-12-24 at 10 45 38 AM" src="https://github.com/user-attachments/assets/01354f0a-4055-448a-980d-972b02c24250" />

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
