### PR TITLE
Fix register_scorer to resolve gateway endpoint ID to name in return value

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2158,7 +2158,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             session.add(sql_scorer_version)
             session.flush()
 
-            return sql_scorer_version.to_mlflow_entity()
+            entity = sql_scorer_version.to_mlflow_entity()
+            # Resolve gateway endpoint ID to name before returning
+            return self._resolve_endpoint_in_scorer(entity)
 
     def list_scorers(self, experiment_id) -> list[ScorerVersion]:
         """

--- a/tests/store/tracking/test_gateway_sql_store.py
+++ b/tests/store/tracking/test_gateway_sql_store.py
@@ -1368,10 +1368,10 @@ def test_register_scorer_resolves_endpoint_name_to_id(store: SqlAlchemyStore):
 
     scorer = store.register_scorer(experiment_id, "my-scorer", serialized_scorer)
 
-    # Internally, the scorer should have the endpoint ID stored
+    # The returned scorer should have the endpoint name (resolved from ID)
     stored_data = json.loads(scorer._serialized_scorer)
     stored_model = stored_data["instructions_judge_pydantic_data"]["model"]
-    assert stored_model == f"gateway:/{endpoint.endpoint_id}"
+    assert stored_model == f"gateway:/{endpoint.name}"
 
 
 def test_register_scorer_with_nonexistent_endpoint_raises(store: SqlAlchemyStore):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/danielseong1/mlflow/pull/19668?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19668/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19668/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19668/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The `register_scorer` method was returning the scorer with the internal gateway endpoint ID instead of resolving it back to the endpoint name. This made it inconsistent with `get_scorer` and `list_scorers` which already resolve endpoint IDs to names before returning.

This change adds `_resolve_endpoint_in_scorer()` call to `register_scorer`'s return path, ensuring consistent behavior across all scorer retrieval APIs.

**Changes:**
- `mlflow/store/tracking/sqlalchemy_store.py`: Added `_resolve_endpoint_in_scorer()` call in `register_scorer` return
- `tests/store/tracking/test_gateway_sql_store.py`: Updated test to expect endpoint name instead of ID in the returned scorer

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Updated `test_register_scorer_resolves_endpoint_name_to_id` to verify the new expected behavior. All gateway scorer tests pass:
- `test_register_scorer_resolves_endpoint_name_to_id`
- `test_register_scorer_with_nonexistent_endpoint_raises`
- `test_get_scorer_resolves_endpoint_id_to_name`
- `test_get_scorer_with_deleted_endpoint_sets_model_to_null`
- `test_list_scorers_batch_resolves_endpoint_ids`

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)