### PR TITLE
Fix prompt registration with model_config on Databricks

### DIFF
--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -6,7 +6,7 @@ import json
 
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.prompt_version import PromptVersion
-from mlflow.prompt.constants import RESPONSE_FORMAT_TAG_KEY
+from mlflow.prompt.constants import PROMPT_MODEL_CONFIG_TAG_KEY, RESPONSE_FORMAT_TAG_KEY
 from mlflow.protos.unity_catalog_prompt_messages_pb2 import (
     PromptAlias as ProtoPromptAlias,
 )
@@ -80,6 +80,11 @@ def proto_to_mlflow_prompt(
     else:
         response_format = None
 
+    if PROMPT_MODEL_CONFIG_TAG_KEY in version_tags:
+        model_config = json.loads(version_tags[PROMPT_MODEL_CONFIG_TAG_KEY])
+    else:
+        model_config = None
+
     version_tags = {
         key: value for key, value in version_tags.items() if not key.startswith("_mlflow")
     }
@@ -102,6 +107,7 @@ def proto_to_mlflow_prompt(
         tags=version_tags,
         aliases=aliases,
         response_format=response_format,
+        model_config=model_config,
     )
 
 

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -16,6 +16,7 @@ from mlflow.entities.model_registry import (
     RegisteredModelTag,
 )
 from mlflow.entities.model_registry.prompt import Prompt
+from mlflow.entities.model_registry.prompt_version import PromptModelConfig
 from mlflow.entities.webhook import (
     Webhook,
     WebhookEvent,
@@ -564,6 +565,7 @@ class ModelRegistryClient:
         description: str | None = None,
         tags: dict[str, str] | None = None,
         response_format: type[BaseModel] | dict[str, Any] | None = None,
+        model_config: "PromptModelConfig | dict[str, Any] | None" = None,
     ) -> PromptVersion:
         """
         Create a new version of an existing prompt.
@@ -584,11 +586,19 @@ class ModelRegistryClient:
             response_format: Optional Pydantic class or dictionary defining the expected response
                 structure. This can be used to specify the schema for structured outputs from LLM
                 calls.
+            model_config: Optional PromptModelConfig or dictionary defining the model configuration.
 
         Returns:
             A PromptVersion object representing the new version.
         """
-        return self.store.create_prompt_version(name, template, description, tags, response_format)
+        return self.store.create_prompt_version(
+            name=name,
+            template=template,
+            description=description,
+            tags=tags,
+            response_format=response_format,
+            model_config=model_config,
+        )
 
     def get_prompt_version(self, name: str, version: str) -> PromptVersion:
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -5879,6 +5879,7 @@ class MlflowClient:
         description: str | None = None,
         tags: dict[str, str] | None = None,
         response_format: type[BaseModel] | dict[str, Any] | None = None,
+        model_config: "PromptModelConfig | dict[str, Any] | None" = None,
     ) -> PromptVersion:
         """
         Create a new version of an existing prompt.
@@ -5894,6 +5895,9 @@ class MlflowClient:
             response_format: Optional Pydantic class or dictionary defining the expected response
                 structure. This can be used to specify the schema for structured
                 outputs from LLM calls.
+            model_config: Optional PromptModelConfig object or dictionary defining the model
+                configuration (model name, parameters, etc.) to use when invoking this
+                prompt version.
 
         Returns:
             A PromptVersion object.
@@ -5914,7 +5918,12 @@ class MlflowClient:
         """
         registry_client = self._get_registry_client()
         return registry_client.create_prompt_version(
-            name, template, description, tags, response_format
+            name=name,
+            template=template,
+            description=description,
+            tags=tags,
+            response_format=response_format,
+            model_config=model_config,
         )
 
     @require_prompt_registry

--- a/tests/store/_unity_catalog/registry/test_uc_prompt_utils.py
+++ b/tests/store/_unity_catalog/registry/test_uc_prompt_utils.py
@@ -3,6 +3,7 @@ import json
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.prompt_version import PromptVersion
 from mlflow.prompt.constants import (
+    PROMPT_MODEL_CONFIG_TAG_KEY,
     PROMPT_TYPE_TAG_KEY,
     PROMPT_TYPE_TEXT,
     RESPONSE_FORMAT_TAG_KEY,
@@ -92,14 +93,31 @@ def test_proto_info_to_mlflow_prompt_info():
 
 
 def test_proto_to_mlflow_prompt():
-    # Test with version tags - the key behavior we care about
+    # Test with version tags including response_format and model_config
     proto_version = ProtoPromptVersion()
     proto_version.name = "test_prompt"
     proto_version.version = "1"
     proto_version.template = json.dumps("Hello {{name}}!")
     proto_version.description = "Test description"
 
-    # Add version tags
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "test_schema",
+            "schema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            },
+        },
+    }
+
+    model_config = {
+        "model_name": "databricks-meta-llama-3-1-70b-instruct",
+        "max_tokens": 100,
+        "temperature": 0.7,
+    }
+
+    # Add version tags including both response_format and model_config
     proto_version.tags.extend(
         [
             ProtoPromptVersionTag(key="env", value="production"),
@@ -107,35 +125,28 @@ def test_proto_to_mlflow_prompt():
             ProtoPromptVersionTag(key=PROMPT_TYPE_TAG_KEY, value=PROMPT_TYPE_TEXT),
             ProtoPromptVersionTag(
                 key=RESPONSE_FORMAT_TAG_KEY,
-                value=json.dumps(
-                    {
-                        "type": "json_schema",
-                        "json_schema": {
-                            "name": "test_schema",
-                            "schema": {
-                                "type": "object",
-                                "properties": {"name": {"type": "string"}},
-                            },
-                        },
-                    }
-                ),
+                value=json.dumps(response_format),
+            ),
+            ProtoPromptVersionTag(
+                key=PROMPT_MODEL_CONFIG_TAG_KEY,
+                value=json.dumps(model_config),
             ),
         ]
     )
 
     result = proto_to_mlflow_prompt(proto_version)
 
-    # The critical test: version tags should go to tags
-    expected_tags = {"env": "production", "author": "alice"}
+    # Verify response_format and model_config are extracted
     assert result.template == "Hello {{name}}!"
-    assert result.response_format == {
-        "type": "json_schema",
-        "json_schema": {
-            "name": "test_schema",
-            "schema": {"type": "object", "properties": {"name": {"type": "string"}}},
-        },
-    }
+    assert result.response_format == response_format
+    assert result.model_config == model_config
+
+    # Verify user tags remain and _mlflow tags are filtered out
+    expected_tags = {"env": "production", "author": "alice"}
     assert result.tags == expected_tags
+    assert RESPONSE_FORMAT_TAG_KEY not in result.tags
+    assert PROMPT_MODEL_CONFIG_TAG_KEY not in result.tags
+    assert PROMPT_TYPE_TAG_KEY not in result.tags
 
     # Test with no tags
     proto_no_tags = ProtoPromptVersion()
@@ -145,6 +156,8 @@ def test_proto_to_mlflow_prompt():
 
     result_no_tags = proto_to_mlflow_prompt(proto_no_tags)
     assert result_no_tags.tags == {}
+    assert result_no_tags.response_format is None
+    assert result_no_tags.model_config is None
 
 
 def test_mlflow_prompt_to_proto():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/19617?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19617/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19617/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19617/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Fix the following error happening when a prompt is registered on Databricks

```
TypeError: ModelRegistryClient.create_prompt_version() got an unexpected keyword argument 'model_config'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
