### PR TITLE
Allow OTLP traces to infer experiment from service.name (#19889)

### DIFF
--- a/tests/server/test_otel_api.py
+++ b/tests/server/test_otel_api.py
@@ -1,0 +1,162 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
+
+
+def _make_export_request_bytes(*, service_names: list[str] | None) -> bytes:
+    export_request = ExportTraceServiceRequest()
+
+    service_names_to_emit = service_names if service_names is not None else [None]
+
+    for service_name in service_names_to_emit:
+        resource_span = export_request.resource_spans.add()
+        if service_name is not None:
+            attr = resource_span.resource.attributes.add()
+            attr.key = "service.name"
+            attr.value.string_value = service_name
+
+        scope_span = resource_span.scope_spans.add()
+        span = scope_span.spans.add()
+        span.name = "test"
+        span.trace_id = b"\x00" * 15 + b"\x01"
+        span.span_id = b"\x00" * 7 + b"\x02"
+        span.start_time_unix_nano = 1
+        span.end_time_unix_nano = 2
+
+    return export_request.SerializeToString()
+
+
+@pytest.fixture
+def otel_client(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_ALLOWED_HOSTS", "*")
+
+    from mlflow.server.fastapi_app import create_fastapi_app
+
+    with TestClient(create_fastapi_app()) as client:
+        yield client
+
+
+def test_export_traces_uses_experiment_id_header(otel_client):
+    store = MagicMock()
+
+    with patch("mlflow.server.otel_api._get_tracking_store", return_value=store):
+        response = otel_client.post(
+            "/v1/traces",
+            headers={
+                "Content-Type": "application/x-protobuf",
+                "x-mlflow-experiment-id": "123",
+            },
+            content=_make_export_request_bytes(service_names=["svc"]),
+        )
+
+    assert response.status_code == 200
+    store.log_spans.assert_called_once()
+    assert store.log_spans.call_args[0][0] == "123"
+    store.get_experiment_by_name.assert_not_called()
+
+
+def test_export_traces_falls_back_to_service_name_existing_experiment(otel_client):
+    store = MagicMock()
+    store.get_experiment_by_name.return_value = MagicMock(experiment_id="exp-1")
+
+    with patch("mlflow.server.otel_api._get_tracking_store", return_value=store):
+        response = otel_client.post(
+            "/v1/traces",
+            headers={"Content-Type": "application/x-protobuf"},
+            content=_make_export_request_bytes(service_names=["svc"]),
+        )
+
+    assert response.status_code == 200
+    store.get_experiment_by_name.assert_called_once_with("svc")
+    store.create_experiment.assert_not_called()
+    store.log_spans.assert_called_once()
+    assert store.log_spans.call_args[0][0] == "exp-1"
+
+
+def test_export_traces_falls_back_to_service_name_creates_experiment(otel_client):
+    store = MagicMock()
+    store.get_experiment_by_name.return_value = None
+    store.create_experiment.return_value = "exp-new"
+
+    with patch("mlflow.server.otel_api._get_tracking_store", return_value=store):
+        response = otel_client.post(
+            "/v1/traces",
+            headers={"Content-Type": "application/x-protobuf"},
+            content=_make_export_request_bytes(service_names=["svc"]),
+        )
+
+    assert response.status_code == 200
+    store.get_experiment_by_name.assert_called_once_with("svc")
+    store.create_experiment.assert_called_once_with("svc")
+    store.log_spans.assert_called_once()
+    assert store.log_spans.call_args[0][0] == "exp-new"
+
+
+def test_export_traces_requires_header_or_service_name(otel_client):
+    store = MagicMock()
+
+    with patch("mlflow.server.otel_api._get_tracking_store", return_value=store):
+        response = otel_client.post(
+            "/v1/traces",
+            headers={"Content-Type": "application/x-protobuf"},
+            content=_make_export_request_bytes(service_names=None),
+        )
+
+    assert response.status_code == 400
+    assert "x-mlflow-experiment-id" in response.json()["detail"]
+    store.log_spans.assert_not_called()
+
+
+def test_export_traces_rejects_multiple_service_names(otel_client):
+    store = MagicMock()
+
+    with patch("mlflow.server.otel_api._get_tracking_store", return_value=store):
+        response = otel_client.post(
+            "/v1/traces",
+            headers={"Content-Type": "application/x-protobuf"},
+            content=_make_export_request_bytes(service_names=["svc-a", "svc-b"]),
+        )
+
+    assert response.status_code == 400
+    assert "multiple" in response.json()["detail"]
+    store.log_spans.assert_not_called()
+
+
+def test_export_traces_requires_header_when_service_name_is_blank(otel_client):
+    store = MagicMock()
+
+    with patch("mlflow.server.otel_api._get_tracking_store", return_value=store):
+        response = otel_client.post(
+            "/v1/traces",
+            headers={"Content-Type": "application/x-protobuf"},
+            content=_make_export_request_bytes(service_names=["   "]),
+        )
+
+    assert response.status_code == 400
+    assert "x-mlflow-experiment-id" in response.json()["detail"]
+    store.log_spans.assert_not_called()
+
+
+def test_export_traces_handles_experiment_creation_race(otel_client):
+    store = MagicMock()
+    store.get_experiment_by_name.side_effect = [None, MagicMock(experiment_id="exp-raced")]
+    store.create_experiment.side_effect = MlflowException(
+        "exists", error_code=RESOURCE_ALREADY_EXISTS
+    )
+
+    with patch("mlflow.server.otel_api._get_tracking_store", return_value=store):
+        response = otel_client.post(
+            "/v1/traces",
+            headers={"Content-Type": "application/x-protobuf"},
+            content=_make_export_request_bytes(service_names=["svc"]),
+        )
+
+    assert response.status_code == 200
+    assert store.get_experiment_by_name.call_count == 2
+    store.log_spans.assert_called_once()
+    assert store.log_spans.call_args[0][0] == "exp-raced"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/okamototk/mlflow/pull/19891?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19891/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19891/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19891/merge
```

</p>
</details>

Make x-mlflow-experiment-id optional so generic OpenTelemetry exporters can send GenAI SemConv traces without custom headers.

### Related Issues/PRs

#19889

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [X] New unit/integration tests

### Does this PR require documentation update?

- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Updates OTLP trace ingestion to make x-mlflow-experiment-id optional and infer the target experiment from the OpenTelemetry service.name resource attribute when the header isn’t provided. This enables standard OpenTelemetry exporters to send GenAI Semantic Convention traces to MLflow without needing MLflow-specific custom headers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] No (this PR will be included in the next minor release)
