### PR TITLE
Support distributed tracing

### DIFF
--- a/mlflow/tracing/distributed/__init__.py
+++ b/mlflow/tracing/distributed/__init__.py
@@ -27,7 +27,7 @@ def get_tracing_context_headers_for_http_request() -> dict[str, str]:
     Returns:
         The http request headers that hold information of the tracing context.
 
-    Example:
+    Example (client code):
 
     .. code-block:: python
 
@@ -39,6 +39,25 @@ def get_tracing_context_headers_for_http_request() -> dict[str, str]:
             # and send request to remote agent with the headers
             headers = get_tracing_context_headers_for_http_request()
             resp = requests.post(f"{base_url}/remote_agent_handler", headers=headers)
+
+    Example (server handler code):
+
+    .. code-block:: python
+
+        import mlflow
+        from flask import Flask, request
+        from mlflow.tracing.distributed import set_tracing_context_from_http_request_headers
+
+        app = Flask(__name__)
+
+
+        @app.post("/agent-handler")
+        def handle():
+            headers = dict(request.headers)
+            with set_tracing_context_from_http_request_headers(headers):
+                with mlflow.start_span("server-handler") as span:
+                    # call agent ...
+                    span.set_attribute("key", "value")
     """
     active_span = mlflow.get_current_active_span()
     if active_span is None:
@@ -64,7 +83,20 @@ def set_tracing_context_from_http_request_headers(headers: dict[str, str]):
     Args:
         headers: The http request headers to extract the trace context from.
 
-    Example:
+    Example (client code):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.tracing.distributed import get_tracing_context_headers_for_http_request
+
+        with mlflow.start_span("client-root") as client_span:
+            # Get the headers that hold information of the tracing context,
+            # and send request to remote agent with the headers
+            headers = get_tracing_context_headers_for_http_request()
+            resp = requests.post(f"{base_url}/remote_agent_handler", headers=headers)
+
+    Example (server handler code):
 
     .. code-block:: python
 

--- a/mlflow/tracing/distributed/__init__.py
+++ b/mlflow/tracing/distributed/__init__.py
@@ -14,7 +14,7 @@ from mlflow.tracing.utils import generate_mlflow_trace_id_from_otel_trace_id
 _logger = logging.getLogger(__name__)
 
 
-def get_tracing_context_headers_for_http_request():
+def get_tracing_context_headers_for_http_request() -> dict[str, str]:
     """
     Get the http request headers that hold information of the tracing context.
     The trace context is serialized as the traceparent header which is defined
@@ -43,8 +43,7 @@ def get_tracing_context_headers_for_http_request():
     active_span = mlflow.get_current_active_span()
     if active_span is None:
         _logger.warning(
-            "'get_tracing_context_headers_for_http_request' does not generate http header "
-            "because There is no active span."
+            "No active span found for fetching the trace context from. Returning an empty header."
         )
     headers = {}
     TraceContextTextMapPropagator().inject(headers)
@@ -52,7 +51,7 @@ def get_tracing_context_headers_for_http_request():
 
 
 @contextmanager
-def set_tracing_context_from_http_request_headers(headers):
+def set_tracing_context_from_http_request_headers(headers: dict[str, str]):
     """
     Context manager to extract the trace context from the http request headers
     and set the extracted trace context as the current trace context within the

--- a/mlflow/tracing/distributed/__init__.py
+++ b/mlflow/tracing/distributed/__init__.py
@@ -7,6 +7,9 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 
 import mlflow
 from mlflow import MlflowException
+from mlflow.entities.trace_info import TraceInfo, TraceState
+from mlflow.tracing.trace_manager import InMemoryTraceManager
+from mlflow.tracing.utils import generate_mlflow_trace_id_from_otel_trace_id
 
 _logger = logging.getLogger(__name__)
 
@@ -26,9 +29,9 @@ def get_tracing_context_headers_for_http_request():
     """
     active_span = mlflow.get_current_active_span()
     if active_span is None:
-        raise MlflowException.invalid_parameter_value(
-            "'get_tracing_context_headers_for_http_request' must be called within the scope "
-            "of an active span."
+        _logger.warning(
+            "'get_tracing_context_headers_for_http_request' does not generate http header "
+            "because There is no active span."
         )
     headers = {}
     TraceContextTextMapPropagator().inject(headers)
@@ -49,10 +52,6 @@ def set_tracing_context_from_http_request_headers(headers):
     Args:
         headers: The http request headers to extract the trace context from.
     """
-    from mlflow.entities.trace_info import TraceInfo, TraceState
-    from mlflow.tracing.trace_manager import InMemoryTraceManager
-    from mlflow.tracing.utils import generate_mlflow_trace_id_from_otel_trace_id
-
     token = None
     otel_trace_id = None
     trace_manager = InMemoryTraceManager.get_instance()

--- a/mlflow/tracing/distributed/__init__.py
+++ b/mlflow/tracing/distributed/__init__.py
@@ -99,7 +99,7 @@ def set_tracing_context_from_http_request_headers(headers):
         span_context = extracted_span.get_span_context()
         otel_trace_id = span_context.trace_id
 
-        trace_manager.register_trace(otel_trace_id, mlflow_trace_info)
+        trace_manager.register_trace(otel_trace_id, mlflow_trace_info, is_remote_trace=True)
 
         if mlflow_trace_info.trace_id != generate_mlflow_trace_id_from_otel_trace_id(otel_trace_id):
             raise MlflowException(

--- a/mlflow/tracing/distributed/__init__.py
+++ b/mlflow/tracing/distributed/__init__.py
@@ -1,0 +1,48 @@
+from contextlib import contextmanager
+
+from opentelemetry import context as context_api
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+def get_tracing_context_headers_for_http_request():
+    """
+    Get the http request headers that hold information of the tracing context.
+    The trace context is serialized as the traceparent header which is defined
+    in the W3C TraceContext specification.
+    For details, you can refer to
+    https://opentelemetry.io/docs/concepts/context-propagation/
+    and
+    https://www.w3.org/TR/trace-context/#traceparent-header
+
+    Returns:
+        The http request headers that hold information of the tracing context.
+    """
+    headers = {}
+    TraceContextTextMapPropagator().inject(headers)
+    return headers
+
+
+@contextmanager
+def set_tracing_context_from_http_request_headers(headers):
+    """
+    Extract the trace context from the http request headers,
+    and return the context manager to set the extracted trace context as the
+    current trace context.
+    The trace context must be serialized as the traceparent header which is defined
+    in the W3C TraceContext specification, please see
+    :py:func:`mlflow.tracing.distributed.get_tracing_context_headers_for_http_request`
+    for how to get the http request headers.
+
+    Args:
+        headers: The http request headers to extract the trace context from.
+    """
+    token = None
+    try:
+        carrier = dict(headers)
+        ctx = TraceContextTextMapPropagator().extract(carrier)
+        token = context_api.attach(ctx)
+
+        yield
+    finally:
+        if token is not None:
+            context_api.detach(token)

--- a/mlflow/tracing/distributed/__init__.py
+++ b/mlflow/tracing/distributed/__init__.py
@@ -1,7 +1,19 @@
+import json
+import logging
 from contextlib import contextmanager
 
 from opentelemetry import context as context_api
+from opentelemetry import trace as trace_api
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+import mlflow
+from mlflow import MlflowException
+from mlflow.tracking.fluent import _get_experiment_id as _get_experiment_id
+
+_logger = logging.getLogger(__name__)
+
+
+_MLFLOW_TRACE_INFO_HTTP_HEADER_KEY = "__MLFLOW_TRACE_INFO__"
 
 
 def get_tracing_context_headers_for_http_request():
@@ -17,8 +29,21 @@ def get_tracing_context_headers_for_http_request():
     Returns:
         The http request headers that hold information of the tracing context.
     """
+    from mlflow.tracing.trace_manager import InMemoryTraceManager
+
+    active_span = mlflow.get_current_active_span()
+    if active_span is None:
+        raise MlflowException.invalid_parameter_value(
+            "'get_tracing_context_headers_for_http_request' must be called within the scope "
+            "of an active span."
+        )
     headers = {}
     TraceContextTextMapPropagator().inject(headers)
+    trace_manager = InMemoryTraceManager.get_instance()
+
+    with trace_manager.get_trace(active_span.trace_id) as trace:
+        headers[_MLFLOW_TRACE_INFO_HTTP_HEADER_KEY] = json.dumps(trace.info.to_dict())
+
     return headers
 
 
@@ -36,11 +61,32 @@ def set_tracing_context_from_http_request_headers(headers):
     Args:
         headers: The http request headers to extract the trace context from.
     """
+    from mlflow.entities.trace_info import TraceInfo
+    from mlflow.tracing.trace_manager import InMemoryTraceManager
+    from mlflow.tracing.utils import generate_mlflow_trace_id_from_otel_trace_id
+
     token = None
     try:
-        carrier = dict(headers)
-        ctx = TraceContextTextMapPropagator().extract(carrier)
+        headers = dict(headers)
+        ctx = TraceContextTextMapPropagator().extract(headers)
         token = context_api.attach(ctx)
+
+        trace_manager = InMemoryTraceManager.get_instance()
+        mlflow_trace_info = TraceInfo.from_dict(
+            json.loads(headers[_MLFLOW_TRACE_INFO_HTTP_HEADER_KEY])
+        )
+
+        extracted_span = trace_api.get_current_span(ctx)
+        span_context = extracted_span.get_span_context()
+        otel_trace_id = span_context.trace_id
+
+        trace_manager.register_trace(otel_trace_id, mlflow_trace_info)
+
+        if mlflow_trace_info.trace_id != generate_mlflow_trace_id_from_otel_trace_id(otel_trace_id):
+            raise MlflowException(
+                "Internal error: The http headers contain mismatched W3C TraceContext information "
+                "and mlflow TraceInfo."
+            )
 
         yield
     finally:

--- a/mlflow/tracing/distributed/__init__.py
+++ b/mlflow/tracing/distributed/__init__.py
@@ -65,6 +65,8 @@ def set_tracing_context_from_http_request_headers(headers):
     from mlflow.tracing.utils import generate_mlflow_trace_id_from_otel_trace_id
 
     token = None
+    otel_trace_id = None
+    trace_manager = InMemoryTraceManager.get_instance()
     try:
         headers = dict(headers)
 
@@ -85,7 +87,6 @@ def set_tracing_context_from_http_request_headers(headers):
         ctx = TraceContextTextMapPropagator().extract(headers)
         token = context_api.attach(ctx)
 
-        trace_manager = InMemoryTraceManager.get_instance()
         try:
             mlflow_trace_info = TraceInfo.from_dict(
                 json.loads(headers[_MLFLOW_TRACE_INFO_HTTP_HEADER_KEY])
@@ -111,3 +112,5 @@ def set_tracing_context_from_http_request_headers(headers):
     finally:
         if token is not None:
             context_api.detach(token)
+        if otel_trace_id is not None:
+            trace_manager.pop_trace(otel_trace_id)

--- a/mlflow/tracing/distributed/__init__.py
+++ b/mlflow/tracing/distributed/__init__.py
@@ -26,6 +26,19 @@ def get_tracing_context_headers_for_http_request():
 
     Returns:
         The http request headers that hold information of the tracing context.
+
+    Example:
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.tracing.distributed import get_tracing_context_headers_for_http_request
+
+        with mlflow.start_span("client-root") as client_span:
+            # Get the headers that hold information of the tracing context,
+            # and send request to remote agent with the headers
+            headers = get_tracing_context_headers_for_http_request()
+            resp = requests.post(f"{base_url}/remote_agent_handler", headers=headers)
     """
     active_span = mlflow.get_current_active_span()
     if active_span is None:
@@ -51,6 +64,25 @@ def set_tracing_context_from_http_request_headers(headers):
 
     Args:
         headers: The http request headers to extract the trace context from.
+
+    Example:
+
+    .. code-block:: python
+
+        import mlflow
+        from flask import Flask, request
+        from mlflow.tracing.distributed import set_tracing_context_from_http_request_headers
+
+        app = Flask(__name__)
+
+
+        @app.post("/agent-handler")
+        def handle():
+            headers = dict(request.headers)
+            with set_tracing_context_from_http_request_headers(headers):
+                with mlflow.start_span("server-handler") as span:
+                    # call agent ...
+                    span.set_attribute("key", "value")
     """
     token = None
     otel_trace_id = None

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -68,14 +68,12 @@ class InferenceTableSpanExporter(SpanExporter):
             spans: A sequence of OpenTelemetry ReadableSpan objects passed from
                 a span processor. Only root spans for each trace should be exported.
         """
-        trace_manager = InMemoryTraceManager.get_instance()
-
         for span in spans:
             if span._parent is not None:
                 _logger.debug("Received a non-root span. Skipping export.")
                 continue
 
-            if trace_manager._is_remote_trace[span.get_span_context().trace_id]:
+            if self._trace_manager._is_remote_trace.get(span.get_span_context().trace_id, False):
                 _logger.warning(
                     "The Databricks InferenceTableSpanExporter does not support exporting spans "
                     "incrementally. In this case, for distributed trace, exporting the span "

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -73,17 +73,17 @@ class InferenceTableSpanExporter(SpanExporter):
                 _logger.debug("Received a non-root span. Skipping export.")
                 continue
 
-            if self._trace_manager._is_remote_trace.get(span.get_span_context().trace_id, False):
-                _logger.warning(
-                    "The Databricks InferenceTableSpanExporter does not support exporting spans "
-                    "incrementally. In this case, for distributed trace, exporting the span "
-                    f"{span.name} that is created in a remote process is not supported."
-                )
-                continue
-
             manager_trace = self._trace_manager.pop_trace(span.context.trace_id)
             if manager_trace is None:
                 _logger.debug(f"Trace for span {span} not found. Skipping export.")
+                continue
+
+            if manager_trace.is_remote_trace:
+                _logger.warning(
+                    "For distributed tracing, the Databricks InferenceTableSpanExporter does not "
+                    f"support exporting the span {span.name} that is created in a remote process "
+                    "is not supported."
+                )
                 continue
 
             trace = manager_trace.trace

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -80,9 +80,8 @@ class InferenceTableSpanExporter(SpanExporter):
 
             if manager_trace.is_remote_trace:
                 _logger.warning(
-                    "For distributed tracing, the Databricks InferenceTableSpanExporter does not "
-                    f"support exporting the span {span.name} that is created in a remote process "
-                    "is not supported."
+                    f"Mlflow does not support exporting the span {span.name} that is created "
+                    "in a remote process to Databricks InferenceTable."
                 )
                 continue
 

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -65,7 +65,7 @@ class MlflowV3SpanExporter(SpanExporter):
         trace_manager = InMemoryTraceManager.get_instance()
 
         for span in spans:
-            if trace_manager._is_distributed_trace[span.get_span_context().trace_id]:
+            if trace_manager._is_remote_trace[span.get_span_context().trace_id]:
                 _logger.warning(
                     "The MLflow tracing store backend does not support exporting spans "
                     "incrementally. In this case, exporting the distributed tracing span "

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -66,6 +66,11 @@ class MlflowV3SpanExporter(SpanExporter):
 
         for span in spans:
             if trace_manager._is_distributed_trace[span.get_span_context().trace_id]:
+                raise RuntimeError(
+                    "The MLflow tracing store backend does not support exporting spans "
+                    "incrementally. In the case, exporting the distributed tracing span "
+                    f"{span.name} that is created in a remote process is not supported."
+                )
                 _logger.warning(
                     "The MLflow tracing store backend does not support exporting spans "
                     "incrementally. In the case, exporting the distributed tracing span "

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -65,7 +65,7 @@ class MlflowV3SpanExporter(SpanExporter):
         trace_manager = InMemoryTraceManager.get_instance()
 
         for span in spans:
-            if trace_manager._is_distributed_trace[span.trace_id]:
+            if trace_manager._is_distributed_trace[span.get_span_context().trace_id]:
                 _logger.warning(
                     "The MLflow tracing store backend does not support exporting spans "
                     "incrementally. In the case, exporting the distributed tracing span "

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -68,9 +68,10 @@ class MlflowV3SpanExporter(SpanExporter):
             if trace_manager._is_remote_trace[span.get_span_context().trace_id]:
                 _logger.warning(
                     "The MLflow tracing store backend does not support exporting spans "
-                    "incrementally. In this case, exporting the distributed tracing span "
+                    "incrementally. In this case, for distributed trace, exporting the span "
                     f"{span.name} that is created in a remote process is not supported."
                 )
+                continue
 
         self._export_traces(spans)
 

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -135,11 +135,11 @@ class MlflowV3SpanExporter(SpanExporter):
                 _logger.debug(f"Trace for root span {span} not found. Skipping full export.")
                 continue
 
-            if manager_trace.is_remote_trace:
+            if manager_trace.is_remote_trace and not self._should_export_spans_incrementally:
                 _logger.warning(
-                    "The MLflow tracing backend does not support exporting spans "
-                    "incrementally. In this case, for distributed trace, exporting the span "
-                    f"{span.name} that is created in a remote process is not supported."
+                    f"Current MLflow server does not support ingesting the span {span.name} "
+                    "that is created in a remote process. Please upgrade the server version and "
+                    "use SQL backend to do distributed tracing."
                 )
                 continue
 

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -68,7 +68,7 @@ class MlflowV3SpanExporter(SpanExporter):
             if trace_manager._is_distributed_trace[span.get_span_context().trace_id]:
                 _logger.warning(
                     "The MLflow tracing store backend does not support exporting spans "
-                    "incrementally. In the case, exporting the distributed tracing span "
+                    "incrementally. In this case, exporting the distributed tracing span "
                     f"{span.name} that is created in a remote process is not supported."
                 )
 

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -66,11 +66,6 @@ class MlflowV3SpanExporter(SpanExporter):
 
         for span in spans:
             if trace_manager._is_distributed_trace[span.get_span_context().trace_id]:
-                raise RuntimeError(
-                    "The MLflow tracing store backend does not support exporting spans "
-                    "incrementally. In the case, exporting the distributed tracing span "
-                    f"{span.name} that is created in a remote process is not supported."
-                )
                 _logger.warning(
                     "The MLflow tracing store backend does not support exporting spans "
                     "incrementally. In the case, exporting the distributed tracing span "

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -58,8 +58,19 @@ class MlflowV3SpanExporter(SpanExporter):
             spans: A sequence of OpenTelemetry ReadableSpan objects passed from
                 a span processor. All spans (root and non-root) are exported.
         """
+
         if self._should_export_spans_incrementally:
             self._export_spans_incrementally(spans)
+
+        trace_manager = InMemoryTraceManager.get_instance()
+
+        for span in spans:
+            if trace_manager._is_distributed_trace[span.trace_id]:
+                _logger.warning(
+                    "The MLflow tracing store backend does not support exporting spans "
+                    "incrementally. In the case, exporting the distributed tracing span "
+                    f"{span.name} that is created in a remote process is not supported."
+                )
 
         self._export_traces(spans)
 

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -130,17 +130,17 @@ class MlflowV3SpanExporter(SpanExporter):
             if span._parent is not None:
                 continue
 
-            if manager._is_remote_trace.get(span.get_span_context().trace_id, False):
+            manager_trace = manager.pop_trace(span.context.trace_id)
+            if manager_trace is None:
+                _logger.debug(f"Trace for root span {span} not found. Skipping full export.")
+                continue
+
+            if manager_trace.is_remote_trace:
                 _logger.warning(
                     "The MLflow tracing backend does not support exporting spans "
                     "incrementally. In this case, for distributed trace, exporting the span "
                     f"{span.name} that is created in a remote process is not supported."
                 )
-                continue
-
-            manager_trace = manager.pop_trace(span.context.trace_id)
-            if manager_trace is None:
-                _logger.debug(f"Trace for root span {span} not found. Skipping full export.")
                 continue
 
             trace = manager_trace.trace

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -185,6 +185,7 @@ class InMemoryTraceManager:
         with self._lock:
             mlflow_trace_id = self._otel_id_to_mlflow_trace_id.pop(otel_trace_id, None)
             internal_trace = self._traces.pop(mlflow_trace_id, None) if mlflow_trace_id else None
+            self._is_remote_trace.pop(otel_trace_id, None)
             if internal_trace is None:
                 return None
             return ManagerTrace(

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -74,7 +74,7 @@ class InMemoryTraceManager:
         self._lock = threading.RLock()  # Lock for _traces
 
         # Store whether the trace ID points to a distributed trace.
-        self._is_distributed_trace: dict[str, bool] = {}
+        self._is_distributed_trace: dict[int, bool] = {}
 
     def register_trace(self, otel_trace_id: int, trace_info: TraceInfo, is_distributed_trace=False):
         """
@@ -90,7 +90,7 @@ class InMemoryTraceManager:
         with self._lock:
             self._traces[trace_info.trace_id] = _Trace(trace_info)
             self._otel_id_to_mlflow_trace_id[otel_trace_id] = trace_info.trace_id
-            self._is_distributed_trace[trace_info.trace_id] = is_distributed_trace
+            self._is_distributed_trace[otel_trace_id] = is_distributed_trace
 
     def register_span(self, span: LiveSpan):
         """

--- a/tests/tracing/test_distributed.py
+++ b/tests/tracing/test_distributed.py
@@ -36,7 +36,6 @@ def _parse_traceparent(header_value: str) -> tuple[int, int]:
 
 def test_get_tracing_context_headers_for_http_request_in_active_span():
     with mlflow.start_span("client-span"):
-        breakpoint()
         current_span = otel_trace.get_current_span()
         assert current_span.get_span_context().is_valid
         client_trace_id = current_span.get_span_context().trace_id

--- a/tests/tracing/test_distributed.py
+++ b/tests/tracing/test_distributed.py
@@ -188,8 +188,8 @@ def test_distributed_tracing_e2e_nested_call(tmp_path):
         from flask import Flask, request, jsonify
         import mlflow
         from mlflow.tracing.distributed import (
-            set_tracing_context_from_http_request_headers
-            get_tracing_context_headers_for_http_request
+            set_tracing_context_from_http_request_headers,
+            get_tracing_context_headers_for_http_request,
         )
 
         app = Flask(__name__)

--- a/tests/tracing/test_distributed.py
+++ b/tests/tracing/test_distributed.py
@@ -172,3 +172,120 @@ def test_distributed_tracing_e2e(tmp_path):
     assert root_span.name == "client-root"
     assert child_span.name == "server-handler"
     assert child_span.parent_id == root_span.span_id
+
+
+def test_distributed_tracing_e2e_nested_call(tmp_path):
+    port = get_safe_port()
+    port2 = get_safe_port()
+    base_url = f"http://127.0.0.1:{port}"
+    base_url2 = f"http://127.0.0.1:{port2}"
+
+    server_code = textwrap.dedent(
+        f"""
+        import sys
+        import json
+        import requests
+        from flask import Flask, request, jsonify
+        import mlflow
+        from mlflow.tracing.distributed import (
+            set_tracing_context_from_http_request_headers
+            get_tracing_context_headers_for_http_request
+        )
+
+        app = Flask(__name__)
+
+        @app.get("/health")
+        def health():
+            return "ok", 200
+
+        @app.post("/handle1")
+        def handle1():
+            # Forward all headers for extraction
+            headers = dict(request.headers)
+            with set_tracing_context_from_http_request_headers(headers):
+                with mlflow.start_span("server-handler1") as span:
+                    headers2 = get_tracing_context_headers_for_http_request()
+                    resp2 = requests.post("{base_url2}/handle2", headers=headers2, timeout=5)
+                    assert resp2.ok
+                    payload2 = resp2.json()
+                    return jsonify({{
+                        "trace_id": span.trace_id,
+                        "span_id": span.span_id,
+                        "parent_id": span.parent_id,
+                        "nested_call_resp": payload2,
+                    }})
+
+        @app.post("/handle2")
+        def handle2():
+            # Forward all headers for extraction
+            headers = dict(request.headers)
+            with set_tracing_context_from_http_request_headers(headers):
+                with mlflow.start_span("server-handler2") as span:
+                    return jsonify({{
+                        "trace_id": span.trace_id,
+                        "span_id": span.span_id,
+                        "parent_id": span.parent_id,
+                    }})
+
+        if __name__ == "__main__":
+            port = int(sys.argv[1])
+            app.run(host="127.0.0.1", port=port, debug=False, use_reloader=False)
+        """
+    )
+
+    server_path = Path(tmp_path) / "flask_server.py"
+    server_path.write_text(server_code)
+
+    # Start server in a separate process
+    proc = Popen([sys.executable, str(server_path), str(port)])
+    proc2 = Popen([sys.executable, str(server_path), str(port2)])
+    try:
+        # Wait until server is ready
+        for _ in range(30):
+            try:
+                r = requests.get(f"{base_url}/health", timeout=1.0)
+                r2 = requests.get(f"{base_url2}/health", timeout=1.0)
+                if r.ok and r2.ok:
+                    break
+            except requests.exceptions.RequestException:
+                time.sleep(0.2)
+        else:
+            raise RuntimeError("Flask server failed to start")
+
+        # Client side: create a span and send headers to server
+        with mlflow.start_span("client-root") as client_span:
+            headers = get_tracing_context_headers_for_http_request()
+            resp = requests.post(f"{base_url}/handle1", headers=headers, timeout=5)
+            assert resp.ok, f"Server returned {resp.status_code}: {resp.text}"
+            payload = resp.json()
+
+            # Validate server span is a child in the same trace
+            assert payload["trace_id"] == client_span.trace_id
+            assert payload["parent_id"] == client_span.span_id
+            child_span1_id = payload["span_id"]
+            assert payload["nested_call_resp"]["trace_id"] == client_span.trace_id
+            assert payload["nested_call_resp"]["parent_id"] == child_span1_id
+            child_span2_id = payload["nested_call_resp"]["span_id"]
+    finally:
+        proc.terminate()
+        proc2.terminate()
+        proc.wait()
+        proc2.wait()
+
+    mlflow.flush_trace_async_logging()
+    trace = mlflow.get_trace(client_span.trace_id)
+
+    assert trace is not None, "Trace not found"
+    spans = trace.data.spans
+    assert len(spans) == 3
+
+    # Identify root and child
+    root_span = next(s for s in spans if s.parent_id is None)
+    child_span1 = next(s for s in spans if s.parent_id == root_span.span_id)
+    child_span2 = next(s for s in spans if s.parent_id == child_span1.span_id)
+
+    assert root_span.name == "client-root"
+    assert child_span1.name == "server-handler1"
+    assert child_span2.name == "server-handler2"
+    assert child_span1.span_id == child_span1_id
+    assert child_span2.span_id == child_span2_id

--- a/tests/tracing/test_distributed.py
+++ b/tests/tracing/test_distributed.py
@@ -5,12 +5,10 @@ import time
 from pathlib import Path
 from subprocess import Popen
 
-import pytest
 import requests
 from opentelemetry import trace as otel_trace
 
 import mlflow
-from mlflow.exceptions import MlflowException
 from mlflow.tracing.distributed import (
     get_tracing_context_headers_for_http_request,
     set_tracing_context_from_http_request_headers,
@@ -53,14 +51,8 @@ def test_get_tracing_context_headers_for_http_request_in_active_span():
 
 
 def test_get_tracing_context_headers_for_http_request_without_active_span():
-    with pytest.raises(
-        MlflowException,
-        match=(
-            "'get_tracing_context_headers_for_http_request' must be called within the scope "
-            "of an active span."
-        ),
-    ):
-        get_tracing_context_headers_for_http_request()
+    headers = get_tracing_context_headers_for_http_request()
+    assert headers == {}
 
 
 def test_set_tracing_context_from_http_request_headers():

--- a/tests/tracing/test_distributed.py
+++ b/tests/tracing/test_distributed.py
@@ -17,6 +17,7 @@ from mlflow.tracing.distributed import (
 )
 
 from tests.helper_functions import get_safe_port
+from tests.tracing.helper import skip_when_testing_trace_sdk
 
 
 def _parse_traceparent(header_value: str) -> tuple[int, int]:
@@ -90,6 +91,7 @@ def test_set_tracing_context_from_http_request_headers():
             assert child_span.trace_id == client_trace_id
 
 
+@skip_when_testing_trace_sdk
 def test_distributed_tracing_e2e(tmp_path):
     # Prepare a minimal Flask server script that extracts headers and starts a child span
     server_code = textwrap.dedent(
@@ -174,6 +176,7 @@ def test_distributed_tracing_e2e(tmp_path):
     assert child_span.parent_id == root_span.span_id
 
 
+@skip_when_testing_trace_sdk
 def test_distributed_tracing_e2e_nested_call(tmp_path):
     port = get_safe_port()
     port2 = get_safe_port()

--- a/tests/tracing/test_distributed.py
+++ b/tests/tracing/test_distributed.py
@@ -156,6 +156,7 @@ def test_distributed_tracing_e2e(tmp_path):
             assert payload["parent_id"] == client_span.span_id
     finally:
         proc.terminate()
+        proc.wait()
 
     mlflow.flush_trace_async_logging()
     trace = mlflow.get_trace(client_span.trace_id)

--- a/tests/tracing/test_distributed.py
+++ b/tests/tracing/test_distributed.py
@@ -1,0 +1,106 @@
+import re
+
+from opentelemetry import trace as otel_trace
+
+import mlflow
+from mlflow.tracing.distributed import (
+    get_tracing_context_headers_for_http_request,
+    set_tracing_context_from_http_request_headers,
+)
+
+
+def _parse_traceparent(header_value: str) -> tuple[int, int]:
+    """
+    Parse W3C traceparent header into (trace_id_int, span_id_int).
+    Format: version-traceid-spanid-flags (all lowercase hex, no 0x prefix).
+    """
+    # Basic validation to provide clearer error messages in case of malformed headers
+    assert isinstance(header_value, str) and header_value, (
+        "traceparent header must be a non-empty string"
+    )
+    parts = header_value.split("-")
+    assert len(parts) == 4, f"Invalid traceparent format: {header_value}"
+    version, trace_id_hex, span_id_hex, flags = parts
+    assert re.fullmatch(r"[0-9a-f]{2}", version), f"Invalid version: {version}"
+    assert re.fullmatch(r"[0-9a-f]{32}", trace_id_hex), f"Invalid trace id: {trace_id_hex}"
+    assert re.fullmatch(r"[0-9a-f]{16}", span_id_hex), f"Invalid span id: {span_id_hex}"
+    assert re.fullmatch(r"[0-9a-f]{2}", flags), f"Invalid flags: {flags}"
+    return int(trace_id_hex, 16), int(span_id_hex, 16)
+
+
+def test_get_tracing_context_headers_for_http_request_in_active_span():
+    with mlflow.start_span("client-span"):
+        current_span = otel_trace.get_current_span()
+        assert current_span.get_span_context().is_valid
+        client_trace_id = current_span.get_span_context().trace_id
+        client_span_id = current_span.get_span_context().span_id
+
+        headers: dict[str, str] = get_tracing_context_headers_for_http_request()
+        assert isinstance(headers, dict)
+        assert "traceparent" in headers and headers["traceparent"]
+
+        # Validate that the header encodes the same trace and span IDs
+        header_trace_id, header_span_id = _parse_traceparent(headers["traceparent"])
+        assert header_trace_id == client_trace_id
+        assert header_span_id == client_span_id
+
+
+def test_get_tracing_context_headers_for_http_request_without_active_span():
+    # No active span: injection should not add a traceparent header
+    headers: dict[str, str] = get_tracing_context_headers_for_http_request()
+    # OpenTelemetry inject typically omits headers when context is invalid
+    assert "traceparent" not in headers
+    assert headers == {} or not headers.get("traceparent")
+
+
+def test_set_tracing_context_from_http_request_headers_attaches_and_detaches():
+    # Create headers from a client context first
+    with mlflow.start_span("client-to-generate-headers"):
+        client_headers = get_tracing_context_headers_for_http_request()
+        assert "traceparent" in client_headers
+        client_trace_id, client_span_id = _parse_traceparent(client_headers["traceparent"])
+        assert client_trace_id != 0 and client_span_id != 0
+
+    # Outside the client span, there should be no active span
+    assert not otel_trace.get_current_span().get_span_context().is_valid
+    assert mlflow.get_current_active_span() is None
+
+    # Attach the context from headers and verify it becomes current inside the block
+    with set_tracing_context_from_http_request_headers(client_headers):
+        current = otel_trace.get_current_span()
+        assert current.get_span_context().is_valid
+        assert current.get_span_context().trace_id == client_trace_id
+        # span_id in context is the parent span id from the header
+        assert current.get_span_context().span_id == client_span_id
+
+    # After exiting, the previously invalid context should be restored
+    assert not otel_trace.get_current_span().get_span_context().is_valid
+    assert mlflow.get_current_active_span() is None
+
+
+def test_end_to_end_inject_extract_and_create_child_span():
+    # Client side: start a span and create headers to send downstream
+    with mlflow.start_span("client-root") as client_mlflow_span:
+        client_current = otel_trace.get_current_span()
+        assert client_current.get_span_context().is_valid
+        client_trace_id = client_current.get_span_context().trace_id
+        client_span_id = client_current.get_span_context().span_id
+
+        headers = get_tracing_context_headers_for_http_request()
+        assert "traceparent" in headers
+        h_trace_id, h_parent_span_id = _parse_traceparent(headers["traceparent"])
+        assert h_trace_id == client_trace_id
+        assert h_parent_span_id == client_span_id
+
+    # Server side: extract headers, set context, and start a child span
+    with set_tracing_context_from_http_request_headers(headers):
+        # Starting a new MLflow span should create a child under the extracted context
+        with mlflow.start_span("server-handler"):
+            server_current = otel_trace.get_current_span()
+            assert server_current.get_span_context().is_valid
+            # Same trace, different (new) span id
+            assert server_current.get_span_context().trace_id == client_trace_id
+            assert server_current.get_span_context().span_id != h_parent_span_id
+
+            # MLflow API should see an active span
+            assert mlflow.get_current_active_span() is not None

--- a/tests/tracing/test_distributed.py
+++ b/tests/tracing/test_distributed.py
@@ -35,12 +35,12 @@ def _parse_traceparent(header_value: str) -> tuple[int, int]:
 
 def test_get_tracing_context_headers_for_http_request_in_active_span():
     with mlflow.start_span("client-span"):
-        current_span = otel_trace.get_current_span()
+        current_span = mlflow.get_current_active_span()._span
         assert current_span.get_span_context().is_valid
         client_trace_id = current_span.get_span_context().trace_id
         client_span_id = current_span.get_span_context().span_id
 
-        headers: dict[str, str] = get_tracing_context_headers_for_http_request()
+        headers = get_tracing_context_headers_for_http_request()
         assert isinstance(headers, dict)
         assert "traceparent" in headers
 

--- a/tests/tracing/test_distributed.py
+++ b/tests/tracing/test_distributed.py
@@ -1,8 +1,10 @@
 import re
 
+import pytest
 from opentelemetry import trace as otel_trace
 
 import mlflow
+from mlflow.exceptions import MlflowException
 from mlflow.tracing.distributed import (
     get_tracing_context_headers_for_http_request,
     set_tracing_context_from_http_request_headers,
@@ -42,9 +44,14 @@ def test_get_tracing_context_headers_for_http_request_in_active_span():
 
 
 def test_get_tracing_context_headers_for_http_request_without_active_span():
-    # No active span: injection should not add a traceparent header
-    headers: dict[str, str] = get_tracing_context_headers_for_http_request()
-    assert headers == {}
+    with pytest.raises(
+        MlflowException,
+        match=(
+            "'get_tracing_context_headers_for_http_request' must be called within the scope "
+            "of an active span."
+        ),
+    ):
+        get_tracing_context_headers_for_http_request()
 
 
 def test_set_tracing_context_from_http_request_headers():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/19920?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19920/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19920/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19920/merge
```

</p>
</details>

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Support distributed tracing.

**Motivation**:
Currently, MLflow can only create a trace from single process/service. However, multi-agent system is becoming more popular, and users can deploy multiple agents as separate services and use them within a single product. For example, they can have "SupervisorAgent", "SQLAgent", "PythonAgent", "WebSearchAgent", deployed into different model serving endpoints, and route requests from chatbot frontend based on user's question. In this case, it is ideal for customers that they can see all those agent actions for a single user request in a single trace. However, since MLflow can only create trace within a scope of process, they can only create separate trace per agent. Debugging issue is painful because they need to find and stitch those traces.

In this PR,
it supports building a trace that spans over multiple services. Note that OpenTelemetry already have a mechanism for that, which is called "[context propagation](https://opentelemetry.io/docs/concepts/context-propagation/)" and use a protocol called W3C TraceContext by default. So that this PR is built on top of it.

**APIs:**

```
def get_tracing_context_headers_for_http_request():
    """
    Get the http request headers that hold information of the tracing context.
    The trace context is serialized as the traceparent header which is defined
    in the W3C TraceContext specification.
    For details, you can refer to
    https://opentelemetry.io/docs/concepts/context-propagation/
    and
    https://www.w3.org/TR/trace-context/#traceparent-header

    Returns:
        The http request headers that hold information of the tracing context.
    """

def set_tracing_context_from_http_request_headers(headers):
    """
    Extract the trace context from the http request headers,
    and return the context manager to set the extracted trace context as the
    current trace context.
    The trace context must be serialized as the traceparent header which is defined
    in the W3C TraceContext specification, please see
    :py:func:`mlflow.tracing.distributed.get_tracing_context_headers_for_http_request`
    for how to get the http request headers.

    Args:
        headers: The http request headers to extract the trace context from.
    """
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Support distributed tracing

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
