### PR TITLE
Fix Python 3.12 `DeprecationWarning` from `generator.throw()` in tracing

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -248,7 +248,10 @@ def _wrap_function(
             # we return control to the coro (in particular, so that the __exit__'s
             # of start_span and OTel's use_span can execute).
             if exc_type is not None:
-                self.coro.throw(exc_type, exc_value, traceback)
+                # Use single-arg signature for Python 3.12+ compatibility
+                if exc_value is None:
+                    exc_value = exc_type()
+                self.coro.throw(exc_value)
             self.coro.close()
 
     if inspect.iscoroutinefunction(fn):

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -248,7 +248,6 @@ def _wrap_function(
             # we return control to the coro (in particular, so that the __exit__'s
             # of start_span and OTel's use_span can execute).
             if exc_type is not None:
-                # Use single-arg signature for Python 3.12+ compatibility
                 if exc_value is None:
                     exc_value = exc_type()
                 self.coro.throw(exc_value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -516,6 +516,8 @@ filterwarnings = [
   "error::pydantic.PydanticDeprecatedSince20:tests",
   # Silence filesystem backend deprecation warnings (https://github.com/mlflow/mlflow/issues/18534)
   "ignore:The filesystem (tracking|model registry) backend.*will be deprecated:FutureWarning",
+  # Prevent deprecated generator.throw(type, value, tb) signature from being used (Python 3.12+)
+  "error:the \\(type, exc, tb\\) signature of throw\\(\\) is deprecated:DeprecationWarning",
 ]
 timeout = 1200
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mr-brobot/mlflow/pull/19629?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19629/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19629/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19629/merge
```

</p>
</details>

### Related Issues/PRs

Resolves #19628

### What changes are proposed in this pull request?

Fixes a `DeprecationWarning` on Python 3.12+ when using `@mlflow.trace` on functions that raise exceptions:

```
DeprecationWarning: the (type, exc, tb) signature of throw() is deprecated, use the single-arg signature instead.
```

**Changes:**
1. Updated `_WrappingContext.__exit__()` in `mlflow/tracing/fluent.py` to use the single-argument `generator.throw(exception)` signature instead of the deprecated three-argument form
2. Added a pytest filterwarnings rule to treat this deprecation as an error, preventing future regressions

The single-argument signature has been available since Python 2.5 (PEP 342), so this change is fully backward compatible.

**Note:** This issue is not currently caught in CI because Python 3.12 is not included in the test matrix. #19630 is a proposal to address this.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified on Python 3.12.12 that the warning no longer appears when tracing functions that raise exceptions.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a `DeprecationWarning` that appeared on Python 3.12+ when using `@mlflow.trace` on functions that raise exceptions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)