### PR TITLE
[UI] Fix session selector table column resizing and link behavior

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/SelectSessionsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectSessionsModal.tsx
@@ -125,7 +125,7 @@ const SelectSessionsModalImpl = ({
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}
             enableRowSelection
-            enableLinks={false}
+            openLinksInNewTab
             empty={<EmptySessionsList />}
             // TODO: Move date selector to the toolbar in all callsites permanently
             toolbarAddons={<TracesV3DateSelector />}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
@@ -86,11 +86,17 @@ interface ExperimentEvaluationDatasetsTableRowProps {
   row: Row<SessionTableRow>;
   enableRowSelection?: boolean;
   enableLinks?: boolean;
+  openLinksInNewTab?: boolean;
 }
 
 const ExperimentChatSessionsTableRow: React.FC<React.PropsWithChildren<ExperimentEvaluationDatasetsTableRowProps>> =
   React.memo(
-    function ExperimentChatSessionsTableRow({ row, enableRowSelection, enableLinks = true }) {
+    function ExperimentChatSessionsTableRow({
+      row,
+      enableRowSelection,
+      enableLinks = true,
+      openLinksInNewTab = false,
+    }) {
       const { search } = useLocation();
       const { theme } = useDesignSystemTheme();
 
@@ -109,7 +115,7 @@ const ExperimentChatSessionsTableRow: React.FC<React.PropsWithChildren<Experimen
             </div>
           )}
           {row.getVisibleCells().map((cell) => (
-            <TableCell key={cell.id}>
+            <TableCell key={cell.id} css={{ flex: `calc(var(--col-${cell.column.id}-size) / 100)` }}>
               {enableLinks ? (
                 <Link
                   to={{
@@ -117,14 +123,16 @@ const ExperimentChatSessionsTableRow: React.FC<React.PropsWithChildren<Experimen
                       row.original.experimentId,
                       row.original.sessionId,
                     ),
-                    search,
+                    search: openLinksInNewTab ? undefined : search,
                   }}
+                  target={openLinksInNewTab ? '_blank' : undefined}
+                  rel={openLinksInNewTab ? 'noopener noreferrer' : undefined}
                   css={{
                     display: 'flex',
                     width: '100%',
                     height: '100%',
                     alignItems: 'center',
-                    color: 'inherit',
+                    color: 'inherit !important',
                     textDecoration: 'none',
                   }}
                 >
@@ -152,6 +160,7 @@ export const GenAIChatSessionsTable = ({
   traceActions,
   enableRowSelection: enableRowSelectionProp = false,
   enableLinks = true,
+  openLinksInNewTab = false,
   empty,
   toolbarAddons,
 }: {
@@ -163,6 +172,7 @@ export const GenAIChatSessionsTable = ({
   traceActions?: TraceActions;
   enableRowSelection?: boolean;
   enableLinks?: boolean;
+  openLinksInNewTab?: boolean;
   empty?: React.ReactElement;
   toolbarAddons?: React.ReactNode;
 }) => {
@@ -286,6 +296,7 @@ export const GenAIChatSessionsTable = ({
                 row={row}
                 enableRowSelection={enableRowSelection}
                 enableLinks={enableLinks}
+                openLinksInNewTab={openLinksInNewTab}
               />
             ))}
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/danielseong1/mlflow/pull/19927?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19927/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19927/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19927/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix two issues with the GenAIChatSessionsTable component:

1. **Column resizing not working**: Table cells were missing the flex CSS property that uses column size CSS variables, causing headers and body cells to become misaligned when resizing columns.

2. **Session links not clickable in modal**: Added `openLinksInNewTab` prop to allow links to open in new tabs (used in SelectSessionsModal). Also fixed link color inheritance with `!important` to prevent blue link styling.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests



https://github.com/user-attachments/assets/b2803a38-61d9-4507-a9d1-ebc7c787905c


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)