### PR TITLE
Fix KnowledgeRetention model parameter not propagating to inner scorer

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -2612,6 +2612,11 @@ class KnowledgeRetention(BuiltInSessionLevelScorer):
         "in earlier conversation turns without forgetting, contradicting, or distorting it."
     )
 
+    def model_post_init(self, __context: Any) -> None:
+        """Propagate model parameter to the inner last_turn_scorer after initialization."""
+        if self.model is not None:
+            self.last_turn_scorer.model = self.model
+
     def _create_judge(self) -> Judge:
         """
         This method is required by BuiltInSessionLevelScorer but is not used.

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import json
 import logging
@@ -2615,6 +2616,8 @@ class KnowledgeRetention(BuiltInSessionLevelScorer):
     def model_post_init(self, __context: Any) -> None:
         """Propagate model parameter to the inner last_turn_scorer after initialization."""
         if self.model is not None:
+            # Make a copy to avoid mutating the caller's scorer
+            self.last_turn_scorer = copy.deepcopy(self.last_turn_scorer)
             self.last_turn_scorer.model = self.model
 
     def _create_judge(self) -> Judge:

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -2191,11 +2191,13 @@ def test_knowledge_retention_model_propagation():
     scorer_default = KnowledgeRetention()
     assert scorer_default.last_turn_scorer.model is None
 
-    # When custom last_turn_scorer is provided with model override
+    # When custom last_turn_scorer is provided with model override,
+    # the original scorer should NOT be mutated (we make a copy)
     custom_scorer = Mock(spec=Scorer)
     custom_scorer.model = None
-    KnowledgeRetention(model="override-model", last_turn_scorer=custom_scorer)
-    assert custom_scorer.model == "override-model"
+    kr = KnowledgeRetention(model="override-model", last_turn_scorer=custom_scorer)
+    assert custom_scorer.model is None  # original unchanged
+    assert kr.last_turn_scorer.model == "override-model"  # copy has new model
 
 
 def test_session_level_scorer_with_invalid_kwargs():

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -2182,6 +2182,22 @@ def test_knowledge_retention_empty_session():
         scorer(session=[])
 
 
+def test_knowledge_retention_model_propagation():
+    # When model is specified, it should propagate
+    scorer = KnowledgeRetention(model="custom-model")
+    assert scorer.last_turn_scorer.model == "custom-model"
+
+    # When model is None (default), last_turn_scorer keeps its default
+    scorer_default = KnowledgeRetention()
+    assert scorer_default.last_turn_scorer.model is None
+
+    # When custom last_turn_scorer is provided with model override
+    custom_scorer = Mock(spec=Scorer)
+    custom_scorer.model = None
+    KnowledgeRetention(model="override-model", last_turn_scorer=custom_scorer)
+    assert custom_scorer.model == "override-model"
+
+
 def test_session_level_scorer_with_invalid_kwargs():
     scorer = UserFrustration()
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/danielseong1/mlflow/pull/19753?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19753/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19753/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19753/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

When creating a `KnowledgeRetention` scorer with a custom `model` parameter, the model was not being propagated to the inner `last_turn_scorer`. This PR adds a `model_post_init` method to propagate the model parameter after initialization.

**Changes:**
- Added `model_post_init` method to `KnowledgeRetention` class that propagates the `model` parameter to `last_turn_scorer`
- Added unit test to verify model propagation behavior

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_knowledge_retention_model_propagation` test that verifies:
1. Model propagates when specified
2. Model stays `None` when not specified  
3. Model propagates to custom `last_turn_scorer` when provided

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)