### PR TITLE
Add token usage chart

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.test.tsx
@@ -211,17 +211,39 @@ describe('ExperimentGenAIOverviewPage', () => {
   });
 
   describe('chart integration', () => {
-    it('should render chart components and pass experimentId', async () => {
+    it('should render all chart components', async () => {
       renderComponent();
 
-      // Verify charts are rendered
+      // Verify all charts are rendered
       await waitFor(() => {
         expect(screen.getByText('Requests')).toBeInTheDocument();
+        expect(screen.getByText('Latency')).toBeInTheDocument();
+        expect(screen.getByText('Errors')).toBeInTheDocument();
+      });
+    });
+
+    it('should pass experimentId to chart API calls', async () => {
+      renderComponent();
+
+      await waitFor(() => {
+        expect(mockFetchOrFail).toHaveBeenCalled();
       });
 
       // Verify experimentId is passed to chart API calls
       const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
       expect(callBody.experiment_ids).toEqual([testExperimentId]);
+    });
+
+    it('should render charts in correct layout', async () => {
+      renderComponent();
+
+      await waitFor(() => {
+        // Requests chart should be present (full width)
+        expect(screen.getByText('Requests')).toBeInTheDocument();
+        // Latency and Errors charts should be present (side by side)
+        expect(screen.getByText('Latency')).toBeInTheDocument();
+        expect(screen.getByText('Errors')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -10,6 +10,7 @@ import { MonitoringConfigProvider, useMonitoringConfig } from '../../hooks/useMo
 import { LazyTraceRequestsChart } from './components/LazyTraceRequestsChart';
 import { LazyTraceLatencyChart } from './components/LazyTraceLatencyChart';
 import { LazyTraceErrorsChart } from './components/LazyTraceErrorsChart';
+import { LazyTraceTokenUsageChart } from './components/LazyTraceTokenUsageChart';
 import { calculateTimeInterval } from './hooks/useTraceMetricsQuery';
 
 enum OverviewTab {
@@ -118,6 +119,9 @@ const ExperimentGenAIOverviewPageImpl = () => {
               <LazyTraceLatencyChart {...chartProps} />
               <LazyTraceErrorsChart {...chartProps} />
             </div>
+
+            {/* Token Usage chart - full width */}
+            <LazyTraceTokenUsageChart {...chartProps} />
           </div>
         </Tabs.Content>
       </Tabs.Root>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceTokenUsageChart.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { LegacySkeleton } from '@databricks/design-system';
+import type { OverviewChartProps } from '../types';
+
+const TraceTokenUsageChart = React.lazy(() =>
+  import('./TraceTokenUsageChart').then((module) => ({ default: module.TraceTokenUsageChart })),
+);
+
+export const LazyTraceTokenUsageChart: React.FC<OverviewChartProps> = (props) => (
+  <React.Suspense fallback={<LegacySkeleton active />}>
+    <TraceTokenUsageChart {...props} />
+  </React.Suspense>
+);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
@@ -31,14 +31,15 @@ const createTraceCountDataPoint = (timeBucket: string, count: number) => ({
 
 describe('TraceRequestsChart', () => {
   const testExperimentId = 'test-experiment-123';
-  const now = Date.now();
-  const oneHourAgo = now - 60 * 60 * 1000;
+  // Use fixed timestamps for predictable bucket generation
+  const startTimeMs = new Date('2025-12-22T10:00:00Z').getTime();
+  const endTimeMs = new Date('2025-12-22T12:00:00Z').getTime(); // 2 hours = 3 buckets with 1hr interval
 
   // Default props reused across tests
   const defaultProps = {
     experimentId: testExperimentId,
-    startTimeMs: oneHourAgo,
-    endTimeMs: now,
+    startTimeMs,
+    endTimeMs,
     timeIntervalSeconds: 3600, // 1 hour
   };
 
@@ -92,20 +93,24 @@ describe('TraceRequestsChart', () => {
   });
 
   describe('empty data state', () => {
-    it('should render empty state message when no data points are returned', async () => {
+    it('should render chart with zeros when no data points are returned', async () => {
       mockApiResponse([]);
 
       renderComponent();
 
+      // Chart should still render with all time buckets (filled with zeros)
       await waitFor(() => {
-        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
+        expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
       });
+
+      // Total should be 0
+      expect(screen.getByText('0')).toBeInTheDocument();
     });
 
-    it('should render empty state when data_points is undefined', async () => {
-      mockApiResponse(undefined);
+    it('should render empty state when time range is not provided', async () => {
+      mockApiResponse([]);
 
-      renderComponent();
+      renderComponent({ startTimeMs: undefined, endTimeMs: undefined });
 
       await waitFor(() => {
         expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
@@ -120,7 +125,7 @@ describe('TraceRequestsChart', () => {
       createTraceCountDataPoint('2025-12-22T12:00:00Z', 100),
     ];
 
-    it('should render chart with data points', async () => {
+    it('should render chart with all time buckets', async () => {
       mockApiResponse(mockDataPoints);
 
       renderComponent();
@@ -129,7 +134,7 @@ describe('TraceRequestsChart', () => {
         expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
       });
 
-      // Verify the bar chart has the correct number of data points
+      // Verify the bar chart has all 3 time buckets
       expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
     });
 
@@ -163,6 +168,21 @@ describe('TraceRequestsChart', () => {
         // Check for locale-formatted number (1,234,567 in US locale)
         expect(screen.getByText('1,234,567')).toBeInTheDocument();
       });
+    });
+
+    it('should fill missing time buckets with zeros', async () => {
+      // Only provide data for one time bucket
+      mockApiResponse([createTraceCountDataPoint('2025-12-22T10:00:00Z', 100)]);
+
+      renderComponent();
+
+      // Chart should still show all 3 time buckets
+      await waitFor(() => {
+        expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
+      });
+
+      // Total should only count the one data point
+      expect(screen.getByText('100')).toBeInTheDocument();
     });
   });
 
@@ -218,34 +238,37 @@ describe('TraceRequestsChart', () => {
         {
           metric_name: TraceMetricKey.TRACE_COUNT,
           dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
-          values: {}, // Missing COUNT value
+          values: {}, // Missing COUNT value - will be treated as 0
         },
         createTraceCountDataPoint('2025-12-22T11:00:00Z', 50),
       ]);
 
       renderComponent();
 
-      // Should still render and show total of 50 (0 + 50)
+      // Should still render with all time buckets and show total of 50 (0 + 50)
       await waitFor(() => {
-        expect(screen.getByText('50')).toBeInTheDocument();
+        expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
       });
+      expect(screen.getByText('50')).toBeInTheDocument();
     });
 
     it('should handle data points with missing time_bucket', async () => {
       mockApiResponse([
         {
           metric_name: TraceMetricKey.TRACE_COUNT,
-          dimensions: {}, // Missing time_bucket
+          dimensions: {}, // Missing time_bucket - won't be mapped to any bucket
           values: { [AggregationType.COUNT]: 25 },
         },
       ]);
 
       renderComponent();
 
-      // Should still render with the count
+      // Should still render with all time buckets (all with 0 values in chart, but total still counts)
       await waitFor(() => {
-        expect(screen.getByText('25')).toBeInTheDocument();
+        expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
       });
+      // Total count still includes the data point
+      expect(screen.getByText('25')).toBeInTheDocument();
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
@@ -1,0 +1,456 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithIntl } from '../../../../common/utils/TestUtils.react18';
+import { TraceTokenUsageChart } from './TraceTokenUsageChart';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { MetricViewType, AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
+
+// Mock FetchUtils
+jest.mock('../../../../common/utils/FetchUtils', () => ({
+  fetchOrFail: jest.fn(),
+  getAjaxUrl: (url: string) => url,
+}));
+
+import { fetchOrFail } from '../../../../common/utils/FetchUtils';
+const mockFetchOrFail = fetchOrFail as jest.MockedFunction<typeof fetchOrFail>;
+
+// Helper to create mock API response
+const mockApiResponse = (dataPoints: any[] | undefined) => {
+  mockFetchOrFail.mockResolvedValue({
+    json: () => Promise.resolve({ data_points: dataPoints }),
+  } as Response);
+};
+
+// Helper to chain mock API responses (for input tokens, output tokens, total tokens)
+const mockApiResponses = (inputDataPoints: any[], outputDataPoints: any[], totalDataPoints: any[]) => {
+  mockFetchOrFail
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ data_points: inputDataPoints }),
+    } as Response)
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ data_points: outputDataPoints }),
+    } as Response)
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve({ data_points: totalDataPoints }),
+    } as Response);
+};
+
+// Helper to create an input tokens data point
+const createInputTokensDataPoint = (timeBucket: string, sum: number) => ({
+  metric_name: TraceMetricKey.INPUT_TOKENS,
+  dimensions: { time_bucket: timeBucket },
+  values: { [AggregationType.SUM]: sum },
+});
+
+// Helper to create an output tokens data point
+const createOutputTokensDataPoint = (timeBucket: string, sum: number) => ({
+  metric_name: TraceMetricKey.OUTPUT_TOKENS,
+  dimensions: { time_bucket: timeBucket },
+  values: { [AggregationType.SUM]: sum },
+});
+
+// Helper to create a total tokens data point (no time bucket)
+const createTotalTokensDataPoint = (sum: number) => ({
+  metric_name: TraceMetricKey.TOTAL_TOKENS,
+  dimensions: {},
+  values: { [AggregationType.SUM]: sum },
+});
+
+// Mock recharts components to avoid rendering issues in tests
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  AreaChart: ({ children, data }: { children: React.ReactNode; data: any[] }) => (
+    <div data-testid="area-chart" data-count={data?.length || 0}>
+      {children}
+    </div>
+  ),
+  Area: ({ name, dataKey }: { name: string; dataKey: string }) => (
+    <div data-testid={`area-${dataKey}`} data-name={name} />
+  ),
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+describe('TraceTokenUsageChart', () => {
+  const testExperimentId = 'test-experiment-123';
+  // Use fixed timestamps for predictable bucket generation
+  const startTimeMs = new Date('2025-12-22T10:00:00Z').getTime();
+  const endTimeMs = new Date('2025-12-22T12:00:00Z').getTime(); // 2 hours = 3 buckets with 1hr interval
+
+  // Default props reused across tests
+  const defaultProps = {
+    experimentId: testExperimentId,
+    startTimeMs,
+    endTimeMs,
+    timeIntervalSeconds: 3600, // 1 hour
+  };
+
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+  const renderComponent = (props: Partial<typeof defaultProps> = {}) => {
+    const queryClient = createQueryClient();
+    return renderWithIntl(
+      <QueryClientProvider client={queryClient}>
+        <DesignSystemProvider>
+          <TraceTokenUsageChart {...defaultProps} {...props} />
+        </DesignSystemProvider>
+      </QueryClientProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiResponse([]);
+  });
+
+  describe('loading state', () => {
+    it('should render loading spinner while data is being fetched', async () => {
+      // Create a promise that never resolves to keep the component in loading state
+      mockFetchOrFail.mockReturnValue(new Promise(() => {}));
+
+      renderComponent();
+
+      // Check for spinner (loading state)
+      expect(screen.getByRole('img')).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('should render error message when API call fails', async () => {
+      mockFetchOrFail.mockRejectedValue(new Error('API Error'));
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load chart data')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('empty data state', () => {
+    it('should render chart with zeros when no data points are returned', async () => {
+      mockApiResponses([], [], []);
+
+      renderComponent();
+
+      // Chart should still render with all time buckets (filled with zeros)
+      await waitFor(() => {
+        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+      });
+
+      // Total tokens should be 0
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('should render empty state when time range is not provided', async () => {
+      mockApiResponse([]);
+
+      renderComponent({ startTimeMs: undefined, endTimeMs: undefined });
+
+      await waitFor(() => {
+        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('with data', () => {
+    const mockInputDataPoints = [
+      createInputTokensDataPoint('2025-12-22T10:00:00Z', 50000),
+      createInputTokensDataPoint('2025-12-22T11:00:00Z', 75000),
+    ];
+
+    const mockOutputDataPoints = [
+      createOutputTokensDataPoint('2025-12-22T10:00:00Z', 20000),
+      createOutputTokensDataPoint('2025-12-22T11:00:00Z', 30000),
+    ];
+
+    const mockTotalDataPoints = [createTotalTokensDataPoint(175000)];
+
+    it('should render chart with data points', async () => {
+      mockApiResponses(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+      });
+
+      // Verify the area chart has all time buckets (3 buckets for 2-hour range with 1hr interval)
+      expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+    });
+
+    it('should display both input and output token areas', async () => {
+      mockApiResponses(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('area-inputTokens')).toBeInTheDocument();
+        expect(screen.getByTestId('area-outputTokens')).toBeInTheDocument();
+      });
+    });
+
+    it('should display the total tokens in header', async () => {
+      mockApiResponses(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      // 175000 should be displayed as 175.00K
+      await waitFor(() => {
+        expect(screen.getByText('175.00K')).toBeInTheDocument();
+      });
+    });
+
+    it('should display the "Token Usage" title', async () => {
+      mockApiResponses(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Token Usage')).toBeInTheDocument();
+      });
+    });
+
+    it('should display input and output tokens in subtitle', async () => {
+      mockApiResponses(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      // Subtitle shows input/output breakdown: (125.00K input, 50.00K output)
+      // Input: 50000 + 75000 = 125000, Output: 20000 + 30000 = 50000
+      await waitFor(() => {
+        expect(screen.getByText(/125\.00K input/)).toBeInTheDocument();
+        expect(screen.getByText(/50\.00K output/)).toBeInTheDocument();
+      });
+    });
+
+    it('should display "Over time" label', async () => {
+      mockApiResponses(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Over time')).toBeInTheDocument();
+      });
+    });
+
+    it('should format token count in millions for values >= 1,000,000', async () => {
+      mockApiResponses(mockInputDataPoints, mockOutputDataPoints, [createTotalTokensDataPoint(1500000)]);
+
+      renderComponent();
+
+      // 1,500,000 should be displayed as 1.50M
+      await waitFor(() => {
+        expect(screen.getByText('1.50M')).toBeInTheDocument();
+      });
+    });
+
+    it('should format token count in thousands for values >= 1,000', async () => {
+      mockApiResponses(mockInputDataPoints, mockOutputDataPoints, [createTotalTokensDataPoint(5000)]);
+
+      renderComponent();
+
+      // 5000 should be displayed as 5.00K
+      await waitFor(() => {
+        expect(screen.getByText('5.00K')).toBeInTheDocument();
+      });
+    });
+
+    it('should format token count with locale string for values < 1,000', async () => {
+      mockApiResponses(mockInputDataPoints, mockOutputDataPoints, [createTotalTokensDataPoint(500)]);
+
+      renderComponent();
+
+      // 500 should be displayed as "500"
+      await waitFor(() => {
+        expect(screen.getByText('500')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('API call parameters', () => {
+    it('should call fetchOrFail for input tokens with correct parameters', async () => {
+      mockApiResponses([], [], []);
+
+      renderComponent();
+
+      await waitFor(() => {
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
+        expect(callBody).toMatchObject({
+          experiment_ids: [testExperimentId],
+          view_type: MetricViewType.TRACES,
+          metric_name: TraceMetricKey.INPUT_TOKENS,
+          aggregations: [{ aggregation_type: AggregationType.SUM }],
+          time_interval_seconds: 3600,
+        });
+      });
+    });
+
+    it('should call fetchOrFail for output tokens with correct parameters', async () => {
+      mockApiResponses([], [], []);
+
+      renderComponent();
+
+      await waitFor(() => {
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[1]?.[1] as any)?.body || '{}');
+        expect(callBody).toMatchObject({
+          experiment_ids: [testExperimentId],
+          view_type: MetricViewType.TRACES,
+          metric_name: TraceMetricKey.OUTPUT_TOKENS,
+          aggregations: [{ aggregation_type: AggregationType.SUM }],
+          time_interval_seconds: 3600,
+        });
+      });
+    });
+
+    it('should call fetchOrFail for total tokens without time interval', async () => {
+      mockApiResponses([], [], []);
+
+      renderComponent();
+
+      await waitFor(() => {
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[2]?.[1] as any)?.body || '{}');
+        expect(callBody).toMatchObject({
+          experiment_ids: [testExperimentId],
+          view_type: MetricViewType.TRACES,
+          metric_name: TraceMetricKey.TOTAL_TOKENS,
+          aggregations: [{ aggregation_type: AggregationType.SUM }],
+        });
+        // Should NOT have time_interval_seconds for total tokens query
+        expect(callBody.time_interval_seconds).toBeUndefined();
+      });
+    });
+
+    it('should use provided time interval', async () => {
+      mockApiResponses([], [], []);
+
+      renderComponent({ timeIntervalSeconds: 60 });
+
+      await waitFor(() => {
+        const callBody = JSON.parse((mockFetchOrFail.mock.calls[0]?.[1] as any)?.body || '{}');
+        expect(callBody.time_interval_seconds).toBe(60);
+      });
+    });
+  });
+
+  describe('data transformation', () => {
+    it('should handle data points with missing token values gracefully', async () => {
+      mockApiResponses(
+        [
+          {
+            metric_name: TraceMetricKey.INPUT_TOKENS,
+            dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
+            values: {}, // Missing SUM value - will be treated as 0
+          },
+        ],
+        [
+          {
+            metric_name: TraceMetricKey.OUTPUT_TOKENS,
+            dimensions: { time_bucket: '2025-12-22T10:00:00Z' },
+            values: {}, // Missing SUM value - will be treated as 0
+          },
+        ],
+        [createTotalTokensDataPoint(0)],
+      );
+
+      renderComponent();
+
+      // Should still render with all 3 time buckets
+      await waitFor(() => {
+        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+      });
+    });
+
+    it('should handle missing total tokens data gracefully', async () => {
+      mockApiResponses(
+        [createInputTokensDataPoint('2025-12-22T10:00:00Z', 1000)],
+        [createOutputTokensDataPoint('2025-12-22T10:00:00Z', 500)],
+        [],
+      );
+
+      renderComponent();
+
+      // Should still render the chart with all time buckets
+      await waitFor(() => {
+        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+      });
+
+      // Should display 0 when total tokens is not available
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('should handle data points with missing time_bucket', async () => {
+      mockApiResponses(
+        [
+          {
+            metric_name: TraceMetricKey.INPUT_TOKENS,
+            dimensions: {}, // Missing time_bucket - won't be mapped to any bucket
+            values: { [AggregationType.SUM]: 1000 },
+          },
+        ],
+        [
+          {
+            metric_name: TraceMetricKey.OUTPUT_TOKENS,
+            dimensions: {}, // Missing time_bucket - won't be mapped to any bucket
+            values: { [AggregationType.SUM]: 500 },
+          },
+        ],
+        [createTotalTokensDataPoint(1500)],
+      );
+
+      renderComponent();
+
+      // Should still render the chart with all generated time buckets (all with 0 values)
+      await waitFor(() => {
+        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+      });
+    });
+
+    it('should fill missing time buckets with zeros', async () => {
+      // Only provide data for one time bucket - the chart should still show all 3 buckets
+      const inputDataPoints = [createInputTokensDataPoint('2025-12-22T10:00:00Z', 1000)];
+      const outputDataPoints = [createOutputTokensDataPoint('2025-12-22T10:00:00Z', 500)];
+
+      mockApiResponses(inputDataPoints, outputDataPoints, [createTotalTokensDataPoint(1500)]);
+
+      renderComponent();
+
+      // Should render chart with all 3 time buckets (missing ones filled with 0)
+      await waitFor(() => {
+        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+      });
+    });
+
+    it('should merge input and output tokens by time bucket', async () => {
+      // Input tokens has data for both time buckets
+      const inputDataPoints = [
+        createInputTokensDataPoint('2025-12-22T10:00:00Z', 1000),
+        createInputTokensDataPoint('2025-12-22T11:00:00Z', 2000),
+      ];
+
+      // Output tokens only has data for the first time bucket (second bucket will be 0)
+      const outputDataPoints = [createOutputTokensDataPoint('2025-12-22T10:00:00Z', 500)];
+
+      mockApiResponses(inputDataPoints, outputDataPoints, [createTotalTokensDataPoint(3500)]);
+
+      renderComponent();
+
+      // Should render chart with all 3 time buckets
+      await waitFor(() => {
+        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+      });
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
@@ -57,25 +57,6 @@ const createTotalTokensDataPoint = (sum: number) => ({
   values: { [AggregationType.SUM]: sum },
 });
 
-// Mock recharts components to avoid rendering issues in tests
-jest.mock('recharts', () => ({
-  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="responsive-container">{children}</div>
-  ),
-  AreaChart: ({ children, data }: { children: React.ReactNode; data: any[] }) => (
-    <div data-testid="area-chart" data-count={data?.length || 0}>
-      {children}
-    </div>
-  ),
-  Area: ({ name, dataKey }: { name: string; dataKey: string }) => (
-    <div data-testid={`area-${dataKey}`} data-name={name} />
-  ),
-  XAxis: () => <div data-testid="x-axis" />,
-  YAxis: () => <div data-testid="y-axis" />,
-  Tooltip: () => <div data-testid="tooltip" />,
-  Legend: () => <div data-testid="legend" />,
-}));
-
 describe('TraceTokenUsageChart', () => {
   const testExperimentId = 'test-experiment-123';
   // Use fixed timestamps for predictable bucket generation

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -1,0 +1,267 @@
+import React, { useMemo, useState } from 'react';
+import { useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import {
+  MetricViewType,
+  AggregationType,
+  TraceMetricKey,
+  TIME_BUCKET_DIMENSION_KEY,
+} from '@databricks/web-shared/model-trace-explorer';
+import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
+import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
+import { formatTimestampForTraceMetrics, generateTimeBuckets } from '../utils/chartUtils';
+import type { OverviewChartProps } from '../types';
+
+// Icon component for token usage (lightning bolt style)
+const TokenIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+    <path d="M8.5 1L3 9h4.5v6L13 7H8.5V1z" />
+  </svg>
+);
+
+/**
+ * Format token count in human-readable format (K, M)
+ */
+function formatTokenCount(count: number): string {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(2)}M`;
+  }
+  if (count >= 1_000) {
+    return `${(count / 1_000).toFixed(2)}K`;
+  }
+  return count.toLocaleString();
+}
+
+export const TraceTokenUsageChart: React.FC<OverviewChartProps> = ({
+  experimentId,
+  startTimeMs,
+  endTimeMs,
+  timeIntervalSeconds,
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  // Fetch input tokens over time
+  const {
+    data: inputTokensData,
+    isLoading: isLoadingInput,
+    error: inputError,
+  } = useTraceMetricsQuery({
+    experimentId,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.INPUT_TOKENS,
+    aggregations: [{ aggregation_type: AggregationType.SUM }],
+    timeIntervalSeconds,
+  });
+
+  // Fetch output tokens over time
+  const {
+    data: outputTokensData,
+    isLoading: isLoadingOutput,
+    error: outputError,
+  } = useTraceMetricsQuery({
+    experimentId,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.OUTPUT_TOKENS,
+    aggregations: [{ aggregation_type: AggregationType.SUM }],
+    timeIntervalSeconds,
+  });
+
+  // Fetch total tokens (without time bucketing) for the header
+  const {
+    data: totalTokensData,
+    isLoading: isLoadingTotal,
+    error: totalError,
+  } = useTraceMetricsQuery({
+    experimentId,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.TOTAL_TOKENS,
+    aggregations: [{ aggregation_type: AggregationType.SUM }],
+  });
+
+  const inputDataPoints = useMemo(() => inputTokensData?.data_points || [], [inputTokensData?.data_points]);
+  const outputDataPoints = useMemo(() => outputTokensData?.data_points || [], [outputTokensData?.data_points]);
+  const isLoading = isLoadingInput || isLoadingOutput || isLoadingTotal;
+  const error = inputError || outputError || totalError;
+
+  // Extract total tokens from the response
+  const totalTokens = totalTokensData?.data_points?.[0]?.values?.[AggregationType.SUM] || 0;
+
+  // Calculate total input and output tokens from time-bucketed data
+  const totalInputTokens = useMemo(
+    () => inputDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0),
+    [inputDataPoints],
+  );
+  const totalOutputTokens = useMemo(
+    () => outputDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0),
+    [outputDataPoints],
+  );
+
+  // Create maps of tokens by timestamp for merging
+  const inputTokensMap = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const dp of inputDataPoints) {
+      const timeBucket = dp.dimensions?.[TIME_BUCKET_DIMENSION_KEY];
+      if (timeBucket) {
+        const ts = new Date(timeBucket).getTime();
+        map.set(ts, dp.values?.[AggregationType.SUM] || 0);
+      }
+    }
+    return map;
+  }, [inputDataPoints]);
+
+  const outputTokensMap = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const dp of outputDataPoints) {
+      const timeBucket = dp.dimensions?.[TIME_BUCKET_DIMENSION_KEY];
+      if (timeBucket) {
+        const ts = new Date(timeBucket).getTime();
+        map.set(ts, dp.values?.[AggregationType.SUM] || 0);
+      }
+    }
+    return map;
+  }, [outputDataPoints]);
+
+  // Generate all time buckets within the selected range
+  const allTimeBuckets = useMemo(
+    () => generateTimeBuckets(startTimeMs, endTimeMs, timeIntervalSeconds),
+    [startTimeMs, endTimeMs, timeIntervalSeconds],
+  );
+
+  // Prepare chart data - fill in all time buckets with 0 for missing data
+  const chartData = useMemo(() => {
+    return allTimeBuckets.map((timestampMs) => ({
+      name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
+      inputTokens: inputTokensMap.get(timestampMs) || 0,
+      outputTokens: outputTokensMap.get(timestampMs) || 0,
+    }));
+  }, [allTimeBuckets, inputTokensMap, outputTokensMap, timeIntervalSeconds]);
+
+  // Track hovered legend item
+  const [hoveredArea, setHoveredArea] = useState<string | null>(null);
+
+  // Area colors
+  const areaColors = {
+    inputTokens: theme.colors.blue400,
+    outputTokens: theme.colors.green400,
+  };
+
+  // Get opacity for an area based on hover state
+  const getAreaOpacity = (areaKey: string) => {
+    if (hoveredArea === null) return 0.8;
+    return hoveredArea === areaKey ? 0.8 : 0.2;
+  };
+
+  // Handle legend hover
+  const handleLegendMouseEnter = (data: { value: string }) => {
+    setHoveredArea(data.value);
+  };
+
+  const handleLegendMouseLeave = () => {
+    setHoveredArea(null);
+  };
+
+  if (isLoading) {
+    return <ChartLoadingState />;
+  }
+
+  if (error) {
+    return <ChartErrorState />;
+  }
+
+  return (
+    <div
+      css={{
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        padding: theme.spacing.lg,
+        backgroundColor: theme.colors.backgroundPrimary,
+      }}
+    >
+      <ChartHeader
+        icon={<TokenIcon />}
+        title={<FormattedMessage defaultMessage="Token Usage" description="Title for the token usage chart" />}
+        value={formatTokenCount(totalTokens)}
+        subtitle={`(${formatTokenCount(totalInputTokens)} input, ${formatTokenCount(totalOutputTokens)} output)`}
+      />
+
+      <OverTimeLabel />
+
+      {/* Chart */}
+      <div css={{ height: 200, marginTop: theme.spacing.sm }}>
+        {chartData.length > 0 ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={chartData} margin={{ top: 10, right: 30, left: 30, bottom: 0 }}>
+              <XAxis
+                dataKey="name"
+                tick={{ fontSize: 10, fill: theme.colors.textSecondary, dy: theme.spacing.sm }}
+                axisLine={false}
+                tickLine={false}
+                interval="preserveStartEnd"
+              />
+              <YAxis hide />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: theme.colors.backgroundPrimary,
+                  border: `1px solid ${theme.colors.border}`,
+                  borderRadius: theme.borders.borderRadiusMd,
+                  fontSize: theme.typography.fontSizeSm,
+                }}
+                cursor={{ fill: theme.colors.actionTertiaryBackgroundHover }}
+                formatter={(value: number, name: string) => [formatTokenCount(value), name]}
+              />
+              <Area
+                type="monotone"
+                dataKey="inputTokens"
+                stackId="1"
+                stroke={areaColors.inputTokens}
+                fill={areaColors.inputTokens}
+                strokeOpacity={getAreaOpacity('Input Tokens')}
+                fillOpacity={getAreaOpacity('Input Tokens')}
+                strokeWidth={2}
+                name="Input Tokens"
+              />
+              <Area
+                type="monotone"
+                dataKey="outputTokens"
+                stackId="1"
+                stroke={areaColors.outputTokens}
+                fill={areaColors.outputTokens}
+                strokeOpacity={getAreaOpacity('Output Tokens')}
+                fillOpacity={getAreaOpacity('Output Tokens')}
+                strokeWidth={2}
+                name="Output Tokens"
+              />
+              <Legend
+                verticalAlign="bottom"
+                iconType="plainline"
+                height={36}
+                onMouseEnter={handleLegendMouseEnter}
+                onMouseLeave={handleLegendMouseLeave}
+                formatter={(value) => (
+                  <span
+                    style={{
+                      color: theme.colors.textPrimary,
+                      fontSize: theme.typography.fontSizeSm,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {value}
+                  </span>
+                )}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        ) : (
+          <ChartEmptyState />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useDesignSystemTheme } from '@databricks/design-system';
+import { useDesignSystemTheme, LightningIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import {
@@ -9,16 +9,15 @@ import {
   TIME_BUCKET_DIMENSION_KEY,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
-import { ChartLoadingState, ChartErrorState, ChartEmptyState, ChartHeader, OverTimeLabel } from './ChartCardWrapper';
+import {
+  OverviewChartLoadingState,
+  OverviewChartErrorState,
+  OverviewChartEmptyState,
+  OverviewChartHeader,
+  OverviewChartTimeLabel,
+} from './OverviewChartComponents';
 import { formatTimestampForTraceMetrics, generateTimeBuckets } from '../utils/chartUtils';
 import type { OverviewChartProps } from '../types';
-
-// Icon component for token usage (lightning bolt style)
-const TokenIcon: React.FC<{ className?: string }> = ({ className }) => (
-  <svg className={className} width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-    <path d="M8.5 1L3 9h4.5v6L13 7H8.5V1z" />
-  </svg>
-);
 
 /**
  * Format token count in human-readable format (K, M)
@@ -168,11 +167,11 @@ export const TraceTokenUsageChart: React.FC<OverviewChartProps> = ({
   };
 
   if (isLoading) {
-    return <ChartLoadingState />;
+    return <OverviewChartLoadingState />;
   }
 
   if (error) {
-    return <ChartErrorState />;
+    return <OverviewChartErrorState />;
   }
 
   return (
@@ -184,14 +183,14 @@ export const TraceTokenUsageChart: React.FC<OverviewChartProps> = ({
         backgroundColor: theme.colors.backgroundPrimary,
       }}
     >
-      <ChartHeader
-        icon={<TokenIcon />}
+      <OverviewChartHeader
+        icon={<LightningIcon />}
         title={<FormattedMessage defaultMessage="Token Usage" description="Title for the token usage chart" />}
         value={formatTokenCount(totalTokens)}
         subtitle={`(${formatTokenCount(totalInputTokens)} input, ${formatTokenCount(totalOutputTokens)} output)`}
       />
 
-      <OverTimeLabel />
+      <OverviewChartTimeLabel />
 
       {/* Chart */}
       <div css={{ height: 200, marginTop: theme.spacing.sm }}>
@@ -259,7 +258,7 @@ export const TraceTokenUsageChart: React.FC<OverviewChartProps> = ({
             </AreaChart>
           </ResponsiveContainer>
         ) : (
-          <ChartEmptyState />
+          <OverviewChartEmptyState />
         )}
       </div>
     </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/chartUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/chartUtils.ts
@@ -39,3 +39,32 @@ export function getTimestampFromDataPoint(dp: MetricDataPoint): number {
   }
   return 0;
 }
+
+/**
+ * Generate all time bucket timestamps within a range
+ * @param startTimeMs - Start of time range in milliseconds
+ * @param endTimeMs - End of time range in milliseconds
+ * @param timeIntervalSeconds - Time interval in seconds for each bucket
+ * @returns Array of timestamps (in ms) for each bucket, aligned to interval boundaries
+ */
+export function generateTimeBuckets(
+  startTimeMs: number | undefined,
+  endTimeMs: number | undefined,
+  timeIntervalSeconds: number,
+): number[] {
+  if (!startTimeMs || !endTimeMs || timeIntervalSeconds <= 0) {
+    return [];
+  }
+
+  const intervalMs = timeIntervalSeconds * 1000;
+  const buckets: number[] = [];
+
+  // Align start time to the interval boundary (floor)
+  const alignedStart = Math.floor(startTimeMs / intervalMs) * intervalMs;
+
+  for (let ts = alignedStart; ts <= endTimeMs; ts += intervalMs) {
+    buckets.push(ts);
+  }
+
+  return buckets;
+}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3749,6 +3749,10 @@
     "defaultMessage": "Page not found",
     "description": "Error message shown to the user when they arrive at a non existent URL"
   },
+  "TLHzWu": {
+    "defaultMessage": "Token Usage",
+    "description": "Title for the token usage chart"
+  },
   "TPspzA": {
     "defaultMessage": "Deleting the section will permanently remove it and the charts it contains. This cannot be undone.",
     "description": "Experiment page > compare runs > chart section > delete section warning message"

--- a/mlflow/server/js/src/setupTests.js
+++ b/mlflow/server/js/src/setupTests.js
@@ -82,7 +82,7 @@ jest.mock('recharts', () => ({
   ),
   Line: ({ name }) => <div data-testid={name ? `line-${name}` : 'line'} />,
   Bar: ({ name }) => <div data-testid={name ? `bar-${name}` : 'bar'} />,
-  Area: ({ name }) => <div data-testid={name ? `area-${name}` : 'area'} />,
+  Area: ({ name, dataKey }) => <div data-testid={`area-${dataKey}`} data-name={name} />,
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: () => <div data-testid="y-axis" />,
   Tooltip: () => <div data-testid="tooltip" />,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19606/files/73ba41d9e7bbc053451f6903daa74da71a6d7040..b4cd1d5373cfce4cd68da2b0d20610286b73e418) to review incremental changes.
- [stack/charts_time_buckets_fix](https://github.com/mlflow/mlflow/pull/19602) [[Files changed](https://github.com/mlflow/mlflow/pull/19602/files)]
  - [stack/latency_time_fix](https://github.com/mlflow/mlflow/pull/19603) [[Files changed](https://github.com/mlflow/mlflow/pull/19603/files/435920e458e7829847b3181d137a39a5146d42db..29c9fb86b7a862f2ec26381376832d18c797a532)]
    - [stack/error_chart_time_fix](https://github.com/mlflow/mlflow/pull/19604) [[Files changed](https://github.com/mlflow/mlflow/pull/19604/files/29c9fb86b7a862f2ec26381376832d18c797a532..73ba41d9e7bbc053451f6903daa74da71a6d7040)]
      - [**stack/token_usage_chart**](https://github.com/mlflow/mlflow/pull/19606) [[Files changed](https://github.com/mlflow/mlflow/pull/19606/files/73ba41d9e7bbc053451f6903daa74da71a6d7040..b4cd1d5373cfce4cd68da2b0d20610286b73e418)]
        - [stack/empty_data_fix](https://github.com/mlflow/mlflow/pull/19607) [[Files changed](https://github.com/mlflow/mlflow/pull/19607/files/b4cd1d5373cfce4cd68da2b0d20610286b73e418..0e90d42e3b9799a6892a4bf8f59def93159ab7d2)]
          - [stack/simplify_charts_components](https://github.com/mlflow/mlflow/pull/19608) [[Files changed](https://github.com/mlflow/mlflow/pull/19608/files/0e90d42e3b9799a6892a4bf8f59def93159ab7d2..96a8eea35f1d1e9b4c785dd2740ef658c2d00ff0)]
            - [stack/token_statistics_chart](https://github.com/mlflow/mlflow/pull/19609) [[Files changed](https://github.com/mlflow/mlflow/pull/19609/files/96a8eea35f1d1e9b4c785dd2740ef658c2d00ff0..bf175bae4cb492a4fc28f2cc30d7bd73e0367630)]
              - [stack/quality_tab](https://github.com/mlflow/mlflow/pull/19619) [[Files changed](https://github.com/mlflow/mlflow/pull/19619/files/bf175bae4cb492a4fc28f2cc30d7bd73e0367630..951ac26023e8c214eeb50fa84b3737e373228533)]
                - [stack/query_assessment_metrics](https://github.com/mlflow/mlflow/pull/19620) [[Files changed](https://github.com/mlflow/mlflow/pull/19620/files/951ac26023e8c214eeb50fa84b3737e373228533..89cff4e95558f38e49b28748ffd1917dc9993538)]
                  - [stack/assessment_chart](https://github.com/mlflow/mlflow/pull/19621) [[Files changed](https://github.com/mlflow/mlflow/pull/19621/files/89cff4e95558f38e49b28748ffd1917dc9993538..5be948ad22ca82075b165897dc7e7b530b1684c4)]
                    - [stack/render_scorer_charts](https://github.com/mlflow/mlflow/pull/19622) [[Files changed](https://github.com/mlflow/mlflow/pull/19622/files/5be948ad22ca82075b165897dc7e7b530b1684c4..fefc3f11457af3d7cba321855cfff132768d7221)]
                      - [stack/scorer_counts](https://github.com/mlflow/mlflow/pull/19624) [[Files changed](https://github.com/mlflow/mlflow/pull/19624/files/fefc3f11457af3d7cba321855cfff132768d7221..7aab15354504d02755258c47dd6ea7466e9b6615)]
                        - [stack/tools_tab](https://github.com/mlflow/mlflow/pull/19632) [[Files changed](https://github.com/mlflow/mlflow/pull/19632/files/7aab15354504d02755258c47dd6ea7466e9b6615..0fe4be8ecf36ba70100757949fb9c31596456c36)]
                          - [stack/query_span_metrics](https://github.com/mlflow/mlflow/pull/19633) [[Files changed](https://github.com/mlflow/mlflow/pull/19633/files/0fe4be8ecf36ba70100757949fb9c31596456c36..29afe2d199f3fc4c4a40f2771729047a720a0de2)]
                            - [stack/tool_calls_statistics](https://github.com/mlflow/mlflow/pull/19634) [[Files changed](https://github.com/mlflow/mlflow/pull/19634/files/29afe2d199f3fc4c4a40f2771729047a720a0de2..d72dd4590544595916ee918ce213759a932846f0)]
                              - [stack/tool_error_rate_charts](https://github.com/mlflow/mlflow/pull/19635) [[Files changed](https://github.com/mlflow/mlflow/pull/19635/files/d72dd4590544595916ee918ce213759a932846f0..94f3d70ea253ff6bbfd5aafe7965b0b21a5d6a6b)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Add token usage chart split by input and output tokens

https://github.com/user-attachments/assets/a362b9b4-e642-4496-8007-361d693cf823


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
