### PR TITLE
Fixes Issue 19649:  MLflow GenAI Tracing, token usage is inflated for streaming traces

### DIFF
--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -14,6 +14,7 @@ from langchain_core.messages import (
     SystemMessage,
     ToolMessage,
 )
+from langchain_core.outputs import ChatGenerationChunk
 from langchain_core.outputs.generation import Generation
 
 from mlflow.environment_variables import MLFLOW_CONVERT_MESSAGES_DICT_FOR_LANGCHAIN
@@ -354,6 +355,24 @@ def parse_token_usage(
     lc_generations: list[Generation],
 ) -> dict[str, int] | None:
     """Parse the token usage from the LangChain generations."""
+
+    # Check if this is streaming (contains ChatGenerationChunk)
+    is_streaming = any(isinstance(gen, ChatGenerationChunk) for gen in lc_generations)
+
+    if is_streaming:
+        # Streaming mode: collect all generations with usage, use only the last one
+        # (which contains the final cumulative token counts)
+        generations_with_usage = [
+            token_usage
+            for generation in lc_generations
+            if (token_usage := _parse_token_usage_from_generation(generation))
+        ]
+
+        if generations_with_usage:
+            return generations_with_usage[-1]
+        return None
+
+    # Non-streaming mode: existing behavior (sum all generations)
     aggregated = defaultdict(int)
     for generation in lc_generations:
         if token_usage := _parse_token_usage_from_generation(generation):

--- a/tests/langchain/test_chat_utils.py
+++ b/tests/langchain/test_chat_utils.py
@@ -9,6 +9,7 @@ from langchain_core.messages import (
     SystemMessage,
     ToolMessage,
 )
+from langchain_core.outputs import ChatGenerationChunk
 from langchain_core.outputs.chat_generation import ChatGeneration
 from langchain_core.outputs.generation import Generation
 
@@ -238,3 +239,97 @@ def test_transform_request_json_for_chat_if_necessary_conversion():
 )
 def test_parse_token_usage(generation, expected):
     assert parse_token_usage([generation]) == expected
+
+
+def test_parse_token_usage_streaming_chunks():
+    """
+    Test that streaming chunks with cumulative token usage are handled correctly.
+
+    In streaming mode, each ChatGenerationChunk contains:
+    - Same input_tokens (repeated for each chunk)
+    - Cumulative output_tokens (increasing with each chunk)
+
+    Expected behavior: Use only the last chunk's usage (final cumulative values)
+    """
+    # Simulate 3 streaming chunks with same input_tokens but cumulative output_tokens
+    # This matches the pattern observed in real streaming scenarios
+    chunks = [
+        ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="Agreement",
+                usage_metadata={
+                    "input_tokens": 16049,
+                    "output_tokens": 2,
+                    "total_tokens": 16051,
+                },
+            )
+        ),
+        ChatGenerationChunk(
+            message=AIMessageChunk(
+                content=" ",
+                usage_metadata={
+                    "input_tokens": 16049,
+                    "output_tokens": 58,
+                    "total_tokens": 16107,
+                },
+            )
+        ),
+        ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="",
+                usage_metadata={
+                    "input_tokens": 16049,
+                    "output_tokens": 115,
+                    "total_tokens": 16164,
+                },
+            )
+        ),
+    ]
+
+    result = parse_token_usage(chunks)
+
+    # Should use only the last chunk's usage (final cumulative values)
+    assert result is not None
+    assert result["input_tokens"] == 16049
+    assert result["output_tokens"] == 115
+    assert result["total_tokens"] == 16164
+
+
+def test_parse_token_usage_non_streaming_multiple_calls():
+    """
+    Test that non-streaming multiple calls still sum correctly (existing behavior).
+
+    When multiple ChatGeneration objects are present (non-streaming), they represent
+    separate LLM calls and should be summed.
+    """
+    # Simulate 2 separate non-streaming calls with different token usage
+    generations = [
+        ChatGeneration(
+            message=AIMessage(
+                content="Response 1",
+                usage_metadata={
+                    "input_tokens": 10,
+                    "output_tokens": 20,
+                    "total_tokens": 30,
+                },
+            )
+        ),
+        ChatGeneration(
+            message=AIMessage(
+                content="Response 2",
+                usage_metadata={
+                    "input_tokens": 15,
+                    "output_tokens": 25,
+                    "total_tokens": 40,
+                },
+            )
+        ),
+    ]
+
+    result = parse_token_usage(generations)
+
+    # Should sum all generations (existing non-streaming behavior)
+    assert result is not None
+    assert result["input_tokens"] == 25  # 10 + 15
+    assert result["output_tokens"] == 45  # 20 + 25
+    assert result["total_tokens"] == 70  # 30 + 40


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/AMRUTH-ASHOK/mlflow/pull/19652?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19652/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19652/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19652/merge
```

</p>
</details>

### Related Issues/PRs
Fix for issue: https://github.com/mlflow/mlflow/issues/19649

### RCA
In streaming, [on_llm_end ](https://github.com/AMRUTH-ASHOK/mlflow/blob/master/mlflow/langchain/langchain_tracer.py#L417)receives LLMResult with generations containing all chunk generations. Each chunk has usage_metadata with:
* Same [input_tokens](https://github.com/AMRUTH-ASHOK/mlflow/blob/master/mlflow/langchain/utils/chat.py#L42) (repeated)
* Cumulative [output_tokens](https://github.com/AMRUTH-ASHOK/mlflow/blob/master/mlflow/langchain/utils/chat.py#L43) (increasing)

[parse_token_usage](https://github.com/AMRUTH-ASHOK/mlflow/blob/master/mlflow/langchain/utils/chat.py#L353) sums usage across all generations, treating each chunk as a separate call, which inflates totals.

Example:
Lets say prompt is 10 tokens and stream 3 output tokens and 3 events.
Each event includes usage_metadata like:
event1: input_tokens=10, output_tokens=1
event2: input_tokens=10, output_tokens=2
event3: input_tokens=10, output_tokens=3

Correct behavior:
input_tokens = 10 (count once)
output_tokens = 3 (final)

Buggy behavior:
input_tokens = 10 + 10 + 10 = 30 
output_tokens = 1 + 2 +3 = 6

### What changes are proposed in this pull request?
- Detect streaming mode by checking for `ChatGenerationChunk` objects
- For streaming: Use only the last chunk's usage (which contains final cumulative values)
- For non-streaming: Preserve existing behavior

### How is this PR tested?
- Added `test_parse_token_usage_streaming_chunks()` - verifies streaming chunks use last chunk's usage
- Added `test_parse_token_usage_non_streaming_multiple_calls()` - verifies non-streaming still sums correctly
- Existing tests for `test_parse_token_usage()` continue to pass


### Does this PR require documentation update?
- [x] No

#### Is this a user-facing change?
- [ ] No
- [x] Yes


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
