### PR TITLE
[Online Scoring][1/x] [BUG FIX] Make temperature optional in AI Gateway requests

### DIFF
--- a/mlflow/gateway/providers/huggingface.py
+++ b/mlflow/gateway/providers/huggingface.py
@@ -58,10 +58,10 @@ class HFTextGenerationInferenceServerProvider(BaseProvider):
         parameters = rename_payload_keys(payload, key_mapping)
 
         # The range of HF TGI's temperature is 0-100, but ours is 0-2, so we multiply
-        # by 50
-        payload["temperature"] = 50 * payload["temperature"]
-        # HF TGI does not support 0 temperature
-        parameters["temperature"] = max(payload["temperature"], 1e-3)
+        # by 50. HF TGI does not support 0 temperature so we use a small default.
+        if "temperature" in payload:
+            scaled_temp = 50 * payload["temperature"]
+            parameters["temperature"] = max(scaled_temp, 1e-3)
         parameters["details"] = True
         parameters["decoder_input_details"] = True
 

--- a/mlflow/gateway/providers/palm.py
+++ b/mlflow/gateway/providers/palm.py
@@ -53,7 +53,8 @@ class PaLMProvider(BaseProvider):
                 )
         payload = rename_payload_keys(payload, key_mapping)
         # The range of PaLM's temperature is 0-1, but ours is 0-2, so we halve it
-        payload["temperature"] = 0.5 * payload["temperature"]
+        if "temperature" in payload:
+            payload["temperature"] = 0.5 * payload["temperature"]
 
         # Replace 'role' with 'author' in payload
         for m in payload["messages"]:
@@ -125,7 +126,8 @@ class PaLMProvider(BaseProvider):
                 )
         payload = rename_payload_keys(payload, key_mapping)
         # The range of PaLM's temperature is 0-1, but ours is 0-2, so we halve it
-        payload["temperature"] = 0.5 * payload["temperature"]
+        if "temperature" in payload:
+            payload["temperature"] = 0.5 * payload["temperature"]
         payload["prompt"] = {"text": payload["prompt"]}
         resp = await self._request(
             f"{self.config.model.name}:generateText",

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -160,7 +160,6 @@ class ResponseFormat(BaseModel):
 class BaseRequestPayload(BaseModel):
     """Common parameters used for chat completions and completion endpoints."""
 
-    temperature: float = Field(0.0, ge=0, le=2)
     n: int = Field(1, ge=1)
     stop: list[str] | None = Field(None, min_length=1)
     max_tokens: int | None = Field(None, ge=1)
@@ -168,6 +167,7 @@ class BaseRequestPayload(BaseModel):
     stream_options: dict[str, Any] | None = None
     model: str | None = None
     response_format: ResponseFormat | None = None
+    temperature: float | None = Field(None, ge=0, le=2)
     top_p: float | None = Field(None, ge=0, le=1)
     presence_penalty: float | None = Field(None, ge=-2, le=2)
     frequency_penalty: float | None = Field(None, ge=-2, le=2)

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -111,7 +111,6 @@ async def test_completions_with_default_max_tokens():
             "https://api.anthropic.com/v1/complete",
             json={
                 "model": "claude-instant-1",
-                "temperature": 0.0,
                 "max_tokens_to_sample": 8192,
                 "prompt": "\n\nHuman: How does a car work?\n\nAssistant:",
             },

--- a/tests/gateway/providers/test_cohere.py
+++ b/tests/gateway/providers/test_cohere.py
@@ -324,7 +324,6 @@ async def test_completions():
                 "model": "command",
                 "num_generations": 1,
                 "stop_sequences": ["foobar"],
-                "temperature": 0.0,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
@@ -424,7 +423,6 @@ async def test_completions_stream():
                 "prompt": "This is a test",
                 "model": "command",
                 "num_generations": 1,
-                "temperature": 0.0,
                 "stream": True,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),

--- a/tests/gateway/providers/test_huggingface.py
+++ b/tests/gateway/providers/test_huggingface.py
@@ -98,7 +98,6 @@ async def test_completions():
             json={
                 "inputs": "This is a test",
                 "parameters": {
-                    "temperature": 0.001,
                     "max_new_tokens": 1000,
                     "details": True,
                     "decoder_input_details": True,

--- a/tests/gateway/providers/test_mistral.py
+++ b/tests/gateway/providers/test_mistral.py
@@ -92,7 +92,6 @@ async def test_completions():
             json={
                 "messages": [{"role": "user", "content": TEST_STRING}],
                 "model": "mistral-tiny",
-                "temperature": 0.0,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )

--- a/tests/gateway/providers/test_mlflow.py
+++ b/tests/gateway/providers/test_mlflow.py
@@ -289,7 +289,7 @@ async def test_chat():
             "http://127.0.0.1:4000/invocations",
             json={
                 "inputs": ["Is this a test?"],
-                "params": {"temperature": 0.0, "n": 1},
+                "params": {"n": 1},
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )

--- a/tests/gateway/providers/test_mosaicml.py
+++ b/tests/gateway/providers/test_mosaicml.py
@@ -66,7 +66,7 @@ async def test_completions():
             "https://models.hosted-on.mosaicml.hosting/mpt-7b-instruct/v1/predict",
             json={
                 "inputs": ["This is a test"],
-                "parameters": {"temperature": 0.0, "n": 1, "max_new_tokens": 1000},
+                "parameters": {"n": 1, "max_new_tokens": 1000},
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
@@ -103,7 +103,6 @@ def chat_response():
             {
                 "inputs": ["<s>[INST] Tell me a joke [/INST]"],
                 "parameters": {
-                    "temperature": 0.0,
                     "n": 1,
                 },
             },
@@ -118,7 +117,6 @@ def chat_response():
             {
                 "inputs": ["<s>[INST] <<SYS>> You're funny <</SYS>> Tell me a joke [/INST]"],
                 "parameters": {
-                    "temperature": 0.0,
                     "n": 1,
                 },
             },
@@ -156,7 +154,6 @@ def chat_response():
                     )
                 ],
                 "parameters": {
-                    "temperature": 0.0,
                     "n": 1,
                 },
             },

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -244,7 +244,6 @@ async def _run_test_chat_stream(resp, provider):
             "https://api.openai.com/v1/chat/completions",
             json={
                 "model": "gpt-4o-mini",
-                "temperature": 0,
                 "n": 1,
                 **payload,
             },
@@ -407,7 +406,6 @@ async def _run_test_completions(resp, provider):
             "https://api.openai.com/v1/completions",
             json={
                 "model": "gpt-4-32k",
-                "temperature": 0,
                 "n": 1,
                 "prompt": "This is a test",
             },
@@ -528,7 +526,6 @@ async def _run_test_completions_stream(resp, provider):
             "https://api.openai.com/v1/completions",
             json={
                 "model": "gpt-4-32k",
-                "temperature": 0,
                 "n": 1,
                 "prompt": "This is a test",
             },
@@ -743,7 +740,6 @@ async def test_azure_openai():
                 "/completions?api-version=2023-05-15"
             ),
             json={
-                "temperature": 0,
                 "n": 1,
                 "prompt": "This is a test",
             },
@@ -782,7 +778,6 @@ async def test_azuread_openai():
                 "/completions?api-version=2023-05-15"
             ),
             json={
-                "temperature": 0,
                 "n": 1,
                 "prompt": "This is a test",
             },

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -78,7 +78,6 @@ async def test_completions():
                 "prompt": {
                     "text": "This is a test",
                 },
-                "temperature": 0.0,
                 "candidateCount": 1,
                 "maxOutputTokens": 1000,
                 "stopSequences": ["foobar"],
@@ -130,7 +129,6 @@ def chat_response():
         (
             {"messages": [{"role": "user", "content": "Tell me a joke"}]},
             {
-                "temperature": 0.0,
                 "candidateCount": 1,
                 "prompt": {"messages": [{"content": "Tell me a joke", "author": "user"}]},
             },
@@ -143,7 +141,6 @@ def chat_response():
                 ]
             },
             {
-                "temperature": 0.0,
                 "candidateCount": 1,
                 "prompt": {
                     "messages": [

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -265,8 +265,8 @@ def test_score_model_bedrock(monkeypatch):
         # and requires "anthropic_version" put within the body not headers.
         body=json.dumps(
             {
-                "temperature": 0,
                 "max_tokens": 1000,
+                "temperature": 0,
                 "messages": [{"role": "user", "content": "input prompt"}],
                 "anthropic_version": "2023-06-01",
             }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19707/files) to review incremental changes.
- [**stack/pr1-temperature-fix**](https://github.com/mlflow/mlflow/pull/19707) [[Files changed](https://github.com/mlflow/mlflow/pull/19707/files)]
  - [stack/pr2-schema-migration](https://github.com/mlflow/mlflow/pull/19708) [[Files changed](https://github.com/mlflow/mlflow/pull/19708/files/36418a0944696d8c7f7b4c2a296cf24864ff13ec..8d046a04abe1009fa0bd1cc05f1bfad38444b054)]
    - [stack/pr3-store-crud](https://github.com/mlflow/mlflow/pull/19709) [[Files changed](https://github.com/mlflow/mlflow/pull/19709/files/8d046a04abe1009fa0bd1cc05f1bfad38444b054..60f17f5f3018ced08c66f4eb3ca75a339ef63bed)]
      - [stack/pr4-rest-api](https://github.com/mlflow/mlflow/pull/19710) [[Files changed](https://github.com/mlflow/mlflow/pull/19710/files/60f17f5f3018ced08c66f4eb3ca75a339ef63bed..c426c122f9bc2dea62362ad77d035478fbbae55e)]
        - [stack/pr5-scorer-integration](https://github.com/mlflow/mlflow/pull/19711) [[Files changed](https://github.com/mlflow/mlflow/pull/19711/files/c426c122f9bc2dea62362ad77d035478fbbae55e..bc79eb66cc137fcb8b1700e2658f469e6d128831)]
          - [stack/pr6a-trace-utilities](https://github.com/mlflow/mlflow/pull/19712) [[Files changed](https://github.com/mlflow/mlflow/pull/19712/files/bc79eb66cc137fcb8b1700e2658f469e6d128831..2d6e1aa81b136b5632d214b5b1ba9051953145fa)]
            - [stack/pr6ahalf-is-null-filter](https://github.com/mlflow/mlflow/pull/19720) [[Files changed](https://github.com/mlflow/mlflow/pull/19720/files/2d6e1aa81b136b5632d214b5b1ba9051953145fa..ba40b2b47a173be59b34ccf5b8a018066f2702df)]
              - [stack/pr6b-trace-processor](https://github.com/mlflow/mlflow/pull/19713) [[Files changed](https://github.com/mlflow/mlflow/pull/19713/files/ba40b2b47a173be59b34ccf5b8a018066f2702df..90313245d19dee4b697c96dad7d6df802ddcb049)]
                - [stack/pr6c-exclusive-flag-job](https://github.com/mlflow/mlflow/pull/19714) [[Files changed](https://github.com/mlflow/mlflow/pull/19714/files/90313245d19dee4b697c96dad7d6df802ddcb049..f1897ed30a5bcf07e5f838aad8b3b31f9956d303)]
                  - [stack/pr7b-completed-sessions](https://github.com/mlflow/mlflow/pull/19718) [[Files changed](https://github.com/mlflow/mlflow/pull/19718/files/f1897ed30a5bcf07e5f838aad8b3b31f9956d303..4e0133698d816091940d3c3f039f2fde83737bfa)]
                    - [stack/pr7c-session-checkpointer](https://github.com/mlflow/mlflow/pull/19759) [[Files changed](https://github.com/mlflow/mlflow/pull/19759/files/4e0133698d816091940d3c3f039f2fde83737bfa..b37c7ab161fc1708ac0e17af36541d0c084cf8d9)]
                      - [stack/pr8-session-job-utils](https://github.com/mlflow/mlflow/pull/19716) [[Files changed](https://github.com/mlflow/mlflow/pull/19716/files/b37c7ab161fc1708ac0e17af36541d0c084cf8d9..d9dfd3b2f43a50982cd8f3eedbfd6aa8b21da39b)]
                        - [stack/pr9-periodic-scheduler](https://github.com/mlflow/mlflow/pull/19717) [[Files changed](https://github.com/mlflow/mlflow/pull/19717/files/d9dfd3b2f43a50982cd8f3eedbfd6aa8b21da39b..935ee6ee32a1a632ef9d41b0aaf153c656f8a193)]
                          - [stack/pr10-online-scoring-ui](https://github.com/mlflow/mlflow/pull/19736) [[Files changed](https://github.com/mlflow/mlflow/pull/19736/files/935ee6ee32a1a632ef9d41b0aaf153c656f8a193..6d59fee126651e124f370bebf82696716e3ef6cf)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Make temperature optional in AI Gateway requests. Otherwise, attempting to use newer reasoning models that don't support `temperature` with AI Gateway fails.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [X] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
