### PR TITLE
Support for conversational datasets with persona, goal, and context

### DIFF
--- a/mlflow/entities/evaluation_dataset.py
+++ b/mlflow/entities/evaluation_dataset.py
@@ -261,7 +261,6 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
         else:
             record_dicts = records
 
-        record_dicts = self._normalize_session_records(record_dicts)
         self._validate_record_dicts(record_dicts)
 
         self._infer_source_types(record_dicts)

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -10,6 +10,8 @@ from mlflow.data.dataset_source_registry import (
     register_dataset_source,
 )
 from mlflow.data.spark_dataset_source import SparkDatasetSource
+from mlflow.entities.evaluation_dataset import DatasetGranularity
+from mlflow.entities.evaluation_dataset import EvaluationDataset as MLflowEvaluationDataset
 from mlflow.genai.datasets.databricks_evaluation_dataset_source import (
     DatabricksEvaluationDatasetSource,
     DatabricksUCTableDatasetSource,
@@ -205,3 +207,42 @@ def test_databricks_uc_table_dataset_source():
     assert source._get_source_type() == "databricks-uc-table"
     assert source.table_name == "catalog.schema.table"
     assert source.dataset_id == "test-id"
+
+
+def _create_mlflow_evaluation_dataset() -> MLflowEvaluationDataset:
+    return MLflowEvaluationDataset(
+        dataset_id="test-id",
+        name="test-dataset",
+        digest="test-digest",
+        created_time=0,
+        last_update_time=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("input_keys", "expected_granularity"),
+    [
+        # empty keys -> UNKNOWN
+        (set(), DatasetGranularity.UNKNOWN),
+        # no 'goal' field -> TRACE
+        ({"request"}, DatasetGranularity.TRACE),
+        ({"messages"}, DatasetGranularity.TRACE),
+        ({"query", "context"}, DatasetGranularity.TRACE),
+        # 'goal' and only session fields -> SESSION
+        ({"goal"}, DatasetGranularity.SESSION),
+        ({"goal", "persona"}, DatasetGranularity.SESSION),
+        ({"goal", "context"}, DatasetGranularity.SESSION),
+        ({"goal", "persona", "context"}, DatasetGranularity.SESSION),
+        # 'goal' mixed with non-session fields -> UNKNOWN
+        ({"goal", "request"}, DatasetGranularity.UNKNOWN),
+        ({"goal", "messages"}, DatasetGranularity.UNKNOWN),
+        ({"goal", "persona", "extra_field"}, DatasetGranularity.UNKNOWN),
+    ],
+)
+def test_classify_input_fields(
+    input_keys,
+    expected_granularity,
+):
+    dataset = _create_mlflow_evaluation_dataset()
+    result = dataset._classify_input_fields(input_keys)
+    assert result == expected_granularity

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -2135,13 +2135,6 @@ def test_wrapper_isinstance_checks_for_dataset_interfaces(tracking_uri, experime
 @pytest.mark.parametrize(
     "records",
     [
-        # Top-level fields
-        [
-            {"persona": "Graduate Student", "goal": "Find peer-reviewed articles"},
-            {"persona": "Student", "goal": "Get help", "context": {"user_id": "U1"}},
-            {"goal": "Just a goal without persona"},
-        ],
-        # Nested in inputs
         [
             {"inputs": {"persona": "Student", "goal": "Find articles"}},
             {"inputs": {"persona": "Researcher", "goal": "Review", "context": {"dept": "CS"}}},
@@ -2162,15 +2155,10 @@ def test_multiturn_valid_formats(tracking_uri, experiments, records):
 @pytest.mark.parametrize(
     ("records", "error_pattern"),
     [
-        # inputs with top-level fields
-        (
-            [{"inputs": {"question": "What is MLflow?"}, "goal": "Answer question"}],
-            "Cannot specify both 'inputs' and top-level session fields",
-        ),
-        # Unknown top-level columns
+        # Top-level session fields
         (
             [{"persona": "Student", "goal": "Find articles", "custom_field": "value"}],
-            "Unknown columns in session format",
+            "Each record must have an 'inputs' field",
         ),
         # Mixed fields in inputs
         (
@@ -2220,15 +2208,19 @@ def test_multiturn_with_expectations_and_tags(tracking_uri, experiments):
     dataset = create_dataset(name="multiturn_full_test", experiment_id=experiments[0])
     records = [
         {
-            "persona": "Graduate Student",
-            "goal": "Find peer-reviewed articles on machine learning",
-            "context": {"user_id": "U0001", "department": "CS"},
+            "inputs": {
+                "persona": "Graduate Student",
+                "goal": "Find peer-reviewed articles on machine learning",
+                "context": {"user_id": "U0001", "department": "CS"},
+            },
             "expectations": {"expected_output": "relevant articles", "quality": "high"},
             "tags": {"difficulty": "medium"},
         },
         {
-            "persona": "Librarian",
-            "goal": "Help with inter-library loan",
+            "inputs": {
+                "persona": "Librarian",
+                "goal": "Help with inter-library loan",
+            },
             "expectations": {"expected_output": "loan information"},
         },
     ]

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -2164,18 +2164,18 @@ def test_multiturn_valid_formats(tracking_uri, experiments, records):
     [
         # inputs with top-level fields
         (
-            [{"inputs": {"question": "What is MLflow?"}, "persona": "Student"}],
-            "Cannot specify both 'inputs' and top-level",
+            [{"inputs": {"question": "What is MLflow?"}, "goal": "Answer question"}],
+            "Cannot specify both 'inputs' and top-level session fields",
         ),
         # Unknown top-level columns
         (
             [{"persona": "Student", "goal": "Find articles", "custom_field": "value"}],
-            "Unknown columns in multiturn format",
+            "Unknown columns in session format",
         ),
         # Mixed fields in inputs
         (
             [{"inputs": {"persona": "Student", "goal": "Find", "custom_field": "value"}}],
-            "Cannot mix multiturn fields.*with custom fields",
+            "Invalid input schema.*cannot mix session fields",
         ),
         # Inconsistent batch schema
         (
@@ -2183,7 +2183,7 @@ def test_multiturn_valid_formats(tracking_uri, experiments, records):
                 {"inputs": {"persona": "Student", "goal": "Find articles"}},
                 {"inputs": {"question": "What is MLflow?"}},
             ],
-            "must use the same schema type",
+            "must use the same granularity.*Found",
         ),
     ],
 )
@@ -2212,7 +2212,7 @@ def test_multiturn_schema_compatibility(tracking_uri, experiments, existing_reco
     dataset = create_dataset(name="multiturn_compat_test", experiment_id=experiments[0])
     dataset.merge_records(existing_records)
 
-    with pytest.raises(MlflowException, match="existing dataset.*schema"):
+    with pytest.raises(MlflowException, match="Cannot mix granularities"):
         dataset.merge_records(new_records)
 
 

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -2130,3 +2130,154 @@ def test_wrapper_isinstance_checks_for_dataset_interfaces(tracking_uri, experime
     assert isinstance(dataset, WrapperEvaluationDataset)
     assert not isinstance(dataset, EntityEvaluationDataset)
     assert isinstance(dataset, (WrapperEvaluationDataset, EntityEvaluationDataset))
+
+
+def test_multiturn_top_level_fields_normalized_to_inputs(tracking_uri, experiments):
+    dataset = create_dataset(
+        name="multiturn_normalize_test",
+        experiment_id=experiments[0],
+    )
+    records = [
+        {"persona": "Graduate Student", "goal": "Find peer-reviewed articles"},
+        {"persona": "Student", "goal": "Get help with research", "context": {"user_id": "U1"}},
+        {"goal": "Just a goal without persona"},
+    ]
+    dataset.merge_records(records)
+    df = dataset.to_df()
+
+    assert len(df) == 3
+    for _, row in df.iterrows():
+        inputs = row["inputs"]
+        assert any(key in inputs for key in ["persona", "goal", "context"])
+
+
+def test_multiturn_nested_in_inputs(tracking_uri, experiments):
+    dataset = create_dataset(
+        name="multiturn_nested_test",
+        experiment_id=experiments[0],
+    )
+    records = [
+        {"inputs": {"persona": "Student", "goal": "Find articles"}},
+        {"inputs": {"persona": "Researcher", "goal": "Review papers", "context": {"dept": "CS"}}},
+        {"inputs": {"goal": "Single goal"}, "expectations": {"output": "expected"}},
+    ]
+    dataset.merge_records(records)
+    df = dataset.to_df()
+
+    assert len(df) == 3
+    for _, row in df.iterrows():
+        inputs = row["inputs"]
+        assert any(key in inputs for key in ["persona", "goal", "context"])
+
+
+def test_multiturn_cannot_use_both_inputs_and_top_level_fields(tracking_uri, experiments):
+    dataset = create_dataset(
+        name="multiturn_conflict_test",
+        experiment_id=experiments[0],
+    )
+    records = [
+        {
+            "inputs": {"question": "What is MLflow?"},
+            "persona": "Student",
+        }
+    ]
+    with pytest.raises(MlflowException, match="Cannot specify both 'inputs' and top-level"):
+        dataset.merge_records(records)
+
+
+def test_multiturn_unknown_columns_rejected(tracking_uri, experiments):
+    dataset = create_dataset(
+        name="multiturn_unknown_col_test",
+        experiment_id=experiments[0],
+    )
+    records = [
+        {
+            "persona": "Student",
+            "goal": "Find articles",
+            "custom_field": "value",
+        }
+    ]
+    with pytest.raises(MlflowException, match="Unknown columns in multiturn format"):
+        dataset.merge_records(records)
+
+
+def test_multiturn_inputs_cannot_mix_with_custom_fields(tracking_uri, experiments):
+    dataset = create_dataset(
+        name="multiturn_mixed_inputs_test",
+        experiment_id=experiments[0],
+    )
+    records = [
+        {
+            "inputs": {
+                "persona": "Student",
+                "goal": "Find articles",
+                "custom_field": "value",
+            }
+        }
+    ]
+    with pytest.raises(MlflowException, match="Cannot mix multiturn fields.*with custom fields"):
+        dataset.merge_records(records)
+
+
+def test_multiturn_batch_consistency_required(tracking_uri, experiments):
+    dataset = create_dataset(
+        name="multiturn_batch_test",
+        experiment_id=experiments[0],
+    )
+    records = [
+        {"inputs": {"persona": "Student", "goal": "Find articles"}},
+        {"inputs": {"question": "What is MLflow?"}},
+    ]
+    with pytest.raises(MlflowException, match="must use the same schema type"):
+        dataset.merge_records(records)
+
+
+def test_multiturn_schema_compatibility_with_existing_records(tracking_uri, experiments):
+    dataset = create_dataset(
+        name="multiturn_compat_test",
+        experiment_id=experiments[0],
+    )
+    multiturn_records = [
+        {"inputs": {"persona": "Student", "goal": "Find articles"}},
+    ]
+    dataset.merge_records(multiturn_records)
+
+    custom_records = [
+        {"inputs": {"question": "What is MLflow?", "model": "gpt-4"}},
+    ]
+
+    with pytest.raises(MlflowException, match="existing dataset.*schema"):
+        dataset.merge_records(custom_records)
+
+
+def test_multiturn_with_expectations_and_tags(tracking_uri, experiments):
+    dataset = create_dataset(
+        name="multiturn_full_test",
+        experiment_id=experiments[0],
+    )
+
+    records = [
+        {
+            "persona": "Graduate Student",
+            "goal": "Find peer-reviewed articles on machine learning",
+            "context": {"user_id": "U0001", "department": "CS"},
+            "expectations": {"expected_output": "relevant articles", "quality": "high"},
+            "tags": {"difficulty": "medium"},
+        },
+        {
+            "persona": "Librarian",
+            "goal": "Help with inter-library loan",
+            "expectations": {"expected_output": "loan information"},
+        },
+    ]
+
+    dataset.merge_records(records)
+
+    df = dataset.to_df()
+    assert len(df) == 2
+
+    grad_record = df[df["inputs"].apply(lambda x: x.get("persona") == "Graduate Student")].iloc[0]
+    assert grad_record["expectations"]["expected_output"] == "relevant articles"
+    assert grad_record["expectations"]["quality"] == "high"
+    assert grad_record["tags"]["difficulty"] == "medium"
+    assert grad_record["inputs"]["context"] == {"user_id": "U0001", "department": "CS"}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SomtochiUmeh/mlflow/pull/19686?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19686/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19686/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19686/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds `persona`, `goal`, and `context` fields for multiturn evaluation datasets. These can be nested directly inside `inputs`:

```python
dataset.merge_records([
    {"inputs": {"persona": "Student", "goal": "Find articles"}},
])
```
<img width="1533" height="624" alt="image" src="https://github.com/user-attachments/assets/a73efc1a-db9a-492f-a424-2587ee3b3c49" />


Validations:
- Custom fields must go inside `context`, not alongside multiturn fields
<img width="1157" height="845" alt="image" src="https://github.com/user-attachments/assets/b446d9a8-3017-41e3-884a-b4f90eac24b7" />

- All records in a single `merge_records()` call must use the same schema (multiturn or regular)
<img width="1005" height="853" alt="image" src="https://github.com/user-attachments/assets/c9f9b4b9-43fb-4856-a00f-c85d00bcd908" />

- New records must match the existing dataset's schema type
<img width="1172" height="835" alt="image" src="https://github.com/user-attachments/assets/487dc4fe-859b-43ed-a8ba-edf129c1a4a0" />

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->



### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
