### PR TITLE
Fix authorization header duplication

### DIFF
--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -301,14 +301,14 @@ class OpenAIProvider(BaseProvider):
         api_type = self.openai_config.openai_api_type
         if api_type == OpenAIAPIType.OPENAI:
             headers = {
-                "Authorization": f"Bearer {self.openai_config.openai_api_key}",
+                "authorization": f"Bearer {self.openai_config.openai_api_key}",
             }
             if org := self.openai_config.openai_organization:
                 headers["OpenAI-Organization"] = org
             return headers
         elif api_type == OpenAIAPIType.AZUREAD:
             return {
-                "Authorization": f"Bearer {self.openai_config.openai_api_key}",
+                "authorization": f"Bearer {self.openai_config.openai_api_key}",
             }
         elif api_type == OpenAIAPIType.AZURE:
             return {
@@ -340,7 +340,6 @@ class OpenAIProvider(BaseProvider):
             client_headers = headers.copy()
             client_headers.pop("host", None)
             client_headers.pop("content-length", None)
-            client_headers.pop("authorization", None)
             # Don't override api key or organization headers
             result_headers = client_headers | result_headers
 

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -340,6 +340,7 @@ class OpenAIProvider(BaseProvider):
             client_headers = headers.copy()
             client_headers.pop("host", None)
             client_headers.pop("content-length", None)
+            client_headers.pop("authorization", None)
             # Don't override api key or organization headers
             result_headers = client_headers | result_headers
 

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -912,6 +912,7 @@ async def test_openai_passthrough_chat():
             "X-Request-ID": "req-123",
             "host": "example.com",
             "content-length": "100",
+            "authorization": "Bearer key",
         }
         response = await provider.passthrough(
             PassthroughAction.OPENAI_CHAT, payload, headers=custom_headers
@@ -934,6 +935,7 @@ async def test_openai_passthrough_chat():
         # Verify gateway specific headers are not propagated
         assert "host" not in call_kwargs["headers"]
         assert "content-length" not in call_kwargs["headers"]
+        assert "authorization" not in call_kwargs["headers"]
 
         # Verify response is raw OpenAI format
         assert response == mock_response

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -120,7 +120,7 @@ async def _run_test_chat(provider):
         }
         mock_build_client.assert_called_once_with(
             headers={
-                "Authorization": "Bearer key",
+                "authorization": "Bearer key",
             }
         )
         mock_client.post.assert_called_once_with(
@@ -237,7 +237,7 @@ async def _run_test_chat_stream(resp, provider):
 
         mock_build_client.assert_called_once_with(
             headers={
-                "Authorization": "Bearer key",
+                "authorization": "Bearer key",
             }
         )
         mock_client.post.assert_called_once_with(
@@ -398,7 +398,7 @@ async def _run_test_completions(resp, provider):
         }
         mock_build_client.assert_called_once_with(
             headers={
-                "Authorization": "Bearer key",
+                "authorization": "Bearer key",
                 "OpenAI-Organization": "test-organization",
             }
         )
@@ -518,7 +518,7 @@ async def _run_test_completions_stream(resp, provider):
 
         mock_build_client.assert_called_once_with(
             headers={
-                "Authorization": "Bearer key",
+                "authorization": "Bearer key",
                 "OpenAI-Organization": "test-organization",
             }
         )
@@ -599,7 +599,7 @@ async def _run_test_embeddings(provider):
         }
         mock_build_client.assert_called_once_with(
             headers={
-                "Authorization": "Bearer key",
+                "authorization": "Bearer key",
             }
         )
         mock_client.post.assert_called_once_with(
@@ -678,7 +678,7 @@ async def test_embeddings_batch_input():
         }
         mock_build_client.assert_called_once_with(
             headers={
-                "Authorization": "Bearer key",
+                "authorization": "Bearer key",
             }
         )
         mock_client.post.assert_called_once_with(
@@ -769,7 +769,7 @@ async def test_azuread_openai():
         }
         mock_build_client.assert_called_once_with(
             headers={
-                "Authorization": "Bearer key",
+                "authorization": "Bearer key",
             }
         )
         mock_client.post.assert_called_once_with(
@@ -926,7 +926,7 @@ async def test_openai_passthrough_chat():
         assert call_kwargs["payload"]["messages"] == [{"role": "user", "content": "Hello"}]
 
         # Verify provider headers are propagated correctly
-        assert call_kwargs["headers"]["Authorization"] == "Bearer key"
+        assert call_kwargs["headers"]["authorization"] == "Bearer key"
 
         # Verify custom headers are propagated correctly
         assert call_kwargs["headers"]["X-Custom-Header"] == "custom-value"
@@ -935,7 +935,6 @@ async def test_openai_passthrough_chat():
         # Verify gateway specific headers are not propagated
         assert "host" not in call_kwargs["headers"]
         assert "content-length" not in call_kwargs["headers"]
-        assert "authorization" not in call_kwargs["headers"]
 
         # Verify response is raw OpenAI format
         assert response == mock_response
@@ -982,7 +981,7 @@ async def test_openai_passthrough_embeddings():
         assert call_kwargs["payload"]["input"] == "Test input"
 
         # Verify provider headers are propagated correctly
-        assert call_kwargs["headers"]["Authorization"] == "Bearer key"
+        assert call_kwargs["headers"]["authorization"] == "Bearer key"
 
         # Verify custom headers are propagated correctly
         assert call_kwargs["headers"]["X-Custom-Header"] == "custom-value"
@@ -1030,7 +1029,7 @@ async def test_openai_passthrough_responses():
         assert call_kwargs["payload"]["instructions"] == "You are a helpful assistant"
 
         # Verify provider headers are propagated correctly
-        assert call_kwargs["headers"]["Authorization"] == "Bearer key"
+        assert call_kwargs["headers"]["authorization"] == "Bearer key"
 
         # Verify custom headers are propagated correctly
         assert call_kwargs["headers"]["X-Trace-ID"] == "trace-456"

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -112,7 +112,7 @@ def test_score_model_openai(set_envs):
         assert resp == "\n\nThis is a test!"
         mock_post.assert_called_once_with(
             endpoint="https://api.openai.com/v1/chat/completions",
-            headers={"Authorization": "Bearer test"},
+            headers={"authorization": "Bearer test"},
             payload={
                 "messages": [{"role": "user", "content": "my prompt"}],
                 "model": "gpt-4o-mini",
@@ -136,7 +136,7 @@ def test_score_model_openai_with_custom_header_and_proxy_url(set_envs):
         assert resp == "\n\nThis is a test!"
         mock_post.assert_called_once_with(
             endpoint="https://my-proxy.com/chat",
-            headers={"Authorization": "Bearer test", "foo": "bar"},
+            headers={"authorization": "Bearer test", "foo": "bar"},
             payload={
                 "messages": [{"role": "user", "content": "my prompt"}],
                 "model": "gpt-4o-mini",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/19853?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19853/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19853/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19853/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

OpenAI SDK uses "authorization" header instead of "Authorization", which causes the header conflict.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
