### PR TITLE
Improve OTEL GenAI SemConv Support for Strands/MAF

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.test.tsx
@@ -1,7 +1,7 @@
 import { describe, test, jest, expect } from '@jest/globals';
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
-import { render, screen } from '../../../common/utils/TestUtils.react18';
-import { TracesViewTableResponsePreviewCell } from './TracesViewTablePreviewCell';
+import { renderWithDesignSystem, screen } from '../../../common/utils/TestUtils.react18';
+import { TracesViewTableRequestPreviewCell, TracesViewTableResponsePreviewCell } from './TracesViewTablePreviewCell';
 import { Table, TableCell, TableRow } from '@databricks/design-system';
 import userEvent from '@testing-library/user-event';
 import { MlflowService } from '../../sdk/MlflowService';
@@ -13,19 +13,29 @@ const longValueTruncated = `{"model_input":[{"query":"What is featured in the la
 const formattedLongValue = JSON.stringify(JSON.parse(longValue), null, 2);
 
 describe('ExperimentViewTracesTablePreviewCell', () => {
-  const renderTable = (value: string) => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const renderTable = ({
+    value,
+    preview,
+  }: {
+    value: string;
+    preview: 'request' | 'response';
+  }) => {
     const Component = () => {
       const table = useReactTable({
         columns: [
           {
             // @ts-expect-error [FEINF-4084] Type 'ColumnDefTemplate<CellContext<ModelTraceInfoWithRunName, unknown>>' is not assignable to type 'ColumnDefTemplate...
-            cell: TracesViewTableResponsePreviewCell,
+            cell: preview === 'request' ? TracesViewTableRequestPreviewCell : TracesViewTableResponsePreviewCell,
             id: 'test',
           },
         ],
         data: [
           {
-            request_metadata: [{ key: 'mlflow.traceOutputs', value }],
+            request_metadata: [{ key: preview === 'request' ? 'mlflow.traceInputs' : 'mlflow.traceOutputs', value }],
             request_id: 'test_request_id',
           },
         ],
@@ -45,7 +55,7 @@ describe('ExperimentViewTracesTablePreviewCell', () => {
       );
     };
 
-    render(<Component />);
+    renderWithDesignSystem(<Component />);
   };
 
   test('it should expand short values and request more data', async () => {
@@ -53,7 +63,7 @@ describe('ExperimentViewTracesTablePreviewCell', () => {
       .spyOn(MlflowService, 'getExperimentTraceData')
       .mockImplementation(() => Promise.resolve({ response: longValue }));
 
-    renderTable(longValueTruncated);
+    renderTable({ value: longValueTruncated, preview: 'response' });
     expect(screen.queryByRole('button')).toBeInTheDocument();
 
     expect(screen.getByText(longValueTruncated)).toBeInTheDocument();
@@ -76,7 +86,63 @@ describe('ExperimentViewTracesTablePreviewCell', () => {
 
     const escapedJson = '{"model_input":"\\uD83D\\uDE42"}';
     const unescapedJson = '{"model_input":"🙂"}';
-    renderTable(escapedJson);
+    renderTable({ value: escapedJson, preview: 'response' });
     expect(screen.getByText(unescapedJson, { collapseWhitespace: false })).toBeInTheDocument();
+  });
+
+  test('it should render OTEL gen_ai messages with role labels when expanded', async () => {
+    const otelMessages = JSON.stringify([
+      { role: 'system', parts: [{ type: 'text', content: 'System instruction' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'User prompt' }] },
+    ]);
+
+    renderTable({ value: otelMessages, preview: 'response' });
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('System')).toBeInTheDocument();
+    expect(screen.getByText('User')).toBeInTheDocument();
+    expect(screen.getByText('System instruction')).toBeInTheDocument();
+    expect(screen.getByText('User prompt')).toBeInTheDocument();
+  });
+
+  test('it should prefer gen_ai.input.messages for request', async () => {
+    const inputOtelMessages = [
+      { role: 'system', parts: [{ type: 'text', content: 'S' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'U' }] },
+    ];
+    const outputOtelMessages = [{ role: 'assistant', parts: [{ type: 'text', content: 'A' }] }];
+
+    const combined = JSON.stringify({
+      'gen_ai.input.messages': inputOtelMessages,
+      'gen_ai.output.messages': outputOtelMessages,
+    });
+
+    renderTable({ value: combined, preview: 'request' });
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('S')).toBeInTheDocument();
+    expect(screen.getByText('U')).toBeInTheDocument();
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
+  });
+
+  test('it should prefer gen_ai.output.messages for response', async () => {
+    const inputOtelMessages = [
+      { role: 'system', parts: [{ type: 'text', content: 'S' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'U' }] },
+    ];
+    const outputOtelMessages = [{ role: 'assistant', parts: [{ type: 'text', content: 'A' }] }];
+
+    const combined = JSON.stringify({
+      'gen_ai.input.messages': inputOtelMessages,
+      'gen_ai.output.messages': outputOtelMessages,
+    });
+
+    renderTable({ value: combined, preview: 'response' });
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.queryByText('S')).not.toBeInTheDocument();
+    expect(screen.queryByText('U')).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/TracesViewTablePreviewCell.tsx
@@ -1,5 +1,5 @@
 import { Button, ChevronDownIcon, ChevronRightIcon, useDesignSystemTheme } from '@databricks/design-system';
-import { isString } from 'lodash';
+import { isObject, isString } from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
 import { MlflowService } from '../../sdk/MlflowService';
 import Utils from '../../../common/utils/Utils';
@@ -7,6 +7,11 @@ import { ErrorWrapper } from '../../../common/utils/ErrorWrapper';
 import type { CellContext, ColumnDefTemplate } from '@tanstack/react-table';
 import type { ModelTraceInfoWithRunName } from './hooks/useExperimentTraces';
 import { getTraceInfoInputs, getTraceInfoOutputs, isTraceMetadataPossiblyTruncated } from './TracesView.utils';
+import {
+  ModelTraceExplorerConversation,
+  normalizeConversation,
+  type ModelTraceChatMessage,
+} from '@databricks/web-shared/model-trace-explorer';
 import { CodeSnippet } from '@databricks/web-shared/snippet';
 import { css } from '@emotion/react';
 
@@ -88,25 +93,93 @@ const TracesViewTablePreviewCell = ({
           !isExpanded && clampedLinesCss,
         ]}
       >
-        {isExpanded ? <ExpandedParamCell value={fullData ?? value} /> : value}
+        {isExpanded ? <ExpandedParamCell value={fullData ?? value} previewFieldName={previewFieldName} /> : value}
       </div>
     </div>
   );
 };
 
-const ExpandedParamCell = ({ value }: { value: string }) => {
+const tryParseJsonString = (value: unknown): unknown => {
+  if (!isString(value)) {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+};
+
+const getChatMessagesFromValue = (
+  value: string,
+  previewFieldName: 'request' | 'response',
+): ModelTraceChatMessage[] | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+
+  // Some integrations may wrap the message list under one of these keys.
+  if (isObject(parsed)) {
+    const obj = parsed as Record<string, unknown>;
+
+    // Prefer input or output messages based on the preview field.
+    // This avoids showing input messages in the response column (and vice versa) when both are present.
+    const candidates: unknown[] =
+      previewFieldName === 'request'
+        ? [obj.messages, obj['gen_ai.input.messages'], obj['gen_ai.output.messages'], parsed]
+        : [obj['gen_ai.output.messages'], obj.messages, obj['gen_ai.input.messages'], parsed];
+
+    for (const candidate of candidates) {
+      const normalized = normalizeConversation(tryParseJsonString(candidate));
+      if (normalized && normalized.length > 0) {
+        return normalized;
+      }
+    }
+    return null;
+  }
+
+  return normalizeConversation(parsed);
+};
+
+const ExpandedParamCell = ({
+  value,
+  previewFieldName,
+}: {
+  value: string;
+  previewFieldName: 'request' | 'response';
+}) => {
   const { theme } = useDesignSystemTheme();
 
   const structuredJSONValue = useMemo(() => {
-    // Attempts to parse the value as JSON and returns a pretty printed version if successful.
-    // If JSON structure is not found, returns null.
     try {
       const objectData = JSON.parse(value);
       return JSON.stringify(objectData, null, 2);
-    } catch (e) {
+    } catch {
       return null;
     }
   }, [value]);
+
+  const chatMessages = useMemo(() => getChatMessagesFromValue(value, previewFieldName), [value, previewFieldName]);
+
+  if (chatMessages && chatMessages.length > 0) {
+    return (
+      <div
+        css={{
+          padding: theme.spacing.sm,
+          border: `1px solid ${theme.colors.border}`,
+          borderRadius: theme.borders.borderRadiusSm,
+          backgroundColor: theme.colors.backgroundPrimary,
+          overflow: 'hidden',
+        }}
+      >
+        <ModelTraceExplorerConversation messages={chatMessages} />
+      </div>
+    );
+  }
+
   return (
     <div
       css={{

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -468,6 +468,36 @@ describe('normalizeNewSpanData', () => {
     expect(normalized.chatTools).toEqual(MOCK_OPENAI_CHAT_INPUT.tools);
   });
 
+  it('should populate inputs from gen_ai.input.messages event when spanInputs missing', () => {
+    const otelMessages = [
+      {
+        role: 'user',
+        parts: [{ type: 'text', content: 'What is the weather now?' }],
+      },
+    ];
+
+    const otelSpan = {
+      ...MOCK_V3_SPANS[0],
+      attributes: {
+        ...MOCK_V3_SPANS[0].attributes,
+        'mlflow.spanInputs': undefined,
+        'mlflow.spanOutputs': undefined,
+      },
+      events: [
+        {
+          name: 'gen_ai.client.inference.operation.details',
+          attributes: {
+            'gen_ai.input.messages': JSON.stringify(otelMessages),
+          },
+        },
+      ],
+    } as any;
+
+    const normalized = normalizeNewSpanData(otelSpan, 0, 0, [], {}, '');
+
+    expect(normalized.inputs).toEqual(otelMessages);
+  });
+
   it('should use mlflow.chat.messages attribute when present and properly formatted', () => {
     const chatMessages: RawModelTraceChatMessage[] = [
       {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.test.ts
@@ -23,6 +23,31 @@ describe('normalizeConversation (OTEL GenAI)', () => {
     ]);
   });
 
+  it('normalizes OTEL messages nested under gen_ai.input.messages', () => {
+    const input = [
+      {
+        role: 'system',
+        parts: [{ type: 'text', content: 'You are helpful.' }],
+      },
+      {
+        role: 'user',
+        parts: [{ type: 'text', content: 'Hello there' }],
+      },
+    ];
+
+    const resultFromString = normalizeConversation({ 'gen_ai.input.messages': JSON.stringify(input) });
+    expect(resultFromString).toEqual([
+      expect.objectContaining({ role: 'system', content: 'You are helpful.' }),
+      expect.objectContaining({ role: 'user', content: 'Hello there' }),
+    ]);
+
+    const resultFromArray = normalizeConversation({ 'gen_ai.input.messages': input });
+    expect(resultFromArray).toEqual([
+      expect.objectContaining({ role: 'system', content: 'You are helpful.' }),
+      expect.objectContaining({ role: 'user', content: 'Hello there' }),
+    ]);
+  });
+
   it('normalizes tool call request and response', () => {
     const input = [
       {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.ts
@@ -13,7 +13,7 @@ type OtelBasePart = { type: string } & Record<string, unknown>;
 type OtelTextPart = OtelBasePart & { type: 'text'; content: string };
 
 type OtelToolCallRequestPart = OtelBasePart & {
-  type: 'tool_call';
+  type: 'tool_call' | 'function_call';
   id?: string | null;
   name: string;
   arguments?: unknown;
@@ -38,7 +38,8 @@ const isOtelTextPart = (obj: unknown): obj is OtelTextPart => {
 };
 
 const isOtelToolCallRequestPart = (obj: unknown): obj is OtelToolCallRequestPart => {
-  if (!isObject(obj) || get(obj, 'type') !== 'tool_call') return false;
+  const type = get(obj, 'type');
+  if (!isObject(obj) || !(type === 'tool_call' || type === 'function_call')) return false;
   if (!isString(get(obj, 'name'))) return false;
   const id = get(obj, 'id');
   return isNil(id) || isString(id);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -19,6 +19,7 @@ export {
   getTotalTokens,
   displayErrorNotification,
   displaySuccessNotification,
+  normalizeConversation,
 } from './ModelTraceExplorer.utils';
 export {
   SESSION_ID_METADATA_KEY,
@@ -40,4 +41,5 @@ export { useUnifiedTraceTagsModal } from './hooks/useUnifiedTraceTagsModal';
 export { ModelTraceExplorerUpdateTraceContextProvider } from './contexts/UpdateTraceContext';
 export { SingleChatTurnMessages } from './session-view/SingleChatTurnMessages';
 export { ModelTraceExplorerChatMessage } from './right-pane/ModelTraceExplorerChatMessage';
+export { ModelTraceExplorerConversation } from './right-pane/ModelTraceExplorerConversation';
 export { SingleChatTurnAssessments } from './session-view/SingleChatTurnAssessments';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummaryIntermediateNode.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummaryIntermediateNode.tsx
@@ -168,6 +168,7 @@ export const ModelTraceExplorerSummaryIntermediateNode = ({
                       data={value}
                       renderMode={renderMode}
                       chatMessageFormat={chatMessageFormat}
+                      chatMessagesDisplayMode="final_assistant"
                     />
                   ))}
                 </div>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySection.tsx
@@ -6,6 +6,7 @@ import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerColla
 import {
   ModelTraceExplorerFieldRenderer,
   DEFAULT_MAX_VISIBLE_CHAT_MESSAGES,
+  type ChatMessagesDisplayMode,
 } from '../field-renderers/ModelTraceExplorerFieldRenderer';
 
 const DEFAULT_MAX_VISIBLE_ITEMS = 3;
@@ -19,6 +20,7 @@ export const ModelTraceExplorerSummarySection = ({
   maxVisibleChatMessages = DEFAULT_MAX_VISIBLE_CHAT_MESSAGES,
   className,
   chatMessageFormat,
+  chatMessagesDisplayMode,
 }: {
   title: React.ReactElement;
   data: { key: string; value: string }[];
@@ -28,6 +30,7 @@ export const ModelTraceExplorerSummarySection = ({
   maxVisibleChatMessages?: number;
   className?: string;
   chatMessageFormat?: string;
+  chatMessagesDisplayMode?: ChatMessagesDisplayMode;
 }) => {
   const { theme } = useDesignSystemTheme();
   const [expanded, setExpanded] = useState(false);
@@ -55,6 +58,7 @@ export const ModelTraceExplorerSummarySection = ({
             data={value}
             renderMode={renderMode}
             chatMessageFormat={chatMessageFormat}
+            chatMessagesDisplayMode={chatMessagesDisplayMode}
             maxVisibleMessages={maxVisibleChatMessages}
           />
         ))}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
@@ -107,6 +107,7 @@ export const ModelTraceExplorerSummarySpans = ({
         data={outputList}
         renderMode={renderMode}
         chatMessageFormat={chatMessageFormat ?? 'openai'}
+        chatMessagesDisplayMode="final_assistant"
       />
     </div>
   );

--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -43,6 +43,13 @@ def _merge_event_attributes(events: list[dict[str, Any]] | None) -> dict[str, An
 
     We use these event attributes as a fallback source for populating MLflow's
     `mlflow.spanInputs` / `mlflow.spanOutputs`.
+
+    Args:
+        events: A list of event dictionaries, each optionally containing an "attributes"
+            mapping, or `None` if no events are available.
+
+    Returns:
+        A dictionary containing the merged attributes from all provided events.
     """
 
     merged: dict[str, Any] = {}

--- a/mlflow/tracing/utils/truncation.py
+++ b/mlflow/tracing/utils/truncation.py
@@ -41,12 +41,24 @@ def _get_truncated_preview(request_or_response: str | dict[str, Any] | None, rol
     elif isinstance(request_or_response, str):
         try:
             obj = json.loads(request_or_response)
+            # Some attributes are JSON-encoded twice (e.g. a JSON string that itself contains
+            # a JSON list/dict). Attempt a second decode so we can still extract message previews.
+            if isinstance(obj, str):
+                try:
+                    obj = json.loads(obj)
+                except json.JSONDecodeError:
+                    pass
         except json.JSONDecodeError:
             pass
 
     if obj is not None:
         if messages := _try_extract_messages(obj):
-            msg = _get_last_message(messages, role=role)
+            # For GenAI semconv `gen_ai.*.messages`, users typically want the initial user prompt
+            # and the final assistant response as quick previews.
+            if isinstance(obj, list) and role == "user":
+                msg = _get_first_message(messages, role=role)
+            else:
+                msg = _get_last_message(messages, role=role)
             content = _get_text_content_from_message(msg)
 
     content = content or request_or_response
@@ -67,7 +79,11 @@ def _get_max_length() -> int:
     )
 
 
-def _try_extract_messages(obj: dict[str, Any]) -> list[dict[str, Any]] | None:
+def _try_extract_messages(obj: Any) -> list[dict[str, Any]] | None:
+    # GenAI semconv `gen_ai.*.messages` is a JSON array of messages.
+    if isinstance(obj, list):
+        return [item for item in obj if _is_message(item)]
+
     if not isinstance(obj, dict):
         return None
 
@@ -102,7 +118,29 @@ def _try_extract_messages(obj: dict[str, Any]) -> list[dict[str, Any]] | None:
 
 
 def _is_message(item: Any) -> bool:
-    return isinstance(item, dict) and "role" in item and "content" in item
+    if not isinstance(item, dict) or "role" not in item:
+        return False
+
+    # OpenAI ChatCompletion / Responses formats
+    if "content" in item:
+        return True
+
+    # GenAI semconv format: {"role": "user", "parts": [{"type": "text", "content": "..."}]}
+    if "parts" in item and isinstance(item["parts"], list):
+        return True
+
+    return False
+
+
+def _get_first_message(messages: list[dict[str, Any]], role: str) -> dict[str, Any]:
+    """Return first message with the given role.
+
+    If the messages don't include a message with the given role, return the first one.
+    """
+    for message in messages:
+        if message.get("role") == role:
+            return message
+    return messages[0]
 
 
 def _get_last_message(messages: list[dict[str, Any]], role: str) -> dict[str, Any]:
@@ -117,14 +155,29 @@ def _get_last_message(messages: list[dict[str, Any]], role: str) -> dict[str, An
 
 
 def _get_text_content_from_message(message: dict[str, Any]) -> str:
+    # OpenAI ChatCompletion / Responses formats
     content = message.get("content")
     if isinstance(content, list):
         # content is a list of content parts
         for part in content:
             if isinstance(part, str):
                 return part
-            elif isinstance(part, dict) and part.get("type") in ["text", "output_text"]:
-                return part.get("text")
+            if isinstance(part, dict) and part.get("type") in ["text", "output_text"]:
+                text = part.get("text")
+                return text if isinstance(text, str) else ""
     elif isinstance(content, str):
         return content
+
+    # GenAI semconv format: message.parts[].content
+    parts = message.get("parts")
+    if isinstance(parts, list):
+        for part in parts:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") != "text":
+                continue
+            text = part.get("content") or part.get("text")
+            if isinstance(text, str):
+                return text
+
     return ""

--- a/mlflow/tracing/utils/truncation.py
+++ b/mlflow/tracing/utils/truncation.py
@@ -135,7 +135,14 @@ def _is_message(item: Any) -> bool:
 def _get_first_message(messages: list[dict[str, Any]], role: str) -> dict[str, Any]:
     """Return first message with the given role.
 
-    If the messages don't include a message with the given role, return the first one.
+    If no message with the given role exists, return the first message.
+
+    Args:
+        messages: List of message dictionaries.
+        role: Role to search for (e.g. "user", "assistant", "system").
+
+    Returns:
+        The first message with the specified role, or the first message if no match is found.
     """
     for message in messages:
         if message.get("role") == role:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/okamototk/mlflow/pull/19730?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19730/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19730/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19730/merge
```

</p>
</details>

### What changes are proposed in this pull request?

This is still draft but I would like to create PR to share my work.

Improve OTEL GenAI SemConv support for Strands/Microsoft Agent Framework especially Trace/Summary pages:

* Set request_preview/response_preview from gen_ai.[input|output].messages to show input message in modal title on Trace/Summary page.
* Show system/user prompts in input and assistant message in output field.
* Enable experiment inference from service.name resource attribute when experiment ID header is missing

These are improved screenshot:

* Strands
<img width="776" height="587" alt="スクリーンショット 2026-01-03 19 23 38" src="https://github.com/user-attachments/assets/63d97d1d-0533-43a4-80bf-7144459df0c0" />

* MAF
<img width="782" height="663" alt="スクリーンショット 2026-01-03 19 26 37" src="https://github.com/user-attachments/assets/bf1b65b9-0644-45bc-89a0-8b38de437028" />


### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (checking actual web pages)

* Strands
  * Using following sample and enable otel export:
    * https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/01-tutorials/01-AgentCore-runtime/01-hosting-agent/01-strands-with-bedrock-model/runtime_with_strands_and_bedrock_models.ipynb

* MAF
  * Using sample code attached

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

* Improve OTEL gen_ai semconv compatibility for trace/summary for Strands and MAF.
* Enable experiment inference from service.name resource attribute when experiment ID header is missing

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes


#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
