### PR TITLE
Reasoning in Chat UI AG2

### DIFF
--- a/mlflow/ag2/ag2_logger.py
+++ b/mlflow/ag2/ag2_logger.py
@@ -289,9 +289,13 @@ class MlflowAg2Logger(BaseLogger):
         usage = getattr(output, "usage", None)
         if usage is None:
             return None
-        input_tokens = usage.prompt_tokens
-        output_tokens = usage.completion_tokens
-        total_tokens = usage.total_tokens
+        # Handle both Chat Completions API (prompt_tokens/completion_tokens) and
+        # Responses API (input_tokens/output_tokens) formats
+        input_tokens = getattr(usage, "prompt_tokens", None) or getattr(usage, "input_tokens", None)
+        output_tokens = getattr(usage, "completion_tokens", None) or getattr(
+            usage, "output_tokens", None
+        )
+        total_tokens = getattr(usage, "total_tokens", None)
         if total_tokens is None and None not in (input_tokens, output_tokens):
             total_tokens = input_tokens + output_tokens
         return {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -1048,6 +1048,15 @@ export const normalizeConversation = (input: any, messageFormat?: string): Model
         const autogenMessages = normalizeAutogenChatInput(input) ?? normalizeAutogenChatOutput(input);
         if (autogenMessages) return autogenMessages;
         break;
+      case 'ag2':
+        // AG2 with Responses API uses OpenAI Responses format for LLM calls
+        const ag2Messages =
+          normalizeOpenAIResponsesOutput(input) ??
+          normalizeOpenAIResponsesInput(input) ??
+          normalizeOpenAIChatInput(input) ??
+          normalizeOpenAIChatResponse(input);
+        if (ag2Messages) return ag2Messages;
+        break;
       case 'bedrock':
         const bedrockMessages = normalizeBedrockChatInput(input) ?? normalizeBedrockChatOutput(input);
         if (bedrockMessages) return bedrockMessages;


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/19671?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19671/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19671/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19671/merge
```

</p>
</details>

### Related Issues/PRs

Towards #19514 

### What changes are proposed in this pull request?

Reasoning in Chat UI AG2 + Token usage for response API OpenAI

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1572" height="900" alt="image" src="https://github.com/user-attachments/assets/6688f741-4587-4597-b42f-b26a7e520011" />


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Reasoning in Chat UI AG2 + Token usage for response API OpenAI

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
