### PR TITLE
[Bug fix] Support search traces by string feedback / expectation values

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5358,16 +5358,16 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
                 span_filters.append(span_subquery)
                 continue
             elif SearchTraceUtils.is_assessment(key_type, key_name, comparator):
-                # Create subquery to find traces with matching feedback
-                value_filter = SearchTraceUtils._get_sql_json_comparison_func(comparator)(
-                    SqlAssessments.value, value
-                )
+                # Create subquery to find traces with matching assessment
+                # Filter by feedback name and check the value
                 feedback_subquery = (
                     session.query(SqlAssessments.trace_id.label("request_id"))
                     .filter(
                         SqlAssessments.assessment_type == key_type,
                         SqlAssessments.name == key_name,
-                        value_filter,
+                        SearchTraceUtils._get_sql_json_comparison_func(comparator)(
+                            SqlAssessments.value, value
+                        ),
                     )
                     .distinct()
                     .subquery()

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5365,7 +5365,7 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
                     .filter(
                         SqlAssessments.assessment_type == key_type,
                         SqlAssessments.name == key_name,
-                        SearchTraceUtils._get_sql_json_comparison_func(comparator)(
+                        SearchTraceUtils._get_sql_json_comparison_func(comparator, dialect)(
                             SqlAssessments.value, value
                         ),
                     )

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5358,8 +5358,8 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
                 span_filters.append(span_subquery)
                 continue
             elif SearchTraceUtils.is_assessment(key_type, key_name, comparator):
-                # Create subquery to find traces with matching assessment
-                # Filter by feedback name and check the value
+                # Create subquery to find traces with matching assessments
+                # Filter by assessment name and check the value
                 feedback_subquery = (
                     session.query(SqlAssessments.trace_id.label("request_id"))
                     .filter(

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5359,15 +5359,15 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
                 continue
             elif SearchTraceUtils.is_assessment(key_type, key_name, comparator):
                 # Create subquery to find traces with matching feedback
-                # Filter by feedback name and check the value
+                value_filter = SearchTraceUtils._get_sql_json_comparison_func(comparator)(
+                    SqlAssessments.value, value
+                )
                 feedback_subquery = (
                     session.query(SqlAssessments.trace_id.label("request_id"))
                     .filter(
                         SqlAssessments.assessment_type == key_type,
                         SqlAssessments.name == key_name,
-                        SearchTraceUtils.get_sql_comparison_func(comparator, dialect)(
-                            SqlAssessments.value, value
-                        ),
+                        value_filter,
                     )
                     .distinct()
                     .subquery()

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -38,8 +38,7 @@ from mlflow.utils.mlflow_tags import (
 )
 
 if TYPE_CHECKING:
-    from sqlalchemy import ColumnElement
-    from sqlalchemy.sql.elements import ClauseElement
+    from sqlalchemy.sql.elements import ClauseElement, ColumnElement
 
 # MSSQL collation for case-sensitive string comparisons
 _MSSQL_CASE_SENSITIVE_COLLATION = "Japanese_Bushu_Kakusu_100_CS_AS_KS_WS"

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1877,9 +1877,9 @@ class SearchTraceUtils(SearchUtils):
 
         def comparison_func(column, value):
             if comparator == "=":
-                return sa.or_(column == value, column == '"' + value + '"')
+                return sa.or_(column == value, column == f'"{value}"')
             elif comparator == "!=":
-                return sa.and_(column != value, column != '"' + value + '"')
+                return sa.and_(column != value, column != f'"{value}"')
             elif comparator == "LIKE":
                 return column.like(value)
             elif comparator == "ILIKE":

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1879,10 +1879,11 @@ class SearchTraceUtils(SearchUtils):
         """
         import sqlalchemy as sa
 
-        def mysql_json_comparison(column, value, quoted_value):
+        def mysql_json_equality_inequality_comparison(column, value):
             # MySQL is case insensitive by default, so we need to use the BINARY operator
             # for case sensitive comparisons. We check both the raw value (for booleans/numbers)
             # and the quoted value (for strings).
+            quoted_value = f'"{value}"'
             col_ref = f"{column.class_.__tablename__}.{column.key}"
             if comparator == "=":
                 template = (
@@ -1903,15 +1904,14 @@ class SearchTraceUtils(SearchUtils):
             if comparator not in ("=", "!="):
                 return SearchTraceUtils.get_sql_comparison_func(comparator, dialect)(column, value)
 
-            quoted_value = f'"{value}"'
-
             if dialect == MYSQL:
-                return mysql_json_comparison(column, value, quoted_value)
+                return mysql_json_equality_inequality_comparison(column, value)
 
             if dialect == MSSQL:
                 # MSSQL uses collation for case-sensitive comparisons on String columns
                 column = column.collate(_MSSQL_CASE_SENSITIVE_COLLATION)
 
+            quoted_value = f'"{value}"'
             if comparator == "=":
                 return sa.or_(column == value, column == quoted_value)
             else:  # !=

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1867,11 +1867,12 @@ class SearchTraceUtils(SearchUtils):
         Returns a comparison function for JSON-serialized values.
 
         Assessment values are stored as JSON primitives in the database:
-          - Boolean False -> "false" (no quotes in JSON)
+          - Boolean False -> false (no quotes in JSON)
+          - Numeric value 5 -> 5 (no quotes in JSON)
           - String "yes" -> '"yes"' (WITH quotes in JSON)
 
-        For equality comparisons, we match either the raw value (for bools/numbers)
-        or the quoted value (for strings).
+        For equality comparisons, we match either the raw JSON primitive value
+        (for booleans and numeric values) or the quoted value (for strings).
         """
         import sqlalchemy as sa
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1862,7 +1862,7 @@ class SearchTraceUtils(SearchUtils):
         return False
 
     @staticmethod
-    def _get_sql_json_comparison_func(comparator):
+    def _get_sql_json_comparison_func(comparator, dialect):
         """
         Returns a comparison function for JSON-serialized values.
 
@@ -1881,11 +1881,7 @@ class SearchTraceUtils(SearchUtils):
                 return sa.or_(column == value, column == f'"{value}"')
             elif comparator == "!=":
                 return sa.and_(column != value, column != f'"{value}"')
-            elif comparator == "LIKE":
-                return column.like(value)
-            elif comparator == "ILIKE":
-                return column.ilike(value)
-            return SearchUtils.get_comparison_func(comparator)(column, value)
+            return SearchTraceUtils.get_sql_comparison_func(comparator, dialect)(column, value)
 
         return comparison_func
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1913,11 +1913,10 @@ class SearchTraceUtils(SearchUtils):
 
         if comparator not in ("=", "!="):
             return SearchTraceUtils.get_sql_comparison_func(comparator, dialect)
-
-        if dialect == MYSQL:
+        elif dialect == MYSQL:
             return mysql_json_equality_inequality_comparison
-
-        return json_equality_inequality_comparison
+        else:
+            return json_equality_inequality_comparison
 
     @classmethod
     def _valid_entity_type(cls, entity_type):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -5525,7 +5525,6 @@ def test_search_traces_with_feedback_and_expectation_filters(store: SqlAlchemySt
         source=AssessmentSource(source_type="HUMAN", source_id="user2@example.com"),
     )
 
-    # String-valued feedback (regression test for JSON quoting bug)
     feedback4 = Feedback(
         trace_id=trace1_id,
         name="quality",
@@ -5555,7 +5554,6 @@ def test_search_traces_with_feedback_and_expectation_filters(store: SqlAlchemySt
         source=AssessmentSource(source_type="CODE", source_id="latency_monitor"),
     )
 
-    # String-valued expectation (regression test for JSON quoting bug)
     expectation4 = Expectation(
         trace_id=trace3_id,
         name="priority",

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -5838,6 +5838,140 @@ def test_search_traces_with_expectation_like_filters(store: SqlAlchemyStore):
     assert traces[0].request_id == trace1_id
 
 
+def test_search_traces_filter_feedback_string_value_equality(store: SqlAlchemyStore):
+    """
+    Test that filtering on string-valued feedback works with = operator.
+
+    This is a regression test for the bug where:
+    - Boolean assessments: feedback.correct = "true" worked
+    - String assessments: feedback.completeness = "yes" failed
+
+    Root cause: Backend compared raw JSON ('"yes"') vs filter value ('yes')
+    Fix: Parse JSON value before comparison
+    """
+    exp_id = store.create_experiment("test_feedback_string_equality")
+
+    # Create traces with string-valued feedback
+    trace1_id = uuid.uuid4().hex
+    trace2_id = uuid.uuid4().hex
+    trace3_id = uuid.uuid4().hex
+
+    _create_trace(store, trace1_id, exp_id, request_time=1000)
+    _create_trace(store, trace2_id, exp_id, request_time=2000)
+    _create_trace(store, trace3_id, exp_id, request_time=3000)
+
+    # Add string-valued feedback to traces
+    # Trace 1: completeness = "yes"
+    feedback1 = Feedback(
+        trace_id=trace1_id,
+        name="completeness",
+        value="yes",
+        source=AssessmentSource(source_type="HUMAN", source_id="user1@example.com"),
+        rationale="Response covers all aspects",
+    )
+    store.create_assessment(feedback1)
+
+    # Trace 2: completeness = "no"
+    feedback2 = Feedback(
+        trace_id=trace2_id,
+        name="completeness",
+        value="no",
+        source=AssessmentSource(source_type="HUMAN", source_id="user2@example.com"),
+        rationale="Response is incomplete",
+    )
+    store.create_assessment(feedback2)
+
+    # Trace 3: completeness = "Pass" (different casing)
+    feedback3 = Feedback(
+        trace_id=trace3_id,
+        name="completeness",
+        value="Pass",
+        source=AssessmentSource(source_type="HUMAN", source_id="user3@example.com"),
+        rationale="Response passed review",
+    )
+    store.create_assessment(feedback3)
+
+    # Test 1: Filter for "yes" - should return trace1 only
+    traces, _ = store.search_traces([exp_id], filter_string='feedback.completeness = "yes"')
+    assert len(traces) == 1
+    assert traces[0].request_id == trace1_id
+
+    # Test 2: Filter for "no" - should return trace2 only
+    traces, _ = store.search_traces([exp_id], filter_string='feedback.completeness = "no"')
+    assert len(traces) == 1
+    assert traces[0].request_id == trace2_id
+
+    # Test 3: Filter for "Pass" (case sensitive) - should return trace3 only
+    traces, _ = store.search_traces([exp_id], filter_string='feedback.completeness = "Pass"')
+    assert len(traces) == 1
+    assert traces[0].request_id == trace3_id
+
+    # Test 4: LIKE operator should still work
+    traces, _ = store.search_traces([exp_id], filter_string='feedback.completeness LIKE "%yes%"')
+    assert len(traces) >= 1
+
+    # Test 5: Verify boolean feedback still works (regression test)
+    bool_feedback = Feedback(
+        trace_id=trace1_id,
+        name="correct",
+        value=True,
+        source=AssessmentSource(source_type="HUMAN", source_id="user1@example.com"),
+    )
+    store.create_assessment(bool_feedback)
+
+    traces, _ = store.search_traces([exp_id], filter_string='feedback.correct = "true"')
+    assert len(traces) == 1
+    assert traces[0].request_id == trace1_id
+
+    # Test 6: Combined filter (string AND boolean)
+    traces, _ = store.search_traces(
+        [exp_id],
+        filter_string='feedback.completeness = "yes" AND feedback.correct = "true"',
+    )
+    assert len(traces) == 1
+    assert traces[0].request_id == trace1_id
+
+
+def test_search_traces_filter_expectation_string_value_equality(store: SqlAlchemyStore):
+    """
+    Test that filtering on string-valued expectations works with = operator.
+    Similar to feedback test but for expectations.
+    """
+    exp_id = store.create_experiment("test_expectation_string_equality")
+
+    trace1_id = uuid.uuid4().hex
+    trace2_id = uuid.uuid4().hex
+
+    _create_trace(store, trace1_id, exp_id, request_time=1000)
+    _create_trace(store, trace2_id, exp_id, request_time=2000)
+
+    # Add string-valued expectations
+    expectation1 = Expectation(
+        trace_id=trace1_id,
+        name="quality",
+        value="high",
+        source=AssessmentSource(source_type="HUMAN", source_id="user1@example.com"),
+    )
+    store.create_assessment(expectation1)
+
+    expectation2 = Expectation(
+        trace_id=trace2_id,
+        name="quality",
+        value="low",
+        source=AssessmentSource(source_type="HUMAN", source_id="user2@example.com"),
+    )
+    store.create_assessment(expectation2)
+
+    # Test expectation filtering with = operator
+    traces, _ = store.search_traces([exp_id], filter_string='expectation.quality = "high"')
+    assert len(traces) == 1
+    assert traces[0].request_id == trace1_id
+
+    traces, _ = store.search_traces([exp_id], filter_string='expectation.quality = "low"')
+    assert len(traces) == 1
+    assert traces[0].request_id == trace2_id
+
+
 def test_search_traces_with_metadata_like_filters(store: SqlAlchemyStore):
     exp_id = store.create_experiment("test_metadata_like")
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -5591,11 +5591,6 @@ def test_search_traces_with_feedback_and_expectation_filters(store: SqlAlchemySt
     assert len(traces) == 1
     assert traces[0].request_id == trace1_id
 
-    # Test: Search for traces with string-valued expectation
-    traces, _ = store.search_traces([exp_id], filter_string='expectation.priority = "urgent"')
-    assert len(traces) == 1
-    assert traces[0].request_id == trace3_id
-
     # Test: Search for traces with response_length expectation = 150
     traces, _ = store.search_traces([exp_id], filter_string='expectation.response_length = "150"')
     assert len(traces) == 1
@@ -5610,6 +5605,11 @@ def test_search_traces_with_feedback_and_expectation_filters(store: SqlAlchemySt
     traces, _ = store.search_traces([exp_id], filter_string='expectation.latency_ms = "1000"')
     assert len(traces) == 1
     assert traces[0].request_id == trace4_id
+
+    # Test: Search for traces with string-valued expectation
+    traces, _ = store.search_traces([exp_id], filter_string='expectation.priority = "urgent"')
+    assert len(traces) == 1
+    assert traces[0].request_id == trace3_id
 
     # Test: Combined filter with AND - trace with multiple expectations
     traces, _ = store.search_traces(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/19719?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19719/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19719/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19719/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Support search traces by string feedback / expectation values

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

When searching traces by feedback or expectations with string values, results are now matched correctly

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
