### PR TITLE
Add explicit disabled messages for registering/aligning 3p scorers

### DIFF
--- a/mlflow/genai/scorers/deepeval/__init__.py
+++ b/mlflow/genai/scorers/deepeval/__init__.py
@@ -94,6 +94,31 @@ class DeepEvalScorer(Scorer):
     def kind(self) -> ScorerKind:
         return ScorerKind.THIRD_PARTY
 
+    def _raise_registration_not_supported(self, method_name: str):
+        raise MlflowException.invalid_parameter_value(
+            f"'{method_name}()' is not supported for third-party scorers like DeepEval. "
+            f"Third-party scorers cannot be registered, started, updated, or stopped. "
+            f"Use them directly in mlflow.genai.evaluate() instead."
+        )
+
+    def register(self, **kwargs):
+        self._raise_registration_not_supported("register")
+
+    def start(self, **kwargs):
+        self._raise_registration_not_supported("start")
+
+    def update(self, **kwargs):
+        self._raise_registration_not_supported("update")
+
+    def stop(self, **kwargs):
+        self._raise_registration_not_supported("stop")
+
+    def align(self, **kwargs):
+        raise MlflowException.invalid_parameter_value(
+            "'align()' is not supported for third-party scorers like DeepEval. "
+            "Alignment is only available for MLflow's built-in judges."
+        )
+
     @property
     def is_session_level_scorer(self) -> bool:
         from deepeval.metrics.base_metric import BaseConversationalMetric

--- a/mlflow/genai/scorers/ragas/__init__.py
+++ b/mlflow/genai/scorers/ragas/__init__.py
@@ -84,6 +84,31 @@ class RagasScorer(Scorer):
     def kind(self) -> ScorerKind:
         return ScorerKind.THIRD_PARTY
 
+    def _raise_registration_not_supported(self, method_name: str):
+        raise MlflowException.invalid_parameter_value(
+            f"'{method_name}()' is not supported for third-party scorers like RAGAS. "
+            f"Third-party scorers cannot be registered, started, updated, or stopped. "
+            f"Use them directly in mlflow.genai.evaluate() instead."
+        )
+
+    def register(self, **kwargs):
+        self._raise_registration_not_supported("register")
+
+    def start(self, **kwargs):
+        self._raise_registration_not_supported("start")
+
+    def update(self, **kwargs):
+        self._raise_registration_not_supported("update")
+
+    def stop(self, **kwargs):
+        self._raise_registration_not_supported("stop")
+
+    def align(self, **kwargs):
+        raise MlflowException.invalid_parameter_value(
+            "'align()' is not supported for third-party scorers like RAGAS. "
+            "Alignment is only available for MLflow's built-in judges."
+        )
+
     def __call__(
         self,
         *,

--- a/tests/genai/scorers/deepeval/test_deepeval_scorer.py
+++ b/tests/genai/scorers/deepeval/test_deepeval_scorer.py
@@ -235,6 +235,26 @@ def test_deepeval_scorer_kind_property():
     assert scorer.kind == ScorerKind.THIRD_PARTY
 
 
+@pytest.mark.parametrize("method_name", ["register", "start", "update", "stop"])
+def test_deepeval_scorer_registration_methods_not_supported(method_name):
+    from mlflow.exceptions import MlflowException
+
+    scorer = get_scorer("ExactMatch")
+    method = getattr(scorer, method_name)
+
+    with pytest.raises(MlflowException, match=f"'{method_name}\\(\\)' is not supported"):
+        method()
+
+
+def test_deepeval_scorer_align_not_supported():
+    from mlflow.exceptions import MlflowException
+
+    scorer = get_scorer("ExactMatch")
+
+    with pytest.raises(MlflowException, match="'align\\(\\)' is not supported"):
+        scorer.align()
+
+
 def test_deepeval_scorer_kind_property_with_llm_metric(mock_deepeval_model):
     with patch(
         "mlflow.genai.scorers.deepeval.create_deepeval_model", return_value=mock_deepeval_model

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -180,6 +180,22 @@ def test_ragas_scorer_kind_property():
     assert scorer.kind == ScorerKind.THIRD_PARTY
 
 
+@pytest.mark.parametrize("method_name", ["register", "start", "update", "stop"])
+def test_ragas_scorer_registration_methods_not_supported(method_name):
+    scorer = get_scorer("ExactMatch")
+    method = getattr(scorer, method_name)
+
+    with pytest.raises(MlflowException, match=f"'{method_name}\\(\\)' is not supported"):
+        method()
+
+
+def test_ragas_scorer_align_not_supported():
+    scorer = get_scorer("ExactMatch")
+
+    with pytest.raises(MlflowException, match="'align\\(\\)' is not supported"):
+        scorer.align()
+
+
 def test_ragas_scorer_kind_property_with_llm_metric():
     with patch("mlflow.genai.scorers.ragas.create_ragas_model"):
         scorer = Faithfulness()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/19696?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19696/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19696/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19696/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Script:
```python
from mlflow.genai.scorers.deepeval import get_scorer as get_deepeval_scorer
from mlflow.genai.scorers.ragas import get_scorer as get_ragas_scorer

# Test DeepEval
ds = get_deepeval_scorer("ExactMatch")
for method in ["register", "start", "update", "stop", "align"]:
    try:
        getattr(ds, method)()
    except Exception as e:
        print(f"DeepEval {method}: {e}")

# Test RAGAS
rs = get_ragas_scorer("ExactMatch")
for method in ["register", "start", "update", "stop", "align"]:
    try:
        getattr(rs, method)()
    except Exception as e:
        print(f"RAGAS {method}: {e}")
```

Output:
```
DeepEval register: 'register()' is not supported for third-party scorers like DeepEval. Third-party scorers cannot be registered, started, updated, or stopped. Use them directly in mlflow.genai.evaluate() instead.
DeepEval start: 'start()' is not supported for third-party scorers like DeepEval. Third-party scorers cannot be registered, started, updated, or stopped. Use them directly in mlflow.genai.evaluate() instead.
DeepEval update: 'update()' is not supported for third-party scorers like DeepEval. Third-party scorers cannot be registered, started, updated, or stopped. Use them directly in mlflow.genai.evaluate() instead.
DeepEval stop: 'stop()' is not supported for third-party scorers like DeepEval. Third-party scorers cannot be registered, started, updated, or stopped. Use them directly in mlflow.genai.evaluate() instead.
DeepEval align: 'align()' is not supported for third-party scorers like DeepEval. Alignment is only available for MLflow's built-in judges.
RAGAS register: 'register()' is not supported for third-party scorers like RAGAS. Third-party scorers cannot be registered, started, updated, or stopped. Use them directly in mlflow.genai.evaluate() instead.
RAGAS start: 'start()' is not supported for third-party scorers like RAGAS. Third-party scorers cannot be registered, started, updated, or stopped. Use them directly in mlflow.genai.evaluate() instead.
RAGAS update: 'update()' is not supported for third-party scorers like RAGAS. Third-party scorers cannot be registered, started, updated, or stopped. Use them directly in mlflow.genai.evaluate() instead.
RAGAS stop: 'stop()' is not supported for third-party scorers like RAGAS. Third-party scorers cannot be registered, started, updated, or stopped. Use them directly in mlflow.genai.evaluate() instead.
RAGAS align: 'align()' is not supported for third-party scorers like RAGAS. Alignment is only available for MLflow's built-in judges.
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
