### PR TITLE
Introduce a conversation simulator into mlflow.genai

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -718,6 +718,7 @@ mlflow.gateway.get_gateway_uri
 mlflow.gateway.set_gateway_uri
 mlflow.gemini.autolog
 mlflow.genai.Agent
+mlflow.genai.ConversationSimulator
 mlflow.genai.LabelingSession
 mlflow.genai.LabelingSession.add_dataset
 mlflow.genai.LabelingSession.add_traces
@@ -1086,6 +1087,7 @@ mlflow.genai.set_prompt_alias
 mlflow.genai.set_prompt_model_config
 mlflow.genai.set_prompt_tag
 mlflow.genai.set_prompt_version_tag
+mlflow.genai.simulators.simulator.ConversationSimulator
 mlflow.genai.to_predict_fn
 mlflow.get_active_model_id
 mlflow.get_active_trace_id

--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -43,6 +43,7 @@ from mlflow.genai.scheduled_scorers import (
     ScorerScheduleConfig,
 )
 from mlflow.genai.scorers import Scorer, scorer
+from mlflow.genai.simulators import ConversationSimulator
 
 __all__ = [
     "datasets",
@@ -85,4 +86,6 @@ __all__ = [
     # git model versioning
     "disable_git_model_versioning",
     "enable_git_model_versioning",
+    # conversation simulation
+    "ConversationSimulator",
 ]

--- a/mlflow/genai/simulators/__init__.py
+++ b/mlflow/genai/simulators/__init__.py
@@ -1,0 +1,5 @@
+from mlflow.genai.simulators.simulator import ConversationSimulator
+
+__all__ = [
+    "ConversationSimulator",
+]

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -8,6 +8,8 @@ Start a conversation about this topic. The way you start the conversation should
 a realistic user as possible. Don't ask about your goal directly - instead start with a broader
 question and let the conversation develop naturally."""
 
+# NB: We embed history into the prompt instead of passing a message list directly to reduce
+#     noise, since the prompt only cares about message content and sender role.
 FOLLOWUP_USER_PROMPT = """{persona}
 
 Your goal: {goal}
@@ -35,3 +37,4 @@ You must output your response as a valid JSON object with the following format:
   Start each rationale with `Let's think step by step`",
   "result": "yes|no"
 }}"""
+# NB: We include "rationale" to invoke chain-of-thought reasoning for better results.

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -1,11 +1,12 @@
-DEFAULT_PERSONA = "You are a helpful user having a natural conversation."
+DEFAULT_PERSONA = "You are an inquisitive user having a natural conversation."
 
 INITIAL_USER_PROMPT = """{persona}
 
 Your goal in this conversation is to: {goal}
 
-Start a conversation about this topic. Don't ask about your goal directly - \
-instead start with a broader question and let the conversation develop naturally."""
+Start a conversation about this topic. The way you start the conversation should sound as much like
+a realistic user as possible. Don't ask about your goal directly - instead start with a broader
+question and let the conversation develop naturally."""
 
 FOLLOWUP_USER_PROMPT = """{persona}
 
@@ -14,12 +15,23 @@ Your goal: {goal}
 Conversation so far:
 {conversation_history}
 
-They just said: {last_response}
+The agent you are talking to just said: {last_response}
 
-Respond naturally and guide the conversation toward your goal."""
+Respond naturally with a follow-up and guide the conversation toward your goal as a
+realistic user."""
 
-CHECK_GOAL_PROMPT = """Goal: {goal}
+CHECK_GOAL_PROMPT = """A user has the following goal: {goal}
 
-Latest response: {last_response}
+The assistant just responded with: {last_response}
 
-Has the conversation achieved the specified goal? Answer only 'yes' or 'no'."""
+Has the user's goal been FULLY and COMPLETELY achieved? The goal should only be considered \
+achieved if the assistant has provided comprehensive, actionable information that fully \
+addresses what the user wanted to learn or accomplish. Simply mentioning the topic or \
+providing partial information is NOT enough.
+
+You must output your response as a valid JSON object with the following format:
+{{
+  "rationale": "Reason for the assessment. Explain whether the goal has been achieved and why.
+  Start each rationale with `Let's think step by step`",
+  "result": "yes|no"
+}}"""

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -1,0 +1,23 @@
+INITIAL_USER_PROMPT = """{persona}
+
+Your goal in this conversation is to: {goal}
+
+Start a conversation about this topic. Don't ask about your goal directly - \
+instead start with a broader question and let the conversation develop naturally."""
+
+FOLLOWUP_USER_PROMPT = """{persona}
+
+Your goal: {goal}
+
+Conversation so far:
+{conversation_history}
+
+They just said: {last_response}
+
+Respond naturally and guide the conversation toward your goal."""
+
+CHECK_GOAL_PROMPT = """Goal: {goal}
+
+Latest response: {last_response}
+
+Has the conversation achieved the specified goal? Answer only 'yes' or 'no'."""

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -1,3 +1,5 @@
+DEFAULT_PERSONA = "You are a helpful user having a natural conversation."
+
 INITIAL_USER_PROMPT = """{persona}
 
 Your goal in this conversation is to: {goal}

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -24,6 +24,9 @@ realistic user."""
 
 CHECK_GOAL_PROMPT = """A user has the following goal: {goal}
 
+Conversation so far:
+{conversation_history}
+
 The assistant just responded with: {last_response}
 
 Has the user's goal been FULLY and COMPLETELY achieved? The goal should only be considered \

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -1,0 +1,263 @@
+import logging
+from typing import Any, Callable
+from uuid import uuid4
+
+import pandas as pd
+
+import mlflow
+from mlflow.entities.span import SpanType
+from mlflow.entities.trace import Trace
+from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm_and_handle_tools
+from mlflow.tracing.constant import TraceMetadataKey
+from mlflow.types.llm import ChatMessage
+from mlflow.types.responses import ResponsesAgentResponse
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_PERSONA = "You are a helpful user having a natural conversation."
+
+
+def _parse_model_string(model: str) -> tuple[str, str]:
+    if "/" in model:
+        provider, model_name = model.split("/", 1)
+        return provider, model_name
+    return "openai", model
+
+
+class SimulatedUserAgent:
+    INITIAL_USER_PROMPT = (
+        "{persona}\n\n"
+        "Your goal in this conversation is to: {goal}\n\n"
+        "Start a conversation about this topic. Don't ask about your goal directly - "
+        "instead start with a broader question and let the conversation develop naturally."
+    )
+
+    FOLLOWUP_USER_PROMPT = (
+        "{persona}\n\n"
+        "Your goal: {goal}\n\n"
+        "Conversation so far:\n{conversation_history}\n\n"
+        "They just said: {last_response}\n\n"
+        "Respond naturally and guide the conversation toward your goal."
+    )
+
+    def __init__(
+        self,
+        goal: str,
+        persona: str | None = None,
+        model: str = "openai/gpt-4o-mini",
+        **inference_params,
+    ):
+        self.goal = goal
+        self.persona = persona or DEFAULT_PERSONA
+        self.model = model
+        self.inference_params = inference_params
+
+    def generate_message(
+        self,
+        conversation_history: list[dict[str, Any]],
+        turn: int = 0,
+    ) -> str:
+        if turn == 0:
+            prompt = self.INITIAL_USER_PROMPT.format(persona=self.persona, goal=self.goal)
+        else:
+            last_response = (
+                conversation_history[-1].get("content", "") if conversation_history else ""
+            )
+            history_str = (
+                self._format_history(conversation_history[:-1])
+                if len(conversation_history) > 1
+                else ""
+            )
+
+            prompt = self.FOLLOWUP_USER_PROMPT.format(
+                persona=self.persona,
+                goal=self.goal,
+                conversation_history=history_str,
+                last_response=last_response,
+            )
+
+        messages = [ChatMessage(role="user", content=prompt)]
+        provider, model_name = _parse_model_string(self.model)
+        response, _ = _invoke_litellm_and_handle_tools(
+            provider=provider,
+            model_name=model_name,
+            messages=messages,
+            trace=None,
+            num_retries=3,
+            inference_params=self.inference_params,
+        )
+        return response
+
+    def _format_history(self, history: list[dict[str, Any]]) -> str:
+        if not history:
+            return ""
+        formatted = []
+        for msg in history:
+            role = msg.get("role", "unknown")
+            content = msg.get("content", "")
+            formatted.append(f"{role}: {content}")
+        return "\n".join(formatted)
+
+
+class ConversationSimulator:
+    def __init__(
+        self,
+        test_cases: list[dict[str, Any]] | pd.DataFrame,
+        max_turns: int = 10,
+        user_model: str = "openai/gpt-4o-mini",
+        **user_llm_params,
+    ):
+        self.test_cases = self._normalize_test_cases(test_cases)
+        self.max_turns = max_turns
+        self.user_model = user_model
+        self.user_llm_params = user_llm_params
+
+    def _normalize_test_cases(
+        self, test_cases: list[dict[str, Any]] | pd.DataFrame
+    ) -> list[dict[str, Any]]:
+        if isinstance(test_cases, pd.DataFrame):
+            return test_cases.to_dict("records")
+        return test_cases
+
+    def simulate(self, predict_fn: Callable[..., dict[str, Any]]) -> list[Trace]:
+        if not self.test_cases:
+            raise ValueError("test_cases cannot be empty")
+
+        all_traces = []
+
+        for test_case in self.test_cases:
+            try:
+                traces = self._run_conversation(test_case, predict_fn)
+                all_traces.extend(traces)
+            except Exception as e:
+                _logger.error(
+                    f"Failed to run conversation for test case {test_case.get('goal')}: {e}"
+                )
+                continue
+
+        return all_traces
+
+    def _run_conversation(
+        self, test_case: dict[str, Any], predict_fn: Callable[..., dict[str, Any]]
+    ) -> list[Trace]:
+        goal = test_case.get("goal")
+        if not goal:
+            raise ValueError("Test case must have 'goal' field")
+
+        persona = test_case.get("persona")
+        context = test_case.get("context", {})
+
+        session_id = f"sim-{uuid4().hex[:16]}"
+
+        user_agent = SimulatedUserAgent(
+            goal=goal,
+            persona=persona,
+            model=self.user_model,
+            **self.user_llm_params,
+        )
+
+        conversation_history = []
+        traces = []
+
+        for turn in range(self.max_turns):
+            try:
+                user_message_content = user_agent.generate_message(conversation_history, turn)
+                user_message = {"role": "user", "content": user_message_content}
+                conversation_history.append(user_message)
+
+                with mlflow.start_span(
+                    name=f"conversation_turn_{turn}",
+                    span_type=SpanType.AGENT,
+                ):
+                    response = predict_fn(input=conversation_history, **context)
+
+                    if not isinstance(response, (dict, ResponsesAgentResponse)):
+                        raise ValueError(
+                            f"predict_fn must return ResponsesAgentResponse or dict, "
+                            f"got {type(response)}"
+                        )
+
+                    if isinstance(response, dict):
+                        response = ResponsesAgentResponse(**response)
+
+                    assistant_message = self._extract_assistant_message(response)
+                    conversation_history.append(assistant_message)
+
+                mlflow.update_current_trace(
+                    metadata={
+                        TraceMetadataKey.TRACE_SESSION: session_id,
+                        "mlflow.simulation.synthetic": "true",
+                        "mlflow.simulation.goal": goal,
+                        "mlflow.simulation.persona": (persona or DEFAULT_PERSONA)[:100],
+                        "mlflow.simulation.turn": str(turn),
+                    },
+                )
+
+                if trace_id := mlflow.get_last_active_trace_id():
+                    trace = mlflow.get_trace(trace_id)
+                    traces.append(trace)
+
+                assistant_content = assistant_message.get("content", "")
+                if not assistant_content or not assistant_content.strip():
+                    _logger.info(f"Stopping conversation: empty response at turn {turn}")
+                    break
+
+                if self._check_goal_achieved(conversation_history, goal):
+                    _logger.info(f"Stopping conversation: goal achieved at turn {turn}")
+                    break
+
+            except Exception as e:
+                _logger.error(f"Error during turn {turn}: {e}")
+                break
+
+        return traces
+
+    def _extract_assistant_message(self, response: ResponsesAgentResponse) -> dict[str, Any]:
+        texts = []
+        for output_item in response.output:
+            output_dict = output_item if isinstance(output_item, dict) else output_item.model_dump()
+            if output_dict.get("type") == "message" and output_dict.get("role") == "assistant":
+                for content_item in output_dict.get("content", []):
+                    content_dict = (
+                        content_item
+                        if isinstance(content_item, dict)
+                        else content_item.model_dump()
+                    )
+                    if content_dict.get("type") == "output_text":
+                        texts.append(content_dict.get("text", ""))
+
+        return {"role": "assistant", "content": "".join(texts)}
+
+    def _check_goal_achieved(self, conversation_history: list[dict[str, Any]], goal: str) -> bool:
+        last_assistant_message = None
+        for msg in reversed(conversation_history):
+            if msg.get("role") == "assistant":
+                last_assistant_message = msg.get("content", "")
+                break
+
+        if not last_assistant_message:
+            return False
+
+        eval_prompt = f"""Goal: {goal}
+
+Latest response: {last_assistant_message}
+
+Has the conversation achieved the specified goal? Answer only 'yes' or 'no'."""
+
+        messages = [ChatMessage(role="user", content=eval_prompt)]
+
+        try:
+            provider, model_name = _parse_model_string(self.user_model)
+            response, _ = _invoke_litellm_and_handle_tools(
+                provider=provider,
+                model_name=model_name,
+                messages=messages,
+                trace=None,
+                num_retries=3,
+                inference_params={"temperature": 0.0, "max_tokens": 10},
+            )
+
+            return response.strip().lower().startswith("yes")
+        except Exception as e:
+            _logger.warning(f"Goal achievement check failed: {e}")
+            return False

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 _MAX_METADATA_LENGTH = 250
+_EXPECTED_TEST_CASE_KEYS = {"goal", "persona", "context"}
 
 _MODEL_API_DOC = {
     "model": """Model to use for generating user messages. Must be one of:
@@ -302,6 +303,17 @@ class ConversationSimulator:
         ]
         if missing_goal_indices:
             raise ValueError(f"Test cases at indices {missing_goal_indices} must have 'goal' field")
+
+        indices_with_extra_keys = [
+            i
+            for i, test_case in enumerate(self.test_cases)
+            if set(test_case.keys()) - _EXPECTED_TEST_CASE_KEYS
+        ]
+        if indices_with_extra_keys:
+            _logger.warning(
+                f"Test cases at indices {indices_with_extra_keys} contain unexpected keys "
+                f"which will be ignored. Expected keys: {_EXPECTED_TEST_CASE_KEYS}."
+            )
 
     def _simulate(self, predict_fn: Callable[..., dict[str, Any]]) -> list[list[str]]:
         num_test_cases = len(self.test_cases)

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -1,15 +1,17 @@
 import logging
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable
 
 import pandas as pd
+import pydantic
 
 import mlflow
-from mlflow.entities.trace import Trace
+from mlflow.environment_variables import MLFLOW_GENAI_EVAL_MAX_WORKERS
 from mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter import (
     _invoke_databricks_serving_endpoint,
 )
-from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm_and_handle_tools
 from mlflow.genai.judges.utils import get_default_model
 from mlflow.genai.simulators.prompts import (
     CHECK_GOAL_PROMPT,
@@ -17,13 +19,12 @@ from mlflow.genai.simulators.prompts import (
     FOLLOWUP_USER_PROMPT,
     INITIAL_USER_PROMPT,
 )
+from mlflow.genai.utils.trace_utils import parse_outputs_to_str
 from mlflow.metrics.genai.model_utils import _parse_model_uri
 from mlflow.tracing.constant import TraceMetadataKey
-from mlflow.tracing.utils.truncation import (
-    _get_text_content_from_message,
-    _try_extract_messages,
-)
+from mlflow.tracing.provider import trace_disabled
 from mlflow.utils.annotations import experimental
+from mlflow.utils.docstring_utils import format_docstring
 
 if TYPE_CHECKING:
     from mlflow.types.llm import ChatMessage
@@ -32,15 +33,51 @@ _logger = logging.getLogger(__name__)
 
 _MAX_METADATA_LENGTH = 250
 
+_MODEL_API_DOC = {
+    "user_model": """User model to use for generating user messages. Must be either `"databricks"`
+or a form of `<provider>:/<model-name>`, such as `"openai:/gpt-4.1-mini"`,
+`"anthropic:/claude-3.5-sonnet-20240620"`. MLflow natively supports
+`["openai", "anthropic", "bedrock", "mistral"]`, and more providers are supported
+through `LiteLLM <https://docs.litellm.ai/docs/providers>`_.
+Default model depends on the tracking URI setup:
 
+* Databricks: `databricks`
+* Otherwise: `openai:/gpt-4.1-mini`.
+""",
+}
+
+
+class GoalCheckResult(pydantic.BaseModel):
+    """Structured output for goal achievement check."""
+
+    rationale: str = pydantic.Field(
+        description="Reason for the assessment explaining whether the goal has been achieved"
+    )
+    result: str = pydantic.Field(description="'yes' if goal achieved, 'no' otherwise")
+
+
+@contextmanager
+def _suppress_tracing_warnings():
+    tracing_logger = logging.getLogger("mlflow.tracing.fluent")
+    original_level = tracing_logger.level
+    tracing_logger.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        tracing_logger.setLevel(original_level)
+
+
+@trace_disabled  # Suppress tracing for our LLM (e.g., user message generation, stopping condition)
 def _invoke_model(
     model_uri: str,
     messages: list["ChatMessage"],
     num_retries: int = 3,
     inference_params: dict[str, Any] | None = None,
-) -> str:
-    provider, model_name = _parse_model_uri(model_uri)
+    response_format: type[pydantic.BaseModel] | None = None,
+) -> str | pydantic.BaseModel:
+    import litellm
 
+    provider, model_name = _parse_model_uri(model_uri)
     if provider in {"databricks", "endpoints"}:
         output = _invoke_databricks_serving_endpoint(
             model_name=model_name,
@@ -48,26 +85,29 @@ def _invoke_model(
             num_retries=num_retries,
             inference_params=inference_params,
         )
-        return output.response
+        content = output.response
+        if response_format:
+            return response_format.model_validate_json(content)
+        return content
 
-    response, _ = _invoke_litellm_and_handle_tools(
-        provider=provider,
-        model_name=model_name,
-        messages=messages,
-        trace=None,
-        num_retries=num_retries,
-        inference_params=inference_params,
-    )
-    return response
+    litellm_messages = [litellm.Message(role=msg.role, content=msg.content) for msg in messages]
 
+    kwargs = {
+        "model": f"{provider}/{model_name}",
+        "messages": litellm_messages,
+        "max_retries": num_retries,
+    }
+    if inference_params:
+        kwargs.update(inference_params)
+    if response_format:
+        kwargs["response_format"] = response_format
 
-def _extract_assistant_content(response: dict[str, Any]) -> str | None:
-    if messages := _try_extract_messages(response):
-        for msg in reversed(messages):
-            if msg.get("role") == "assistant":
-                return _get_text_content_from_message(msg)
-        return _get_text_content_from_message(messages[-1])
-    return None
+    response = litellm.completion(**kwargs)
+    content = response.choices[0].message.content
+
+    if response_format:
+        return response_format.model_validate_json(content)
+    return content
 
 
 def _get_last_response(conversation_history: list[dict[str, Any]]) -> str | None:
@@ -79,7 +119,8 @@ def _get_last_response(conversation_history: list[dict[str, Any]]) -> str | None
     if isinstance(content, str) and content:
         return content
 
-    if result := _extract_assistant_content(last_msg):
+    result = parse_outputs_to_str(last_msg)
+    if result and result.strip():
         return result
 
     return _format_history(conversation_history)
@@ -98,6 +139,21 @@ def _format_history(history: list[dict[str, Any]]) -> str | None:
 
 @experimental(version="3.9.0")
 class SimulatedUserAgent:
+    """
+    An LLM-powered agent that simulates user behavior in conversations.
+
+    The agent generates realistic user messages based on a specified goal and persona,
+    enabling automated testing of conversational AI systems.
+
+    Args:
+        goal: The objective the simulated user is trying to achieve in the conversation.
+        persona: Description of the user's personality and background. If None, uses a
+            default helpful user persona.
+        model: Model URI for generating messages (e.g., "openai:/gpt-4o-mini").
+            If None, uses the default model.
+        **inference_params: Additional parameters passed to the LLM (e.g., temperature).
+    """
+
     def __init__(
         self,
         goal: str,
@@ -115,6 +171,8 @@ class SimulatedUserAgent:
         conversation_history: list[dict[str, Any]],
         turn: int = 0,
     ) -> str:
+        from mlflow.types.llm import ChatMessage
+
         if turn == 0:
             prompt = INITIAL_USER_PROMPT.format(persona=self.persona, goal=self.goal)
         else:
@@ -127,8 +185,6 @@ class SimulatedUserAgent:
                 last_response=last_response if last_response is not None else "",
             )
 
-        from mlflow.types.llm import ChatMessage
-
         messages = [ChatMessage(role="user", content=prompt)]
         return _invoke_model(
             model_uri=self.model,
@@ -138,8 +194,42 @@ class SimulatedUserAgent:
         )
 
 
+@format_docstring(_MODEL_API_DOC)
 @experimental(version="3.9.0")
 class ConversationSimulator:
+    """
+    Generates multi-turn conversations by simulating user interactions with a target agent.
+
+    The simulator creates a simulated user agent that interacts with your agent's predict function.
+    Each conversation is traced in MLflow, allowing you to evaluate how your agent handles
+    various user goals and personas.
+
+    Args:
+        test_cases: List of test case dictionaries or DataFrame. Each test case must have a
+            "goal" field describing what the simulated user wants to achieve. Optional fields:
+            - "persona": Custom persona for the simulated user
+            - "context": Dict of additional kwargs to pass to predict_fn
+        max_turns: Maximum number of conversation turns before stopping. Default is 10.
+        user_model: {{ user_model }}
+        **user_llm_params: Additional parameters passed to the simulated user's LLM calls.
+
+    Example:
+        .. code-block:: python
+            from mlflow.genai.simulators import ConversationSimulator
+
+            simulator = ConversationSimulator(
+                test_cases=[
+                    {"goal": "Learn about MLflow tracking", "persona": "A beginner data scientist"},
+                    {
+                        "goal": "Debug a model deployment issue",
+                        "persona": "An experienced ML engineer",
+                    },
+                ],
+                max_turns=5,
+                user_model="openai:/gpt-4o-mini",
+            )
+    """
+
     def __init__(
         self,
         test_cases: list[dict[str, Any]] | pd.DataFrame,
@@ -164,32 +254,47 @@ class ConversationSimulator:
         if not self.test_cases:
             raise ValueError("test_cases cannot be empty")
 
-        for i, test_case in enumerate(self.test_cases):
-            if not test_case.get("goal"):
-                raise ValueError(f"Test case at index {i} must have 'goal' field")
+        missing_goal_indices = [
+            i for i, test_case in enumerate(self.test_cases) if not test_case.get("goal")
+        ]
+        if missing_goal_indices:
+            raise ValueError(f"Test cases at indices {missing_goal_indices} must have 'goal' field")
 
-    def _simulate(self, predict_fn: Callable[..., dict[str, Any]]) -> list[list[Trace]]:
-        all_traces = []
+    def _simulate(self, predict_fn: Callable[..., dict[str, Any]]) -> list[list[str]]:
+        num_test_cases = len(self.test_cases)
+        all_trace_ids: list[list[str] | None] = [None] * num_test_cases
+        max_workers = min(num_test_cases, MLFLOW_GENAI_EVAL_MAX_WORKERS.get())
 
-        for test_case in self.test_cases:
-            try:
-                traces = self._run_conversation(test_case, predict_fn)
-                all_traces.append(traces)
-            except Exception as e:
-                _logger.error(
-                    f"Failed to run conversation for test case {test_case.get('goal')}: {e}"
-                )
+        with ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="MlflowConversationSimulator",
+        ) as executor:
+            futures = {
+                executor.submit(self._run_conversation, test_case, predict_fn): i
+                for i, test_case in enumerate(self.test_cases)
+            }
 
-        return all_traces
+            for future in as_completed(futures):
+                idx = futures[future]
+                test_case = self.test_cases[idx]
+                try:
+                    trace_ids = future.result()
+                    all_trace_ids[idx] = trace_ids
+                except Exception as e:
+                    _logger.error(
+                        f"Failed to run conversation for test case {test_case.get('goal')}: {e}"
+                    )
+                    all_trace_ids[idx] = []
+
+        return [ids for ids in all_trace_ids if ids is not None]
 
     def _run_conversation(
         self, test_case: dict[str, Any], predict_fn: Callable[..., dict[str, Any]]
-    ) -> list[Trace]:
+    ) -> list[str]:
         goal = test_case["goal"]
         persona = test_case.get("persona")
         context = test_case.get("context", {})
-
-        session_id = f"sim-{uuid.uuid4().hex[:16]}"
+        trace_session_id = f"sim-{uuid.uuid4().hex[:16]}"
 
         user_agent = SimulatedUserAgent(
             goal=goal,
@@ -199,38 +304,35 @@ class ConversationSimulator:
         )
 
         conversation_history: list[dict[str, Any]] = []
-        traces: list[Trace] = []
-
-        wrapped_predict = self._wrap_predict_fn(
-            predict_fn=predict_fn,
-            session_id=session_id,
-            goal=goal,
-            persona=persona,
-        )
+        trace_ids: list[str] = []
 
         for turn in range(self.max_turns):
             try:
+                # Generate a user message using the simulated user agent.
                 user_message_content = user_agent.generate_message(conversation_history, turn)
                 user_message = {"role": "user", "content": user_message_content}
                 conversation_history.append(user_message)
 
-                response, trace = wrapped_predict(
+                # Invoke the predict_fn with the user message and context.
+                response, trace_id = self._invoke_predict_fn(
+                    predict_fn=predict_fn,
                     input_messages=conversation_history,
+                    trace_session_id=trace_session_id,
+                    goal=goal,
+                    persona=persona,
                     turn=turn,
                     **context,
                 )
 
-                if trace:
-                    traces.append(trace)
+                if trace_id:
+                    trace_ids.append(trace_id)
 
-                assistant_content = _extract_assistant_content(response)
-                assistant_message = {"role": "assistant", "content": assistant_content or ""}
-                conversation_history.append(assistant_message)
-
+                # Parse the assistant's response and check if the goal has been achieved.
+                assistant_content = parse_outputs_to_str(response)
                 if not assistant_content or not assistant_content.strip():
                     _logger.debug(f"Stopping conversation: empty response at turn {turn}")
                     break
-
+                conversation_history.append({"role": "assistant", "content": assistant_content})
                 if self._check_goal_achieved(assistant_content, goal):
                     _logger.debug(f"Stopping conversation: goal achieved at turn {turn}")
                     break
@@ -239,62 +341,57 @@ class ConversationSimulator:
                 _logger.error(f"Error during turn {turn}: {e}")
                 break
 
-        return traces
+        return trace_ids
 
-    def _wrap_predict_fn(
+    def _invoke_predict_fn(
         self,
         predict_fn: Callable[..., dict[str, Any]],
-        session_id: str,
+        input_messages: list[dict[str, Any]],
+        trace_session_id: str,
         goal: str,
         persona: str | None,
-    ) -> Callable[..., tuple[dict[str, Any], Trace | None]]:
-        def wrapped(
-            input_messages: list[dict[str, Any]],
-            turn: int,
-            **context,
-        ) -> tuple[dict[str, Any], Trace | None]:
-            @mlflow.trace(name=f"simulation_turn_{turn}")
-            def traced_predict():
-                mlflow.update_current_trace(
-                    metadata={
-                        TraceMetadataKey.TRACE_SESSION: session_id,
-                        "mlflow.simulation.synthetic": "true",
-                        "mlflow.simulation.goal": goal[:_MAX_METADATA_LENGTH],
-                        "mlflow.simulation.persona": (persona or DEFAULT_PERSONA)[
-                            :_MAX_METADATA_LENGTH
-                        ],
-                        "mlflow.simulation.turn": str(turn),
-                    },
-                )
-                return predict_fn(input=input_messages, **context)
+        turn: int,
+        **context,
+    ) -> tuple[dict[str, Any], str | None]:
+        # NB: We trace the predict_fn call to add session and simulation metadata to the trace.
+        #     This adds a new root span to the trace, with the same inputs and outputs as the
+        #     predict_fn call.
+        @mlflow.trace(name=f"simulation_turn_{turn}")
+        def traced_predict(input: list[dict[str, Any]], **context):
+            mlflow.update_current_trace(
+                metadata={
+                    TraceMetadataKey.TRACE_SESSION: trace_session_id,
+                    "mlflow.simulation.synthetic": "true",
+                    "mlflow.simulation.goal": goal[:_MAX_METADATA_LENGTH],
+                    "mlflow.simulation.persona": (persona or DEFAULT_PERSONA)[
+                        :_MAX_METADATA_LENGTH
+                    ],
+                    "mlflow.simulation.turn": str(turn),
+                },
+            )
+            return predict_fn(input=input, **context)
 
-            response = traced_predict()
-            trace_id = mlflow.get_last_active_trace_id(thread_local=True)
-            trace = mlflow.get_trace(trace_id) if trace_id else None
-
-            return response, trace
-
-        return wrapped
+        response = traced_predict(input=input_messages, **context)
+        return response, mlflow.get_last_active_trace_id(thread_local=True)
 
     def _check_goal_achieved(self, last_response: str, goal: str) -> bool:
-        if not last_response:
-            return False
-
         from mlflow.types.llm import ChatMessage
 
         eval_prompt = CHECK_GOAL_PROMPT.format(goal=goal, last_response=last_response)
-
         messages = [ChatMessage(role="user", content=eval_prompt)]
 
         try:
-            response = _invoke_model(
+            text_result = _invoke_model(
                 model_uri=self.user_model,
                 messages=messages,
                 num_retries=3,
-                inference_params={"temperature": 0.0, "max_tokens": 10},
+                inference_params={"temperature": 0.0},
             )
-
-            return response.strip().lower().startswith("yes")
+            result = GoalCheckResult.model_validate_json(text_result)
+            return result.result.strip().lower() == "yes"
+        except pydantic.ValidationError:
+            _logger.warning("Goal achievement check: could not parse response")
+            return False
         except Exception as e:
             _logger.warning(f"Goal achievement check failed: {e}")
             return False

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -1,50 +1,47 @@
 import logging
+import uuid
 from typing import Any, Callable
-from uuid import uuid4
 
 import pandas as pd
 
 import mlflow
-from mlflow.entities.span import SpanType
 from mlflow.entities.trace import Trace
 from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm_and_handle_tools
+from mlflow.genai.simulators.prompts import (
+    CHECK_GOAL_PROMPT,
+    FOLLOWUP_USER_PROMPT,
+    INITIAL_USER_PROMPT,
+)
+from mlflow.metrics.genai.model_utils import _parse_model_uri
 from mlflow.tracing.constant import TraceMetadataKey
+from mlflow.tracing.utils.truncation import (
+    _get_text_content_from_message,
+    _try_extract_messages,
+)
 from mlflow.types.llm import ChatMessage
-from mlflow.types.responses import ResponsesAgentResponse
+from mlflow.utils.annotations import experimental
 
 _logger = logging.getLogger(__name__)
 
 DEFAULT_PERSONA = "You are a helpful user having a natural conversation."
 
 
-def _parse_model_string(model: str) -> tuple[str, str]:
-    if "/" in model:
-        provider, model_name = model.split("/", 1)
-        return provider, model_name
-    return "openai", model
+def _extract_assistant_content(response: dict[str, Any]) -> str:
+    if messages := _try_extract_messages(response):
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant":
+                return _get_text_content_from_message(msg)
+        return _get_text_content_from_message(messages[-1])
+    return ""
 
 
+@experimental(version="3.9.0")
 class SimulatedUserAgent:
-    INITIAL_USER_PROMPT = (
-        "{persona}\n\n"
-        "Your goal in this conversation is to: {goal}\n\n"
-        "Start a conversation about this topic. Don't ask about your goal directly - "
-        "instead start with a broader question and let the conversation develop naturally."
-    )
-
-    FOLLOWUP_USER_PROMPT = (
-        "{persona}\n\n"
-        "Your goal: {goal}\n\n"
-        "Conversation so far:\n{conversation_history}\n\n"
-        "They just said: {last_response}\n\n"
-        "Respond naturally and guide the conversation toward your goal."
-    )
-
     def __init__(
         self,
         goal: str,
         persona: str | None = None,
-        model: str = "openai/gpt-4o-mini",
+        model: str = "openai:/gpt-4o-mini",
         **inference_params,
     ):
         self.goal = goal
@@ -58,18 +55,11 @@ class SimulatedUserAgent:
         turn: int = 0,
     ) -> str:
         if turn == 0:
-            prompt = self.INITIAL_USER_PROMPT.format(persona=self.persona, goal=self.goal)
+            prompt = INITIAL_USER_PROMPT.format(persona=self.persona, goal=self.goal)
         else:
-            last_response = (
-                conversation_history[-1].get("content", "") if conversation_history else ""
-            )
-            history_str = (
-                self._format_history(conversation_history[:-1])
-                if len(conversation_history) > 1
-                else ""
-            )
-
-            prompt = self.FOLLOWUP_USER_PROMPT.format(
+            last_response = self._get_last_response(conversation_history)
+            history_str = self._format_history(conversation_history[:-1])
+            prompt = FOLLOWUP_USER_PROMPT.format(
                 persona=self.persona,
                 goal=self.goal,
                 conversation_history=history_str,
@@ -77,7 +67,7 @@ class SimulatedUserAgent:
             )
 
         messages = [ChatMessage(role="user", content=prompt)]
-        provider, model_name = _parse_model_string(self.model)
+        provider, model_name = _parse_model_uri(self.model)
         response, _ = _invoke_litellm_and_handle_tools(
             provider=provider,
             model_name=model_name,
@@ -87,6 +77,21 @@ class SimulatedUserAgent:
             inference_params=self.inference_params,
         )
         return response
+
+    def _get_last_response(self, conversation_history: list[dict[str, Any]]) -> str:
+        if not conversation_history:
+            return ""
+
+        last_msg = conversation_history[-1]
+        content = last_msg.get("content", "")
+        if isinstance(content, str) and content:
+            return content
+
+        result = _extract_assistant_content(last_msg)
+        if result and result.strip():
+            return result
+
+        return self._format_history(conversation_history)
 
     def _format_history(self, history: list[dict[str, Any]]) -> str:
         if not history:
@@ -99,15 +104,17 @@ class SimulatedUserAgent:
         return "\n".join(formatted)
 
 
+@experimental(version="3.9.0")
 class ConversationSimulator:
     def __init__(
         self,
         test_cases: list[dict[str, Any]] | pd.DataFrame,
         max_turns: int = 10,
-        user_model: str = "openai/gpt-4o-mini",
+        user_model: str = "openai:/gpt-4o-mini",
         **user_llm_params,
     ):
         self.test_cases = self._normalize_test_cases(test_cases)
+        self._validate_test_cases()
         self.max_turns = max_turns
         self.user_model = user_model
         self.user_llm_params = user_llm_params
@@ -119,35 +126,37 @@ class ConversationSimulator:
             return test_cases.to_dict("records")
         return test_cases
 
-    def simulate(self, predict_fn: Callable[..., dict[str, Any]]) -> list[Trace]:
+    def _validate_test_cases(self) -> None:
         if not self.test_cases:
             raise ValueError("test_cases cannot be empty")
 
+        for i, test_case in enumerate(self.test_cases):
+            if not test_case.get("goal"):
+                raise ValueError(f"Test case at index {i} must have 'goal' field")
+
+    def _simulate(self, predict_fn: Callable[..., dict[str, Any]]) -> list[list[Trace]]:
         all_traces = []
 
         for test_case in self.test_cases:
             try:
                 traces = self._run_conversation(test_case, predict_fn)
-                all_traces.extend(traces)
+                all_traces.append(traces)
             except Exception as e:
                 _logger.error(
                     f"Failed to run conversation for test case {test_case.get('goal')}: {e}"
                 )
-                continue
+                all_traces.append([])
 
         return all_traces
 
     def _run_conversation(
         self, test_case: dict[str, Any], predict_fn: Callable[..., dict[str, Any]]
     ) -> list[Trace]:
-        goal = test_case.get("goal")
-        if not goal:
-            raise ValueError("Test case must have 'goal' field")
-
+        goal = test_case["goal"]
         persona = test_case.get("persona")
         context = test_case.get("context", {})
 
-        session_id = f"sim-{uuid4().hex[:16]}"
+        session_id = f"sim-{uuid.uuid4().hex[:16]}"
 
         user_agent = SimulatedUserAgent(
             goal=goal,
@@ -156,8 +165,15 @@ class ConversationSimulator:
             **self.user_llm_params,
         )
 
-        conversation_history = []
-        traces = []
+        conversation_history: list[dict[str, Any]] = []
+        traces: list[Trace] = []
+
+        wrapped_predict = self._wrap_predict_fn(
+            predict_fn=predict_fn,
+            session_id=session_id,
+            goal=goal,
+            persona=persona,
+        )
 
         for turn in range(self.max_turns):
             try:
@@ -165,44 +181,24 @@ class ConversationSimulator:
                 user_message = {"role": "user", "content": user_message_content}
                 conversation_history.append(user_message)
 
-                with mlflow.start_span(
-                    name=f"conversation_turn_{turn}",
-                    span_type=SpanType.AGENT,
-                ):
-                    response = predict_fn(input=conversation_history, **context)
-
-                    if not isinstance(response, (dict, ResponsesAgentResponse)):
-                        raise ValueError(
-                            f"predict_fn must return ResponsesAgentResponse or dict, "
-                            f"got {type(response)}"
-                        )
-
-                    if isinstance(response, dict):
-                        response = ResponsesAgentResponse(**response)
-
-                    assistant_message = self._extract_assistant_message(response)
-                    conversation_history.append(assistant_message)
-
-                mlflow.update_current_trace(
-                    metadata={
-                        TraceMetadataKey.TRACE_SESSION: session_id,
-                        "mlflow.simulation.synthetic": "true",
-                        "mlflow.simulation.goal": goal,
-                        "mlflow.simulation.persona": (persona or DEFAULT_PERSONA)[:100],
-                        "mlflow.simulation.turn": str(turn),
-                    },
+                response, trace = wrapped_predict(
+                    input_messages=conversation_history,
+                    turn=turn,
+                    **context,
                 )
 
-                if trace_id := mlflow.get_last_active_trace_id():
-                    trace = mlflow.get_trace(trace_id)
+                if trace:
                     traces.append(trace)
 
-                assistant_content = assistant_message.get("content", "")
+                assistant_content = _extract_assistant_content(response)
+                assistant_message = {"role": "assistant", "content": assistant_content}
+                conversation_history.append(assistant_message)
+
                 if not assistant_content or not assistant_content.strip():
                     _logger.info(f"Stopping conversation: empty response at turn {turn}")
                     break
 
-                if self._check_goal_achieved(conversation_history, goal):
+                if self._check_goal_achieved(assistant_content, goal):
                     _logger.info(f"Stopping conversation: goal achieved at turn {turn}")
                     break
 
@@ -212,42 +208,49 @@ class ConversationSimulator:
 
         return traces
 
-    def _extract_assistant_message(self, response: ResponsesAgentResponse) -> dict[str, Any]:
-        texts = []
-        for output_item in response.output:
-            output_dict = output_item if isinstance(output_item, dict) else output_item.model_dump()
-            if output_dict.get("type") == "message" and output_dict.get("role") == "assistant":
-                for content_item in output_dict.get("content", []):
-                    content_dict = (
-                        content_item
-                        if isinstance(content_item, dict)
-                        else content_item.model_dump()
-                    )
-                    if content_dict.get("type") == "output_text":
-                        texts.append(content_dict.get("text", ""))
+    def _wrap_predict_fn(
+        self,
+        predict_fn: Callable[..., dict[str, Any]],
+        session_id: str,
+        goal: str,
+        persona: str | None,
+    ) -> Callable[..., tuple[dict[str, Any], Trace | None]]:
+        def wrapped(
+            input_messages: list[dict[str, Any]],
+            turn: int,
+            **context,
+        ) -> tuple[dict[str, Any], Trace | None]:
+            @mlflow.trace(name=f"simulation_turn_{turn}")
+            def traced_predict():
+                mlflow.update_current_trace(
+                    metadata={
+                        TraceMetadataKey.TRACE_SESSION: session_id,
+                        "mlflow.simulation.synthetic": "true",
+                        "mlflow.simulation.goal": goal,
+                        "mlflow.simulation.persona": (persona or DEFAULT_PERSONA)[:100],
+                        "mlflow.simulation.turn": str(turn),
+                    },
+                )
+                return predict_fn(input=input_messages, **context)
 
-        return {"role": "assistant", "content": "".join(texts)}
+            response = traced_predict()
+            trace_id = mlflow.get_last_active_trace_id()
+            trace = mlflow.get_trace(trace_id) if trace_id else None
 
-    def _check_goal_achieved(self, conversation_history: list[dict[str, Any]], goal: str) -> bool:
-        last_assistant_message = None
-        for msg in reversed(conversation_history):
-            if msg.get("role") == "assistant":
-                last_assistant_message = msg.get("content", "")
-                break
+            return response, trace
 
-        if not last_assistant_message:
+        return wrapped
+
+    def _check_goal_achieved(self, last_response: str, goal: str) -> bool:
+        if not last_response:
             return False
 
-        eval_prompt = f"""Goal: {goal}
-
-Latest response: {last_assistant_message}
-
-Has the conversation achieved the specified goal? Answer only 'yes' or 'no'."""
+        eval_prompt = CHECK_GOAL_PROMPT.format(goal=goal, last_response=last_response)
 
         messages = [ChatMessage(role="user", content=eval_prompt)]
 
         try:
-            provider, model_name = _parse_model_string(self.user_model)
+            provider, model_name = _parse_model_uri(self.user_model)
             response, _ = _invoke_litellm_and_handle_tools(
                 provider=provider,
                 model_name=model_name,

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -401,13 +401,13 @@ class ConversationSimulator:
     ) -> tuple[dict[str, Any], str | None]:
         # NB: We trace the predict_fn call to add session and simulation metadata to the trace.
         #     This adds a new root span to the trace, with the same inputs and outputs as the
-        #     predict_fn call.
+        #     predict_fn call. The goal/persona/turn metadata is used for trace comparison UI
+        #     since message content may differ between simulation runs.
         @mlflow.trace(name=f"simulation_turn_{turn}", span_type="CHAIN")
         def traced_predict(input: list[dict[str, Any]], **context):
             mlflow.update_current_trace(
                 metadata={
                     TraceMetadataKey.TRACE_SESSION: trace_session_id,
-                    "mlflow.simulation.synthetic": "true",
                     "mlflow.simulation.goal": goal[:_MAX_METADATA_LENGTH],
                     "mlflow.simulation.persona": (persona or DEFAULT_PERSONA)[
                         :_MAX_METADATA_LENGTH

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -52,6 +52,7 @@ _MESSAGE_KEY = "message"
 _MESSAGES_KEY = "messages"
 _CHOICES_KEY = "choices"
 _CONTENT_KEY = "content"
+_OUTPUT_KEY = "output"
 
 
 def extract_request_from_trace(trace: Trace) -> str | None:
@@ -614,9 +615,37 @@ def parse_outputs_to_str(value: Any) -> str:
         content = value[_CHOICES_KEY][0][_MESSAGE_KEY][_CONTENT_KEY]
     elif _is_chat_messages(value.get(_MESSAGES_KEY)):
         content = value[_MESSAGES_KEY][-1][_CONTENT_KEY]
+    elif _is_responses_api_output(value.get(_OUTPUT_KEY)):
+        content = _extract_responses_api_content(value[_OUTPUT_KEY])
     else:
         content = json.dumps(value, cls=TraceJSONEncoder)
     return content
+
+
+def _is_responses_api_output(maybe_output: Any) -> bool:
+    """Check if the value is an OpenAI Responses API output format."""
+    if not maybe_output or not isinstance(maybe_output, list) or len(maybe_output) == 0:
+        return False
+    last_item = maybe_output[-1]
+    return (
+        isinstance(last_item, dict)
+        and last_item.get("type") == "message"
+        and "content" in last_item
+    )
+
+
+def _extract_responses_api_content(output: list[dict[str, Any]]) -> str:
+    """Extract text content from OpenAI Responses API output format."""
+    for item in reversed(output):
+        if item.get("role") == "assistant" and "content" in item:
+            content = item["content"]
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") in ("text", "output_text"):
+                        return part.get("text", json.dumps(output))
+    return json.dumps(output)
 
 
 def _is_chat_choices(maybe_choices: Any) -> bool:

--- a/tests/genai/simulators/conftest.py
+++ b/tests/genai/simulators/conftest.py
@@ -1,0 +1,75 @@
+import pytest
+
+
+@pytest.fixture
+def mock_llm_response():
+    return "This is a test response from the user agent."
+
+
+@pytest.fixture
+def mock_predict_fn():
+    def predict_fn(input=None, messages=None, context=None):
+        return {
+            "output": [
+                {
+                    "id": "msg_123",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "This is a mock response from the agent.",
+                        }
+                    ],
+                }
+            ]
+        }
+
+    return predict_fn
+
+
+@pytest.fixture
+def mock_predict_fn_with_context():
+    def predict_fn(input=None, messages=None, **kwargs):
+        context_info = f" Context: {kwargs}" if kwargs else ""
+
+        return {
+            "output": [
+                {
+                    "id": "msg_123",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": f"Mock response.{context_info}",
+                        }
+                    ],
+                }
+            ]
+        }
+
+    return predict_fn
+
+
+@pytest.fixture
+def simple_test_case():
+    return {
+        "goal": "Learn about MLflow tracing",
+    }
+
+
+@pytest.fixture
+def test_case_with_persona():
+    return {
+        "goal": "Understand model deployment",
+        "persona": "You are an expert who asks direct questions.",
+    }
+
+
+@pytest.fixture
+def test_case_with_context():
+    return {
+        "goal": "Debug an error",
+        "context": {"user_id": "U001", "session_id": "S001"},
+    }

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -1,0 +1,277 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mlflow.genai.simulators import ConversationSimulator
+from mlflow.genai.simulators.simulator import SimulatedUserAgent
+
+
+def test_simulated_user_agent_generate_initial_message():
+    with patch("mlflow.genai.simulators.simulator._invoke_litellm_and_handle_tools") as mock_invoke:
+        mock_invoke.return_value = ("Hello, I have a question about ML.", None)
+
+        agent = SimulatedUserAgent(
+            goal="Learn about MLflow",
+            persona="You are a beginner who asks curious questions.",
+            model="openai/gpt-4o-mini",
+        )
+
+        message = agent.generate_message([], turn=0)
+
+        assert message == "Hello, I have a question about ML."
+        mock_invoke.assert_called_once()
+
+        call_args = mock_invoke.call_args
+        messages = call_args.kwargs["messages"]
+        prompt = messages[0].content
+
+        assert "Learn about MLflow" in prompt
+        assert "beginner" in prompt
+
+
+def test_simulated_user_agent_generate_followup_message():
+    with patch("mlflow.genai.simulators.simulator._invoke_litellm_and_handle_tools") as mock_invoke:
+        mock_invoke.return_value = ("Can you tell me more?", None)
+
+        agent = SimulatedUserAgent(
+            goal="Learn about MLflow",
+            model="openai/gpt-4o-mini",
+        )
+
+        history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        message = agent.generate_message(history, turn=1)
+
+        assert message == "Can you tell me more?"
+        mock_invoke.assert_called_once()
+
+        call_args = mock_invoke.call_args
+        messages = call_args.kwargs["messages"]
+        prompt = messages[0].content
+
+        assert "Hi there!" in prompt
+
+
+def test_simulated_user_agent_default_persona():
+    with patch("mlflow.genai.simulators.simulator._invoke_litellm_and_handle_tools") as mock_invoke:
+        mock_invoke.return_value = ("Test message", None)
+
+        agent = SimulatedUserAgent(
+            goal="Learn about ML",
+            model="openai/gpt-4o-mini",
+        )
+
+        message = agent.generate_message([], turn=0)
+
+        assert message == "Test message"
+
+        call_args = mock_invoke.call_args
+        messages = call_args.kwargs["messages"]
+        prompt = messages[0].content
+
+        assert "helpful user" in prompt.lower()
+
+
+def test_conversation_simulator_basic_simulation(simple_test_case, mock_predict_fn):
+    with (
+        patch("mlflow.genai.simulators.simulator._invoke_litellm_and_handle_tools") as mock_invoke,
+        patch("mlflow.start_span") as mock_start_span,
+        patch("mlflow.get_last_active_trace_id") as mock_get_trace_id,
+        patch("mlflow.update_current_trace") as mock_update_current_trace,
+        patch("mlflow.get_trace") as mock_get_trace,
+    ):
+        mock_invoke.side_effect = [
+            ("What is MLflow?", None),
+            ("no", None),
+            ("Can you explain more?", None),
+            ("no", None),
+        ]
+
+        mock_get_trace_id.return_value = "trace_123"
+        mock_trace = MagicMock()
+        mock_get_trace.return_value = mock_trace
+        mock_start_span.return_value.__enter__.return_value = MagicMock()
+
+        simulator = ConversationSimulator(
+            test_cases=[simple_test_case],
+            max_turns=2,
+            user_model="openai/gpt-4o-mini",
+        )
+
+        traces = simulator.simulate(mock_predict_fn)
+
+        assert len(traces) == 2
+        assert mock_invoke.call_count == 4
+        assert mock_update_current_trace.call_count == 2
+
+
+def test_conversation_simulator_max_turns_stopping(simple_test_case, mock_predict_fn):
+    with (
+        patch("mlflow.genai.simulators.simulator._invoke_litellm_and_handle_tools") as mock_invoke,
+        patch("mlflow.start_span") as mock_start_span,
+        patch("mlflow.get_last_active_trace_id") as mock_get_trace_id,
+        patch("mlflow.update_current_trace"),
+        patch("mlflow.get_trace") as mock_get_trace,
+    ):
+        mock_invoke.side_effect = [
+            ("Test message", None),
+            ("no", None),
+            ("Test message", None),
+            ("no", None),
+            ("Test message", None),
+            ("no", None),
+        ]
+        mock_get_trace_id.return_value = "trace_123"
+        mock_trace = MagicMock()
+        mock_get_trace.return_value = mock_trace
+        mock_start_span.return_value.__enter__.return_value = MagicMock()
+
+        simulator = ConversationSimulator(
+            test_cases=[simple_test_case],
+            max_turns=3,
+        )
+
+        traces = simulator.simulate(mock_predict_fn)
+
+        assert len(traces) == 3
+
+
+def test_conversation_simulator_empty_response_stopping(simple_test_case):
+    with (
+        patch("mlflow.genai.simulators.simulator._invoke_litellm_and_handle_tools") as mock_invoke,
+        patch("mlflow.start_span") as mock_start_span,
+        patch("mlflow.get_last_active_trace_id") as mock_get_trace_id,
+        patch("mlflow.update_current_trace"),
+        patch("mlflow.get_trace") as mock_get_trace,
+    ):
+        mock_invoke.return_value = ("Test message", None)
+        mock_get_trace_id.return_value = "trace_123"
+        mock_trace = MagicMock()
+        mock_get_trace.return_value = mock_trace
+        mock_start_span.return_value.__enter__.return_value = MagicMock()
+
+        def empty_predict_fn(input=None, messages=None):
+            return {
+                "output": [
+                    {
+                        "id": "msg_123",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": ""}],
+                    }
+                ]
+            }
+
+        simulator = ConversationSimulator(
+            test_cases=[simple_test_case],
+            max_turns=5,
+        )
+
+        traces = simulator.simulate(empty_predict_fn)
+
+        assert len(traces) == 1
+        assert mock_invoke.call_count == 1
+
+
+def test_conversation_simulator_goal_achieved_stopping(simple_test_case, mock_predict_fn):
+    with (
+        patch("mlflow.genai.simulators.simulator._invoke_litellm_and_handle_tools") as mock_invoke,
+        patch("mlflow.start_span") as mock_start_span,
+        patch("mlflow.get_last_active_trace_id") as mock_get_trace_id,
+        patch("mlflow.update_current_trace"),
+        patch("mlflow.get_trace") as mock_get_trace,
+    ):
+        mock_invoke.side_effect = [
+            ("Test message", None),
+            ("yes it is achieved", None),
+        ]
+        mock_get_trace_id.return_value = "trace_123"
+        mock_trace = MagicMock()
+        mock_get_trace.return_value = mock_trace
+        mock_start_span.return_value.__enter__.return_value = MagicMock()
+
+        simulator = ConversationSimulator(
+            test_cases=[simple_test_case],
+            max_turns=5,
+        )
+
+        traces = simulator.simulate(mock_predict_fn)
+
+        assert len(traces) == 1
+        assert mock_invoke.call_count == 2
+
+
+def test_conversation_simulator_context_passing(
+    test_case_with_context, mock_predict_fn_with_context
+):
+    with (
+        patch("mlflow.genai.simulators.simulator._invoke_litellm_and_handle_tools") as mock_invoke,
+        patch("mlflow.start_span") as mock_start_span,
+        patch("mlflow.get_last_active_trace_id") as mock_get_trace_id,
+        patch("mlflow.update_current_trace"),
+        patch("mlflow.get_trace") as mock_get_trace,
+    ):
+        mock_invoke.side_effect = [
+            ("Test message", None),
+            ("no", None),
+        ]
+        mock_get_trace_id.return_value = "trace_123"
+        mock_trace = MagicMock()
+        mock_get_trace.return_value = mock_trace
+        mock_start_span.return_value.__enter__.return_value = MagicMock()
+
+        simulator = ConversationSimulator(
+            test_cases=[test_case_with_context],
+            max_turns=1,
+        )
+
+        traces = simulator.simulate(mock_predict_fn_with_context)
+
+        assert len(traces) == 1
+
+
+def test_conversation_simulator_multiple_test_cases(
+    simple_test_case, test_case_with_persona, mock_predict_fn
+):
+    with (
+        patch("mlflow.genai.simulators.simulator._invoke_litellm_and_handle_tools") as mock_invoke,
+        patch("mlflow.start_span") as mock_start_span,
+        patch("mlflow.get_last_active_trace_id") as mock_get_trace_id,
+        patch("mlflow.update_current_trace"),
+        patch("mlflow.get_trace") as mock_get_trace,
+    ):
+        mock_invoke.side_effect = [
+            ("Test message", None),
+            ("no", None),
+            ("Test message", None),
+            ("no", None),
+            ("Test message", None),
+            ("no", None),
+            ("Test message", None),
+            ("no", None),
+        ]
+        mock_get_trace_id.return_value = "trace_123"
+        mock_trace = MagicMock()
+        mock_get_trace.return_value = mock_trace
+        mock_start_span.return_value.__enter__.return_value = MagicMock()
+
+        simulator = ConversationSimulator(
+            test_cases=[simple_test_case, test_case_with_persona],
+            max_turns=2,
+        )
+
+        traces = simulator.simulate(mock_predict_fn)
+
+        assert len(traces) == 4
+
+
+def test_conversation_simulator_empty_test_cases(mock_predict_fn):
+    simulator = ConversationSimulator(
+        test_cases=[],
+        max_turns=2,
+    )
+    with pytest.raises(ValueError, match="test_cases cannot be empty"):
+        simulator.simulate(mock_predict_fn)

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -13,7 +13,6 @@ def test_simulated_user_agent_generate_initial_message():
         agent = SimulatedUserAgent(
             goal="Learn about MLflow",
             persona="You are a beginner who asks curious questions.",
-            model="openai:/gpt-4o-mini",
         )
 
         message = agent.generate_message([], turn=0)
@@ -35,7 +34,6 @@ def test_simulated_user_agent_generate_followup_message():
 
         agent = SimulatedUserAgent(
             goal="Learn about MLflow",
-            model="openai:/gpt-4o-mini",
         )
 
         history = [
@@ -61,7 +59,6 @@ def test_simulated_user_agent_default_persona():
 
         agent = SimulatedUserAgent(
             goal="Learn about ML",
-            model="openai:/gpt-4o-mini",
         )
 
         message = agent.generate_message([], turn=0)
@@ -98,7 +95,6 @@ def test_conversation_simulator_basic_simulation(simple_test_case, mock_predict_
         simulator = ConversationSimulator(
             test_cases=[simple_test_case],
             max_turns=2,
-            user_model="openai:/gpt-4o-mini",
         )
 
         all_traces = simulator._simulate(mock_predict_fn)

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -531,6 +531,67 @@ def test_parse_inputs_to_str(input_data, expected):
             {"messages": ["a", "b", "c"]},
             '{"messages": ["a", "b", "c"]}',
         ),
+        # OpenAI Responses API format with output_text content type
+        (
+            {
+                "output": [
+                    {
+                        "id": "msg_123",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Response from Responses API"}],
+                    }
+                ]
+            },
+            "Response from Responses API",
+        ),
+        # OpenAI Responses API format with text content type
+        (
+            {
+                "output": [
+                    {
+                        "id": "msg_456",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "Text type response"}],
+                    }
+                ]
+            },
+            "Text type response",
+        ),
+        # OpenAI Responses API format with string content
+        (
+            {
+                "output": [
+                    {
+                        "id": "msg_789",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": "Direct string content",
+                    }
+                ]
+            },
+            "Direct string content",
+        ),
+        # OpenAI Responses API format with multiple output items (gets last assistant message)
+        (
+            {
+                "output": [
+                    {
+                        "id": "item_1",
+                        "type": "function_call",
+                        "name": "get_weather",
+                    },
+                    {
+                        "id": "msg_final",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Final response"}],
+                    },
+                ]
+            },
+            "Final response",
+        ),
     ],
 )
 def test_parse_outputs_to_str(output_data, expected):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/19614?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19614/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19614/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19614/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Introduce a conversation simulator into mlflow.genai

A small side effect of this PR is supporting responses API parsing for the output.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Tested with 

- [x] OpenAI model
- [x] DBX Endpoint
- [x] DBX default model

```
import mlflow
from openai import OpenAI

from mlflow.genai.simulators import ConversationSimulator

mlflow.openai.autolog()

mlflow.set_tracking_uri("databricks")

client = OpenAI()


def predict_fn(input: list[dict], **kwargs):
    print(f"Context: {kwargs}")
    response = client.chat.completions.create(
        model="gpt-4o-mini",
        messages=input,
    )
    return response

test_cases = [
    {
        "goal": "Learn how to log traces in MLflow and then use them to evaluate the performance of an agent.",
        "persona": "You are a data scientist who is new to MLflow and wants to learn the basics.",
        "context": {"user_id": "123"}
    },
]

simulator = ConversationSimulator(
    test_cases=test_cases,
    max_turns=3,
    user_model="databricks:/databricks-gpt-5-2",
)

print("Running simulation...")
all_trace_ids = simulator._simulate(predict_fn)

print(f"\nSimulation complete! {len(all_trace_ids)} test case(s), {len(all_trace_ids[0])} turn(s)")
```

Output:
```
Running simulation...
Context: {'user_id': '123'}
Context: {'user_id': '123'}
Context: {'user_id': '123'}

Simulation complete! 1 test case(s), 3 turn(s)
```

<img width="1342" height="1008" alt="Screenshot 2025-12-30 at 2 11 50 PM" src="https://github.com/user-attachments/assets/27d4f2be-ee4a-43b1-8127-043497ca7b1b" />


### Does this PR require documentation update?

This will be done in a future iteration.

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Introduce a conversation simulator to be used in multi-turn evaluation in `mlflow.genai.evaluate`

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
