### PR TITLE
bug(tracing): POC for multiple OTel sources

### DIFF
--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -126,7 +126,8 @@ class MlflowV3SpanExporter(SpanExporter):
         """
         manager = InMemoryTraceManager.get_instance()
         for span in spans:
-            if span._parent is not None:
+            should_be_root_span = span.name == "abatch"
+            if span._parent is not None and not should_be_root_span:
                 continue
 
             manager_trace = manager.pop_trace(span.context.trace_id)

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -136,7 +136,8 @@ def start_span_in_context(name: str, experiment_id: str | None = None) -> trace.
         attributes[SpanAttributeKey.EXPERIMENT_ID] = json.dumps(experiment_id)
     span = _get_tracer(__name__).start_span(name, attributes=attributes)
 
-    if experiment_id and getattr(span, "_parent", None):
+    should_be_root_span = name == "abatch"
+    if experiment_id and getattr(span, "_parent", None) and not should_be_root_span:
         _logger.warning(
             "The `experiment_id` parameter can only be used for root spans, but the span "
             f"`{name}` is not a root span. The specified value `{experiment_id}` will be ignored."
@@ -178,7 +179,8 @@ def start_detached_span(
         attributes[SpanAttributeKey.EXPERIMENT_ID] = json.dumps(experiment_id)
     span = tracer.start_span(name, context=context, attributes=attributes, start_time=start_time_ns)
 
-    if experiment_id and getattr(span, "_parent", None):
+    should_be_root_span = name == "abatch"
+    if experiment_id and getattr(span, "_parent", None) and not should_be_root_span:
         _logger.warning(
             "The `experiment_id` parameter can only be used for root spans, but the span "
             f"`{name}` is not a root span. The specified value `{experiment_id}` will be ignored."

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -188,8 +188,9 @@ def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
     roots: list[LiveSpan] = []
 
     for span in spans:
+        should_be_root_span = span.name == "abatch"
         parent_id = span.parent_id
-        if parent_id and parent_id in span_id_to_spans:
+        if parent_id and parent_id in span_id_to_spans and not should_be_root_span:
             children_map[parent_id].append(span)
         else:
             roots.append(span)


### PR DESCRIPTION
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs
<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #19035

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
- This PR is to POC changes required to successfully log MLflow traces while using existing OpenTelemetry instrumentation for other packages.
- Relevant environment variables:
```
MLFLOW_USE_DEFAULT_TRACER_PROVIDER=True  # default, ensures isolated tracer provider
MLFLOW_ENABLE_OTLP_EXPORTER=False  # required if `OTEL_EXPORTER_OTLP_ENDPOINT` is set separately for other telemetry
OTEL_PYTHON_REQUESTS_EXCLUDED_URLS=my.databricks.domain.com  # required to avoid exporting auto-instrumented `requests` traces to /oidc and other databricks mlflow APIs
```
- The solution proposed here is not robust - it relies on the fact that I know the `abatch` method is the entrypoint/intended root span. However, it is not recognized as a root span, due to existing spans from other auto-instrumented packages (FastAPI, Celery, etc.) leveraging my other tracer provider
- The point of this draft PR is to illustrate all of the points of failure when tracing langchain code with MLflow

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
