### PR TITLE
Migrate Python style guide to `.claude/rules/`

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -45,7 +45,6 @@ Automatically review a GitHub pull request and provide feedback on code quality,
   ```bash
   uv run .claude/skills/fetch-diff/fetch_diff.py <pr_url>
   ```
-- **If reviewing Python files**: Read `dev/guides/python.md` and create a checklist of all style rules with their exceptions before proceeding
 
 ### 3. Review Changed Lines
 
@@ -53,7 +52,7 @@ Automatically review a GitHub pull request and provide feedback on code quality,
 
 Carefully examine **only the changed lines** (added, modified, or deleted) in the diff for:
 
-- Style guide violations (using your checklist if Python files)
+- Style guide violations (see `.claude/rules/` for language-specific rules)
 - Potential bugs and code quality issues
 - Common mistakes
 

--- a/.claude/commands/resolve.md
+++ b/.claude/commands/resolve.md
@@ -50,7 +50,6 @@ Automatically fetch and address PR review comments. This command examines review
 
    - Read the file and surrounding code for context
    - Make minimal, precise changes to address the feedback
-   - Follow project style guides (Python: see `dev/guides/python.md`)
 
 5. After making all changes, commit them:
 

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -1,3 +1,7 @@
+---
+paths: "**/*.py"
+---
+
 # Python Style Guide
 
 This guide documents Python coding conventions that go beyond what [ruff](https://docs.astral.sh/ruff/) and [clint](../../dev/clint/) can enforce. The practices below require human judgment to implement correctly and improve code readability, maintainability, and testability across the MLflow codebase.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -4,4 +4,4 @@ applyTo: "**/*.py"
 
 # Python Code Review Instructions
 
-For style conventions and code examples, see [dev/guides/python.md](../../dev/guides/python.md).
+For style conventions and code examples, see [.claude/rules/python.md](../../.claude/rules/python.md).

--- a/.gitignore
+++ b/.gitignore
@@ -132,8 +132,8 @@ gunicorn.conf.py
 
 # ignore everything in .claude
 .claude/*
-# except commands and skills
 !.claude/commands/
 !.claude/skills/
 !.claude/hooks/
+!.claude/rules/
 !.claude/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,10 +153,6 @@ cd docs && npm run serve --port 8080
 
 See `mlflow/server/js/` for frontend development.
 
-## Language-Specific Style Guides
-
-- [Python](/dev/guides/python.md)
-
 ## Git Workflow
 
 ### Committing Changes


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Migrate `dev/guides/python.md` to `.claude/rules/python.md` with path-scoped frontmatter so it's automatically loaded by Claude Code when working with Python files, rather than requiring manual file reads.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)