### PR TITLE
[Part 7/x] Evaluating UI sessions via judges: refactor useEvaluateTraces

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
@@ -1,8 +1,9 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { IntlProvider } from '@databricks/i18n';
 import { useForm } from 'react-hook-form';
 import SampleScorerOutputPanelContainer from './SampleScorerOutputPanelContainer';
-import { useEvaluateTraces, type JudgeEvaluationResult } from './useEvaluateTraces';
+import { useEvaluateTraces } from './useEvaluateTraces';
+import { type JudgeEvaluationResult } from './useEvaluateTraces.common';
 import { type ModelTrace } from '@databricks/web-shared/model-trace-explorer';
 import SampleScorerOutputPanelRenderer from './SampleScorerOutputPanelRenderer';
 import type { ScorerFormData } from './utils/scorerTransformUtils';
@@ -203,14 +204,19 @@ describe('SampleScorerOutputPanelContainer', () => {
     it('should call onScorerFinished when evaluation succeeds with results', async () => {
       const onScorerFinished = jest.fn();
       const mockResults = [createMockEvalResult('trace-1')];
-      mockEvaluateTraces.mockResolvedValue(mockResults);
+      mockEvaluateTraces.mockImplementation(() => {
+        onScorerFinished();
+        return Promise.resolve(mockResults);
+      });
 
       renderComponent({ onScorerFinished });
 
       const rendererProps = mockedRenderer.mock.calls[0][0];
       await rendererProps.handleRunScorer();
 
-      expect(onScorerFinished).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(onScorerFinished).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
@@ -284,7 +290,7 @@ describe('SampleScorerOutputPanelContainer', () => {
     });
 
     it('should handle evaluation errors gracefully', async () => {
-      mockEvaluateTraces.mockRejectedValue(new Error('API error'));
+      mockEvaluateTraces.mockImplementation(() => Promise.reject(new Error('API error')));
 
       renderComponent();
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/llmScorerUtils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/llmScorerUtils.tsx
@@ -3,7 +3,7 @@ import { useIntl } from '@databricks/i18n';
 import { LLM_TEMPLATE } from './types';
 import type { FeedbackAssessment } from '@databricks/web-shared/model-trace-explorer';
 import { getModelTraceId } from '@databricks/web-shared/model-trace-explorer';
-import type { JudgeEvaluationResult } from './useEvaluateTraces';
+import type { JudgeEvaluationResult } from './useEvaluateTraces.common';
 import { TEMPLATE_VARIABLES } from '../../utils/evaluationUtils';
 
 // Custom hook for template options

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.common.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.common.ts
@@ -1,0 +1,38 @@
+import type { FeedbackAssessment, ModelTrace } from '@databricks/web-shared/model-trace-explorer';
+import { fetchOrFail, getAjaxUrl } from '../../../common/utils/FetchUtils';
+
+/**
+ * Fetches a single full trace from the MLflow API.
+ * TODO: move and/or reuse it in shared/model-trace-explorer/api.ts
+ */
+export const getMlflowTraceV3ForEvaluation = async (requestId: string): Promise<ModelTrace> => {
+  const [traceInfoResponse, traceDataResponse] = await Promise.all([
+    fetchOrFail(getAjaxUrl(`ajax-api/3.0/mlflow/traces/${requestId}`)),
+    fetchOrFail(getAjaxUrl(`ajax-api/3.0/mlflow/get-trace-artifact?request_id=${requestId}`)),
+  ]);
+  const [traceInfo, traceData] = await Promise.all([traceInfoResponse.json(), traceDataResponse.json()]);
+
+  return {
+    info: traceInfo?.trace?.trace_info || {},
+    data: traceData,
+  } as ModelTrace;
+};
+
+/**
+ * Result from evaluating a judge on a single trace.
+ * Always returns results as an array, even for single-result assessments.
+ * This simplifies rendering logic as components can always iterate over results.
+ */
+interface JudgeSimplifiedAssessmentResult {
+  assessment_id?: string;
+  result: string | null;
+  rationale: string | null;
+  error: string | null;
+  span_name?: string;
+}
+
+export interface JudgeEvaluationResult {
+  trace: ModelTrace | null;
+  results: JudgeSimplifiedAssessmentResult[]; // Always an array, even for single-result assessments
+  error: string | null;
+}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
@@ -1,7 +1,8 @@
 import { jest, describe, beforeEach, it, expect } from '@jest/globals';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
-import { useEvaluateTraces, type JudgeEvaluationResult } from './useEvaluateTraces';
+import { useEvaluateTraces } from './useEvaluateTraces';
+import { type JudgeEvaluationResult } from './useEvaluateTraces.common';
 import type { ModelTrace, ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
 import { SEARCH_MLFLOW_TRACES_QUERY_KEY } from '@databricks/web-shared/genai-traces-table';
 import { fetchOrFail } from '../../../common/utils/FetchUtils';
@@ -283,7 +284,7 @@ describe('useEvaluateTraces', () => {
       });
 
       expect(evaluationResults).toHaveLength(3);
-      evaluationResults.forEach((evalResult, index) => {
+      evaluationResults?.forEach((evalResult, index) => {
         expect(evalResult).toEqual({
           trace: mockTraces[index],
           results: [
@@ -592,7 +593,7 @@ describe('useEvaluateTraces', () => {
       expect(evaluationResults).toHaveLength(3);
 
       // First trace should succeed
-      expect(evaluationResults[0]).toEqual({
+      expect(evaluationResults?.[0]).toEqual({
         trace: mockTraces[0],
         results: [
           {
@@ -606,14 +607,14 @@ describe('useEvaluateTraces', () => {
       });
 
       // Second trace should have error
-      expect(evaluationResults[1]).toEqual({
+      expect(evaluationResults?.[1]).toEqual({
         trace: mockTraces[1],
         results: [],
         error: 'Network error',
       });
 
       // Third trace should succeed
-      expect(evaluationResults[2]).toEqual({
+      expect(evaluationResults?.[2]).toEqual({
         trace: mockTraces[2],
         results: [
           {
@@ -987,7 +988,7 @@ describe('useEvaluateTraces', () => {
         });
 
         expect(evaluationResults).toHaveLength(2);
-        evaluationResults.forEach((evalResult, index) => {
+        evaluationResults?.forEach((evalResult, index) => {
           expect(evalResult).toEqual({
             trace: mockTraces[index],
             results: [
@@ -1330,7 +1331,7 @@ describe('useEvaluateTraces', () => {
         });
 
         expect(evaluationResults).toHaveLength(2);
-        expect(evaluationResults[0]).toEqual({
+        expect(evaluationResults?.[0]).toEqual({
           trace: mockTraces[0],
           results: [
             {
@@ -1342,7 +1343,7 @@ describe('useEvaluateTraces', () => {
           ],
           error: null,
         });
-        expect(evaluationResults[1]).toEqual({
+        expect(evaluationResults?.[1]).toEqual({
           trace: mockTraces[1],
           results: [],
           error: 'Assessment failed',

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
-import { isRunningScorersEnabled } from '../../../common/utils/FeatureUtils';
+import { isEvaluatingSessionsInScorersEnabled, isRunningScorersEnabled } from '../../../common/utils/FeatureUtils';
 import { fetchOrFail, getAjaxUrl } from '../../../common/utils/FetchUtils';
 import type { ModelTrace } from '@databricks/web-shared/model-trace-explorer';
 import type {
@@ -14,7 +14,7 @@ import {
   extractTemplateVariables,
 } from '../../utils/evaluationUtils';
 import { searchMlflowTracesQueryFn, SEARCH_MLFLOW_TRACES_QUERY_KEY } from '@databricks/web-shared/genai-traces-table';
-import { DEFAULT_TRACE_COUNT, RETRIEVAL_ASSESSMENTS } from './constants';
+import { DEFAULT_TRACE_COUNT, RETRIEVAL_ASSESSMENTS, ScorerEvaluationScope } from './constants';
 import {
   extractInputs,
   extractOutputs,
@@ -25,6 +25,7 @@ import {
 } from '../../utils/TraceUtils';
 import { EvaluateChatCompletionsParams, EvaluateTracesParams } from './types';
 import { useGetTraceIdsForEvaluation } from './useGetTracesForEvaluation';
+import { getMlflowTraceV3ForEvaluation, JudgeEvaluationResult } from './useEvaluateTraces.common';
 
 /**
  * Response from the chat completions API
@@ -43,38 +44,6 @@ interface ChatCompletionsRequest {
   system_prompt?: string | null;
   experiment_id: string;
 }
-
-/**
- * Result from evaluating a judge on a single trace.
- * Always returns results as an array, even for single-result assessments.
- * This simplifies rendering logic as components can always iterate over results.
- */
-export interface AssessmentResult {
-  assessment_id?: string;
-  result: string | null;
-  rationale: string | null;
-  error: string | null;
-  span_name?: string;
-}
-
-export interface JudgeEvaluationResult {
-  trace: ModelTrace | null;
-  results: AssessmentResult[]; // Always an array, even for single-result assessments
-  error: string | null;
-}
-
-const getMlflowTraceV3 = async (requestId: string): Promise<ModelTrace> => {
-  const [traceInfoResponse, traceDataResponse] = await Promise.all([
-    fetchOrFail(getAjaxUrl(`ajax-api/3.0/mlflow/traces/${requestId}`)),
-    fetchOrFail(getAjaxUrl(`ajax-api/3.0/mlflow/get-trace-artifact?request_id=${requestId}`)),
-  ]);
-  const [traceInfo, traceData] = await Promise.all([traceInfoResponse.json(), traceDataResponse.json()]);
-
-  return {
-    info: traceInfo?.trace?.trace_info || {},
-    data: traceData,
-  } as ModelTrace;
-};
 
 async function callChatCompletions(
   userPrompt: string,
@@ -341,18 +310,33 @@ export interface EvaluateTracesState {
  * Supports both custom LLM judges (via chat-completions) and built-in judges (via chat-assessments).
  * Results from both endpoints will not be cached since LLM responses are not deterministic.
  */
-export function useEvaluateTraces(): [
-  (params: EvaluateTracesParams) => Promise<JudgeEvaluationResult[]>,
-  EvaluateTracesState,
-] {
+export function useEvaluateTraces({
+  onScorerFinished,
+}: {
+  /**
+   * Callback to be called when the evaluation is finished.
+   */
+  onScorerFinished?: () => void;
+} = {}): [(params: EvaluateTracesParams) => Promise<JudgeEvaluationResult[] | void>, EvaluateTracesState] {
   const [isLoading, setIsLoading] = useState(false);
   const [data, setData] = useState<JudgeEvaluationResult[] | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const queryClient = useQueryClient();
   const getTraceIdsForEvaluation = useGetTraceIdsForEvaluation();
+  const invocationCounterRef = useRef(0);
 
-  const evaluateTraces = useCallback(
+  /**
+   * Enables asynchronous evaluation. If enabled, the evaluation will be done as a
+   * queued job on the server and the results will be polled for asynchronously.
+   */
+  const usingAsyncMode = isEvaluatingSessionsInScorersEnabled();
+
+  const evaluateTracesSync = useCallback(
     async (params: EvaluateTracesParams): Promise<JudgeEvaluationResult[]> => {
+      // Track this invocation to ensure only the latest one calls onScorerFinished
+      invocationCounterRef.current += 1;
+      const currentInvocationId = invocationCounterRef.current;
+
       setIsLoading(true);
       setError(null);
       setData(null);
@@ -373,7 +357,7 @@ export function useEvaluateTraces(): [
               // Fetch trace data with React Query caching
               fullTrace = await queryClient.fetchQuery({
                 queryKey: ['GetMlflowTraceV3', traceId],
-                queryFn: () => getMlflowTraceV3(traceId),
+                queryFn: () => getMlflowTraceV3ForEvaluation(traceId),
                 staleTime: Infinity,
                 cacheTime: Infinity,
               });
@@ -578,6 +562,12 @@ export function useEvaluateTraces(): [
         const evaluationResults: JudgeEvaluationResult[] = evaluationResultsNested.flat();
 
         setData(evaluationResults);
+
+        // Only call onScorerFinished if this is still the latest invocation
+        if (currentInvocationId === invocationCounterRef.current && onScorerFinished) {
+          onScorerFinished();
+        }
+
         return evaluationResults;
       } catch (err) {
         const errorObj = err instanceof Error ? err : new Error(String(err));
@@ -587,7 +577,7 @@ export function useEvaluateTraces(): [
         setIsLoading(false);
       }
     },
-    [queryClient, getTraceIdsForEvaluation],
+    [queryClient, getTraceIdsForEvaluation, onScorerFinished],
   );
 
   const reset = useCallback(() => {
@@ -596,8 +586,12 @@ export function useEvaluateTraces(): [
     setIsLoading(false);
   }, []);
 
+  if (usingAsyncMode) {
+    // TODO(next PRs): Return controls and state for async evaluation
+  }
+
   return [
-    evaluateTraces,
+    evaluateTracesSync,
     {
       data,
       isLoading,
@@ -659,7 +653,7 @@ export function usePrefetchTraces({ traceCount, locations }: PrefetchTracesParam
           traceIds.map((traceId) =>
             queryClient.prefetchQuery({
               queryKey: ['GetMlflowTraceV3', traceId],
-              queryFn: () => getMlflowTraceV3(traceId),
+              queryFn: () => getMlflowTraceV3ForEvaluation(traceId),
               staleTime: Infinity,
               cacheTime: Infinity,
             }),


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19663/files) to review incremental changes.
- [**stack/select-traces-for-scorers-part7**](https://github.com/mlflow/mlflow/pull/19663) [[Files changed](https://github.com/mlflow/mlflow/pull/19663/files)]
  - [stack/select-traces-for-scorers-part8](https://github.com/mlflow/mlflow/pull/19664) [[Files changed](https://github.com/mlflow/mlflow/pull/19664/files/6f9b2c4b1d99219d3314a03426d517d14bd923fc..eb005ce8ebbc9fa617c1ca1f18b17440af2fd63b)]
    - [stack/select-traces-for-scorers-part9](https://github.com/mlflow/mlflow/pull/19688) [[Files changed](https://github.com/mlflow/mlflow/pull/19688/files/eb005ce8ebbc9fa617c1ca1f18b17440af2fd63b..cbd8ad941ecc9efea6ce21450a90ca2521c70eea)]
      - [stack/select-traces-for-scorers-part10](https://github.com/mlflow/mlflow/pull/19689) [[Files changed](https://github.com/mlflow/mlflow/pull/19689/files/cbd8ad941ecc9efea6ce21450a90ca2521c70eea..f9bcea373fc68b43b393b36dbdfdbe9e78d1779c)]
        - [stack/select-traces-for-scorers-part11](https://github.com/mlflow/mlflow/pull/19693) [[Files changed](https://github.com/mlflow/mlflow/pull/19693/files/f9bcea373fc68b43b393b36dbdfdbe9e78d1779c..2a0f317acac662b711420f8f5812eb68fa68175e)]

---------
### What changes are proposed in this pull request?

Refactors the `useEvaluateTraces` hook
- extracts shared logic into a new `useEvaluateTraces.common.ts` module. This separation improves code organization and enables reuse of common evaluation utilities across different evaluation contexts (sync and async). 
- updates `onScorerFinished` callback to be handled internally in `useEvaluateTraces` instead of upstream so it's unified logic

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
