### PR TITLE
Make conversation simulator work with datasets

### DIFF
--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -319,29 +319,30 @@ def test_conversation_simulator_validation(test_cases, expected_error):
 
 
 @pytest.mark.parametrize(
-    ("inputs", "should_succeed"),
+    "inputs",
     [
-        # Valid conversational datasets with 'goal' field
-        ([{"goal": "Learn about MLflow"}], True),
-        ([{"goal": "Debug issue", "persona": "Engineer"}], True),
-        (
-            [{"goal": "Ask questions", "persona": "Student", "context": {"id": "1"}}],
-            True,
-        ),
-        # Invalid single-turn datasets without 'goal' field
-        ([{"request": "What is MLflow?"}], False),
-        ([{"inputs": {"query": "Help me"}, "expected_response": "Sure!"}], False),
-        ([{"question": "How to log?", "answer": "Use mlflow.log"}], False),
-        ([], False),
+        [{"goal": "Learn about MLflow"}],
+        [{"goal": "Debug issue", "persona": "Engineer"}],
+        [{"goal": "Ask questions", "persona": "Student", "context": {"id": "1"}}],
     ],
 )
-def test_conversation_simulator_evaluation_dataset_validation(inputs, should_succeed):
+def test_conversation_simulator_evaluation_dataset_valid(inputs):
     mock_dataset = create_mock_evaluation_dataset(inputs)
+    simulator = ConversationSimulator(test_cases=mock_dataset, max_turns=2)
+    assert len(simulator.test_cases) == len(inputs)
+    assert simulator.test_cases == inputs
 
-    if should_succeed:
-        simulator = ConversationSimulator(test_cases=mock_dataset, max_turns=2)
-        assert len(simulator.test_cases) == len(inputs)
-        assert simulator.test_cases == inputs
-    else:
-        with pytest.raises(ValueError, match="conversational test cases with a 'goal' field"):
-            ConversationSimulator(test_cases=mock_dataset, max_turns=2)
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        [{"request": "What is MLflow?"}],
+        [{"inputs": {"query": "Help me"}, "expected_response": "Sure!"}],
+        [{"inputs": {"question": "How to log?", "answer": "Use mlflow.log"}}],
+        [],
+    ],
+)
+def test_conversation_simulator_evaluation_dataset_invalid(inputs):
+    mock_dataset = create_mock_evaluation_dataset(inputs)
+    with pytest.raises(ValueError, match="conversational test cases with a 'goal' field"):
+        ConversationSimulator(test_cases=mock_dataset, max_turns=2)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SomtochiUmeh/mlflow/pull/19845?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19845/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19845/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19845/merge
```

</p>
</details>

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
With multiturn dataset:
```
multiturn_dataset = get_dataset("somto.default.multiturn")
records = [
    {
        "inputs": {"persona": "Student", "goal": "Find articles on religion"},
        "expectations": {"expected_output": "articles"},
    },
    {
        "inputs": {"persona": "New employee", "goal": "Get help on contributing to mlflow", "context": {"id": "U1"}},
        "expectations": {"expected_output": "help"},
    }
]
multiturn_dataset.merge_records(records)

simulator_with_dataset = ConversationSimulator(test_cases=multiturn_dataset, user_model="databricks:/databricks-gpt-5-2", max_turns=3)

client = OpenAI()
def predict_fn(input: list[dict], **kwargs):
    print(f"Context: {kwargs}")
    response = client.chat.completions.create(
        model="gpt-4o-mini",
        messages=input,
    )
    return response

print("Running simulation...")
all_trace_ids = simulator_with_dataset._simulate(predict_fn)

print(f"\nSimulation complete! {len(all_trace_ids)} test case(s), {len(all_trace_ids[0])} turn(s)")
```
<img width="1414" height="119" alt="image" src="https://github.com/user-attachments/assets/f6da288c-7cd3-489e-80cb-b6531e0d433d" />
<img width="1430" height="917" alt="image" src="https://github.com/user-attachments/assets/fceafe46-9087-46f5-9864-51a7cd59cc14" />


With inputs dataset:
<img width="905" height="484" alt="image" src="https://github.com/user-attachments/assets/97488b25-2c64-4327-b822-3ba8b59a785a" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
