### PR TITLE
Fix chart rendering when no data

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.test.tsx
@@ -109,18 +109,14 @@ describe('TraceErrorsChart', () => {
   });
 
   describe('empty data state', () => {
-    it('should render chart with zeros when no data points are returned', async () => {
+    it('should render empty state when no data points are returned', async () => {
       mockApiResponses([], []);
 
       renderComponent();
 
-      // Chart should still render with all time buckets (filled with zeros)
       await waitFor(() => {
-        expect(screen.getByTestId('composed-chart')).toHaveAttribute('data-count', '3');
+        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
       });
-
-      // Total errors should be 0
-      expect(screen.getByText(/^0$/)).toBeInTheDocument();
     });
 
     it('should render empty state when time range is not provided', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
@@ -180,7 +180,7 @@ export const TraceErrorsChart: React.FC<OverviewChartProps> = ({
 
       {/* Chart */}
       <div css={{ height: 200, marginTop: theme.spacing.sm }}>
-        {chartData.length > 0 ? (
+        {totalDataPoints.length > 0 ? (
           <ResponsiveContainer width="100%" height="100%">
             <ComposedChart data={chartData} margin={{ top: 10, right: 10, left: 10, bottom: 0 }}>
               <XAxis

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.test.tsx
@@ -123,14 +123,13 @@ describe('TraceLatencyChart', () => {
   });
 
   describe('empty data state', () => {
-    it('should render chart with zeros when no data points are returned', async () => {
+    it('should render empty state when no data points are returned', async () => {
       mockApiResponses([], []);
 
       renderComponent();
 
-      // Chart should still render with all time buckets (filled with zeros)
       await waitFor(() => {
-        expect(screen.getByTestId('line-chart')).toHaveAttribute('data-count', '3');
+        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
       });
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
@@ -169,7 +169,7 @@ export const TraceLatencyChart: React.FC<OverviewChartProps> = ({
 
       {/* Chart */}
       <div css={{ height: 200, marginTop: theme.spacing.sm }}>
-        {chartData.length > 0 ? (
+        {latencyDataPoints.length > 0 ? (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartData} margin={{ top: 10, right: 30, left: 30, bottom: 0 }}>
               <XAxis

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
@@ -93,18 +93,14 @@ describe('TraceRequestsChart', () => {
   });
 
   describe('empty data state', () => {
-    it('should render chart with zeros when no data points are returned', async () => {
+    it('should render empty state when no data points are returned', async () => {
       mockApiResponse([]);
 
       renderComponent();
 
-      // Chart should still render with all time buckets (filled with zeros)
       await waitFor(() => {
-        expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-count', '3');
+        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
       });
-
-      // Total should be 0
-      expect(screen.getByText('0')).toBeInTheDocument();
     });
 
     it('should render empty state when time range is not provided', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
@@ -103,7 +103,7 @@ export const TraceRequestsChart: React.FC<OverviewChartProps> = ({
 
       {/* Chart */}
       <div css={{ height: 200 }}>
-        {chartData.length > 0 ? (
+        {traceCountDataPoints.length > 0 ? (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={chartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
               <XAxis

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
@@ -121,18 +121,14 @@ describe('TraceTokenUsageChart', () => {
   });
 
   describe('empty data state', () => {
-    it('should render chart with zeros when no data points are returned', async () => {
+    it('should render empty state when no data points are returned', async () => {
       mockApiResponses([], [], []);
 
       renderComponent();
 
-      // Chart should still render with all time buckets (filled with zeros)
       await waitFor(() => {
-        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+        expect(screen.getByText('No data available for the selected time range')).toBeInTheDocument();
       });
-
-      // Total tokens should be 0
-      expect(screen.getByText('0')).toBeInTheDocument();
     });
 
     it('should render empty state when time range is not provided', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -194,7 +194,7 @@ export const TraceTokenUsageChart: React.FC<OverviewChartProps> = ({
 
       {/* Chart */}
       <div css={{ height: 200, marginTop: theme.spacing.sm }}>
-        {chartData.length > 0 ? (
+        {inputDataPoints.length > 0 || outputDataPoints.length > 0 ? (
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={chartData} margin={{ top: 10, right: 30, left: 30, bottom: 0 }}>
               <XAxis


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19607/files) to review incremental changes.
- [**stack/empty_data_fix**](https://github.com/mlflow/mlflow/pull/19607) [[Files changed](https://github.com/mlflow/mlflow/pull/19607/files)]
  - [stack/simplify_charts_components](https://github.com/mlflow/mlflow/pull/19608) [[Files changed](https://github.com/mlflow/mlflow/pull/19608/files/7e272e25da6d260e0f69256af447725cde765a2f..b39d8362eead0459c83be2445849f027a6391220)]
    - [stack/token_statistics_chart](https://github.com/mlflow/mlflow/pull/19609) [[Files changed](https://github.com/mlflow/mlflow/pull/19609/files/b39d8362eead0459c83be2445849f027a6391220..d6e78115c66f4e7bd0be609a608be5ddbf61a11e)]
      - [stack/quality_tab](https://github.com/mlflow/mlflow/pull/19619) [[Files changed](https://github.com/mlflow/mlflow/pull/19619/files/d6e78115c66f4e7bd0be609a608be5ddbf61a11e..c31ca40ef400c3c7727bf154b37adade35e33372)]
        - [stack/query_assessment_metrics](https://github.com/mlflow/mlflow/pull/19620) [[Files changed](https://github.com/mlflow/mlflow/pull/19620/files/c31ca40ef400c3c7727bf154b37adade35e33372..6317dabe1ba0c6ee9f519370496bc9d48c115929)]
          - [stack/assessment_chart](https://github.com/mlflow/mlflow/pull/19621) [[Files changed](https://github.com/mlflow/mlflow/pull/19621/files/6317dabe1ba0c6ee9f519370496bc9d48c115929..aa35917013991d95033343b9f14eaf7820acd642)]
            - [stack/render_scorer_charts](https://github.com/mlflow/mlflow/pull/19622) [[Files changed](https://github.com/mlflow/mlflow/pull/19622/files/aa35917013991d95033343b9f14eaf7820acd642..b75a770c8a575cb7db9cd33e9b97aee5e54dacac)]
              - [stack/scorer_counts](https://github.com/mlflow/mlflow/pull/19624) [[Files changed](https://github.com/mlflow/mlflow/pull/19624/files/b75a770c8a575cb7db9cd33e9b97aee5e54dacac..112b8fec7d61effe68353f1e218f08ce396e4ac2)]
                - [stack/tools_tab](https://github.com/mlflow/mlflow/pull/19632) [[Files changed](https://github.com/mlflow/mlflow/pull/19632/files/112b8fec7d61effe68353f1e218f08ce396e4ac2..6b5b8ea42193b2ce767fdaff0fdbc538c9144436)]
                  - [stack/query_span_metrics](https://github.com/mlflow/mlflow/pull/19633) [[Files changed](https://github.com/mlflow/mlflow/pull/19633/files/6b5b8ea42193b2ce767fdaff0fdbc538c9144436..312163c63bbcfa95fa45370163a6a1fc14affb7d)]
                    - [stack/tool_calls_statistics](https://github.com/mlflow/mlflow/pull/19634) [[Files changed](https://github.com/mlflow/mlflow/pull/19634/files/312163c63bbcfa95fa45370163a6a1fc14affb7d..bd86204dcedb364955a1c36adde8de8c9b72caa8)]
                      - [stack/tool_error_rate_charts](https://github.com/mlflow/mlflow/pull/19635) [[Files changed](https://github.com/mlflow/mlflow/pull/19635/files/bd86204dcedb364955a1c36adde8de8c9b72caa8..d9bfe62bf050b162286caf710b6ce1bd63e896e1)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
We should show no data available when there's no data returned from backend, since we fill out missing data on purpose.
Before:
<img width="1328" height="886" alt="Screenshot 2025-12-24 at 12 02 56 PM" src="https://github.com/user-attachments/assets/8955c270-bc80-41b5-9c9c-2a709c94bf1a" />

After:
<img width="1328" height="886" alt="Screenshot 2025-12-24 at 12 02 29 PM" src="https://github.com/user-attachments/assets/efe68994-145b-4bec-a124-7f4637930e95" />


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
