### PR TITLE
Make local artifact location creation lazy to support read-only proxy environments

### DIFF
--- a/docs/docs/self-hosting/architecture/tracking-server.mdx
+++ b/docs/docs/self-hosting/architecture/tracking-server.mdx
@@ -51,7 +51,7 @@ for details.
 
 :::tip Read-only Filesystems
 When running in containers with read-only root filesystems (common in Kubernetes with `securityContext.readOnlyRootFilesystem: true`),
-use `--serve-artifacts` with `--artifacts-destination` to store artifacts remotely. The tracking server does not create
+configure remote artifact storage using `--artifacts-destination` (artifact serving is enabled by default). The tracking server does not create
 local directories at startup when using remote artifact storage, making it compatible with read-only environments.
 
 ```bash

--- a/docs/docs/self-hosting/architecture/tracking-server.mdx
+++ b/docs/docs/self-hosting/architecture/tracking-server.mdx
@@ -49,6 +49,19 @@ to specify which domains can access your server. See [Security Configuration](/s
 for details.
 :::
 
+:::tip Read-only Filesystems
+When running in containers with read-only root filesystems (common in Kubernetes with `securityContext.readOnlyRootFilesystem: true`),
+use `--serve-artifacts` with `--artifacts-destination` to store artifacts remotely. The tracking server does not create
+local directories at startup when using remote artifact storage, making it compatible with read-only environments.
+
+```bash
+mlflow server \
+    --host 0.0.0.0 \
+    --backend-store-uri postgresql://user:pass@host/db \
+    --artifacts-destination s3://my-bucket
+```
+:::
+
 ## Logging to a Tracking Server \{#logging_to_a_tracking_server}
 
 Once the tracking server is started, connect your local clients by setting the `MLFLOW_TRACKING_URI` environment variable to the

--- a/docs/docs/self-hosting/architecture/tracking-server.mdx
+++ b/docs/docs/self-hosting/architecture/tracking-server.mdx
@@ -60,6 +60,7 @@ mlflow server \
     --backend-store-uri postgresql://user:pass@host/db \
     --artifacts-destination s3://my-bucket
 ```
+
 :::
 
 ## Logging to a Tracking Server \{#logging_to_a_tracking_server}

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -146,7 +146,6 @@ from mlflow.tracing.utils import (
     generate_request_id_v2,
 )
 from mlflow.tracing.utils.truncation import _get_truncated_preview
-from mlflow.utils.file_utils import local_file_uri_to_path, mkdir
 from mlflow.utils.mlflow_tags import (
     MLFLOW_ARTIFACT_LOCATION,
     MLFLOW_DATASET_CONTEXT,
@@ -168,7 +167,6 @@ from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.uri import (
     append_to_uri_path,
     extract_db_type_from_uri,
-    is_local_uri,
     resolve_uri_if_local,
 )
 from mlflow.utils.validation import (
@@ -279,8 +277,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         )
         mlflow.store.db.utils._verify_schema(self.engine)
 
-        if is_local_uri(default_artifact_root):
-            mkdir(local_file_uri_to_path(default_artifact_root))
+        # Note: We intentionally do NOT create the artifact root directory here.
+        # The LocalArtifactRepository creates it lazily when the first artifact is logged.
+        # This avoids permission errors in read-only environments (e.g., K8s containers)
+        # when the artifact root is local but never actually used.
 
         # Check if default experiment exists (not just if any experiments exist)
         # This is important for databases that persist across test runs

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4156,6 +4156,29 @@ def test_sqlalchemy_store_does_not_create_artifact_root_directory_on_init(tmp_pa
     store._dispose_engine()
 
 
+def test_sqlalchemy_store_creates_artifact_directory_on_log_artifact(tmp_path):
+    from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+
+    db_path = tmp_path / "mlflow.db"
+    artifact_root = tmp_path / "artifacts"
+
+    store = SqlAlchemyStore(f"sqlite:///{db_path}", str(artifact_root))
+    exp_id = store.create_experiment("test")
+    run = store.create_run(exp_id, user_id="user", start_time=0, tags=[], run_name="run")
+
+    assert not artifact_root.exists()
+
+    src_file = tmp_path / "test.txt"
+    src_file.write_text("hello")
+
+    artifact_repo = get_artifact_repository(run.info.artifact_uri)
+    artifact_repo.log_artifact(str(src_file))
+
+    assert artifact_root.exists()
+
+    store._dispose_engine()
+
+
 class TextClauseMatcher:
     def __init__(self, text):
         self.text = text

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4136,6 +4136,26 @@ def test_sqlalchemy_store_can_be_initialized_when_default_experiment_has_been_de
     SqlAlchemyStore(tmp_sqlite_uri, ARTIFACT_URI)
 
 
+def test_sqlalchemy_store_does_not_create_artifact_root_directory_on_init(tmp_path):
+    """
+    Verify that SqlAlchemyStore does NOT create the artifact root directory during initialization.
+
+    The directory should only be created lazily when the first artifact is logged. This allows
+    MLflow servers to run in read-only environments (e.g., K8s containers) when artifacts are
+    stored remotely and the local artifact root is never actually used.
+
+    See: https://github.com/mlflow/mlflow/issues/XXXXX
+    """
+    db_path = tmp_path / "mlflow.db"
+    artifact_root = tmp_path / "artifacts"
+
+    store = SqlAlchemyStore(f"sqlite:///{db_path}", str(artifact_root))
+
+    assert not artifact_root.exists()
+
+    store._dispose_engine()
+
+
 class TextClauseMatcher:
     def __init__(self, text):
         self.text = text
@@ -4243,29 +4263,29 @@ def test_get_orderby_clauses(tmp_sqlite_uri):
 def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
     artifact_root_uri, expected_artifact_uri_format
 ):
-    # Patch `is_local_uri` to prevent the SqlAlchemy store from attempting to create local
-    # filesystem directories for file URI and POSIX path test cases
-    with mock.patch("mlflow.store.tracking.sqlalchemy_store.is_local_uri", return_value=False):
-        with TempDir() as tmp:
-            dbfile_path = tmp.path("db")
-            store = SqlAlchemyStore(
-                db_uri="sqlite:///" + dbfile_path,
-                default_artifact_root=artifact_root_uri,
-            )
-            exp_id = store.create_experiment(name="exp")
-            exp = store.get_experiment(exp_id)
+    # Note: Previously this test patched `is_local_uri` to prevent directory creation,
+    # but SqlAlchemyStore no longer creates the artifact root directory during initialization.
+    # The directory is now created lazily when the first artifact is logged.
+    with TempDir() as tmp:
+        dbfile_path = tmp.path("db")
+        store = SqlAlchemyStore(
+            db_uri="sqlite:///" + dbfile_path,
+            default_artifact_root=artifact_root_uri,
+        )
+        exp_id = store.create_experiment(name="exp")
+        exp = store.get_experiment(exp_id)
 
-            if hasattr(store, "__del__"):
-                store.__del__()
+        if hasattr(store, "__del__"):
+            store.__del__()
 
-            cwd = Path.cwd().as_posix()
-            drive = Path.cwd().drive
-            if is_windows() and expected_artifact_uri_format.startswith("file:"):
-                cwd = f"/{cwd}"
-                drive = f"{drive}/"
-            assert exp.artifact_location == expected_artifact_uri_format.format(
-                e=exp_id, cwd=cwd, drive=drive
-            )
+        cwd = Path.cwd().as_posix()
+        drive = Path.cwd().drive
+        if is_windows() and expected_artifact_uri_format.startswith("file:"):
+            cwd = f"/{cwd}"
+            drive = f"{drive}/"
+        assert exp.artifact_location == expected_artifact_uri_format.format(
+            e=exp_id, cwd=cwd, drive=drive
+        )
 
 
 @pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
@@ -4351,35 +4371,35 @@ def test_create_experiment_appends_to_artifact_uri_path_correctly(input_uri, exp
 def _assert_create_run_appends_to_artifact_uri_path_correctly(
     artifact_root_uri, expected_artifact_uri_format
 ):
-    # Patch `is_local_uri` to prevent the SqlAlchemy store from attempting to create local
-    # filesystem directories for file URI and POSIX path test cases
-    with mock.patch("mlflow.store.tracking.sqlalchemy_store.is_local_uri", return_value=False):
-        with TempDir() as tmp:
-            dbfile_path = tmp.path("db")
-            store = SqlAlchemyStore(
-                db_uri="sqlite:///" + dbfile_path,
-                default_artifact_root=artifact_root_uri,
-            )
-            exp_id = store.create_experiment(name="exp")
-            run = store.create_run(
-                experiment_id=exp_id,
-                user_id="user",
-                start_time=0,
-                tags=[],
-                run_name="name",
-            )
+    # Note: Previously this test patched `is_local_uri` to prevent directory creation,
+    # but SqlAlchemyStore no longer creates the artifact root directory during initialization.
+    # The directory is now created lazily when the first artifact is logged.
+    with TempDir() as tmp:
+        dbfile_path = tmp.path("db")
+        store = SqlAlchemyStore(
+            db_uri="sqlite:///" + dbfile_path,
+            default_artifact_root=artifact_root_uri,
+        )
+        exp_id = store.create_experiment(name="exp")
+        run = store.create_run(
+            experiment_id=exp_id,
+            user_id="user",
+            start_time=0,
+            tags=[],
+            run_name="name",
+        )
 
-            if hasattr(store, "__del__"):
-                store.__del__()
+        if hasattr(store, "__del__"):
+            store.__del__()
 
-            cwd = Path.cwd().as_posix()
-            drive = Path.cwd().drive
-            if is_windows() and expected_artifact_uri_format.startswith("file:"):
-                cwd = f"/{cwd}"
-                drive = f"{drive}/"
-            assert run.info.artifact_uri == expected_artifact_uri_format.format(
-                e=exp_id, r=run.info.run_id, cwd=cwd, drive=drive
-            )
+        cwd = Path.cwd().as_posix()
+        drive = Path.cwd().drive
+        if is_windows() and expected_artifact_uri_format.startswith("file:"):
+            cwd = f"/{cwd}"
+            drive = f"{drive}/"
+        assert run.info.artifact_uri == expected_artifact_uri_format.format(
+            e=exp_id, r=run.info.run_id, cwd=cwd, drive=drive
+        )
 
 
 @pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4144,7 +4144,7 @@ def test_sqlalchemy_store_does_not_create_artifact_root_directory_on_init(tmp_pa
     MLflow servers to run in read-only environments (e.g., K8s containers) when artifacts are
     stored remotely and the local artifact root is never actually used.
 
-    See: https://github.com/mlflow/mlflow/issues/XXXXX
+    See: https://github.com/mlflow/mlflow/issues/19658
     """
     db_path = tmp_path / "mlflow.db"
     artifact_root = tmp_path / "artifacts"

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4158,11 +4158,12 @@ def test_sqlalchemy_store_does_not_create_artifact_root_directory_on_init(tmp_pa
 
 def test_sqlalchemy_store_creates_artifact_directory_on_log_artifact(tmp_path):
     from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+    from mlflow.utils.file_utils import path_to_local_file_uri
 
     db_path = tmp_path / "mlflow.db"
     artifact_root = tmp_path / "artifacts"
 
-    store = SqlAlchemyStore(f"sqlite:///{db_path}", str(artifact_root))
+    store = SqlAlchemyStore(f"sqlite:///{db_path}", path_to_local_file_uri(str(artifact_root)))
     exp_id = store.create_experiment("test")
     run = store.create_run(exp_id, user_id="user", start_time=0, tags=[], run_name="run")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -319,7 +319,7 @@ def sqlite_store():
     store = SqlAlchemyStore(db_uri, "artifact_folder")
     yield (store, db_uri)
     os.remove(temp_dbfile)
-    shutil.rmtree("artifact_folder")
+    shutil.rmtree("artifact_folder", ignore_errors=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/19678?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19678/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19678/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19678/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #19658 

### What changes are proposed in this pull request?

The eager directory location when starting the backend store forces the creation of a local directory (./mlruns) that serves no purpose when a tracking server is setup for remote tracking store and remote artifact store management. This can create issues when deploying MLflow in read-only file systems (i.e., a k8s deployment). 
The current behavior in the log_artifact APIs is already lazily evaluated to create a directory locally if needed depending on the server configuration. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
