### PR TITLE
Improve error logging for 5xx responses in catch_mlflow_exception

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -799,7 +799,10 @@ def catch_mlflow_exception(func):
             response.set_data(e.serialize_as_json())
             response.status_code = e.get_http_status_code()
             if response.status_code >= 500:
-                _logger.debug(f"Error in {func.__name__}: {e}", exc_info=True)
+                _logger.error(
+                    f"Error in {func.__name__}: {e}",
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
+                )
             return response
 
     return wrapper

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -799,10 +799,11 @@ def catch_mlflow_exception(func):
             response.set_data(e.serialize_as_json())
             response.status_code = e.get_http_status_code()
             if response.status_code >= 500:
-                _logger.error(
-                    f"Error in {func.__name__}: {e}",
-                    exc_info=_logger.isEnabledFor(logging.DEBUG),
-                )
+                is_debug = _logger.isEnabledFor(logging.DEBUG)
+                msg = f"Error in {func.__name__}: {e}"
+                if not is_debug:
+                    msg += ". Set MLFLOW_LOGGING_LEVEL=DEBUG for traceback."
+                _logger.error(msg, exc_info=is_debug)
             return response
 
     return wrapper


### PR DESCRIPTION
### Related Issues/PRs

#19781

### What changes are proposed in this pull request?

Improves 5xx error logging in `catch_mlflow_exception` introduced in #19781:
- Change logging level from `debug` to `error` so server errors are visible by default
- Include traceback only when debug mode is enabled (`MLFLOW_LOGGING_LEVEL=DEBUG`) to keep production logs clean

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)