### PR TITLE
Implement chat streaming support in MistralProvider 

### DIFF
--- a/tests/gateway/providers/test_mistral.py
+++ b/tests/gateway/providers/test_mistral.py
@@ -12,7 +12,7 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.mistral import MistralProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse
+from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, mock_http_client
 
 TEST_STRING = "This is a test"
 CONTENT_TYPE = "application/json"
@@ -352,3 +352,97 @@ async def test_chat_with_structured_output():
             "type": "json_schema",
             "json_schema": json_schema,
         }
+
+
+def chat_stream_response():
+    return [
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1677858242,'
+        b'"model":"mistral-large-latest","choices":[{"index":0,"finish_reason":null,'
+        b'"delta":{"role":"assistant"}}]}\n',
+        b"\n",
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1677858242,'
+        b'"model":"mistral-large-latest","choices":[{"index":0,"finish_reason":null,'
+        b'"delta":{"content":"Hello"}}]}\n',
+        b"\n",
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1677858242,'
+        b'"model":"mistral-large-latest","choices":[{"index":0,"finish_reason":null,'
+        b'"delta":{"content":" there"}}]}\n',
+        b"\n",
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1677858242,'
+        b'"model":"mistral-large-latest","choices":[{"index":0,"finish_reason":"stop",'
+        b'"delta":{}}]}\n',
+        b"\n",
+        b"data: [DONE]\n",
+    ]
+
+
+def chat_stream_response_incomplete():
+    return [
+        # contains first half of a chunk
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1677858242,'
+        b'"model":"mistral-large-latest","choi',
+        # contains second half of first chunk and first half of second chunk
+        b'ces":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}]}\n\n'
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1677858242,'
+        b'"model":"mistral-large-la',
+        # contains second half of second chunk
+        b'test","choices":[{"index":0,"finish_reason":null,"delta":{"content":"test"}}]}\n',
+        b"\n",
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1677858242,'
+        b'"model":"mistral-large-latest","choices":[{"index":0,"finish_reason":"stop",'
+        b'"delta":{}}]}\n',
+        b"\n",
+        b"data: [DONE]\n",
+    ]
+
+
+async def _run_test_chat_stream(resp, provider):
+    mock_client = mock_http_client(MockAsyncStreamingResponse(resp))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_build_client:
+        payload = {"messages": [{"role": "user", "content": "Tell me a joke"}]}
+        response = provider.chat_stream(chat.RequestPayload(**payload))
+
+        chunks = [jsonable_encoder(chunk) async for chunk in response]
+
+        # Verify we got the expected number of chunks (excluding [DONE])
+        assert len(chunks) >= 3
+
+        # Verify the first chunk has the assistant role
+        assert chunks[0]["choices"][0]["delta"]["role"] == "assistant"
+
+        # Verify the last chunk has finish_reason "stop"
+        assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+
+        # Verify all chunks have the expected structure
+        for chunk in chunks:
+            assert "id" in chunk
+            assert chunk["object"] == "chat.completion.chunk"
+            assert "created" in chunk
+            assert "model" in chunk
+            assert "choices" in chunk
+            assert len(chunk["choices"]) == 1
+            assert "delta" in chunk["choices"][0]
+
+        mock_build_client.assert_called_once_with(
+            headers={
+                "Authorization": "Bearer key",
+            }
+        )
+        mock_client.post.assert_called_once_with(
+            "https://api.mistral.ai/v1/chat/completions",
+            json={
+                "model": "mistral-large-latest",
+                "n": 1,
+                **payload,
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+        )
+
+
+@pytest.mark.parametrize("resp", [chat_stream_response(), chat_stream_response_incomplete()])
+@pytest.mark.asyncio
+async def test_chat_stream(resp):
+    config = chat_config()
+    provider = MistralProvider(EndpointConfig(**config))
+    await _run_test_chat_stream(resp, provider)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/19858?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19858/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19858/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19858/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Support chat stream for mistral provider

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
