### PR TITLE
Fix Gateway error handling to translate MlflowException to HTTPException

### DIFF
--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -354,5 +354,7 @@ def translate_http_exception(func):
             return await func(*args, **kwargs)
         except AIGatewayException as e:
             raise HTTPException(status_code=e.status_code, detail=e.detail)
+        except MlflowException as e:
+            raise HTTPException(status_code=e.get_http_status_code(), detail=str(e))
 
     return wrapper

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -355,6 +355,9 @@ def translate_http_exception(func):
         except AIGatewayException as e:
             raise HTTPException(status_code=e.status_code, detail=e.detail)
         except MlflowException as e:
-            raise HTTPException(status_code=e.get_http_status_code(), detail=str(e))
+            raise HTTPException(
+                status_code=e.get_http_status_code(),
+                detail={"error_code": e.error_code, "message": e.message},
+            )
 
     return wrapper

--- a/tests/gateway/test_utils.py
+++ b/tests/gateway/test_utils.py
@@ -148,7 +148,7 @@ def test_search_routes_token_with_invalid_token_values(index):
 async def test_translate_http_exception_handles_ai_gateway_exception():
     @translate_http_exception
     async def raise_ai_gateway_exception():
-        raise AIGatewayException("AI Gateway error", status_code=503)
+        raise AIGatewayException(status_code=503, detail="AI Gateway error")
 
     with pytest.raises(HTTPException, match="AI Gateway error") as exc_info:
         await raise_ai_gateway_exception()
@@ -167,7 +167,10 @@ async def test_translate_http_exception_handles_mlflow_exception():
         await raise_mlflow_exception()
 
     assert exc_info.value.status_code == 400
-    assert "Invalid parameter" in exc_info.value.detail
+    assert exc_info.value.detail == {
+        "error_code": "INVALID_PARAMETER_VALUE",
+        "message": "Invalid parameter",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_utils.py
+++ b/tests/gateway/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
+from fastapi import HTTPException
 
 from mlflow.exceptions import MlflowException
+from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.utils import (
     SearchRoutesToken,
     _is_valid_uri,
@@ -10,7 +12,9 @@ from mlflow.gateway.utils import (
     is_valid_endpoint_name,
     resolve_route_url,
     set_gateway_uri,
+    translate_http_exception,
 )
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
 
 @pytest.mark.parametrize(
@@ -138,3 +142,39 @@ def test_search_routes_token_with_invalid_token_values(index):
     encoded_token = token.encode()
     with pytest.raises(MlflowException, match="Invalid SearchRoutes token"):
         SearchRoutesToken.decode(encoded_token)
+
+
+@pytest.mark.asyncio
+async def test_translate_http_exception_handles_ai_gateway_exception():
+    @translate_http_exception
+    async def raise_ai_gateway_exception():
+        raise AIGatewayException("AI Gateway error", status_code=503)
+
+    with pytest.raises(HTTPException, match="AI Gateway error") as exc_info:
+        await raise_ai_gateway_exception()
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "AI Gateway error"
+
+
+@pytest.mark.asyncio
+async def test_translate_http_exception_handles_mlflow_exception():
+    @translate_http_exception
+    async def raise_mlflow_exception():
+        raise MlflowException("Invalid parameter", error_code=INVALID_PARAMETER_VALUE)
+
+    with pytest.raises(HTTPException, match="Invalid parameter") as exc_info:
+        await raise_mlflow_exception()
+
+    assert exc_info.value.status_code == 400
+    assert "Invalid parameter" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_translate_http_exception_passes_through_other_exceptions():
+    @translate_http_exception
+    async def raise_value_error():
+        raise ValueError("Some value error")
+
+    with pytest.raises(ValueError, match="Some value error"):
+        await raise_value_error()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/danielseong1/mlflow/pull/19728?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19728/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19728/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19728/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The `translate_http_exception` decorator in the Gateway was only handling `AIGatewayException` but not `MlflowException`. This caused unhandled exceptions when MlflowException was raised from gateway endpoints, resulting in 500 errors instead of proper HTTP error responses.

This change adds a handler for `MlflowException` that converts it to an HTTPException using the exception's `get_http_status_code()` method for the status code and the string representation for the detail message.

Key changes:
- Added exception handler for `MlflowException` in `translate_http_exception` decorator
- Added unit tests for `translate_http_exception` covering `AIGatewayException`, `MlflowException`, and pass-through behavior for other exceptions

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Manual tests:

Before (generic error message):
<img width="388" height="329" alt="image" src="https://github.com/user-attachments/assets/aabd8df9-dd5d-4f19-b9d3-616c9f6a5aa1" />

After:
<img width="389" height="383" alt="image" src="https://github.com/user-attachments/assets/b50171f6-4166-41cf-8c06-90dc135bbe93" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Gateway endpoints now properly return appropriate HTTP error codes when MlflowException is raised, instead of returning generic 500 errors.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)