### PR TITLE
Fix redirects on inferred experiments

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useInferExperimentKind.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useInferExperimentKind.tsx
@@ -3,6 +3,8 @@ import { useExperimentContainsTraces } from '../../traces/hooks/useExperimentCon
 import { ExperimentKind, ExperimentPageTabName } from '../../../constants';
 import { useExperimentContainsTrainingRuns } from '../../traces/hooks/useExperimentContainsTrainingRuns';
 import { isEditableExperimentKind } from '../../../utils/ExperimentKindUtils';
+import { matchPath, useLocation } from '../../../../common/utils/RoutingUtils';
+import { RoutePaths } from '../../../routes';
 
 export const useInferExperimentKind = ({
   experimentId,
@@ -51,7 +53,16 @@ export const useInferExperimentKind = ({
     containsRuns,
   ]);
 
+  // Check if the user landed on the experiment page without a specific tab in the URL.
+  // If the URL already contains a tab name (e.g. /experiments/1/traces), we should not
+  // redirect them.
+  const { pathname } = useLocation();
+  const isOnExperimentPageWithoutTab = Boolean(matchPath(RoutePaths.experimentPage, pathname));
+
   const inferredExperimentPageTab = useMemo(() => {
+    if (!isOnExperimentPageWithoutTab) {
+      return undefined;
+    }
     if (inferredExperimentKind === ExperimentKind.GENAI_DEVELOPMENT_INFERRED) {
       return ExperimentPageTabName.Overview;
     }
@@ -59,7 +70,7 @@ export const useInferExperimentKind = ({
       return ExperimentPageTabName.Runs;
     }
     return undefined;
-  }, [inferredExperimentKind]);
+  }, [inferredExperimentKind, isOnExperimentPageWithoutTab]);
 
   // automatically update the experiment type if it's not user-editable
   useEffect(() => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.test.tsx
@@ -178,8 +178,8 @@ describe('ExperimentLoggedModelListPage', () => {
       ),
     ).toBeInTheDocument();
 
-    // Check we've been redirected to the Overview tab
-    expect(await screen.findByText('Experiment overview page')).toBeInTheDocument();
+    // Since we started on the /models tab, we should remain on the models tab (no redirect)
+    expect(await screen.findByText('ExperimentLoggedModelListPage')).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19915/files) to review incremental changes.
- [**stack/preserve_current_page**](https://github.com/mlflow/mlflow/pull/19915) [[Files changed](https://github.com/mlflow/mlflow/pull/19915/files)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
We should only redirect to overview/runs tab for GenAI/ML experiments if users are on the default experiment page, but no redirects if they're already on some tabs.

https://github.com/user-attachments/assets/05ad1a33-5200-4ae6-8206-3a99fd55032b


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
