### PR TITLE
Chat UI + Reasoning in Chat UI Strands Agents

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/index.ts
@@ -21,3 +21,8 @@ export {
   normalizeVoltAgentChatOutput,
   synthesizeVoltAgentChatMessages,
 } from './voltagent';
+export {
+  normalizeStrandsChatInput,
+  normalizeStrandsChatOutput,
+  synthesizeStrandsChatMessages,
+} from './strands';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/index.ts
@@ -21,8 +21,4 @@ export {
   normalizeVoltAgentChatOutput,
   synthesizeVoltAgentChatMessages,
 } from './voltagent';
-export {
-  normalizeStrandsChatInput,
-  normalizeStrandsChatOutput,
-  synthesizeStrandsChatMessages,
-} from './strands';
+export { normalizeStrandsChatInput, normalizeStrandsChatOutput, synthesizeStrandsChatMessages } from './strands';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/strands.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/strands.test.ts
@@ -223,11 +223,7 @@ describe('synthesizeStrandsChatMessages', () => {
       } as ModelTraceSpanNode,
     ];
 
-    const result = synthesizeStrandsChatMessages(
-      MOCK_STRANDS_USER_INPUT,
-      MOCK_STRANDS_PLAIN_STRING_OUTPUT,
-      children,
-    );
+    const result = synthesizeStrandsChatMessages(MOCK_STRANDS_USER_INPUT, MOCK_STRANDS_PLAIN_STRING_OUTPUT, children);
 
     expect(result).toHaveLength(4);
 
@@ -295,11 +291,9 @@ describe('synthesizeStrandsChatMessages', () => {
       children: [MOCK_CHAT_SPAN_WITH_TOOL as ModelTraceSpanNode, MOCK_TOOL_SPAN as ModelTraceSpanNode],
     };
 
-    const result = synthesizeStrandsChatMessages(
-      MOCK_STRANDS_USER_INPUT,
-      MOCK_STRANDS_PLAIN_STRING_OUTPUT,
-      [eventLoopSpan as ModelTraceSpanNode],
-    );
+    const result = synthesizeStrandsChatMessages(MOCK_STRANDS_USER_INPUT, MOCK_STRANDS_PLAIN_STRING_OUTPUT, [
+      eventLoopSpan as ModelTraceSpanNode,
+    ]);
 
     expect(result).toHaveLength(4);
     expect(result?.[1]?.tool_calls).toBeDefined();
@@ -321,11 +315,7 @@ describe('synthesizeStrandsChatMessages', () => {
       } as ModelTraceSpanNode,
     ];
 
-    const result = synthesizeStrandsChatMessages(
-      MOCK_STRANDS_USER_INPUT,
-      MOCK_STRANDS_PLAIN_STRING_OUTPUT,
-      children,
-    );
+    const result = synthesizeStrandsChatMessages(MOCK_STRANDS_USER_INPUT, MOCK_STRANDS_PLAIN_STRING_OUTPUT, children);
 
     // Should have: user, assistant with reasoning + tool calls, tool result, final assistant
     expect(result).toHaveLength(4);
@@ -404,4 +394,3 @@ describe('synthesizeStrandsChatMessages', () => {
     );
   });
 });
-

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/strands.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/strands.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { normalizeStrandsChatInput, normalizeStrandsChatOutput, synthesizeStrandsChatMessages } from './strands';
+import { ModelSpanType, type ModelTraceSpanNode } from '../ModelTrace.types';
+
+const MOCK_STRANDS_USER_INPUT = [
+  {
+    role: 'user',
+    content: [{ text: 'What is 2+2' }],
+  },
+];
+
+const MOCK_STRANDS_TOOL_CALL_OUTPUT = [
+  {
+    toolUse: {
+      toolUseId: 'call_PHijhFE1QjCO6ZuW1F9yYAXo',
+      name: 'calculator',
+      input: { expression: '2+2' },
+    },
+  },
+];
+
+const MOCK_STRANDS_TEXT_OUTPUT = [{ text: 'The result of (2 + 2) is 4.' }];
+
+const MOCK_STRANDS_PLAIN_STRING_OUTPUT = 'The result of (2 + 2) is 4.';
+
+const MOCK_STRANDS_REASONING_OUTPUT = [
+  {
+    reasoningContent: {
+      reasoningText: {
+        text: 'Let me think about this step by step. 2+2=4.',
+        signature: 'some_signature_here',
+      },
+    },
+  },
+  {
+    toolUse: {
+      toolUseId: 'call_PHijhFE1QjCO6ZuW1F9yYAXo',
+      name: 'calculator',
+      input: { expression: '2+2' },
+    },
+  },
+];
+
+const MOCK_STRANDS_REASONING_WITH_TEXT_OUTPUT = [
+  {
+    reasoningContent: {
+      reasoningText: {
+        text: 'Thinking about the math problem...',
+        signature: 'sig123',
+      },
+    },
+  },
+  { text: 'The answer is 4.' },
+];
+
+const MOCK_TOOL_SPAN: Partial<ModelTraceSpanNode> = {
+  title: 'execute_tool calculator',
+  type: ModelSpanType.TOOL,
+  outputs: [{ text: 'Result: 4' }],
+  attributes: {
+    'gen_ai.tool.call.id': 'call_PHijhFE1QjCO6ZuW1F9yYAXo',
+  },
+};
+
+const MOCK_CHAT_SPAN_WITH_TOOL: Partial<ModelTraceSpanNode> = {
+  title: 'chat',
+  type: ModelSpanType.CHAT_MODEL,
+  inputs: MOCK_STRANDS_USER_INPUT,
+  outputs: MOCK_STRANDS_TOOL_CALL_OUTPUT,
+};
+
+const MOCK_CHAT_SPAN_WITH_TEXT: Partial<ModelTraceSpanNode> = {
+  title: 'chat',
+  type: ModelSpanType.CHAT_MODEL,
+  inputs: MOCK_STRANDS_USER_INPUT,
+  outputs: MOCK_STRANDS_TEXT_OUTPUT,
+};
+
+describe('normalizeStrandsChatInput', () => {
+  it('should normalize user input with text content', () => {
+    const result = normalizeStrandsChatInput(MOCK_STRANDS_USER_INPUT);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: 'What is 2+2',
+      }),
+    ]);
+  });
+
+  it('should handle system messages', () => {
+    const input = [{ role: 'system', content: [{ text: 'You are helpful' }] }];
+    const result = normalizeStrandsChatInput(input);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        role: 'system',
+        content: 'You are helpful',
+      }),
+    ]);
+  });
+
+  it('should return null for empty input', () => {
+    expect(normalizeStrandsChatInput([])).toBeNull();
+    expect(normalizeStrandsChatInput(null)).toBeNull();
+    expect(normalizeStrandsChatInput(undefined)).toBeNull();
+  });
+
+  it('should return null for invalid input format', () => {
+    expect(normalizeStrandsChatInput([{ invalid: 'data' }])).toBeNull();
+    expect(normalizeStrandsChatInput('not an array')).toBeNull();
+  });
+});
+
+describe('normalizeStrandsChatOutput', () => {
+  it('should normalize tool call output', () => {
+    const result = normalizeStrandsChatOutput(MOCK_STRANDS_TOOL_CALL_OUTPUT);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        tool_calls: [
+          expect.objectContaining({
+            id: 'call_PHijhFE1QjCO6ZuW1F9yYAXo',
+            function: expect.objectContaining({
+              name: 'calculator',
+              arguments: expect.stringContaining('expression'),
+            }),
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it('should normalize text output', () => {
+    const result = normalizeStrandsChatOutput(MOCK_STRANDS_TEXT_OUTPUT);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'The result of (2 + 2) is 4.',
+      }),
+    ]);
+  });
+
+  it('should normalize plain string output', () => {
+    const result = normalizeStrandsChatOutput(MOCK_STRANDS_PLAIN_STRING_OUTPUT);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'The result of (2 + 2) is 4.',
+      }),
+    ]);
+  });
+
+  it('should return null for empty output', () => {
+    expect(normalizeStrandsChatOutput([])).toBeNull();
+    expect(normalizeStrandsChatOutput(null)).toBeNull();
+    expect(normalizeStrandsChatOutput('')).toBeNull();
+  });
+
+  it('should normalize output with reasoning content and tool calls', () => {
+    const result = normalizeStrandsChatOutput(MOCK_STRANDS_REASONING_OUTPUT);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        reasoning: 'Let me think about this step by step. 2+2=4.',
+        tool_calls: [
+          expect.objectContaining({
+            id: 'call_PHijhFE1QjCO6ZuW1F9yYAXo',
+            function: expect.objectContaining({
+              name: 'calculator',
+            }),
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it('should normalize output with reasoning content and text', () => {
+    const result = normalizeStrandsChatOutput(MOCK_STRANDS_REASONING_WITH_TEXT_OUTPUT);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'The answer is 4.',
+        reasoning: 'Thinking about the math problem...',
+      }),
+    ]);
+  });
+
+  it('should handle reasoning content only (no text or tool calls)', () => {
+    const reasoningOnly = [
+      {
+        reasoningContent: {
+          reasoningText: {
+            text: 'Just thinking...',
+            signature: 'sig',
+          },
+        },
+      },
+    ];
+    const result = normalizeStrandsChatOutput(reasoningOnly);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        reasoning: 'Just thinking...',
+      }),
+    ]);
+  });
+});
+
+describe('synthesizeStrandsChatMessages', () => {
+  it('should synthesize complete conversation with tool calls', () => {
+    const children = [
+      {
+        ...MOCK_CHAT_SPAN_WITH_TOOL,
+        children: [MOCK_TOOL_SPAN as ModelTraceSpanNode],
+      } as ModelTraceSpanNode,
+    ];
+
+    const result = synthesizeStrandsChatMessages(
+      MOCK_STRANDS_USER_INPUT,
+      MOCK_STRANDS_PLAIN_STRING_OUTPUT,
+      children,
+    );
+
+    expect(result).toHaveLength(4);
+
+    // User message
+    expect(result?.[0]).toEqual(
+      expect.objectContaining({
+        role: 'user',
+        content: 'What is 2+2',
+      }),
+    );
+
+    // Assistant with tool calls
+    expect(result?.[1]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        tool_calls: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'call_PHijhFE1QjCO6ZuW1F9yYAXo',
+            function: expect.objectContaining({
+              name: 'calculator',
+            }),
+          }),
+        ]),
+      }),
+    );
+
+    // Tool result
+    expect(result?.[2]).toEqual(
+      expect.objectContaining({
+        role: 'tool',
+        content: 'Result: 4',
+        tool_call_id: 'call_PHijhFE1QjCO6ZuW1F9yYAXo',
+      }),
+    );
+
+    // Final assistant response
+    expect(result?.[3]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'The result of (2 + 2) is 4.',
+      }),
+    );
+  });
+
+  it('should handle simple response without tool calls', () => {
+    const children = [MOCK_CHAT_SPAN_WITH_TEXT as ModelTraceSpanNode];
+
+    const result = synthesizeStrandsChatMessages(MOCK_STRANDS_USER_INPUT, 'Simple answer', children);
+
+    expect(result).toHaveLength(2);
+    expect(result?.[0]).toEqual(expect.objectContaining({ role: 'user' }));
+    expect(result?.[1]).toEqual(expect.objectContaining({ role: 'assistant', content: 'Simple answer' }));
+  });
+
+  it('should return null for empty inputs and children', () => {
+    const result = synthesizeStrandsChatMessages([], null, []);
+    expect(result).toBeNull();
+  });
+
+  it('should find tool spans nested in children', () => {
+    // Simulate the actual trace structure with nested spans
+    const eventLoopSpan: Partial<ModelTraceSpanNode> = {
+      title: 'execute_event_loop_cycle',
+      type: undefined,
+      children: [MOCK_CHAT_SPAN_WITH_TOOL as ModelTraceSpanNode, MOCK_TOOL_SPAN as ModelTraceSpanNode],
+    };
+
+    const result = synthesizeStrandsChatMessages(
+      MOCK_STRANDS_USER_INPUT,
+      MOCK_STRANDS_PLAIN_STRING_OUTPUT,
+      [eventLoopSpan as ModelTraceSpanNode],
+    );
+
+    expect(result).toHaveLength(4);
+    expect(result?.[1]?.tool_calls).toBeDefined();
+    expect(result?.[2]?.role).toBe('tool');
+  });
+
+  it('should synthesize conversation with reasoning content', () => {
+    const chatSpanWithReasoning: Partial<ModelTraceSpanNode> = {
+      title: 'chat',
+      type: ModelSpanType.CHAT_MODEL,
+      inputs: MOCK_STRANDS_USER_INPUT,
+      outputs: MOCK_STRANDS_REASONING_OUTPUT,
+    };
+
+    const children = [
+      {
+        ...chatSpanWithReasoning,
+        children: [MOCK_TOOL_SPAN as ModelTraceSpanNode],
+      } as ModelTraceSpanNode,
+    ];
+
+    const result = synthesizeStrandsChatMessages(
+      MOCK_STRANDS_USER_INPUT,
+      MOCK_STRANDS_PLAIN_STRING_OUTPUT,
+      children,
+    );
+
+    // Should have: user, assistant with reasoning + tool calls, tool result, final assistant
+    expect(result).toHaveLength(4);
+
+    // User message
+    expect(result?.[0]).toEqual(
+      expect.objectContaining({
+        role: 'user',
+      }),
+    );
+
+    // Assistant with reasoning and tool calls
+    expect(result?.[1]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        reasoning: 'Let me think about this step by step. 2+2=4.',
+        tool_calls: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'call_PHijhFE1QjCO6ZuW1F9yYAXo',
+          }),
+        ]),
+      }),
+    );
+
+    // Tool result
+    expect(result?.[2]).toEqual(
+      expect.objectContaining({
+        role: 'tool',
+      }),
+    );
+
+    // Final response
+    expect(result?.[3]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'The result of (2 + 2) is 4.',
+      }),
+    );
+  });
+
+  it('should not duplicate response when reasoning present without tool calls', () => {
+    // Simulate a simple query with reasoning but no tools
+    const reasoningOnlyOutput = [
+      {
+        reasoningContent: {
+          reasoningText: {
+            text: 'Let me calculate 2+2. That equals 4.',
+            signature: 'sig123',
+          },
+        },
+      },
+      { text: '2 + 2 = 4' },
+    ];
+
+    const chatSpanWithReasoningNoTools: Partial<ModelTraceSpanNode> = {
+      title: 'chat',
+      type: ModelSpanType.CHAT_MODEL,
+      inputs: MOCK_STRANDS_USER_INPUT,
+      outputs: reasoningOnlyOutput,
+    };
+
+    const children = [chatSpanWithReasoningNoTools as ModelTraceSpanNode];
+
+    // Root output is same as CHAT_MODEL text output
+    const result = synthesizeStrandsChatMessages(MOCK_STRANDS_USER_INPUT, '2 + 2 = 4', children);
+
+    // Should have only 2 messages: user + assistant (with reasoning), NOT a duplicate assistant
+    expect(result).toHaveLength(2);
+    expect(result?.[0]).toEqual(expect.objectContaining({ role: 'user' }));
+    expect(result?.[1]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        content: '2 + 2 = 4',
+        reasoning: 'Let me calculate 2+2. That equals 4.',
+      }),
+    );
+  });
+});
+

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/strands.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/strands.ts
@@ -41,7 +41,9 @@ const extractTextContent = (content: unknown): string | undefined => {
   if (isString(content)) return content;
   if (!isArray(content)) return undefined;
 
-  const texts = content.filter((item) => isObject(item) && isString((item as any).text)).map((item) => (item as any).text);
+  const texts = content
+    .filter((item) => isObject(item) && isString((item as any).text))
+    .map((item) => (item as any).text);
   return texts.length > 0 ? texts.join('\n\n') : undefined;
 };
 
@@ -204,7 +206,9 @@ export const synthesizeStrandsChatMessages = (
         if (!toolSpan) continue;
 
         const output = toolSpan.outputs;
-        const resultContent = isArray(output) ? extractTextContent(output) ?? JSON.stringify(output) : String(output ?? '');
+        const resultContent = isArray(output)
+          ? extractTextContent(output) ?? JSON.stringify(output)
+          : String(output ?? '');
 
         const toolMsg = prettyPrintChatMessage({ role: 'tool', content: resultContent, tool_call_id: toolCall.id });
         if (toolMsg) messages.push(toolMsg);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/strands.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/strands.ts
@@ -1,0 +1,226 @@
+import { has, isArray, isObject, isString, get } from 'lodash';
+
+import type { ModelTraceChatMessage, ModelTraceSpanNode, ModelTraceToolCall } from '../ModelTrace.types';
+import { prettyPrintChatMessage, prettyPrintToolCall } from '../ModelTraceExplorer.utils';
+
+/**
+ * Strands Agent Message Format:
+ *
+ * Input format: [{"role": "user", "content": [{"text": "..."}]}]
+ * Output format: [{"toolUse": {...}}] or [{"text": "..."}] or [{"reasoningContent": {...}}]
+ */
+
+type StrandsToolUse = {
+  toolUseId: string;
+  name: string;
+  input: any;
+};
+
+type StrandsReasoningContent = {
+  reasoningText: {
+    text: string;
+    signature?: string;
+  };
+};
+
+const isStrandsToolUse = (obj: unknown): obj is StrandsToolUse => {
+  if (!isObject(obj)) return false;
+  return isString((obj as any).toolUseId) && isString((obj as any).name);
+};
+
+const isStrandsReasoningContent = (obj: unknown): obj is StrandsReasoningContent => {
+  if (!isObject(obj)) return false;
+  const typedObj = obj as any;
+  return isObject(typedObj.reasoningText) && isString(typedObj.reasoningText.text);
+};
+
+/**
+ * Extract text from Strands content format: [{"text": "..."}] or "..."
+ */
+const extractTextContent = (content: unknown): string | undefined => {
+  if (isString(content)) return content;
+  if (!isArray(content)) return undefined;
+
+  const texts = content.filter((item) => isObject(item) && isString((item as any).text)).map((item) => (item as any).text);
+  return texts.length > 0 ? texts.join('\n\n') : undefined;
+};
+
+/**
+ * Parse output array into tool calls, text, and reasoning
+ */
+const parseOutputArray = (
+  outputs: unknown[],
+): { toolCalls: ModelTraceToolCall[]; textParts: string[]; reasoningParts: string[] } => {
+  const toolCalls: ModelTraceToolCall[] = [];
+  const textParts: string[] = [];
+  const reasoningParts: string[] = [];
+
+  for (const item of outputs) {
+    if (!isObject(item)) continue;
+
+    const reasoning = get(item, 'reasoningContent');
+    if (isStrandsReasoningContent(reasoning)) {
+      reasoningParts.push((reasoning as StrandsReasoningContent).reasoningText.text);
+      continue;
+    }
+
+    const toolUse = get(item, 'toolUse');
+    if (isStrandsToolUse(toolUse)) {
+      const tu = toolUse as StrandsToolUse;
+      toolCalls.push({
+        id: tu.toolUseId,
+        function: {
+          name: tu.name,
+          arguments: JSON.stringify(tu.input, null, 2),
+        },
+      });
+    } else {
+      const text = get(item, 'text');
+      if (isString(text)) {
+        textParts.push(text);
+      }
+    }
+  }
+
+  return { toolCalls, textParts, reasoningParts };
+};
+
+/**
+ * Normalize Strands input messages
+ */
+export const normalizeStrandsChatInput = (obj: unknown): ModelTraceChatMessage[] | null => {
+  if (!isArray(obj) || obj.length === 0) return null;
+
+  const messages: ModelTraceChatMessage[] = [];
+
+  for (const msg of obj) {
+    if (!isObject(msg) || !has(msg, 'role') || !has(msg, 'content')) continue;
+
+    const role = (msg as any).role;
+    if (role !== 'user' && role !== 'system') continue;
+
+    const text = extractTextContent((msg as any).content);
+    const processed = prettyPrintChatMessage({ role, content: text });
+    if (processed) messages.push(processed);
+  }
+
+  return messages.length > 0 ? messages : null;
+};
+
+/**
+ * Normalize Strands output
+ */
+export const normalizeStrandsChatOutput = (obj: unknown): ModelTraceChatMessage[] | null => {
+  // Plain string output
+  if (isString(obj) && obj.trim()) {
+    const msg = prettyPrintChatMessage({ role: 'assistant', content: obj });
+    return msg ? [msg] : null;
+  }
+
+  if (!isArray(obj) || obj.length === 0) return null;
+
+  const { toolCalls, textParts, reasoningParts } = parseOutputArray(obj);
+  const reasoningText = reasoningParts.length > 0 ? reasoningParts.join('\n\n') : undefined;
+  const contentText = textParts.length > 0 ? textParts.join('\n\n') : undefined;
+
+  if (toolCalls.length > 0) {
+    return [
+      {
+        role: 'assistant',
+        content: contentText,
+        tool_calls: toolCalls.map(prettyPrintToolCall),
+        ...(reasoningText && { reasoning: reasoningText }),
+      },
+    ];
+  }
+
+  if (contentText) {
+    const msg = prettyPrintChatMessage({ role: 'assistant', content: contentText });
+    return msg ? [{ ...msg, ...(reasoningText && { reasoning: reasoningText }) }] : null;
+  }
+
+  if (reasoningText) {
+    return [{ role: 'assistant', reasoning: reasoningText }];
+  }
+
+  return null;
+};
+
+/**
+ * Recursively flatten all spans from the tree
+ */
+const flattenSpans = (children: ModelTraceSpanNode[]): ModelTraceSpanNode[] => {
+  const result: ModelTraceSpanNode[] = [];
+  for (const child of children) {
+    result.push(child);
+    if (child.children?.length) {
+      result.push(...flattenSpans(child.children));
+    }
+  }
+  return result;
+};
+
+/**
+ * Synthesize chat messages from Strands agent spans
+ */
+export const synthesizeStrandsChatMessages = (
+  inputs: any,
+  outputs: any,
+  children: ModelTraceSpanNode[],
+): ModelTraceChatMessage[] | null => {
+  const messages: ModelTraceChatMessage[] = [];
+
+  // 1. Add user message from inputs
+  const inputMessages = normalizeStrandsChatInput(inputs);
+  if (inputMessages?.length) {
+    messages.push(inputMessages[0]);
+  }
+
+  // 2. Find all CHAT_MODEL and TOOL spans
+  const allSpans = flattenSpans(children);
+  const chatSpans = allSpans.filter((s) => s.type === 'CHAT_MODEL');
+  const toolSpans = allSpans.filter((s) => s.type === 'TOOL');
+
+  // 3. Process CHAT_MODEL spans
+  for (const chatSpan of chatSpans) {
+    if (!isArray(chatSpan.outputs)) continue;
+
+    const { toolCalls, textParts, reasoningParts } = parseOutputArray(chatSpan.outputs);
+    const reasoningText = reasoningParts.length > 0 ? reasoningParts.join('\n\n') : undefined;
+    const contentText = textParts.length > 0 ? textParts.join('\n\n') : undefined;
+
+    if (toolCalls.length > 0) {
+      // Assistant message with tool calls
+      messages.push({
+        role: 'assistant',
+        content: contentText,
+        tool_calls: toolCalls.map(prettyPrintToolCall),
+        ...(reasoningText && { reasoning: reasoningText }),
+      });
+
+      // Add tool results
+      for (const toolCall of toolCalls) {
+        const toolSpan = toolSpans.find((ts) => get(ts.attributes, 'gen_ai.tool.call.id') === toolCall.id);
+        if (!toolSpan) continue;
+
+        const output = toolSpan.outputs;
+        const resultContent = isArray(output) ? extractTextContent(output) ?? JSON.stringify(output) : String(output ?? '');
+
+        const toolMsg = prettyPrintChatMessage({ role: 'tool', content: resultContent, tool_call_id: toolCall.id });
+        if (toolMsg) messages.push(toolMsg);
+      }
+    } else if (reasoningText) {
+      // CHAT_MODEL with reasoning but no tool calls
+      messages.push({ role: 'assistant', content: contentText, reasoning: reasoningText });
+    }
+  }
+
+  // 4. Add final response from root output (avoid duplicates)
+  const hasAssistantWithContent = messages.some((m) => m.role === 'assistant' && m.content && !m.tool_calls);
+  if (isString(outputs) && outputs.trim() && !hasAssistantWithContent) {
+    const finalMsg = prettyPrintChatMessage({ role: 'assistant', content: outputs.trim() });
+    if (finalMsg) messages.push(finalMsg);
+  }
+
+  return messages.length > 0 ? messages : null;
+};

--- a/mlflow/strands/autolog.py
+++ b/mlflow/strands/autolog.py
@@ -90,10 +90,14 @@ def _set_span_type(mlflow_span: LiveSpan, span: OTelReadableSpan) -> None:
     # "invoke_agent" for single agent and "invoke_{agent_name}" for multi agents
     if isinstance(operation, str) and operation.startswith("invoke_"):
         mlflow_span.set_span_type(SpanType.AGENT)
+        # Set message format for chat UI rendering on AGENT spans
+        mlflow_span.set_attribute(SpanAttributeKey.MESSAGE_FORMAT, "strands")
     elif operation == "execute_tool":
         mlflow_span.set_span_type(SpanType.TOOL)
     elif operation == "chat":
         mlflow_span.set_span_type(SpanType.CHAT_MODEL)
+        # Set message format for chat UI rendering on CHAT_MODEL spans
+        mlflow_span.set_attribute(SpanAttributeKey.MESSAGE_FORMAT, "strands")
     else:
         pass
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/19646?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19646/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19646/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19646/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

Towards #19514 

### What changes are proposed in this pull request?

Chat UI + Reasoning in Chat UI Strands Agents

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1570" height="886" alt="Screenshot 2025-12-26 at 6 31 22 PM" src="https://github.com/user-attachments/assets/695e799c-a1c9-4ead-8db6-7c9853a833df" />


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Chat UI + Reasoning in Chat UI Strands Agents

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
