### PR TITLE
Address vulnerability in container build process

### DIFF
--- a/tests/models/container/test_command_injection_vulnerability.py
+++ b/tests/models/container/test_command_injection_vulnerability.py
@@ -1,0 +1,173 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from mlflow.models.container import _install_model_dependencies_to_env, _validate_dependency_string
+from mlflow.utils import env_manager as em
+
+
+@pytest.fixture
+def model_dir_factory(tmp_path: Path):
+    def _create(
+        dependencies: list[str] | None = None,
+        build_dependencies: list[str] | None = None,
+    ) -> Path:
+        model_path = (
+            tmp_path / f"model_{hash((tuple(dependencies or []), tuple(build_dependencies or [])))}"
+        )
+        model_path.mkdir(exist_ok=True)
+
+        mlmodel = {"flavors": {"python_function": {"env": {"virtualenv": "python_env.yaml"}}}}
+        (model_path / "MLmodel").write_text(yaml.safe_dump(mlmodel))
+
+        python_env = {
+            "python": "3.12",
+            "build_dependencies": build_dependencies or [],
+            "dependencies": dependencies or [],
+        }
+        (model_path / "python_env.yaml").write_text(yaml.safe_dump(python_env))
+        (model_path / "requirements.txt").write_text("requests>=2.0\n")
+
+        return model_path
+
+    return _create
+
+
+@pytest.fixture
+def mock_subprocess_run():
+    calls: list[list[str]] = []
+
+    def _run(cmd: list[str], **kwargs) -> MagicMock:
+        calls.append(cmd)
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    with patch("mlflow.models.container.subprocess.run", side_effect=_run):
+        yield calls
+
+
+MALICIOUS_DEPENDENCIES = [
+    "numpy; whoami",
+    "numpy && id",
+    "numpy || true",
+    "numpy | cat /etc/passwd",
+    "numpy > /tmp/output",
+    "numpy < /dev/null",
+    "$(id)",
+    "`id`",
+    "numpy\nmalicious",
+    "numpy$HOME",
+    "numpy${PATH}",
+    "numpy'injection",
+    'numpy"injection',
+    "numpy\\injection",
+    "numpy()",
+    "numpy{}",
+]
+
+VALID_DEPENDENCIES = [
+    "numpy",
+    "numpy==1.24.0",
+    "numpy>=1.20,<2.0",
+    "scikit-learn",
+    "scikit_learn",
+    "tensorflow-cpu",
+    "package[extra]",
+    "package[extra1,extra2]",
+    "mlflow>=2.0.0",
+    "package==1.0.0",
+    "package>=1.0",
+    "package<=2.0",
+    "package!=1.5",
+    "package~=1.0",
+    "package>=1.0,<2.0,!=1.5",
+]
+
+
+@pytest.mark.parametrize("malicious_dep", MALICIOUS_DEPENDENCIES)
+def test_malicious_dependency_rejected(model_dir_factory, malicious_dep: str):
+    model_path = model_dir_factory(dependencies=[malicious_dep])
+    with pytest.raises(ValueError, match="Invalid dependency string"):
+        _install_model_dependencies_to_env(str(model_path), em.LOCAL)
+
+
+@pytest.mark.parametrize("malicious_dep", MALICIOUS_DEPENDENCIES)
+def test_malicious_build_dependency_rejected(model_dir_factory, malicious_dep: str):
+    model_path = model_dir_factory(build_dependencies=[malicious_dep])
+    with pytest.raises(ValueError, match="Invalid dependency string"):
+        _install_model_dependencies_to_env(str(model_path), em.LOCAL)
+
+
+@pytest.mark.parametrize("valid_dep", VALID_DEPENDENCIES)
+def test_valid_dependency_accepted(model_dir_factory, mock_subprocess_run, valid_dep: str):
+    model_path = model_dir_factory(dependencies=[valid_dep])
+    _install_model_dependencies_to_env(str(model_path), em.LOCAL)
+
+    assert len(mock_subprocess_run) == 1
+    assert valid_dep in mock_subprocess_run[0]
+
+
+def test_valid_model_uses_subprocess_list_not_shell(model_dir_factory, mock_subprocess_run):
+    model_path = model_dir_factory(
+        build_dependencies=["pip==23.0", "setuptools>=65.0", "wheel"],
+        dependencies=["-r requirements.txt"],
+    )
+    _install_model_dependencies_to_env(str(model_path), em.LOCAL)
+
+    assert len(mock_subprocess_run) == 1
+    cmd = mock_subprocess_run[0]
+    assert isinstance(cmd, list)
+    assert cmd[:4] == ["python", "-m", "pip", "install"]
+    assert "pip==23.0" in cmd
+    assert "setuptools>=65.0" in cmd
+    assert "wheel" in cmd
+    assert "-r" in cmd
+
+
+def test_requirements_txt_path_expanded(model_dir_factory, mock_subprocess_run):
+    model_path = model_dir_factory(dependencies=["-r requirements.txt"])
+    _install_model_dependencies_to_env(str(model_path), em.LOCAL)
+
+    cmd = mock_subprocess_run[0]
+    r_index = cmd.index("-r")
+    requirements_path = cmd[r_index + 1]
+    assert requirements_path.endswith("requirements.txt")
+    assert str(model_path) in requirements_path
+
+
+@pytest.mark.parametrize(
+    "dep",
+    [
+        "numpy; rm -rf /",
+        "numpy | cat",
+        "numpy && id",
+        "numpy$HOME",
+        "`whoami`",
+        "numpy > /tmp/out",
+        "numpy < /etc/passwd",
+        "numpy\nmalicious",
+    ],
+)
+def test_validate_dependency_string_rejects_dangerous(dep: str):
+    with pytest.raises(ValueError, match="Invalid dependency string"):
+        _validate_dependency_string(dep)
+
+
+@pytest.mark.parametrize(
+    "dep",
+    [
+        "numpy",
+        "numpy==1.24.0",
+        "scikit-learn>=1.0",
+        "package>=1.0,<2.0",
+        "package<=2.0",
+        "package<2.0",
+        "package>1.0",
+        "numpy>=1.0,<2.0,!=1.5",
+    ],
+)
+def test_validate_dependency_string_accepts_valid(dep: str):
+    _validate_dependency_string(dep)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/19612?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19612/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19612/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19612/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Inspects and sanitizes the inputs to container build to prevent RCE vulnerability. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
