### PR TITLE
Add debug logging for 500 errors in catch_mlflow_exception

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -793,6 +793,8 @@ def catch_mlflow_exception(func):
             response = Response(mimetype="application/json")
             response.set_data(e.serialize_as_json())
             response.status_code = e.get_http_status_code()
+            if response.status_code >= 500:
+                _logger.debug(f"Error in {func.__name__}: {e}", exc_info=True)
             return response
 
     return wrapper


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/19781?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19781/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19781/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19781/merge
```

</p>
</details>

### What changes are proposed in this pull request?

When `MlflowException` results in a 500 status code, log the error with full traceback at DEBUG level. This helps with debugging server-side issues that were previously silent - the `catch_mlflow_exception` decorator was catching and returning errors to clients but not logging them on the server side.

To see the logs, users can set `MLFLOW_LOGGING_LEVEL=DEBUG`.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add debug logging for 500 errors in server handlers to help with debugging server-side issues.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)