### PR TITLE
Fix bug that prevented updating labeling schema inputs

### DIFF
--- a/mlflow/genai/labeling/stores.py
+++ b/mlflow/genai/labeling/stores.py
@@ -417,7 +417,7 @@ class DatabricksLabelingStore(AbstractLabelingStore):
     ) -> LabelSchema:
         """Create a new label schema."""
         app = get_databricks_review_app()
-        return app.create_label_schema(
+        databricks_schema = app.create_label_schema(
             name=name,
             type=type,
             title=title,
@@ -426,6 +426,7 @@ class DatabricksLabelingStore(AbstractLabelingStore):
             enable_comment=enable_comment,
             overwrite=overwrite,
         )
+        return LabelSchema._from_databricks_label_schema(databricks_schema)
 
     def delete_label_schema(self, name: str) -> None:
         """Delete a label schema."""


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/AveshCSingh/mlflow/pull/19695?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19695/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19695/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19695/merge
```

</p>
</details>

Bug: When calling create_label_schema(), the returned object was a raw Databricks schema instead of an MLflow LabelSchema. This caused the input field to have Databricks types instead of MLflow types, making isinstance checks fail and causing inconsistent behavior between create_label_schema() and get_label_schema().

Fix: Convert the Databricks schema to MLflow LabelSchema using _from_databricks_label_schema() before returning from DatabricksLabelingStore.create_label_schema().

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Verification script:
```
#!/usr/bin/env python
"""
Test script to verify the labeling schema overwrite bug fix.

Bug: When updating a labeling schema with overwrite=True and changing the input=,
the returned schema had the wrong type (raw Databricks object instead of MLflow LabelSchema).

Usage:
    export DATABRICKS_HOST=... DATABRICKS_TOKEN=...
    conda activate mlflow-dev-env
    PYTHONPATH=/home/avesh.singh/mlflow python tmp/scripts/test_label_schema_overwrite.py
"""

import os
import sys
import uuid

sys.path.insert(0, "/home/avesh.singh/mlflow")

import mlflow
from mlflow.genai.label_schemas import (
    InputCategorical,
    InputText,
    LabelSchema,
    create_label_schema,
    delete_label_schema,
)

# Setup
mlflow.set_tracking_uri("databricks")
mlflow.set_experiment(f"/Users/{os.environ.get('USER')}@databricks.com/test_label_schema_overwrite")

schema_name = f"test_overwrite_{uuid.uuid4().hex[:8]}"

try:
    # Create schema with InputCategorical
    result_v1 = create_label_schema(
        name=schema_name,
        type="feedback",
        title="Test Schema v1",
        input=InputCategorical(options=["good", "bad"]),
    )
    print(f"First create - type: {type(result_v1).__name__}, input type: {type(result_v1.input).__name__}")
    assert isinstance(result_v1, LabelSchema), f"Expected LabelSchema, got {type(result_v1)}"
    assert isinstance(result_v1.input, InputCategorical), f"Expected InputCategorical, got {type(result_v1.input)}"

    # Overwrite with InputText
    result_v2 = create_label_schema(
        name=schema_name,
        type="feedback",
        title="Test Schema v2",
        input=InputText(max_length=500),
        overwrite=True,
    )
    print(f"Overwrite - type: {type(result_v2).__name__}, input type: {type(result_v2.input).__name__}")
    assert isinstance(result_v2, LabelSchema), f"Expected LabelSchema, got {type(result_v2)}"
    assert isinstance(result_v2.input, InputText), f"Expected InputText, got {type(result_v2.input)}"
    print("\nPASSED: overwrite=True correctly returns MLflow LabelSchema with updated input type")

finally:
    try:
        delete_label_schema(schema_name)
    except Exception:
        pass
```

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
