### PR TITLE
 fix for addressing rest api call latency in databricks job run

### DIFF
--- a/mlflow/tracking/request_header/databricks_request_header_provider.py
+++ b/mlflow/tracking/request_header/databricks_request_header_provider.py
@@ -25,9 +25,6 @@ class DatabricksRequestHeaderProvider(RequestHeaderProvider):
             request_headers["job_type"] = databricks_utils.get_job_type()
         if databricks_utils.is_in_cluster():
             request_headers["cluster_id"] = databricks_utils.get_cluster_id()
-        command_run_id = databricks_utils.get_command_run_id()
-        if command_run_id is not None:
-            request_headers["command_run_id"] = command_run_id
         workload_id = databricks_utils.get_workload_id()
         workload_class = databricks_utils.get_workload_class()
         if workload_id is not None:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -545,15 +545,6 @@ def get_job_type_info():
         return None
 
 
-@_use_repl_context_if_available("commandRunId")
-def get_command_run_id():
-    try:
-        return _get_command_context().commandRunId().get()
-    except Exception:
-        # Older runtimes may not have the commandRunId available
-        return None
-
-
 @_use_repl_context_if_available("workloadId")
 def get_workload_id():
     try:

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -56,7 +56,6 @@ def test_databricks_request_header_provider_request_headers(
         mock.patch("mlflow.utils.databricks_utils.get_job_run_id") as job_run_id_mock,
         mock.patch("mlflow.utils.databricks_utils.get_job_type") as job_type_mock,
         mock.patch("mlflow.utils.databricks_utils.get_cluster_id") as cluster_id_mock,
-        mock.patch("mlflow.utils.databricks_utils.get_command_run_id") as command_run_id_mock,
         mock.patch("mlflow.utils.databricks_utils.get_workload_id") as workload_id_mock,
         mock.patch("mlflow.utils.databricks_utils.get_workload_class") as workload_class_mock,
     ):
@@ -80,11 +79,6 @@ def test_databricks_request_header_provider_request_headers(
             assert request_headers["cluster_id"] == cluster_id_mock.return_value
         else:
             assert "cluster_id" not in request_headers
-
-        if command_run_id_mock.return_value is not None:
-            assert request_headers["command_run_id"] == command_run_id_mock.return_value
-        else:
-            assert "command_run_id" not in request_headers
 
         if workload_id_mock.return_value is not None:
             assert request_headers["workload_id"] == workload_id_mock.return_value


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/19886?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19886/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19886/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19886/merge
```

</p>
</details>

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
 fix for addressing rest api call latency in databricks job run

The "command_run_id" fetching causes huge performance gap in Databricks job run .
since command run ID was only used for the deprecated / removed "reproduce run" feature on Databricks,
we can remove it.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
