### PR TITLE
Add missing retrieval context error for retrieval scorers

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -470,6 +470,12 @@ class RetrievalRelevance(BuiltInScorer):
         request = extract_request_from_trace(trace)
         span_id_to_context = extract_retrieval_context_from_trace(trace)
 
+        if not span_id_to_context:
+            raise MlflowException(
+                "No retrieval context found in the trace. The RetrievalRelevance "
+                "scorer requires the trace to contain at least one span with type 'RETRIEVER'."
+            )
+
         feedbacks = []
         for span_id, context in span_id_to_context.items():
             feedbacks.extend(self._compute_span_relevance(span_id, request, context))
@@ -614,6 +620,12 @@ class RetrievalSufficiency(BuiltInScorer):
         request = extract_request_from_trace(trace)
         span_id_to_context = extract_retrieval_context_from_trace(trace)
 
+        if not span_id_to_context:
+            raise MlflowException(
+                "No retrieval context found in the trace. The RetrievalSufficiency "
+                "scorer requires the trace to contain at least one span with type 'RETRIEVER'."
+            )
+
         expectations = expectations or {}
         expected_facts = expectations.get("expected_facts")
         expected_response = expectations.get("expected_response")
@@ -721,6 +733,13 @@ class RetrievalGroundedness(BuiltInScorer):
         request = extract_request_from_trace(trace)
         response = extract_response_from_trace(trace)
         span_id_to_context = extract_retrieval_context_from_trace(trace)
+
+        if not span_id_to_context:
+            raise MlflowException(
+                "No retrieval context found in the trace. The RetrievalGroundedness "
+                "scorer requires the trace to contain at least one span with type 'RETRIEVER'."
+            )
+
         feedbacks = []
         for span_id, context in span_id_to_context.items():
             feedback = judges.is_grounded(

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/SimplifiedAssessmentView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/SimplifiedAssessmentView.tsx
@@ -57,6 +57,7 @@ const AssessmentCard = ({ assessment }: { assessment: FeedbackAssessment }) => {
   const value = getAssessmentValue(assessment);
   const rationale = assessment.rationale;
   const hasError = !isNil(assessment.feedback.error);
+  const hasNullValue = !hasError && isNil(value);
 
   return (
     <div
@@ -90,8 +91,15 @@ const AssessmentCard = ({ assessment }: { assessment: FeedbackAssessment }) => {
       {/* Error display */}
       {hasError && <FeedbackErrorItem error={assessment.feedback.error as AssessmentError} />}
 
+      {/* Null value display - show as error */}
+      {hasNullValue && (
+        <FeedbackErrorItem
+          error={{ error_code: 'NO_RESULT', error_message: 'The scorer did not return a result for this trace.' }}
+        />
+      )}
+
       {/* Result value */}
-      {!hasError && value !== undefined && (
+      {!hasError && !hasNullValue && (
         <div css={{ display: 'flex', alignItems: 'center' }}>
           <AssessmentDisplayValue jsonValue={JSON.stringify(value)} assessmentName={assessment.assessment_name} />
         </div>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/danielseong1/mlflow/pull/19895?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19895/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19895/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19895/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Retrieval scorers (`RetrievalRelevance`, `RetrievalSufficiency`, `RetrievalGroundedness`) now raise `MlflowException` with a clear error message when the trace has no `RETRIEVER` spans, instead of silently returning empty results or failing with unclear errors.

**Python SDK changes:**
- Add validation in all three retrieval scorers to check for retrieval context before processing
- Raise `MlflowException` with descriptive message when no RETRIEVER spans are found
- Consistent with how other scorers (e.g., `Correctness`) handle missing required data

**UI changes:**
- Fix `SimplifiedAssessmentView` to treat both `null` and `undefined` values consistently as "no result" errors using `isNil()`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added parametrized unit test `test_retrieval_scorers_raise_error_without_retriever_span` that covers all three retrieval scorers.

<img width="1711" height="830" alt="Screenshot 2026-01-10 at 6 47 50 PM" src="https://github.com/user-attachments/assets/e49b3e8f-06fe-46fd-8880-af28fb9e8e7e" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Retrieval scorers (`RetrievalRelevance`, `RetrievalSufficiency`, `RetrievalGroundedness`) now raise a clear `MlflowException` when the trace has no `RETRIEVER` spans, instead of silently returning empty results.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)