### PR TITLE
Fix the conversation simulator when running on DBX quota

### DIFF
--- a/mlflow/genai/judges/adapters/databricks_managed_judge_adapter.py
+++ b/mlflow/genai/judges/adapters/databricks_managed_judge_adapter.py
@@ -185,7 +185,7 @@ def _parse_databricks_judge_response(
     )
 
 
-def _create_litellm_message_from_databricks_response(
+def create_litellm_message_from_databricks_response(
     response_data: dict[str, Any],
 ) -> Any:
     """
@@ -240,7 +240,7 @@ def _create_litellm_message_from_databricks_response(
     )
 
 
-def _serialize_messages_to_databricks_prompts(
+def serialize_messages_to_databricks_prompts(
     messages: list[Any],
 ) -> tuple[str, str | None]:
     """
@@ -314,7 +314,7 @@ def _run_databricks_agentic_loop(
             _raise_iteration_limit_exceeded(max_iterations)
 
         try:
-            user_prompt, system_prompt = _serialize_messages_to_databricks_prompts(messages)
+            user_prompt, system_prompt = serialize_messages_to_databricks_prompts(messages)
 
             llm_result = call_chat_completions(
                 user_prompt, system_prompt or "", tools=tools, model=_DATABRICKS_AGENTIC_JUDGE_MODEL
@@ -325,7 +325,7 @@ def _run_databricks_agentic_loop(
                 raise MlflowException("Empty response from Databricks judge")
 
             parsed_json = json.loads(output_json) if isinstance(output_json, str) else output_json
-            message = _create_litellm_message_from_databricks_response(parsed_json)
+            message = create_litellm_message_from_databricks_response(parsed_json)
 
             if not message.tool_calls:
                 return on_final_answer(message.content)

--- a/tests/genai/judges/adapters/test_databricks_adapter.py
+++ b/tests/genai/judges/adapters/test_databricks_adapter.py
@@ -15,6 +15,8 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     _run_databricks_agentic_loop,
     call_chat_completions,
+    create_litellm_message_from_databricks_response,
+    serialize_messages_to_databricks_prompts,
 )
 from mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter import (
     InvokeDatabricksModelOutput,
@@ -23,6 +25,7 @@ from mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter import (
     _record_judge_model_usage_failure_databricks_telemetry,
     _record_judge_model_usage_success_databricks_telemetry,
 )
+from mlflow.types.llm import ChatMessage
 from mlflow.utils import AttrDict
 
 
@@ -934,3 +937,286 @@ def test_agentic_loop_max_iteration_limit(mock_trace, monkeypatch):
 
         # Verify we hit the limit (called once before raising)
         assert mock_call.call_count == 1
+
+
+def _create_message(message_type, role, content=None, **kwargs):
+    if message_type == "litellm":
+        return litellm.Message(role=role, content=content, **kwargs)
+    else:
+        return ChatMessage(role=role, content=content, **kwargs)
+
+
+def _create_tool_call(message_type, tool_id, function_name, arguments):
+    if message_type == "litellm":
+        return litellm.ChatCompletionMessageToolCall(
+            id=tool_id,
+            type="function",
+            function=litellm.Function(name=function_name, arguments=arguments),
+        )
+    else:
+        from mlflow.types.llm import FunctionToolCallArguments, ToolCall
+
+        return ToolCall(
+            id=tool_id,
+            type="function",
+            function=FunctionToolCallArguments(name=function_name, arguments=arguments),
+        )
+
+
+@pytest.mark.parametrize("message_type", ["litellm", "chatmessage"])
+@pytest.mark.parametrize(
+    ("messages_builder", "expected_user_prompt", "expected_system_prompt"),
+    [
+        # System message is extracted separately, user message becomes user_prompt
+        (
+            lambda mt: [
+                _create_message(mt, "system", "You are a helpful assistant"),
+                _create_message(mt, "user", "What is 2+2?"),
+            ],
+            "What is 2+2?",
+            "You are a helpful assistant",
+        ),
+        # No system message results in None for system_prompt
+        (
+            lambda mt: [_create_message(mt, "user", "What is 2+2?")],
+            "What is 2+2?",
+            None,
+        ),
+        # Multiple user messages are concatenated with \n\n separator
+        (
+            lambda mt: [
+                _create_message(mt, "user", "First question"),
+                _create_message(mt, "user", "Second question"),
+            ],
+            "First question\n\nSecond question",
+            None,
+        ),
+        # Assistant messages are prefixed with "Assistant: " in the user_prompt
+        (
+            lambda mt: [
+                _create_message(mt, "user", "What is 2+2?"),
+                _create_message(mt, "assistant", "4"),
+                _create_message(mt, "user", "What is 3+3?"),
+            ],
+            "What is 2+2?\n\nAssistant: 4\n\nWhat is 3+3?",
+            None,
+        ),
+        # Assistant with tool calls shows "[Called tools]" placeholder
+        (
+            lambda mt: [
+                _create_message(mt, "user", "Get the root span"),
+                _create_message(
+                    mt,
+                    "assistant",
+                    None,
+                    tool_calls=[_create_tool_call(mt, "call_123", "get_root_span", "{}")],
+                ),
+            ],
+            "Get the root span\n\nAssistant: [Called tools]",
+            None,
+        ),
+        # Tool messages are formatted as "Tool {name}: {content}"
+        (
+            lambda mt: [
+                _create_message(mt, "user", "Get the root span"),
+                _create_message(
+                    mt,
+                    "assistant",
+                    None,
+                    tool_calls=[_create_tool_call(mt, "call_123", "get_root_span", "{}")],
+                ),
+                _create_message(
+                    mt,
+                    "tool",
+                    '{"name": "root_span"}',
+                    tool_call_id="call_123",
+                    name="get_root_span",
+                ),
+            ],
+            "Get the root span\n\nAssistant: [Called tools]\n\nTool get_root_span: "
+            '{"name": "root_span"}',
+            None,
+        ),
+        # Full multi-turn conversation with system prompt
+        (
+            lambda mt: [
+                _create_message(mt, "system", "You are helpful"),
+                _create_message(mt, "user", "Question 1"),
+                _create_message(mt, "assistant", "Answer 1"),
+                _create_message(mt, "user", "Question 2"),
+            ],
+            "Question 1\n\nAssistant: Answer 1\n\nQuestion 2",
+            "You are helpful",
+        ),
+    ],
+    ids=[
+        "with_system_message",
+        "without_system_message",
+        "multiple_user_messages",
+        "with_assistant_messages",
+        "with_tool_calls",
+        "with_tool_messages",
+        "full_conversation",
+    ],
+)
+def test_serialize_messages_to_databricks_prompts(
+    message_type, messages_builder, expected_user_prompt, expected_system_prompt
+):
+    messages = messages_builder(message_type)
+    user_prompt, system_prompt = serialize_messages_to_databricks_prompts(messages)
+
+    assert user_prompt == expected_user_prompt
+    assert system_prompt == expected_system_prompt
+
+
+@pytest.mark.parametrize(
+    ("response_data", "expected_role", "expected_content"),
+    [
+        # Simple string content is extracted as-is
+        (
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "This is a response",
+                        }
+                    }
+                ]
+            },
+            "assistant",
+            "This is a response",
+        ),
+        # List content with text blocks are concatenated with newlines (reasoning models)
+        (
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {"type": "text", "text": "First part"},
+                                {"type": "text", "text": "Second part"},
+                                {"type": "other", "data": "ignored"},
+                            ],
+                        }
+                    }
+                ]
+            },
+            "assistant",
+            "First part\nSecond part",
+        ),
+        # List content with no text blocks results in None
+        (
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "other", "data": "no text"}],
+                        }
+                    }
+                ]
+            },
+            "assistant",
+            None,
+        ),
+    ],
+    ids=["string_content", "list_content", "empty_list_content"],
+)
+def test_create_litellm_message_from_databricks_response(
+    response_data, expected_role, expected_content
+):
+    message = create_litellm_message_from_databricks_response(response_data)
+
+    assert isinstance(message, litellm.Message)
+    assert message.role == expected_role
+    assert message.content == expected_content
+    assert message.tool_calls is None
+
+
+def test_create_litellm_message_from_databricks_response_with_single_tool_call():
+    response_data = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_123",
+                            "type": "function",
+                            "function": {
+                                "name": "get_root_span",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    message = create_litellm_message_from_databricks_response(response_data)
+
+    assert isinstance(message, litellm.Message)
+    assert message.role == "assistant"
+    assert message.content is None
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 1
+    assert message.tool_calls[0].id == "call_123"
+    assert message.tool_calls[0].type == "function"
+    assert message.tool_calls[0].function.name == "get_root_span"
+    assert message.tool_calls[0].function.arguments == "{}"
+
+
+def test_create_litellm_message_from_databricks_response_with_multiple_tool_calls():
+    response_data = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_root_span", "arguments": "{}"},
+                        },
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "list_spans", "arguments": "{}"},
+                        },
+                    ],
+                }
+            }
+        ]
+    }
+
+    message = create_litellm_message_from_databricks_response(response_data)
+
+    assert isinstance(message, litellm.Message)
+    assert message.role == "assistant"
+    assert message.content is None
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 2
+    assert message.tool_calls[0].id == "call_1"
+    assert message.tool_calls[0].function.name == "get_root_span"
+    assert message.tool_calls[1].id == "call_2"
+    assert message.tool_calls[1].function.name == "list_spans"
+
+
+@pytest.mark.parametrize(
+    ("response_data", "expected_error"),
+    [
+        # Response without choices field raises ValueError
+        ({}, "missing 'choices' field"),
+        # Response with empty choices array raises ValueError
+        ({"choices": []}, "missing 'choices' field"),
+    ],
+    ids=["missing_choices", "empty_choices"],
+)
+def test_create_litellm_message_from_databricks_response_errors(response_data, expected_error):
+    with pytest.raises(ValueError, match=expected_error):
+        create_litellm_message_from_databricks_response(response_data)


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fixes running the conversation simulator on the Agent Evaluation quota on DBX.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

<img width="1274" height="1298" alt="Screenshot 2026-01-12 at 10 00 22 PM" src="https://github.com/user-attachments/assets/d0f03dcf-d350-42b8-9b43-72f403669434" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
