### PR TITLE
Fix fallback for structured response on databricks serving endpoint adapter

### DIFF
--- a/mlflow/genai/judges/adapters/databricks_serving_endpoint_adapter.py
+++ b/mlflow/genai/judges/adapters/databricks_serving_endpoint_adapter.py
@@ -29,6 +29,15 @@ from mlflow.telemetry.utils import _log_error
 
 _logger = logging.getLogger(__name__)
 
+_RESPONSE_FORMAT_ERROR_MESSAGES = (
+    "response_format",
+    "response_schema",
+    "response format",
+    "responseformatobject",
+    'unknown field "properties"',
+    'unknown field \\"properties\\"',
+)
+
 
 @dataclass
 class InvokeDatabricksModelOutput:
@@ -176,8 +185,8 @@ def _invoke_databricks_serving_endpoint(
             # If so, drop the parameter and retry. This mimics LiteLLM's drop_params behavior.
             # Some endpoints return errors about 'response_format', others about 'response_schema'.
             error_text_lower = res.text.lower()
-            is_response_format_error = (
-                "response_format" in error_text_lower or "response_schema" in error_text_lower
+            is_response_format_error = any(
+                s in error_text_lower for s in _RESPONSE_FORMAT_ERROR_MESSAGES
             )
             if res.status_code == 400 and include_response_format and is_response_format_error:
                 _logger.debug(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19843/files) to review incremental changes.
- [**stack/fix-failing-fallback-for-structured-response-on-dbrx-serving-endpoint-adapter**](https://github.com/mlflow/mlflow/pull/19843) [[Files changed](https://github.com/mlflow/mlflow/pull/19843/files)]
  - [stack/add-best-effort-structured-response-params-to-request-for-each-model-provider](https://github.com/mlflow/mlflow/pull/19846) [[Files changed](https://github.com/mlflow/mlflow/pull/19846/files/3616198169ed589fdaa0dc00a787826fa62b0251..62cbc667ba19e8ffd07750180279688015051a8f)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Currently we have a fallback mechanism for `databricks_serving_endpoint_adapter` such that when we fail to call LLM with structured output, we will retry without structured output and return raw string.

We currently catch failures related structured output by keyword matching from the error message but the current match list doesn't cover all major model providers, and a majority of non-OpenAI model served by databricks throws exceptions when we run judge on them.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
#### Manual Test
| Model | Before | After |
|--------|--------|-------|
| databricks-claude-sonnet-4-5 | <img width="666" height="323" alt="Screenshot 2026-01-08 at 11 48 31 AM" src="https://github.com/user-attachments/assets/aa97626f-077d-4dd1-958f-efb4271f4462" /> | <img width="664" height="356" alt="Screenshot 2026-01-08 at 11 41 50 AM" src="https://github.com/user-attachments/assets/afdca783-20d5-43c9-8604-536406487da7" />|
| databricks-gemini-3-pro | <img width="667" height="324" alt="Screenshot 2026-01-08 at 11 46 46 AM" src="https://github.com/user-attachments/assets/07d82400-efde-4c4d-9ff2-4d324175500f" /> | <img width="665" height="324" alt="Screenshot 2026-01-08 at 11 43 11 AM" src="https://github.com/user-attachments/assets/0cd24eae-e799-4301-8af4-c799e9bb9256" /> |
| databricks-gpt-oss-120b | <img width="667" height="323" alt="Screenshot 2026-01-08 at 11 45 53 AM" src="https://github.com/user-attachments/assets/60d80733-552a-49aa-942f-af01485b4d18" /> | <img width="671" height="327" alt="Screenshot 2026-01-08 at 11 43 27 AM" src="https://github.com/user-attachments/assets/78e46335-2402-4982-b24e-ddc7190d4103" /> |
| databricks-meta-llama-3-3-70b-instruct | <img width="665" height="340" alt="Screenshot 2026-01-08 at 11 45 13 AM" src="https://github.com/user-attachments/assets/6639a1f8-618a-4194-822e-eeb0987f250e" /> | <img width="665" height="373" alt="Screenshot 2026-01-08 at 11 43 50 AM" src="https://github.com/user-attachments/assets/5ee4e3b8-d95e-4bdf-ad22-ac98526d0e58" /> |
| databricks-gpt-5-1 | <img width="666" height="357" alt="Screenshot 2026-01-08 at 11 46 20 AM" src="https://github.com/user-attachments/assets/17214627-e3d5-424d-9d58-881f9077c316" /> | <img width="666" height="361" alt="Screenshot 2026-01-08 at 11 42 53 AM" src="https://github.com/user-attachments/assets/dd6842af-3ccc-4a8b-9086-d15388b6d465" /> |

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
