### PR TITLE
[Part 11/x] Evaluating UI sessions via judges: time range selectors in trace/session select modals

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
@@ -10,6 +10,13 @@ import {
   TracesTableColumnType,
 } from '@databricks/web-shared/genai-traces-table';
 import { INPUTS_COLUMN_ID, RESPONSE_COLUMN_ID } from '@databricks/web-shared/genai-traces-table/hooks/useTableColumns';
+import { TracesV3DateSelector } from './experiment-page/components/traces-v3/TracesV3DateSelector';
+import {
+  MonitoringFilters,
+  MonitoringFiltersUpdateContext,
+  useMonitoringFilters,
+  useMonitoringFiltersTimeRange,
+} from '../hooks/useMonitoringFilters';
 
 /**
  * Default columns to be visible when selecting traces.
@@ -21,20 +28,25 @@ const defaultCustomDefaultSelectedColumns = (column: TracesTableColumn) => {
   return [TRACE_ID_COLUMN_ID, INPUTS_COLUMN_ID, RESPONSE_COLUMN_ID].includes(column.id);
 };
 
-export const SelectTracesModal = ({
-  onClose,
-  onSuccess,
-  maxTraceCount,
-  customDefaultSelectedColumns = defaultCustomDefaultSelectedColumns,
-  initialTraceIdsSelected = [],
-}: {
+interface SelectTracesModalProps {
   onClose?: () => void;
   onSuccess?: (traceIds: string[]) => void;
   maxTraceCount?: number;
   customDefaultSelectedColumns?: (column: TracesTableColumn) => boolean;
   initialTraceIdsSelected?: string[];
-}) => {
+}
+
+const SelectTracesModalImpl = ({
+  onClose,
+  onSuccess,
+  maxTraceCount,
+  customDefaultSelectedColumns = defaultCustomDefaultSelectedColumns,
+  initialTraceIdsSelected = [],
+}: SelectTracesModalProps) => {
   const { experimentId } = useParams();
+  const [monitoringFilters] = useMonitoringFilters();
+
+  const timeRange = useMonitoringFiltersTimeRange();
 
   const [rowSelection, setRowSelection] = useState<Record<string, boolean>>(
     initialTraceIdsSelected.reduce((acc, traceId) => {
@@ -83,9 +95,29 @@ export const SelectTracesModal = ({
         <TracesV3Logs
           disableActions
           experimentId={experimentId}
+          timeRange={timeRange}
           customDefaultSelectedColumns={customDefaultSelectedColumns}
+          // TODO: Move date selector to the toolbar in all callsites permanently
+          toolbarAddons={<TracesV3DateSelector />}
         />
       </GenAiTraceTableRowSelectionProvider>
     </Modal>
+  );
+};
+
+export const SelectTracesModal = (props: SelectTracesModalProps) => {
+  const [monitoringFilters, setMonitoringFilters] = useState<MonitoringFilters>({
+    startTimeLabel: 'LAST_7_DAYS',
+    startTime: undefined,
+    endTime: undefined,
+  });
+  const contextValue = useMemo(
+    () => ({ params: monitoringFilters, setParams: setMonitoringFilters, disableAutomaticInitialization: true }),
+    [monitoringFilters, setMonitoringFilters],
+  );
+  return (
+    <MonitoringFiltersUpdateContext.Provider value={contextValue}>
+      <SelectTracesModalImpl {...props} />
+    </MonitoringFiltersUpdateContext.Provider>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -64,6 +64,7 @@ const TracesV3LogsImpl = React.memo(
     loggedModelId,
     disableActions = false,
     customDefaultSelectedColumns,
+    toolbarAddons,
   }: {
     experimentId: string;
     endpointName?: string;
@@ -72,6 +73,7 @@ const TracesV3LogsImpl = React.memo(
     loggedModelId?: string;
     disableActions?: boolean;
     customDefaultSelectedColumns?: (column: TracesTableColumn) => boolean;
+    toolbarAddons?: React.ReactNode;
   }) => {
     const makeHtmlFromMarkdown = useMarkdownConverter();
     const intl = useIntl();
@@ -366,6 +368,7 @@ const TracesV3LogsImpl = React.memo(
             isMetadataLoading={isMetadataLoading}
             metadataError={metadataError}
             usesV4APIs={usesV4APIs}
+            addons={toolbarAddons}
           />
           {renderMainContent()}
         </div>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
@@ -8,10 +8,7 @@ import {
 } from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringConfig';
 import { TracesV3PageWrapper } from './TracesV3PageWrapper';
 import { useMonitoringViewState } from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringViewState';
-import {
-  getAbsoluteStartEndTime,
-  useMonitoringFilters,
-} from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringFilters';
+import { useMonitoringFiltersTimeRange } from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringFilters';
 import { useExperiments } from '../../hooks/useExperiments';
 import { TracesV3Toolbar } from './TracesV3Toolbar';
 
@@ -50,20 +47,13 @@ const TracesV3ViewImpl = ({
   isLoadingExperiment?: boolean;
 }) => {
   const { theme } = useDesignSystemTheme();
-  const [monitoringFilters, _setMonitoringFilters] = useMonitoringFilters();
   const monitoringConfig = useMonitoringConfig();
 
   // Traces view only works with one experiment
   const experimentId = experimentIds[0];
   const [viewState] = useMonitoringViewState();
 
-  const timeRange = useMemo(() => {
-    const { startTime, endTime } = getAbsoluteStartEndTime(monitoringConfig.dateNow, monitoringFilters);
-    return {
-      startTime: startTime ? new Date(startTime).getTime().toString() : undefined,
-      endTime: endTime ? new Date(endTime).getTime().toString() : undefined,
-    };
-  }, [monitoringConfig.dateNow, monitoringFilters]);
+  const timeRange = useMonitoringFiltersTimeRange(monitoringConfig.dateNow);
 
   return (
     <div

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useSetInitialTimeFilter.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useSetInitialTimeFilter.ts
@@ -28,12 +28,11 @@ export const useSetInitialTimeFilter = ({
   disabled?: boolean;
 }) => {
   const [searchParams] = useSearchParams();
-  const [monitoringFilters, setMonitoringFilters] = useMonitoringFilters();
+  const [monitoringFilters, setMonitoringFilters, disableAutomaticInitialization] = useMonitoringFilters();
 
   // Additional hook for fetching traces when there is no time range filters set in the
   // url params and no traces.
-  const shouldFetchForEmptyCheck =
-    isTracesEmpty && !isTraceMetadataLoading && !searchParams.has(START_TIME_LABEL_QUERY_PARAM_KEY);
+  const shouldFetchForEmptyCheck = isTracesEmpty && !isTraceMetadataLoading && !disableAutomaticInitialization;
 
   const { data: emptyCheckTraces, isLoading: emptyCheckLoading } = useSearchMlflowTraces({
     locations,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
@@ -13,7 +13,7 @@ import {
   useSearchMlflowTraces,
 } from '@databricks/web-shared/genai-traces-table';
 import { MonitoringConfigProvider, useMonitoringConfig } from '../../hooks/useMonitoringConfig';
-import { getAbsoluteStartEndTime, useMonitoringFilters } from '../../hooks/useMonitoringFilters';
+import { useMonitoringFiltersTimeRange } from '../../hooks/useMonitoringFilters';
 import { SESSION_ID_METADATA_KEY, shouldUseTracesV4API } from '@databricks/web-shared/model-trace-explorer';
 import { useGetExperimentQuery } from '../../hooks/useExperimentQuery';
 import { getChatSessionsFilter } from './utils';
@@ -25,7 +25,6 @@ const ExperimentChatSessionsPageImpl = () => {
   const [searchQuery, setSearchQuery] = useState<string>('');
   invariant(experimentId, 'Experiment ID must be defined');
 
-  const [monitoringFilters] = useMonitoringFilters();
   const monitoringConfig = useMonitoringConfig();
   const { loading: isLoadingExperiment } = useGetExperimentQuery({
     experimentId,
@@ -34,13 +33,7 @@ const ExperimentChatSessionsPageImpl = () => {
     },
   });
 
-  const timeRange = useMemo(() => {
-    const { startTime, endTime } = getAbsoluteStartEndTime(monitoringConfig.dateNow, monitoringFilters);
-    return {
-      startTime: startTime ? new Date(startTime).getTime().toString() : undefined,
-      endTime: endTime ? new Date(endTime).getTime().toString() : undefined,
-    };
-  }, [monitoringConfig.dateNow, monitoringFilters]);
+  const timeRange = useMonitoringFiltersTimeRange(monitoringConfig.dateNow);
 
   const traceSearchLocations = useMemo(
     () => {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
@@ -75,6 +75,9 @@ interface GenAITracesTableToolbarProps {
   // available in the new APIs. this param is somewhat confusingly named
   // in OSS, since the "new APIs" still use the v3 prefixes
   usesV4APIs?: boolean;
+
+  // Additional elements to render in the toolbar
+  addons?: React.ReactNode;
 }
 
 export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITracesTableToolbarProps>> = React.memo(
@@ -99,6 +102,7 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
       isMetadataLoading,
       usesV4APIs,
       metadataError,
+      addons,
     } = props;
     const { theme } = useDesignSystemTheme();
 
@@ -157,6 +161,7 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
           {traceActions && (
             <GenAITracesTableActions experimentId={experimentId} traceActions={traceActions} traceInfos={traceInfos} />
           )}
+          {addons}
         </TableFilterLayout>
         <SampledInfoBadge countInfo={countInfo} />
       </div>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
@@ -165,6 +165,7 @@ export const GenAIChatSessionsTable = ({
   enableRowSelection: enableRowSelectionProp = false,
   enableLinks = true,
   empty,
+  toolbarAddons,
 }: {
   experimentId: string;
   traces: ModelTraceInfoV3[];
@@ -175,6 +176,7 @@ export const GenAIChatSessionsTable = ({
   enableRowSelection?: boolean;
   enableLinks?: boolean;
   empty?: React.ReactElement;
+  toolbarAddons?: React.ReactNode;
 }) => {
   const { theme } = useDesignSystemTheme();
 
@@ -247,6 +249,7 @@ export const GenAIChatSessionsTable = ({
         experimentId={experimentId}
         selectedSessions={selectedSessions}
         setRowSelection={setRowSelection}
+        addons={toolbarAddons}
       />
       <Table
         style={{ ...columnSizeVars }}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsToolbar.tsx
@@ -26,6 +26,7 @@ export const GenAIChatSessionsToolbar = ({
   experimentId,
   selectedSessions,
   setRowSelection,
+  addons,
 }: {
   columns: SessionTableColumn[];
   columnVisibility: Record<string, boolean>;
@@ -36,6 +37,7 @@ export const GenAIChatSessionsToolbar = ({
   experimentId: string;
   selectedSessions: SessionTableRow[];
   setRowSelection?: React.Dispatch<React.SetStateAction<RowSelectionState>>;
+  addons?: React.ReactNode;
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -93,6 +95,7 @@ export const GenAIChatSessionsToolbar = ({
           setRowSelection={setRowSelection}
         />
       )}
+      {addons}
     </div>
   );
 };


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19693/files) to review incremental changes.
- [**stack/select-traces-for-scorers-part11**](https://github.com/mlflow/mlflow/pull/19693) [[Files changed](https://github.com/mlflow/mlflow/pull/19693/files)]

---------
### What changes are proposed in this pull request?

- Rewires time range selection logic in `useMonitoringFilters`, allowing to embed time range selector UI and consume it in arbitrary place
- Adds time selectors on trace and session selection modals, used in judge configuration modal

https://github.com/user-attachments/assets/fba6742d-de1f-4fe8-a527-9c2912350440

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
