### PR TITLE
Add callsite field to simulate conversation telemetry event

### DIFF
--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -4,10 +4,19 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from mlflow.entities import Feedback
-from mlflow.telemetry.constant import GENAI_MODULES, MODULES_TO_CHECK_IMPORT
+from mlflow.telemetry.constant import (
+    GENAI_MODULES,
+    MODULES_TO_CHECK_IMPORT,
+)
 
 if TYPE_CHECKING:
     from mlflow.genai.scorers.base import Scorer
+
+
+GENAI_EVALUATION_PATH = "mlflow/genai/evaluation/base"
+GENAI_SCORERS_PATH = "mlflow/genai/scorers/base"
+GENAI_EVALUATE_FUNCTION = "_run_harness"
+SCORER_RUN_FUNCTION = "run"
 
 
 def _get_scorer_class_name_for_tracking(scorer: "Scorer") -> str:
@@ -404,6 +413,22 @@ class SimulateConversationEvent(Event):
     name: str = "simulate_conversation"
 
     @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        callsite = "conversation_simulator"
+        for frame_info in inspect.stack()[:10]:
+            frame_filename = frame_info.filename
+            frame_function = frame_info.function
+
+            if (
+                GENAI_EVALUATION_PATH in frame_filename.replace("\\", "/")
+                and frame_function == GENAI_EVALUATE_FUNCTION
+            ):
+                callsite = "genai_evaluate"
+                break
+
+        return {"callsite": callsite}
+
+    @classmethod
     def parse_result(cls, result: Any) -> dict[str, Any] | None:
         return {
             "simulated_conversation_info": [
@@ -428,10 +453,12 @@ class ScorerCallEvent(Event):
             frame_filename = frame_info.filename
             frame_function = frame_info.function
 
-            if "mlflow/genai/scorers/base" in frame_filename.replace("\\", "/"):
-                if frame_function == "run":
-                    callsite = "genai.evaluate"
-                    break
+            if (
+                GENAI_SCORERS_PATH in frame_filename.replace("\\", "/")
+                and frame_function == SCORER_RUN_FUNCTION
+            ):
+                callsite = "genai_evaluate"
+                break
 
         return {
             "scorer_class": _get_scorer_class_name_for_tracking(scorer_instance),

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -226,3 +226,8 @@ def test_prompt_optimization_parse_params(arguments, expected_params):
 )
 def test_simulate_conversation_parse_result(result, expected_params):
     assert SimulateConversationEvent.parse_result(result) == expected_params
+
+
+def test_simulate_conversation_parse_params():
+    result = SimulateConversationEvent.parse({})
+    assert result == {"callsite": "conversation_simulator"}

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -599,12 +599,58 @@ def test_simulate_conversation(mock_requests, mock_telemetry_client: TelemetryCl
         mock_requests,
         SimulateConversationEvent.name,
         {
+            "callsite": "conversation_simulator",
             "simulated_conversation_info": [
                 {"turn_count": len(result[0])},
                 {"turn_count": len(result[1])},
-            ]
+            ],
         },
     )
+
+
+def test_simulate_conversation_from_genai_evaluate(
+    mock_requests, mock_telemetry_client: TelemetryClient
+):
+    simulator = ConversationSimulator(
+        test_cases=[
+            {"goal": "Learn about MLflow"},
+        ],
+        max_turns=1,
+    )
+
+    def mock_predict_fn(input, **kwargs):
+        return {"role": "assistant", "content": "Mock response"}
+
+    @scorer
+    def simple_scorer(outputs) -> bool:
+        return len(outputs) > 0
+
+    with (
+        mock.patch(
+            "mlflow.genai.simulators.simulator._invoke_model_without_tracing",
+            return_value="Mock user message",
+        ),
+        mock.patch(
+            "mlflow.genai.simulators.simulator.ConversationSimulator._check_goal_achieved",
+            return_value=True,
+        ),
+    ):
+        mlflow.genai.evaluate(data=simulator, predict_fn=mock_predict_fn, scorers=[simple_scorer])
+
+    mock_telemetry_client.flush()
+
+    simulate_events = [
+        record
+        for record in mock_requests
+        if record["data"]["event_name"] == SimulateConversationEvent.name
+    ]
+    assert len(simulate_events) == 1
+
+    event_params = json.loads(simulate_events[0]["data"]["params"])
+    assert event_params == {
+        "callsite": "genai_evaluate",
+        "simulated_conversation_info": [{"turn_count": 1}],
+    }
 
 
 def test_prompt_optimization(mock_requests, mock_telemetry_client: TelemetryClient):
@@ -1310,7 +1356,7 @@ def test_scorer_call_from_genai_evaluate(mock_requests, mock_telemetry_client: T
         if params["scorer_class"] == "UserDefinedScorer"
         and params["scorer_kind"] == "decorator"
         and params["is_session_level_scorer"] is False
-        and params["callsite"] == "genai.evaluate"
+        and params["callsite"] == "genai_evaluate"
         and params["has_feedback_error"] is False
     ]
     assert len(response_level_events) == 2
@@ -1322,7 +1368,7 @@ def test_scorer_call_from_genai_evaluate(mock_requests, mock_telemetry_client: T
         if params["scorer_class"] == "UserDefinedScorer"
         and params["scorer_kind"] == "instructions"
         and params["is_session_level_scorer"] is True
-        and params["callsite"] == "genai.evaluate"
+        and params["callsite"] == "genai_evaluate"
         and params["has_feedback_error"] is False
     ]
     assert len(session_level_events) == 1
@@ -1509,7 +1555,7 @@ def test_scorer_call_wrapped_builtin_scorer_from_genai_evaluate(
             "scorer_class": "UserFrustration",
             "scorer_kind": "builtin",
             "is_session_level_scorer": True,
-            "callsite": "genai.evaluate",
+            "callsite": "genai_evaluate",
             "has_feedback_error": False,
         },
     )


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19884/files) to review incremental changes.
- [**stack/add-callsite-field-to-simulate-conversation-telemetry-event**](https://github.com/mlflow/mlflow/pull/19884) [[Files changed](https://github.com/mlflow/mlflow/pull/19884/files)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
We want to add a telemetry field `callsite` to track whether the `_simulate` is called directly on the simulator or called inside `genai.evaluate`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
#### Manual Test
Run simulation directly:
```
import mlflow
from mlflow.genai.simulators import ConversationSimulator

mlflow.set_tracking_uri("sqlite:///mlflow.db")
mlflow.set_experiment("Debug Conversation Simulator")

simulator = ConversationSimulator(
    test_cases=[{"goal": "Ask about the weather"}],
    max_turns=3,
    user_model="openai:/gpt-4o-mini",
)

def predict_fn(input, **kwargs):
    return {"role": "assistant", "content": f"I don't know the answer to your questions"}

result = simulator._simulate(predict_fn=predict_fn)
print(f"Result: {result}")
```
printed the following param:
```
simulate_conversation record_params: {'callsite': 'conversation_simulator', 'simulated_conversation_info': [{'turn_count': 3}], 'mlflow_experiment_id': '1'}
```

Run simulation from evaluation:
```
from mlflow.genai.scorers import UserFrustration

result = mlflow.genai.evaluate(
    data=simulator,
    predict_fn=predict_fn,
    scorers=[UserFrustration()]
)
```
printed the following params:
```
simulate_conversation record_params: {'callsite': 'genai_evaluate', 'simulated_conversation_info': [{'turn_count': 3}], 'mlflow_experiment_id': '1'}
```


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
