### PR TITLE
Fix scorer creation UX issues

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -146,6 +146,7 @@ def serve_upload_artifact():
 # and render them in the Trace UI. The request body should contain the request_id
 # of the trace.
 @app.route(_add_static_prefix("/ajax-api/2.0/mlflow/get-trace-artifact"), methods=["GET"])
+@app.route(_add_static_prefix("/ajax-api/3.0/mlflow/get-trace-artifact"), methods=["GET"])
 def serve_get_trace_artifact():
     return get_trace_artifact_handler()
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
@@ -183,10 +183,7 @@ const NameSection: React.FC<NameSectionProps> = ({ mode, control }) => {
         <FormattedMessage defaultMessage="Name" description="Section header for optional judge name" />
       </FormUI.Label>
       <FormUI.Hint>
-        <FormattedMessage
-          defaultMessage="Must be unique in this experiment. Cannot be changed after creation."
-          description="Hint text for Name section"
-        />
+        <FormattedMessage defaultMessage="Cannot be changed after creation." description="Hint text for Name section" />
       </FormUI.Hint>
       <Controller
         name="name"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
@@ -19,8 +19,6 @@ import { SelectSessionsModal } from '../../components/SelectSessionsModal';
 
 enum PickerOption {
   'LAST_TRACE_OR_SESSION' = '1',
-  'LAST_5_TRACES_OR_SESSIONS' = '5',
-  'LAST_10_TRACES_OR_SESSIONS' = '10',
   'CUSTOM' = 'custom',
 }
 
@@ -28,14 +26,6 @@ const PickerOptionsLabelsForTraces = {
   [PickerOption.LAST_TRACE_OR_SESSION]: defineMessage({
     defaultMessage: 'Last trace',
     description: 'Option for last trace',
-  }),
-  [PickerOption.LAST_5_TRACES_OR_SESSIONS]: defineMessage({
-    defaultMessage: 'Last 5 traces',
-    description: 'Option for last 5 traces',
-  }),
-  [PickerOption.LAST_10_TRACES_OR_SESSIONS]: defineMessage({
-    defaultMessage: 'Last 10 traces',
-    description: 'Option for last 10 traces',
   }),
   [PickerOption.CUSTOM]: defineMessage({
     defaultMessage: 'Select traces',
@@ -47,14 +37,6 @@ const PickerOptionsLabelsForSessions = {
   [PickerOption.LAST_TRACE_OR_SESSION]: defineMessage({
     defaultMessage: 'Last session',
     description: 'Option for last session',
-  }),
-  [PickerOption.LAST_5_TRACES_OR_SESSIONS]: defineMessage({
-    defaultMessage: 'Last 5 sessions',
-    description: 'Option for last 5 sessions',
-  }),
-  [PickerOption.LAST_10_TRACES_OR_SESSIONS]: defineMessage({
-    defaultMessage: 'Last 10 sessions',
-    description: 'Option for last 10 sessions',
   }),
   [PickerOption.CUSTOM]: defineMessage({
     defaultMessage: 'Select sessions',
@@ -81,7 +63,7 @@ export const SampleScorerTracesToEvaluatePicker = ({
     if (!isEmpty(itemsToEvaluate.itemIds)) {
       return PickerOption.CUSTOM;
     }
-    return coerceToEnum(PickerOption, String(itemsToEvaluate.itemCount), PickerOption.LAST_10_TRACES_OR_SESSIONS);
+    return coerceToEnum(PickerOption, String(itemsToEvaluate.itemCount), PickerOption.LAST_TRACE_OR_SESSION);
   }, [itemsToEvaluate]);
 
   return (
@@ -118,21 +100,15 @@ export const SampleScorerTracesToEvaluatePicker = ({
         </DialogComboboxCustomButtonTriggerWrapper>
         <DialogComboboxContent align="end">
           <DialogComboboxOptionList>
-            {[
-              PickerOption.LAST_TRACE_OR_SESSION,
-              PickerOption.LAST_5_TRACES_OR_SESSIONS,
-              PickerOption.LAST_10_TRACES_OR_SESSIONS,
-            ].map((value) => (
-              <DialogComboboxOptionListSelectItem
-                value={value}
-                checked={itemsToEvaluateDropdownValue === value}
-                onChange={() => {
-                  onItemsToEvaluateChange({ itemCount: Number(value), itemIds: undefined });
-                }}
-              >
-                <FormattedMessage {...PickerOptionsLabels[value]} />
-              </DialogComboboxOptionListSelectItem>
-            ))}
+            <DialogComboboxOptionListSelectItem
+              value={PickerOption.LAST_TRACE_OR_SESSION}
+              checked={itemsToEvaluateDropdownValue === PickerOption.LAST_TRACE_OR_SESSION}
+              onChange={() => {
+                onItemsToEvaluateChange({ itemCount: Number(PickerOption.LAST_TRACE_OR_SESSION), itemIds: undefined });
+              }}
+            >
+              <FormattedMessage {...PickerOptionsLabels[PickerOption.LAST_TRACE_OR_SESSION]} />
+            </DialogComboboxOptionListSelectItem>
             <DialogComboboxOptionListSelectItem
               value={PickerOption.CUSTOM}
               checked={itemsToEvaluateDropdownValue === PickerOption.CUSTOM}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useGetSessionsForEvaluation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useGetSessionsForEvaluation.tsx
@@ -4,7 +4,7 @@ import { QueryClient, useQueryClient } from '@databricks/web-shared/query-client
 import { groupTracesBySession } from '@databricks/web-shared/genai-traces-table/sessions-table/utils';
 import { ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
 import { EvaluateTracesParams } from './types';
-import { isEmpty } from 'lodash';
+import { isEmpty, sortBy } from 'lodash';
 
 const fetchSessions = async (
   queryClient: QueryClient,
@@ -37,7 +37,7 @@ const fetchSessions = async (
 
   const sessionArray = Object.entries(sessions).map(([sessionId, traceInfos]) => ({
     sessionId,
-    traceInfos,
+    traceInfos: sortBy(traceInfos, (trace) => new Date(trace.request_time)),
   }));
 
   if (itemIds && !isEmpty(itemIds)) {

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
@@ -9,6 +9,7 @@ import {
   Spinner,
   ChevronLeftIcon,
   ChevronRightIcon,
+  Alert,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useProvidersQuery } from '../../hooks/useProvidersQuery';
@@ -247,13 +248,13 @@ const ProviderSelectCombobox = ({
       setViewMode('common');
       comboboxState.setInputValue('');
     }
-  }, [comboboxState.isOpen, comboboxState]);
+  }, [comboboxState.isOpen, comboboxState.setInputValue]);
 
   useEffect(() => {
     if (!comboboxState.isOpen) {
       comboboxState.setInputValue(selectedDisplayName);
     }
-  }, [selectedDisplayName, comboboxState.isOpen, comboboxState]);
+  }, [selectedDisplayName, comboboxState.isOpen, comboboxState.setInputValue]);
 
   const getItemKey = (item: MenuItem) => {
     if (item.type === 'group') return `group-${item.groupId}`;
@@ -395,7 +396,7 @@ export const ProviderSelect = ({
   componentIdPrefix = 'mlflow.gateway.provider-select',
 }: ProviderSelectProps) => {
   const { theme } = useDesignSystemTheme();
-  const { data: providers, isLoading } = useProvidersQuery();
+  const { data: providers, isLoading, error: queryError } = useProvidersQuery();
 
   const { commonItems, litellmItems, otherProviders } = useMemo(() => {
     if (!providers)
@@ -471,6 +472,22 @@ export const ProviderSelect = ({
     },
     [onChange],
   );
+
+  if (queryError) {
+    return (
+      <div>
+        <FormUI.Label htmlFor={componentIdPrefix}>
+          <FormattedMessage defaultMessage="Provider" description="Label for provider select field" />
+        </FormUI.Label>
+        <Alert
+          componentId={`${componentIdPrefix}.error`}
+          type="error"
+          message={queryError.message}
+          css={{ marginTop: theme.spacing.xs }}
+        />
+      </div>
+    );
+  }
 
   if (isLoading || commonItems.length === 0) {
     return (

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -862,10 +862,6 @@
     "defaultMessage": "Experiment Runs - Databricks",
     "description": "Title on a page used to manage MLflow experiments runs"
   },
-  "5Jg2dq": {
-    "defaultMessage": "Last 10 traces",
-    "description": "Option for last 10 traces"
-  },
   "5Mzn2b": {
     "defaultMessage": "Creator",
     "description": "Label name for creator metadata in model version page"
@@ -3661,10 +3657,6 @@
     "defaultMessage": "Last session",
     "description": "Option for last session"
   },
-  "SXKt8h": {
-    "defaultMessage": "Must be unique in this experiment. Cannot be changed after creation.",
-    "description": "Hint text for Name section"
-  },
   "SZj964": {
     "defaultMessage": "Copy S3 URI to clipboard",
     "description": "Text for the HTTP/HF location link in the experiment run dataset drawer"
@@ -4282,10 +4274,6 @@
   "Xs1oJm": {
     "defaultMessage": "Search metric charts",
     "description": "Run page > Charts tab > Filter metric charts input > placeholder"
-  },
-  "XutL+P": {
-    "defaultMessage": "Last 5 traces",
-    "description": "Option for last 5 traces"
   },
   "Xuz/xh": {
     "defaultMessage": "Models",
@@ -4990,10 +4978,6 @@
   "cy9EfG": {
     "defaultMessage": "Attributes",
     "description": "Experiment page > group by runs control > attributes section label"
-  },
-  "d+WXp2": {
-    "defaultMessage": "Last 5 sessions",
-    "description": "Option for last 5 sessions"
   },
   "d00egE": {
     "defaultMessage": "No span with type RETRIEVER found in trace.",
@@ -5814,10 +5798,6 @@
   "j7cj5r": {
     "defaultMessage": "Please log at least one table artifact containing evaluation data. <link>Learn more</link>.",
     "description": "Experiment page > artifact compare view > empty state for no evaluation tables logged > subtitle"
-  },
-  "j9F8Nt": {
-    "defaultMessage": "Last 10 sessions",
-    "description": "Option for last 10 sessions"
   },
   "jA7Y1x": {
     "defaultMessage": "Edit API key",
@@ -6710,6 +6690,10 @@
   "qNCHNh": {
     "defaultMessage": "Select model",
     "description": "Model selector modal title"
+  },
+  "qNaoD5": {
+    "defaultMessage": "Cannot be changed after creation.",
+    "description": "Hint text for Name section"
   },
   "qNtagt": {
     "defaultMessage": "Track and compare versions of your GenAI app",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/danielseong1/mlflow/pull/19756?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19756/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19756/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19756/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Small UX improvements for the scorer creation flow:

- **Simplify trace/session picker**: Removed "Last 5" and "Last 10" options, now just "Last" and "Select custom" for a cleaner interface
- **Sort session traces chronologically**: Traces within sessions are now sorted by `request_time` for consistent ordering
- **Correct Name field hint**: Removed "Must be unique in this experiment" text since it's not valid for OSS
- **Add provider query error handling**: ProviderSelect now displays an error alert when the providers query fails
- **Fix infinite render loop**: Fixed infinite render loop caused by useEffect dependency array in ProviderSelect
- **Add 3.0 API route**: Added `/ajax-api/3.0/mlflow/get-trace-artifact` endpoint

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual testing of scorer creation flow verified the UX improvements work as expected.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved scorer creation UX with simplified trace/session picker options and better error handling.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)