### PR TITLE
[Part 8/x] Evaluating UI sessions via judges: hook for async evaluation

### DIFF
--- a/mlflow/server/js/src/common/hooks/useGetTrackingServerJobStatus.tsx
+++ b/mlflow/server/js/src/common/hooks/useGetTrackingServerJobStatus.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react';
+import { fetchAPI, getAjaxUrl } from '../utils/FetchUtils';
+import { QueryFunctionContext, useQuery, UseQueryOptions } from '../utils/reactQueryHooks';
+
+const GET_JOB_DATA_QUERY_KEY = 'GET_TRACKING_SERVER_JOB_STATUS';
+
+export enum TrackingJobStatus {
+  RUNNING = 'RUNNING',
+  PENDING = 'PENDING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+  TIMEOUT = 'TIMEOUT',
+}
+
+export type TrackingJobQueryResult<ResultType> = (
+  | {
+      status:
+        | TrackingJobStatus.RUNNING
+        | TrackingJobStatus.PENDING
+        | TrackingJobStatus.CANCELLED
+        | TrackingJobStatus.TIMEOUT;
+    }
+  | {
+      status: TrackingJobStatus.SUCCEEDED;
+      // Actual result is present in the payload if the job succeeded
+      result: ResultType;
+    }
+  | {
+      status: TrackingJobStatus.FAILED;
+      // In case of failure, the result is the error message
+      result: string;
+    }
+) & {
+  jobId: string;
+};
+
+type QueryKey = [typeof GET_JOB_DATA_QUERY_KEY, string[] | undefined];
+
+const queryFn = async ({ queryKey: [, jobIds] }: QueryFunctionContext<QueryKey>) => {
+  const responsesData = await Promise.all(
+    (jobIds ?? []).map(async (jobId) => {
+      const responseData = await fetchAPI(getAjaxUrl(`ajax-api/3.0/jobs/${jobId}`));
+      const { status, result } = responseData;
+      return { jobId, status, result };
+    }),
+  );
+  return responsesData;
+};
+
+/**
+ * Gets the current status of a tracking server job.
+ */
+export const useGetTrackingServerJobStatus = <T = any,>(
+  jobIds?: string[],
+  options?: UseQueryOptions<TrackingJobQueryResult<T>[], Error, TrackingJobQueryResult<T>[], QueryKey>,
+) => {
+  const isEnabled = options?.enabled ?? true;
+  const queryResult = useQuery<TrackingJobQueryResult<T>[], Error, TrackingJobQueryResult<T>[], QueryKey>({
+    queryKey: [GET_JOB_DATA_QUERY_KEY, jobIds],
+    queryFn,
+    ...options,
+  });
+
+  // Determine if any of the jobs are still running
+  const areJobsRunning =
+    isEnabled &&
+    (queryResult.isLoading ||
+      queryResult.data?.some(
+        (response) => response.status === TrackingJobStatus.PENDING || response.status === TrackingJobStatus.RUNNING,
+      ));
+
+  const jobResults = useMemo(
+    () =>
+      queryResult.data?.reduce((acc, response) => {
+        acc[response.jobId] = response;
+        return acc;
+      }, {} as Record<string, TrackingJobQueryResult<T>>),
+    [queryResult.data],
+  );
+
+  return { jobResults, areJobsRunning };
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor } from '@testing-library/react';
 import { IntlProvider } from '@databricks/i18n';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import SampleScorerOutputPanelContainer from './SampleScorerOutputPanelContainer';
 import { useEvaluateTraces } from './useEvaluateTraces';
 import { type JudgeEvaluationResult } from './useEvaluateTraces.common';
@@ -51,7 +51,7 @@ interface TestWrapperProps {
 }
 
 function TestWrapper({ defaultValues, onScorerFinished }: TestWrapperProps) {
-  const { control } = useForm<ScorerFormData>({
+  const form = useForm<ScorerFormData>({
     defaultValues: {
       name: 'Test Scorer',
       instructions: 'Test instructions',
@@ -64,11 +64,13 @@ function TestWrapper({ defaultValues, onScorerFinished }: TestWrapperProps) {
 
   return (
     <IntlProvider locale="en">
-      <SampleScorerOutputPanelContainer
-        control={control}
-        experimentId={experimentId}
-        onScorerFinished={onScorerFinished}
-      />
+      <FormProvider {...form}>
+        <SampleScorerOutputPanelContainer
+          control={form.control}
+          experimentId={experimentId}
+          onScorerFinished={onScorerFinished}
+        />
+      </FormProvider>
     </IntlProvider>
   );
 }

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
@@ -200,6 +200,7 @@ describe('SampleScorerOutputPanelContainer', () => {
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions: 'Test instructions',
         experimentId,
+        serializedScorer: expect.any(String),
       });
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
@@ -1,15 +1,16 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import type { Control } from 'react-hook-form';
-import { useWatch, useFormState } from 'react-hook-form';
+import { useWatch, useFormState, useFormContext } from 'react-hook-form';
 import { useIntl } from '@databricks/i18n';
 import { type ScorerFormData } from './utils/scorerTransformUtils';
 import { useEvaluateTraces } from './useEvaluateTraces';
 import SampleScorerOutputPanelRenderer from './SampleScorerOutputPanelRenderer';
 import { convertEvaluationResultToAssessment } from './llmScorerUtils';
 import { extractTemplateVariables } from '../../utils/evaluationUtils';
-import { DEFAULT_TRACE_COUNT, ASSESSMENT_NAME_TEMPLATE_MAPPING, ScorerEvaluationScope } from './constants';
+import { DEFAULT_TRACE_COUNT, ASSESSMENT_NAME_TEMPLATE_MAPPING, ScorerEvaluationScope, SCORER_TYPE } from './constants';
 import { EvaluateTracesParams, LLM_TEMPLATE } from './types';
 import { coerceToEnum } from '../../../shared/web-shared/utils';
+import { useGetSerializedScorerFromForm } from './useGetSerializedScorerFromForm';
 
 interface SampleScorerOutputPanelContainerProps {
   control: Control<ScorerFormData>;
@@ -32,6 +33,8 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
   const evaluationScopeFormValue = useWatch({ control, name: 'evaluationScope' });
   const evaluationScope = coerceToEnum(ScorerEvaluationScope, evaluationScopeFormValue, ScorerEvaluationScope.TRACES);
 
+  const getSerializedScorer = useGetSerializedScorerFromForm();
+
   const [itemsToEvaluate, setItemsToEvaluate] = useState<Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>>({
     itemCount: DEFAULT_TRACE_COUNT,
     itemIds: [],
@@ -39,6 +42,7 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
 
   const [evaluateTraces, { data, isLoading, error, reset }] = useEvaluateTraces({
     onScorerFinished,
+    getSerializedScorer,
   });
 
   // Carousel state for navigating through traces

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
@@ -33,7 +33,7 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
   const evaluationScopeFormValue = useWatch({ control, name: 'evaluationScope' });
   const evaluationScope = coerceToEnum(ScorerEvaluationScope, evaluationScopeFormValue, ScorerEvaluationScope.TRACES);
 
-  const getSerializedScorer = useGetSerializedScorerFromForm();
+  const getSerializedScorerFromForm = useGetSerializedScorerFromForm();
 
   const [itemsToEvaluate, setItemsToEvaluate] = useState<Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>>({
     itemCount: DEFAULT_TRACE_COUNT,
@@ -42,7 +42,6 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
 
   const [evaluateTraces, { data, isLoading, error, reset }] = useEvaluateTraces({
     onScorerFinished,
-    getSerializedScorer,
   });
 
   // Carousel state for navigating through traces
@@ -76,6 +75,8 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
       return;
     }
 
+    const serializedScorer = getSerializedScorerFromForm();
+
     // Reset to first trace when running scorer
     setCurrentTraceIndex(0);
 
@@ -88,6 +89,7 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
             locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' as const }],
             judgeInstructions: judgeInstructions || '',
             experimentId,
+            serializedScorer,
           }
         : {
             itemCount: itemsToEvaluate.itemCount,
@@ -101,13 +103,23 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
             ],
             experimentId,
             guidelines: guidelines ? [guidelines] : undefined,
+            serializedScorer,
           };
 
       await evaluateTraces(evaluationParams);
     } catch (error) {
       // Error is already handled by the hook's error state
     }
-  }, [isCustomMode, judgeInstructions, llmTemplate, guidelines, itemsToEvaluate, evaluateTraces, experimentId]);
+  }, [
+    isCustomMode,
+    judgeInstructions,
+    llmTemplate,
+    guidelines,
+    itemsToEvaluate,
+    evaluateTraces,
+    experimentId,
+    getSerializedScorerFromForm,
+  ]);
 
   // Navigation handlers
   const handlePrevious = () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/llmScorerUtils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/llmScorerUtils.tsx
@@ -3,7 +3,7 @@ import { useIntl } from '@databricks/i18n';
 import { LLM_TEMPLATE } from './types';
 import type { FeedbackAssessment } from '@databricks/web-shared/model-trace-explorer';
 import { getModelTraceId } from '@databricks/web-shared/model-trace-explorer';
-import type { JudgeEvaluationResult } from './useEvaluateTraces.common';
+import { isFeedbackAssessmentInJudgeEvaluationResult, type JudgeEvaluationResult } from './useEvaluateTraces.common';
 import { TEMPLATE_VARIABLES } from '../../utils/evaluationUtils';
 
 // Custom hook for template options
@@ -145,6 +145,11 @@ export const convertEvaluationResultToAssessment = (
 
   // Get the first result from the results array (there should only be one when converting to assessment)
   const firstResult = evaluationResult.results[0];
+
+  // If the evaluation result is already an assessment, return it with trace ID attached and assessment ID generated
+  if (firstResult && isFeedbackAssessmentInJudgeEvaluationResult(firstResult)) {
+    return { ...firstResult, trace_id: traceId, assessment_id: `${Date.now()}-${index}` };
+  }
 
   return {
     assessment_id: `${Date.now()}`,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
@@ -77,6 +77,7 @@ interface EvaluateChatParamsBase {
   itemIds?: string[];
   locations: (ModelTraceLocationMlflowExperiment | ModelTraceLocationUcSchema)[];
   experimentId: string;
+  serializedScorer?: string;
 }
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.common.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.common.ts
@@ -38,5 +38,5 @@ export interface JudgeEvaluationResult {
 }
 
 export const isFeedbackAssessmentInJudgeEvaluationResult = (result: any): result is FeedbackAssessment => {
-  return 'assessment_name' in result;
+  return 'assessment_name' in result && 'feedback' in result;
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.common.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.common.ts
@@ -33,6 +33,10 @@ interface JudgeSimplifiedAssessmentResult {
 
 export interface JudgeEvaluationResult {
   trace: ModelTrace | null;
-  results: JudgeSimplifiedAssessmentResult[]; // Always an array, even for single-result assessments
+  results: (FeedbackAssessment | JudgeSimplifiedAssessmentResult)[]; // Always an array, even for single-result assessments
   error: string | null;
 }
+
+export const isFeedbackAssessmentInJudgeEvaluationResult = (result: any): result is FeedbackAssessment => {
+  return 'assessment_name' in result;
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
@@ -15,6 +15,12 @@ jest.mock('../../../common/utils/FetchUtils', () => ({
   fetchOrFail: jest.fn(),
 }));
 
+// Mock the feature flag to explicitly use sync mode for these tests
+jest.mock('../../../common/utils/FeatureUtils', () => ({
+  ...jest.requireActual<typeof import('../../../common/utils/FeatureUtils')>('../../../common/utils/FeatureUtils'),
+  isEvaluatingSessionsInScorersEnabled: () => false,
+}));
+
 const mockedFetchOrFail = jest.mocked(fetchOrFail);
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
@@ -26,6 +26,7 @@ import {
 import { EvaluateChatCompletionsParams, EvaluateTracesParams } from './types';
 import { useGetTraceIdsForEvaluation } from './useGetTracesForEvaluation';
 import { getMlflowTraceV3ForEvaluation, JudgeEvaluationResult } from './useEvaluateTraces.common';
+import { useEvaluateTracesAsync } from './useEvaluateTracesAsync';
 
 /**
  * Response from the chat completions API
@@ -312,11 +313,13 @@ export interface EvaluateTracesState {
  */
 export function useEvaluateTraces({
   onScorerFinished,
+  getSerializedScorer,
 }: {
   /**
    * Callback to be called when the evaluation is finished.
    */
   onScorerFinished?: () => void;
+  getSerializedScorer?: () => string;
 } = {}): [(params: EvaluateTracesParams) => Promise<JudgeEvaluationResult[] | void>, EvaluateTracesState] {
   const [isLoading, setIsLoading] = useState(false);
   const [data, setData] = useState<JudgeEvaluationResult[] | null>(null);
@@ -586,8 +589,10 @@ export function useEvaluateTraces({
     setIsLoading(false);
   }, []);
 
+  const [evaluateTracesAsync, asyncEvaluationState] = useEvaluateTracesAsync({ getSerializedScorer, onScorerFinished });
+
   if (usingAsyncMode) {
-    // TODO(next PRs): Return controls and state for async evaluation
+    return [evaluateTracesAsync, asyncEvaluationState] as const;
   }
 
   return [

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
@@ -313,13 +313,11 @@ export interface EvaluateTracesState {
  */
 export function useEvaluateTraces({
   onScorerFinished,
-  getSerializedScorer,
 }: {
   /**
    * Callback to be called when the evaluation is finished.
    */
   onScorerFinished?: () => void;
-  getSerializedScorer?: () => string;
 } = {}): [(params: EvaluateTracesParams) => Promise<JudgeEvaluationResult[] | void>, EvaluateTracesState] {
   const [isLoading, setIsLoading] = useState(false);
   const [data, setData] = useState<JudgeEvaluationResult[] | null>(null);
@@ -589,7 +587,7 @@ export function useEvaluateTraces({
     setIsLoading(false);
   }, []);
 
-  const [evaluateTracesAsync, asyncEvaluationState] = useEvaluateTracesAsync({ getSerializedScorer, onScorerFinished });
+  const [evaluateTracesAsync, asyncEvaluationState] = useEvaluateTracesAsync({ onScorerFinished });
 
   if (usingAsyncMode) {
     return [evaluateTracesAsync, asyncEvaluationState] as const;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx
@@ -159,13 +159,11 @@ describe('useEvaluateTracesAsync', () => {
       setupTraceFetchHandlers(server, traces);
 
       const onScorerFinished = jest.fn();
-      const getSerializedScorer = jest.fn<() => string>().mockReturnValue(serializedScorer);
 
       const { result } = renderHook(
         () =>
           useEvaluateTracesAsync({
             onScorerFinished,
-            getSerializedScorer,
           }),
         { wrapper },
       );
@@ -183,6 +181,7 @@ describe('useEvaluateTracesAsync', () => {
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test instructions',
+          serializedScorer,
         });
       });
 
@@ -247,13 +246,11 @@ describe('useEvaluateTracesAsync', () => {
       setupTraceFetchHandlers(server, traces);
 
       const onScorerFinished = jest.fn();
-      const getSerializedScorer = jest.fn<() => string>().mockReturnValue(serializedScorer);
 
       const { result } = renderHook(
         () =>
           useEvaluateTracesAsync({
             onScorerFinished,
-            getSerializedScorer,
           }),
         { wrapper },
       );
@@ -265,6 +262,7 @@ describe('useEvaluateTracesAsync', () => {
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test instructions',
+          serializedScorer,
         });
       });
 
@@ -348,7 +346,6 @@ describe('useEvaluateTracesAsync', () => {
         () =>
           useEvaluateTracesAsync({
             onScorerFinished,
-            getSerializedScorer: () => serializedScorer,
           }),
         { wrapper },
       );
@@ -361,6 +358,7 @@ describe('useEvaluateTracesAsync', () => {
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test instructions',
+          serializedScorer,
         });
       });
 
@@ -411,7 +409,7 @@ describe('useEvaluateTracesAsync', () => {
       // Setup trace fetching handlers using MSW
       setupTraceFetchHandlers(server, traces);
 
-      const { result } = renderHook(() => useEvaluateTracesAsync({ getSerializedScorer: () => serializedScorer }), {
+      const { result } = renderHook(() => useEvaluateTracesAsync({}), {
         wrapper,
       });
 
@@ -422,6 +420,7 @@ describe('useEvaluateTracesAsync', () => {
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test',
+          serializedScorer,
         });
       });
 
@@ -463,7 +462,7 @@ describe('useEvaluateTracesAsync', () => {
       // Setup trace fetching handlers using MSW
       setupTraceFetchHandlers(server, traces);
 
-      const { result } = renderHook(() => useEvaluateTracesAsync({ getSerializedScorer: () => serializedScorer }), {
+      const { result } = renderHook(() => useEvaluateTracesAsync({}), {
         wrapper,
       });
 
@@ -475,6 +474,7 @@ describe('useEvaluateTracesAsync', () => {
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test',
+          serializedScorer,
         });
       });
 
@@ -530,7 +530,7 @@ describe('useEvaluateTracesAsync', () => {
 
       setupTraceFetchHandlers(server, traces);
 
-      const { result } = renderHook(() => useEvaluateTracesAsync({ getSerializedScorer: () => serializedScorer }), {
+      const { result } = renderHook(() => useEvaluateTracesAsync({}), {
         wrapper,
       });
 
@@ -541,6 +541,7 @@ describe('useEvaluateTracesAsync', () => {
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test',
+          serializedScorer,
         });
       });
 
@@ -598,7 +599,7 @@ describe('useEvaluateTracesAsync', () => {
       // Setup trace fetching handlers using MSW
       setupTraceFetchHandlers(server, traces);
 
-      const { result } = renderHook(() => useEvaluateTracesAsync({ getSerializedScorer: () => serializedScorer }), {
+      const { result } = renderHook(() => useEvaluateTracesAsync({}), {
         wrapper,
       });
 
@@ -609,6 +610,7 @@ describe('useEvaluateTracesAsync', () => {
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test',
+          serializedScorer,
         });
       });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx
@@ -1,0 +1,631 @@
+import { jest, describe, beforeEach, it, expect } from '@jest/globals';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
+import { useEvaluateTracesAsync } from './useEvaluateTracesAsync';
+import type { ModelTrace, ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
+import { setupServer } from '../../../common/utils/setup-msw';
+import { rest } from 'msw';
+
+jest.useFakeTimers();
+
+/**
+ * Helper to create mock trace data with proper V3 structure
+ */
+function createMockTrace(traceId: string): ModelTrace {
+  return {
+    info: {
+      trace_id: traceId,
+      // trace_location is required for isV3ModelTraceInfo to return true
+      trace_location: {
+        type: 'MLFLOW_EXPERIMENT',
+        mlflow_experiment: { experiment_id: 'exp-123' },
+      },
+    } as ModelTraceInfoV3,
+    data: {
+      spans: [
+        {
+          trace_id: traceId,
+          span_id: `span-${traceId}`,
+          name: 'root',
+          trace_state: '',
+          parent_span_id: null,
+          start_time_unix_nano: '0',
+          end_time_unix_nano: '1000000',
+          status: { code: 'STATUS_CODE_UNSET' },
+          attributes: {
+            'mlflow.spanInputs': `input-${traceId}`,
+            'mlflow.spanOutputs': `output-${traceId}`,
+          },
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Helper to setup MSW handlers for trace fetching endpoints
+ */
+function setupTraceFetchHandlers(server: ReturnType<typeof setupServer>, traces: Map<string, ModelTrace>) {
+  // Handler for trace info endpoint: GET ajax-api/3.0/mlflow/traces/:traceId
+  server.use(
+    rest.get('ajax-api/3.0/mlflow/traces/:traceId', (req, res, ctx) => {
+      const { traceId } = req.params;
+      const trace = traces.get(traceId as string);
+      return res(
+        ctx.json({
+          trace: {
+            trace_info: trace?.info || {},
+          },
+        }),
+      );
+    }),
+  );
+
+  // Handler for trace artifact/data endpoint: GET ajax-api/3.0/mlflow/get-trace-artifact
+  server.use(
+    rest.get('ajax-api/3.0/mlflow/get-trace-artifact', (req, res, ctx) => {
+      const requestId = req.url.searchParams.get('request_id');
+      const trace = traces.get(requestId || '');
+      return res(ctx.json(trace?.data || {}));
+    }),
+  );
+}
+
+describe('useEvaluateTracesAsync', () => {
+  const server = setupServer();
+  let queryClient: QueryClient;
+  let wrapper: React.ComponentType<{ children: React.ReactNode }>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+
+    wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    jest.clearAllMocks();
+  });
+
+  describe('Happy Path - Job Initiation and Job Succeeds', () => {
+    it('should successfully start evaluation job and return results when job succeeds', async () => {
+      const traceId = 'trace-1';
+      const experimentId = 'exp-123';
+      const jobId = 'job-123';
+      const serializedScorer = 'mock-serialized-scorer';
+
+      const mockTrace = createMockTrace(traceId);
+      const traces = new Map([[traceId, mockTrace]]);
+
+      // Setup trace search handler
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              traces: [{ trace_id: traceId }],
+              next_page_token: undefined,
+            }),
+          );
+        }),
+      );
+
+      // Setup scorer invoke handler - returns job ID
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              jobs: [{ job_id: jobId }],
+            }),
+          );
+        }),
+      );
+
+      // Setup job status handler - first call returns RUNNING, second returns SUCCEEDED
+      let jobStatusCallCount = 0;
+      server.use(
+        rest.get(`ajax-api/3.0/jobs/${jobId}`, (_req, res, ctx) => {
+          jobStatusCallCount++;
+          if (jobStatusCallCount === 1) {
+            return res(ctx.json({ status: 'RUNNING' }));
+          }
+          return res(
+            ctx.json({
+              status: 'SUCCEEDED',
+              result: {
+                [traceId]: {
+                  assessments: [
+                    {
+                      assessment_name: 'test_scorer',
+                      numeric_value: 0.9,
+                      rationale: 'Test passed',
+                    },
+                  ],
+                },
+              },
+            }),
+          );
+        }),
+      );
+
+      // Setup trace fetching handlers using MSW
+      setupTraceFetchHandlers(server, traces);
+
+      const onScorerFinished = jest.fn();
+      const getSerializedScorer = jest.fn<() => string>().mockReturnValue(serializedScorer);
+
+      const { result } = renderHook(
+        () =>
+          useEvaluateTracesAsync({
+            onScorerFinished,
+            getSerializedScorer,
+          }),
+        { wrapper },
+      );
+
+      // Initial state should be idle
+      expect(result.current[1].data).toBeNull();
+      expect(result.current[1].isLoading).toBe(false);
+      expect(result.current[1].error).toBeNull();
+
+      // Start evaluation
+      act(() => {
+        const [evaluateFunction] = result.current;
+        evaluateFunction({
+          itemCount: 1,
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test instructions',
+        });
+      });
+
+      // Wait for job to complete and results to be available
+      await waitFor(() => {
+        expect(result.current[1].isLoading).toBe(false);
+        expect(result.current[1].data).not.toBeNull();
+      });
+
+      const [, finalState] = result.current;
+
+      // Verify final state
+      expect(finalState.data).toHaveLength(1);
+      expect(finalState.data?.[0]).toEqual({
+        trace: mockTrace,
+        results: [
+          {
+            assessment_name: 'test_scorer',
+            numeric_value: 0.9,
+            rationale: 'Test passed',
+          },
+        ],
+        error: null,
+      });
+      expect(finalState.error).toBeNull();
+
+      // Verify onScorerFinished was called once
+      expect(onScorerFinished).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Bad Path - Job Creation Fails', () => {
+    it('should handle error when scorer invoke endpoint fails', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      const traceId = 'trace-1';
+      const experimentId = 'exp-123';
+      const serializedScorer = 'mock-serialized-scorer';
+
+      const mockTrace = createMockTrace(traceId);
+      const traces = new Map([[traceId, mockTrace]]);
+
+      // Setup trace search handler
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              traces: [{ trace_id: traceId }],
+              next_page_token: undefined,
+            }),
+          );
+        }),
+      );
+
+      // Setup scorer invoke handler to return an error
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(ctx.status(500), ctx.json({ error_code: 'INTERNAL_ERROR', message: 'Failed to create job' }));
+        }),
+      );
+
+      // Setup trace fetching handlers using MSW
+      setupTraceFetchHandlers(server, traces);
+
+      const onScorerFinished = jest.fn();
+      const getSerializedScorer = jest.fn<() => string>().mockReturnValue(serializedScorer);
+
+      const { result } = renderHook(
+        () =>
+          useEvaluateTracesAsync({
+            onScorerFinished,
+            getSerializedScorer,
+          }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        const [evaluateFunction] = result.current;
+        evaluateFunction({
+          itemCount: 1,
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test instructions',
+        });
+      });
+
+      // Wait for the error to propagate and loading to finish
+      await waitFor(() => {
+        expect(result.current[1].error).not.toBeNull();
+        expect(result.current[1].isLoading).toBe(false);
+      });
+
+      const [, state] = result.current;
+
+      // Should have error state
+      expect(state.error).toBeTruthy();
+      expect(state.isLoading).toBe(false);
+
+      // onScorerFinished should NOT be called when job creation fails (job never started)
+      expect(onScorerFinished).not.toHaveBeenCalled();
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('Bad Path - Job Fails After Two Polls', () => {
+    it('should handle job failure after initial PENDING and RUNNING states', async () => {
+      const traceId = 'trace-1';
+      const experimentId = 'exp-123';
+      const jobId = 'job-failing';
+      const serializedScorer = 'mock-serialized-scorer';
+
+      const mockTrace = createMockTrace(traceId);
+      const traces = new Map([[traceId, mockTrace]]);
+
+      // Setup trace search handler
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              traces: [{ trace_id: traceId }],
+              next_page_token: undefined,
+            }),
+          );
+        }),
+      );
+
+      // Setup scorer invoke handler
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(ctx.json({ jobs: [{ job_id: jobId }] }));
+        }),
+      );
+
+      // Setup job status handler:
+      // Poll 1: PENDING
+      // Poll 2: RUNNING
+      // Poll 3: FAILED
+      let jobStatusCallCount = 0;
+      server.use(
+        rest.get(`ajax-api/3.0/jobs/${jobId}`, (_req, res, ctx) => {
+          jobStatusCallCount++;
+          if (jobStatusCallCount === 1) {
+            return res(ctx.json({ status: 'PENDING' }));
+          }
+          if (jobStatusCallCount === 2) {
+            return res(ctx.json({ status: 'RUNNING' }));
+          }
+          // Third poll - job fails
+          return res(
+            ctx.json({
+              status: 'FAILED',
+              result: 'Scorer execution failed: Model endpoint unavailable',
+            }),
+          );
+        }),
+      );
+
+      // Setup trace fetching handlers using MSW
+      setupTraceFetchHandlers(server, traces);
+
+      const onScorerFinished = jest.fn();
+
+      const { result } = renderHook(
+        () =>
+          useEvaluateTracesAsync({
+            onScorerFinished,
+            getSerializedScorer: () => serializedScorer,
+          }),
+        { wrapper },
+      );
+
+      // Start evaluation
+      act(() => {
+        const [evaluateTracesFn] = result.current;
+        evaluateTracesFn({
+          itemCount: 1,
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test instructions',
+        });
+      });
+
+      // Wait for job to fail - error is set when job fails
+      await waitFor(() => {
+        expect(result.current[1].isLoading).toBe(false);
+        expect(result.current[1].error?.message).toBe('Scorer execution failed: Model endpoint unavailable');
+      });
+
+      // Verify job was polled at least 3 times
+      expect(jobStatusCallCount).toBeGreaterThanOrEqual(3);
+
+      // onScorerFinished IS called when job finishes, even on failure
+      expect(onScorerFinished).toHaveBeenCalledTimes(1);
+    }, 30000);
+
+    it('should handle job failure with detailed error message', async () => {
+      const traceId = 'trace-1';
+      const experimentId = 'exp-123';
+      const jobId = 'job-error';
+      const serializedScorer = 'mock-serialized-scorer';
+      const errorMessage = 'Rate limit exceeded: Too many requests to the scoring endpoint';
+
+      const mockTrace = createMockTrace(traceId);
+      const traces = new Map([[traceId, mockTrace]]);
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(ctx.json({ traces: [{ trace_id: traceId }], next_page_token: undefined }));
+        }),
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(ctx.json({ jobs: [{ job_id: jobId }] }));
+        }),
+      );
+
+      // Poll 1: RUNNING, Poll 2: FAILED
+      let pollCount = 0;
+      server.use(
+        rest.get(`ajax-api/3.0/jobs/${jobId}`, (_req, res, ctx) => {
+          pollCount++;
+          if (pollCount === 1) {
+            return res(ctx.json({ status: 'RUNNING' }));
+          }
+          return res(ctx.json({ status: 'FAILED', result: errorMessage }));
+        }),
+      );
+
+      // Setup trace fetching handlers using MSW
+      setupTraceFetchHandlers(server, traces);
+
+      const { result } = renderHook(() => useEvaluateTracesAsync({ getSerializedScorer: () => serializedScorer }), {
+        wrapper,
+      });
+
+      act(() => {
+        const [evaluateTracesFn] = result.current;
+        evaluateTracesFn({
+          itemCount: 1,
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test',
+        });
+      });
+
+      // Wait for job to fail - error is set when job fails
+      await waitFor(() => {
+        expect(result.current[1].isLoading).toBe(false);
+        expect(result.current[1].error?.message).toBe(errorMessage);
+      });
+    }, 30000);
+  });
+
+  describe('Reset Functionality', () => {
+    it('should reset state when reset is called', async () => {
+      const traceId = 'trace-1';
+      const experimentId = 'exp-123';
+      const jobId = 'job-reset';
+      const serializedScorer = 'mock-serialized-scorer';
+
+      const mockTrace = createMockTrace(traceId);
+      const traces = new Map([[traceId, mockTrace]]);
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(ctx.json({ traces: [{ trace_id: traceId }], next_page_token: undefined }));
+        }),
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(ctx.json({ jobs: [{ job_id: jobId }] }));
+        }),
+        rest.get(`ajax-api/3.0/jobs/${jobId}`, (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              status: 'SUCCEEDED',
+              result: { [traceId]: { assessments: [{ assessment_name: 'test', numeric_value: 1 }] } },
+            }),
+          );
+        }),
+      );
+
+      // Setup trace fetching handlers using MSW
+      setupTraceFetchHandlers(server, traces);
+
+      const { result } = renderHook(() => useEvaluateTracesAsync({ getSerializedScorer: () => serializedScorer }), {
+        wrapper,
+      });
+
+      // Run evaluation
+      await act(async () => {
+        const [evaluateTracesFn] = result.current;
+        evaluateTracesFn({
+          itemCount: 1,
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test',
+        });
+      });
+
+      // Wait for results
+      await waitFor(() => {
+        expect(result.current[1].data).not.toBeNull();
+      });
+
+      // Reset
+      act(() => {
+        result.current[1].reset();
+      });
+
+      // Verify state is reset
+      await waitFor(() => {
+        expect(result.current[1].data).toBeNull();
+        expect(result.current[1].isLoading).toBe(false);
+      });
+    });
+  });
+
+  describe('Job Success with Trace Failures', () => {
+    it('should return failure error messages when job succeeds but contains trace-level failures', async () => {
+      const traceId = 'trace-1';
+      const experimentId = 'exp-123';
+      const jobId = 'job-with-failures';
+      const serializedScorer = 'mock-serialized-scorer';
+
+      const mockTrace = createMockTrace(traceId);
+      const traces = new Map([[traceId, mockTrace]]);
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(ctx.json({ traces: [{ trace_id: traceId }], next_page_token: undefined }));
+        }),
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(ctx.json({ jobs: [{ job_id: jobId }] }));
+        }),
+        rest.get(`ajax-api/3.0/jobs/${jobId}`, (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              status: 'SUCCEEDED',
+              result: {
+                [traceId]: {
+                  assessments: [],
+                  failures: [{ error_code: 'SCORER_ERROR', error_message: 'Scorer failed to process trace' }],
+                },
+              },
+            }),
+          );
+        }),
+      );
+
+      setupTraceFetchHandlers(server, traces);
+
+      const { result } = renderHook(() => useEvaluateTracesAsync({ getSerializedScorer: () => serializedScorer }), {
+        wrapper,
+      });
+
+      act(() => {
+        const [evaluateTracesFn] = result.current;
+        evaluateTracesFn({
+          itemCount: 1,
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test',
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current[1].data).not.toBeNull();
+        expect(result.current[1].isLoading).toBe(false);
+      });
+
+      const [, state] = result.current;
+
+      // Job succeeded overall
+      expect(state.error).toBeNull();
+      // But individual trace has failure error
+      expect(state.data).toHaveLength(1);
+      expect(state.data?.[0].error).toBe('Scorer failed to process trace');
+      expect(state.data?.[0].results).toEqual([]);
+    });
+  });
+
+  describe('Polling Behavior', () => {
+    it('should stop polling when job completes', async () => {
+      const traceId = 'trace-1';
+      const experimentId = 'exp-123';
+      const jobId = 'job-poll-stop';
+      const serializedScorer = 'mock-serialized-scorer';
+
+      const mockTrace = createMockTrace(traceId);
+      const traces = new Map([[traceId, mockTrace]]);
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(ctx.json({ traces: [{ trace_id: traceId }], next_page_token: undefined }));
+        }),
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(ctx.json({ jobs: [{ job_id: jobId }] }));
+        }),
+      );
+
+      let pollCount = 0;
+      server.use(
+        rest.get(`ajax-api/3.0/jobs/${jobId}`, (_req, res, ctx) => {
+          pollCount++;
+          if (pollCount <= 2) {
+            return res(ctx.json({ status: 'RUNNING' }));
+          }
+          return res(
+            ctx.json({
+              status: 'SUCCEEDED',
+              result: { [traceId]: { assessments: [] } },
+            }),
+          );
+        }),
+      );
+
+      // Setup trace fetching handlers using MSW
+      setupTraceFetchHandlers(server, traces);
+
+      const { result } = renderHook(() => useEvaluateTracesAsync({ getSerializedScorer: () => serializedScorer }), {
+        wrapper,
+      });
+
+      await act(async () => {
+        const [evaluateTracesFn] = result.current;
+        evaluateTracesFn({
+          itemCount: 1,
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test',
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current[1].data).not.toBeNull();
+      });
+
+      const pollCountAfterSuccess = pollCount;
+
+      // Wait a bit more and verify polling has stopped
+      act(() => {
+        jest.advanceTimersByTime(10000);
+      });
+
+      // Poll count should not increase significantly after job succeeded
+      // Allow for one additional poll that might have been in-flight
+      expect(pollCount).toBeLessThanOrEqual(pollCountAfterSuccess + 1);
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
@@ -1,0 +1,169 @@
+import { fetchAPI, getAjaxUrl } from '../../../common/utils/FetchUtils';
+import { useMutation, useQueryClient } from '../../../common/utils/reactQueryHooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FeedbackAssessment, isV3ModelTraceInfo, ModelTrace } from '../../../shared/web-shared/model-trace-explorer';
+import { EvaluateTracesParams } from './types';
+import { useGetTraceIdsForEvaluation } from './useGetTracesForEvaluation';
+import { getMlflowTraceV3ForEvaluation, JudgeEvaluationResult } from './useEvaluateTraces.common';
+import {
+  TrackingJobQueryResult,
+  TrackingJobStatus,
+  useGetTrackingServerJobStatus,
+} from '../../../common/hooks/useGetTrackingServerJobStatus';
+import { compact, zipObject } from 'lodash';
+
+type EvaluateTracesAsyncJobResult = {
+  [traceId: string]: {
+    assessments: FeedbackAssessment[];
+    failures?: {
+      error_code: string;
+      error_message: string;
+    }[];
+  };
+};
+
+const JOB_POLLING_INTERVAL = 2500;
+
+const isJobRunning = (jobData?: TrackingJobQueryResult<EvaluateTracesAsyncJobResult>): boolean => {
+  return jobData?.status === TrackingJobStatus.RUNNING || jobData?.status === TrackingJobStatus.PENDING;
+};
+
+type StartEvaluationJobParams = { evaluateParams: EvaluateTracesParams; traceIds: string[]; serializedScorer: string };
+type StartEvaluationJobResponse = { jobs: { job_id: string }[] };
+export const useEvaluateTracesAsync = ({
+  onScorerFinished,
+  getSerializedScorer,
+}: {
+  onScorerFinished?: () => void;
+  getSerializedScorer?: () => string;
+}) => {
+  const queryClient = useQueryClient();
+  const [currentJobsId, setCurrentJobsId] = useState<string[] | undefined>(undefined);
+  const getTraceIdsForEvaluation = useGetTraceIdsForEvaluation();
+
+  const [tracesData, setTracesData] = useState<Record<string, ModelTrace> | undefined>();
+  const lastFinishedJobsIdRef = useRef<string[] | undefined>(undefined);
+
+  const { jobResults, areJobsRunning } = useGetTrackingServerJobStatus<EvaluateTracesAsyncJobResult>(currentJobsId, {
+    enabled: Boolean(currentJobsId),
+    refetchInterval: (data) => {
+      if (data?.some((job) => isJobRunning(job))) {
+        return JOB_POLLING_INTERVAL;
+      }
+      return false;
+    },
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
+  // Call onScorerFinished when the job successfully completes (once per job)
+  useEffect(() => {
+    if (!areJobsRunning && currentJobsId && lastFinishedJobsIdRef.current !== currentJobsId) {
+      lastFinishedJobsIdRef.current = currentJobsId;
+      onScorerFinished?.();
+    }
+  }, [areJobsRunning, currentJobsId, onScorerFinished]);
+
+  const {
+    mutate: startEvaluationJob,
+    isLoading: isJobStarting,
+    error: startEvaluationJobError,
+  } = useMutation<StartEvaluationJobResponse, Error, StartEvaluationJobParams>({
+    mutationFn: async ({ evaluateParams, traceIds, serializedScorer }) => {
+      const responseData = await fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/scorer/invoke`), 'POST', {
+        experiment_id: evaluateParams.experimentId,
+        serialized_scorer: serializedScorer,
+        trace_ids: traceIds,
+      });
+      return responseData;
+    },
+    onSuccess: (data) => {
+      setCurrentJobsId(data.jobs.map((job) => job.job_id));
+    },
+  });
+
+  const isLoading = areJobsRunning || isJobStarting;
+
+  const evaluateTracesAsync = useCallback(
+    async (params: EvaluateTracesParams) => {
+      const traceIds = await getTraceIdsForEvaluation(params);
+
+      const serializedScorer = getSerializedScorer?.();
+
+      if (!serializedScorer) {
+        throw new Error('Cannot build serialized scorer');
+      }
+
+      // Start the evaluation job
+      startEvaluationJob({ evaluateParams: params, traceIds, serializedScorer });
+
+      // After the job is started, fetch all the traces in parallel
+      const traces = await Promise.all(
+        traceIds.map(async (traceId) => {
+          return await queryClient.fetchQuery({
+            queryKey: ['GetMlflowTraceV3', traceId],
+            queryFn: () => getMlflowTraceV3ForEvaluation(traceId),
+            staleTime: Infinity,
+            cacheTime: Infinity,
+          });
+        }),
+      );
+      setTracesData(zipObject(traceIds, traces));
+    },
+    [startEvaluationJob, getTraceIdsForEvaluation, queryClient, getSerializedScorer],
+  );
+
+  const reset = useCallback(() => {
+    setCurrentJobsId(undefined);
+    setTracesData(undefined);
+    lastFinishedJobsIdRef.current = undefined;
+  }, []);
+
+  const error = useMemo(() => {
+    if (startEvaluationJobError) {
+      return startEvaluationJobError;
+    }
+    if (areJobsRunning) {
+      return null;
+    }
+    for (const job of Object.values(jobResults ?? {})) {
+      if (job.status === TrackingJobStatus.FAILED) {
+        return new Error(job.result);
+      }
+    }
+    return null;
+  }, [jobResults, areJobsRunning, startEvaluationJobError]);
+
+  // Combine the traces data and the evaluation job data to get the results
+  const data = useMemo<JudgeEvaluationResult[] | null>(() => {
+    if (!tracesData || isLoading || error) {
+      return null;
+    }
+    const aggregatedJobResults: EvaluateTracesAsyncJobResult = {};
+    // Get data from all successful jobs
+    for (const job of Object.values(jobResults ?? {})) {
+      if (job.status === TrackingJobStatus.SUCCEEDED) {
+        for (const traceId of Object.keys(job.result)) {
+          aggregatedJobResults[traceId] = {
+            assessments: job.result[traceId]?.assessments ?? [],
+            failures: job.result[traceId]?.failures ?? [],
+          };
+        }
+      }
+    }
+
+    const evaluationResults = Object.entries(tracesData).map(([traceId, trace]) => {
+      const results = aggregatedJobResults[traceId]?.assessments ?? [];
+      const failureString = aggregatedJobResults[traceId]?.failures?.map((failure) => failure.error_message).join(', ');
+      return {
+        trace,
+        results,
+        error: failureString || null,
+      };
+    });
+
+    return compact(evaluationResults);
+  }, [jobResults, isLoading, tracesData, error]);
+
+  return [evaluateTracesAsync, { data, isLoading, error, reset }] as const;
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useGetSerializedScorerFromForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useGetSerializedScorerFromForm.tsx
@@ -1,0 +1,24 @@
+import { useFormContext } from 'react-hook-form';
+import {
+  convertFormDataToScheduledScorer,
+  ScorerFormData,
+  transformScheduledScorer,
+} from './utils/scorerTransformUtils';
+import { useCallback } from 'react';
+
+/**
+ * Returns a function that can be used to build the serialized scorer based on the current form data.
+ */
+export const useGetSerializedScorerFromForm = () => {
+  const { getValues } = useFormContext<ScorerFormData>();
+
+  return useCallback(() => {
+    const formData = getValues();
+    // Convert the form data to a scheduled scorer
+    const scheduledScorer = convertFormDataToScheduledScorer(formData, undefined);
+    // Transform the scheduled scorer to a backend scorer config
+    const scorerConfig = transformScheduledScorer(scheduledScorer);
+    // Return the serialized scorer
+    return scorerConfig.serialized_scorer;
+  }, [getValues]);
+};


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19664/files) to review incremental changes.
- [**stack/select-traces-for-scorers-part8**](https://github.com/mlflow/mlflow/pull/19664) [[Files changed](https://github.com/mlflow/mlflow/pull/19664/files)]
  - [stack/select-traces-for-scorers-part9](https://github.com/mlflow/mlflow/pull/19688) [[Files changed](https://github.com/mlflow/mlflow/pull/19688/files/3f51d7ec2c2c891ab66318c0099493066176a891..09afa62d2d8e0dfc55ba739643bf5d0c49e3f0d1)]
    - [stack/select-traces-for-scorers-part10](https://github.com/mlflow/mlflow/pull/19689) [[Files changed](https://github.com/mlflow/mlflow/pull/19689/files/09afa62d2d8e0dfc55ba739643bf5d0c49e3f0d1..4238b1fc863318f478a7fd80a5f2057380d435de)]
      - [stack/select-traces-for-scorers-part11](https://github.com/mlflow/mlflow/pull/19693) [[Files changed](https://github.com/mlflow/mlflow/pull/19693/files/4238b1fc863318f478a7fd80a5f2057380d435de..4a35219d5123a9f12dc3d78a58581b6e66d365e6)]

---------
### What changes are proposed in this pull request?

Introduces a bulk of logic necessary for async judge evaluation:
- Adds a hook for polling the status of async job (`useGetTrackingServerJobStatus`)
- Adds a new `useEvaluateTracesAsync` hook for running trace evaluations asynchronously with polling-based job status tracking.
- Introduces `useGetSerializedScorerFromForm` hook to serialize scorer form data.

https://github.com/user-attachments/assets/2fa63914-b672-461e-b31c-eb83af0c608f

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
