### PR TITLE
Implemented process-level system metrics tracking

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -239,7 +239,9 @@ if not IS_TRACING_SDK_ONLY:
     # For backward compatibility, we expose the following functions and classes at the top level in
     # addition to `mlflow.config`.
     from mlflow.config import (
+        disable_process_metrics,
         disable_system_metrics_logging,
+        enable_process_metrics,
         enable_system_metrics_logging,
         get_registry_uri,
         set_registry_uri,
@@ -334,8 +336,10 @@ if not IS_TRACING_SDK_ONLY:
         "delete_experiment",
         "delete_run",
         "delete_tag",
+        "disable_process_metrics",
         "disable_system_metrics_logging",
         "doctor",
+        "enable_process_metrics",
         "enable_system_metrics_logging",
         "end_run",
         "evaluate",

--- a/mlflow/config/__init__.py
+++ b/mlflow/config/__init__.py
@@ -2,7 +2,9 @@ from mlflow.environment_variables import (
     MLFLOW_ENABLE_ASYNC_LOGGING,
 )
 from mlflow.system_metrics import (
+    disable_process_metrics,
     disable_system_metrics_logging,
+    enable_process_metrics,
     enable_system_metrics_logging,
     set_system_metrics_node_id,
     set_system_metrics_samples_before_logging,
@@ -42,15 +44,17 @@ def enable_async_logging(enable=True):
 
 
 __all__ = [
-    "enable_system_metrics_logging",
+    "disable_process_metrics",
     "disable_system_metrics_logging",
     "enable_async_logging",
+    "enable_process_metrics",
+    "enable_system_metrics_logging",
     "get_registry_uri",
     "get_tracking_uri",
     "is_tracking_uri_set",
     "set_registry_uri",
-    "set_system_metrics_sampling_interval",
-    "set_system_metrics_samples_before_logging",
     "set_system_metrics_node_id",
+    "set_system_metrics_samples_before_logging",
+    "set_system_metrics_sampling_interval",
     "set_tracking_uri",
 ]

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -521,6 +521,20 @@ MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING = _EnvironmentVariable(
 #: training) setup.
 MLFLOW_SYSTEM_METRICS_NODE_ID = _EnvironmentVariable("MLFLOW_SYSTEM_METRICS_NODE_ID", str, None)
 
+#: Specifies whether to include process-level metrics (CPU, memory, threads of the current process
+#: and its children) in addition to system-wide metrics. Useful in shared/multi-tenant environments.
+#: (default: ``False``)
+MLFLOW_SYSTEM_METRICS_INCLUDE_PROCESS = _BooleanEnvironmentVariable(
+    "MLFLOW_SYSTEM_METRICS_INCLUDE_PROCESS", False
+)
+
+#: Specifies whether to include child processes when collecting process-level metrics.
+#: Only effective when MLFLOW_SYSTEM_METRICS_INCLUDE_PROCESS is True.
+#: (default: ``True``)
+MLFLOW_SYSTEM_METRICS_INCLUDE_CHILD_PROCESSES = _BooleanEnvironmentVariable(
+    "MLFLOW_SYSTEM_METRICS_INCLUDE_CHILD_PROCESSES", True
+)
+
 
 # Private environment variable to specify the number of chunk download retries for multipart
 # download.

--- a/mlflow/system_metrics/__init__.py
+++ b/mlflow/system_metrics/__init__.py
@@ -2,6 +2,8 @@
 
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING,
+    MLFLOW_SYSTEM_METRICS_INCLUDE_CHILD_PROCESSES,
+    MLFLOW_SYSTEM_METRICS_INCLUDE_PROCESS,
     MLFLOW_SYSTEM_METRICS_NODE_ID,
     MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING,
     MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL,
@@ -59,3 +61,37 @@ def set_system_metrics_node_id(node_id):
         MLFLOW_SYSTEM_METRICS_NODE_ID.unset()
     else:
         MLFLOW_SYSTEM_METRICS_NODE_ID.set(node_id)
+
+
+def enable_process_metrics(include_children=True):
+    """Enable process-level metrics logging.
+
+    When enabled, MLflow will log CPU, memory, thread count, and file descriptor metrics
+    specific to the current Python process (and optionally its child processes), rather than
+    just system-wide metrics. This is particularly useful in shared environments where
+    multiple processes run on the same machine.
+
+    Args:
+        include_children: If True (default), also aggregate metrics from child processes.
+            This is useful for tracking resource usage of subprocesses spawned by your
+            training script.
+
+    Example:
+        >>> import mlflow
+        >>> mlflow.enable_system_metrics_logging()
+        >>> mlflow.enable_process_metrics()  # Enable process-level tracking
+        >>> with mlflow.start_run():
+        ...     # Your training code here
+        ...     pass
+        >>> # Process metrics like system/process_cpu_percentage will be logged
+    """
+    MLFLOW_SYSTEM_METRICS_INCLUDE_PROCESS.set(True)
+    MLFLOW_SYSTEM_METRICS_INCLUDE_CHILD_PROCESSES.set(include_children)
+
+
+def disable_process_metrics():
+    """Disable process-level metrics logging.
+
+    After calling this, only system-wide metrics will be logged (the default behavior).
+    """
+    MLFLOW_SYSTEM_METRICS_INCLUDE_PROCESS.set(False)

--- a/mlflow/system_metrics/metrics/process_monitor.py
+++ b/mlflow/system_metrics/metrics/process_monitor.py
@@ -1,0 +1,116 @@
+"""Class for monitoring process-level stats."""
+
+import logging
+import os
+
+import psutil
+
+from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+
+_logger = logging.getLogger(__name__)
+
+
+class ProcessMonitor(BaseMetricsMonitor):
+    """Monitor metrics for the current process and optionally its children.
+
+    This monitor tracks CPU, memory, thread count, and open file descriptors
+    for the current Python process. When `include_children` is True, metrics
+    from all child processes are aggregated.
+    """
+
+    def __init__(self, include_children: bool = True):
+        """Initialize the ProcessMonitor.
+
+        Args:
+            include_children: If True, aggregate metrics from child processes.
+        """
+        super().__init__()
+        self._include_children = include_children
+        try:
+            self._process = psutil.Process(os.getpid())
+            # Initialize cpu_percent to avoid first-call returning 0
+            self._process.cpu_percent()
+        except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
+            _logger.warning(f"Failed to initialize ProcessMonitor: {e}")
+            self._process = None
+
+    def _get_processes(self):
+        """Get the list of processes to monitor."""
+        if self._process is None:
+            return []
+
+        processes = [self._process]
+        if self._include_children:
+            try:
+                processes.extend(self._process.children(recursive=True))
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        return processes
+
+    def collect_metrics(self):
+        """Collect process-level metrics."""
+        if self._process is None:
+            return
+
+        processes = self._get_processes()
+        if not processes:
+            return
+
+        # Aggregate metrics across all processes
+        total_cpu_percent = 0.0
+        total_memory_rss = 0
+        total_memory_vms = 0
+        total_threads = 0
+        total_open_files = 0
+
+        for proc in processes:
+            try:
+                # CPU percentage
+                total_cpu_percent += proc.cpu_percent()
+
+                # Memory info
+                mem_info = proc.memory_info()
+                total_memory_rss += mem_info.rss
+                total_memory_vms += mem_info.vms
+
+                # Thread count
+                total_threads += proc.num_threads()
+
+                # Open file descriptors (not available on all platforms)
+                try:
+                    total_open_files += proc.num_fds()
+                except AttributeError:
+                    # num_fds() not available on Windows, use num_handles() instead
+                    try:
+                        total_open_files += proc.num_handles()
+                    except AttributeError:
+                        pass
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                # Process may have terminated or we don't have access
+                continue
+
+        # Get memory percentage relative to total system memory
+        try:
+            memory_percent = self._process.memory_percent()
+            if self._include_children:
+                # Recalculate based on total RSS
+                total_memory = psutil.virtual_memory().total
+                memory_percent = (total_memory_rss / total_memory) * 100 if total_memory > 0 else 0
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            memory_percent = 0
+
+        # Store metrics
+        self._metrics["process_cpu_percentage"].append(total_cpu_percent)
+        self._metrics["process_memory_rss_megabytes"].append(total_memory_rss / 1e6)
+        self._metrics["process_memory_vms_megabytes"].append(total_memory_vms / 1e6)
+        self._metrics["process_memory_percentage"].append(memory_percent)
+        self._metrics["process_threads"].append(total_threads)
+        self._metrics["process_open_files"].append(total_open_files)
+
+    def aggregate_metrics(self):
+        """Aggregate collected metrics by averaging."""
+        aggregated = {}
+        for key, values in self._metrics.items():
+            if values:
+                aggregated[key] = round(sum(values) / len(values), 1)
+        return aggregated

--- a/tests/system_metrics/test_process_monitor.py
+++ b/tests/system_metrics/test_process_monitor.py
@@ -1,0 +1,220 @@
+import subprocess
+import sys
+import time
+
+from mlflow.system_metrics.metrics.process_monitor import ProcessMonitor
+
+
+def test_collect_metrics_returns_expected_keys():
+    monitor = ProcessMonitor(include_children=False)
+    monitor.collect_metrics()
+
+    expected_keys = [
+        "process_cpu_percentage",
+        "process_memory_rss_megabytes",
+        "process_memory_vms_megabytes",
+        "process_memory_percentage",
+        "process_threads",
+    ]
+
+    for key in expected_keys:
+        assert key in monitor.metrics, f"Expected key '{key}' not found in metrics"
+        assert len(monitor.metrics[key]) == 1, f"Expected 1 value for '{key}'"
+
+
+def test_aggregate_metrics_returns_numeric_values():
+    monitor = ProcessMonitor(include_children=False)
+
+    # Collect multiple samples
+    for _ in range(3):
+        monitor.collect_metrics()
+        time.sleep(0.1)
+
+    aggregated = monitor.aggregate_metrics()
+
+    # Check that all values are numeric
+    for key, value in aggregated.items():
+        assert isinstance(value, (int, float)), f"Expected numeric value for '{key}'"
+        assert value >= 0, f"Expected non-negative value for '{key}'"
+
+
+def test_cpu_percentage_non_zero_after_work():
+    monitor = ProcessMonitor(include_children=False)
+
+    # Do some CPU work
+    _ = sum(i * i for i in range(100000))
+
+    monitor.collect_metrics()
+    aggregated = monitor.aggregate_metrics()
+
+    # CPU percentage should have been collected
+    assert "process_cpu_percentage" in aggregated
+
+
+def test_memory_tracking():
+    monitor = ProcessMonitor(include_children=False)
+    monitor.collect_metrics()
+    aggregated = monitor.aggregate_metrics()
+
+    # RSS and VMS should be positive
+    assert aggregated["process_memory_rss_megabytes"] > 0
+    assert aggregated["process_memory_vms_megabytes"] > 0
+    assert 0 <= aggregated["process_memory_percentage"] <= 100
+
+
+def test_thread_count():
+    monitor = ProcessMonitor(include_children=False)
+    monitor.collect_metrics()
+    aggregated = monitor.aggregate_metrics()
+
+    # Should have at least 1 thread (the main thread)
+    assert aggregated["process_threads"] >= 1
+
+
+def test_include_children_aggregates_child_processes():
+    monitor_with_children = ProcessMonitor(include_children=True)
+    monitor_without_children = ProcessMonitor(include_children=False)
+
+    # Spawn a child process that does some work
+    child_process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(2)"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        # Give the child process time to start
+        time.sleep(0.5)
+
+        monitor_with_children.collect_metrics()
+        monitor_without_children.collect_metrics()
+
+        with_children = monitor_with_children.aggregate_metrics()
+        without_children = monitor_without_children.aggregate_metrics()
+
+        # Thread count should be higher when including children
+        # (or at least equal if child has fewer threads)
+        assert with_children["process_threads"] >= without_children["process_threads"]
+
+    finally:
+        child_process.terminate()
+        child_process.wait()
+
+
+def test_clear_metrics():
+    monitor = ProcessMonitor(include_children=False)
+    monitor.collect_metrics()
+    assert len(monitor.metrics) > 0
+
+    monitor.clear_metrics()
+    assert len(monitor.metrics) == 0
+
+
+def test_handles_missing_process_gracefully():
+    monitor = ProcessMonitor(include_children=False)
+
+    # Simulate process being inaccessible
+    original_process = monitor._process
+    monitor._process = None
+
+    # Should not raise an exception
+    monitor.collect_metrics()
+    aggregated = monitor.aggregate_metrics()
+
+    # Should return empty dict when no process
+    assert aggregated == {}
+
+    # Restore
+    monitor._process = original_process
+
+
+def test_multiple_collections_aggregate_correctly():
+    monitor = ProcessMonitor(include_children=False)
+
+    # Collect 5 samples
+    for _ in range(5):
+        monitor.collect_metrics()
+
+    # Each metric should have 5 values
+    for key, values in monitor.metrics.items():
+        assert len(values) == 5, f"Expected 5 values for '{key}', got {len(values)}"
+
+    aggregated = monitor.aggregate_metrics()
+
+    # Values should be rounded to 1 decimal place
+    for key, value in aggregated.items():
+        # Check that value is properly rounded
+        assert value == round(value, 1)
+
+
+def test_process_monitor_works_with_system_monitor():
+    from mlflow.system_metrics.metrics.cpu_monitor import CPUMonitor
+
+    process_monitor = ProcessMonitor()
+    cpu_monitor = CPUMonitor()
+
+    # Both should work independently
+    process_monitor.collect_metrics()
+    cpu_monitor.collect_metrics()
+
+    process_metrics = process_monitor.aggregate_metrics()
+    cpu_metrics = cpu_monitor.aggregate_metrics()
+
+    # Both should have metrics
+    assert len(process_metrics) > 0
+    assert len(cpu_metrics) > 0
+
+    # Keys should be different (process-level vs system-level)
+    assert "process_cpu_percentage" in process_metrics
+    assert "cpu_utilization_percentage" in cpu_metrics
+
+
+def test_process_metrics_logged_to_mlflow_e2e():
+    import mlflow
+    from mlflow.environment_variables import (
+        MLFLOW_SYSTEM_METRICS_INCLUDE_CHILD_PROCESSES,
+        MLFLOW_SYSTEM_METRICS_INCLUDE_PROCESS,
+    )
+    from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
+
+    # Clean state
+    MLFLOW_SYSTEM_METRICS_INCLUDE_PROCESS.unset()
+    MLFLOW_SYSTEM_METRICS_INCLUDE_CHILD_PROCESSES.unset()
+
+    try:
+        # Enable process metrics via public API
+        mlflow.enable_process_metrics(include_children=False)
+
+        with mlflow.start_run(log_system_metrics=False) as run:
+            # Manually create monitor to control timing (like existing tests)
+            system_monitor = SystemMetricsMonitor(
+                run.info.run_id,
+                sampling_interval=0.1,
+                samples_before_logging=1,
+            )
+            system_monitor.start()
+
+            # Wait for metrics to be logged
+            time.sleep(0.5)
+
+        # Give time for metrics to finalize
+        time.sleep(0.3)
+
+        # Verify process metrics were logged
+        client = mlflow.MlflowClient()
+        run_data = client.get_run(run.info.run_id)
+        metric_keys = list(run_data.data.metrics.keys())
+
+        # Check that process metrics are present
+        process_metrics = [k for k in metric_keys if "process_" in k]
+        assert len(process_metrics) > 0, f"Expected process metrics, got: {metric_keys}"
+
+        # Verify specific process metrics exist
+        assert any("process_cpu_percentage" in k for k in metric_keys)
+        assert any("process_memory_rss_megabytes" in k for k in metric_keys)
+
+    finally:
+        # Cleanup
+        mlflow.disable_process_metrics()
+        MLFLOW_SYSTEM_METRICS_INCLUDE_PROCESS.unset()
+        MLFLOW_SYSTEM_METRICS_INCLUDE_CHILD_PROCESSES.unset()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sinanshamsudheen/mlflow/pull/19810?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19810/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19810/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19810/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #12916

### What changes are proposed in this pull request?

Adds process-level system metrics tracking via a new `ProcessMonitor` class. This enables users to track CPU, memory, threads, and file descriptors for the current Python process (and optionally child processes), rather than just system-wide metrics. Useful in shared/multi-tenant environments (SLURM clusters, Kubernetes pods) where global metrics don't reflect individual workload consumption.

**Key changes:**
- New `ProcessMonitor` class in `mlflow/system_metrics/metrics/`
- Two new environment variables: `MLFLOW_SYSTEM_METRICS_INCLUDE_PROCESS`, `MLFLOW_SYSTEM_METRICS_INCLUDE_CHILD_PROCESSES`
- Public API: `mlflow.enable_process_metrics()` and `mlflow.disable_process_metrics()`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

10 new tests in `tests/system_metrics/test_process_monitor.py` covering metric collection, aggregation, child process handling, and edge cases. All 4 existing system metrics tests continue to pass.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added process-level system metrics tracking. Users can now enable `mlflow.enable_process_metrics()` to log CPU, memory, and thread metrics for the current process instead of system-wide metrics—ideal for shared compute environments.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
