### PR TITLE
Agno ChatUI

### DIFF
--- a/mlflow/agno/autolog_v1.py
+++ b/mlflow/agno/autolog_v1.py
@@ -76,6 +76,8 @@ def _set_span_inputs_attributes(span: LiveSpan, instance: Any, raw_inputs: dict[
 
         if isinstance(instance, (Agent, Team)):
             span.set_attributes(_get_agent_attributes(instance))
+            # Set message format for ChatUI rendering
+            span.set_attribute(SpanAttributeKey.MESSAGE_FORMAT, "agno")
             # Filter out None values from inputs because Agent/Team's
             # run method has so many optional arguments.
             span.set_inputs({k: v for k, v in raw_inputs.items() if v is not None})
@@ -104,6 +106,8 @@ def _set_span_inputs_attributes(span: LiveSpan, instance: Any, raw_inputs: dict[
         ):
             raw_inputs["messages"] = [m.to_dict() for m in messages]
             span.set_inputs(raw_inputs)
+            # Set message format for ChatUI rendering on LLM spans
+            span.set_attribute(SpanAttributeKey.MESSAGE_FORMAT, "agno")
             return
     except Exception as exc:  # pragma: no cover
         _logger.debug("Unable to parse input message: %s", exc)

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/agno.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/agno.test.ts
@@ -286,9 +286,7 @@ describe('Agno Chat Normalization', () => {
     });
 
     it('should extract system prompt from first LLM span inputs', () => {
-      const children = [
-        createMockLLMSpan('[{"role": "assistant", "content": "Hello!"}]', MOCK_LLM_INPUTS_WITH_SYSTEM),
-      ];
+      const children = [createMockLLMSpan('[{"role": "assistant", "content": "Hello!"}]', MOCK_LLM_INPUTS_WITH_SYSTEM)];
 
       const result = synthesizeAgnoChatMessages(MOCK_AGNO_AGENT_INPUT, MOCK_AGNO_AGENT_OUTPUT, children);
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/agno.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/agno.test.ts
@@ -1,0 +1,416 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { normalizeConversation } from '../ModelTraceExplorer.utils';
+import { normalizeAgnoChatInput, normalizeAgnoChatOutput, synthesizeAgnoChatMessages } from './agno';
+import type { ModelTraceSpanNode } from '../ModelTrace.types';
+import { ModelSpanType } from '../ModelTrace.types';
+
+// Mock Agno LLM span input: { messages: [...] }
+const MOCK_AGNO_LLM_INPUT = {
+  messages: [
+    {
+      id: '1',
+      role: 'system',
+      content: 'You are a helpful assistant.',
+      from_history: false,
+      created_at: 1767285202,
+    },
+    {
+      id: '2',
+      role: 'user',
+      content: 'What is the stock price of Apple?',
+      from_history: false,
+      created_at: 1767285202,
+    },
+  ],
+};
+
+// Mock Agno LLM input with tool calls from assistant
+const MOCK_AGNO_LLM_INPUT_WITH_TOOL_CALLS = {
+  messages: [
+    { role: 'system', content: 'Be helpful.' },
+    { role: 'user', content: 'Get the weather' },
+    {
+      role: 'assistant',
+      tool_calls: [
+        {
+          id: 'call_123',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '{"location": "NYC"}' },
+        },
+      ],
+    },
+  ],
+};
+
+// Mock Agno combined tool message format
+const MOCK_AGNO_LLM_INPUT_WITH_TOOL_RESULTS = {
+  messages: [
+    { role: 'system', content: 'Be helpful.' },
+    { role: 'user', content: 'Get the weather for multiple cities' },
+    {
+      role: 'assistant',
+      tool_calls: [
+        { id: 'call_1', type: 'function', function: { name: 'get_weather', arguments: '{"city": "NYC"}' } },
+        { id: 'call_2', type: 'function', function: { name: 'get_weather', arguments: '{"city": "LA"}' } },
+      ],
+    },
+    {
+      role: 'tool',
+      content: ['72°F sunny', '85°F clear'],
+      tool_name: 'get_weather, get_weather',
+      tool_calls: [
+        { tool_call_id: 'call_1', tool_name: 'get_weather', content: '72°F sunny' },
+        { tool_call_id: 'call_2', tool_name: 'get_weather', content: '85°F clear' },
+      ],
+    },
+  ],
+};
+
+// Mock Agno LLM output: JSON string of messages
+const MOCK_AGNO_LLM_OUTPUT_WITH_TOOL_CALLS =
+  '[{"role": "assistant", "tool_calls": [{"id": "call_123", "type": "function", "function": {"name": "get_weather", "arguments": "{\\"location\\": \\"NYC\\"}"}}]}]';
+
+const MOCK_AGNO_LLM_OUTPUT_WITH_CONTENT = '[{"role": "assistant", "content": "The weather in NYC is 72°F and sunny."}]';
+
+// Mock Agno AGENT span input/output (plain strings)
+const MOCK_AGNO_AGENT_INPUT = 'What is the stock price of Apple?';
+const MOCK_AGNO_AGENT_OUTPUT = '| Company | Symbol | Price |\n|---------|--------|-------|\n| Apple | AAPL | 271.86 |';
+
+describe('Agno Chat Normalization', () => {
+  describe('normalizeAgnoChatInput', () => {
+    it('should normalize LLM span input with messages array', () => {
+      const result = normalizeAgnoChatInput(MOCK_AGNO_LLM_INPUT);
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(2);
+      expect(result![0]).toEqual(expect.objectContaining({ role: 'system', content: 'You are a helpful assistant.' }));
+      expect(result![1]).toEqual(
+        expect.objectContaining({ role: 'user', content: 'What is the stock price of Apple?' }),
+      );
+    });
+
+    it('should normalize AGENT span input as user message', () => {
+      const result = normalizeAgnoChatInput(MOCK_AGNO_AGENT_INPUT);
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(1);
+      expect(result![0]).toEqual(
+        expect.objectContaining({ role: 'user', content: 'What is the stock price of Apple?' }),
+      );
+    });
+
+    it('should normalize messages with tool calls', () => {
+      const result = normalizeAgnoChatInput(MOCK_AGNO_LLM_INPUT_WITH_TOOL_CALLS);
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(3);
+
+      const assistantMessage = result![2];
+      expect(assistantMessage.role).toBe('assistant');
+      expect(assistantMessage.tool_calls).toBeDefined();
+      expect(assistantMessage.tool_calls).toHaveLength(1);
+      expect(assistantMessage.tool_calls![0].id).toBe('call_123');
+      expect(assistantMessage.tool_calls![0].function.name).toBe('get_weather');
+    });
+
+    it('should normalize combined tool message with individual tool results', () => {
+      const result = normalizeAgnoChatInput(MOCK_AGNO_LLM_INPUT_WITH_TOOL_RESULTS);
+
+      expect(result).not.toBeNull();
+
+      // Should have: system, user, assistant (with tool_calls), tool (NYC), tool (LA)
+      const toolMessages = result!.filter((m) => m.role === 'tool');
+      expect(toolMessages).toHaveLength(2);
+      expect(toolMessages[0].content).toBe('72°F sunny');
+      expect(toolMessages[0].tool_call_id).toBe('call_1');
+      expect(toolMessages[1].content).toBe('85°F clear');
+      expect(toolMessages[1].tool_call_id).toBe('call_2');
+    });
+
+    it('should return null for invalid input', () => {
+      expect(normalizeAgnoChatInput(null)).toBeNull();
+      expect(normalizeAgnoChatInput(undefined)).toBeNull();
+      expect(normalizeAgnoChatInput({ invalid: 'data' })).toBeNull();
+      expect(normalizeAgnoChatInput({ messages: [] })).toBeNull();
+    });
+
+    it('should not treat JSON strings as user messages', () => {
+      // JSON strings should be handled by normalizeAgnoChatOutput, not input
+      const jsonString = '[{"role": "assistant", "content": "Hello"}]';
+      const result = normalizeAgnoChatInput(jsonString);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('normalizeAgnoChatOutput', () => {
+    it('should normalize LLM output JSON string with tool calls', () => {
+      const result = normalizeAgnoChatOutput(MOCK_AGNO_LLM_OUTPUT_WITH_TOOL_CALLS);
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(1);
+
+      const assistantMessage = result![0];
+      expect(assistantMessage.role).toBe('assistant');
+      expect(assistantMessage.tool_calls).toBeDefined();
+      expect(assistantMessage.tool_calls).toHaveLength(1);
+      expect(assistantMessage.tool_calls![0].function.name).toBe('get_weather');
+    });
+
+    it('should normalize LLM output JSON string with content', () => {
+      const result = normalizeAgnoChatOutput(MOCK_AGNO_LLM_OUTPUT_WITH_CONTENT);
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(1);
+      expect(result![0]).toEqual(
+        expect.objectContaining({ role: 'assistant', content: 'The weather in NYC is 72°F and sunny.' }),
+      );
+    });
+
+    it('should normalize AGENT output as assistant message', () => {
+      const result = normalizeAgnoChatOutput(MOCK_AGNO_AGENT_OUTPUT);
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(1);
+      expect(result![0].role).toBe('assistant');
+      expect(result![0].content).toContain('Apple');
+      expect(result![0].content).toContain('271.86');
+    });
+
+    it('should return null for empty or invalid output', () => {
+      expect(normalizeAgnoChatOutput(null)).toBeNull();
+      expect(normalizeAgnoChatOutput(undefined)).toBeNull();
+      expect(normalizeAgnoChatOutput('')).toBeNull();
+      expect(normalizeAgnoChatOutput({ invalid: 'data' })).toBeNull();
+    });
+  });
+
+  describe('synthesizeAgnoChatMessages', () => {
+    const createMockLLMSpan = (outputs: string, inputs?: unknown): ModelTraceSpanNode => ({
+      key: 'llm_span',
+      title: 'OpenAIResponses.invoke',
+      icon: null,
+      start: 0,
+      end: 100,
+      type: ModelSpanType.LLM,
+      traceId: 'trace_123',
+      inputs: inputs ?? {},
+      outputs: outputs,
+      attributes: { 'mlflow.spanType': 'LLM' },
+      events: [],
+      children: [],
+      assessments: [],
+    });
+
+    const MOCK_LLM_INPUTS_WITH_SYSTEM = {
+      messages: [
+        { role: 'system', content: 'You are a helpful financial assistant.' },
+        { role: 'user', content: 'What is the stock price of Apple?' },
+      ],
+    };
+
+    const createMockToolSpan = (name: string, outputs: unknown): ModelTraceSpanNode => ({
+      key: 'tool_span',
+      title: name,
+      icon: null,
+      start: 0,
+      end: 100,
+      type: ModelSpanType.TOOL,
+      traceId: 'trace_123',
+      inputs: {},
+      outputs: outputs,
+      attributes: { 'mlflow.spanType': 'TOOL', 'tool.name': name },
+      events: [],
+      children: [],
+      assessments: [],
+    });
+
+    it('should synthesize messages from AGENT inputs, LLM outputs, and TOOL spans', () => {
+      const children = [
+        createMockLLMSpan(
+          '[{"role": "assistant", "tool_calls": [{"id": "1", "type": "function", "function": {"name": "get_price", "arguments": "{}"}}]}]',
+        ),
+        createMockToolSpan('get_price', '271.86'),
+        createMockLLMSpan('[{"role": "assistant", "content": "The price is $271.86"}]'),
+      ];
+
+      const result = synthesizeAgnoChatMessages(MOCK_AGNO_AGENT_INPUT, MOCK_AGNO_AGENT_OUTPUT, children);
+
+      expect(result).not.toBeNull();
+      expect(result!.length).toBeGreaterThan(1);
+
+      // First message should be user input
+      expect(result![0].role).toBe('user');
+      expect(result![0].content).toBe('What is the stock price of Apple?');
+
+      // Should have assistant messages from LLM spans
+      const assistantMessages = result!.filter((m) => m.role === 'assistant');
+      expect(assistantMessages.length).toBeGreaterThanOrEqual(1);
+
+      // Should have tool result
+      const toolMessages = result!.filter((m) => m.role === 'tool');
+      expect(toolMessages).toHaveLength(1);
+      expect(toolMessages[0].content).toContain('271.86');
+    });
+
+    it('should maintain chronological order: system -> user -> LLM (tool call) -> TOOL (result) -> LLM (final answer)', () => {
+      const children = [
+        createMockLLMSpan(
+          '[{"role": "assistant", "tool_calls": [{"id": "1", "type": "function", "function": {"name": "get_price", "arguments": "{}"}}]}]',
+          MOCK_LLM_INPUTS_WITH_SYSTEM,
+        ),
+        createMockToolSpan('get_price', '271.86'),
+        createMockLLMSpan('[{"role": "assistant", "content": "The price is $271.86"}]'),
+      ];
+
+      const result = synthesizeAgnoChatMessages(MOCK_AGNO_AGENT_INPUT, MOCK_AGNO_AGENT_OUTPUT, children);
+
+      expect(result).not.toBeNull();
+      expect(result!.length).toBe(5);
+
+      // Verify exact order:
+      // 1. System prompt (extracted from first LLM span inputs)
+      expect(result![0].role).toBe('system');
+      expect(result![0].content).toContain('financial assistant');
+      // 2. User input
+      expect(result![1].role).toBe('user');
+      // 3. Assistant with tool call (from first LLM span)
+      expect(result![2].role).toBe('assistant');
+      expect(result![2].tool_calls).toBeDefined();
+      // 4. Tool result (from TOOL span)
+      expect(result![3].role).toBe('tool');
+      expect(result![3].content).toContain('271.86');
+      // 5. Assistant with final answer (from second LLM span)
+      expect(result![4].role).toBe('assistant');
+      expect(result![4].content).toContain('$271.86');
+    });
+
+    it('should extract system prompt from first LLM span inputs', () => {
+      const children = [
+        createMockLLMSpan('[{"role": "assistant", "content": "Hello!"}]', MOCK_LLM_INPUTS_WITH_SYSTEM),
+      ];
+
+      const result = synthesizeAgnoChatMessages(MOCK_AGNO_AGENT_INPUT, MOCK_AGNO_AGENT_OUTPUT, children);
+
+      expect(result).not.toBeNull();
+      expect(result!.length).toBe(3);
+      expect(result![0].role).toBe('system');
+      expect(result![0].content).toBe('You are a helpful financial assistant.');
+      expect(result![1].role).toBe('user');
+      expect(result![2].role).toBe('assistant');
+    });
+
+    it('should return null when no valid input', () => {
+      const result = synthesizeAgnoChatMessages({ invalid: 'data' }, 'output', []);
+      expect(result).toBeNull();
+    });
+
+    it('should return only user input when no children', () => {
+      const result = synthesizeAgnoChatMessages(MOCK_AGNO_AGENT_INPUT, MOCK_AGNO_AGENT_OUTPUT, []);
+
+      expect(result).not.toBeNull();
+      expect(result!.length).toBe(1);
+      expect(result![0].role).toBe('user');
+    });
+  });
+
+  describe('normalizeConversation with agno format', () => {
+    it('should handle agno message format for LLM inputs', () => {
+      const result = normalizeConversation(MOCK_AGNO_LLM_INPUT, 'agno');
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(2);
+      expect(result![0]).toEqual(expect.objectContaining({ role: 'system' }));
+      expect(result![1]).toEqual(expect.objectContaining({ role: 'user' }));
+    });
+
+    it('should handle agno message format for LLM outputs', () => {
+      const result = normalizeConversation(MOCK_AGNO_LLM_OUTPUT_WITH_CONTENT, 'agno');
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(1);
+      expect(result![0]).toEqual(expect.objectContaining({ role: 'assistant' }));
+    });
+
+    it('should handle agno format with tool calls', () => {
+      const result = normalizeConversation(MOCK_AGNO_LLM_INPUT_WITH_TOOL_CALLS, 'agno');
+
+      expect(result).not.toBeNull();
+      expect(result![2].tool_calls).toBeDefined();
+      expect(result![2].tool_calls![0].function.name).toBe('get_weather');
+    });
+
+    it('should return null for invalid agno data', () => {
+      expect(normalizeConversation({ invalid: 'data' }, 'agno')).toBeNull();
+    });
+
+    it('should return null for null input', () => {
+      expect(normalizeConversation(null, 'agno')).toBeNull();
+    });
+
+    it('should return null for undefined input', () => {
+      expect(normalizeConversation(undefined, 'agno')).toBeNull();
+    });
+
+    it('should normalize LLM JSON output with agno format', () => {
+      // JSON array outputs are correctly parsed as assistant messages
+      const result = normalizeConversation(MOCK_AGNO_LLM_OUTPUT_WITH_CONTENT, 'agno');
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(1);
+      expect(result![0].role).toBe('assistant');
+      expect(result![0].content).toContain('weather');
+    });
+
+    it('should treat plain string as user message in normalizeConversation', () => {
+      // Plain strings are ambiguous - normalizeConversation tries input first
+      // For actual output handling, use normalizeAgnoChatOutput directly
+      const result = normalizeConversation(MOCK_AGNO_AGENT_OUTPUT, 'agno');
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(1);
+      // Plain strings are treated as user messages by normalizeAgnoChatInput
+      expect(result![0].role).toBe('user');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle messages with empty content', () => {
+      const messagesWithEmptyContent = { messages: [{ role: 'user', content: '' }] };
+      const result = normalizeAgnoChatInput(messagesWithEmptyContent);
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(1);
+      expect(result![0].role).toBe('user');
+    });
+
+    it('should handle single tool result (not combined format)', () => {
+      const singleToolResult = {
+        messages: [{ role: 'tool', content: 'Tool result', tool_call_id: 'call_1', tool_name: 'my_tool' }],
+      };
+      const result = normalizeAgnoChatInput(singleToolResult);
+
+      expect(result).not.toBeNull();
+      expect(result![0].role).toBe('tool');
+    });
+
+    it('should handle content as array (fallback for tool messages)', () => {
+      const toolWithContentArray = {
+        messages: [{ role: 'tool', content: ['Result 1', 'Result 2'] }],
+      };
+      const result = normalizeAgnoChatInput(toolWithContentArray);
+
+      expect(result).not.toBeNull();
+      expect(result!.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should handle malformed JSON output gracefully', () => {
+      const malformedJson = '[{invalid json}]';
+      const result = normalizeAgnoChatOutput(malformedJson);
+
+      // Should fall back to treating as plain string
+      expect(result).not.toBeNull();
+      expect(result![0].role).toBe('assistant');
+    });
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/agno.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/agno.ts
@@ -1,0 +1,434 @@
+import { get, isArray, isObject, isString } from 'lodash';
+
+import type { ModelTraceChatMessage, ModelTraceSpanNode, ModelTraceToolCall } from '../ModelTrace.types';
+import { prettyPrintChatMessage } from '../ModelTraceExplorer.utils';
+
+/**
+ * Agno message structure.
+ *
+ *   System:    { role: "system", content: "You are helpful." }
+ *   User:      { role: "user", content: "What is 2+2?" }
+ *   Assistant: { role: "assistant", content: "4" }
+ *   Assistant with tool calls: { role: "assistant", tool_calls: [{ id, type, function: { name, arguments } }] }
+ *   Tool:      { role: "tool", content: "result", tool_call_id: "call_123", tool_name: "calculator" }
+ *   Combined tool: { role: "tool", content: ["r1", "r2"], tool_calls: [{ tool_call_id, tool_name, content }] }
+ */
+type AgnoMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content?: string | string[] | null;
+  tool_calls?: AgnoToolCall[] | AgnoToolResult[];
+  tool_call_id?: string;
+  tool_name?: string;
+};
+
+/**
+ * Tool call from assistant message (requesting tool execution).
+ *
+ * Found in: assistant message's tool_calls array
+ *   {
+ *     id: "call_abc123",
+ *     type: "function",
+ *     function: {
+ *       name: "get_stock_price",
+ *       arguments: '{"symbol": "AAPL"}'
+ *     }
+ *   }
+ */
+type AgnoToolCall = {
+  id: string;
+  type: string;
+  function: {
+    name: string;
+    arguments: string;
+  };
+};
+
+/**
+ * Tool result in combined tool message.
+ *
+ * Found in: tool message's tool_calls array (when multiple tools executed)
+ *   {
+ *     tool_call_id: "call_abc123",
+ *     tool_name: "get_stock_price",
+ *     content: "$150.25"
+ *   }
+ */
+type AgnoToolResult = {
+  tool_call_id: string;
+  tool_name: string;
+  content: string;
+};
+
+/**
+ * Check if object is a valid Agno message.
+ *
+ * Valid if: object has 'role' field with value 'system', 'user', 'assistant', or 'tool'
+ *   { role: "user", content: "Hello" }
+ *   { role: "assistant", tool_calls: [...] }
+ *   { role: "tool", content: "result" }
+ */
+const isAgnoMessage = (obj: unknown): obj is AgnoMessage => {
+  if (!isObject(obj)) return false;
+  const role = get(obj, 'role');
+  return isString(role) && ['system', 'user', 'assistant', 'tool'].includes(role);
+};
+
+/**
+ * Check if object is an Agno tool call (from assistant).
+ *
+ * Valid if: object has 'function' field (indicating it's a tool call request)
+ *   { id: "call_123", type: "function", function: { name: "calc", arguments: "{}" }
+ */
+const isAgnoToolCall = (tc: unknown): tc is AgnoToolCall => {
+  if (!isObject(tc)) return false;
+  return 'function' in (tc as Record<string, unknown>);
+};
+
+/**
+ * Check if object is an Agno tool result.
+ *
+ * Valid if: object has both 'tool_call_id' AND 'tool_name' fields
+ *   { tool_call_id: "call_123", tool_name: "get_weather", content: "72°F" }
+ */
+const isAgnoToolResult = (tc: unknown): tc is AgnoToolResult => {
+  if (!isObject(tc)) return false;
+  return 'tool_call_id' in (tc as Record<string, unknown>) && 'tool_name' in (tc as Record<string, unknown>);
+};
+
+/**
+ * Convert Agno tool call to ModelTraceToolCall format.
+ *
+ * Input:  { id: "call_123", type: "function", function: { name: "calc", arguments: '{"x":1}' } }
+ * Output: { id: "call_123", function: { name: "calc", arguments: '{"x":1}' } }
+ */
+const normalizeToolCall = (tc: AgnoToolCall): ModelTraceToolCall => ({
+  id: tc.id,
+  function: {
+    name: tc.function.name,
+    arguments: tc.function.arguments,
+  },
+});
+
+/**
+ * Normalize a tool message to ModelTraceChatMessage array.
+ *
+ * Handles three formats:
+ *
+ * 1. Combined tool message with tool_calls array (preferred):
+ *    Input:  { role: "tool", tool_calls: [
+ *              { tool_call_id: "call_1", tool_name: "weather", content: "72°F" },
+ *              { tool_call_id: "call_2", tool_name: "stock", content: "$150" }
+ *            ] }
+ *    Output: [
+ *              { role: "tool", content: "72°F", tool_call_id: "call_1", name: "weather" },
+ *              { role: "tool", content: "$150", tool_call_id: "call_2", name: "stock" }
+ *            ]
+ *
+ * 2. Content as array of strings:
+ *    Input:  { role: "tool", content: ["72°F", "$150"] }
+ *    Output: [{ role: "tool", content: "72°F" }, { role: "tool", content: "$150" }]
+ *
+ * 3. Single string content:
+ *    Input:  { role: "tool", content: "72°F", tool_call_id: "call_1" }
+ *    Output: [{ role: "tool", content: "72°F", tool_call_id: "call_1" }]
+ */
+const normalizeToolMessage = (msg: AgnoMessage): ModelTraceChatMessage[] => {
+  const results: ModelTraceChatMessage[] = [];
+
+  // Priority 1: Extract individual tool results from tool_calls array
+  // Format: { role: "tool", tool_calls: [{ tool_call_id, tool_name, content }, ...] }
+  const toolCalls = msg.tool_calls;
+  if (isArray(toolCalls)) {
+    const toolResults = toolCalls.filter(isAgnoToolResult);
+    for (const tc of toolResults) {
+      const m = prettyPrintChatMessage({
+        role: 'tool',
+        content: tc.content,
+        tool_call_id: tc.tool_call_id,
+        name: tc.tool_name,
+      });
+      if (m) results.push(m);
+    }
+  }
+
+  // Priority 2: Fallback - use content array
+  // Format: { role: "tool", content: ["result1", "result2"] }
+  if (results.length === 0 && isArray(msg.content)) {
+    const stringContents = msg.content.filter(isString);
+    for (const c of stringContents) {
+      const m = prettyPrintChatMessage({ role: 'tool', content: c });
+      if (m) results.push(m);
+    }
+  }
+
+  // Priority 3: Fallback - single string content
+  // Format: { role: "tool", content: "result", tool_call_id: "call_1" }
+  if (results.length === 0 && isString(msg.content)) {
+    const m = prettyPrintChatMessage({
+      role: 'tool',
+      content: msg.content,
+      ...(msg.tool_call_id && { tool_call_id: msg.tool_call_id }),
+    });
+    if (m) results.push(m);
+  }
+
+  return results;
+};
+
+/**
+ * Normalize any Agno message to ModelTraceChatMessage array.
+ *
+ * Routes to appropriate handler based on role:
+ *
+ * Tool message (role: "tool"):
+ *   Delegates to normalizeToolMessage()
+ *
+ * Assistant message (role: "assistant"):
+ *   Input:  { role: "assistant", content: "Hello!", tool_calls: [{ id, function: {...} }] }
+ *   Output: [{ role: "assistant", content: "Hello!", tool_calls: [...] }]
+ *
+ * System/User message (role: "system" | "user"):
+ *   Input:  { role: "user", content: "What is 2+2?" }
+ *   Output: [{ role: "user", content: "What is 2+2?" }]
+ *
+ *   Input:  { role: "user", content: ["line1", "line2"] }  // array content
+ *   Output: [{ role: "user", content: "line1\nline2" }]    // joined with newlines
+ */
+const normalizeMessage = (msg: AgnoMessage): ModelTraceChatMessage[] => {
+  // Tool messages have special handling for combined results
+  if (msg.role === 'tool') {
+    return normalizeToolMessage(msg);
+  }
+
+  // Assistant message - may have tool_calls
+  // Format: { role: "assistant", content?: "...", tool_calls?: [{ id, type, function }] }
+  if (msg.role === 'assistant') {
+    const toolCalls = isArray(msg.tool_calls) ? msg.tool_calls.filter(isAgnoToolCall).map(normalizeToolCall) : [];
+    const content = isString(msg.content) ? msg.content : undefined;
+    const m = prettyPrintChatMessage({
+      role: 'assistant',
+      content,
+      ...(toolCalls.length > 0 && { tool_calls: toolCalls }),
+    });
+    return m ? [m] : [];
+  }
+
+  // System or user message
+  // Format: { role: "system"|"user", content: "..." } or { role: "...", content: ["line1", "line2"] }
+  const content = isString(msg.content) ? msg.content : isArray(msg.content) ? msg.content.join('\n') : undefined;
+  const m = prettyPrintChatMessage({ role: msg.role, content });
+  return m ? [m] : [];
+};
+
+/**
+ * Normalize an array of Agno messages.
+ *
+ * Input:  [{ role: "system", content: "..." }, { role: "user", content: "..." }]
+ * Output: [{ role: "system", content: "..." }, { role: "user", content: "..." }]
+ */
+const normalizeMessagesArray = (messages: unknown[]): ModelTraceChatMessage[] => {
+  const result: ModelTraceChatMessage[] = [];
+  messages.forEach((m) => {
+    if (isAgnoMessage(m)) {
+      result.push(...normalizeMessage(m));
+    }
+  });
+  return result;
+};
+
+/**
+ * Parse Agno INPUT data.
+ *
+ * Handles two formats:
+ *
+ * 1. LLM span input (object with messages array):
+ *    Input:  { messages: [{ role: "system", content: "..." }, { role: "user", content: "..." }] }
+ *    Output: [{ role: "system", content: "..." }, { role: "user", content: "..." }]
+ *
+ * 2. AGENT span input (plain string, NOT JSON):
+ *    Input:  "What is the stock price of Apple?"
+ *    Output: [{ role: "user", content: "What is the stock price of Apple?" }]
+ *
+ * Does NOT handle:
+ *    - JSON strings starting with '[' or '{' (those go to normalizeAgnoChatOutput)
+ *    - null/undefined values
+ */
+export const normalizeAgnoChatInput = (obj: unknown): ModelTraceChatMessage[] | null => {
+  if (!obj) return null;
+
+  // Format 1: LLM span input - object with messages array
+  // Example: { messages: [{ role: "user", content: "Hello" }] }
+  if (isObject(obj)) {
+    const messagesArr = get(obj, 'messages');
+    if (isArray(messagesArr)) {
+      const result = normalizeMessagesArray(messagesArr);
+      return result.length > 0 ? result : null;
+    }
+  }
+
+  // Format 2: AGENT span input - plain string (NOT JSON)
+  // Example: "What is the stock price of Apple?"
+  // Excludes: '[{"role":"assistant",...}]' or '{"key":"value"}' (these are JSON, handled elsewhere)
+  if (isString(obj) && !obj.startsWith('[') && !obj.startsWith('{')) {
+    const msg = prettyPrintChatMessage({ role: 'user', content: obj });
+    return msg ? [msg] : null;
+  }
+
+  return null;
+};
+
+/**
+ * Parse Agno OUTPUT data.
+ *
+ * Handles two formats:
+ *
+ * 1. LLM span output (JSON string of message array):
+ *    Input:  '[{"role":"assistant","content":"Hello!"}]'
+ *    Output: [{ role: "assistant", content: "Hello!" }]
+ *
+ *    Input:  '[{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"calc","arguments":"{}"}}]}]'
+ *    Output: [{ role: "assistant", tool_calls: [{ id: "call_1", function: { name: "calc", arguments: "{}" } }] }]
+ *
+ * 2. AGENT span output (plain markdown string):
+ *    Input:  "## Stock Price\n\nApple is trading at $150."
+ *    Output: [{ role: "assistant", content: "## Stock Price\n\nApple is trading at $150." }]
+ *
+ */
+export const normalizeAgnoChatOutput = (obj: unknown): ModelTraceChatMessage[] | null => {
+  if (!obj) return null;
+
+  if (isString(obj)) {
+    // Format 1: LLM output - JSON string starting with '[' (array of messages)
+    // Example: '[{"role":"assistant","content":"The answer is 42."}]'
+    if (obj.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(obj);
+        if (isArray(parsed)) {
+          const result = normalizeMessagesArray(parsed);
+          return result.length > 0 ? result : null;
+        }
+      } catch {
+        // Not valid JSON, fall through to plain string handling
+      }
+    }
+
+    // Format 2: AGENT output - plain string (markdown response)
+    // Example: "## Results\n\nThe stock price is $150."
+    const msg = prettyPrintChatMessage({ role: 'assistant', content: obj });
+    return msg ? [msg] : null;
+  }
+
+  return null;
+};
+
+/**
+ * Extract system prompt from the first LLM child span's inputs.
+ *
+ * LLM span inputs have this structure:
+ *   { messages: [{ role: "system", content: "..." }, { role: "user", content: "..." }, ...] }
+ *
+ * We extract the first system message to show in the AGENT ChatUI.
+ */
+const extractSystemPromptFromChildren = (children: ModelTraceSpanNode[]): ModelTraceChatMessage | null => {
+  for (const child of children) {
+    const spanType = child.type || child.attributes?.['mlflow.spanType'];
+    if (spanType !== 'LLM') continue;
+
+    // LLM span inputs: { messages: [...] }
+    const llmInputs = child.inputs;
+    if (!isObject(llmInputs)) continue;
+
+    const messages = get(llmInputs, 'messages');
+    if (!isArray(messages)) continue;
+
+    // Find the first system message
+    for (const msg of messages as unknown[]) {
+      if (isObject(msg) && get(msg, 'role') === 'system') {
+        const content = get(msg, 'content') as unknown;
+        if (isString(content) && content.trim()) {
+          return prettyPrintChatMessage({ role: 'system', content: content.trim() });
+        }
+      }
+    }
+    // Only check the first LLM span
+    break;
+  }
+  return null;
+};
+
+/**
+ * Synthesize chat messages for AGENT spans from child LLM/TOOL spans.
+ *
+ * AGENT spans only have simple string input/output. The full conversation
+ * with tool calls is in child LLM spans. This function aggregates them.
+ *
+ * Input structure:
+ *   inputs:   "What is the stock price?" (plain string - user query)
+ *   outputs:  "Apple is $150." (plain string - final answer)
+ *   children: [
+ *     { type: "LLM", inputs: { messages: [{ role: "system", content: "..." }, ...] }, outputs: '[{"role":"assistant","tool_calls":[...]}]' },
+ *     { type: "TOOL", attributes: { "tool.name": "get_stock" }, outputs: "$150" },
+ *     { type: "LLM", outputs: '[{"role":"assistant","content":"Apple is $150."}]' }
+ *   ]
+ *
+ * Output:
+ *   [
+ *     { role: "system", content: "You are a helpful assistant..." },
+ *     { role: "user", content: "What is the stock price?" },
+ *     { role: "assistant", tool_calls: [...] },
+ *     { role: "tool", content: "$150", name: "get_stock" },
+ *     { role: "assistant", content: "Apple is $150." }
+ *   ]
+ */
+export const synthesizeAgnoChatMessages = (
+  inputs: unknown,
+  outputs: unknown,
+  children: ModelTraceSpanNode[],
+): ModelTraceChatMessage[] | null => {
+  const messages: ModelTraceChatMessage[] = [];
+
+  // Extract system prompt from first LLM child span
+  const systemPrompt = extractSystemPromptFromChildren(children);
+  if (systemPrompt) {
+    messages.push(systemPrompt);
+  }
+
+  // Add user input
+  // Format: plain string "What is the stock price?"
+  const inputMessages = normalizeAgnoChatInput(inputs);
+  if (!inputMessages?.length) return null;
+  messages.push(...inputMessages);
+
+  // Process children IN ORDER (chronological execution order)
+  // This is critical: LLM1 (tool call) → TOOL (result) → LLM2 (final answer)
+  // We must NOT group by type, as that breaks the conversation flow
+  for (const child of children) {
+    const spanType = child.type || child.attributes?.['mlflow.spanType'];
+
+    if (spanType === 'LLM') {
+      // LLM span output: '[{"role":"assistant","content":"..."}]' or '[{"role":"assistant","tool_calls":[...]}]'
+      const llmMessages = normalizeAgnoChatOutput(child.outputs);
+      if (llmMessages) {
+        for (const msg of llmMessages) {
+          if (msg.role === 'assistant') {
+            messages.push(msg);
+          }
+        }
+      }
+    } else if (spanType === 'TOOL') {
+      // TOOL span: { attributes: { "tool.name": "get_weather" }, outputs: "72°F" }
+      const toolName = (child.attributes?.['tool.name'] as string) || String(child.title || child.key);
+      const toolOutput = isObject(child.outputs)
+        ? JSON.stringify(child.outputs, null, 2)
+        : String(child.outputs || '');
+      const msg = prettyPrintChatMessage({
+        role: 'tool',
+        content: toolOutput,
+        name: toolName,
+      });
+      if (msg) messages.push(msg);
+    }
+  }
+
+  return messages.length > 0 ? messages : null;
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/index.ts
@@ -1,3 +1,4 @@
+export { normalizeAgnoChatInput, normalizeAgnoChatOutput, synthesizeAgnoChatMessages } from './agno';
 export { normalizeAnthropicChatInput, normalizeAnthropicChatOutput } from './anthropic';
 export { normalizeAutogenChatInput, normalizeAutogenChatOutput } from './autogen';
 export { normalizeBedrockChatInput, normalizeBedrockChatOutput } from './bedrock';

--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from mlflow.entities.span import Span
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+from mlflow.tracing.otel.translation.agno import AgnoTranslator
 from mlflow.tracing.otel.translation.base import OtelSchemaTranslator
 from mlflow.tracing.otel.translation.genai_semconv import GenAiTranslator
 from mlflow.tracing.otel.translation.google_adk import GoogleADKTranslator
@@ -31,6 +32,7 @@ _TRANSLATORS: list[OtelSchemaTranslator] = [
     GoogleADKTranslator(),
     VercelAITranslator(),
     VoltAgentTranslator(),
+    AgnoTranslator(),
 ]
 
 

--- a/mlflow/tracing/otel/translation/agno.py
+++ b/mlflow/tracing/otel/translation/agno.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from mlflow.tracing.otel.translation.open_inference import OpenInferenceTranslator
+
+
+class AgnoTranslator(OpenInferenceTranslator):
+    """
+    Translator for Agno traces via OpenInference semantic conventions.
+
+    Detection: Only uses `agno.*` prefixed attributes which are guaranteed
+    to be set by Agno's OpenInference instrumentation:
+    - agno.agent.id
+    - agno.team.id
+    - agno.run.id
+    - agno.model.id
+
+    This is the only reliable detection method. Message structure-based
+    detection is not used as it could cause false positives with other frameworks.
+    """
+
+    MESSAGE_FORMAT = "agno"
+    AGNO_ATTRIBUTE_PREFIX = "agno."
+
+    def get_message_format(self, attributes: dict[str, Any]) -> str | None:
+        """Return 'agno' if this is an Agno trace, None otherwise."""
+        # Only check for agno.* prefixed attributes - this is the only reliable detection
+        # Examples: agno.agent.id, agno.team.id, agno.run.id, agno.model.id
+        if any(key.startswith(self.AGNO_ATTRIBUTE_PREFIX) for key in attributes):
+            return self.MESSAGE_FORMAT
+        return None

--- a/tests/tracing/otel/test_agno_translation.py
+++ b/tests/tracing/otel/test_agno_translation.py
@@ -1,0 +1,164 @@
+import json
+from unittest import mock
+
+import pytest
+
+from mlflow.entities.span import Span, SpanType
+from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracing.otel.translation import (
+    translate_span_type_from_otel,
+    translate_span_when_storing,
+)
+from mlflow.tracing.otel.translation.agno import AgnoTranslator
+
+
+@pytest.mark.parametrize(
+    ("attributes", "expected_format"),
+    [
+        ({"agno.agent.id": "agent_123"}, "agno"),
+        ({"agno.team.id": "team_456"}, "agno"),
+        ({"agno.model.id": "gemini-2.0-flash-thinking"}, "agno"),
+        ({"agno.run.id": "run_789"}, "agno"),
+        ({"agno.agent.id": "agent_1", "openinference.span.kind": "AGENT"}, "agno"),
+        ({"agno.agent.id": "a", "agno.run.id": "r", "other.attr": "val"}, "agno"),
+    ],
+)
+def test_agno_detects_agno_prefixed_attributes(attributes, expected_format):
+    translator = AgnoTranslator()
+    result = translator.get_message_format(attributes)
+    assert result == expected_format
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        # Generic LLM messages - no agno.* prefix
+        {
+            "openinference.span.kind": "LLM",
+            "input.value": json.dumps({"messages": [{"role": "user", "content": "Hi"}]}),
+        },
+        # Messages with Agno-like fields but no agno.* prefix
+        {
+            "openinference.span.kind": "LLM",
+            "input.value": json.dumps(
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Hi",
+                            "from_history": True,
+                            "stop_after_tool_call": False,
+                        }
+                    ]
+                }
+            ),
+        },
+        # Unknown span kind
+        {"openinference.span.kind": "UNKNOWN"},
+        # No relevant attributes
+        {"some.other.attribute": "value"},
+        # Empty attributes
+        {},
+    ],
+)
+def test_agno_returns_none_without_agno_prefix(attributes):
+    translator = AgnoTranslator()
+    result = translator.get_message_format(attributes)
+    assert result is None
+
+
+def test_agno_translator_inherits_from_open_inference():
+    from mlflow.tracing.otel.translation.open_inference import OpenInferenceTranslator
+
+    translator = AgnoTranslator()
+    assert isinstance(translator, OpenInferenceTranslator)
+
+
+def test_agno_translator_message_format_constant():
+    translator = AgnoTranslator()
+    assert translator.MESSAGE_FORMAT == "agno"
+
+
+def test_agno_translator_attribute_prefix():
+    translator = AgnoTranslator()
+    assert translator.AGNO_ATTRIBUTE_PREFIX == "agno."
+
+
+@pytest.mark.parametrize(
+    ("attributes", "expected_type"),
+    [
+        ({"openinference.span.kind": "LLM"}, SpanType.LLM),
+        ({"openinference.span.kind": "AGENT"}, SpanType.AGENT),
+        ({"openinference.span.kind": "CHAIN"}, SpanType.CHAIN),
+        ({"openinference.span.kind": "TOOL"}, SpanType.TOOL),
+        ({"openinference.span.kind": json.dumps("LLM")}, SpanType.LLM),
+        ({"openinference.span.kind": json.dumps("AGENT")}, SpanType.AGENT),
+    ],
+)
+def test_agno_span_type_from_otel(attributes, expected_type):
+    result = translate_span_type_from_otel(attributes)
+    assert result == expected_type
+
+
+def test_agno_translate_span_sets_message_format():
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            "openinference.span.kind": "LLM",
+            "agno.agent.id": "agent_123",
+            "input.value": json.dumps({"messages": [{"role": "user", "content": "Hi"}]}),
+            "output.value": json.dumps("Hello!"),
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    assert SpanAttributeKey.MESSAGE_FORMAT in result["attributes"]
+    message_format = json.loads(result["attributes"][SpanAttributeKey.MESSAGE_FORMAT])
+    assert message_format == "agno"
+
+
+def test_agno_translate_span_sets_inputs_outputs():
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    input_messages = {"messages": [{"role": "user", "content": "Hello"}]}
+    span_dict = {
+        "attributes": {
+            "openinference.span.kind": "LLM",
+            "agno.agent.id": "agent_123",
+            "input.value": json.dumps(input_messages),
+            "output.value": json.dumps("Hi there!"),
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    inputs = json.loads(result["attributes"][SpanAttributeKey.INPUTS])
+    assert inputs == input_messages
+
+    outputs = json.loads(result["attributes"][SpanAttributeKey.OUTPUTS])
+    assert outputs == "Hi there!"
+
+
+def test_agno_does_not_match_similar_frameworks():
+    translator = AgnoTranslator()
+
+    # LangChain-like
+    assert translator.get_message_format({"langchain.run_type": "llm"}) is None
+
+    # CrewAI-like
+    assert translator.get_message_format({"crewai.agent.role": "researcher"}) is None
+
+    # Generic OpenInference
+    assert (
+        translator.get_message_format(
+            {
+                "openinference.span.kind": "LLM",
+                "llm.model_name": "gpt-4",
+            }
+        )
+        is None
+    )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/19723?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19723/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19723/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19723/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs


### What changes are proposed in this pull request?

ChatUI in Agno

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1571" height="894" alt="image" src="https://github.com/user-attachments/assets/938669b6-e8bd-4f4b-b3f7-0187402c1acb" />


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

ChatUI in Agno

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
