### PR TITLE
Small improvements on charts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useInferExperimentKind.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useInferExperimentKind.test.tsx
@@ -5,7 +5,7 @@ import { useInferExperimentKind } from './useInferExperimentKind';
 import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { setupServer } from '../../../../common/utils/setup-msw';
 import { rest } from 'msw';
-import { ExperimentKind } from '../../../constants';
+import { ExperimentKind, ExperimentPageTabName } from '../../../constants';
 
 describe('useInferExperimentKind', () => {
   const server = setupServer();
@@ -47,10 +47,11 @@ describe('useInferExperimentKind', () => {
     });
 
     expect(result.current.inferredExperimentKind).toBe(ExperimentKind.NO_INFERRED_TYPE);
+    expect(result.current.inferredExperimentPageTab).toBeUndefined();
     expect(updateExperimentKind).not.toHaveBeenCalled();
   });
 
-  test('it should infer GenAI type when traces are present', async () => {
+  test('it should infer GenAI type when traces are present and return Overview tab', async () => {
     server.use(
       rest.get('/ajax-api/2.0/mlflow/traces', (req, res, ctx) => {
         return res(ctx.json({ traces: [{ id: 'trace1' }] }));
@@ -67,10 +68,11 @@ describe('useInferExperimentKind', () => {
     });
 
     expect(result.current.inferredExperimentKind).toBe(ExperimentKind.GENAI_DEVELOPMENT_INFERRED);
+    expect(result.current.inferredExperimentPageTab).toBe(ExperimentPageTabName.Overview);
     expect(updateExperimentKind).not.toHaveBeenCalled();
   });
 
-  test('it should infer custom model development when no traces, but training runs are present', async () => {
+  test('it should infer custom model development when no traces, but training runs are present and return Runs tab', async () => {
     server.use(
       rest.get('/ajax-api/2.0/mlflow/traces', (req, res, ctx) => {
         return res(ctx.json({ traces: [] }));
@@ -87,6 +89,7 @@ describe('useInferExperimentKind', () => {
     });
 
     expect(result.current.inferredExperimentKind).toBe(ExperimentKind.CUSTOM_MODEL_DEVELOPMENT_INFERRED);
+    expect(result.current.inferredExperimentPageTab).toBe(ExperimentPageTabName.Runs);
     expect(updateExperimentKind).not.toHaveBeenCalled();
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useInferExperimentKind.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useInferExperimentKind.tsx
@@ -53,7 +53,7 @@ export const useInferExperimentKind = ({
 
   const inferredExperimentPageTab = useMemo(() => {
     if (inferredExperimentKind === ExperimentKind.GENAI_DEVELOPMENT_INFERRED) {
-      return ExperimentPageTabName.Traces;
+      return ExperimentPageTabName.Overview;
     }
     if (inferredExperimentKind === ExperimentKind.CUSTOM_MODEL_DEVELOPMENT_INFERRED) {
       return ExperimentPageTabName.Runs;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.test.tsx
@@ -28,14 +28,17 @@ describe('ExperimentGenAIOverviewPage', () => {
       },
     });
 
-  const renderComponent = (initialUrl = `/experiments/${testExperimentId}/overview`) => {
+  const renderComponent = (initialUrl = `/experiments/${testExperimentId}/overview/usage`) => {
     const queryClient = createQueryClient();
     return renderWithIntl(
       <QueryClientProvider client={queryClient}>
         <DesignSystemProvider>
           <MemoryRouter initialEntries={[initialUrl]}>
             <Routes>
-              <Route path="/experiments/:experimentId/overview" element={<ExperimentGenAIOverviewPage />} />
+              <Route
+                path="/experiments/:experimentId/overview/:overviewTab?"
+                element={<ExperimentGenAIOverviewPage />}
+              />
             </Routes>
           </MemoryRouter>
         </DesignSystemProvider>
@@ -230,7 +233,7 @@ describe('ExperimentGenAIOverviewPage', () => {
     it('should handle custom time range from URL parameters', async () => {
       const customStartTime = '2025-01-01T00:00:00.000Z';
       const customEndTime = '2025-01-07T23:59:59.999Z';
-      const urlWithParams = `/experiments/${testExperimentId}/overview?startTimeLabel=CUSTOM&startTime=${encodeURIComponent(
+      const urlWithParams = `/experiments/${testExperimentId}/overview/usage?startTimeLabel=CUSTOM&startTime=${encodeURIComponent(
         customStartTime,
       )}&endTime=${encodeURIComponent(customEndTime)}`;
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -22,18 +22,13 @@ import { TabContentContainer, ChartGrid } from './components/OverviewLayoutCompo
 import { calculateTimeInterval } from './hooks/useTraceMetricsQuery';
 import { generateTimeBuckets } from './utils/chartUtils';
 import { OverviewChartProvider } from './OverviewChartContext';
-
-enum OverviewTab {
-  Usage = 'usage',
-  Quality = 'quality',
-  ToolCalls = 'tool-calls',
-}
+import { useOverviewTab, OverviewTab } from './hooks/useOverviewTab';
 
 const ExperimentGenAIOverviewPageImpl = () => {
   const { experimentId } = useParams();
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
-  const [activeTab, setActiveTab] = useState<OverviewTab>(OverviewTab.Usage);
+  const [activeTab, setActiveTab] = useOverviewTab();
   const [searchQuery, setSearchQuery] = useState('');
 
   invariant(experimentId, 'Experiment ID must be defined');

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -98,7 +98,7 @@ const ExperimentGenAIOverviewPageImpl = () => {
             display: 'flex',
             alignItems: 'center',
             gap: theme.spacing.sm,
-            padding: `${theme.spacing.sm}px 0`,
+            padding: `0 0`,
           }}
         >
           {/* Search input */}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/AssessmentChartsSection.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/AssessmentChartsSection.test.tsx
@@ -94,7 +94,7 @@ describe('AssessmentChartsSection', () => {
       renderComponent();
 
       // Check that actual chart content is not rendered during loading
-      expect(screen.queryByText('Scorer Insights')).not.toBeInTheDocument();
+      expect(screen.queryByText('Quality Insights')).not.toBeInTheDocument();
     });
   });
 
@@ -139,7 +139,7 @@ describe('AssessmentChartsSection', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Scorer Insights')).toBeInTheDocument();
+        expect(screen.getByText('Quality Insights')).toBeInTheDocument();
       });
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/AssessmentChartsSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/AssessmentChartsSection.tsx
@@ -47,8 +47,8 @@ export const AssessmentChartsSection: React.FC = () => {
           <SparkleIcon css={{ color: theme.colors.yellow500 }} />
           <Typography.Text bold size="lg">
             <FormattedMessage
-              defaultMessage="Scorer Insights"
-              description="Title for the scorer insights section in quality tab"
+              defaultMessage="Quality Insights"
+              description="Title for the quality insights section in quality tab"
             />
           </Typography.Text>
         </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewLayoutComponents.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewLayoutComponents.tsx
@@ -75,7 +75,7 @@ export const TabContentContainer: React.FC<{ children?: React.ReactNode }> = ({ 
         display: 'flex',
         flexDirection: 'column',
         gap: theme.spacing.lg,
-        padding: `${theme.spacing.sm}px 0`,
+        padding: `${theme.spacing.md}px 0`,
       }}
     >
       {children}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolCallStatistics.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolCallStatistics.tsx
@@ -41,19 +41,19 @@ export const ToolCallStatistics: React.FC = () => {
         isLoading={isLoading}
       />
       <StatCard
-        icon={<CheckCircleIcon />}
-        iconColor={theme.colors.green600}
-        iconBgColor={theme.colors.green100}
-        value={`${successRate.toFixed(2)}%`}
-        label={<FormattedMessage defaultMessage="Success Rate" description="Label for success rate statistic" />}
-        isLoading={isLoading}
-      />
-      <StatCard
         icon={<ClockIcon />}
         iconColor={theme.colors.yellow600}
         iconBgColor={theme.colors.yellow100}
         value={formatLatency(avgLatency)}
         label={<FormattedMessage defaultMessage="Avg Latency" description="Label for average latency statistic" />}
+        isLoading={isLoading}
+      />
+      <StatCard
+        icon={<CheckCircleIcon />}
+        iconColor={theme.colors.green600}
+        iconBgColor={theme.colors.green100}
+        value={`${successRate.toFixed(2)}%`}
+        label={<FormattedMessage defaultMessage="Success Rate" description="Label for success rate statistic" />}
         isLoading={isLoading}
       />
       <StatCard

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useOverviewTab.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useOverviewTab.test.tsx
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useOverviewTab, OverviewTab } from './useOverviewTab';
 
 // Mock the routing utils
@@ -67,57 +67,8 @@ describe('useOverviewTab', () => {
     });
   });
 
-  describe('redirect behavior', () => {
-    it('should redirect to default tab when no tab specified', async () => {
-      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: undefined });
-      mockUseLocation.mockReturnValue({ search: '' });
-
-      renderHook(() => useOverviewTab());
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/experiments/123/overview/usage', { replace: true });
-      });
-    });
-
-    it('should redirect to default tab when invalid tab specified', async () => {
-      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'invalid' });
-      mockUseLocation.mockReturnValue({ search: '' });
-
-      renderHook(() => useOverviewTab());
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/experiments/123/overview/usage', { replace: true });
-      });
-    });
-
-    it('should preserve query params when redirecting', async () => {
-      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: undefined });
-      mockUseLocation.mockReturnValue({ search: '?startTimeLabel=LAST_7_DAYS' });
-
-      renderHook(() => useOverviewTab());
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/experiments/123/overview/usage?startTimeLabel=LAST_7_DAYS', {
-          replace: true,
-        });
-      });
-    });
-
-    it('should not redirect when valid tab is specified', async () => {
-      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'quality' });
-      mockUseLocation.mockReturnValue({ search: '' });
-
-      renderHook(() => useOverviewTab());
-
-      // Wait a tick to ensure useEffect has run
-      await waitFor(() => {
-        expect(mockNavigate).not.toHaveBeenCalled();
-      });
-    });
-  });
-
   describe('setActiveTab', () => {
-    it('should navigate to the new tab', async () => {
+    it('should navigate to the new tab', () => {
       mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'usage' });
       mockUseLocation.mockReturnValue({ search: '' });
 
@@ -127,12 +78,10 @@ describe('useOverviewTab', () => {
         result.current[1](OverviewTab.Quality);
       });
 
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/experiments/123/overview/quality', { replace: true });
-      });
+      expect(mockNavigate).toHaveBeenCalledWith('/experiments/123/overview/quality', { replace: true });
     });
 
-    it('should preserve query params when changing tabs', async () => {
+    it('should preserve query params when changing tabs', () => {
       mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'usage' });
       mockUseLocation.mockReturnValue({ search: '?startTimeLabel=LAST_7_DAYS&foo=bar' });
 
@@ -142,15 +91,13 @@ describe('useOverviewTab', () => {
         result.current[1](OverviewTab.ToolCalls);
       });
 
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith(
-          '/experiments/123/overview/tool-calls?startTimeLabel=LAST_7_DAYS&foo=bar',
-          { replace: true },
-        );
-      });
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/experiments/123/overview/tool-calls?startTimeLabel=LAST_7_DAYS&foo=bar',
+        { replace: true },
+      );
     });
 
-    it('should navigate to usage tab', async () => {
+    it('should navigate to usage tab', () => {
       mockUseParams.mockReturnValue({ experimentId: '456', overviewTab: 'quality' });
       mockUseLocation.mockReturnValue({ search: '' });
 
@@ -160,9 +107,7 @@ describe('useOverviewTab', () => {
         result.current[1](OverviewTab.Usage);
       });
 
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/experiments/456/overview/usage', { replace: true });
-      });
+      expect(mockNavigate).toHaveBeenCalledWith('/experiments/456/overview/usage', { replace: true });
     });
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useOverviewTab.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useOverviewTab.test.tsx
@@ -1,0 +1,176 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useOverviewTab, OverviewTab } from './useOverviewTab';
+
+// Mock the routing utils
+const mockNavigate = jest.fn();
+const mockUseParams = jest.fn();
+const mockUseLocation = jest.fn();
+
+jest.mock('@mlflow/mlflow/src/common/utils/RoutingUtils', () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => mockUseParams(),
+  useLocation: () => mockUseLocation(),
+}));
+
+describe('useOverviewTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default mock values
+    mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: undefined });
+    mockUseLocation.mockReturnValue({ search: '' });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('activeTab', () => {
+    it('should return "usage" as default when no tab in URL', () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: undefined });
+
+      const { result } = renderHook(() => useOverviewTab());
+
+      expect(result.current[0]).toBe(OverviewTab.Usage);
+    });
+
+    it('should return "usage" when overviewTab is "usage"', () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'usage' });
+
+      const { result } = renderHook(() => useOverviewTab());
+
+      expect(result.current[0]).toBe(OverviewTab.Usage);
+    });
+
+    it('should return "quality" when overviewTab is "quality"', () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'quality' });
+
+      const { result } = renderHook(() => useOverviewTab());
+
+      expect(result.current[0]).toBe(OverviewTab.Quality);
+    });
+
+    it('should return "tool-calls" when overviewTab is "tool-calls"', () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'tool-calls' });
+
+      const { result } = renderHook(() => useOverviewTab());
+
+      expect(result.current[0]).toBe(OverviewTab.ToolCalls);
+    });
+
+    it('should return default "usage" when overviewTab is invalid', () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'invalid-tab' });
+
+      const { result } = renderHook(() => useOverviewTab());
+
+      expect(result.current[0]).toBe(OverviewTab.Usage);
+    });
+  });
+
+  describe('redirect behavior', () => {
+    it('should redirect to default tab when no tab specified', async () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: undefined });
+      mockUseLocation.mockReturnValue({ search: '' });
+
+      renderHook(() => useOverviewTab());
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/experiments/123/overview/usage', { replace: true });
+      });
+    });
+
+    it('should redirect to default tab when invalid tab specified', async () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'invalid' });
+      mockUseLocation.mockReturnValue({ search: '' });
+
+      renderHook(() => useOverviewTab());
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/experiments/123/overview/usage', { replace: true });
+      });
+    });
+
+    it('should preserve query params when redirecting', async () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: undefined });
+      mockUseLocation.mockReturnValue({ search: '?startTimeLabel=LAST_7_DAYS' });
+
+      renderHook(() => useOverviewTab());
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/experiments/123/overview/usage?startTimeLabel=LAST_7_DAYS', {
+          replace: true,
+        });
+      });
+    });
+
+    it('should not redirect when valid tab is specified', async () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'quality' });
+      mockUseLocation.mockReturnValue({ search: '' });
+
+      renderHook(() => useOverviewTab());
+
+      // Wait a tick to ensure useEffect has run
+      await waitFor(() => {
+        expect(mockNavigate).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('setActiveTab', () => {
+    it('should navigate to the new tab', async () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'usage' });
+      mockUseLocation.mockReturnValue({ search: '' });
+
+      const { result } = renderHook(() => useOverviewTab());
+
+      act(() => {
+        result.current[1](OverviewTab.Quality);
+      });
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/experiments/123/overview/quality', { replace: true });
+      });
+    });
+
+    it('should preserve query params when changing tabs', async () => {
+      mockUseParams.mockReturnValue({ experimentId: '123', overviewTab: 'usage' });
+      mockUseLocation.mockReturnValue({ search: '?startTimeLabel=LAST_7_DAYS&foo=bar' });
+
+      const { result } = renderHook(() => useOverviewTab());
+
+      act(() => {
+        result.current[1](OverviewTab.ToolCalls);
+      });
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/experiments/123/overview/tool-calls?startTimeLabel=LAST_7_DAYS&foo=bar',
+          { replace: true },
+        );
+      });
+    });
+
+    it('should navigate to usage tab', async () => {
+      mockUseParams.mockReturnValue({ experimentId: '456', overviewTab: 'quality' });
+      mockUseLocation.mockReturnValue({ search: '' });
+
+      const { result } = renderHook(() => useOverviewTab());
+
+      act(() => {
+        result.current[1](OverviewTab.Usage);
+      });
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/experiments/456/overview/usage', { replace: true });
+      });
+    });
+  });
+
+  describe('OverviewTab enum', () => {
+    it('should have correct values', () => {
+      expect(OverviewTab.Usage).toBe('usage');
+      expect(OverviewTab.Quality).toBe('quality');
+      expect(OverviewTab.ToolCalls).toBe('tool-calls');
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useOverviewTab.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useOverviewTab.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect } from 'react';
+import { useNavigate, useParams, useLocation } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+
+export enum OverviewTab {
+  Usage = 'usage',
+  Quality = 'quality',
+  ToolCalls = 'tool-calls',
+}
+
+const DEFAULT_TAB = OverviewTab.Usage;
+
+/**
+ * Path param-powered hook that returns the active overview tab from the URL.
+ * Uses URL path segments (e.g., /overview/usage) for shareable links.
+ */
+export const useOverviewTab = () => {
+  const { experimentId, overviewTab } = useParams<{ experimentId: string; overviewTab?: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Validate the tab value, fallback to default if invalid
+  const activeTab = Object.values(OverviewTab).includes(overviewTab as OverviewTab)
+    ? (overviewTab as OverviewTab)
+    : DEFAULT_TAB;
+
+  // Redirect to default tab if no tab specified or invalid tab
+  useEffect(() => {
+    if (!overviewTab || !Object.values(OverviewTab).includes(overviewTab as OverviewTab)) {
+      navigate(`/experiments/${experimentId}/overview/${DEFAULT_TAB}${location.search}`, { replace: true });
+    }
+  }, [overviewTab, experimentId, navigate, location.search]);
+
+  const setActiveTab = useCallback(
+    (tab: OverviewTab) => {
+      navigate(`/experiments/${experimentId}/overview/${tab}${location.search}`, { replace: true });
+    },
+    [experimentId, navigate, location.search],
+  );
+
+  return [activeTab, setActiveTab] as const;
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useOverviewTab.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useOverviewTab.ts
@@ -23,13 +23,6 @@ export const useOverviewTab = () => {
     ? (overviewTab as OverviewTab)
     : DEFAULT_TAB;
 
-  // Redirect to default tab if no tab specified or invalid tab
-  useEffect(() => {
-    if (!overviewTab || !Object.values(OverviewTab).includes(overviewTab as OverviewTab)) {
-      navigate(`/experiments/${experimentId}/overview/${DEFAULT_TAB}${location.search}`, { replace: true });
-    }
-  }, [overviewTab, experimentId, navigate, location.search]);
-
   const setActiveTab = useCallback(
     (tab: OverviewTab) => {
       navigate(`/experiments/${experimentId}/overview/${tab}${location.search}`, { replace: true });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.test.tsx
@@ -32,6 +32,12 @@ jest.mock('../experiment-traces/ExperimentTracesPage', () => ({
   default: () => <div>Experiment traces page</div>,
 }));
 
+jest.mock('../experiment-overview/ExperimentGenAIOverviewPage', () => ({
+  // mock default export
+  __esModule: true,
+  default: () => <div>Experiment overview page</div>,
+}));
+
 describe('ExperimentLoggedModelListPage', () => {
   const { history } = setupTestRouter();
   const createTestExperiment = (
@@ -82,6 +88,13 @@ describe('ExperimentLoggedModelListPage', () => {
                       pageId: PageId.experimentPage,
                       element: createLazyRouteElement(() => import('./ExperimentPageTabs')),
                       children: [
+                        {
+                          path: RoutePaths.experimentPageTabOverview,
+                          pageId: PageId.experimentPageTabOverview,
+                          element: createLazyRouteElement(
+                            () => import('../experiment-overview/ExperimentGenAIOverviewPage'),
+                          ),
+                        },
                         {
                           path: RoutePaths.experimentPageTabTraces,
                           pageId: PageId.experimentPageTabTraces,
@@ -165,8 +178,8 @@ describe('ExperimentLoggedModelListPage', () => {
       ),
     ).toBeInTheDocument();
 
-    // Check we've been redirected to the Traces tab
-    expect(await screen.findByText('Experiment traces page')).toBeInTheDocument();
+    // Check we've been redirected to the Overview tab
+    expect(await screen.findByText('Experiment overview page')).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -49,7 +49,7 @@ export class RoutePaths {
   }
   // Child routes for experiment page:
   static get experimentPageTabOverview() {
-    return createMLflowRoutePath('/experiments/:experimentId/overview');
+    return createMLflowRoutePath('/experiments/:experimentId/overview/:overviewTab?');
   }
   static get experimentPageTabRuns() {
     return createMLflowRoutePath('/experiments/:experimentId/runs');

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5791,6 +5791,10 @@
     "defaultMessage": "collapse {title}",
     "description": "Common component > collapsible section > alternative label when expand"
   },
+  "ic8x74": {
+    "defaultMessage": "Quality Insights",
+    "description": "Title for the quality insights section in quality tab"
+  },
   "icBP3T": {
     "defaultMessage": "TRUE",
     "description": "Header label for boolean assessment type for the true rate"
@@ -5958,10 +5962,6 @@
   "k0m460": {
     "defaultMessage": "Failed to load child runs",
     "description": "Run page > Overview > Child runs error"
-  },
-  "k3V20c": {
-    "defaultMessage": "Scorer Insights",
-    "description": "Title for the scorer insights section in quality tab"
   },
   "kA+QJr": {
     "defaultMessage": "Overview",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19869/files/abbb7d82c4296a20a92de282e1c73e1d6cd50ba2..374d8b088eacd997d55b13bac0f0569eb871669f) to review incremental changes.
- [stack/add_tab_name_in_url](https://github.com/mlflow/mlflow/pull/19865) [[Files changed](https://github.com/mlflow/mlflow/pull/19865/files)]
  - [stack/overview_refresh_redirect](https://github.com/mlflow/mlflow/pull/19867) [[Files changed](https://github.com/mlflow/mlflow/pull/19867/files/4667073f2670bd82a34a7ba586ab8e5915071bbe..abbb7d82c4296a20a92de282e1c73e1d6cd50ba2)]
    - [**stack/small_improvements**](https://github.com/mlflow/mlflow/pull/19869) [[Files changed](https://github.com/mlflow/mlflow/pull/19869/files/abbb7d82c4296a20a92de282e1c73e1d6cd50ba2..374d8b088eacd997d55b13bac0f0569eb871669f)]
      - [stack/preserve_current_page](https://github.com/mlflow/mlflow/pull/19915) [[Files changed](https://github.com/mlflow/mlflow/pull/19915/files/374d8b088eacd997d55b13bac0f0569eb871669f..3697835a2b18d23abb0783e7b1e099587ac3c8fa)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
1. rename 'Scorer insights' to 'Quality insights'
Before:
<img width="356" height="181" alt="Screenshot 2026-01-12 at 2 15 21 PM" src="https://github.com/user-attachments/assets/7813fb3c-b26d-477e-acd6-4104400039aa" />

After:
<img width="278" height="165" alt="Screenshot 2026-01-12 at 2 16 15 PM" src="https://github.com/user-attachments/assets/344a48a9-b9dc-45cb-aec5-611e68db2780" />

2. update the stats card order
Before:
<img width="1098" height="127" alt="Screenshot 2026-01-12 at 2 15 39 PM" src="https://github.com/user-attachments/assets/58747c27-71ed-427e-893b-f4127cb1d694" />

After:
<img width="1097" height="126" alt="Screenshot 2026-01-12 at 2 16 24 PM" src="https://github.com/user-attachments/assets/06c22b1e-6dc0-4cc8-8324-4ac58f5836f8" />

3. Adjust the padding so now the gap between 'tab' and 'search box' is the same as the gap between 'search box' and 'first chart' as 16px.
Before:
<img width="610" height="117" alt="Screenshot 2026-01-12 at 2 15 56 PM" src="https://github.com/user-attachments/assets/dbdb10db-9b73-4866-bcb8-07c94eecb336" />

After:
<img width="602" height="118" alt="Screenshot 2026-01-12 at 2 16 31 PM" src="https://github.com/user-attachments/assets/aaf88ef7-eb28-4710-a98c-cf2d4b0ddd95" />

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
