### PR TITLE
[Online Scoring][2/x] Add schema migration for online_scoring_configs table

### DIFF
--- a/mlflow/gateway/providers/huggingface.py
+++ b/mlflow/gateway/providers/huggingface.py
@@ -58,10 +58,10 @@ class HFTextGenerationInferenceServerProvider(BaseProvider):
         parameters = rename_payload_keys(payload, key_mapping)
 
         # The range of HF TGI's temperature is 0-100, but ours is 0-2, so we multiply
-        # by 50
-        payload["temperature"] = 50 * payload["temperature"]
-        # HF TGI does not support 0 temperature
-        parameters["temperature"] = max(payload["temperature"], 1e-3)
+        # by 50. HF TGI does not support 0 temperature so we use a small default.
+        if "temperature" in payload:
+            scaled_temp = 50 * payload["temperature"]
+            parameters["temperature"] = max(scaled_temp, 1e-3)
         parameters["details"] = True
         parameters["decoder_input_details"] = True
 

--- a/mlflow/gateway/providers/palm.py
+++ b/mlflow/gateway/providers/palm.py
@@ -53,7 +53,8 @@ class PaLMProvider(BaseProvider):
                 )
         payload = rename_payload_keys(payload, key_mapping)
         # The range of PaLM's temperature is 0-1, but ours is 0-2, so we halve it
-        payload["temperature"] = 0.5 * payload["temperature"]
+        if "temperature" in payload:
+            payload["temperature"] = 0.5 * payload["temperature"]
 
         # Replace 'role' with 'author' in payload
         for m in payload["messages"]:
@@ -125,7 +126,8 @@ class PaLMProvider(BaseProvider):
                 )
         payload = rename_payload_keys(payload, key_mapping)
         # The range of PaLM's temperature is 0-1, but ours is 0-2, so we halve it
-        payload["temperature"] = 0.5 * payload["temperature"]
+        if "temperature" in payload:
+            payload["temperature"] = 0.5 * payload["temperature"]
         payload["prompt"] = {"text": payload["prompt"]}
         resp = await self._request(
             f"{self.config.model.name}:generateText",

--- a/mlflow/genai/scorers/online/__init__.py
+++ b/mlflow/genai/scorers/online/__init__.py
@@ -1,8 +1,7 @@
 """Online scoring subpackage for scheduled scorer execution."""
 
-from mlflow.genai.scorers.online.entities import OnlineScorer, OnlineScoringConfig
+from mlflow.genai.scorers.online.entities import OnlineScoringConfig
 
 __all__ = [
-    "OnlineScorer",
     "OnlineScoringConfig",
 ]

--- a/mlflow/genai/scorers/online/__init__.py
+++ b/mlflow/genai/scorers/online/__init__.py
@@ -1,0 +1,20 @@
+"""Online scoring subpackage for scheduled scorer execution."""
+
+from mlflow.genai.scorers.online.entities import OnlineScorer, OnlineScoringConfig
+from mlflow.genai.scorers.online.sampler import OnlineScorerSampler
+from mlflow.genai.scorers.online.session_checkpointer import OnlineSessionCheckpointManager
+from mlflow.genai.scorers.online.session_processor import OnlineSessionScoringProcessor
+from mlflow.genai.scorers.online.trace_checkpointer import OnlineTraceCheckpointManager
+from mlflow.genai.scorers.online.trace_loader import OnlineTraceLoader
+from mlflow.genai.scorers.online.trace_processor import OnlineTraceScoringProcessor
+
+__all__ = [
+    "OnlineScorer",
+    "OnlineScorerSampler",
+    "OnlineScoringConfig",
+    "OnlineSessionCheckpointManager",
+    "OnlineSessionScoringProcessor",
+    "OnlineTraceCheckpointManager",
+    "OnlineTraceLoader",
+    "OnlineTraceScoringProcessor",
+]

--- a/mlflow/genai/scorers/online/__init__.py
+++ b/mlflow/genai/scorers/online/__init__.py
@@ -1,20 +1,8 @@
 """Online scoring subpackage for scheduled scorer execution."""
 
 from mlflow.genai.scorers.online.entities import OnlineScorer, OnlineScoringConfig
-from mlflow.genai.scorers.online.sampler import OnlineScorerSampler
-from mlflow.genai.scorers.online.session_checkpointer import OnlineSessionCheckpointManager
-from mlflow.genai.scorers.online.session_processor import OnlineSessionScoringProcessor
-from mlflow.genai.scorers.online.trace_checkpointer import OnlineTraceCheckpointManager
-from mlflow.genai.scorers.online.trace_loader import OnlineTraceLoader
-from mlflow.genai.scorers.online.trace_processor import OnlineTraceScoringProcessor
 
 __all__ = [
     "OnlineScorer",
-    "OnlineScorerSampler",
     "OnlineScoringConfig",
-    "OnlineSessionCheckpointManager",
-    "OnlineSessionScoringProcessor",
-    "OnlineTraceCheckpointManager",
-    "OnlineTraceLoader",
-    "OnlineTraceScoringProcessor",
 ]

--- a/mlflow/genai/scorers/online/entities.py
+++ b/mlflow/genai/scorers/online/entities.py
@@ -24,7 +24,6 @@ class OnlineScoringConfig:
     filter_string: str | None = None
 
     def to_dict(self) -> dict[str, str | float]:
-        """Convert the entity to a dictionary for JSON serialization."""
         result: dict[str, str | float] = {
             "online_scoring_config_id": self.online_scoring_config_id,
             "scorer_id": self.scorer_id,

--- a/mlflow/genai/scorers/online/entities.py
+++ b/mlflow/genai/scorers/online/entities.py
@@ -9,23 +9,6 @@ from dataclasses import dataclass
 
 
 @dataclass
-class OnlineScorer:
-    """
-    Internal entity representing a serialized scorer and its online execution configuration.
-
-    This entity specifies how a scorer should be applied to traces in an online/real-time
-    manner, including which traces to score (via filter_string) and at what sampling rate.
-    The scorer itself is stored in serialized form for execution by the online scoring jobs.
-    """
-
-    name: str
-    experiment_id: str
-    serialized_scorer: str
-    sample_rate: float
-    filter_string: str | None = None
-
-
-@dataclass
 class OnlineScoringConfig:
     """
     Internal entity representing the online configuration for a scorer.

--- a/mlflow/genai/scorers/online/entities.py
+++ b/mlflow/genai/scorers/online/entities.py
@@ -1,0 +1,52 @@
+"""
+Online scorer entities and configuration.
+
+This module contains entities for online scorer configuration used by the store layer
+and online scoring infrastructure.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class OnlineScorer:
+    """
+    Internal entity representing a serialized scorer and its online execution configuration.
+
+    This entity specifies how a scorer should be applied to traces in an online/real-time
+    manner, including which traces to score (via filter_string) and at what sampling rate.
+    The scorer itself is stored in serialized form for execution by the online scoring jobs.
+    """
+
+    name: str
+    experiment_id: str
+    serialized_scorer: str
+    sample_rate: float
+    filter_string: str | None = None
+
+
+@dataclass
+class OnlineScoringConfig:
+    """
+    Internal entity representing the online configuration for a scorer.
+
+    This configuration controls how a scorer is applied to traces in an online/real-time
+    manner. It defines sampling rates and optional filters for selecting which traces
+    should be scored.
+    """
+
+    online_scoring_config_id: str
+    scorer_id: str
+    sample_rate: float
+    filter_string: str | None = None
+
+    def to_dict(self) -> dict[str, str | float]:
+        """Convert the entity to a dictionary for JSON serialization."""
+        result: dict[str, str | float] = {
+            "online_scoring_config_id": self.online_scoring_config_id,
+            "scorer_id": self.scorer_id,
+            "sample_rate": self.sample_rate,
+        }
+        if self.filter_string is not None:
+            result["filter_string"] = self.filter_string
+        return result

--- a/mlflow/genai/scorers/online/entities.py
+++ b/mlflow/genai/scorers/online/entities.py
@@ -21,6 +21,7 @@ class OnlineScoringConfig:
     online_scoring_config_id: str
     scorer_id: str
     sample_rate: float
+    experiment_id: str
     filter_string: str | None = None
 
     def to_dict(self) -> dict[str, str | float]:
@@ -28,6 +29,7 @@ class OnlineScoringConfig:
             "online_scoring_config_id": self.online_scoring_config_id,
             "scorer_id": self.scorer_id,
             "sample_rate": self.sample_rate,
+            "experiment_id": self.experiment_id,
         }
         if self.filter_string is not None:
             result["filter_string"] = self.filter_string

--- a/mlflow/store/db_migrations/versions/2c33131f4dae_add_online_scoring_configs_table.py
+++ b/mlflow/store/db_migrations/versions/2c33131f4dae_add_online_scoring_configs_table.py
@@ -22,6 +22,7 @@ def upgrade():
         sa.Column("online_scoring_config_id", sa.String(length=36), nullable=False),
         sa.Column("scorer_id", sa.String(length=36), nullable=False),
         sa.Column("sample_rate", sa.types.Float(precision=53), nullable=False),
+        sa.Column("experiment_id", sa.Integer(), nullable=False),
         sa.Column("filter_string", sa.Text(), nullable=True),
         sa.ForeignKeyConstraint(
             ["scorer_id"],
@@ -29,8 +30,13 @@ def upgrade():
             name="fk_online_scoring_configs_scorer_id",
             ondelete="CASCADE",
         ),
+        sa.ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_online_scoring_configs_experiment_id",
+            ondelete="CASCADE",
+        ),
         sa.PrimaryKeyConstraint("online_scoring_config_id", name="online_scoring_config_pk"),
-        sa.UniqueConstraint("scorer_id", name="unique_online_scoring_config_scorer_id"),
     )
 
 

--- a/mlflow/store/db_migrations/versions/2c33131f4dae_add_online_scoring_configs_table.py
+++ b/mlflow/store/db_migrations/versions/2c33131f4dae_add_online_scoring_configs_table.py
@@ -1,0 +1,38 @@
+"""add online_scoring_configs table
+
+Create Date: 2025-01-27 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from mlflow.store.tracking.dbmodels.models import SqlOnlineScoringConfig
+
+# revision identifiers, used by Alembic.
+revision = "2c33131f4dae"
+down_revision = "c9d4e5f6a7b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        SqlOnlineScoringConfig.__tablename__,
+        sa.Column("online_scoring_config_id", sa.String(length=36), nullable=False),
+        sa.Column("scorer_id", sa.String(length=36), nullable=False),
+        sa.Column("sample_rate", sa.types.Float(precision=53), nullable=False),
+        sa.Column("filter_string", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["scorer_id"],
+            ["scorers.scorer_id"],
+            name="fk_online_scoring_configs_scorer_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("online_scoring_config_id", name="online_scoring_config_pk"),
+        sa.UniqueConstraint("scorer_id", name="unique_online_scoring_config_scorer_id"),
+    )
+
+
+def downgrade():
+    op.drop_table(SqlOnlineScoringConfig.__tablename__)

--- a/mlflow/store/db_migrations/versions/2c33131f4dae_add_online_scoring_configs_table.py
+++ b/mlflow/store/db_migrations/versions/2c33131f4dae_add_online_scoring_configs_table.py
@@ -34,7 +34,6 @@ def upgrade():
             ["experiment_id"],
             ["experiments.experiment_id"],
             name="fk_online_scoring_configs_experiment_id",
-            ondelete="CASCADE",
         ),
         sa.PrimaryKeyConstraint("online_scoring_config_id", name="online_scoring_config_pk"),
     )

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2012,6 +2012,12 @@ class SqlOnlineScoringConfig(Base):
     Sample rate for online scoring: `Float` (double precision).
     Value between 0 and 1 representing the fraction of traces to sample.
     """
+    experiment_id = Column(
+        Integer, ForeignKey("experiments.experiment_id", ondelete="CASCADE"), nullable=False
+    )
+    """
+    Experiment ID: `Integer`. *Foreign Key* into ``experiments`` table.
+    """
     filter_string = Column(Text, nullable=True)
     """
     Filter string for online scoring: `Text`. Optional filter expression to select traces.
@@ -2025,13 +2031,12 @@ class SqlOnlineScoringConfig(Base):
 
     __table_args__ = (
         PrimaryKeyConstraint("online_scoring_config_id", name="online_scoring_config_pk"),
-        UniqueConstraint("scorer_id", name="unique_online_scoring_config_scorer_id"),
     )
 
     def __repr__(self):
         return (
             f"<SqlOnlineScoringConfig ({self.online_scoring_config_id}, {self.scorer_id}, "
-            f"{self.sample_rate}, {self.filter_string})>"
+            f"{self.sample_rate}, {self.experiment_id}, {self.filter_string})>"
         )
 
     def to_mlflow_entity(self) -> OnlineScoringConfig:
@@ -2045,6 +2050,7 @@ class SqlOnlineScoringConfig(Base):
             online_scoring_config_id=self.online_scoring_config_id,
             scorer_id=self.scorer_id,
             sample_rate=self.sample_rate,
+            experiment_id=str(self.experiment_id),
             filter_string=self.filter_string,
         )
 

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -69,6 +69,7 @@ from mlflow.entities.logged_model_tag import LoggedModelTag
 from mlflow.entities.trace_location import TraceLocation
 from mlflow.entities.trace_state import TraceState
 from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers.online.entities import OnlineScoringConfig
 from mlflow.store.db.base_sql_model import Base
 from mlflow.tracing.utils import generate_assessment_id
 from mlflow.utils.mlflow_tags import MLFLOW_USER, _get_run_name_from_tags
@@ -1984,6 +1985,77 @@ class SqlScorerVersion(Base):
             serialized_scorer=self.serialized_scorer,
             creation_time=self.creation_time,
             scorer_id=self.scorer_id,
+        )
+
+
+class SqlOnlineScoringConfig(Base):
+    """
+    DB model for storing online scoring configuration. These are recorded in
+    ``online_scoring_configs`` table.
+    """
+
+    __tablename__ = "online_scoring_configs"
+
+    online_scoring_config_id = Column(String(36), nullable=False)
+    """
+    Online Scoring Config ID: `String` (limit 36 characters). *Primary Key* for
+    ``online_scoring_configs`` table.
+    """
+    scorer_id = Column(
+        String(36), ForeignKey("scorers.scorer_id", ondelete="CASCADE"), nullable=False
+    )
+    """
+    Scorer ID: `String` (limit 36 characters). *Foreign Key* into ``scorers`` table.
+    """
+    sample_rate = Column(sa.types.Float(precision=53), nullable=False)
+    """
+    Sample rate for online scoring: `Float` (double precision).
+    Value between 0 and 1 representing the fraction of traces to sample.
+    """
+    filter_string = Column(Text, nullable=True)
+    """
+    Filter string for online scoring: `Text`. Optional filter expression to select traces.
+    """
+
+    # Relationship to the parent scorer
+    scorer = relationship("SqlScorer", backref=backref("online_configs", cascade="all"))
+    """
+    SQLAlchemy relationship (many:one) with :py:class:`mlflow.store.dbmodels.models.SqlScorer`.
+    """
+
+    __table_args__ = (
+        PrimaryKeyConstraint("online_scoring_config_id", name="online_scoring_config_pk"),
+        UniqueConstraint("scorer_id", name="unique_online_scoring_config_scorer_id"),
+    )
+
+    def to_mlflow_entity(self):
+        from mlflow.genai.scorers.online.entities import OnlineScoringConfig
+
+        return OnlineScoringConfig(
+            online_scoring_config_id=self.online_scoring_config_id,
+            scorer_id=self.scorer_id,
+            sample_rate=self.sample_rate,
+            filter_string=self.filter_string,
+        )
+
+    def __repr__(self):
+        return (
+            f"<SqlOnlineScoringConfig ({self.online_scoring_config_id}, {self.scorer_id}, "
+            f"{self.sample_rate})>"
+        )
+
+    def to_mlflow_entity(self) -> OnlineScoringConfig:
+        """
+        Convert this SqlOnlineScoringConfig to an OnlineScoringConfig entity.
+
+        Returns:
+            OnlineScoringConfig: The entity representation of this online config.
+        """
+        return OnlineScoringConfig(
+            online_scoring_config_id=self.online_scoring_config_id,
+            scorer_id=self.scorer_id,
+            sample_rate=self.sample_rate,
+            filter_string=self.filter_string,
         )
 
 

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2012,9 +2012,7 @@ class SqlOnlineScoringConfig(Base):
     Sample rate for online scoring: `Float` (double precision).
     Value between 0 and 1 representing the fraction of traces to sample.
     """
-    experiment_id = Column(
-        Integer, ForeignKey("experiments.experiment_id", ondelete="CASCADE"), nullable=False
-    )
+    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id"), nullable=False)
     """
     Experiment ID: `Integer`. *Foreign Key* into ``experiments`` table.
     """

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2028,16 +2028,6 @@ class SqlOnlineScoringConfig(Base):
         UniqueConstraint("scorer_id", name="unique_online_scoring_config_scorer_id"),
     )
 
-    def to_mlflow_entity(self):
-        from mlflow.genai.scorers.online.entities import OnlineScoringConfig
-
-        return OnlineScoringConfig(
-            online_scoring_config_id=self.online_scoring_config_id,
-            scorer_id=self.scorer_id,
-            sample_rate=self.sample_rate,
-            filter_string=self.filter_string,
-        )
-
     def __repr__(self):
         return (
             f"<SqlOnlineScoringConfig ({self.online_scoring_config_id}, {self.scorer_id}, "

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2031,7 +2031,7 @@ class SqlOnlineScoringConfig(Base):
     def __repr__(self):
         return (
             f"<SqlOnlineScoringConfig ({self.online_scoring_config_id}, {self.scorer_id}, "
-            f"{self.sample_rate})>"
+            f"{self.sample_rate}, {self.filter_string})>"
         )
 
     def to_mlflow_entity(self) -> OnlineScoringConfig:

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -160,7 +160,6 @@ class ResponseFormat(BaseModel):
 class BaseRequestPayload(BaseModel):
     """Common parameters used for chat completions and completion endpoints."""
 
-    temperature: float = Field(0.0, ge=0, le=2)
     n: int = Field(1, ge=1)
     stop: list[str] | None = Field(None, min_length=1)
     max_tokens: int | None = Field(None, ge=1)
@@ -168,6 +167,7 @@ class BaseRequestPayload(BaseModel):
     stream_options: dict[str, Any] | None = None
     model: str | None = None
     response_format: ResponseFormat | None = None
+    temperature: float | None = Field(None, ge=0, le=2)
     top_p: float | None = Field(None, ge=0, le=1)
     presence_penalty: float | None = Field(None, ge=-2, le=2)
     frequency_penalty: float | None = Field(None, ge=-2, le=2)

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -442,7 +442,7 @@ CREATE TABLE online_scoring_configs (
 	filter_string TEXT COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
 	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
 
 

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -438,7 +438,7 @@ CREATE TABLE online_scoring_configs (
 	online_scoring_config_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	scorer_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	sample_rate FLOAT NOT NULL,
-	filter_string VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	filter_string TEXT COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
 	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
 )

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -434,6 +434,17 @@ CREATE TABLE model_version_tags (
 )
 
 
+CREATE TABLE online_scoring_configs (
+	online_scoring_config_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	scorer_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	sample_rate FLOAT NOT NULL,
+	filter_string VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
+	CONSTRAINT unique_online_scoring_config_scorer_id UNIQUE (scorer_id)
+)
+
+
 CREATE TABLE params (
 	key VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	value VARCHAR(8000) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -439,10 +439,10 @@ CREATE TABLE online_scoring_configs (
 	scorer_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	sample_rate FLOAT NOT NULL,
 	experiment_id INTEGER NOT NULL,
-	filter_string TEXT COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	filter_string VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
-	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -440,8 +440,7 @@ CREATE TABLE online_scoring_configs (
 	sample_rate FLOAT NOT NULL,
 	filter_string VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
-	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT unique_online_scoring_config_scorer_id UNIQUE (scorer_id)
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -438,9 +438,11 @@ CREATE TABLE online_scoring_configs (
 	online_scoring_config_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	scorer_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	sample_rate FLOAT NOT NULL,
-	filter_string VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	experiment_id INTEGER NOT NULL,
+	filter_string TEXT COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
-	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -438,7 +438,7 @@ CREATE TABLE online_scoring_configs (
 	online_scoring_config_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	scorer_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	sample_rate FLOAT NOT NULL,
-	filter_string TEXT COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	filter_string VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
 	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
 )

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -446,9 +446,11 @@ CREATE TABLE online_scoring_configs (
 	online_scoring_config_id VARCHAR(36) NOT NULL,
 	scorer_id VARCHAR(36) NOT NULL,
 	sample_rate DOUBLE NOT NULL,
+	experiment_id INTEGER NOT NULL,
 	filter_string TEXT,
 	PRIMARY KEY (online_scoring_config_id),
-	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -450,7 +450,7 @@ CREATE TABLE online_scoring_configs (
 	filter_string TEXT,
 	PRIMARY KEY (online_scoring_config_id),
 	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -442,6 +442,16 @@ CREATE TABLE model_version_tags (
 )
 
 
+CREATE TABLE online_scoring_configs (
+	online_scoring_config_id VARCHAR(36) NOT NULL,
+	scorer_id VARCHAR(36) NOT NULL,
+	sample_rate DOUBLE NOT NULL,
+	filter_string TEXT,
+	PRIMARY KEY (online_scoring_config_id),
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE params (
 	key VARCHAR(250) NOT NULL,
 	value VARCHAR(8000) NOT NULL,

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -449,8 +449,8 @@ CREATE TABLE online_scoring_configs (
 	experiment_id INTEGER NOT NULL,
 	filter_string TEXT,
 	PRIMARY KEY (online_scoring_config_id),
-	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -449,7 +449,7 @@ CREATE TABLE online_scoring_configs (
 	filter_string TEXT,
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
 	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -441,6 +441,17 @@ CREATE TABLE model_version_tags (
 )
 
 
+CREATE TABLE online_scoring_configs (
+	online_scoring_config_id VARCHAR(36) NOT NULL,
+	scorer_id VARCHAR(36) NOT NULL,
+	sample_rate DOUBLE PRECISION NOT NULL,
+	filter_string TEXT,
+	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
+	CONSTRAINT unique_online_scoring_config_scorer_id UNIQUE (scorer_id)
+)
+
+
 CREATE TABLE params (
 	key VARCHAR(250) NOT NULL,
 	value VARCHAR(8000) NOT NULL,

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -445,10 +445,11 @@ CREATE TABLE online_scoring_configs (
 	online_scoring_config_id VARCHAR(36) NOT NULL,
 	scorer_id VARCHAR(36) NOT NULL,
 	sample_rate DOUBLE PRECISION NOT NULL,
+	experiment_id INTEGER NOT NULL,
 	filter_string TEXT,
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
 	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT unique_online_scoring_config_scorer_id UNIQUE (scorer_id)
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -448,8 +448,8 @@ CREATE TABLE online_scoring_configs (
 	experiment_id INTEGER NOT NULL,
 	filter_string TEXT,
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
-	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -444,6 +444,17 @@ CREATE TABLE model_version_tags (
 )
 
 
+CREATE TABLE online_scoring_configs (
+	online_scoring_config_id VARCHAR(36) NOT NULL,
+	scorer_id VARCHAR(36) NOT NULL,
+	sample_rate FLOAT NOT NULL,
+	filter_string TEXT,
+	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
+	CONSTRAINT unique_online_scoring_config_scorer_id UNIQUE (scorer_id)
+)
+
+
 CREATE TABLE params (
 	key VARCHAR(250) NOT NULL,
 	value VARCHAR(8000) NOT NULL,

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -448,10 +448,11 @@ CREATE TABLE online_scoring_configs (
 	online_scoring_config_id VARCHAR(36) NOT NULL,
 	scorer_id VARCHAR(36) NOT NULL,
 	sample_rate FLOAT NOT NULL,
+	experiment_id INTEGER NOT NULL,
 	filter_string TEXT,
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
 	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT unique_online_scoring_config_scorer_id UNIQUE (scorer_id)
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -452,7 +452,7 @@ CREATE TABLE online_scoring_configs (
 	filter_string TEXT,
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
 	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
 
 

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -111,7 +111,6 @@ async def test_completions_with_default_max_tokens():
             "https://api.anthropic.com/v1/complete",
             json={
                 "model": "claude-instant-1",
-                "temperature": 0.0,
                 "max_tokens_to_sample": 8192,
                 "prompt": "\n\nHuman: How does a car work?\n\nAssistant:",
             },

--- a/tests/gateway/providers/test_cohere.py
+++ b/tests/gateway/providers/test_cohere.py
@@ -324,7 +324,6 @@ async def test_completions():
                 "model": "command",
                 "num_generations": 1,
                 "stop_sequences": ["foobar"],
-                "temperature": 0.0,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
@@ -424,7 +423,6 @@ async def test_completions_stream():
                 "prompt": "This is a test",
                 "model": "command",
                 "num_generations": 1,
-                "temperature": 0.0,
                 "stream": True,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),

--- a/tests/gateway/providers/test_huggingface.py
+++ b/tests/gateway/providers/test_huggingface.py
@@ -98,7 +98,6 @@ async def test_completions():
             json={
                 "inputs": "This is a test",
                 "parameters": {
-                    "temperature": 0.001,
                     "max_new_tokens": 1000,
                     "details": True,
                     "decoder_input_details": True,

--- a/tests/gateway/providers/test_mistral.py
+++ b/tests/gateway/providers/test_mistral.py
@@ -92,7 +92,6 @@ async def test_completions():
             json={
                 "messages": [{"role": "user", "content": TEST_STRING}],
                 "model": "mistral-tiny",
-                "temperature": 0.0,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )

--- a/tests/gateway/providers/test_mlflow.py
+++ b/tests/gateway/providers/test_mlflow.py
@@ -289,7 +289,7 @@ async def test_chat():
             "http://127.0.0.1:4000/invocations",
             json={
                 "inputs": ["Is this a test?"],
-                "params": {"temperature": 0.0, "n": 1},
+                "params": {"n": 1},
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )

--- a/tests/gateway/providers/test_mosaicml.py
+++ b/tests/gateway/providers/test_mosaicml.py
@@ -66,7 +66,7 @@ async def test_completions():
             "https://models.hosted-on.mosaicml.hosting/mpt-7b-instruct/v1/predict",
             json={
                 "inputs": ["This is a test"],
-                "parameters": {"temperature": 0.0, "n": 1, "max_new_tokens": 1000},
+                "parameters": {"n": 1, "max_new_tokens": 1000},
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
@@ -103,7 +103,6 @@ def chat_response():
             {
                 "inputs": ["<s>[INST] Tell me a joke [/INST]"],
                 "parameters": {
-                    "temperature": 0.0,
                     "n": 1,
                 },
             },
@@ -118,7 +117,6 @@ def chat_response():
             {
                 "inputs": ["<s>[INST] <<SYS>> You're funny <</SYS>> Tell me a joke [/INST]"],
                 "parameters": {
-                    "temperature": 0.0,
                     "n": 1,
                 },
             },
@@ -156,7 +154,6 @@ def chat_response():
                     )
                 ],
                 "parameters": {
-                    "temperature": 0.0,
                     "n": 1,
                 },
             },

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -244,7 +244,6 @@ async def _run_test_chat_stream(resp, provider):
             "https://api.openai.com/v1/chat/completions",
             json={
                 "model": "gpt-4o-mini",
-                "temperature": 0,
                 "n": 1,
                 **payload,
             },
@@ -407,7 +406,6 @@ async def _run_test_completions(resp, provider):
             "https://api.openai.com/v1/completions",
             json={
                 "model": "gpt-4-32k",
-                "temperature": 0,
                 "n": 1,
                 "prompt": "This is a test",
             },
@@ -528,7 +526,6 @@ async def _run_test_completions_stream(resp, provider):
             "https://api.openai.com/v1/completions",
             json={
                 "model": "gpt-4-32k",
-                "temperature": 0,
                 "n": 1,
                 "prompt": "This is a test",
             },
@@ -743,7 +740,6 @@ async def test_azure_openai():
                 "/completions?api-version=2023-05-15"
             ),
             json={
-                "temperature": 0,
                 "n": 1,
                 "prompt": "This is a test",
             },
@@ -782,7 +778,6 @@ async def test_azuread_openai():
                 "/completions?api-version=2023-05-15"
             ),
             json={
-                "temperature": 0,
                 "n": 1,
                 "prompt": "This is a test",
             },

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -78,7 +78,6 @@ async def test_completions():
                 "prompt": {
                     "text": "This is a test",
                 },
-                "temperature": 0.0,
                 "candidateCount": 1,
                 "maxOutputTokens": 1000,
                 "stopSequences": ["foobar"],
@@ -130,7 +129,6 @@ def chat_response():
         (
             {"messages": [{"role": "user", "content": "Tell me a joke"}]},
             {
-                "temperature": 0.0,
                 "candidateCount": 1,
                 "prompt": {"messages": [{"content": "Tell me a joke", "author": "user"}]},
             },
@@ -143,7 +141,6 @@ def chat_response():
                 ]
             },
             {
-                "temperature": 0.0,
                 "candidateCount": 1,
                 "prompt": {
                     "messages": [

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -265,8 +265,8 @@ def test_score_model_bedrock(monkeypatch):
         # and requires "anthropic_version" put within the body not headers.
         body=json.dumps(
             {
-                "temperature": 0,
                 "max_tokens": 1000,
+                "temperature": 0,
                 "messages": [{"role": "user", "content": "input prompt"}],
                 "anthropic_version": "2023-06-01",
             }

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -206,6 +206,21 @@ CREATE TABLE experiment_tags (
 )
 
 
+CREATE TABLE issues (
+	issue_id VARCHAR(36) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	name VARCHAR(500) NOT NULL,
+	description TEXT,
+	state VARCHAR(20) NOT NULL,
+	creation_time BIGINT NOT NULL,
+	last_update_time BIGINT NOT NULL,
+	tags TEXT,
+	CONSTRAINT issues_pk PRIMARY KEY (issue_id),
+	CONSTRAINT fk_issues_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
+	CONSTRAINT issues_state CHECK (state IN ('draft', 'open', 'closed'))
+)
+
+
 CREATE TABLE logged_models (
 	model_id VARCHAR(36) NOT NULL,
 	experiment_id INTEGER NOT NULL,
@@ -368,6 +383,18 @@ CREATE TABLE endpoint_model_mappings (
 )
 
 
+CREATE TABLE issue_comments (
+	comment_id VARCHAR(36) NOT NULL,
+	issue_id VARCHAR(36) NOT NULL,
+	content TEXT NOT NULL,
+	author VARCHAR(256),
+	creation_time BIGINT NOT NULL,
+	last_update_time BIGINT NOT NULL,
+	CONSTRAINT issue_comments_pk PRIMARY KEY (comment_id),
+	CONSTRAINT fk_issue_comments_issue_id FOREIGN KEY(issue_id) REFERENCES issues (issue_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE latest_metrics (
 	key VARCHAR(250) NOT NULL,
 	value FLOAT NOT NULL,
@@ -441,6 +468,17 @@ CREATE TABLE model_version_tags (
 	version INTEGER NOT NULL,
 	CONSTRAINT model_version_tag_pk PRIMARY KEY (key, name, version),
 	FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE
+)
+
+
+CREATE TABLE online_scoring_configs (
+	online_scoring_config_id VARCHAR(36) NOT NULL,
+	scorer_id VARCHAR(36) NOT NULL,
+	sample_rate FLOAT NOT NULL,
+	filter_string TEXT,
+	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
+	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
+	CONSTRAINT unique_online_scoring_config_scorer_id UNIQUE (scorer_id)
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -448,10 +448,11 @@ CREATE TABLE online_scoring_configs (
 	online_scoring_config_id VARCHAR(36) NOT NULL,
 	scorer_id VARCHAR(36) NOT NULL,
 	sample_rate FLOAT NOT NULL,
+	experiment_id INTEGER NOT NULL,
 	filter_string TEXT,
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
 	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT unique_online_scoring_config_scorer_id UNIQUE (scorer_id)
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -206,21 +206,6 @@ CREATE TABLE experiment_tags (
 )
 
 
-CREATE TABLE issues (
-	issue_id VARCHAR(36) NOT NULL,
-	experiment_id INTEGER NOT NULL,
-	name VARCHAR(500) NOT NULL,
-	description TEXT,
-	state VARCHAR(20) NOT NULL,
-	creation_time BIGINT NOT NULL,
-	last_update_time BIGINT NOT NULL,
-	tags TEXT,
-	CONSTRAINT issues_pk PRIMARY KEY (issue_id),
-	CONSTRAINT fk_issues_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
-	CONSTRAINT issues_state CHECK (state IN ('draft', 'open', 'closed'))
-)
-
-
 CREATE TABLE logged_models (
 	model_id VARCHAR(36) NOT NULL,
 	experiment_id INTEGER NOT NULL,
@@ -380,18 +365,6 @@ CREATE TABLE endpoint_model_mappings (
 	CONSTRAINT endpoint_model_mappings_pk PRIMARY KEY (mapping_id),
 	CONSTRAINT fk_endpoint_model_mappings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
 	CONSTRAINT fk_endpoint_model_mappings_model_definition_id FOREIGN KEY(model_definition_id) REFERENCES model_definitions (model_definition_id)
-)
-
-
-CREATE TABLE issue_comments (
-	comment_id VARCHAR(36) NOT NULL,
-	issue_id VARCHAR(36) NOT NULL,
-	content TEXT NOT NULL,
-	author VARCHAR(256),
-	creation_time BIGINT NOT NULL,
-	last_update_time BIGINT NOT NULL,
-	CONSTRAINT issue_comments_pk PRIMARY KEY (comment_id),
-	CONSTRAINT fk_issue_comments_issue_id FOREIGN KEY(issue_id) REFERENCES issues (issue_id) ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -452,7 +452,7 @@ CREATE TABLE online_scoring_configs (
 	filter_string TEXT,
 	CONSTRAINT online_scoring_config_pk PRIMARY KEY (online_scoring_config_id),
 	CONSTRAINT fk_online_scoring_configs_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE,
-	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+	CONSTRAINT fk_online_scoring_configs_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
 
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19708/files/36418a0944696d8c7f7b4c2a296cf24864ff13ec..8d046a04abe1009fa0bd1cc05f1bfad38444b054) to review incremental changes.
- [stack/pr1-temperature-fix](https://github.com/mlflow/mlflow/pull/19707) [[Files changed](https://github.com/mlflow/mlflow/pull/19707/files)]
  - [**stack/pr2-schema-migration**](https://github.com/mlflow/mlflow/pull/19708) [[Files changed](https://github.com/mlflow/mlflow/pull/19708/files/36418a0944696d8c7f7b4c2a296cf24864ff13ec..8d046a04abe1009fa0bd1cc05f1bfad38444b054)]
    - [stack/pr3-store-crud](https://github.com/mlflow/mlflow/pull/19709) [[Files changed](https://github.com/mlflow/mlflow/pull/19709/files/8d046a04abe1009fa0bd1cc05f1bfad38444b054..60f17f5f3018ced08c66f4eb3ca75a339ef63bed)]
      - [stack/pr4-rest-api](https://github.com/mlflow/mlflow/pull/19710) [[Files changed](https://github.com/mlflow/mlflow/pull/19710/files/60f17f5f3018ced08c66f4eb3ca75a339ef63bed..c426c122f9bc2dea62362ad77d035478fbbae55e)]
        - [stack/pr5-scorer-integration](https://github.com/mlflow/mlflow/pull/19711) [[Files changed](https://github.com/mlflow/mlflow/pull/19711/files/c426c122f9bc2dea62362ad77d035478fbbae55e..bc79eb66cc137fcb8b1700e2658f469e6d128831)]
          - [stack/pr6a-trace-utilities](https://github.com/mlflow/mlflow/pull/19712) [[Files changed](https://github.com/mlflow/mlflow/pull/19712/files/bc79eb66cc137fcb8b1700e2658f469e6d128831..2d6e1aa81b136b5632d214b5b1ba9051953145fa)]
            - [stack/pr6ahalf-is-null-filter](https://github.com/mlflow/mlflow/pull/19720) [[Files changed](https://github.com/mlflow/mlflow/pull/19720/files/2d6e1aa81b136b5632d214b5b1ba9051953145fa..ba40b2b47a173be59b34ccf5b8a018066f2702df)]
              - [stack/pr6b-trace-processor](https://github.com/mlflow/mlflow/pull/19713) [[Files changed](https://github.com/mlflow/mlflow/pull/19713/files/ba40b2b47a173be59b34ccf5b8a018066f2702df..90313245d19dee4b697c96dad7d6df802ddcb049)]
                - [stack/pr6c-exclusive-flag-job](https://github.com/mlflow/mlflow/pull/19714) [[Files changed](https://github.com/mlflow/mlflow/pull/19714/files/90313245d19dee4b697c96dad7d6df802ddcb049..f1897ed30a5bcf07e5f838aad8b3b31f9956d303)]
                  - [stack/pr7b-completed-sessions](https://github.com/mlflow/mlflow/pull/19718) [[Files changed](https://github.com/mlflow/mlflow/pull/19718/files/f1897ed30a5bcf07e5f838aad8b3b31f9956d303..4e0133698d816091940d3c3f039f2fde83737bfa)]
                    - [stack/pr7c-session-checkpointer](https://github.com/mlflow/mlflow/pull/19759) [[Files changed](https://github.com/mlflow/mlflow/pull/19759/files/4e0133698d816091940d3c3f039f2fde83737bfa..b37c7ab161fc1708ac0e17af36541d0c084cf8d9)]
                      - [stack/pr8-session-job-utils](https://github.com/mlflow/mlflow/pull/19716) [[Files changed](https://github.com/mlflow/mlflow/pull/19716/files/b37c7ab161fc1708ac0e17af36541d0c084cf8d9..d9dfd3b2f43a50982cd8f3eedbfd6aa8b21da39b)]
                        - [stack/pr9-periodic-scheduler](https://github.com/mlflow/mlflow/pull/19717) [[Files changed](https://github.com/mlflow/mlflow/pull/19717/files/d9dfd3b2f43a50982cd8f3eedbfd6aa8b21da39b..935ee6ee32a1a632ef9d41b0aaf153c656f8a193)]
                          - [stack/pr10-online-scoring-ui](https://github.com/mlflow/mlflow/pull/19736) [[Files changed](https://github.com/mlflow/mlflow/pull/19736/files/935ee6ee32a1a632ef9d41b0aaf153c656f8a193..6d59fee126651e124f370bebf82696716e3ef6cf)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

SQL schema changes to support online scoring

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
