### PR TITLE
fix(evaluation): avoid shap summary rng warning

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1280,6 +1280,10 @@ def evaluate(
           explainability insights. Default value is 2000.
         - **explainability_kernel_link**: The kernel link function used by shap kernel explainer.
           Available values are "identity" and "logit". Default value is "identity".
+        - **shap_plot_seed**: Optional seed (integer or ``numpy.random.Generator``) that is used
+          to initialize the random number generator for SHAP summary plots when SHAP >= 0.47.0.
+          Configure this to silence NumPy RNG warnings or to make SHAP plots reproducible. When
+          not set, a fresh generator is created for every evaluation.
         - **max_classes_for_multiclass_roc_pr**:
           For multiclass classification tasks, the maximum number of classes for which to log
           the per-class ROC curve and Precision-Recall curve. If the number of classes is

--- a/tests/evaluate/test_shap_rng.py
+++ b/tests/evaluate/test_shap_rng.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib
+import importlib.machinery
+import sys
+import types
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+from packaging.version import Version
+from sklearn.datasets import load_diabetes
+from sklearn.linear_model import LinearRegression
+
+def _ensure_databricks_stub():
+    if "databricks" not in sys.modules:
+        databricks_module = types.ModuleType("databricks")
+        databricks_module.__spec__ = importlib.machinery.ModuleSpec(
+            "databricks", loader=None
+        )
+        sys.modules["databricks"] = databricks_module
+    if "databricks.agents" not in sys.modules:
+        agents_module = types.ModuleType("databricks.agents")
+        agents_module.__spec__ = importlib.machinery.ModuleSpec(
+            "databricks.agents", loader=None
+        )
+        sys.modules["databricks.agents"] = agents_module
+        sys.modules["databricks"].agents = agents_module
+
+
+_ensure_databricks_stub()
+
+import mlflow
+from mlflow.models.evaluation.base import evaluate
+
+
+@pytest.fixture(scope="module")
+def logged_linear_regressor():
+    data = load_diabetes()
+    features = pd.DataFrame(data.data, columns=data.feature_names)
+    targets = pd.Series(data.target, name="target")
+
+    model = LinearRegression().fit(features, targets)
+    with mlflow.start_run():
+        model_info = mlflow.sklearn.log_model(model, artifact_path="model")
+    return model_info.model_uri, features.assign(target=targets)
+
+
+def test_shap_summary_plot_uses_local_rng(logged_linear_regressor):
+    try:
+        shap = importlib.import_module("shap")
+    except OSError as exc:
+        pytest.skip(f"shap is not available in this environment: {exc}")
+
+    if Version(shap.__version__) < Version("0.47.0"):
+        pytest.skip("shap>=0.47.0 is required for RNG support in summary plots")
+
+    model_uri, eval_df = logged_linear_regressor
+    warning_pattern = r"The NumPy global RNG was seeded"
+    rng_state = np.random.get_state()
+    np.random.seed(7)
+
+    def _run_eval(config):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", message=warning_pattern, category=FutureWarning)
+            with mlflow.start_run():
+                evaluate(
+                    model_uri,
+                    eval_df.copy(),
+                    model_type="regressor",
+                    targets="target",
+                    evaluators="default",
+                    evaluator_config=config,
+                )
+
+    try:
+        _run_eval({"shap_plot_seed": 123})
+        _run_eval({})
+    finally:
+        np.random.set_state(rng_state)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/osasisorae/mlflow/pull/19724?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19724/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19724/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19724/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #17387

### What changes are proposed in this pull request?

- Introduce `shap_plot_seed` evaluator_config option so SHAP summary plots can opt into a local RNG (or reproducible seed) without touching NumPy’s global RNG.
- When SHAP ≥ 0.47.0 is available, `ShapEvaluator` now builds a `np.random.Generator` for summary plots and passes it via `rng=…`, eliminating the FutureWarning raised by NumPy’s upcoming RNG policy.
- Document the new knob in the evaluator config section.
- Add `tests/evaluate/test_shap_rng.py` to guard against regressions; it verifies that SHAP evaluation no longer emits the warning (skips automatically if the runtime SHAP build isn’t present).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

> `PYTHONPATH=/tmp/databricks_stub python -m pytest tests/evaluate/test_shap_rng.py`
> (skips locally when the SHAP wheel isn’t available for the host arch; CI runners with SHAP wheels will exercise it fully.)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

> Fix SHAP evaluator FutureWarning by seeding plots with a local RNG (optional `shap_plot_seed`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [x] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix`
- [ ] `rn/documentation`

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
