### PR TITLE
Remove databricks-connect workarounds

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -299,15 +299,6 @@ jobs:
           pytest tests/genai --ignore tests/genai/test_genai_import_without_agent_sdk.py \
             --ignore tests/genai/optimize --ignore tests/genai/prompts
 
-      - name: Run Tests with Local Spark Session
-        run: |
-          # databricks-agents installs databricks-connect that blocks us from running spark-related
-          # tests with local spark session. To work around this, we run skipped tests after
-          # uninstalling databricks-connect.
-          pip uninstall -y databricks-connect pyspark
-          pip install pyspark
-          pytest tests/genai/evaluate/test_utils.py
-
   pyfunc:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -634,10 +634,6 @@ langchain:
           # required for testing legacy modules
           "langchain-classic",
         ]
-    pre_test: |
-      # Installing both pyspark and databricks-connect causes a conflict
-      pip uninstall -y databricks-connect
-      pip install --no-deps --force-reinstall pyspark
     run: |
       # Some dependencies above includes 'mlflow-skinny' but not full 'mlflow', such as databricks-vectorsearch.
       # This causes installation of mlflow-skinny from stable version, while 'mlflow' points to the dev version,
@@ -663,10 +659,6 @@ langchain:
           "langchain-openai>=0.2.0",
         ]
       ">= 1.0.0": ["langchain-classic"]
-    pre_test: |
-      # Installing both pyspark and databricks-connect causes a conflict
-      pip uninstall -y databricks-connect
-      pip install --no-deps --force-reinstall pyspark
     run: |
       pytest tests/langchain/test_langchain_autolog.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -634,6 +634,10 @@ langchain:
           # required for testing legacy modules
           "langchain-classic",
         ]
+    pre_test: |
+      # Installing both pyspark and databricks-connect causes a conflict
+      pip uninstall -y databricks-connect
+      pip install --no-deps --force-reinstall pyspark
     run: |
       # Some dependencies above includes 'mlflow-skinny' but not full 'mlflow', such as databricks-vectorsearch.
       # This causes installation of mlflow-skinny from stable version, while 'mlflow' points to the dev version,
@@ -659,6 +663,10 @@ langchain:
           "langchain-openai>=0.2.0",
         ]
       ">= 1.0.0": ["langchain-classic"]
+    pre_test: |
+      # Installing both pyspark and databricks-connect causes a conflict
+      pip uninstall -y databricks-connect
+      pip install --no-deps --force-reinstall pyspark
     run: |
       pytest tests/langchain/test_langchain_autolog.py
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/19769?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19769/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19769/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19769/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Depends on #19780. `databricks-agents` no longer depends on `databricks-connect`, so we can remove the workarounds that were needed to handle the conflict between `databricks-connect` and `pyspark`.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)