### PR TITLE
Preserve start time label in overview tab

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/utils.tsx
@@ -2,6 +2,7 @@ import { ExperimentPageTabName } from '../../../constants';
 
 export const isTracesRelatedTab = (tabName: ExperimentPageTabName) => {
   return (
+    tabName === ExperimentPageTabName.Overview ||
     tabName === ExperimentPageTabName.Traces ||
     tabName === ExperimentPageTabName.SingleChatSession ||
     tabName === ExperimentPageTabName.ChatSessions


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19864/files) to review incremental changes.
- [**stack/start_time_preservation**](https://github.com/mlflow/mlflow/pull/19864) [[Files changed](https://github.com/mlflow/mlflow/pull/19864/files)]
  - [stack/add_tab_name_in_url](https://github.com/mlflow/mlflow/pull/19865) [[Files changed](https://github.com/mlflow/mlflow/pull/19865/files/7945961c9d07b6e077323e1f388f35eb37a8bbb3..cdea73ef429d60cda656157181dcb0b4041801c3)]
    - [stack/overview_refresh_redirect](https://github.com/mlflow/mlflow/pull/19867) [[Files changed](https://github.com/mlflow/mlflow/pull/19867/files/cdea73ef429d60cda656157181dcb0b4041801c3..167e0a1d781ca0be407ecab98d76c8828528e934)]
      - [stack/small_improvements](https://github.com/mlflow/mlflow/pull/19869) [[Files changed](https://github.com/mlflow/mlflow/pull/19869/files/167e0a1d781ca0be407ecab98d76c8828528e934..f656f46395d00917fb44c80b6cc89f4089b68d8d)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Make sure start time label is preserved when switching between overview tab and other tabs

https://github.com/user-attachments/assets/5c553e79-14dd-4ad7-87b1-7944dd92cc2d


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
