### PR TITLE
Distinguish local remote server

### DIFF
--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -32,11 +32,13 @@ def _is_localhost_uri(uri: str) -> bool | None:
 
     Returns:
         True if the URI points to localhost, False if it points to a remote host,
-        or None if the URI cannot be parsed.
+        or None if the URI cannot be parsed or has no hostname.
     """
     try:
         parsed = urllib.parse.urlparse(uri)
-        hostname = parsed.hostname or ""
+        hostname = parsed.hostname
+        if not hostname:
+            return None
         return (
             hostname in (".", "::1")
             or hostname.startswith("localhost")
@@ -44,6 +46,31 @@ def _is_localhost_uri(uri: str) -> bool | None:
         )
     except Exception:
         return None
+
+
+def _get_tracking_uri_info() -> tuple[str | None, bool | None]:
+    """
+    Get tracking URI information including scheme and localhost status.
+
+    Returns:
+        A tuple of (scheme, is_localhost). is_localhost is only set for http/https schemes.
+    """
+    # import here to avoid circular import
+    from mlflow.tracking._tracking_service.utils import (
+        _get_tracking_scheme_with_resolved_uri,
+        get_tracking_uri,
+    )
+
+    try:
+        tracking_uri = get_tracking_uri()
+        scheme = _get_tracking_scheme_with_resolved_uri(tracking_uri)
+
+        # Check if http/https points to localhost
+        is_localhost = _is_localhost_uri(tracking_uri) if scheme in ("http", "https") else None
+
+        return scheme, is_localhost
+    except Exception:
+        return None, None
 
 
 class TelemetryClient:
@@ -368,18 +395,11 @@ class TelemetryClient:
         method to update the backend store info at sending telemetry step.
         """
         try:
-            # import here to avoid circular import
-            from mlflow.tracking._tracking_service.utils import (
-                _get_tracking_scheme,
-                get_tracking_uri,
-            )
-
-            scheme = _get_tracking_scheme()
-            self.info["tracking_uri_scheme"] = scheme
-
-            # Check if http/https points to localhost
-            if scheme in ("http", "https"):
-                self.info["is_localhost"] = _is_localhost_uri(get_tracking_uri())
+            scheme, is_localhost = _get_tracking_uri_info()
+            if scheme is not None:
+                self.info["tracking_uri_scheme"] = scheme
+            if is_localhost is not None:
+                self.info["is_localhost"] = is_localhost
         except Exception as e:
             _log_error(f"Failed to update backend store: {e}")
 

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -68,6 +68,7 @@ class TelemetryInfo:
     )
     operating_system: str = platform.platform()
     tracking_uri_scheme: str | None = None
+    is_localhost: bool | None = None
     installation_id: str | None = None
 
 

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -14,6 +14,7 @@ from mlflow.telemetry.client import (
     MAX_QUEUE_SIZE,
     MAX_WORKERS,
     TelemetryClient,
+    _is_localhost_uri,
     get_telemetry_client,
 )
 from mlflow.telemetry.events import CreateLoggedModelEvent, CreateRunEvent
@@ -981,9 +982,7 @@ def test_fetch_config_after_first_record():
     ],
 )
 def test_is_localhost_uri_returns_true_for_localhost(uri):
-    from mlflow.telemetry.client import _is_localhost_uri
-
-    assert _is_localhost_uri(uri) is True
+    assert _is_localhost_uri(uri)
 
 
 @pytest.mark.parametrize(
@@ -999,20 +998,14 @@ def test_is_localhost_uri_returns_true_for_localhost(uri):
     ],
 )
 def test_is_localhost_uri_returns_false_for_remote(uri):
-    from mlflow.telemetry.client import _is_localhost_uri
-
     assert _is_localhost_uri(uri) is False
 
 
-def test_is_localhost_uri_returns_false_for_empty_hostname():
-    from mlflow.telemetry.client import _is_localhost_uri
-
-    assert _is_localhost_uri("file:///tmp/mlruns") is False
+def test_is_localhost_uri_returns_none_for_empty_hostname():
+    assert _is_localhost_uri("file:///tmp/mlruns") is None
 
 
 def test_is_localhost_uri_returns_none_on_parse_error():
-    from mlflow.telemetry.client import _is_localhost_uri
-
     # urlparse doesn't raise on most inputs, but we test the fallback behavior
     # by mocking urlparse to raise
     with mock.patch("urllib.parse.urlparse", side_effect=ValueError("Invalid URI")):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/19893?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19893/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19893/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19893/merge
```

</p>
</details>

### What changes are proposed in this pull request?

In telemetry, both local and remote server is captured as `http(s)` schema. Adding a flag to distinguish local server.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
