### PR TITLE
[Part 6/x] Evaluating UI sessions via judges: session selector

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/SelectSessionsModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectSessionsModal.test.tsx
@@ -1,0 +1,121 @@
+import { describe, jest, test, expect, beforeEach, beforeAll } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { SelectSessionsModal } from './SelectSessionsModal';
+import { useGenAiTraceTableRowSelection } from '../../shared/web-shared/genai-traces-table/hooks/useGenAiTraceTableRowSelection';
+import { GenAIChatSessionsTable, useSearchMlflowTraces } from '@databricks/web-shared/genai-traces-table';
+import { TestRouter, testRoute } from '../../common/utils/RoutingTestUtils';
+
+// Mock GenAIChatSessionsTable to keep this test simple
+jest.mock('@databricks/web-shared/genai-traces-table', () => ({
+  ...jest.requireActual<typeof import('@databricks/web-shared/genai-traces-table')>(
+    '@databricks/web-shared/genai-traces-table',
+  ),
+  GenAIChatSessionsTable: jest.fn(),
+  useSearchMlflowTraces: jest.fn(),
+}));
+
+const testExperimentId = 'test-experiment-123';
+
+describe('SelectSessionsModal', () => {
+  beforeAll(() => {
+    // Mock useSearchMlflowTraces to return empty data, we'll mock sessions directly
+    jest.mocked(useSearchMlflowTraces).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as any);
+
+    // Mock the GenAIChatSessionsTable component to return a simple mock sessions table
+    const MockGenAIChatSessionsTable = () => {
+      const { rowSelection, setRowSelection } = useGenAiTraceTableRowSelection();
+
+      // A few sessions and checkboxes
+      const mockSessions = [
+        { id: 'session-1', name: 'Session 1' },
+        { id: 'session-2', name: 'Session 2' },
+        { id: 'session-3', name: 'Session 3' },
+      ];
+
+      return (
+        <div data-testid="mock-sessions-table">
+          {mockSessions.map((session) => (
+            <label key={session.id} data-testid={`session-row-${session.id}`}>
+              <input
+                type="checkbox"
+                checked={Boolean(rowSelection[session.id])}
+                onChange={(e) => {
+                  setRowSelection((prev: Record<string, boolean>) => ({
+                    ...prev,
+                    [session.id]: e.target.checked,
+                  }));
+                }}
+                data-testid={`checkbox-${session.id}`}
+              />
+              {session.name}
+            </label>
+          ))}
+        </div>
+      );
+    };
+    jest.mocked(GenAIChatSessionsTable).mockImplementation(MockGenAIChatSessionsTable as any);
+  });
+
+  const renderTestComponent = (props: { onClose?: () => void; onSuccess?: (sessionIds: string[]) => void }) => {
+    return render(
+      <DesignSystemProvider>
+        <IntlProvider locale="en">
+          <TestRouter
+            routes={[testRoute(<SelectSessionsModal {...props} />, '/experiments/:experimentId')]}
+            initialEntries={[`/experiments/${testExperimentId}`]}
+          />
+        </IntlProvider>
+      </DesignSystemProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Re-setup the mock for useSearchMlflowTraces after clearAllMocks
+    jest.mocked(useSearchMlflowTraces).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as any);
+  });
+
+  test('should call onSuccess with selected session IDs when OK is clicked', async () => {
+    const onSuccessMock = jest.fn();
+    renderTestComponent({ onSuccess: onSuccessMock });
+
+    // Select two sessions
+    await userEvent.click(screen.getByTestId('checkbox-session-1'));
+    await userEvent.click(screen.getByTestId('checkbox-session-2'));
+
+    // Click the Select button
+    const selectButton = screen.getByRole('button', { name: /select/i });
+    await userEvent.click(selectButton);
+
+    // Verify onSuccess was called with the selected session IDs
+    expect(onSuccessMock).toHaveBeenCalledTimes(1);
+    expect(onSuccessMock).toHaveBeenCalledWith(['session-1', 'session-2']);
+  });
+
+  test('should disable OK button if all sessions are deselected', async () => {
+    renderTestComponent({});
+
+    // Select a session
+    await userEvent.click(screen.getByTestId('checkbox-session-1'));
+
+    // The Select button should be enabled
+    let selectButton = screen.getByRole('button', { name: /select/i });
+    expect(selectButton).toBeEnabled();
+
+    // Deselect the session
+    await userEvent.click(screen.getByTestId('checkbox-session-1'));
+
+    // The Select button should be disabled again
+    selectButton = screen.getByRole('button', { name: /select/i });
+    expect(selectButton).toBeDisabled();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/SelectSessionsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectSessionsModal.tsx
@@ -6,8 +6,6 @@ import { GenAiTraceTableRowSelectionProvider } from '@databricks/web-shared/gena
 import { GenAIChatSessionsTable, useSearchMlflowTraces } from '@databricks/web-shared/genai-traces-table';
 import { getChatSessionsFilter } from '../pages/experiment-chat-sessions/utils';
 
-const MAX_TRACES_PER_PAGE = 500;
-
 export const SelectSessionsModal = ({
   onClose,
   onSuccess,
@@ -39,8 +37,6 @@ export const SelectSessionsModal = ({
 
   const { data: traceInfos, isLoading } = useSearchMlflowTraces({
     locations: [{ mlflow_experiment: { experiment_id: experimentId ?? '' }, type: 'MLFLOW_EXPERIMENT' as const }],
-    pageSize: MAX_TRACES_PER_PAGE,
-    limit: MAX_TRACES_PER_PAGE,
     disabled: !experimentId,
     filters,
     searchQuery,
@@ -68,18 +64,20 @@ export const SelectSessionsModal = ({
       onOk={handleOk}
       cancelText={<FormattedMessage defaultMessage="Cancel" description="Cancel button in the select sessions modal" />}
     >
-      <GenAiTraceTableRowSelectionProvider rowSelection={rowSelection} setRowSelection={setRowSelection}>
-        <GenAIChatSessionsTable
-          experimentId={experimentId}
-          traces={traceInfos ?? []}
-          isLoading={isLoading}
-          searchQuery={searchQuery}
-          setSearchQuery={setSearchQuery}
-          enableRowSelection
-          enableLinks={false}
-          empty={<EmptySessionsList />}
-        />
-      </GenAiTraceTableRowSelectionProvider>
+      <div css={{ height: '100%', display: 'flex', overflow: 'hidden' }}>
+        <GenAiTraceTableRowSelectionProvider rowSelection={rowSelection} setRowSelection={setRowSelection}>
+          <GenAIChatSessionsTable
+            experimentId={experimentId}
+            traces={traceInfos ?? []}
+            isLoading={isLoading}
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+            enableRowSelection
+            enableLinks={false}
+            empty={<EmptySessionsList />}
+          />
+        </GenAiTraceTableRowSelectionProvider>
+      </div>
     </Modal>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/SelectSessionsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectSessionsModal.tsx
@@ -1,0 +1,101 @@
+import { Empty, Modal } from '@databricks/design-system';
+import { useMemo, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { useParams } from '../../common/utils/RoutingUtils';
+import { GenAiTraceTableRowSelectionProvider } from '@databricks/web-shared/genai-traces-table/hooks/useGenAiTraceTableRowSelection';
+import { GenAIChatSessionsTable, useSearchMlflowTraces } from '@databricks/web-shared/genai-traces-table';
+import { getChatSessionsFilter } from '../pages/experiment-chat-sessions/utils';
+
+const MAX_TRACES_PER_PAGE = 500;
+
+export const SelectSessionsModal = ({
+  onClose,
+  onSuccess,
+  initialSessionIdsSelected = [],
+}: {
+  onClose?: () => void;
+  onSuccess?: (traceIds: string[]) => void;
+  initialSessionIdsSelected?: string[];
+}) => {
+  const { experimentId } = useParams();
+
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const [rowSelection, setRowSelection] = useState<Record<string, boolean>>(() =>
+    initialSessionIdsSelected.reduce((acc, sessionId) => {
+      acc[sessionId] = true;
+      return acc;
+    }, {} as Record<string, boolean>),
+  );
+
+  const handleOk = async () => {
+    const selectedSessionIds = Object.entries(rowSelection)
+      .filter(([_, isSelected]) => isSelected)
+      .map(([traceId]) => traceId);
+    onSuccess?.(selectedSessionIds);
+  };
+
+  const filters = useMemo(() => getChatSessionsFilter({ sessionId: null }), []);
+
+  const { data: traceInfos, isLoading } = useSearchMlflowTraces({
+    locations: [{ mlflow_experiment: { experiment_id: experimentId ?? '' }, type: 'MLFLOW_EXPERIMENT' as const }],
+    pageSize: MAX_TRACES_PER_PAGE,
+    limit: MAX_TRACES_PER_PAGE,
+    disabled: !experimentId,
+    filters,
+    searchQuery,
+    // TODO (next PRs): Add time range filters
+  });
+
+  if (!experimentId) {
+    return null;
+  }
+
+  return (
+    <Modal
+      visible
+      title={<FormattedMessage defaultMessage="Select sessions" description="Title for the select sessions modal" />}
+      componentId="mlflow.experiment-scorers.form.select-sessions-modal"
+      onCancel={onClose}
+      css={{ width: '90% !important' }}
+      size="wide"
+      verticalSizing="maxed_out"
+      okText={<FormattedMessage defaultMessage="Select" description="Confirm button in the select sessions modal" />}
+      okButtonProps={{
+        type: 'primary',
+        disabled: Object.values(rowSelection).every((isSelected) => !isSelected),
+      }}
+      onOk={handleOk}
+      cancelText={<FormattedMessage defaultMessage="Cancel" description="Cancel button in the select sessions modal" />}
+    >
+      <GenAiTraceTableRowSelectionProvider rowSelection={rowSelection} setRowSelection={setRowSelection}>
+        <GenAIChatSessionsTable
+          experimentId={experimentId}
+          traces={traceInfos ?? []}
+          isLoading={isLoading}
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          enableRowSelection
+          enableLinks={false}
+          empty={<EmptySessionsList />}
+        />
+      </GenAiTraceTableRowSelectionProvider>
+    </Modal>
+  );
+};
+
+const EmptySessionsList = () => {
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+      <Empty
+        title={
+          <FormattedMessage
+            defaultMessage="No sessions found"
+            description="Title for the empty sessions list in the select sessions modal"
+          />
+        }
+        description={null}
+      />
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
@@ -7,8 +7,9 @@ import { useEvaluateTraces } from './useEvaluateTraces';
 import SampleScorerOutputPanelRenderer from './SampleScorerOutputPanelRenderer';
 import { convertEvaluationResultToAssessment } from './llmScorerUtils';
 import { extractTemplateVariables } from '../../utils/evaluationUtils';
-import { DEFAULT_TRACE_COUNT, ASSESSMENT_NAME_TEMPLATE_MAPPING } from './constants';
+import { DEFAULT_TRACE_COUNT, ASSESSMENT_NAME_TEMPLATE_MAPPING, ScorerEvaluationScope } from './constants';
 import { EvaluateTracesParams, LLM_TEMPLATE } from './types';
+import { coerceToEnum } from '../../../shared/web-shared/utils';
 
 interface SampleScorerOutputPanelContainerProps {
   control: Control<ScorerFormData>;
@@ -28,6 +29,8 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
   const guidelines = useWatch({ control, name: 'guidelines' });
   const scorerType = useWatch({ control, name: 'scorerType' });
   const { errors } = useFormState({ control });
+  const evaluationScopeFormValue = useWatch({ control, name: 'evaluationScope' });
+  const evaluationScope = coerceToEnum(ScorerEvaluationScope, evaluationScopeFormValue, ScorerEvaluationScope.TRACES);
 
   const [itemsToEvaluate, setItemsToEvaluate] = useState<Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>>({
     itemCount: DEFAULT_TRACE_COUNT,
@@ -49,6 +52,15 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
     reset();
     setCurrentTraceIndex(0);
   }, [llmTemplate, reset]);
+
+  // Reset evaluation config when switching evaluation scope
+  useEffect(() => {
+    reset();
+    setItemsToEvaluate({
+      itemCount: DEFAULT_TRACE_COUNT,
+      itemIds: [],
+    });
+  }, [evaluationScope, reset]);
 
   // Handle the "Run scorer" button click
   const handleRunScorer = useCallback(async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
@@ -15,6 +15,7 @@ import { SelectTracesModal } from '../../components/SelectTracesModal';
 import { ScorerFormData } from './utils/scorerTransformUtils';
 import { useFormContext } from 'react-hook-form';
 import { ScorerEvaluationScope } from './constants';
+import { SelectSessionsModal } from '../../components/SelectSessionsModal';
 
 enum PickerOption {
   'LAST_TRACE_OR_SESSION' = '1',
@@ -97,11 +98,19 @@ export const SampleScorerTracesToEvaluatePicker = ({
             endIcon={<ChevronDownIcon />}
           >
             {itemsToEvaluateDropdownValue === PickerOption.CUSTOM ? (
-              <FormattedMessage
-                defaultMessage="{count, plural, one {1 trace selected} other {# traces selected}}"
-                description="Label for the number of traces selected"
-                values={{ count: itemsToEvaluate.itemIds?.length }}
-              />
+              evaluationScope === ScorerEvaluationScope.TRACES ? (
+                <FormattedMessage
+                  defaultMessage="{count, plural, one {1 trace selected} other {# traces selected}}"
+                  description="Label for the number of traces selected"
+                  values={{ count: itemsToEvaluate.itemIds?.length }}
+                />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="{count, plural, one {1 session selected} other {# sessions selected}}"
+                  description="Label for the number of sessions selected"
+                  values={{ count: itemsToEvaluate.itemIds?.length }}
+                />
+              )
             ) : (
               <FormattedMessage {...PickerOptionsLabels[itemsToEvaluateDropdownValue]} />
             )}
@@ -136,7 +145,7 @@ export const SampleScorerTracesToEvaluatePicker = ({
           </DialogComboboxOptionList>
         </DialogComboboxContent>
       </DialogCombobox>
-      {displayPickCustomTracesModal && (
+      {displayPickCustomTracesModal && evaluationScope === ScorerEvaluationScope.TRACES && (
         <SelectTracesModal
           onClose={() => {
             onItemsToEvaluateChange({ ...itemsToEvaluate });
@@ -149,6 +158,21 @@ export const SampleScorerTracesToEvaluatePicker = ({
             setDisplayPickCustomTracesModal(false);
           }}
           initialTraceIdsSelected={itemsToEvaluate.itemIds}
+        />
+      )}
+      {displayPickCustomTracesModal && evaluationScope === ScorerEvaluationScope.SESSIONS && (
+        <SelectSessionsModal
+          onClose={() => {
+            onItemsToEvaluateChange({ ...itemsToEvaluate });
+            setDisplayPickCustomTracesModal(false);
+          }}
+          onSuccess={(traceIds) => {
+            if (!isEmpty(traceIds)) {
+              onItemsToEvaluateChange({ itemCount: undefined, itemIds: traceIds });
+            }
+            setDisplayPickCustomTracesModal(false);
+          }}
+          initialSessionIdsSelected={itemsToEvaluate.itemIds}
         />
       )}
     </>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -51,6 +51,10 @@
     "defaultMessage": "Step 1: Install MLflow",
     "description": "Step 1 title for custom judge creation"
   },
+  "+Njd07": {
+    "defaultMessage": "No sessions found",
+    "description": "Title for the empty sessions list in the select sessions modal"
+  },
   "+Oupsq": {
     "defaultMessage": "Start with a built-in LLM judge template or create your own.",
     "description": "Hint text for LLM template selection with documentation link"
@@ -769,6 +773,10 @@
   "4OcdLd": {
     "defaultMessage": "This version",
     "description": "Model registry > model version alias select > Indicator for alias of selected version"
+  },
+  "4PhvDM": {
+    "defaultMessage": "Select",
+    "description": "Confirm button in the select sessions modal"
   },
   "4TDvGX": {
     "defaultMessage": "edited {when} by {user}",
@@ -3541,6 +3549,10 @@
     "defaultMessage": "An error occurred while rendering this component.",
     "description": "Description of error fallback component"
   },
+  "S+cwv0": {
+    "defaultMessage": "Select sessions",
+    "description": "Title for the select sessions modal"
+  },
   "S3YY1P": {
     "defaultMessage": "Span: {spanName}",
     "description": "Label for the span name in assessment metadata"
@@ -5523,6 +5535,10 @@
     "defaultMessage": "Provider",
     "description": "Secret provider label"
   },
+  "hKQs4I": {
+    "defaultMessage": "{count, plural, one {1 session selected} other {# sessions selected}}",
+    "description": "Label for the number of sessions selected"
+  },
   "hR2Zvd": {
     "defaultMessage": "Create a custom judge function using the {decorator} decorator. Implement your scoring logic in the function body. {link}",
     "description": "Step 2 description for defining judge function"
@@ -6618,6 +6634,10 @@
   "qIsNL0": {
     "defaultMessage": "Value",
     "description": "Run page > Overview > Parameters table > Value column header"
+  },
+  "qJEdUj": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel button in the select sessions modal"
   },
   "qKGnLV": {
     "defaultMessage": "Model Config:",

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
@@ -25,6 +25,7 @@ import { getSessionTableRows } from './utils';
 import type { TraceActions } from '../types';
 import MlflowUtils from '../utils/MlflowUtils';
 import { Link, useLocation } from '../utils/RoutingUtils';
+import { useGenAiTraceTableRowSelection } from '../hooks/useGenAiTraceTableRowSelection';
 
 const columns: SessionTableColumn[] = [
   {
@@ -84,11 +85,12 @@ const columns: SessionTableColumn[] = [
 interface ExperimentEvaluationDatasetsTableRowProps {
   row: Row<SessionTableRow>;
   enableRowSelection?: boolean;
+  enableLinks?: boolean;
 }
 
 const ExperimentChatSessionsTableRow: React.FC<React.PropsWithChildren<ExperimentEvaluationDatasetsTableRowProps>> =
   React.memo(
-    ({ row, enableRowSelection }) => {
+    ({ row, enableRowSelection, enableLinks = true }) => {
       const { search } = useLocation();
       const { theme } = useDesignSystemTheme();
 
@@ -122,25 +124,29 @@ const ExperimentChatSessionsTableRow: React.FC<React.PropsWithChildren<Experimen
                 ...(cell.column.id === 'actions' && { paddingLeft: 0, paddingRight: 0 }),
               }}
             >
-              <Link
-                to={{
-                  pathname: MlflowUtils.getExperimentChatSessionPageRoute(
-                    row.original.experimentId,
-                    row.original.sessionId,
-                  ),
-                  search,
-                }}
-                css={{
-                  display: 'flex',
-                  width: '100%',
-                  height: '100%',
-                  alignItems: 'center',
-                  color: 'inherit',
-                  textDecoration: 'none',
-                }}
-              >
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </Link>
+              {enableLinks ? (
+                <Link
+                  to={{
+                    pathname: MlflowUtils.getExperimentChatSessionPageRoute(
+                      row.original.experimentId,
+                      row.original.sessionId,
+                    ),
+                    search,
+                  }}
+                  css={{
+                    display: 'flex',
+                    width: '100%',
+                    height: '100%',
+                    alignItems: 'center',
+                    color: 'inherit',
+                    textDecoration: 'none',
+                  }}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </Link>
+              ) : (
+                flexRender(cell.column.columnDef.cell, cell.getContext())
+              )}
             </TableCell>
           ))}
         </TableRow>
@@ -156,6 +162,9 @@ export const GenAIChatSessionsTable = ({
   searchQuery,
   setSearchQuery,
   traceActions,
+  enableRowSelection: enableRowSelectionProp = false,
+  enableLinks = true,
+  empty,
 }: {
   experimentId: string;
   traces: ModelTraceInfoV3[];
@@ -163,18 +172,21 @@ export const GenAIChatSessionsTable = ({
   searchQuery: string;
   setSearchQuery: (query: string) => void;
   traceActions?: TraceActions;
+  enableRowSelection?: boolean;
+  enableLinks?: boolean;
+  empty?: React.ReactElement;
 }) => {
   const { theme } = useDesignSystemTheme();
 
   const sessionTableRows = useMemo(() => getSessionTableRows(experimentId, traces), [experimentId, traces]);
   const [sorting, setSorting] = useState<SortingState>([{ id: 'sessionStartTime', desc: true }]);
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const { rowSelection, setRowSelection } = useGenAiTraceTableRowSelection();
   const { columnVisibility, setColumnVisibility } = useSessionsTableColumnVisibility({
     experimentId,
     columns,
   });
 
-  const enableRowSelection = Boolean(traceActions);
+  const enableRowSelection = enableRowSelectionProp || Boolean(traceActions);
 
   const table = useReactTable<SessionTableRow>({
     data: sessionTableRows,
@@ -212,6 +224,8 @@ export const GenAIChatSessionsTable = ({
     [rowSelection],
   );
 
+  const emptyStateElement = empty ?? <GenAIChatSessionsEmptyState />;
+
   return (
     <div
       css={{
@@ -236,7 +250,7 @@ export const GenAIChatSessionsTable = ({
       />
       <Table
         style={{ ...columnSizeVars }}
-        empty={!isLoading && sessionTableRows.length === 0 ? <GenAIChatSessionsEmptyState /> : undefined}
+        empty={!isLoading && sessionTableRows.length === 0 ? emptyStateElement : undefined}
         scrollable
         someRowsSelected={
           enableRowSelection ? table.getIsAllRowsSelected() || table.getIsSomeRowsSelected() : undefined
@@ -276,7 +290,12 @@ export const GenAIChatSessionsTable = ({
           table
             .getRowModel()
             .rows.map((row) => (
-              <ExperimentChatSessionsTableRow key={row.id} row={row} enableRowSelection={enableRowSelection} />
+              <ExperimentChatSessionsTableRow
+                key={row.id}
+                row={row}
+                enableRowSelection={enableRowSelection}
+                enableLinks={enableLinks}
+              />
             ))}
 
         {isLoading && <TableSkeletonRows table={table} />}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19660/files) to review incremental changes.
- [**stack/select-traces-for-scorers-part6**](https://github.com/mlflow/mlflow/pull/19660) [[Files changed](https://github.com/mlflow/mlflow/pull/19660/files)]
  - [stack/select-traces-for-scorers-part7](https://github.com/mlflow/mlflow/pull/19663) [[Files changed](https://github.com/mlflow/mlflow/pull/19663/files/e57d6328dcb3d38572725d668561843f230183ac..3bba36f1817c209474724f460e8f78d5094a7abb)]
    - [stack/select-traces-for-scorers-part8](https://github.com/mlflow/mlflow/pull/19664) [[Files changed](https://github.com/mlflow/mlflow/pull/19664/files/3bba36f1817c209474724f460e8f78d5094a7abb..075bcb4a15a86744b10aaa55f232475a0e767e5c)]
      - [stack/select-traces-for-scorers-part9](https://github.com/mlflow/mlflow/pull/19688) [[Files changed](https://github.com/mlflow/mlflow/pull/19688/files/075bcb4a15a86744b10aaa55f232475a0e767e5c..6317e9a3002c8beca2a4c9627e8d83c8692c2a6d)]
        - [stack/select-traces-for-scorers-part10](https://github.com/mlflow/mlflow/pull/19689) [[Files changed](https://github.com/mlflow/mlflow/pull/19689/files/6317e9a3002c8beca2a4c9627e8d83c8692c2a6d..37a4934465279afb188f09122e8af80f5c547e68)]
          - [stack/select-traces-for-scorers-part11](https://github.com/mlflow/mlflow/pull/19693) [[Files changed](https://github.com/mlflow/mlflow/pull/19693/files/37a4934465279afb188f09122e8af80f5c547e68..09e248fd72135cca00fe403a81aeec84633b41ff)]

---------
### What changes are proposed in this pull request?

Introduces a SelectSessionsModal component that allows users to browse and select chat sessions for evaluation with scorers. The modal integrates with the existing traces picker and chat sessions table, enabling session-based evaluation workflows.

https://github.com/user-attachments/assets/0d9a856a-4709-4de8-84f1-32b5591aa53e

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
