### PR TITLE
Implement tool choice and max_completion_tokens

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -1618,6 +1618,8 @@ mlflow.types.chat.ResponseFormat
 mlflow.types.chat.TextContentPart
 mlflow.types.chat.ToolCall
 mlflow.types.chat.ToolCallDelta
+mlflow.types.chat.ToolChoice
+mlflow.types.chat.ToolChoiceFunction
 mlflow.types.llm.ChatChoice
 mlflow.types.llm.ChatChoiceDelta
 mlflow.types.llm.ChatChoiceLogProbs

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -35,7 +35,10 @@ class AnthropicAdapter(ProviderAdapter):
                 status_code=422, detail="Cannot set both 'temperature' and 'top_p' parameters."
             )
 
-        max_tokens = payload.get("max_tokens", MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS)
+        max_completion_tokens = payload.pop("max_completion_tokens", None)
+        max_tokens = payload.get("max_tokens") or max_completion_tokens
+        if max_tokens is None:
+            max_tokens = MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS
         if max_tokens > MLFLOW_AI_GATEWAY_ANTHROPIC_MAXIMUM_MAX_TOKENS:
             raise AIGatewayException(
                 status_code=422,

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -130,17 +130,15 @@ class AnthropicAdapter(ProviderAdapter):
         # OpenAI format: "none", "auto", "required", {"type": "...", "function": {"name": "..."}}
         # Anthropic format: {"type": "auto"}, {"type": "tool", "name": "..."}
         if tool_choice := payload.pop("tool_choice", None):
-            if tool_choice == "none":
-                payload["tool_choice"] = {"type": "none"}
-            elif tool_choice == "auto":
-                payload["tool_choice"] = {"type": "auto"}
-            elif tool_choice == "required":
-                payload["tool_choice"] = {"type": "any"}
-            elif isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
-                payload["tool_choice"] = {
-                    "type": "tool",
-                    "name": tool_choice["function"]["name"],
-                }
+            match tool_choice:
+                case "none":
+                    payload["tool_choice"] = {"type": "none"}
+                case "auto":
+                    payload["tool_choice"] = {"type": "auto"}
+                case "required":
+                    payload["tool_choice"] = {"type": "any"}
+                case {"type": "function", "function": {"name": name}}:
+                    payload["tool_choice"] = {"type": "tool", "name": name}
 
         # Transform response_format for Anthropic structured outputs
         # Anthropic uses output_format with {"type": "json_schema", "schema": {...}}

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -123,6 +123,22 @@ class AnthropicAdapter(ProviderAdapter):
 
             payload["tools"] = converted_tools
 
+        # convert tool_choice to Anthropic format
+        # OpenAI format: "none", "auto", "required", {"type": "...", "function": {"name": "..."}}
+        # Anthropic format: {"type": "auto"}, {"type": "tool", "name": "..."}
+        if tool_choice := payload.pop("tool_choice", None):
+            if tool_choice == "none":
+                payload["tool_choice"] = {"type": "none"}
+            elif tool_choice == "auto":
+                payload["tool_choice"] = {"type": "auto"}
+            elif tool_choice == "required":
+                payload["tool_choice"] = {"type": "any"}
+            elif isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+                payload["tool_choice"] = {
+                    "type": "tool",
+                    "name": tool_choice["function"]["name"],
+                }
+
         # Transform response_format for Anthropic structured outputs
         # Anthropic uses output_format with {"type": "json_schema", "schema": {...}}
         if response_format := payload.pop("response_format", None):

--- a/mlflow/gateway/providers/gemini.py
+++ b/mlflow/gateway/providers/gemini.py
@@ -95,6 +95,10 @@ class GeminiAdapter(ProviderAdapter):
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
 
+        if "max_completion_tokens" in payload:
+            if "max_tokens" not in payload:
+                payload["max_tokens"] = payload.pop("max_completion_tokens")
+
         payload = rename_payload_keys(payload, GENERATION_CONFIG_KEY_MAPPING)
 
         contents = []

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -180,6 +180,7 @@ class BaseRequestPayload(BaseModel):
     n: int = Field(1, ge=1)
     stop: list[str] | None = Field(None, min_length=1)
     max_tokens: int | None = Field(None, ge=1)
+    max_completion_tokens: int | None = Field(None, ge=1)
     stream: bool | None = None
     stream_options: dict[str, Any] | None = None
     model: str | None = None

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -157,6 +157,23 @@ class ResponseFormat(BaseModel):
     json_schema: dict[str, Any] | None = None
 
 
+class ToolChoiceFunction(BaseModel):
+    """Specifies a tool the model should use."""
+
+    name: str
+
+
+class ToolChoice(BaseModel):
+    """
+    Specifies a particular tool to use.
+
+    OpenAI format: {"type": "function", "function": {"name": "my_function"}}
+    """
+
+    type: Literal["function"]
+    function: ToolChoiceFunction
+
+
 class BaseRequestPayload(BaseModel):
     """Common parameters used for chat completions and completion endpoints."""
 
@@ -232,6 +249,7 @@ class ChatCompletionRequest(BaseRequestPayload):
 
     messages: list[ChatMessage] = Field(..., min_length=1)
     tools: list[ChatTool] | None = Field(None, min_length=1)
+    tool_choice: Literal["none", "auto", "required"] | ToolChoice | None = None
 
 
 class ChatCompletionResponse(BaseModel):

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -301,6 +301,26 @@ async def test_chat():
         )
 
 
+@pytest.mark.asyncio
+async def test_chat_with_max_completion_tokens():
+    resp = chat_response()
+    config = chat_config()
+    with (
+        mock.patch("time.time", return_value=1677858242),
+        mock.patch("aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)) as mock_post,
+    ):
+        provider = AnthropicProvider(EndpointConfig(**config))
+        payload = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_completion_tokens": 500,
+        }
+        await provider.chat(chat.RequestPayload(**payload))
+
+        call_kwargs = mock_post.call_args[1]
+        assert call_kwargs["json"]["max_tokens"] == 500
+        assert "max_completion_tokens" not in call_kwargs["json"]
+
+
 def chat_function_calling_payload(stream: bool = False):
     payload = {
         "messages": [

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -358,6 +358,28 @@ async def test_gemini_chat():
 
 
 @pytest.mark.asyncio
+async def test_gemini_chat_with_max_completion_tokens():
+    config = chat_config()
+    provider = GeminiProvider(EndpointConfig(**config))
+    payload = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_completion_tokens": 500,
+    }
+
+    with (
+        mock.patch("time.time", return_value=1234567890),
+        mock.patch(
+            "aiohttp.ClientSession.post",
+            return_value=MockAsyncResponse(fake_chat_response()),
+        ) as mock_post,
+    ):
+        await provider.chat(chat.RequestPayload(**payload))
+
+    call_kwargs = mock_post.call_args[1]
+    assert call_kwargs["json"]["generationConfig"]["maxOutputTokens"] == 500
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("override", "exclude_keys", "expected_msg"),
     [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/19849?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19849/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19849/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19849/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Support following missing gateway parameters:
- tool_choice for Anthropic
- max_completion_tokens for Anthropic and Gemini

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
