### PR TITLE
Fix response_format parameter format in databricks serving endpoint adapter

### DIFF
--- a/mlflow/genai/judges/adapters/databricks_serving_endpoint_adapter.py
+++ b/mlflow/genai/judges/adapters/databricks_serving_endpoint_adapter.py
@@ -154,7 +154,13 @@ def _invoke_databricks_serving_endpoint(
             payload = {"messages": messages}
 
             if include_response_format:
-                payload["response_format"] = response_format.model_json_schema()
+                payload["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "response",
+                        "schema": response_format.model_json_schema(),
+                    },
+                }
 
             # Add inference parameters if provided (e.g., temperature, top_p, max_tokens)
             if inference_params:

--- a/tests/genai/judges/adapters/test_databricks_adapter.py
+++ b/tests/genai/judges/adapters/test_databricks_adapter.py
@@ -312,13 +312,39 @@ def test_invoke_databricks_serving_endpoint_with_response_format(mock_databricks
         # Verify response_format was included in the payload
         assert captured_payload is not None
         assert "response_format" in captured_payload
-        assert captured_payload["response_format"] == ResponseFormat.model_json_schema()
+        assert captured_payload["response_format"] == {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "response",
+                "schema": ResponseFormat.model_json_schema(),
+            },
+        }
 
         # Verify the response was returned correctly
         assert output.response == '{"result": 8, "rationale": "Good quality"}'
 
 
-def test_invoke_databricks_serving_endpoint_response_format_fallback(mock_databricks_creds):
+@pytest.mark.parametrize(
+    "error_text",
+    [
+        '{"error": "Invalid parameter: response_format is not supported"}',
+        (
+            '{"error_code":"BAD_REQUEST",'
+            '"message":"Bad request: json: unknown field \\"response_schema\\""}'
+        ),
+        (
+            '{"error_code":"INVALID_PARAMETER_VALUE",'
+            '"message": "INVALID_PARAMETER_VALUE: Response format type object '
+            'is not supported for this model."}'
+        ),
+        '{"error": "ResponseFormatObject is not supported by this model"}',
+        '{"error": "Bad request: json: unknown field \\"properties\\""}',
+        '{"error": "Bad request: json: unknown field "properties""}',
+    ],
+)
+def test_invoke_databricks_serving_endpoint_response_format_error_detection(
+    mock_databricks_creds, error_text: str
+):
     class ResponseFormat(BaseModel):
         result: int
         rationale: str
@@ -333,11 +359,9 @@ def test_invoke_databricks_serving_endpoint_response_format_fallback(mock_databr
 
         mock_response = mock.Mock()
         if call_count == 1:
-            # First call with response_format fails
             mock_response.status_code = 400
-            mock_response.text = '{"error": "Invalid parameter: response_format is not supported"}'
+            mock_response.text = error_text
         else:
-            # Second call without response_format succeeds
             mock_response.status_code = 200
             mock_response.json.return_value = {
                 "choices": [{"message": {"content": '{"result": 8, "rationale": "Good quality"}'}}],
@@ -357,69 +381,7 @@ def test_invoke_databricks_serving_endpoint_response_format_fallback(mock_databr
         ),
     ):
         output = _invoke_databricks_serving_endpoint(
-            model_name="my-endpoint",
-            prompt="Rate this",
-            num_retries=1,
-            response_format=ResponseFormat,
-        )
-
-        # Verify we made 2 calls, the first with response_format, the second without
-        assert call_count == 2
-        assert "response_format" in captured_payloads[0]
-        assert "response_format" not in captured_payloads[1]
-        assert output.response == '{"result": 8, "rationale": "Good quality"}'
-
-
-def test_invoke_databricks_serving_endpoint_response_schema_fallback(mock_databricks_creds):
-    """Test that fallback works when error contains 'response_schema' instead of 'response_format'.
-
-    This regression test covers GitHub issue #19739: Databricks endpoints may return errors
-    referencing 'response_schema' rather than 'response_format', and the fallback logic
-    should handle both variants.
-    """
-
-    class ResponseFormat(BaseModel):
-        result: int
-        rationale: str
-
-    call_count = 0
-    captured_payloads = []
-
-    def mock_post(*args, **kwargs):
-        nonlocal call_count
-        captured_payloads.append(kwargs.get("json"))
-        call_count += 1
-
-        mock_response = mock.Mock()
-        if call_count == 1:
-            # First call with response_format fails with response_schema error (issue #19739)
-            mock_response.status_code = 400
-            mock_response.text = (
-                '{"error_code":"BAD_REQUEST",'
-                '"message":"Bad request: json: unknown field \\"response_schema\\""}'
-            )
-        else:
-            # Second call without response_format succeeds
-            mock_response.status_code = 200
-            mock_response.json.return_value = {
-                "choices": [{"message": {"content": '{"result": 8, "rationale": "Good quality"}'}}],
-                "usage": {"prompt_tokens": 10, "completion_tokens": 5},
-                "id": "test-request-id",
-            }
-        return mock_response
-
-    with (
-        mock.patch(
-            "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.requests.post",
-            side_effect=mock_post,
-        ),
-        mock.patch(
-            "mlflow.utils.databricks_utils.get_databricks_host_creds",
-            return_value=mock_databricks_creds,
-        ),
-    ):
-        output = _invoke_databricks_serving_endpoint(
-            model_name="databricks-claude-sonnet-4",
+            model_name="test-model",
             prompt="Rate this",
             num_retries=1,
             response_format=ResponseFormat,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19846/files) to review incremental changes.
- [**stack/add-best-effort-structured-response-params-to-request-for-each-model-provider**](https://github.com/mlflow/mlflow/pull/19846) [[Files changed](https://github.com/mlflow/mlflow/pull/19846/files)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
The format that we provided `response_format` right now doesn't match databricks serving endpoint's expectation for most non-OpenAI model served by databricks. This PR updates the format and so that it can be handled by most chat models served by databricks.

Claude summarized the following context around structured output for databricks serving endpoint:
Structured output is supported via the `response_format` parameter in the `/serving-endpoints/{model_name}/invocations` endpoint for most chat models including GPT-5 (native OpenAI API support), GPT-OSS, Llama 3.x/4, Gemma 3, and Gemini models (all using vLLM/RexIE with xgrammar guided decoding), and Claude models (implemented via tool-based workaround). The standard request format uses 
```
response_format: {"type": "json_schema", "json_schema": {"name": "schema_name", "schema": {...}}} 
```
for schema-validated JSON or `{"type": "json_object"}` for unstructured JSON. 

Key limitations: Claude only supports json_schema (not json_object) and cannot be used with streaming or combined with explicit tools/tool_choice; GPT-5's strict: true mode requires all objects to include "additionalProperties": false in the schema; Gemini and Gemma use native Vertex AI responseMimeType/responseJsonSchema parameters internally. All models except Claude support streaming with structured output, though implementation varies between native API pass-through (GPT-5) and grammar-constrained generation (open-source models).

Code Pointers Validating this format: https://docs.google.com/document/d/1DhqyjKlN45K9F14EVa77EKLn8yB7K6ZaIEtu2tjfN14/edit?usp=sharing 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Manual Test
Verified with this notebook that the structured output is working with claude, gemini, gemma gpt oss and llama: https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/2738700022758522?o=6051921418418893

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
