### PR TITLE
[POC] Add top-level workflow selector to sidebar navigation

### DIFF
--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -42,11 +42,11 @@ const MlflowRootRoute = () => {
   const { setIsDarkTheme } = useDarkThemeContext();
   const isDarkTheme = theme.isDarkMode;
 
-  // Hide sidebar if we are in a single experiment page
-  const isSingleExperimentPage = Boolean(experimentId);
-  useEffect(() => {
-    setShowSidebar(!isSingleExperimentPage);
-  }, [isSingleExperimentPage]);
+  // POC: Always show sidebar, including in experiment pages
+  // const isSingleExperimentPage = Boolean(experimentId);
+  // useEffect(() => {
+  //   setShowSidebar(!isSingleExperimentPage);
+  // }, [isSingleExperimentPage]);
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', height: '100%' }}>

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -12,9 +12,22 @@ import {
   useDesignSystemTheme,
   DesignSystemEventProviderComponentTypes,
   DesignSystemEventProviderAnalyticsEventTypes,
+  SegmentedControlGroup,
+  SegmentedControlButton,
+  ChartLineIcon,
+  DatabaseIcon,
+  ForkHorizontalIcon,
+  GavelIcon,
+  ListIcon,
+  PlusMinusSquareIcon,
+  SpeechBubbleIcon,
+  Tooltip,
+  UserGroupIcon,
+  Popover,
+  CloseIcon,
 } from '@databricks/design-system';
 import type { Location } from '../utils/RoutingUtils';
-import { Link, matchPath, useLocation, useNavigate } from '../utils/RoutingUtils';
+import { Link, matchPath, useLocation, useNavigate, useParams } from '../utils/RoutingUtils';
 import ExperimentTrackingRoutes from '../../experiment-tracking/routes';
 import { ModelRegistryRoutes } from '../../model-registry/routes';
 import GatewayRoutes from '../../gateway/routes';
@@ -29,14 +42,66 @@ import {
 import Routes from '../../experiment-tracking/routes';
 import { FormattedMessage } from 'react-intl';
 import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
+import { ExperimentKind, ExperimentPageTabName } from '../../experiment-tracking/constants';
+import { enableScorersUI, shouldEnableExperimentOverviewTab } from '../utils/FeatureUtils';
+import { useLocalStorage } from '../../shared/web-shared/hooks';
+import { useEffect } from 'react';
 
 const isHomeActive = (location: Location) => matchPath({ path: '/', end: true }, location.pathname);
-const isExperimentsActive = (location: Location) =>
-  matchPath('/experiments/*', location.pathname) || matchPath('/compare-experiments/*', location.pathname);
+// POC: Experiments link should only be active on the experiments list page, not when viewing a specific experiment
+const isExperimentsActive = (location: Location) => {
+  const isExperimentsList = matchPath('/experiments', location.pathname);
+  const isCompareExperiments = matchPath('/compare-experiments/*', location.pathname);
+  const isSingleExperiment = matchPath('/experiments/:experimentId/*', location.pathname);
+  return (isExperimentsList || isCompareExperiments) && !isSingleExperiment;
+};
 const isModelsActive = (location: Location) => matchPath('/models/*', location.pathname);
 const isPromptsActive = (location: Location) => matchPath('/prompts/*', location.pathname);
 const isGatewayActive = (location: Location) => matchPath('/gateway/*', location.pathname);
 const isSettingsActive = (location: Location) => matchPath('/settings/*', location.pathname);
+
+// Helper to check if we're in an experiment page
+const isInExperimentPage = (location: Location) => {
+  const match = matchPath('/experiments/:experimentId/*', location.pathname);
+  return Boolean(match && match.params.experimentId);
+};
+
+// Helper to determine active experiment tab
+const getActiveExperimentTab = (location: Location): ExperimentPageTabName | null => {
+  if (matchPath('/experiments/:experimentId/overview', location.pathname)) {
+    return ExperimentPageTabName.Overview;
+  }
+  if (matchPath('/experiments/:experimentId/runs', location.pathname)) {
+    return ExperimentPageTabName.Runs;
+  }
+  if (matchPath('/experiments/:experimentId/traces', location.pathname)) {
+    return ExperimentPageTabName.Traces;
+  }
+  if (matchPath('/experiments/:experimentId/chat-sessions*', location.pathname)) {
+    return ExperimentPageTabName.ChatSessions;
+  }
+  if (matchPath('/experiments/:experimentId/datasets', location.pathname)) {
+    return ExperimentPageTabName.Datasets;
+  }
+  if (matchPath('/experiments/:experimentId/evaluation-runs', location.pathname)) {
+    return ExperimentPageTabName.EvaluationRuns;
+  }
+  if (matchPath('/experiments/:experimentId/judges', location.pathname)) {
+    return ExperimentPageTabName.Judges;
+  }
+  if (matchPath('/experiments/:experimentId/prompts*', location.pathname)) {
+    return ExperimentPageTabName.Prompts;
+  }
+  if (matchPath('/experiments/:experimentId/models', location.pathname)) {
+    return ExperimentPageTabName.Models;
+  }
+  return null;
+};
+
+const EXPERIMENT_TYPE_POSITION_STORAGE_KEY = 'mlflow.sidebar.experimentTypeSelectorPosition';
+const EXPERIMENT_TYPE_POSITION_STORAGE_VERSION = 1;
+const WORKFLOW_SELECTOR_GUIDANCE_STORAGE_KEY = 'mlflow.sidebar.workflowSelectorGuidanceShown';
+const WORKFLOW_SELECTOR_GUIDANCE_STORAGE_VERSION = 1;
 
 export function MlflowSidebar() {
   const location = useLocation();
@@ -44,6 +109,7 @@ export function MlflowSidebar() {
   const invalidateExperimentList = useInvalidateExperimentList();
   const navigate = useNavigate();
   const viewId = useMemo(() => uuidv4(), []);
+  const { experimentId } = useParams();
 
   const [showCreateExperimentModal, setShowCreateExperimentModal] = useState(false);
   const [showCreateModelModal, setShowCreateModelModal] = useState(false);
@@ -52,7 +118,59 @@ export function MlflowSidebar() {
     onSuccess: ({ promptName }) => navigate(Routes.getPromptDetailsPageRoute(promptName)),
   });
 
-  const menuItems = [
+  // Track selected experiment type (GenAI or Machine Learning)
+  // Use localStorage to persist selection across page reloads
+  const [selectedExperimentType, setSelectedExperimentType] = useState<'genai' | 'ml'>(() => {
+    const stored = localStorage.getItem('mlflow.sidebar.experimentType');
+    return (stored === 'genai' || stored === 'ml') ? stored : 'genai';
+  });
+
+  // Read the experiment type selector position setting
+  const [isExperimentTypeSelectorAtTop] = useLocalStorage({
+    key: EXPERIMENT_TYPE_POSITION_STORAGE_KEY,
+    version: EXPERIMENT_TYPE_POSITION_STORAGE_VERSION,
+    initialValue: false,
+  });
+
+  // Track whether the user has seen the workflow selector guidance
+  const [hasSeenGuidance, setHasSeenGuidance] = useLocalStorage({
+    key: WORKFLOW_SELECTOR_GUIDANCE_STORAGE_KEY,
+    version: WORKFLOW_SELECTOR_GUIDANCE_STORAGE_VERSION,
+    initialValue: false,
+  });
+
+  // Control popover visibility
+  const [showGuidancePopover, setShowGuidancePopover] = useState(false);
+
+  // Show guidance popover on first visit
+  useEffect(() => {
+    if (!hasSeenGuidance) {
+      // Delay slightly to ensure the component is mounted and visible
+      const timer = setTimeout(() => {
+        setShowGuidancePopover(true);
+      }, 500);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [hasSeenGuidance]);
+
+  const handleDismissGuidance = () => {
+    setShowGuidancePopover(false);
+    setHasSeenGuidance(true);
+  };
+
+  const handleExperimentTypeChange = (e: any) => {
+    const value = e.target.value;
+    if (value === 'genai' || value === 'ml') {
+      setSelectedExperimentType(value);
+      localStorage.setItem('mlflow.sidebar.experimentType', value);
+    }
+  };
+
+  const inExperimentPage = isInExperimentPage(location);
+  const activeExperimentTab = getActiveExperimentTab(location);
+
+  const topLevelMenuItems = [
     {
       key: 'home',
       icon: <HomeIcon />,
@@ -83,6 +201,9 @@ export function MlflowSidebar() {
         ),
       },
     },
+  ];
+
+  const bottomMenuItems = [
     {
       key: 'models',
       icon: <ModelsIcon />,
@@ -135,12 +256,347 @@ export function MlflowSidebar() {
     },
   ];
 
+  const mainMenuItems = [...topLevelMenuItems, ...bottomMenuItems];
+
+  // Experiment-level tabs with section groupings - replicating useExperimentPageSideNavConfig structure
+  const experimentTabsGenAI = {
+    'top-level': [
+      ...(shouldEnableExperimentOverviewTab()
+        ? [
+            {
+              key: 'exp-overview',
+              icon: <ChartLineIcon />,
+              linkProps: {
+                to: experimentId
+                  ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Overview)
+                  : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+                isActive: () => activeExperimentTab === ExperimentPageTabName.Overview,
+                children: (
+                  <FormattedMessage defaultMessage="Overview" description="Sidebar link for experiment overview tab" />
+                ),
+              },
+              componentId: 'mlflow.sidebar.experiment.overview',
+              disabled: !experimentId,
+            },
+          ]
+        : []),
+    ],
+    observability: [
+      {
+        key: 'exp-traces',
+        icon: <ForkHorizontalIcon />,
+        linkProps: {
+          to: experimentId
+            ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Traces)
+            : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+          isActive: () => activeExperimentTab === ExperimentPageTabName.Traces,
+          children: <FormattedMessage defaultMessage="Traces" description="Sidebar link for experiment traces tab" />,
+        },
+        componentId: 'mlflow.sidebar.experiment.traces',
+        disabled: !experimentId,
+      },
+      {
+        key: 'exp-sessions',
+        icon: <SpeechBubbleIcon />,
+        linkProps: {
+          to: experimentId
+            ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.ChatSessions)
+            : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+          isActive: () => activeExperimentTab === ExperimentPageTabName.ChatSessions,
+          children: (
+            <FormattedMessage defaultMessage="Sessions" description="Sidebar link for experiment sessions tab" />
+          ),
+        },
+        componentId: 'mlflow.sidebar.experiment.sessions',
+        disabled: !experimentId,
+      },
+    ],
+    evaluation: [
+      {
+        key: 'exp-datasets',
+        icon: <DatabaseIcon />,
+        linkProps: {
+          to: experimentId
+            ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Datasets)
+            : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+          isActive: () => activeExperimentTab === ExperimentPageTabName.Datasets,
+          children: (
+            <FormattedMessage defaultMessage="Datasets" description="Sidebar link for experiment datasets tab" />
+          ),
+        },
+        componentId: 'mlflow.sidebar.experiment.datasets',
+        disabled: !experimentId,
+      },
+      {
+        key: 'exp-eval-runs',
+        icon: <PlusMinusSquareIcon />,
+        linkProps: {
+          to: experimentId
+            ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.EvaluationRuns)
+            : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+          isActive: () => activeExperimentTab === ExperimentPageTabName.EvaluationRuns,
+          children: (
+            <FormattedMessage
+              defaultMessage="Evaluation runs"
+              description="Sidebar link for experiment evaluation runs tab"
+            />
+          ),
+        },
+        componentId: 'mlflow.sidebar.experiment.evaluation-runs',
+        disabled: !experimentId,
+      },
+      ...(enableScorersUI()
+        ? [
+            {
+              key: 'exp-judges',
+              icon: <GavelIcon />,
+              linkProps: {
+                to: experimentId
+                  ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Judges)
+                  : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+                isActive: () => activeExperimentTab === ExperimentPageTabName.Judges,
+                children: (
+                  <FormattedMessage defaultMessage="Judges" description="Sidebar link for experiment judges tab" />
+                ),
+              },
+              componentId: 'mlflow.sidebar.experiment.judges',
+              disabled: !experimentId,
+            },
+          ]
+        : []),
+    ],
+    'prompts-versions': [
+      {
+        key: 'exp-prompts',
+        icon: <TextBoxIcon />,
+        linkProps: {
+          to: experimentId
+            ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Prompts)
+            : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+          isActive: () => activeExperimentTab === ExperimentPageTabName.Prompts,
+          children: (
+            <FormattedMessage defaultMessage="Prompts" description="Sidebar link for experiment prompts tab" />
+          ),
+        },
+        componentId: 'mlflow.sidebar.experiment.prompts',
+        disabled: !experimentId,
+      },
+      {
+        key: 'exp-models',
+        icon: <ModelsIcon />,
+        linkProps: {
+          to: experimentId
+            ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Models)
+            : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+          isActive: () => activeExperimentTab === ExperimentPageTabName.Models,
+          children: (
+            <FormattedMessage
+              defaultMessage="Agent versions"
+              description="Sidebar link for experiment agent versions tab"
+            />
+          ),
+        },
+        componentId: 'mlflow.sidebar.experiment.models',
+        disabled: !experimentId,
+      },
+    ],
+  };
+
+  const experimentTabsML = {
+    'top-level': [
+      {
+        key: 'exp-runs',
+        icon: <ListIcon />,
+        linkProps: {
+          to: experimentId
+            ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Runs)
+            : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+          isActive: () => activeExperimentTab === ExperimentPageTabName.Runs,
+          children: <FormattedMessage defaultMessage="Runs" description="Sidebar link for experiment runs tab" />,
+        },
+        componentId: 'mlflow.sidebar.experiment.runs',
+        disabled: !experimentId,
+      },
+      {
+        key: 'exp-models-ml',
+        icon: <ModelsIcon />,
+        linkProps: {
+          to: experimentId
+            ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Models)
+            : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+          isActive: () => activeExperimentTab === ExperimentPageTabName.Models,
+          children: <FormattedMessage defaultMessage="Models" description="Sidebar link for experiment models tab" />,
+        },
+        componentId: 'mlflow.sidebar.experiment.models',
+        disabled: !experimentId,
+      },
+      {
+        key: 'exp-traces-ml',
+        icon: <ForkHorizontalIcon />,
+        linkProps: {
+          to: experimentId
+            ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Traces)
+            : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+          isActive: () => activeExperimentTab === ExperimentPageTabName.Traces,
+          children: <FormattedMessage defaultMessage="Traces" description="Sidebar link for experiment traces tab" />,
+        },
+        componentId: 'mlflow.sidebar.experiment.traces',
+        disabled: !experimentId,
+      },
+    ],
+  };
+
+  const experimentTabs = selectedExperimentType === 'genai' ? experimentTabsGenAI : experimentTabsML;
+
+  // Helper function to get section label
+  const getSectionLabel = (sectionKey: string): React.ReactNode | undefined => {
+    switch (sectionKey) {
+      case 'observability':
+        return (
+          <FormattedMessage
+            defaultMessage="Observability"
+            description="Label for the observability section in the MLflow experiment navbar"
+          />
+        );
+      case 'evaluation':
+        return (
+          <FormattedMessage
+            defaultMessage="Evaluation"
+            description="Label for the evaluation section in the MLflow experiment navbar"
+          />
+        );
+      case 'prompts-versions':
+        return (
+          <FormattedMessage
+            defaultMessage="Prompts & versions"
+            description="Label for the versions section in the MLflow experiment navbar"
+          />
+        );
+      default:
+        return undefined;
+    }
+  };
+
   const logTelemetryEvent = useLogTelemetryEvent();
+
+  // Workflow switcher component - can be rendered at top or bottom
+  // When at top: no top margin, border at bottom
+  // When at bottom: top margin, border at top
+  const getWorkflowSwitcher = (position: 'top' | 'bottom') => {
+    const switcherContent = (
+      <div
+        css={{
+          marginTop: position === 'bottom' ? theme.spacing.sm : 0,
+          paddingTop: position === 'bottom' ? theme.spacing.md : 0,
+          paddingBottom: position === 'top' ? theme.spacing.md : 0,
+          borderTop: position === 'bottom' ? `1px solid ${theme.colors.border}` : 'none',
+          borderBottom: position === 'top' ? `1px solid ${theme.colors.border}` : 'none',
+          backgroundColor: theme.colors.backgroundSecondary,
+        }}
+      >
+        <div
+          css={{
+            fontSize: theme.typography.fontSizeSm,
+            color: theme.colors.textSecondary,
+            marginBottom: theme.spacing.xs,
+            paddingInline: theme.spacing.sm,
+            fontWeight: theme.typography.typographyBoldFontWeight,
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+          }}
+        >
+          <FormattedMessage defaultMessage="Workflow Type" description="Label for workflow type switcher" />
+        </div>
+        <SegmentedControlGroup
+          name="experiment-type-switcher"
+          componentId="mlflow.sidebar.experiment_type_switcher"
+          value={selectedExperimentType}
+          onChange={handleExperimentTypeChange}
+          css={{ width: '100%', padding: theme.spacing.xs }}
+        >
+          <SegmentedControlButton value="genai" css={{ flex: 1, fontSize: theme.typography.fontSizeSm }}>
+            <FormattedMessage defaultMessage="GenAI" description="GenAI workflow option" />
+          </SegmentedControlButton>
+          <SegmentedControlButton value="ml" css={{ flex: 1, fontSize: theme.typography.fontSizeSm }}>
+            <FormattedMessage defaultMessage="Machine Learning" description="Machine Learning workflow option" />
+          </SegmentedControlButton>
+        </SegmentedControlGroup>
+      </div>
+    );
+
+    // Wrap in Popover if guidance should be shown
+    if (showGuidancePopover) {
+      return (
+        <Popover.Root
+          componentId="mlflow.sidebar.workflow_guidance"
+          open={showGuidancePopover}
+          onOpenChange={(open) => {
+            // Only allow closing via explicit dismiss actions, not by clicking outside
+            if (!open) {
+              return;
+            }
+            setShowGuidancePopover(open);
+          }}
+          modal
+        >
+          <Popover.Trigger asChild>
+            <div css={{ position: 'relative', zIndex: 1001 }}>{switcherContent}</div>
+          </Popover.Trigger>
+          <Popover.Content
+            side="right"
+            align="start"
+            onEscapeKeyDown={(e) => e.preventDefault()}
+            onPointerDownOutside={(e) => e.preventDefault()}
+            onInteractOutside={(e) => e.preventDefault()}
+            css={{
+              maxWidth: 280,
+              padding: theme.spacing.md,
+              zIndex: 1000,
+              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.5), 0 8px 24px rgba(0, 0, 0, 0.4)',
+            }}
+          >
+            <Popover.Arrow css={{ fill: theme.colors.backgroundPrimary }} />
+            <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: theme.spacing.sm }}>
+              <div css={{ fontWeight: theme.typography.typographyBoldFontWeight, fontSize: theme.typography.fontSizeMd }}>
+                <FormattedMessage defaultMessage="Choose your workflow" description="Workflow selector guidance title" />
+              </div>
+              <Button
+                componentId="mlflow.sidebar.workflow_guidance.dismiss"
+                icon={<CloseIcon />}
+                onClick={handleDismissGuidance}
+                css={{
+                  padding: 0,
+                  minWidth: 'auto',
+                  border: 'none',
+                  background: 'transparent',
+                }}
+              />
+            </div>
+            <div css={{ fontSize: theme.typography.fontSizeSm, color: theme.colors.textSecondary }}>
+              <FormattedMessage
+                defaultMessage="Select your workflow type to customize which features and tabs are shown in the sidebar. You can switch between GenAI and Machine Learning workflows at any time."
+                description="Workflow selector guidance message"
+              />
+            </div>
+            <Button
+              componentId="mlflow.sidebar.workflow_guidance.got_it"
+              onClick={handleDismissGuidance}
+              css={{ marginTop: theme.spacing.md, width: '100%' }}
+            >
+              <FormattedMessage defaultMessage="Got it" description="Workflow selector guidance dismiss button" />
+            </Button>
+          </Popover.Content>
+        </Popover.Root>
+      );
+    }
+
+    return switcherContent;
+  };
 
   return (
     <aside
       css={{
-        width: 200,
+        width: 230,
         flexShrink: 0,
         padding: theme.spacing.sm,
         display: 'inline-flex',
@@ -148,6 +604,9 @@ export function MlflowSidebar() {
         gap: theme.spacing.md,
       }}
     >
+      {/* Render workflow switcher at top (above New button) if setting enabled */}
+      {isExperimentTypeSelectorAtTop && getWorkflowSwitcher('top')}
+
       <DropdownMenu.Root modal={false}>
         <DropdownMenu.Trigger asChild>
           <Button componentId="mlflow.sidebar.new_button" icon={<PlusIcon />}>
@@ -159,98 +618,265 @@ export function MlflowSidebar() {
         </DropdownMenu.Trigger>
 
         <DropdownMenu.Content side="right" sideOffset={theme.spacing.sm} align="start">
-          {menuItems
+          {mainMenuItems
             .filter((item) => item.dropdownProps !== undefined)
             .map(({ key, icon, dropdownProps }) => (
-              <DropdownMenu.Item key={key} componentId={dropdownProps.componentId} onClick={dropdownProps.onClick}>
+              <DropdownMenu.Item key={key} componentId={dropdownProps!.componentId} onClick={dropdownProps!.onClick}>
                 <DropdownMenu.IconWrapper>{icon}</DropdownMenu.IconWrapper>
-                {dropdownProps.children}
+                {dropdownProps!.children}
               </DropdownMenu.Item>
             ))}
         </DropdownMenu.Content>
       </DropdownMenu.Root>
 
       <nav css={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between', height: '100%' }}>
-        <ul
-          css={{
-            listStyleType: 'none',
-            padding: 0,
-            margin: 0,
-          }}
-        >
-          {menuItems.map(({ key, icon, linkProps, componentId }) => (
-            <li key={key}>
-              <Link
-                to={linkProps.to}
-                aria-current={linkProps.isActive(location) ? 'page' : undefined}
-                css={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: theme.spacing.sm,
-                  color: theme.colors.textPrimary,
-                  paddingInline: theme.spacing.md,
-                  paddingBlock: theme.spacing.xs,
-                  borderRadius: theme.borders.borderRadiusSm,
-                  '&:hover': {
-                    color: theme.colors.actionLinkHover,
-                    backgroundColor: theme.colors.actionDefaultBackgroundHover,
-                  },
-                  '&[aria-current="page"]': {
-                    backgroundColor: theme.colors.actionDefaultBackgroundPress,
-                    color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
-                    fontWeight: theme.typography.typographyBoldFontWeight,
-                  },
-                }}
-                onClick={() =>
-                  logTelemetryEvent({
-                    componentId,
-                    componentViewId: viewId,
-                    componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
-                    componentSubType: null,
-                    eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
-                  })
-                }
-              >
-                {icon}
-                {linkProps.children}
-              </Link>
-            </li>
-          ))}
-        </ul>
-        <Link
-          to={ExperimentTrackingRoutes.settingsPageRoute}
-          aria-current={isSettingsActive(location) ? 'page' : undefined}
-          css={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: theme.spacing.sm,
-            color: theme.colors.textPrimary,
-            paddingInline: theme.spacing.md,
-            paddingBlock: theme.spacing.sm,
-            borderRadius: theme.borders.borderRadiusSm,
-            '&:hover': {
-              color: theme.colors.actionLinkHover,
-              backgroundColor: theme.colors.actionDefaultBackgroundHover,
-            },
-            '&[aria-current="page"]': {
-              backgroundColor: theme.colors.actionDefaultBackgroundPress,
-              color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
-              fontWeight: theme.typography.typographyBoldFontWeight,
-            },
-          }}
-          onClick={() =>
-            logTelemetryEvent({
-              componentId: 'mlflow.sidebar.settings_tab_link',
-              componentViewId: viewId,
-              componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
-              componentSubType: null,
-              eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
-            })
-          }
-        >
-          <GearIcon />
-          <FormattedMessage defaultMessage="Settings" description="Sidebar link for settings page" />
-        </Link>
+        <div>
+          <ul
+            css={{
+              listStyleType: 'none',
+              padding: 0,
+              margin: 0,
+            }}
+          >
+            {/* Top-level items (Home, Experiments) */}
+            {topLevelMenuItems.map(({ key, icon, linkProps, componentId }) => (
+              <li key={key}>
+                <Link
+                  to={linkProps.to}
+                  aria-current={linkProps.isActive(location) ? 'page' : undefined}
+                  css={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: theme.spacing.sm,
+                    color: theme.colors.textPrimary,
+                    paddingInline: theme.spacing.md,
+                    paddingBlock: theme.spacing.xs,
+                    borderRadius: theme.borders.borderRadiusSm,
+                    '&:hover': {
+                      color: theme.colors.actionLinkHover,
+                      backgroundColor: theme.colors.actionDefaultBackgroundHover,
+                    },
+                    '&[aria-current="page"]': {
+                      backgroundColor: theme.colors.actionDefaultBackgroundPress,
+                      color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
+                      fontWeight: theme.typography.typographyBoldFontWeight,
+                    },
+                  }}
+                  onClick={() =>
+                    logTelemetryEvent({
+                      componentId,
+                      componentViewId: viewId,
+                      componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
+                      componentSubType: null,
+                      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+                    })
+                  }
+                >
+                  {icon}
+                  {linkProps.children}
+                </Link>
+
+                {/* Nested experiment tabs under Experiments with section groupings */}
+                {key === 'experiments' && (
+                  <div
+                    css={{
+                      paddingLeft: theme.spacing.lg,
+                      paddingBottom: theme.spacing.sm,
+                    }}
+                  >
+                    {Object.entries(experimentTabs).map(([sectionKey, sectionItems]) => {
+                      const sectionLabel = getSectionLabel(sectionKey);
+                      if (!sectionItems || sectionItems.length === 0) return null;
+
+                      return (
+                        <div key={sectionKey}>
+                          {sectionLabel && (
+                            <div
+                              css={{
+                                fontSize: theme.typography.fontSizeSm,
+                                color: theme.colors.textSecondary,
+                                paddingInline: theme.spacing.md,
+                                paddingTop: theme.spacing.sm,
+                                paddingBottom: theme.spacing.xs,
+                              }}
+                            >
+                              {sectionLabel}
+                            </div>
+                          )}
+                          <ul
+                            css={{
+                              listStyleType: 'none',
+                              padding: 0,
+                              margin: 0,
+                            }}
+                          >
+                            {sectionItems.map(
+                              ({
+                                key: tabKey,
+                                icon: tabIcon,
+                                linkProps: tabLinkProps,
+                                componentId: tabComponentId,
+                                disabled,
+                              }) => {
+                                const linkContent = (
+                                  <Link
+                                    to={tabLinkProps.to}
+                                    aria-current={!disabled && tabLinkProps.isActive() ? 'page' : undefined}
+                                    css={{
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      gap: theme.spacing.sm,
+                                      color: disabled ? theme.colors.textSecondary : theme.colors.textPrimary,
+                                      opacity: disabled ? 0.5 : 1,
+                                      paddingInline: theme.spacing.md,
+                                      paddingBlock: theme.spacing.xs,
+                                      borderRadius: theme.borders.borderRadiusSm,
+                                      pointerEvents: disabled ? 'none' : 'auto',
+                                      cursor: disabled ? 'not-allowed' : 'pointer',
+                                      '&:hover': disabled
+                                        ? {}
+                                        : {
+                                            color: theme.colors.actionLinkHover,
+                                            backgroundColor: theme.colors.actionDefaultBackgroundHover,
+                                          },
+                                      '&[aria-current="page"]': disabled
+                                        ? {}
+                                        : {
+                                            backgroundColor: theme.colors.actionDefaultBackgroundPress,
+                                            color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
+                                            fontWeight: theme.typography.typographyBoldFontWeight,
+                                          },
+                                    }}
+                                    onClick={(e) => {
+                                      if (disabled) {
+                                        e.preventDefault();
+                                        return;
+                                      }
+                                      logTelemetryEvent({
+                                        componentId: tabComponentId,
+                                        componentViewId: viewId,
+                                        componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
+                                        componentSubType: null,
+                                        eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+                                      });
+                                    }}
+                                  >
+                                    {tabIcon}
+                                    {tabLinkProps.children}
+                                  </Link>
+                                );
+
+                                return (
+                                  <li key={tabKey}>
+                                    {disabled ? (
+                                      <Tooltip
+                                        componentId={`${tabComponentId}.tooltip`}
+                                        content={
+                                          <FormattedMessage
+                                            defaultMessage="Select an experiment to view this tab"
+                                            description="Tooltip for disabled experiment tab"
+                                          />
+                                        }
+                                      >
+                                        <div>{linkContent}</div>
+                                      </Tooltip>
+                                    ) : (
+                                      linkContent
+                                    )}
+                                  </li>
+                                );
+                              },
+                            )}
+                          </ul>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </li>
+            ))}
+
+            {/* Bottom items (Models, Prompts, Gateway) */}
+            {bottomMenuItems.map(({ key, icon, linkProps, componentId }) => (
+              <li key={key}>
+                <Link
+                  to={linkProps.to}
+                  aria-current={linkProps.isActive(location) ? 'page' : undefined}
+                  css={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: theme.spacing.sm,
+                    color: theme.colors.textPrimary,
+                    paddingInline: theme.spacing.md,
+                    paddingBlock: theme.spacing.xs,
+                    borderRadius: theme.borders.borderRadiusSm,
+                    '&:hover': {
+                      color: theme.colors.actionLinkHover,
+                      backgroundColor: theme.colors.actionDefaultBackgroundHover,
+                    },
+                    '&[aria-current="page"]': {
+                      backgroundColor: theme.colors.actionDefaultBackgroundPress,
+                      color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
+                      fontWeight: theme.typography.typographyBoldFontWeight,
+                    },
+                  }}
+                  onClick={() =>
+                    logTelemetryEvent({
+                      componentId,
+                      componentViewId: viewId,
+                      componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
+                      componentSubType: null,
+                      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+                    })
+                  }
+                >
+                  {icon}
+                  {linkProps.children}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <Link
+            to={ExperimentTrackingRoutes.settingsPageRoute}
+            aria-current={isSettingsActive(location) ? 'page' : undefined}
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+              color: theme.colors.textPrimary,
+              paddingInline: theme.spacing.md,
+              paddingBlock: theme.spacing.sm,
+              borderRadius: theme.borders.borderRadiusSm,
+              '&:hover': {
+                color: theme.colors.actionLinkHover,
+                backgroundColor: theme.colors.actionDefaultBackgroundHover,
+              },
+              '&[aria-current="page"]': {
+                backgroundColor: theme.colors.actionDefaultBackgroundPress,
+                color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
+                fontWeight: theme.typography.typographyBoldFontWeight,
+              },
+            }}
+            onClick={() =>
+              logTelemetryEvent({
+                componentId: 'mlflow.sidebar.settings_tab_link',
+                componentViewId: viewId,
+                componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
+                componentSubType: null,
+                eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+              })
+            }
+          >
+            <GearIcon />
+            <FormattedMessage defaultMessage="Settings" description="Sidebar link for settings page" />
+          </Link>
+
+          {/* Render workflow switcher at bottom if setting disabled */}
+          {!isExperimentTypeSelectorAtTop && getWorkflowSwitcher('bottom')}
+        </div>
       </nav>
 
       <CreateExperimentModal

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.tsx
@@ -149,14 +149,8 @@ const ExperimentPageTabsImpl = () => {
         inferredExperimentKind={inferredExperimentKind}
         refetchExperiment={refetchExperiment}
         experimentKindSelector={
-          <ExperimentViewHeaderKindSelector
-            value={experimentKind}
-            inferredExperimentKind={inferredExperimentKind}
-            onChange={(kind) => updateExperimentKind({ experimentId, kind })}
-            isUpdating={updatingExperimentKind || inferringExperimentType}
-            key={inferredExperimentKind}
-            readOnly={!canUpdateExperimentKind}
-          />
+          // POC: Hide experiment type selector from header, it's now in the sidebar
+          undefined
         }
       />
       {!shouldEnableExperimentPageSideTabs() && (
@@ -167,14 +161,15 @@ const ExperimentPageTabsImpl = () => {
       )}
       {shouldEnableExperimentPageSideTabs() ? (
         <div css={{ display: 'flex', flex: 1, minWidth: 0, minHeight: 0 }}>
-          {loadingExperiment || inferringExperimentType ? (
+          {/* POC: Hide experiment-level side nav, tabs are now in main sidebar */}
+          {/* {loadingExperiment || inferringExperimentType ? (
             <ExperimentPageSideNavSkeleton />
           ) : (
             <ExperimentPageSideNav
               experimentKind={experimentKind ?? inferredExperimentKind ?? ExperimentKind.CUSTOM_MODEL_DEVELOPMENT}
               activeTab={activeTab}
             />
-          )}
+          )} */}
           <div
             css={{
               display: 'flex',

--- a/mlflow/server/js/src/gateway/pages/GatewayPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayPage.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { ScrollablePageWrapper } from '@mlflow/mlflow/src/common/components/ScrollablePageWrapper';
 import {
   Button,
@@ -16,7 +15,6 @@ import { Link, Outlet, useLocation } from '../../common/utils/RoutingUtils';
 import { withErrorBoundary } from '../../common/utils/withErrorBoundary';
 import ErrorUtils from '../../common/utils/ErrorUtils';
 import { EndpointsList } from '../components/endpoints';
-import { GatewaySideNav, type GatewayTab } from '../components/side-nav';
 import { GatewaySetupGuide } from '../components/SecretsSetupGuide';
 import { DefaultPassphraseBanner } from '../components/DefaultPassphraseBanner';
 import { useSecretsConfigQuery } from '../hooks/useSecretsConfigQuery';
@@ -37,13 +35,6 @@ const GatewayPage = () => {
   const { theme } = useDesignSystemTheme();
   const location = useLocation();
   const { data: secretsConfig, isLoading: isLoadingConfig } = useSecretsConfigQuery();
-
-  const activeTab: GatewayTab = useMemo(() => {
-    if (location.pathname.includes('/api-keys')) {
-      return 'api-keys';
-    }
-    return 'endpoints';
-  }, [location.pathname]);
 
   const isIndexRoute = location.pathname === '/gateway' || location.pathname === '/gateway/';
   const isApiKeysRoute = location.pathname.includes('/api-keys');
@@ -95,49 +86,46 @@ const GatewayPage = () => {
       <Spacer shrinks={false} />
       <Header title={<GatewayPageTitle />} />
       {isUsingDefaultPassphrase && <DefaultPassphraseBanner />}
-      <div css={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-        <GatewaySideNav activeTab={activeTab} />
-        <div css={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-          {isNestedRoute ? (
-            <Outlet />
-          ) : (
-            <>
-              {isIndexRoute && (
-                <div css={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
-                  <div
-                    css={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      padding: theme.spacing.md,
-                      borderBottom: `1px solid ${theme.colors.borderDecorative}`,
-                    }}
+      <div css={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {isNestedRoute ? (
+          <Outlet />
+        ) : (
+          <>
+            {isIndexRoute && (
+              <div css={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
+                <div
+                  css={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    padding: theme.spacing.md,
+                    borderBottom: `1px solid ${theme.colors.borderDecorative}`,
+                  }}
+                >
+                  <Typography.Title
+                    level={3}
+                    css={{ margin: 0, display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}
                   >
-                    <Typography.Title
-                      level={3}
-                      css={{ margin: 0, display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}
-                    >
-                      <ChainIcon />
-                      <FormattedMessage defaultMessage="Endpoints" description="Endpoints page title" />
-                    </Typography.Title>
-                    <Link to={GatewayRoutes.createEndpointPageRoute}>
-                      <Button componentId="mlflow.gateway.endpoints.create-button" type="primary" icon={<PlusIcon />}>
-                        <FormattedMessage
-                          defaultMessage="Create endpoint"
-                          description="Gateway > Endpoints page > Create endpoint button"
-                        />
-                      </Button>
-                    </Link>
-                  </div>
-                  <div css={{ flex: 1, overflow: 'auto', padding: theme.spacing.md }}>
-                    <EndpointsList />
-                  </div>
+                    <ChainIcon />
+                    <FormattedMessage defaultMessage="Endpoints" description="Endpoints page title" />
+                  </Typography.Title>
+                  <Link to={GatewayRoutes.createEndpointPageRoute}>
+                    <Button componentId="mlflow.gateway.endpoints.create-button" type="primary" icon={<PlusIcon />}>
+                      <FormattedMessage
+                        defaultMessage="Create endpoint"
+                        description="Gateway > Endpoints page > Create endpoint button"
+                      />
+                    </Button>
+                  </Link>
                 </div>
-              )}
-              {isApiKeysRoute && <ApiKeysPage />}
-            </>
-          )}
-        </div>
+                <div css={{ flex: 1, overflow: 'auto', padding: theme.spacing.md }}>
+                  <EndpointsList />
+                </div>
+              </div>
+            )}
+            {isApiKeysRoute && <ApiKeysPage />}
+          </>
+        )}
       </div>
     </ScrollablePageWrapper>
   );

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -123,6 +123,10 @@
     "defaultMessage": "No traces found. Try clearing your active filters to see more traces.",
     "description": "Text displayed when no traces are found in the trace review page"
   },
+  "+um1FW": {
+    "defaultMessage": "Got it",
+    "description": "Workflow selector guidance dismiss button"
+  },
   "+w9a+1": {
     "defaultMessage": "Open runs in this group in the new tab",
     "description": "Experiment page > grouped runs table > tooltip for a button that opens runs in a group in a new tab"
@@ -270,6 +274,10 @@
   "/qIHh7": {
     "defaultMessage": "Traces",
     "description": "Label for the scorer evaluation scope selection"
+  },
+  "/rbfKX": {
+    "defaultMessage": "Sessions",
+    "description": "Sidebar link for experiment sessions tab"
   },
   "/sk75d": {
     "defaultMessage": "Experiment not found",
@@ -439,6 +447,10 @@
     "defaultMessage": "{count, plural, one {1 trace selected} other {# traces selected}}",
     "description": "Label for the number of traces selected"
   },
+  "1PtVxM": {
+    "defaultMessage": "Agent versions",
+    "description": "Sidebar link for experiment agent versions tab"
+  },
   "1RxxTj": {
     "defaultMessage": "(Version {sourceModelVersion})",
     "description": "Version number of the source model version"
@@ -559,6 +571,10 @@
     "defaultMessage": "Please select parameters and/or metrics to display the comparison.",
     "description": "Explanation displayed in the metrics and params compare plot when no values are selected"
   },
+  "2NbGr8": {
+    "defaultMessage": "Select an experiment to view this tab",
+    "description": "Tooltip for disabled experiment tab"
+  },
   "2NfDVN": {
     "defaultMessage": "Load the model",
     "description": "Heading text for stating how to load the model from the experiment run"
@@ -646,6 +662,10 @@
   "2zy+D5": {
     "defaultMessage": "Add new tag",
     "description": "Experiment tracking > experiment page > runs > add new tag button"
+  },
+  "35+lCG": {
+    "defaultMessage": "Reset workflow selector guidance",
+    "description": "Reset workflow selector guidance settings title"
   },
   "36g3aR": {
     "defaultMessage": "Edit",
@@ -862,6 +882,10 @@
     "defaultMessage": "Validate the model before deployment",
     "description": "Heading text for validating the model before deploying it for serving"
   },
+  "5C31eo": {
+    "defaultMessage": "Controls whether the workflow type selector (GenAI / Machine Learning) appears at the top or bottom of the sidebar.",
+    "description": "Workflow type selector position settings description"
+  },
   "5GCYzy": {
     "defaultMessage": "Experiment Runs - Databricks",
     "description": "Title on a page used to manage MLflow experiments runs"
@@ -921,6 +945,10 @@
   "5fUTaz": {
     "defaultMessage": "Or {enterManually}",
     "description": "Text with link to switch to manual model entry"
+  },
+  "5hp6kR": {
+    "defaultMessage": "Bottom",
+    "description": "Workflow selector at bottom"
   },
   "5jXYY4": {
     "defaultMessage": "Detailed assessments",
@@ -1210,6 +1238,10 @@
     "defaultMessage": "Move to bottom",
     "description": "Experiment page > compare runs tab > chart header > move to bottom option"
   },
+  "7UkHyt": {
+    "defaultMessage": "Runs",
+    "description": "Sidebar link for experiment runs tab"
+  },
   "7WkP1e": {
     "defaultMessage": "Delete",
     "description": "Menu item to delete an experiment run"
@@ -1425,6 +1457,10 @@
   "961sxj": {
     "defaultMessage": "Success Rate",
     "description": "Label for success rate statistic"
+  },
+  "97AkqA": {
+    "defaultMessage": "GenAI",
+    "description": "GenAI workflow option"
   },
   "97xY+o": {
     "defaultMessage": "Loading endpoints...",
@@ -1830,6 +1866,10 @@
     "defaultMessage": "Are retrieved documents relevant to the user's request?",
     "description": "Hint for RetrievalRelevance template"
   },
+  "BzuoQc": {
+    "defaultMessage": "Evaluation runs",
+    "description": "Sidebar link for experiment evaluation runs tab"
+  },
   "C+nay+": {
     "defaultMessage": "Evaluation",
     "description": "Label for the evaluation section in the MLflow experiment navbar"
@@ -2134,6 +2174,10 @@
     "defaultMessage": "Request",
     "description": "Column label for request"
   },
+  "Ey/A0T": {
+    "defaultMessage": "Choose your workflow",
+    "description": "Workflow selector guidance title"
+  },
   "F16DNA": {
     "defaultMessage": "Version {versionNum}",
     "description": "Title text for model version page"
@@ -2165,6 +2209,10 @@
   "FFe+Ug": {
     "defaultMessage": "Type a value",
     "description": "Key-value tag editor modal > Value input placeholder"
+  },
+  "FGkJCf": {
+    "defaultMessage": "Reset",
+    "description": "Reset guidance button"
   },
   "FKoHx5": {
     "defaultMessage": "Security Notice: Default Passphrase in Use",
@@ -2309,6 +2357,14 @@
   "GdtTc/": {
     "defaultMessage": "Run evaluation",
     "description": "Home page quick action title for running evaluations"
+  },
+  "GeKTpz": {
+    "defaultMessage": "Show the workflow type selector guidance popover again on your next page navigation.",
+    "description": "Reset workflow selector guidance settings description"
+  },
+  "GewFAR": {
+    "defaultMessage": "Datasets",
+    "description": "Sidebar link for experiment datasets tab"
   },
   "Gg/vLZ": {
     "defaultMessage": "Delete Model",
@@ -2665,6 +2721,10 @@
   "JuHp/q": {
     "defaultMessage": "Hugging Face",
     "description": "Experiment dataset drawer > source type > Hugging Face source type label"
+  },
+  "JuaNHx": {
+    "defaultMessage": "Traces",
+    "description": "Sidebar link for experiment traces tab"
   },
   "JwhonN": {
     "defaultMessage": "Authentication method",
@@ -4024,6 +4084,10 @@
     "defaultMessage": "Add New Tag",
     "description": "Add new key-value tag modal > Modal title"
   },
+  "VHN4Si": {
+    "defaultMessage": "API Keys",
+    "description": "Sidebar link for gateway API keys tab"
+  },
   "VLonhQ": {
     "defaultMessage": "Requests",
     "description": "Title for the trace requests chart"
@@ -4059,6 +4123,10 @@
   "VcNdOq": {
     "defaultMessage": "No description",
     "description": "Run page > Overview > Description section > Empty value placeholder"
+  },
+  "VcrPJw": {
+    "defaultMessage": "Judges",
+    "description": "Sidebar link for experiment judges tab"
   },
   "VfGJFc": {
     "defaultMessage": "Deleted traces cannot be restored. Are you sure you want to proceed?",
@@ -4107,6 +4175,10 @@
   "W1ZIP4": {
     "defaultMessage": "Safety",
     "description": "LLM template option"
+  },
+  "W3FO1m": {
+    "defaultMessage": "Machine Learning",
+    "description": "Machine Learning workflow option"
   },
   "W60/kq": {
     "defaultMessage": "regression",
@@ -4494,6 +4566,10 @@
   "Z6kodo": {
     "defaultMessage": "Move down",
     "description": "Experiment page > compare runs tab > chart header > move down option"
+  },
+  "Z9USpa": {
+    "defaultMessage": "Workflow type selector position",
+    "description": "Workflow type selector position settings title"
   },
   "ZAqdq9": {
     "defaultMessage": "Edit API key",
@@ -5123,6 +5199,10 @@
     "defaultMessage": "You cannot select rows when comparing runs",
     "description": "Tooltip message for the select button when comparing runs"
   },
+  "drrY3e": {
+    "defaultMessage": "Select your workflow type to customize which features and tabs are shown in the sidebar. You can switch between GenAI and Machine Learning workflows at any time.",
+    "description": "Workflow selector guidance message"
+  },
   "dsPsxG": {
     "defaultMessage": "OpenAI-Compatible Chat Completions API",
     "description": "OpenAI compatible API section title"
@@ -5715,6 +5795,10 @@
     "defaultMessage": "Evaluation settings",
     "description": "Section header for evaluation settings"
   },
+  "i41nuf": {
+    "defaultMessage": "Endpoints",
+    "description": "Sidebar link for gateway endpoints tab"
+  },
   "i49wE6": {
     "defaultMessage": "We couldn't load your experiments.",
     "description": "Home page experiments error message"
@@ -5770,6 +5854,10 @@
   "iT8ODo": {
     "defaultMessage": "Minimum",
     "description": "Experiment page > group by runs control > minimum aggregate function"
+  },
+  "iTE0UW": {
+    "defaultMessage": "Prompts",
+    "description": "Sidebar link for experiment prompts tab"
   },
   "iVrgfC": {
     "defaultMessage": "Datasets",
@@ -6298,6 +6386,10 @@
   "mpHsCg": {
     "defaultMessage": "Size:",
     "description": "Label to display the size of the artifact of the experiment"
+  },
+  "mpiSER": {
+    "defaultMessage": "Top",
+    "description": "Workflow selector at top"
   },
   "mqDCNl": {
     "defaultMessage": "Unable to parse JSON file. The file should contain an object with 'columns' and 'data' keys.",
@@ -7375,6 +7467,10 @@
     "defaultMessage": "All",
     "description": "Tab text to view all versions under details tab on the model view page"
   },
+  "vjta6x": {
+    "defaultMessage": "Models",
+    "description": "Sidebar link for experiment models tab"
+  },
   "vlUEAo": {
     "defaultMessage": "Delete",
     "description": "Delete assessment modal button text"
@@ -7758,6 +7854,10 @@
   "yjerKR": {
     "defaultMessage": "<link>Version {versionNumber}</link>",
     "description": "Link to model version in the model version table"
+  },
+  "ylqv4U": {
+    "defaultMessage": "Overview",
+    "description": "Sidebar link for experiment overview tab"
   },
   "yltHdB": {
     "defaultMessage": "Run name",

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -1,9 +1,14 @@
-import { Switch, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Button, Switch, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from '@databricks/i18n';
 import { useLocalStorage } from '../shared/web-shared/hooks';
 import { TELEMETRY_ENABLED_STORAGE_KEY, TELEMETRY_ENABLED_STORAGE_VERSION } from '../telemetry/utils';
 import { telemetryClient } from '../telemetry';
 import { useCallback } from 'react';
+
+const EXPERIMENT_TYPE_POSITION_STORAGE_KEY = 'mlflow.sidebar.experimentTypeSelectorPosition';
+const EXPERIMENT_TYPE_POSITION_STORAGE_VERSION = 1;
+const WORKFLOW_SELECTOR_GUIDANCE_STORAGE_KEY = 'mlflow.sidebar.workflowSelectorGuidanceShown';
+const WORKFLOW_SELECTOR_GUIDANCE_STORAGE_VERSION = 1;
 
 const SettingsPage = () => {
   const { theme } = useDesignSystemTheme();
@@ -14,6 +19,22 @@ const SettingsPage = () => {
     version: TELEMETRY_ENABLED_STORAGE_VERSION,
     initialValue: true,
   });
+
+  const [isExperimentTypeSelectorAtTop, setIsExperimentTypeSelectorAtTop] = useLocalStorage({
+    key: EXPERIMENT_TYPE_POSITION_STORAGE_KEY,
+    version: EXPERIMENT_TYPE_POSITION_STORAGE_VERSION,
+    initialValue: false,
+  });
+
+  const [hasSeenGuidance, setHasSeenGuidance] = useLocalStorage({
+    key: WORKFLOW_SELECTOR_GUIDANCE_STORAGE_KEY,
+    version: WORKFLOW_SELECTOR_GUIDANCE_STORAGE_VERSION,
+    initialValue: false,
+  });
+
+  const handleResetGuidance = useCallback(() => {
+    setHasSeenGuidance(false);
+  }, [setHasSeenGuidance]);
 
   const handleTelemetryToggle = useCallback(
     (checked: boolean) => {
@@ -65,6 +86,75 @@ const SettingsPage = () => {
           inactiveLabel={intl.formatMessage({ defaultMessage: 'Off', description: 'Telemetry disabled label' })}
           disabledLabel=" "
         />
+      </div>
+
+      <div
+        css={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          maxWidth: 600,
+          marginTop: theme.spacing.lg,
+        }}
+      >
+        <div css={{ display: 'flex', flexDirection: 'column', marginRight: theme.spacing.lg }}>
+          <Typography.Title level={4}>
+            <FormattedMessage
+              defaultMessage="Workflow type selector position"
+              description="Workflow type selector position settings title"
+            />
+          </Typography.Title>
+          <Typography.Text>
+            <FormattedMessage
+              defaultMessage="Controls whether the workflow type selector (GenAI / Machine Learning) appears at the top or bottom of the sidebar."
+              description="Workflow type selector position settings description"
+            />
+          </Typography.Text>
+        </div>
+        <Switch
+          componentId="mlflow.settings.experiment-type-position.toggle-switch"
+          checked={isExperimentTypeSelectorAtTop}
+          onChange={setIsExperimentTypeSelectorAtTop}
+          label=" "
+          activeLabel={intl.formatMessage({ defaultMessage: 'Top', description: 'Workflow selector at top' })}
+          inactiveLabel={intl.formatMessage({
+            defaultMessage: 'Bottom',
+            description: 'Workflow selector at bottom',
+          })}
+          disabledLabel=" "
+        />
+      </div>
+
+      <div
+        css={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          maxWidth: 600,
+          marginTop: theme.spacing.lg,
+        }}
+      >
+        <div css={{ display: 'flex', flexDirection: 'column', marginRight: theme.spacing.lg }}>
+          <Typography.Title level={4}>
+            <FormattedMessage
+              defaultMessage="Reset workflow selector guidance"
+              description="Reset workflow selector guidance settings title"
+            />
+          </Typography.Title>
+          <Typography.Text>
+            <FormattedMessage
+              defaultMessage="Show the workflow type selector guidance popover again on your next page navigation."
+              description="Reset workflow selector guidance settings description"
+            />
+          </Typography.Text>
+        </div>
+        <Button
+          componentId="mlflow.settings.workflow-guidance.reset-button"
+          onClick={handleResetGuidance}
+          disabled={!hasSeenGuidance}
+        >
+          <FormattedMessage defaultMessage="Reset" description="Reset guidance button" />
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/19827?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19827/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19827/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19827/merge
```

</p>
</details>

## Summary

This POC reimagines the MLflow navigation structure by moving the Gen AI/Classical ML workflow selector from experiment-level to top-level in the main sidebar. This provides a cleaner, more discoverable navigation experience.

Go to the settings page to play with different selector positions / reset the new product onboarding experience.

## Demo

 

https://github.com/user-attachments/assets/cad9e068-f568-447d-891f-91f5cda78290



## Key Changes

### 1. **Top-Level Workflow Selector**
- Moved workflow type selector (Gen AI / Classical ML) from experiment page to main sidebar
- Configurable position: can be placed at top or bottom of sidebar via Settings page
- Renamed from "Experiment type" to "Workflow Type" for better clarity at top level

### 2. **Nested Experiment Navigation**
- Experiment-level tabs now nested under "Experiments" link in main sidebar
- Tabs organized by sections (Observability, Evaluation, Prompts & versions)
- All tabs always visible but disabled with tooltips when no experiment selected
- Different tab sets based on workflow type (Gen AI vs Classical ML)

### 3. **Simplified UI**
- Removed experiment-level side navigation entirely
- Sidebar always visible (no hiding when viewing experiments)
- More screen space for content

### 4. **First-Time User Experience**
- Guidance popover appears on first visit to explain workflow selector
- Modal overlay with arrow pointing to selector
- Dismissible via X button or "Got it" button
- Reset option in Settings for debugging

### 5. **Settings Page Enhancements**
- Toggle for workflow selector position (Top/Bottom)
- Button to reset first-time guidance (useful for testing)

## Benefits

- **Better discoverability**: All features visible at top level
- **Clearer hierarchy**: Experiments and their tabs have clear parent-child relationship
- **More flexible**: User can customize workflow selector position
- **Better onboarding**: First-time guidance helps users understand workflow types
- **More space**: Removed duplicate navigation frees up screen real estate

## Test Plan

1. Navigate to MLflow UI with dev server running
2. Verify workflow selector appears (default: bottom of sidebar)
3. Click different workflow types and verify correct tabs appear under Experiments
4. Go to Settings and toggle workflow selector position
5. Navigate to an experiment and verify tabs are nested and functional
6. Clear localStorage and reload to see first-time guidance popover
7. Use Reset button in Settings to test guidance again


🤖 Generated with [Claude Code](https://claude.com/claude-code)