### PR TITLE
Importing metrics from ragas.metrics.collections

### DIFF
--- a/mlflow/genai/scorers/ragas/__init__.py
+++ b/mlflow/genai/scorers/ragas/__init__.py
@@ -206,7 +206,7 @@ class RagasScorer(Scorer):
     def _evaluate(self, sample: SingleTurnSample):
         if hasattr(self._metric, "single_turn_score"):
             return self._metric.single_turn_score(sample)
-        elif hasattr(self._metric, "score"):
+        elif hasattr(self._metric, "ascore"):
             # need to inspect the signature as each metric has a different one for the ascore method
             sig = inspect.signature(self._metric.ascore)
             kwargs = {}

--- a/mlflow/genai/scorers/ragas/__init__.py
+++ b/mlflow/genai/scorers/ragas/__init__.py
@@ -206,7 +206,8 @@ class RagasScorer(Scorer):
     def _evaluate(self, sample: SingleTurnSample):
         if hasattr(self._metric, "single_turn_score"):
             return self._metric.single_turn_score(sample)
-        elif hasattr(self._metric, "ascore"):
+        elif hasattr(self._metric, "score"):
+            # need to inspect the signature as each metric has a different one for the ascore method
             sig = inspect.signature(self._metric.ascore)
             kwargs = {}
             for param_name in sig.parameters:

--- a/mlflow/genai/scorers/ragas/__init__.py
+++ b/mlflow/genai/scorers/ragas/__init__.py
@@ -18,10 +18,12 @@ Example usage:
 
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import Any
 
 from pydantic import PrivateAttr
+from ragas.dataset_schema import SingleTurnSample
 
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
@@ -32,11 +34,15 @@ from mlflow.genai.judges.utils import CategoricalRating, get_default_model
 from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
 from mlflow.genai.scorers.base import Scorer, ScorerKind
 from mlflow.genai.scorers.ragas.models import create_ragas_model
-from mlflow.genai.scorers.ragas.registry import get_metric_class, is_deterministic_metric
+from mlflow.genai.scorers.ragas.registry import (
+    get_metric_class,
+    is_deterministic_metric,
+)
 from mlflow.genai.scorers.ragas.utils import (
     create_mlflow_error_message_from_ragas_param,
     map_scorer_inputs_to_ragas_sample,
 )
+from mlflow.genai.utils.trace_utils import _wrap_async_predict_fn
 from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import format_docstring
 
@@ -148,12 +154,7 @@ class RagasScorer(Scorer):
                 trace=trace,
             )
 
-            if hasattr(self._metric, "single_turn_score"):
-                result = self._metric.single_turn_score(sample)
-            elif hasattr(self._metric, "score"):
-                result = self._metric.score(sample)
-            else:
-                raise MlflowException(f"RAGAS metric {self.name} is currently not supported")
+            result = self._evaluate(sample)
 
             score = float(result)
 
@@ -178,8 +179,8 @@ class RagasScorer(Scorer):
                 trace_id=None,
                 metadata=metadata,
             )
-        except (KeyError, IndexError) as e:
-            # RAGAS raises KeyError/IndexError when required parameters are missing
+        except (KeyError, IndexError, ValueError) as e:
+            # RAGAS raises KeyError/IndexError/ValueError when required parameters are missing
             error_msg = str(e).strip("'\"")
             mlflow_error_message = create_mlflow_error_message_from_ragas_param(
                 error_msg, self.name
@@ -201,6 +202,25 @@ class RagasScorer(Scorer):
                 error=e,
                 source=assessment_source,
             )
+
+    def _evaluate(self, sample: SingleTurnSample):
+        if hasattr(self._metric, "single_turn_score"):
+            return self._metric.single_turn_score(sample)
+        elif hasattr(self._metric, "ascore"):
+            sig = inspect.signature(self._metric.ascore)
+            kwargs = {}
+            for param_name in sig.parameters:
+                if param_name == "self":
+                    continue
+
+                if hasattr(sample, param_name):
+                    value = getattr(sample, param_name)
+                    kwargs[param_name] = value
+
+            sync_score = _wrap_async_predict_fn(self._metric.ascore)
+            return sync_score(**kwargs)
+        else:
+            raise MlflowException(f"RAGAS metric {self.name} is not currently supported")
 
     def _validate_kwargs(self, **metric_kwargs):
         if is_deterministic_metric(self.metric_name):

--- a/mlflow/genai/scorers/ragas/models.py
+++ b/mlflow/genai/scorers/ragas/models.py
@@ -28,14 +28,15 @@ class DatabricksRagasLLM(InstructorBaseRagasLLM):
 
     def __init__(self):
         super().__init__()
-
-    async def agenerate(self, prompt: str, response_model: type[T]) -> T:
-        return self.generate(prompt, response_model)
+        self.is_async = False
 
     def generate(self, prompt: str, response_model: type[T]) -> T:
         full_prompt = _build_json_prompt(prompt, response_model)
         result = call_chat_completions(user_prompt=full_prompt, system_prompt="")
         return _parse_json_response(result.output, response_model)
+
+    async def agenerate(self, prompt: str, response_model: type[T]) -> T:
+        return self.generate(prompt, response_model)
 
     def get_model_name(self) -> str:
         return _DATABRICKS_DEFAULT_JUDGE_MODEL
@@ -51,6 +52,7 @@ class DatabricksServingEndpointRagasLLM(InstructorBaseRagasLLM):
     def __init__(self, endpoint_name: str):
         super().__init__()
         self._endpoint_name = endpoint_name
+        self.is_async = False
 
     def generate(self, prompt: str, response_model: type[T]) -> T:
         try:

--- a/mlflow/genai/scorers/ragas/models.py
+++ b/mlflow/genai/scorers/ragas/models.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
+import typing as t
+
 import instructor
 import litellm
-from langchain_core.outputs import Generation, LLMResult
-from ragas.llms import BaseRagasLLM
+from pydantic import BaseModel
+from ragas.llms import InstructorBaseRagasLLM
 from ragas.llms.litellm_llm import LiteLLMStructuredLLM
 
 from mlflow.exceptions import MlflowException
@@ -16,7 +19,7 @@ from mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter import (
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 
 
-class DatabricksRagasLLM(BaseRagasLLM):
+class DatabricksRagasLLM(InstructorBaseRagasLLM):
     """
     RAGAS LLM adapter for Databricks managed judge.
 
@@ -26,29 +29,19 @@ class DatabricksRagasLLM(BaseRagasLLM):
     def __init__(self):
         super().__init__()
 
-    def generate_text(self, prompt: str, **kwargs) -> str:
-        # Convert LangChain StringPromptValue to string if needed
-        if hasattr(prompt, "to_string"):
-            prompt = prompt.to_string()
-        elif not isinstance(prompt, str):
-            prompt = str(prompt)
+    async def agenerate(self, prompt: str, response_model: type[T]) -> T:
+        return self.generate(prompt, response_model)
 
-        result = call_chat_completions(user_prompt=prompt, system_prompt="")
-        return result.output
-
-    async def agenerate_text(self, prompt: str, **kwargs):
-        text = self.generate_text(prompt, **kwargs)
-        generation = Generation(text=text)
-        return LLMResult(generations=[[generation]])
+    def generate(self, prompt: str, response_model: type[T]) -> T:
+        full_prompt = _build_json_prompt(prompt, response_model)
+        result = call_chat_completions(user_prompt=full_prompt, system_prompt="")
+        return _parse_json_response(result.output, response_model)
 
     def get_model_name(self) -> str:
         return _DATABRICKS_DEFAULT_JUDGE_MODEL
 
-    def is_finished(self, result=None) -> bool:
-        return True
 
-
-class DatabricksServingEndpointRagasLLM(BaseRagasLLM):
+class DatabricksServingEndpointRagasLLM(InstructorBaseRagasLLM):
     """
     RAGAS LLM adapter for Databricks serving endpoints.
 
@@ -59,31 +52,33 @@ class DatabricksServingEndpointRagasLLM(BaseRagasLLM):
         super().__init__()
         self._endpoint_name = endpoint_name
 
-    def generate_text(self, prompt: str, **kwargs) -> str:
-        # Convert LangChain StringPromptValue to string if needed
-        if hasattr(prompt, "to_string"):
-            prompt = prompt.to_string()
-        elif not isinstance(prompt, str):
-            prompt = str(prompt)
+    def generate(self, prompt: str, response_model: type[T]) -> T:
+        try:
+            output = _invoke_databricks_serving_endpoint(
+                model_name=self._endpoint_name,
+                prompt=prompt,
+                num_retries=3,
+                response_format=response_model,
+            )
+            return _parse_json_response(output.response, response_model)
+        except MlflowException as e:
+            if "Response format type object is not supported" in str(e):
+                full_prompt = _build_json_prompt(prompt, response_model)
+                output = _invoke_databricks_serving_endpoint(
+                    model_name=self._endpoint_name,
+                    prompt=full_prompt,
+                    num_retries=3,
+                    response_format=None,
+                )
+                return _parse_json_response(output.response, response_model)
+            else:
+                raise
 
-        output = _invoke_databricks_serving_endpoint(
-            model_name=self._endpoint_name,
-            prompt=prompt,
-            num_retries=3,
-            response_format=None,
-        )
-        return output.response
-
-    async def agenerate_text(self, prompt: str, **kwargs):
-        text = self.generate_text(prompt, **kwargs)
-        generation = Generation(text=text)
-        return LLMResult(generations=[[generation]])
+    async def agenerate(self, prompt: str, response_model: type[T]) -> T:
+        return self.generate(prompt, response_model)
 
     def get_model_name(self) -> str:
         return f"databricks:/{self._endpoint_name}"
-
-    def is_finished(self, result=None) -> bool:
-        return True
 
 
 def create_ragas_model(model_uri: str):
@@ -110,7 +105,7 @@ def create_ragas_model(model_uri: str):
     elif ":" in model_uri:
         provider, model_name = model_uri.split(":", 1)
         model_name = model_name.removeprefix("/")
-        client = instructor.from_litellm(litellm.completion)
+        client = instructor.from_litellm(litellm.acompletion)
         return LiteLLMStructuredLLM(
             client=client,
             model=f"{provider}/{model_name}",
@@ -122,3 +117,31 @@ def create_ragas_model(model_uri: str):
             f"Must be 'databricks' or include a provider prefix (e.g., 'openai:/gpt-4') "
             f"or a Databricks serving endpoint (e.g., 'databricks:/<endpoint_name>')."
         )
+
+
+T = t.TypeVar("T", bound=BaseModel)
+
+
+def _build_json_prompt(prompt: str, response_model: type[T]) -> str:
+    schema = response_model.model_json_schema()
+    fields = schema.get("properties", {})
+    field_desc = ", ".join(f'"{k}"' for k in fields.keys())
+    return (
+        f"{prompt}\n\n"
+        f"OUTPUT FORMAT: Respond ONLY with a JSON object "
+        f"containing these fields: {field_desc}, no other text."
+    )
+
+
+def _parse_json_response(response: str, response_model: type[T]) -> T:
+    text = response.strip()
+    # remove lines with ```json or ```
+    if text.startswith("```"):
+        lines = text.split("\n")[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        text = "\n".join(lines).strip()
+    try:
+        return response_model.model_validate(json.loads(text))
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Failed to parse JSON. Response was: {response}") from e

--- a/mlflow/genai/scorers/ragas/models.py
+++ b/mlflow/genai/scorers/ragas/models.py
@@ -17,6 +17,7 @@ from mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter import (
     _invoke_databricks_serving_endpoint,
 )
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
+from mlflow.genai.judges.utils.parsing_utils import _strip_markdown_code_blocks
 
 
 class DatabricksRagasLLM(InstructorBaseRagasLLM):
@@ -64,7 +65,7 @@ class DatabricksServingEndpointRagasLLM(InstructorBaseRagasLLM):
             )
             return _parse_json_response(output.response, response_model)
         except MlflowException as e:
-            if "Response format type object is not supported" in str(e):
+            if "Response format type" in str(e) and "is not supported" in str(e):
                 full_prompt = _build_json_prompt(prompt, response_model)
                 output = _invoke_databricks_serving_endpoint(
                     model_name=self._endpoint_name,
@@ -131,18 +132,13 @@ def _build_json_prompt(prompt: str, response_model: type[T]) -> str:
     return (
         f"{prompt}\n\n"
         f"OUTPUT FORMAT: Respond ONLY with a JSON object "
-        f"containing these fields: {field_desc}, no other text."
+        f"containing these fields: {field_desc}, no other text. "
+        f"Do not add markdown formatting to the response."
     )
 
 
 def _parse_json_response(response: str, response_model: type[T]) -> T:
-    text = response.strip()
-    # remove lines with ```json or ```
-    if text.startswith("```"):
-        lines = text.split("\n")[1:]
-        if lines and lines[-1].strip() == "```":
-            lines = lines[:-1]
-        text = "\n".join(lines).strip()
+    text = _strip_markdown_code_blocks(response)
     try:
         return response_model.model_validate(json.loads(text))
     except json.JSONDecodeError as e:

--- a/mlflow/genai/scorers/ragas/registry.py
+++ b/mlflow/genai/scorers/ragas/registry.py
@@ -5,18 +5,18 @@ from mlflow.exceptions import MlflowException
 # (classpath, is_deterministic)
 _METRIC_REGISTRY = {
     # Retrieval Augmented Generation
-    "ContextPrecision": ("ragas.metrics.ContextPrecision", False),
+    "ContextPrecision": ("ragas.metrics.collections.ContextPrecision", False),
     "NonLLMContextPrecisionWithReference": (
         "ragas.metrics.NonLLMContextPrecisionWithReference",
         True,
     ),
-    "ContextRecall": ("ragas.metrics.ContextRecall", False),
+    "ContextRecall": ("ragas.metrics.collections.ContextRecall", False),
     "NonLLMContextRecall": ("ragas.metrics.NonLLMContextRecall", True),
-    "ContextEntityRecall": ("ragas.metrics.ContextEntityRecall", False),
-    "NoiseSensitivity": ("ragas.metrics.NoiseSensitivity", False),
+    "ContextEntityRecall": ("ragas.metrics.collections.ContextEntityRecall", False),
+    "NoiseSensitivity": ("ragas.metrics.collections.NoiseSensitivity", False),
     # TODO: ResponseRelevancy requires embeddings model instead of LLM
     # "ResponseRelevancy": ("ragas.metrics.ResponseRelevancy", False),
-    "Faithfulness": ("ragas.metrics.Faithfulness", False),
+    "Faithfulness": ("ragas.metrics.collections.Faithfulness", False),
     # TODO: Nvidia Metrics not yet supported
     # "AnswerAccuracy": ("ragas.metrics.AnswerAccuracy", False),
     # "ContextRelevance": ("ragas.metrics.ContextRelevance", False),
@@ -27,15 +27,18 @@ _METRIC_REGISTRY = {
     # "ToolCallF1": ("ragas.metrics.ToolCallF1", False),
     # "AgentGoalAccuracy": ("ragas.metrics.AgentGoalAccuracy", False),
     # Natural Language Comparison
-    "FactualCorrectness": ("ragas.metrics.FactualCorrectness", False),
+    "FactualCorrectness": ("ragas.metrics.collections.FactualCorrectness", False),
     # TODO: SemanticSimilarity requires embeddings model instead of LLM
     # "SemanticSimilarity": ("ragas.metrics.SemanticSimilarity", False),
-    "NonLLMStringSimilarity": ("ragas.metrics.NonLLMStringSimilarity", True),
-    "BleuScore": ("ragas.metrics.BleuScore", True),
-    "ChrfScore": ("ragas.metrics.ChrfScore", True),
-    "RougeScore": ("ragas.metrics.RougeScore", True),
-    "StringPresence": ("ragas.metrics.StringPresence", True),
-    "ExactMatch": ("ragas.metrics.ExactMatch", True),
+    "NonLLMStringSimilarity": (
+        "ragas.metrics.collections.NonLLMStringSimilarity",
+        True,
+    ),
+    "BleuScore": ("ragas.metrics.collections.BleuScore", True),
+    "CHRFScore": ("ragas.metrics.collections.CHRFScore", True),
+    "RougeScore": ("ragas.metrics.collections.RougeScore", True),
+    "StringPresence": ("ragas.metrics.collections.StringPresence", True),
+    "ExactMatch": ("ragas.metrics.collections.ExactMatch", True),
     # TODO: SQL metrics not yet supported
     # "DatacompyScore": ("ragas.metrics.DatacompyScore", False),
     # "SQLSemanticEquivalence": ("ragas.metrics.SQLSemanticEquivalence", False),

--- a/mlflow/genai/scorers/ragas/utils.py
+++ b/mlflow/genai/scorers/ragas/utils.py
@@ -93,8 +93,6 @@ def create_mlflow_error_message_from_ragas_param(error_msg: str, metric_name: st
             mlflow_param = corresponding_mlflow_param
             break
 
-    ragas_to_mlflow_param_mapping.get(ragas_param, ragas_param)
-
     message_parts = [
         f"RAGAS metric '{metric_name}' requires '{mlflow_param}' parameter, which is missing."
     ]

--- a/tests/genai/scorers/ragas/test_models.py
+++ b/tests/genai/scorers/ragas/test_models.py
@@ -1,29 +1,37 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from pydantic import BaseModel
 
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers.ragas.models import DatabricksRagasLLM, create_ragas_model
+
+
+class DummyResponseModel(BaseModel):
+    answer: str
+    score: int
 
 
 @pytest.fixture
 def mock_call_chat_completions():
     with patch("mlflow.genai.scorers.ragas.models.call_chat_completions") as mock:
         result = Mock()
-        result.output = "Test output"
+        result.output = '{"answer": "Test output", "score": 42}'
         mock.return_value = result
         yield mock
 
 
 def test_databricks_ragas_llm_generate_text(mock_call_chat_completions):
     llm = DatabricksRagasLLM()
-    result = llm.generate_text(prompt="Test prompt")
+    result = llm.generate(prompt="Test prompt", response_model=DummyResponseModel)
 
-    assert result == "Test output"
-    mock_call_chat_completions.assert_called_once_with(
-        user_prompt="Test prompt",
-        system_prompt="",
-    )
+    assert isinstance(result, DummyResponseModel)
+    assert result.answer == "Test output"
+    assert result.score == 42
+    mock_call_chat_completions.assert_called_once()
+    call_args = mock_call_chat_completions.call_args
+    assert "answer" in call_args.kwargs["user_prompt"]
+    assert "score" in call_args.kwargs["user_prompt"]
 
 
 def test_create_ragas_model_databricks():

--- a/tests/genai/scorers/ragas/test_models.py
+++ b/tests/genai/scorers/ragas/test_models.py
@@ -28,10 +28,14 @@ def test_databricks_ragas_llm_generate_text(mock_call_chat_completions):
     assert isinstance(result, DummyResponseModel)
     assert result.answer == "Test output"
     assert result.score == 42
-    mock_call_chat_completions.assert_called_once()
-    call_args = mock_call_chat_completions.call_args
-    assert "answer" in call_args.kwargs["user_prompt"]
-    assert "score" in call_args.kwargs["user_prompt"]
+    mock_call_chat_completions.assert_called_once_with(
+        user_prompt=(
+            "Test prompt\n\nOUTPUT FORMAT: Respond ONLY with a JSON object "
+            'containing these fields: "answer", "score", no other text. '
+            "Do not add markdown formatting to the response."
+        ),
+        system_prompt="",
+    )
 
 
 def test_create_ragas_model_databricks():

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -32,9 +32,21 @@ from mlflow.telemetry.events import GenAIEvaluateEvent, ScorerCallEvent
 from tests.telemetry.helper_functions import validate_telemetry_record
 
 
+def make_mock_ascore(return_value=1.0, error=None):
+    async def mock_ascore(response=None, reference=None):
+        if error:
+            raise error
+        return return_value
+
+    return mock_ascore
+
+
 @pytest.fixture(autouse=True)
 def mock_get_telemetry_client(mock_telemetry_client: TelemetryClient):
-    with patch("mlflow.telemetry.track.get_telemetry_client", return_value=mock_telemetry_client):
+    with patch(
+        "mlflow.telemetry.track.get_telemetry_client",
+        return_value=mock_telemetry_client,
+    ):
         yield
 
 
@@ -78,13 +90,13 @@ def test_deterministic_metric_does_not_require_model():
 def test_ragas_scorer_with_threshold_returns_categorical():
     judge = get_scorer("ExactMatch")
     judge._metric.threshold = 0.5
-    with patch.object(judge._metric, "single_turn_score", return_value=0.8):
+
+    with patch.object(judge._metric, "ascore", make_mock_ascore(0.8)):
         result = judge(
             inputs="What is MLflow?",
             outputs="MLflow is a platform",
             expectations={"expected_output": "MLflow is a platform"},
         )
-
         assert result.value == CategoricalRating.YES
         assert result.metadata["score"] == 0.8
         assert result.metadata["threshold"] == 0.5
@@ -93,7 +105,8 @@ def test_ragas_scorer_with_threshold_returns_categorical():
 def test_ragas_scorer_with_threshold_returns_no_when_below():
     judge = get_scorer("ExactMatch")
     judge._metric.threshold = 0.5
-    with patch.object(judge._metric, "single_turn_score", return_value=0.0):
+
+    with patch.object(judge._metric, "ascore", make_mock_ascore(0.0)):
         result = judge(
             inputs="What is MLflow?",
             outputs="Databricks is a company",
@@ -119,7 +132,7 @@ def test_ragas_scorer_without_threshold_returns_float():
 def test_ragas_scorer_returns_error_feedback_on_exception():
     judge = get_scorer("ExactMatch")
 
-    with patch.object(judge._metric, "single_turn_score", side_effect=RuntimeError("Test error")):
+    with patch.object(judge._metric, "ascore", make_mock_ascore(error=RuntimeError("Test error"))):
         result = judge(inputs="What is MLflow?", outputs="Test output")
 
     assert isinstance(result, Feedback)
@@ -138,7 +151,10 @@ def test_unknown_metric_raises_error():
 
 def test_missing_reference_parameter_returns_mlflow_error():
     judge = get_scorer("ContextPrecision")
-    result = judge(inputs="What is MLflow?")
+    result = judge(
+        inputs="What is MLflow?",
+        expectations={"expected_output": "MLflow is a platform"},
+    )
     assert isinstance(result, Feedback)
     assert result.error is not None
     assert "ContextPrecision" in result.error.error_message  # metric name
@@ -197,9 +213,8 @@ def test_ragas_scorer_align_not_supported():
 
 
 def test_ragas_scorer_kind_property_with_llm_metric():
-    with patch("mlflow.genai.scorers.ragas.create_ragas_model"):
-        scorer = Faithfulness()
-        assert scorer.kind == ScorerKind.THIRD_PARTY
+    scorer = Faithfulness()
+    assert scorer.kind == ScorerKind.THIRD_PARTY
 
 
 @pytest.mark.parametrize(
@@ -211,11 +226,15 @@ def test_ragas_scorer_kind_property_with_llm_metric():
     ids=["direct_instantiation", "get_scorer"],
 )
 def test_ragas_scorer_telemetry_direct_call(
-    enable_telemetry_in_tests, mock_requests, mock_telemetry_client, scorer_factory, expected_class
+    enable_telemetry_in_tests,
+    mock_requests,
+    mock_telemetry_client,
+    scorer_factory,
+    expected_class,
 ):
     ragas_scorer = scorer_factory()
 
-    with patch.object(ragas_scorer._metric, "single_turn_score", return_value=1.0):
+    with patch.object(ragas_scorer._metric, "ascore", make_mock_ascore(1.0)):
         result = ragas_scorer(
             inputs="What is MLflow?",
             outputs="MLflow is a platform",
@@ -249,7 +268,11 @@ def test_ragas_scorer_telemetry_direct_call(
     ids=["direct_instantiation", "get_scorer"],
 )
 def test_ragas_scorer_telemetry_in_genai_evaluate(
-    enable_telemetry_in_tests, mock_requests, mock_telemetry_client, scorer_factory, expected_class
+    enable_telemetry_in_tests,
+    mock_requests,
+    mock_telemetry_client,
+    scorer_factory,
+    expected_class,
 ):
     ragas_scorer = scorer_factory()
 
@@ -261,7 +284,7 @@ def test_ragas_scorer_telemetry_in_genai_evaluate(
         }
     ]
 
-    with patch.object(ragas_scorer._metric, "single_turn_score", return_value=1.0):
+    with patch.object(ragas_scorer._metric, "ascore", make_mock_ascore(1.0)):
         mlflow.genai.evaluate(data=data, scorers=[ragas_scorer])
 
     validate_telemetry_record(

--- a/tests/genai/scorers/ragas/test_registry.py
+++ b/tests/genai/scorers/ragas/test_registry.py
@@ -25,7 +25,7 @@ def test_get_metric_class_raises_error_for_invalid_name():
         ("RougeScore", True),
         ("NonLLMStringSimilarity", True),
         ("StringPresence", True),
-        ("ChrfScore", True),
+        ("CHRFScore", True),
         ("Faithfulness", False),
         ("ContextPrecision", False),
     ],


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SomtochiUmeh/mlflow/pull/19880?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19880/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19880/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19880/merge
```

</p>
</details>

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Tested with litellm, databricks, and databricks-served models:
```python
def create_rag_trace():
    @mlflow.trace(name="rag_query", span_type=SpanType.AGENT)
    def rag_pipeline(question):
        contexts = retrieve_documents(question)
        return generate_answer(question, contexts)

    @mlflow.trace(span_type=SpanType.RETRIEVER)
    def retrieve_documents(question):
        return [
            Document(
                page_content="MLflow is an open-source platform for managing the ML lifecycle.",
                metadata={"doc_uri": "https://mlflow.org/docs/"},
            ),
            Document(
                page_content="MLflow provides Tracking, Projects, Models, and Model Registry.",
                metadata={"doc_uri": "https://mlflow.org/features/"},
            ),
        ]

    @mlflow.trace(span_type=SpanType.LLM)
    def generate_answer(question, contexts):
        return (
            "MLflow is an open-source platform for managing machine learning workflows."
        )

    rag_pipeline("What is MLflow?")
    return mlflow.get_trace(mlflow.get_last_active_trace_id())


def test_rag_metric(
    metric_name, model="openai:/gpt-4o-mini", needs_expectation=False, **kwargs
):
    trace = create_rag_trace()
    if needs_expectation:
        mlflow.log_expectation(
            trace_id=trace.info.trace_id,
            name="expected_output",
            value="MLflow is a platform for managing the machine learning lifecycle.",
        )
        trace = mlflow.get_trace(trace.info.trace_id)

    scorer = get_scorer(metric_name, model=model, **kwargs)
    return scorer(trace=trace)


def test_simple_metric(metric_name, model=None, **kwargs):
    if model:
        scorer = get_scorer(metric_name, model=model, **kwargs)
    else:
        scorer = get_scorer(metric_name, **kwargs)
    return scorer(
        inputs="What is MLflow?",
        outputs="MLflow is an open-source platform for managing machine learning workflows.",
        expectations={
            "expected_output": "MLflow is a platform for managing ML workflows.",
            "rubrics": {
                "0": "Off-topic or irrelevant.",
                "1": "Fully relevant and focused.",
            },
        },
    )


# RAG metrics (require traces)
rag_metrics = [
    ("ContextPrecision", True),
    ("NonLLMContextPrecisionWithReference", True),
    ("ContextRecall", True),
    ("NonLLMContextRecall", True),
    ("ContextEntityRecall", True),
    ("NoiseSensitivity", True),
    ("Faithfulness", False),
    ("FactualCorrectness", True),
    ("SummarizationScore", True),
]

for metric, needs_expectation in rag_metrics:
    try:
        result = test_rag_metric(metric, needs_expectation=needs_expectation)
        print(f"✅ {metric}: Success: {result.feedback}")
    except Exception as e:
        print(f"❌ {metric}: Failed: {e}")

# Deterministic metrics (no LLM needed)
deterministic_metrics = [
    "ExactMatch",
    "BleuScore",
    "RougeScore",
    "NonLLMStringSimilarity",
    "CHRFScore",
    "StringPresence",
]

for metric in deterministic_metrics:
    try:
        result = test_simple_metric(metric)
        print(f"✅ {metric}: Success: {result.feedback}")
    except Exception as e:
        print(f"❌ {metric}: Failed: {e}")

# LLM-based general metrics
try:
    result = test_simple_metric(
        "AspectCritic",
        name="helpfulness",
        definition="Is the response helpful?",
    )
    print(f"✅ AspectCritic: Success: {result.feedback}")
except Exception as e:
    print(f"❌ AspectCritic: Failed: {e}")

try:
    result = test_simple_metric(
        "RubricsScore",
        rubrics={
            "score1_description": "Not helpful",
            "score2_description": "Helpful",
        },
    )
    print(f"✅ RubricsScore: Success: {result.feedback}")
except Exception as e:
    print(f"❌ RubricsScore: Failed: {e}")

# InstanceRubrics (requires rubrics in expectations)
try:
    result = test_simple_metric("InstanceRubrics")
    print(f"✅ InstanceRubrics: Success: {result.feedback}")
except Exception as e:
    print(f"❌ InstanceRubrics: Failed: {e}")
```

```
✅ ContextPrecision: Success: FeedbackValue(value=0.99999999995, error=None)
✅ NonLLMContextPrecisionWithReference: Success: FeedbackValue(value=<CategoricalRating.YES: 'yes'>, error=None)
✅ ContextRecall: Success: FeedbackValue(value=1.0, error=None)
✅ NonLLMContextRecall: Success: FeedbackValue(value=<CategoricalRating.YES: 'yes'>, error=None)
✅ ContextEntityRecall: Success: FeedbackValue(value=0.9999999900000002, error=None)
✅ NoiseSensitivity: Success: FeedbackValue(value=0.5, error=None)
✅ Faithfulness: Success: FeedbackValue(value=0.5, error=None)
✅ FactualCorrectness: Success: FeedbackValue(value=0.67, error=None)
✅ SummarizationScore: Success: FeedbackValue(value=0.5125000000000642, error=None)
✅ ExactMatch: Success: FeedbackValue(value=0.0, error=None)
✅ BleuScore: Success: FeedbackValue(value=0.20504572236241866, error=None)
✅ RougeScore: Success: FeedbackValue(value=0.631578947368421, error=None)
✅ NonLLMStringSimilarity: Success: FeedbackValue(value=0.6081081081081081, error=None)
✅ CHRFScore: Success: FeedbackValue(value=0.7139993484795175, error=None)
✅ StringPresence: Success: FeedbackValue(value=0.0, error=None)
✅ AspectCritic: Success: FeedbackValue(value=1.0, error=None)
✅ RubricsScore: Success: FeedbackValue(value=2.0, error=None)
✅ InstanceRubrics: Success: FeedbackValue(value=1.0, error=None)
```
### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
