### PR TITLE
[Part 9/x] Evaluating UI sessions via judges: add session templates, prompts and variables

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
@@ -384,11 +384,15 @@ const InstructionsSection: React.FC<InstructionsSectionProps> = ({ mode, control
                 rows={7}
                 placeholder={
                   isSessionLevelScorer
-                    ? intl.formatMessage({
-                        defaultMessage:
-                          "Evaluate the conversation between a user and an assistant '{{ conversation }}'.",
-                        description: 'Placeholder text for session level instructions textarea',
-                      })
+                    ? intl.formatMessage(
+                        {
+                          defaultMessage: `Analyze the '{{ conversation }}' and determine if the agent maintains a polite and professional tone throughout all interactions.{br}Rate as 'consistently_polite', 'mostly_polite', or 'impolite'.`,
+                          description: 'Placeholder text for session level instructions textarea. {br} is a newline.',
+                        },
+                        {
+                          br: '\n',
+                        },
+                      )
                     : intl.formatMessage({
                         defaultMessage:
                           "Evaluate if the response in '{{ outputs }}' correctly answers the question in '{{ inputs }}'. The response should be accurate, complete, and professional.",

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import type { Control, UseFormSetValue, UseFormGetValues } from 'react-hook-form';
-import { Controller, useWatch } from 'react-hook-form';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import {
   useDesignSystemTheme,
   Typography,
@@ -23,7 +23,7 @@ import {
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from '@databricks/i18n';
 import { useTemplateOptions, validateInstructions } from './llmScorerUtils';
-import type { SCORER_TYPE } from './constants';
+import { type SCORER_TYPE, ScorerEvaluationScope } from './constants';
 import { COMPONENT_ID_PREFIX, type ScorerFormMode, SCORER_FORM_MODE } from './constants';
 import { LLM_TEMPLATE } from './types';
 import { TEMPLATE_INSTRUCTIONS_MAP, EDITABLE_TEMPLATES } from './prompts';
@@ -42,6 +42,7 @@ export interface LLMScorerFormData {
   model: string;
   disableMonitoring?: boolean;
   isInstructionsJudge?: boolean;
+  evaluationScope?: ScorerEvaluationScope;
 }
 
 interface LLMScorerFormRendererProps {
@@ -60,8 +61,10 @@ interface LLMTemplateSectionProps {
 
 const LLMTemplateSection: React.FC<LLMTemplateSectionProps> = ({ mode, control, setValue, currentTemplate }) => {
   const { theme } = useDesignSystemTheme();
+  const { watch } = useFormContext<LLMScorerFormData>();
+  const scope = watch('evaluationScope');
   const intl = useIntl();
-  const { templateOptions, displayMap } = useTemplateOptions();
+  const { templateOptions, displayMap } = useTemplateOptions(scope);
 
   const stopPropagationClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -213,6 +216,8 @@ interface InstructionsSectionProps {
 
 const InstructionsSection: React.FC<InstructionsSectionProps> = ({ mode, control, setValue, getValues }) => {
   const intl = useIntl();
+  const { watch } = useFormContext<LLMScorerFormData>();
+  const scope = watch('evaluationScope');
 
   const stopPropagationClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -225,6 +230,103 @@ const InstructionsSection: React.FC<InstructionsSectionProps> = ({ mode, control
 
   const isInstructionsJudge = useWatch({ control, name: 'isInstructionsJudge' }) ?? false;
   const isReadOnly = mode === SCORER_FORM_MODE.DISPLAY || !isInstructionsJudge;
+  const isSessionLevelScorer = scope === ScorerEvaluationScope.SESSIONS;
+
+  const traceLevelTemplateVariables = (
+    <>
+      <DropdownMenu.Item
+        componentId={`${COMPONENT_ID_PREFIX}.add-variable-inputs`}
+        onClick={(e) => {
+          e.stopPropagation();
+          appendVariable('{{ inputs }}');
+        }}
+      >
+        <FormattedMessage defaultMessage="Inputs" description="Label for inputs variable option" />
+        <DropdownMenu.HintRow>
+          <FormattedMessage defaultMessage="Input for the trace" description="Description for inputs variable" />
+        </DropdownMenu.HintRow>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item
+        componentId={`${COMPONENT_ID_PREFIX}.add-variable-outputs`}
+        onClick={(e) => {
+          e.stopPropagation();
+          appendVariable('{{ outputs }}');
+        }}
+      >
+        <FormattedMessage defaultMessage="Outputs" description="Label for outputs variable option" />
+        <DropdownMenu.HintRow>
+          <FormattedMessage defaultMessage="Output for the trace" description="Description for outputs variable" />
+        </DropdownMenu.HintRow>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item
+        componentId={`${COMPONENT_ID_PREFIX}.add-variable-expectations`}
+        onClick={(e) => {
+          e.stopPropagation();
+          appendVariable('{{ expectations }}');
+        }}
+      >
+        <FormattedMessage defaultMessage="Expectations" description="Label for expectations variable option" />
+        <DropdownMenu.HintRow>
+          <FormattedMessage
+            defaultMessage="Expectations added for a trace"
+            description="Description for expectations variable"
+          />
+        </DropdownMenu.HintRow>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item
+        componentId={`${COMPONENT_ID_PREFIX}.add-variable-trace`}
+        onClick={(e) => {
+          e.stopPropagation();
+          appendVariable('{{ trace }}');
+        }}
+      >
+        <FormattedMessage defaultMessage="Trace" description="Label for trace variable option" />
+        <DropdownMenu.HintRow>
+          <FormattedMessage
+            defaultMessage="Full trace with an agent using the right part of the trace to use to judge"
+            description="Description for trace variable"
+          />
+        </DropdownMenu.HintRow>
+      </DropdownMenu.Item>
+    </>
+  );
+
+  const sessionLevelTemplateVariables = (
+    <>
+      <DropdownMenu.Item
+        componentId={`${COMPONENT_ID_PREFIX}.add-variable-conversation`}
+        onClick={(e) => {
+          e.stopPropagation();
+          appendVariable('{{ conversation }}');
+        }}
+      >
+        <FormattedMessage defaultMessage="Conversation" description="Label for conversation variable option" />
+        <DropdownMenu.HintRow>
+          <FormattedMessage
+            defaultMessage="Full conversation between a user and an assistant"
+            description="Description for conversation variable"
+          />
+        </DropdownMenu.HintRow>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item
+        componentId={`${COMPONENT_ID_PREFIX}.add-variable-expectations`}
+        onClick={(e) => {
+          e.stopPropagation();
+          appendVariable('{{ expectations }}');
+        }}
+      >
+        <FormattedMessage defaultMessage="Expectations" description="Label for expectations variable option" />
+        <DropdownMenu.HintRow>
+          <FormattedMessage
+            defaultMessage="Expectations added for a trace"
+            description="Description for expectations variable"
+          />
+        </DropdownMenu.HintRow>
+      </DropdownMenu.Item>
+    </>
+  );
+
+  const templateVariables = isSessionLevelScorer ? sessionLevelTemplateVariables : traceLevelTemplateVariables;
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column' }}>
@@ -245,68 +347,7 @@ const InstructionsSection: React.FC<InstructionsSectionProps> = ({ mode, control
                 <FormattedMessage defaultMessage="Add variable" description="Button text for adding variables" />
               </Button>
             </DropdownMenu.Trigger>
-            <DropdownMenu.Content align="end">
-              <DropdownMenu.Item
-                componentId={`${COMPONENT_ID_PREFIX}.add-variable-inputs`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  appendVariable('{{ inputs }}');
-                }}
-              >
-                <FormattedMessage defaultMessage="Inputs" description="Label for inputs variable option" />
-                <DropdownMenu.HintRow>
-                  <FormattedMessage
-                    defaultMessage="Input for the trace"
-                    description="Description for inputs variable"
-                  />
-                </DropdownMenu.HintRow>
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                componentId={`${COMPONENT_ID_PREFIX}.add-variable-outputs`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  appendVariable('{{ outputs }}');
-                }}
-              >
-                <FormattedMessage defaultMessage="Outputs" description="Label for outputs variable option" />
-                <DropdownMenu.HintRow>
-                  <FormattedMessage
-                    defaultMessage="Output for the trace"
-                    description="Description for outputs variable"
-                  />
-                </DropdownMenu.HintRow>
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                componentId={`${COMPONENT_ID_PREFIX}.add-variable-expectations`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  appendVariable('{{ expectations }}');
-                }}
-              >
-                <FormattedMessage defaultMessage="Expectations" description="Label for expectations variable option" />
-                <DropdownMenu.HintRow>
-                  <FormattedMessage
-                    defaultMessage="Expectations added for a trace"
-                    description="Description for expectations variable"
-                  />
-                </DropdownMenu.HintRow>
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                componentId={`${COMPONENT_ID_PREFIX}.add-variable-trace`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  appendVariable('{{ trace }}');
-                }}
-              >
-                <FormattedMessage defaultMessage="Trace" description="Label for trace variable option" />
-                <DropdownMenu.HintRow>
-                  <FormattedMessage
-                    defaultMessage="Full trace with an agent using the right part of the trace to use to judge"
-                    description="Description for trace variable"
-                  />
-                </DropdownMenu.HintRow>
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
+            <DropdownMenu.Content align="end">{templateVariables}</DropdownMenu.Content>
           </DropdownMenu.Root>
         </div>
         <FormUI.Hint>
@@ -331,7 +372,7 @@ const InstructionsSection: React.FC<InstructionsSectionProps> = ({ mode, control
           control={control}
           rules={{
             required: isInstructionsJudge,
-            validate: (value) => (isInstructionsJudge ? validateInstructions(value) : true),
+            validate: (value) => (isInstructionsJudge ? validateInstructions(value, scope) : true),
           }}
           render={({ field, fieldState }) => {
             const textArea = (
@@ -341,11 +382,19 @@ const InstructionsSection: React.FC<InstructionsSectionProps> = ({ mode, control
                 id="mlflow-experiment-scorers-instructions"
                 readOnly={isReadOnly}
                 rows={7}
-                placeholder={intl.formatMessage({
-                  defaultMessage:
-                    "Evaluate if the response in '{{ outputs }}' correctly answers the question in '{{ inputs }}'. The response should be accurate, complete, and professional.",
-                  description: 'Example placeholder text for instructions textarea',
-                })}
+                placeholder={
+                  isSessionLevelScorer
+                    ? intl.formatMessage({
+                        defaultMessage:
+                          "Evaluate the conversation between a user and an assistant '{{ conversation }}'.",
+                        description: 'Placeholder text for session level instructions textarea',
+                      })
+                    : intl.formatMessage({
+                        defaultMessage:
+                          "Evaluate if the response in '{{ outputs }}' correctly answers the question in '{{ inputs }}'. The response should be accurate, complete, and professional.",
+                        description: 'Example placeholder text for instructions textarea',
+                      })
+                }
                 css={{ resize: 'vertical', cursor: isReadOnly ? 'auto' : 'text' }}
                 onClick={stopPropagationClick}
               />

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
@@ -29,6 +29,7 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
   const llmTemplate = useWatch({ control, name: 'llmTemplate' });
   const guidelines = useWatch({ control, name: 'guidelines' });
   const scorerType = useWatch({ control, name: 'scorerType' });
+  const { resetField } = useFormContext<ScorerFormData>();
   const { errors } = useFormState({ control });
   const evaluationScopeFormValue = useWatch({ control, name: 'evaluationScope' });
   const evaluationScope = coerceToEnum(ScorerEvaluationScope, evaluationScopeFormValue, ScorerEvaluationScope.TRACES);
@@ -66,7 +67,9 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
       itemCount: DEFAULT_TRACE_COUNT,
       itemIds: [],
     });
-  }, [evaluationScope, reset]);
+    resetField('instructions');
+    resetField('llmTemplate');
+  }, [evaluationScope, reset, resetField]);
 
   // Handle the "Run scorer" button click
   const handleRunScorer = useCallback(async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerCardContainer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerCardContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import type { ScheduledScorer } from './types';
 import { useDeleteScheduledScorerMutation } from './hooks/useDeleteScheduledScorer';
 import { syncFormWithScorer, getFormValuesFromScorer } from './scorerCardUtils';
@@ -23,9 +23,11 @@ const ScorerCardContainer: React.FC<ScorerCardContainerProps> = ({ scorer, exper
   const deleteScorerMutation = useDeleteScheduledScorerMutation();
 
   // React Hook Form for display mode
-  const { control, reset, setValue, getValues } = useForm<LLMScorerFormData | CustomCodeScorerFormData>({
+  const form = useForm<LLMScorerFormData | CustomCodeScorerFormData>({
     defaultValues: getFormValuesFromScorer(scorer),
   });
+
+  const { control, reset, setValue, getValues } = form;
 
   // Sync form state with scorer prop changes
   useEffect(() => {
@@ -77,7 +79,7 @@ const ScorerCardContainer: React.FC<ScorerCardContainerProps> = ({ scorer, exper
   }, [deleteScorerMutation]);
 
   return (
-    <>
+    <FormProvider {...form}>
       <ScorerCardRenderer
         scorer={scorer}
         isExpanded={isExpanded}
@@ -104,7 +106,7 @@ const ScorerCardContainer: React.FC<ScorerCardContainerProps> = ({ scorer, exper
         isLoading={deleteScorerMutation.isLoading}
         error={deleteScorerMutation.error}
       />
-    </>
+    </FormProvider>
   );
 };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/llmScorerUtils.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/llmScorerUtils.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { validateInstructions } from './llmScorerUtils';
+import { ScorerEvaluationScope } from './constants';
 
 describe('validateInstructions', () => {
   describe('Golden Path - Successful Operations', () => {
@@ -142,6 +143,160 @@ describe('validateInstructions', () => {
       const result = validateInstructions('Check {{ input123 }} with numbers');
 
       expect(result).toContain('Invalid variable: {{ input123 }}');
+    });
+  });
+
+  describe('Session Level Traces - Golden Path', () => {
+    it('should return true for valid instructions with {{ conversation }} variable', () => {
+      const result = validateInstructions(
+        'Evaluate the {{ conversation }} for completeness',
+        ScorerEvaluationScope.SESSIONS,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should accept {{ conversation }} without spaces ({{conversation}})', () => {
+      const result = validateInstructions(
+        'Analyze {{conversation}} for user frustration',
+        ScorerEvaluationScope.SESSIONS,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should accept {{ conversation }} with irregular spacing', () => {
+      const result = validateInstructions('Check {{ conversation}} quality', ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe(true);
+    });
+
+    it('should accept {{ conversation }} with trailing space', () => {
+      const result = validateInstructions('Check {{conversation }} for issues', ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe(true);
+    });
+
+    it('should accept {{ conversation }} used multiple times', () => {
+      const result = validateInstructions(
+        'First check {{ conversation }} for context, then analyze {{ conversation }} for retention',
+        ScorerEvaluationScope.SESSIONS,
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Session Level Traces - Edge Cases', () => {
+    it('should return true for empty string in session scope', () => {
+      const result = validateInstructions('', ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for undefined in session scope', () => {
+      const result = validateInstructions(undefined, ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for whitespace-only string in session scope', () => {
+      const result = validateInstructions('   \n\t   ', ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe(true);
+    });
+
+    it('should handle instructions with braces that are not template variables in session scope', () => {
+      const result = validateInstructions(
+        'Use {bracket} notation and {{ conversation }} variable',
+        ScorerEvaluationScope.SESSIONS,
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Session Level Traces - Error Conditions', () => {
+    it('should reject {{ inputs }} in session scope', () => {
+      const result = validateInstructions('Check {{ inputs }} in conversation', ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe('Invalid variable: {{ inputs }}. Only {{ conversation }}, {{ expectations }} are allowed');
+    });
+
+    it('should reject {{ outputs }} in session scope', () => {
+      const result = validateInstructions('Check {{ outputs }} in conversation', ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe('Invalid variable: {{ outputs }}. Only {{ conversation }}, {{ expectations }} are allowed');
+    });
+
+    it('should reject {{ trace }} in session scope', () => {
+      const result = validateInstructions('Check {{ trace }} in conversation', ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe('Invalid variable: {{ trace }}. Only {{ conversation }}, {{ expectations }} are allowed');
+    });
+
+    it('should reject invalid variable names in session scope', () => {
+      const result = validateInstructions('Check {{ invalid_var }} in conversation', ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe(
+        'Invalid variable: {{ invalid_var }}. Only {{ conversation }}, {{ expectations }} are allowed',
+      );
+    });
+
+    it('should return error when no template variables present in session scope', () => {
+      const result = validateInstructions('This has no variables', ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe('Must contain at least one variable: {{ conversation }}, {{ expectations }}');
+    });
+
+    it('should reject multiple invalid trace-level variables in session scope', () => {
+      const result = validateInstructions(
+        'Check {{ inputs }} and {{ outputs }} in session',
+        ScorerEvaluationScope.SESSIONS,
+      );
+
+      expect(result).toBe('Invalid variable: {{ inputs }}. Only {{ conversation }}, {{ expectations }} are allowed');
+    });
+
+    it('should reject case-sensitive variable names ({{ Conversation }})', () => {
+      const result = validateInstructions('Check {{ Conversation }} with capital C', ScorerEvaluationScope.SESSIONS);
+
+      expect(result).toBe(
+        'Invalid variable: {{ Conversation }}. Only {{ conversation }}, {{ expectations }} are allowed',
+      );
+    });
+
+    it('should reject {{ conversation }} mixed with trace-level variables', () => {
+      const result = validateInstructions('Check {{ conversation }} with {{ inputs }}', ScorerEvaluationScope.SESSIONS);
+
+      // The first invalid variable found should trigger the error
+      expect(result).toBe('Invalid variable: {{ inputs }}. Only {{ conversation }}, {{ expectations }} are allowed');
+    });
+  });
+
+  describe('Trace Level vs Session Level Scope', () => {
+    it('should reject {{ conversation }} in trace scope', () => {
+      const result = validateInstructions('Check {{ conversation }}', ScorerEvaluationScope.TRACES);
+
+      expect(result).toContain('Invalid variable: {{ conversation }}');
+    });
+
+    it('should accept {{ inputs }} in trace scope (explicit)', () => {
+      const result = validateInstructions('Check {{ inputs }}', ScorerEvaluationScope.TRACES);
+
+      expect(result).toBe(true);
+    });
+
+    it('should accept {{ inputs }} when scope is undefined (defaults to trace level)', () => {
+      const result = validateInstructions('Check {{ inputs }}');
+
+      expect(result).toBe(true);
+    });
+
+    it('should reject {{ conversation }} when scope is undefined (defaults to trace level)', () => {
+      const result = validateInstructions('Check {{ conversation }}');
+
+      expect(result).toContain('Invalid variable: {{ conversation }}');
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/llmScorerUtils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/llmScorerUtils.tsx
@@ -1,17 +1,19 @@
 import { useMemo } from 'react';
 import { useIntl } from '@databricks/i18n';
-import { LLM_TEMPLATE } from './types';
+import { LLM_TEMPLATE, SESSION_LEVEL_LLM_TEMPLATES, TRACE_LEVEL_LLM_TEMPLATES } from './types';
 import type { FeedbackAssessment } from '@databricks/web-shared/model-trace-explorer';
 import { getModelTraceId } from '@databricks/web-shared/model-trace-explorer';
 import { isFeedbackAssessmentInJudgeEvaluationResult, type JudgeEvaluationResult } from './useEvaluateTraces.common';
-import { TEMPLATE_VARIABLES } from '../../utils/evaluationUtils';
+import { SESSION_TEMPLATE_VARIABLES, TEMPLATE_VARIABLES } from '../../utils/evaluationUtils';
+import { ScorerEvaluationScope } from './constants';
 
 // Custom hook for template options
-export const useTemplateOptions = () => {
+export const useTemplateOptions = (scope?: ScorerEvaluationScope) => {
   const intl = useIntl();
 
-  const templateOptions = useMemo(
+  const allTemplateOptions = useMemo(
     () => [
+      // Trace-level templates
       {
         value: LLM_TEMPLATE.CORRECTNESS,
         label: intl.formatMessage({ defaultMessage: 'Correctness', description: 'LLM template option' }),
@@ -60,6 +62,32 @@ export const useTemplateOptions = () => {
           description: 'Hint for Safety template',
         }),
       },
+      // Session-level templates
+      {
+        value: LLM_TEMPLATE.CONVERSATION_COMPLETENESS,
+        label: intl.formatMessage({ defaultMessage: 'Conversation completeness', description: 'LLM template option' }),
+        hint: intl.formatMessage({
+          defaultMessage: "Did the conversation fully address the user's request?",
+          description: 'Hint for ConversationCompleteness template',
+        }),
+      },
+      {
+        value: LLM_TEMPLATE.KNOWLEDGE_RETENTION,
+        label: intl.formatMessage({ defaultMessage: 'Knowledge retention', description: 'LLM template option' }),
+        hint: intl.formatMessage({
+          defaultMessage: 'Did the assistant remember context from earlier in the conversation?',
+          description: 'Hint for KnowledgeRetention template',
+        }),
+      },
+      {
+        value: LLM_TEMPLATE.USER_FRUSTRATION,
+        label: intl.formatMessage({ defaultMessage: 'User frustration', description: 'LLM template option' }),
+        hint: intl.formatMessage({
+          defaultMessage: 'Did the conversation avoid causing user frustration?',
+          description: 'Hint for UserFrustration template',
+        }),
+      },
+      // Custom template (available for both trace and session level)
       {
         value: LLM_TEMPLATE.CUSTOM,
         label: intl.formatMessage({
@@ -74,6 +102,14 @@ export const useTemplateOptions = () => {
     ],
     [intl],
   );
+
+  const templateOptions = useMemo(() => {
+    if (scope === ScorerEvaluationScope.SESSIONS) {
+      return allTemplateOptions.filter((option) => SESSION_LEVEL_LLM_TEMPLATES.includes(option.value));
+    }
+
+    return allTemplateOptions.filter((option) => TRACE_LEVEL_LLM_TEMPLATES.includes(option.value));
+  }, [allTemplateOptions, scope]);
 
   const displayMap = useMemo(
     () =>
@@ -92,7 +128,9 @@ export const useTemplateOptions = () => {
  * and that at least one variable is present.
  *
  * Validation rules:
- * 1. Only 4 reserved variables are allowed: inputs, outputs, expectations, trace
+ * 1. A limited set of reserved variables is allowed based on the scope:
+ *    - trace level: inputs, outputs, expectations, trace
+ *    - session level: conversation
  * 2. At least one template variable must be present
  * 3. Variable names are case-sensitive and must match exactly
  * 4. {{ trace }} can be combined with {{ inputs }}, {{ outputs }}, or {{ expectations }}
@@ -101,9 +139,13 @@ export const useTemplateOptions = () => {
  * @param value - The instructions text to validate
  * @returns true if valid, or an error message string if invalid
  */
-export const validateInstructions = (value: string | undefined): true | string => {
+export const validateInstructions = (value: string | undefined, scope?: ScorerEvaluationScope): true | string => {
   // Allow empty values - the 'required' rule handles that separately
   if (!value || value.trim() === '') return true;
+
+  const isSessionLevel = scope === ScorerEvaluationScope.SESSIONS;
+
+  const validVariables = isSessionLevel ? SESSION_TEMPLATE_VARIABLES : TEMPLATE_VARIABLES;
 
   // Extract all template variables in the format {{ variableName }} or {{variableName}}
   const variablePattern = /\{\{\s*(\w+)\s*\}\}/g;
@@ -113,14 +155,18 @@ export const validateInstructions = (value: string | undefined): true | string =
   // Check 1: Validate that all variables are from the allowed list
   for (const match of matches) {
     const varName = match[1];
-    if (!TEMPLATE_VARIABLES.includes(varName)) {
-      return `Invalid variable: {{ ${varName} }}. Only {{ inputs }}, {{ outputs }}, {{ expectations }}, {{ trace }} are allowed`;
+    if (!validVariables.includes(varName)) {
+      const validVariablesString = validVariables.map((v) => `{{ ${v} }}`).join(', ');
+      return `Invalid variable: {{ ${varName} }}. Only ${validVariablesString} are allowed`;
     }
     foundVariables.add(varName);
   }
 
   // Check 2: Require at least one template variable
   if (foundVariables.size === 0) {
+    if (isSessionLevel) {
+      return 'Must contain at least one variable: {{ conversation }}, {{ expectations }}';
+    }
     return 'Must contain at least one variable: {{ inputs }}, {{ outputs }}, {{ expectations }}, or {{ trace }}';
   }
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/prompts.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/prompts.ts
@@ -99,6 +99,56 @@ export const TEMPLATE_INSTRUCTIONS_MAP: Record<string, string> = {
     '}\n\n' +
     '<text>{{ outputs }}</text>',
 
+  // Session-level template instructions.
+  [LLM_TEMPLATE.CONVERSATION_COMPLETENESS]:
+    'Consider the following conversation history between a user and an assistant.\n' +
+    'Your task is to output exactly one label: "yes" or "no" based on the criteria below.\n\n' +
+    'First, list all explicit user requests made throughout the conversation in the rationale section.\n' +
+    'Second, for each request, determine whether it was addressed by the assistant by the end of the conversation, ' +
+    "and **quote** the assistant's explicit response in the rationale section if you judge the request as addressed.\n" +
+    'If there is no explicit response to a request—or the response can only be inferred from context—mark that request as incomplete.\n' +
+    'Requests may be satisfied at any point in the dialogue as long as they are resolved by the final turn.\n' +
+    'A refusal counts as addressed only if the assistant provides a clear and explicit explanation; refusals without reasoning should be marked incomplete.\n' +
+    'Do not assume completeness merely because the user seems satisfied; evaluate solely whether each identified request was actually fulfilled.\n' +
+    'Output "no" only if one or more user requests remain unaddressed in the final state. Output "yes" if all requests were addressed.\n' +
+    'Base your judgment strictly on information explicitly stated or strongly implied in the conversation, without using outside assumptions.\n\n' +
+    '<conversation>{{ conversation }}</conversation>',
+
+  [LLM_TEMPLATE.KNOWLEDGE_RETENTION]:
+    'Your task is to evaluate the LAST AI response in the {{ conversation }} and determine if it:\n' +
+    '- Correctly uses or references information the user provided in earlier turns\n' +
+    '- Avoids contradicting information the user provided in earlier turns\n' +
+    '- Accurately recalls details without distortion\n\n' +
+    'Output "yes" if the AI\'s last response correctly retains any referenced prior user information.\n' +
+    'Output "no" if the AI\'s last response:\n' +
+    '- Contradicts information the user provided earlier\n' +
+    '- Misrepresents or inaccurately recalls user-provided information\n' +
+    '- Forgets or ignores information that is directly relevant to answering the current user question\n\n' +
+    'IMPORTANT GUIDELINES:\n' +
+    '1. Only evaluate information explicitly provided by the USER in prior turns\n' +
+    '2. Focus on factual information (names, dates, preferences, context) rather than opinions\n' +
+    '3. Not all prior information needs to be referenced in every response - only evaluate information\n' +
+    "   that is directly relevant to the current user's question or request\n" +
+    "4. If the AI doesn't reference prior information because it's not relevant to the current turn,\n" +
+    '   that\'s acceptable (output "yes")\n' +
+    '5. Only output "no" if there\'s a clear contradiction, distortion, or problematic forgetting of\n' +
+    '   information that should have been used\n' +
+    '6. Evaluate ONLY the last AI response, not the entire conversation\n\n' +
+    'Base your judgment strictly on the conversation content provided. Do not use outside knowledge.',
+
+  [LLM_TEMPLATE.USER_FRUSTRATION]:
+    'Consider the following conversation history between a user and an assistant. Your task is to\n' +
+    "determine the user's emotional trajectory and output exactly one of the following labels:\n" +
+    '"none", "resolved", or "unresolved".\n\n' +
+    'Return "none" when the user **never** expresses frustration at any point in the conversation;\n' +
+    'Return "unresolved" when the user is frustrated near the end or leaves without clear satisfaction.\n' +
+    'Only return "resolved" when the user **is frustrated at some point** in the conversation but clearly ends the conversation satisfied or reassured;\n' +
+    "    - Do not assume the user is satisfied just because the assistant's final response is helpful, constructive, or polite;\n" +
+    '    - Only label a conversation as "resolved" if the user explicitly or strongly implies satisfaction, relief, or acceptance in their own final turns.\n\n' +
+    'Base your decision only on explicit or strongly implied signals in the conversation and do not\n' +
+    'use outside knowledge or assumptions.\n\n' +
+    '<conversation>{{ conversation }}</conversation>',
+
   // Custom template has no default instructions
   [LLM_TEMPLATE.CUSTOM]: '',
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
@@ -16,16 +16,39 @@ interface ScheduledScorerBase {
 }
 
 // LLM Template Constants
-export const LLM_TEMPLATE = {
-  CORRECTNESS: 'Correctness',
-  GUIDELINES: 'Guidelines',
-  RELEVANCE_TO_QUERY: 'RelevanceToQuery',
-  RETRIEVAL_GROUNDEDNESS: 'RetrievalGroundedness',
-  RETRIEVAL_RELEVANCE: 'RetrievalRelevance',
-  RETRIEVAL_SUFFICIENCY: 'RetrievalSufficiency',
-  SAFETY: 'Safety',
-  CUSTOM: 'Custom',
-} as const;
+export enum LLM_TEMPLATE {
+  CORRECTNESS = 'Correctness',
+  GUIDELINES = 'Guidelines',
+  RELEVANCE_TO_QUERY = 'RelevanceToQuery',
+  RETRIEVAL_GROUNDEDNESS = 'RetrievalGroundedness',
+  RETRIEVAL_RELEVANCE = 'RetrievalRelevance',
+  RETRIEVAL_SUFFICIENCY = 'RetrievalSufficiency',
+  SAFETY = 'Safety',
+  CUSTOM = 'Custom',
+
+  // Session-level templates:
+  CONVERSATION_COMPLETENESS = 'ConversationCompleteness',
+  KNOWLEDGE_RETENTION = 'KnowledgeRetention',
+  USER_FRUSTRATION = 'UserFrustration',
+}
+
+export const TRACE_LEVEL_LLM_TEMPLATES = [
+  LLM_TEMPLATE.CORRECTNESS,
+  LLM_TEMPLATE.GUIDELINES,
+  LLM_TEMPLATE.RELEVANCE_TO_QUERY,
+  LLM_TEMPLATE.RETRIEVAL_GROUNDEDNESS,
+  LLM_TEMPLATE.RETRIEVAL_RELEVANCE,
+  LLM_TEMPLATE.RETRIEVAL_SUFFICIENCY,
+  LLM_TEMPLATE.SAFETY,
+  LLM_TEMPLATE.CUSTOM,
+];
+
+export const SESSION_LEVEL_LLM_TEMPLATES = [
+  LLM_TEMPLATE.CONVERSATION_COMPLETENESS,
+  LLM_TEMPLATE.KNOWLEDGE_RETENTION,
+  LLM_TEMPLATE.USER_FRUSTRATION,
+  LLM_TEMPLATE.CUSTOM,
+];
 
 export type LLMTemplate =
   | 'Correctness'

--- a/mlflow/server/js/src/experiment-tracking/utils/evaluationUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/evaluationUtils.ts
@@ -32,6 +32,7 @@ const TEMPLATE_VARIABLE_PATTERN = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][
 
 // Reserved template variables that can be used in instructions
 export const TEMPLATE_VARIABLES = ['inputs', 'outputs', 'expectations', 'trace'];
+export const SESSION_TEMPLATE_VARIABLES = ['conversation', 'expectations'];
 
 /**
  * Extracts template variables from instructions string. Variables are returned in the order they first appear.

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -143,10 +143,6 @@
     "defaultMessage": "Oops!",
     "description": "Error modal title to rendering errors"
   },
-  "/3dY2h": {
-    "defaultMessage": "Evaluate the conversation between a user and an assistant '{{ conversation }}'.",
-    "description": "Placeholder text for session level instructions textarea"
-  },
   "/4Aok8": {
     "defaultMessage": "Run",
     "description": "Column header for the run name in the runs table on the logged model details page"
@@ -5938,6 +5934,10 @@
   "kCsAho": {
     "defaultMessage": "Correctness",
     "description": "LLM template option"
+  },
+  "kHDQiE": {
+    "defaultMessage": "Analyze the '{{ conversation }}' and determine if the agent maintains a polite and professional tone throughout all interactions.{br}Rate as 'consistently_polite', 'mostly_polite', or 'impolite'.",
+    "description": "Placeholder text for session level instructions textarea. {br} is a newline."
   },
   "kHN/4I": {
     "defaultMessage": "Edited {timeSince} by {source}. Original value: {value}",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -143,6 +143,10 @@
     "defaultMessage": "Oops!",
     "description": "Error modal title to rendering errors"
   },
+  "/3dY2h": {
+    "defaultMessage": "Evaluate the conversation between a user and an assistant '{{ conversation }}'.",
+    "description": "Placeholder text for session level instructions textarea"
+  },
   "/4Aok8": {
     "defaultMessage": "Run",
     "description": "Column header for the run name in the runs table on the logged model details page"
@@ -427,6 +431,10 @@
     "defaultMessage": "Copy",
     "description": "Button text for copy button"
   },
+  "1JiZwB": {
+    "defaultMessage": "Did the conversation fully address the user's request?",
+    "description": "Hint for ConversationCompleteness template"
+  },
   "1NeHsz": {
     "defaultMessage": "{count, plural, one {1 trace selected} other {# traces selected}}",
     "description": "Label for the number of traces selected"
@@ -474,6 +482,10 @@
   "1jPG5D": {
     "defaultMessage": "Creator",
     "description": "Lable name for the creator under details tab on the model view page"
+  },
+  "1l/c+M": {
+    "defaultMessage": "User frustration",
+    "description": "LLM template option"
   },
   "1wfVV5": {
     "defaultMessage": "Currently sorted by",
@@ -2706,6 +2718,10 @@
     "defaultMessage": "Section title loading",
     "description": "Loading skeleton label for overview page section title in Catalog Explorer"
   },
+  "KLTGMn": {
+    "defaultMessage": "Full conversation between a user and an assistant",
+    "description": "Description for conversation variable"
+  },
   "KMVqUP": {
     "defaultMessage": "Tags",
     "description": "Header for the tags column in the registered prompts table"
@@ -3198,6 +3214,10 @@
     "defaultMessage": "Close",
     "description": "Error modal close button text"
   },
+  "OilzZP": {
+    "defaultMessage": "Conversation",
+    "description": "Label for conversation variable option"
+  },
   "OimAJb": {
     "defaultMessage": "Scatter Plot",
     "description": "Tab pane title for scatterplots on the compare runs page"
@@ -3485,6 +3505,10 @@
     "defaultMessage": "Connections",
     "description": "Section title for authentication"
   },
+  "RRvtnM": {
+    "defaultMessage": "Did the conversation avoid causing user frustration?",
+    "description": "Hint for UserFrustration template"
+  },
   "RUju4k": {
     "defaultMessage": "Charts",
     "description": "Tooltip for charts page mode toggle in evaluation runs table controls"
@@ -3552,6 +3576,10 @@
   "RyNXc+": {
     "defaultMessage": "Loading endpoint...",
     "description": "Loading message for endpoint"
+  },
+  "RySezx": {
+    "defaultMessage": "Did the assistant remember context from earlier in the conversation?",
+    "description": "Hint for KnowledgeRetention template"
   },
   "RzZVxC": {
     "defaultMessage": "An error occurred while rendering this component.",
@@ -5803,6 +5831,10 @@
     "defaultMessage": "Gateway returned the following error: \"{errorMessage}\"",
     "description": "Experiment page > gateway error message"
   },
+  "jIrCsp": {
+    "defaultMessage": "Knowledge retention",
+    "description": "LLM template option"
+  },
   "jMUqD1": {
     "defaultMessage": "Safety",
     "description": "Evaluation results > known type of evaluation result assessment > safety assessment. Used to indicate if the result is safe in context of LLMs evaluation. Label displayed if user provided custom value, e.g. \"Safety: moderate\""
@@ -6698,6 +6730,10 @@
   "qr7dhT": {
     "defaultMessage": "None",
     "description": "Label for experiments with no automatically inferred experiment type"
+  },
+  "qskex0": {
+    "defaultMessage": "Conversation completeness",
+    "description": "LLM template option"
   },
   "quxZB8": {
     "defaultMessage": "Create version",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19688/files) to review incremental changes.
- [**stack/select-traces-for-scorers-part9**](https://github.com/mlflow/mlflow/pull/19688) [[Files changed](https://github.com/mlflow/mlflow/pull/19688/files)]
  - [stack/select-traces-for-scorers-part10](https://github.com/mlflow/mlflow/pull/19689) [[Files changed](https://github.com/mlflow/mlflow/pull/19689/files/7a9cb38b84773c9d773c6a70f7b34a517d5225ba..82610d5055877218e94c7edc1ae7b1e98e770ade)]
    - [stack/select-traces-for-scorers-part11](https://github.com/mlflow/mlflow/pull/19693) [[Files changed](https://github.com/mlflow/mlflow/pull/19693/files/82610d5055877218e94c7edc1ae7b1e98e770ade..c217087ab276aea37a6d931591405dbb99d2cfc1)]

---------
### What changes are proposed in this pull request?

Extends the scorer form with session-specific prompt templates, variables, and type definitions for session-based evaluation. Updates `LLMScorerFormRenderer` and `ScorerCardContainer` to support session evaluation scope, and adds new prompt templates in prompts.ts for session scoring use cases. 

https://github.com/user-attachments/assets/be084ec6-4666-4239-95f9-5fe2738fad70

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
