### PR TITLE
[MultiTurn] Add new telemetry for conversation simulation

### DIFF
--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -30,6 +30,8 @@ from mlflow.genai.simulators.prompts import (
     INITIAL_USER_PROMPT,
 )
 from mlflow.genai.utils.trace_utils import parse_outputs_to_str
+from mlflow.telemetry.events import SimulateConversationEvent
+from mlflow.telemetry.track import record_usage_event
 from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracing.provider import trace_disabled
 from mlflow.utils.annotations import experimental
@@ -315,6 +317,7 @@ class ConversationSimulator:
                 f"which will be ignored. Expected keys: {_EXPECTED_TEST_CASE_KEYS}."
             )
 
+    @record_usage_event(SimulateConversationEvent)
     def _simulate(self, predict_fn: Callable[..., dict[str, Any]]) -> list[list[str]]:
         num_test_cases = len(self.test_cases)
         all_trace_ids: list[list[str]] = [[] for _ in range(num_test_cases)]

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -400,6 +400,18 @@ class TracesReceivedByServerEvent(Event):
     name: str = "traces_received_by_server"
 
 
+class SimulateConversationEvent(Event):
+    name: str = "simulate_conversation"
+
+    @classmethod
+    def parse_result(cls, result: Any) -> dict[str, Any] | None:
+        return {
+            "simulated_conversation_info": [
+                {"turn_count": len(conversation)} for conversation in result
+            ]
+        }
+
+
 class ScorerCallEvent(Event):
     name: str = "scorer_call"
 

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -18,6 +18,7 @@ from mlflow.telemetry.events import (
     MakeJudgeEvent,
     MergeRecordsEvent,
     PromptOptimizationEvent,
+    SimulateConversationEvent,
     StartTraceEvent,
 )
 
@@ -93,6 +94,7 @@ def test_event_name():
     assert MakeJudgeEvent.name == "make_judge"
     assert AlignJudgeEvent.name == "align_judge"
     assert PromptOptimizationEvent.name == "prompt_optimization"
+    assert SimulateConversationEvent.name == "simulate_conversation"
 
 
 @pytest.mark.parametrize(
@@ -209,3 +211,18 @@ def test_align_judge_parse_params(arguments, expected_params):
 )
 def test_prompt_optimization_parse_params(arguments, expected_params):
     assert PromptOptimizationEvent.parse(arguments) == expected_params
+
+
+@pytest.mark.parametrize(
+    ("result", "expected_params"),
+    [
+        (
+            [["t1", "t2", "t3"], ["t1"]],
+            {"simulated_conversation_info": [{"turn_count": 3}, {"turn_count": 1}]},
+        ),
+        ([[]], {"simulated_conversation_info": [{"turn_count": 0}]}),
+        ([], {"simulated_conversation_info": []}),
+    ],
+)
+def test_simulate_conversation_parse_result(result, expected_params):
+    assert SimulateConversationEvent.parse_result(result) == expected_params

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -26,6 +26,7 @@ from mlflow.genai.scorers.builtin_scorers import (
     Safety,
     UserFrustration,
 )
+from mlflow.genai.simulators import ConversationSimulator
 from mlflow.pyfunc.model import ResponsesAgent, ResponsesAgentRequest, ResponsesAgentResponse
 from mlflow.telemetry.client import TelemetryClient
 from mlflow.telemetry.events import (
@@ -57,6 +58,7 @@ from mlflow.telemetry.events import (
     MergeRecordsEvent,
     PromptOptimizationEvent,
     ScorerCallEvent,
+    SimulateConversationEvent,
     StartTraceEvent,
 )
 from mlflow.tracking.fluent import _create_dataset_input, _initialize_logged_model
@@ -564,6 +566,45 @@ def test_genai_evaluate_telemetry_data_fields(
         validate_telemetry_record(
             mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
         )
+
+
+def test_simulate_conversation(mock_requests, mock_telemetry_client: TelemetryClient):
+    simulator = ConversationSimulator(
+        test_cases=[
+            {"goal": "Learn about MLflow"},
+            {"goal": "Debug an issue"},
+        ],
+        max_turns=2,
+    )
+
+    def mock_predict_fn(input, **kwargs):
+        return {"role": "assistant", "content": "Mock response"}
+
+    with (
+        mock.patch(
+            "mlflow.genai.simulators.simulator._invoke_model",
+            return_value="Mock user message",
+        ),
+        mock.patch(
+            "mlflow.genai.simulators.simulator.ConversationSimulator._check_goal_achieved",
+            return_value=False,
+        ),
+    ):
+        result = simulator._simulate(predict_fn=mock_predict_fn)
+
+    assert len(result) == 2
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        SimulateConversationEvent.name,
+        {
+            "simulated_conversation_info": [
+                {"turn_count": len(result[0])},
+                {"turn_count": len(result[1])},
+            ]
+        },
+    )
 
 
 def test_prompt_optimization(mock_requests, mock_telemetry_client: TelemetryClient):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/xsh310/mlflow/pull/19813?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19813/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19813/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19813/merge
```

</p>
</details>

## 🥞 Stacked PR
Use this [link](#) to review incremental changes.

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Adding a new telemetry event `simulate_conversation` when `_simulate` in `ConversationSimulator` gets called.
We want to capture 
- num of conversation generated, 
- DAU/Session, 
- num of turns per conversation.

We will be adding the following field for now
```
simulated_conversation_info: 
list [
    {
        “turn_count”: int
        …
    }
]
```

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
#### Manual Testing
Code Snippet:
```
import mlflow
from mlflow.genai.simulators import ConversationSimulator

mlflow.set_tracking_uri("sqlite:///mlflow.db")

simulator = ConversationSimulator(
    test_cases=[{"goal": "Ask about the weather"}],
    max_turns=3,
    user_model="openai:/gpt-4o-mini",
)

def predict_fn(input, **kwargs):
    return {"role": "assistant", "content": f"I don't know the answer to your questions"}

result = simulator._simulate(predict_fn=predict_fn)
```

Printed Output:
```
simulate_conversation record_params: {
  "simulated_conversation_info": [
    {
      "turn_count": 3
    }
  ]
}
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
