### PR TITLE
Only render valid data points for assessment charts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { TableSkeleton, TitleSkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 
@@ -276,6 +276,33 @@ export function useChartYAxisProps() {
     tickLine: false,
     width: 40,
   };
+}
+
+/**
+ * Checks if a value at the given index is isolated (non-null with null neighbors on both sides).
+ * Used for determining when to render dots for single data points in line charts.
+ */
+export function isIsolatedPoint<T>(values: (T | null)[], index: number): boolean {
+  return (
+    values[index] !== null &&
+    (index === 0 || values[index - 1] === null) &&
+    (index === values.length - 1 || values[index + 1] === null)
+  );
+}
+
+/**
+ * Returns a memoized dot renderer for line charts that only renders dots for isolated points.
+ * Used when chart data has `isIsolated` field pre-computed to indicate points surrounded by nulls.
+ *
+ * @param color - The fill color for the dot
+ * @param fieldName - The field name to check for isolation (defaults to 'isIsolated')
+ */
+export function useIsolatedDotRenderer(color: string, fieldName = 'isIsolated') {
+  return useCallback(
+    ({ cx, cy, payload }: { cx?: number; cy?: number; payload?: Record<string, unknown> }) =>
+      payload?.[fieldName] ? <circle cx={cx} cy={cy} r={2} fill={color} /> : <></>,
+    [color, fieldName],
+  );
 }
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.tsx
@@ -24,6 +24,7 @@ import {
   useChartXAxisProps,
   useChartYAxisProps,
   useScrollableLegendProps,
+  useIsolatedDotRenderer,
 } from './OverviewChartComponents';
 
 /** Local component for chart panel with label */
@@ -67,6 +68,9 @@ export const TraceAssessmentChart: React.FC<TraceAssessmentChartProps> = ({ asse
     (value: number) => [value.toFixed(2), assessmentName] as [string, string],
     [assessmentName],
   );
+
+  // Dot renderer for isolated points only
+  const isolatedDotRenderer = useIsolatedDotRenderer(chartLineColor);
 
   // Fetch and process all chart data using the custom hook
   const { timeSeriesChartData, distributionChartData, isLoading, error, hasData } =
@@ -149,7 +153,7 @@ export const TraceAssessmentChart: React.FC<TraceAssessmentChartProps> = ({ asse
                 name={assessmentName}
                 stroke={chartLineColor}
                 strokeWidth={2}
-                dot={false}
+                dot={isolatedDotRenderer}
                 legendType="plainline"
               />
               <ReferenceLine


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19937/files) to review incremental changes.
- [**stack/null_values_render**](https://github.com/mlflow/mlflow/pull/19937) [[Files changed](https://github.com/mlflow/mlflow/pull/19937/files)]
  - [stack/small_improves](https://github.com/mlflow/mlflow/pull/19938) [[Files changed](https://github.com/mlflow/mlflow/pull/19938/files/ff1d440bd6fac4f85925e0b7f5a43a42b94ada58..980e9c8c0c89ed32d296b72a3aa0264d1d08012a)]
    - [stack/tool_cards](https://github.com/mlflow/mlflow/pull/19939) [[Files changed](https://github.com/mlflow/mlflow/pull/19939/files/980e9c8c0c89ed32d296b72a3aa0264d1d08012a..a23fac536461caaecd8e830b6144ed12ee4eb042)]
      - [stack/remove_search_charts_box](https://github.com/mlflow/mlflow/pull/19940) [[Files changed](https://github.com/mlflow/mlflow/pull/19940/files/a23fac536461caaecd8e830b6144ed12ee4eb042..387775bca2b04e36875fac32fa803b18fb94da10)]
        - [stack/sort_tool_perf_summary](https://github.com/mlflow/mlflow/pull/19952) [[Files changed](https://github.com/mlflow/mlflow/pull/19952/files/387775bca2b04e36875fac32fa803b18fb94da10..4cd55b643edb0dfdbfe09d2139ddec82c844946a)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Previously null data points are filled with 0 so the whole graph contains value, however it's a bit confusing for assessments chart since it looks like the moving average fluctuates a lot. This PR removes the 0 filling logic and uses null values, then update it to render isolated single value as dots.

Before:
<img width="1632" height="1005" alt="Screenshot 2026-01-13 at 12 18 24 PM" src="https://github.com/user-attachments/assets/82985ab8-62df-4618-a438-296bc8e12af4" />

After:
<img width="1632" height="1005" alt="Screenshot 2026-01-13 at 12 18 34 PM" src="https://github.com/user-attachments/assets/54115ac0-3b12-4e93-9971-1288b1bd8cdd" />

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
