### PR TITLE
Allow params key in parse_tf_serving_input for MLServer

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -648,7 +648,9 @@ def parse_tf_serving_input(inp_dict, schema=None):
     if "signature_name" in inp_dict:
         raise MlflowInvalidInputException('"signature_name" parameter is currently not supported')
 
-    if not (list(inp_dict.keys()) == ["instances"] or list(inp_dict.keys()) == ["inputs"]):
+    # Allow optional "params" key alongside data keys (for MLServer compatibility)
+    data_keys = set(inp_dict.keys()) - {"params"}
+    if data_keys not in ({"instances"}, {"inputs"}):
         raise MlflowInvalidInputException(
             'One of "instances" and "inputs" must be specified (not both or any other keys).'
             f"Received: {list(inp_dict.keys())}"

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -449,6 +449,33 @@ def test_parse_tf_serving_raises_expected_errors():
         parse_tf_serving_input(tfserving_input)
 
 
+def test_parse_tf_serving_input_with_params():
+    # Verify params key is tolerated alongside instances/inputs (for MLServer compatibility)
+    # With instances - single array
+    result = parse_tf_serving_input({"instances": [[1, 2, 3], [4, 5, 6]], "params": {"top_k": 5}})
+    expected = np.array([[1, 2, 3], [4, 5, 6]], dtype="int64")
+    assert (result == expected).all()
+
+    # With instances - list of dicts
+    result = parse_tf_serving_input(
+        {"instances": [{"a": 1, "b": 2}, {"a": 3, "b": 4}], "params": {"temperature": 0.7}}
+    )
+    assert (result["a"] == np.array([1, 3])).all()
+    assert (result["b"] == np.array([2, 4])).all()
+
+    # With inputs - dict format
+    result = parse_tf_serving_input(
+        {"inputs": {"a": [1, 2], "b": [3, 4]}, "params": {"capture": True}}
+    )
+    assert (result["a"] == np.array([1, 2])).all()
+    assert (result["b"] == np.array([3, 4])).all()
+
+    # With inputs - single array
+    result = parse_tf_serving_input({"inputs": [[1, 2], [3, 4]], "params": {"max_tokens": 100}})
+    expected = np.array([[1, 2], [3, 4]], dtype="int64")
+    assert (result == expected).all()
+
+
 def test_dataframe_from_json():
     source = pd.DataFrame(
         {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sinanshamsudheen/mlflow/pull/19808?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19808/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19808/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19808/merge
```

</p>
</details>

### Related Issues/PRs

Resolves #19667

### What changes are proposed in this pull request?

Allow [params](cci:1://file:///home/zero/OpenSource/mlflow/mlflow/models/utils.py:125:0-130:13) key in [parse_tf_serving_input](cci:1://file:///home/zero/OpenSource/mlflow/mlflow/utils/proto_json_utils.py:638:0-678:16) so MLServer can accept inference parameters.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed inference requests with [params](cci:1://file:///home/zero/OpenSource/mlflow/mlflow/models/utils.py:125:0-130:13) being rejected when using MLServer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/scoring`

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix`

#### Should this PR be included in the next patch release?

- [x] Yes
- [ ] No