### PR TITLE
Normalize model_code_path to portable UNIX-style path

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -690,7 +690,10 @@ def add_to_model(
     if model_config:
         params[MODEL_CONFIG] = model_config
     if model_code_path:
-        params[MODEL_CODE_PATH] = model_code_path
+        if isinstance(model_code_path, str):
+            params[MODEL_CODE_PATH] = Path(model_code_path).as_posix()
+        else:
+            params[MODEL_CODE_PATH] = model_code_path.as_posix()
     return model.add_flavor(FLAVOR_NAME, **params)
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Lakshman142/mlflow/pull/19898?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19898/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19898/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19898/merge
```

</p>
</details>

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #19744

### What changes are proposed in this pull request?

This PR fixes an issue where models logged on Windows using the pyfunc
Models-from-Code workflow store absolute Windows-style paths with backslashes
in `model_code_path` inside the MLmodel file.

The Windows-style path (e.g. `C:\Users\...`) causes model loading to fail on
non-Windows platforms because os.path.basename() doesn't recognize backslashes
as path separators on Linux. This change normalizes `model_code_path` to use
POSIX-style forward slashes, ensuring models logged on Windows can be loaded
correctly on Linux and other operating systems.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

```artifact_path: file:C:/Users/laksh/Downloads/mlflow_test/mlruns/0/models/m-20dbd93bba15421e9fa10421758929e0/artifacts
flavors:
  python_function:
    cloudpickle_version: 3.0.0
    code: null
    env:
      conda: conda.yaml
      virtualenv: python_env.yaml
    loader_module: mlflow.pyfunc.loaders.code_model
    model_code_path: C:/Users/laksh/Downloads/mlflow_test/model.py
    python_version: 3.12.7
    streamable: false
mlflow_version: 3.8.2.dev0
model_id: m-20dbd93bba15421e9fa10421758929e0
model_size_bytes: 246
model_uuid: m-20dbd93bba15421e9fa10421758929e0
prompts: null
run_id: 7616d174b2314c24a58fce78a1726a51
utc_time_created: '2026-01-11 05:42:24.085432'
```
**Above is the MLModel after the fix, model_code_path is now in normalized UNIX style**
Manual testing:
- Logged a pyfunc model on Windows using the patched MLflow.
- Verified the generated MLmodel file contains a portable `model_code_path`.
- Successfully loaded the same model in a Linux Docker container without errors.
```
root@e6166fe27004:/app# uname -a
Linux e6166fe27004 5.15.167.4-microsoft-standard-WSL2 #1 SMP Tue Nov 5 00:21:55 UTC 2024 x86_64 GNU/Linux
root@e6166fe27004:/app# 
root@e6166fe27004:/app# python
Python 3.12.12 (main, Dec 30 2025, 03:58:12) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import mlflow
>>> model = mlflow.pyfunc.load_model("file:///app/mlflow_test/mlruns/0/models/m-20dbd93bba15421e9fa10421758929e0/artifacts")
2026/01/11 06:31:55 WARNING mlflow.utils.requirements_utils: Detected one or more mismatches between the model's dependencies and the current Python environment:
 - cloudpickle (current: 3.1.2, required: cloudpickle==3.0.0)
To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` to fetch the model's environment and install dependencies using the resulting environment file.
/app/mlflow/pyfunc/utils/data_validation.py:186: UserWarning: Add type hints to the `predict` method to enable data validation and automatic signature inference during model logging. Check https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel for more details.
  color_warning(
2026/01/11 06:31:57 INFO alembic.runtime.migration: Context impl SQLiteImpl.
2026/01/11 06:31:57 INFO alembic.runtime.migration: Will assume non-transactional DDL.
>>> model.predict(2)
4
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a cross-platform bug where models logged on Windows using the pyfunc
Models-from-Code workflow could not be loaded on Linux due to OS-specific
absolute paths stored in the MLmodel file.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
