### PR TITLE
Improvements and convert assessment charts to horizontal

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.tsx
@@ -2,7 +2,10 @@ import React, { useCallback } from 'react';
 import { TableSkeleton, TitleSkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 
-const DEFAULT_CHART_HEIGHT = 280;
+export const DEFAULT_CHART_HEIGHT = 280;
+export const DEFAULT_CHART_CONTENT_HEIGHT = 200;
+export const DEFAULT_TOOLTIP_MAX_HEIGHT = 120;
+export const DEFAULT_LEGEND_MAX_HEIGHT = 60;
 
 interface OverviewChartHeaderProps {
   /** Icon component to display before the title */
@@ -190,8 +193,6 @@ export const ScrollableTooltip: React.FC<ScrollableTooltipProps> = ({ active, pa
     return null;
   }
 
-  const maxHeight = 120;
-
   return (
     <div
       css={{
@@ -213,7 +214,7 @@ export const ScrollableTooltip: React.FC<ScrollableTooltipProps> = ({ active, pa
       {label && <div css={{ fontWeight: 500, marginBottom: theme.spacing.xs }}>{label}</div>}
       <div
         css={{
-          maxHeight,
+          maxHeight: DEFAULT_TOOLTIP_MAX_HEIGHT,
           overflowY: 'auto',
           overflowX: 'hidden',
         }}
@@ -324,7 +325,7 @@ interface ScrollableLegendConfig {
  */
 export function useScrollableLegendProps(config?: ScrollableLegendConfig) {
   const { theme } = useDesignSystemTheme();
-  const maxHeight = config?.maxHeight ?? 60;
+  const maxHeight = config?.maxHeight ?? DEFAULT_LEGEND_MAX_HEIGHT;
 
   const formatter = (value: string) => (
     <span

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolErrorRateChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolErrorRateChart.tsx
@@ -1,19 +1,8 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { WrenchIcon, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
-import {
-  MetricViewType,
-  AggregationType,
-  SpanMetricKey,
-  SpanFilterKey,
-  SpanType,
-  SpanStatus,
-  SpanDimensionKey,
-  TIME_BUCKET_DIMENSION_KEY,
-  createSpanFilter,
-} from '@databricks/web-shared/model-trace-explorer';
-import { useTraceMetricsQuery } from '../hooks/useTraceMetricsQuery';
+import { useToolErrorRateChartData } from '../hooks/useToolErrorRateChartData';
 import {
   OverviewChartLoadingState,
   OverviewChartErrorState,
@@ -25,9 +14,8 @@ import {
   useChartXAxisProps,
   useChartYAxisProps,
   useScrollableLegendProps,
+  DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
-import { formatTimestampForTraceMetrics } from '../utils/chartUtils';
-import { useOverviewChartContext } from '../OverviewChartContext';
 
 export interface ToolErrorRateChartProps {
   /** The name of the tool to display */
@@ -39,7 +27,6 @@ export interface ToolErrorRateChartProps {
 }
 
 export const ToolErrorRateChart: React.FC<ToolErrorRateChartProps> = ({ toolName, lineColor, overallErrorRate }) => {
-  const { experimentId, startTimeMs, endTimeMs, timeIntervalSeconds, timeBuckets } = useOverviewChartContext();
   const { theme } = useDesignSystemTheme();
   const xAxisProps = useChartXAxisProps();
   const yAxisProps = useChartYAxisProps();
@@ -47,68 +34,8 @@ export const ToolErrorRateChart: React.FC<ToolErrorRateChartProps> = ({ toolName
 
   const chartLineColor = lineColor || theme.colors.red500;
 
-  // Filter for TOOL type spans with specific name
-  const toolFilters = useMemo(
-    () => [createSpanFilter(SpanFilterKey.TYPE, SpanType.TOOL), createSpanFilter(SpanFilterKey.NAME, toolName)],
-    [toolName],
-  );
-
-  // Query span counts grouped by status and time bucket
-  const { data, isLoading, error } = useTraceMetricsQuery({
-    experimentId,
-    startTimeMs,
-    endTimeMs,
-    viewType: MetricViewType.SPANS,
-    metricName: SpanMetricKey.SPAN_COUNT,
-    aggregations: [{ aggregation_type: AggregationType.COUNT }],
-    filters: toolFilters,
-    dimensions: [SpanDimensionKey.SPAN_STATUS],
-    timeIntervalSeconds,
-  });
-
-  const dataPoints = useMemo(() => data?.data_points || [], [data?.data_points]);
-
-  // Group data by time bucket and calculate error rate for each bucket
-  const errorRateByTimestamp = useMemo(() => {
-    const bucketData = new Map<number, { error: number; total: number }>();
-
-    for (const dp of dataPoints) {
-      const timeBucket = dp.dimensions?.[TIME_BUCKET_DIMENSION_KEY];
-      if (!timeBucket) continue;
-
-      const timestampMs = new Date(timeBucket).getTime();
-      const count = dp.values?.[AggregationType.COUNT] || 0;
-      const status = dp.dimensions?.[SpanDimensionKey.SPAN_STATUS];
-
-      if (!bucketData.has(timestampMs)) {
-        bucketData.set(timestampMs, { error: 0, total: 0 });
-      }
-
-      const bucket = bucketData.get(timestampMs)!;
-      bucket.total += count;
-      if (status === SpanStatus.ERROR) {
-        bucket.error += count;
-      }
-    }
-
-    // Convert to error rate map
-    const rateMap = new Map<number, number>();
-    for (const [ts, { error, total }] of bucketData) {
-      rateMap.set(ts, total > 0 ? (error / total) * 100 : 0);
-    }
-    return rateMap;
-  }, [dataPoints]);
-
-  // Build chart data with all time buckets
-  const chartData = useMemo(() => {
-    return timeBuckets.map((timestampMs) => ({
-      name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
-      errorRate: errorRateByTimestamp.get(timestampMs) || 0,
-    }));
-  }, [timeBuckets, errorRateByTimestamp, timeIntervalSeconds]);
-
-  // Check if we have actual data
-  const hasData = dataPoints.length > 0;
+  // Fetch and process error rate chart data
+  const { chartData, isLoading, error, hasData } = useToolErrorRateChartData({ toolName });
 
   const tooltipFormatter = useCallback(
     (value: number) => [`${value.toFixed(2)}%`, 'Error Rate'] as [string, string],
@@ -145,7 +72,7 @@ export const ToolErrorRateChart: React.FC<ToolErrorRateChartProps> = ({ toolName
 
       <OverviewChartTimeLabel />
 
-      <div css={{ height: 200 }}>
+      <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT }}>
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={chartData} margin={{ top: 10, right: 10, left: 10, bottom: 0 }}>
             <XAxis dataKey="name" {...xAxisProps} />

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolLatencyChart.tsx
@@ -14,6 +14,7 @@ import {
   useChartXAxisProps,
   useChartYAxisProps,
   useScrollableLegendProps,
+  DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
 import { formatLatency, useLegendHighlight, useChartColors } from '../utils/chartUtils';
 
@@ -60,7 +61,7 @@ export const ToolLatencyChart: React.FC = () => {
       <OverviewChartTimeLabel />
 
       {/* Chart */}
-      <div css={{ height: 200, marginTop: theme.spacing.sm }}>
+      <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT, marginTop: theme.spacing.sm }}>
         {hasData ? (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartData} margin={{ top: 10, right: 10, left: 10, bottom: 0 }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolUsageChart.tsx
@@ -14,6 +14,7 @@ import {
   useChartXAxisProps,
   useChartYAxisProps,
   useScrollableLegendProps,
+  DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
 import { formatCount, useLegendHighlight, useChartColors } from '../utils/chartUtils';
 
@@ -55,7 +56,7 @@ export const ToolUsageChart: React.FC = () => {
       <OverviewChartTimeLabel />
 
       {/* Chart */}
-      <div css={{ height: 200, marginTop: theme.spacing.sm }}>
+      <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT, marginTop: theme.spacing.sm }}>
         {hasData ? (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={chartData} margin={{ top: 10, right: 10, left: 10, bottom: 0 }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.tsx
@@ -25,6 +25,7 @@ import {
   useChartYAxisProps,
   useScrollableLegendProps,
   useIsolatedDotRenderer,
+  DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
 
 /** Local component for chart panel with label */
@@ -35,7 +36,7 @@ const ChartPanel: React.FC<{ label: React.ReactNode; children: React.ReactElemen
       <Typography.Text color="secondary" size="sm">
         {label}
       </Typography.Text>
-      <div css={{ height: 200, marginTop: theme.spacing.sm }}>
+      <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT, marginTop: theme.spacing.sm }}>
         <ResponsiveContainer width="100%" height="100%">
           {children}
         </ResponsiveContainer>
@@ -117,15 +118,15 @@ export const TraceAssessmentChart: React.FC<TraceAssessmentChartProps> = ({ asse
             />
           }
         >
-          <BarChart data={distributionChartData} margin={{ top: 10, right: 10, left: 10, bottom: 0 }}>
-            <XAxis dataKey="name" {...xAxisProps} />
-            <YAxis allowDecimals={false} {...yAxisProps} />
+          <BarChart data={distributionChartData} layout="vertical" margin={{ top: 10, right: 10, left: 10, bottom: 0 }}>
+            <XAxis type="number" allowDecimals={false} {...xAxisProps} />
+            <YAxis type="category" dataKey="name" {...yAxisProps} width={60} />
             <Tooltip
               content={<ScrollableTooltip formatter={distributionTooltipFormatter} />}
               cursor={{ fill: theme.colors.actionTertiaryBackgroundHover }}
             />
             <Legend {...scrollableLegendProps} />
-            <Bar dataKey="count" fill={chartLineColor} radius={[4, 4, 0, 0]} />
+            <Bar dataKey="count" fill={chartLineColor} radius={[0, 4, 4, 0]} />
           </BarChart>
         </ChartPanel>
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
@@ -14,6 +14,7 @@ import {
   useChartXAxisProps,
   useChartYAxisProps,
   useScrollableLegendProps,
+  DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
 import { useLegendHighlight } from '../utils/chartUtils';
 
@@ -55,7 +56,7 @@ export const TraceErrorsChart: React.FC = () => {
       <OverviewChartTimeLabel />
 
       {/* Chart */}
-      <div css={{ height: 200, marginTop: theme.spacing.sm }}>
+      <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT, marginTop: theme.spacing.sm }}>
         {hasData ? (
           <ResponsiveContainer width="100%" height="100%">
             <ComposedChart data={chartData} margin={{ top: 10, right: 10, left: 10, bottom: 0 }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.test.tsx
@@ -197,9 +197,9 @@ describe('TraceLatencyChart', () => {
 
       renderComponent();
 
-      // Average is 250ms
+      // Average is 250ms (formatted as "250.00ms" by formatLatency)
       await waitFor(() => {
-        expect(screen.getByText('250 ms')).toBeInTheDocument();
+        expect(screen.getByText('250.00ms')).toBeInTheDocument();
       });
     });
 
@@ -228,9 +228,9 @@ describe('TraceLatencyChart', () => {
 
       renderComponent();
 
-      // 1500ms should be displayed as 1.50 sec
+      // 1500ms should be displayed as 1.50s
       await waitFor(() => {
-        expect(screen.getByText('1.50 sec')).toBeInTheDocument();
+        expect(screen.getByText('1.50s')).toBeInTheDocument();
       });
     });
 
@@ -242,7 +242,7 @@ describe('TraceLatencyChart', () => {
       await waitFor(() => {
         const referenceLine = screen.getByTestId('reference-line');
         expect(referenceLine).toBeInTheDocument();
-        expect(referenceLine).toHaveAttribute('data-label', 'AVG (250 ms)');
+        expect(referenceLine).toHaveAttribute('data-label', 'AVG (250.00ms)');
       });
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
@@ -14,18 +14,9 @@ import {
   useChartXAxisProps,
   useChartYAxisProps,
   useScrollableLegendProps,
+  DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
-import { useLegendHighlight } from '../utils/chartUtils';
-
-/**
- * Format latency value in human-readable format
- */
-function formatLatency(ms: number): string {
-  if (ms >= 1000) {
-    return `${(ms / 1000).toFixed(2)} sec`;
-  }
-  return `${ms.toFixed(0)} ms`;
-}
+import { formatLatency, useLegendHighlight } from '../utils/chartUtils';
 
 export const TraceLatencyChart: React.FC = () => {
   const { theme } = useDesignSystemTheme();
@@ -68,7 +59,7 @@ export const TraceLatencyChart: React.FC = () => {
       <OverviewChartTimeLabel />
 
       {/* Chart */}
-      <div css={{ height: 200, marginTop: theme.spacing.sm }}>
+      <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT, marginTop: theme.spacing.sm }}>
         {hasData ? (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartData} margin={{ top: 10, right: 30, left: 10, bottom: 0 }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
@@ -14,6 +14,7 @@ import {
   useChartXAxisProps,
   useChartYAxisProps,
   useChartZoomSelectionProps,
+  DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
 
 export const TraceRequestsChart: React.FC = () => {
@@ -54,7 +55,7 @@ export const TraceRequestsChart: React.FC = () => {
       <OverviewChartTimeLabel />
 
       {/* Chart */}
-      <div css={{ height: 200, userSelect: 'none' }}>
+      <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT, userSelect: 'none' }}>
         {hasData ? (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenStatsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenStatsChart.tsx
@@ -14,6 +14,7 @@ import {
   useChartXAxisProps,
   useChartYAxisProps,
   useScrollableLegendProps,
+  DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
 import { formatCount, useLegendHighlight } from '../utils/chartUtils';
 
@@ -63,7 +64,7 @@ export const TraceTokenStatsChart: React.FC = () => {
       <OverviewChartTimeLabel />
 
       {/* Chart */}
-      <div css={{ height: 200, marginTop: theme.spacing.sm }}>
+      <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT, marginTop: theme.spacing.sm }}>
         {hasData ? (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartData} margin={{ top: 10, right: 30, left: 10, bottom: 0 }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -14,6 +14,7 @@ import {
   useChartXAxisProps,
   useChartYAxisProps,
   useScrollableLegendProps,
+  DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
 import { formatCount, useLegendHighlight } from '../utils/chartUtils';
 
@@ -59,7 +60,7 @@ export const TraceTokenUsageChart: React.FC = () => {
       <OverviewChartTimeLabel />
 
       {/* Chart */}
-      <div css={{ height: 200, marginTop: theme.spacing.sm }}>
+      <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT, marginTop: theme.spacing.sm }}>
         {hasData ? (
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={chartData} margin={{ top: 10, right: 30, left: 10, bottom: 0 }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useToolErrorRateChartData.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useToolErrorRateChartData.test.tsx
@@ -1,0 +1,467 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { useToolErrorRateChartData } from './useToolErrorRateChartData';
+import {
+  AggregationType,
+  SpanMetricKey,
+  SpanDimensionKey,
+  SpanStatus,
+} from '@databricks/web-shared/model-trace-explorer';
+import type { ReactNode } from 'react';
+import { setupServer } from '../../../../common/utils/setup-msw';
+import { rest } from 'msw';
+import { OverviewChartProvider } from '../OverviewChartContext';
+
+// Helper to create a span count data point with status
+const createSpanCountDataPoint = (timeBucket: string, status: string, count: number) => ({
+  metric_name: SpanMetricKey.SPAN_COUNT,
+  dimensions: {
+    time_bucket: timeBucket,
+    [SpanDimensionKey.SPAN_STATUS]: status,
+  },
+  values: { [AggregationType.COUNT]: count },
+});
+
+describe('useToolErrorRateChartData', () => {
+  const testExperimentId = 'test-experiment-123';
+  const startTimeMs = new Date('2025-12-22T10:00:00Z').getTime();
+  const endTimeMs = new Date('2025-12-22T12:00:00Z').getTime();
+  const timeIntervalSeconds = 3600; // 1 hour
+
+  const timeBuckets = [
+    new Date('2025-12-22T10:00:00Z').getTime(),
+    new Date('2025-12-22T11:00:00Z').getTime(),
+    new Date('2025-12-22T12:00:00Z').getTime(),
+  ];
+
+  const contextProps = {
+    experimentId: testExperimentId,
+    startTimeMs,
+    endTimeMs,
+    timeIntervalSeconds,
+    timeBuckets,
+  };
+
+  const defaultToolName = 'test_tool';
+
+  const server = setupServer();
+
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+  const createWrapper = (contextOverrides: Partial<typeof contextProps> = {}) => {
+    const queryClient = createQueryClient();
+    const mergedContextProps = { ...contextProps, ...contextOverrides };
+    return ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <OverviewChartProvider {...mergedContextProps}>{children}</OverviewChartProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  // Helper to setup MSW handler for the trace metrics endpoint
+  const setupTraceMetricsHandler = (dataPoints: any[]) => {
+    server.use(
+      rest.post('ajax-api/3.0/mlflow/traces/metrics', (_req, res, ctx) => {
+        return res(ctx.json({ data_points: dataPoints }));
+      }),
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: return empty data points
+    setupTraceMetricsHandler([]);
+  });
+
+  describe('loading state', () => {
+    it('should return isLoading true while fetching', async () => {
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', (_req, res, ctx) => {
+          return res(ctx.delay('infinite'));
+        }),
+      );
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+      // chartData is computed from timeBuckets (from context), so it has entries even during loading
+      expect(result.current.chartData).toHaveLength(3);
+      expect(result.current.hasData).toBe(false);
+    });
+  });
+
+  describe('error state', () => {
+    it('should return error when API call fails', async () => {
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', (_req, res, ctx) => {
+          return res(ctx.status(500), ctx.json({ error: 'API Error' }));
+        }),
+      );
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
+    });
+  });
+
+  describe('empty data', () => {
+    it('should return hasData false when no data points', async () => {
+      // Default handler returns empty array
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasData).toBe(false);
+      // Chart data still has time bucket entries with 0 error rates
+      expect(result.current.chartData).toHaveLength(3);
+      expect(result.current.chartData[0]).toHaveProperty('errorRate', 0);
+    });
+
+    it('should return hasData false when time range is not provided', async () => {
+      // Default handler returns empty array
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper({
+          startTimeMs: undefined,
+          endTimeMs: undefined,
+          timeBuckets: [],
+        }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasData).toBe(false);
+      expect(result.current.chartData).toHaveLength(0);
+    });
+  });
+
+  describe('data transformation', () => {
+    it('should calculate error rate correctly for a single time bucket', async () => {
+      // 10% error rate: 10 errors out of 100 total
+      setupTraceMetricsHandler([
+        createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.OK, 90),
+        createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.ERROR, 10),
+      ]);
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasData).toBe(true);
+      expect(result.current.chartData[0]).toHaveProperty('errorRate', 10);
+    });
+
+    it('should calculate error rate for multiple time buckets', async () => {
+      // First bucket: 10% error rate (10/100)
+      // Second bucket: 25% error rate (25/100)
+      // Third bucket: no data (should be 0)
+      setupTraceMetricsHandler([
+        createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.OK, 90),
+        createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.ERROR, 10),
+        createSpanCountDataPoint('2025-12-22T11:00:00Z', SpanStatus.OK, 75),
+        createSpanCountDataPoint('2025-12-22T11:00:00Z', SpanStatus.ERROR, 25),
+      ]);
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.chartData).toHaveLength(3);
+      expect(result.current.chartData[0]).toHaveProperty('errorRate', 10);
+      expect(result.current.chartData[1]).toHaveProperty('errorRate', 25);
+      expect(result.current.chartData[2]).toHaveProperty('errorRate', 0);
+    });
+
+    it('should handle 100% error rate', async () => {
+      setupTraceMetricsHandler([createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.ERROR, 50)]);
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.chartData[0]).toHaveProperty('errorRate', 100);
+    });
+
+    it('should handle 0% error rate (all OK)', async () => {
+      setupTraceMetricsHandler([createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.OK, 100)]);
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.chartData[0]).toHaveProperty('errorRate', 0);
+    });
+
+    it('should fill missing time buckets with 0 error rate', async () => {
+      // Only provide data for the first bucket
+      setupTraceMetricsHandler([
+        createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.OK, 80),
+        createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.ERROR, 20),
+      ]);
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Should have all 3 time buckets
+      expect(result.current.chartData).toHaveLength(3);
+      // First bucket has 20% error rate
+      expect(result.current.chartData[0]).toHaveProperty('errorRate', 20);
+      // Missing buckets should be filled with 0
+      expect(result.current.chartData[1]).toHaveProperty('errorRate', 0);
+      expect(result.current.chartData[2]).toHaveProperty('errorRate', 0);
+    });
+
+    it('should include formatted timestamp in chart data', async () => {
+      setupTraceMetricsHandler([createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.OK, 100)]);
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Each data point should have a name (formatted timestamp)
+      expect(result.current.chartData[0]).toHaveProperty('name');
+      expect(typeof result.current.chartData[0].name).toBe('string');
+    });
+
+    it('should skip data points with missing time_bucket', async () => {
+      setupTraceMetricsHandler([
+        {
+          metric_name: SpanMetricKey.SPAN_COUNT,
+          dimensions: {
+            [SpanDimensionKey.SPAN_STATUS]: SpanStatus.ERROR,
+            // Missing time_bucket
+          },
+          values: { [AggregationType.COUNT]: 100 },
+        },
+        createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.OK, 100),
+      ]);
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Should have data, but missing time_bucket data point is ignored
+      expect(result.current.hasData).toBe(true);
+      // First bucket should have 0% error rate (only OK data counted)
+      expect(result.current.chartData[0]).toHaveProperty('errorRate', 0);
+    });
+
+    it('should handle data points with missing count value', async () => {
+      setupTraceMetricsHandler([
+        {
+          metric_name: SpanMetricKey.SPAN_COUNT,
+          dimensions: {
+            time_bucket: '2025-12-22T10:00:00Z',
+            [SpanDimensionKey.SPAN_STATUS]: SpanStatus.ERROR,
+          },
+          values: {}, // Missing COUNT value
+        },
+        createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.OK, 100),
+      ]);
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Missing count defaults to 0, so error rate is 0/100 = 0%
+      expect(result.current.chartData[0]).toHaveProperty('errorRate', 0);
+    });
+
+    it('should return hasData true when there are data points', async () => {
+      setupTraceMetricsHandler([createSpanCountDataPoint('2025-12-22T10:00:00Z', SpanStatus.OK, 100)]);
+
+      const { result } = renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasData).toBe(true);
+    });
+  });
+
+  describe('API request', () => {
+    it('should include SPAN_STATUS dimension in request', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.dimensions).toContain(SpanDimensionKey.SPAN_STATUS);
+    });
+
+    it('should filter for TOOL type spans', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.filters).toContainEqual('span.type = "TOOL"');
+    });
+
+    it('should filter for specific tool name', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useToolErrorRateChartData({ toolName: 'my_custom_tool' }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.filters).toContainEqual('span.name = "my_custom_tool"');
+    });
+
+    it('should request COUNT aggregation for span count', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.aggregations).toContainEqual({ aggregation_type: AggregationType.COUNT });
+    });
+
+    it('should include time interval for time bucketing', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper({ timeIntervalSeconds: 1800 }),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.time_interval_seconds).toBe(1800);
+    });
+
+    it('should include time range in API call', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useToolErrorRateChartData({ toolName: defaultToolName }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.start_time_ms).toBe(startTimeMs);
+      expect(capturedBody.end_time_ms).toBe(endTimeMs);
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useToolErrorRateChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useToolErrorRateChartData.ts
@@ -1,0 +1,120 @@
+import { useMemo } from 'react';
+import {
+  MetricViewType,
+  AggregationType,
+  SpanMetricKey,
+  SpanFilterKey,
+  SpanType,
+  SpanStatus,
+  SpanDimensionKey,
+  TIME_BUCKET_DIMENSION_KEY,
+  createSpanFilter,
+} from '@databricks/web-shared/model-trace-explorer';
+import { useTraceMetricsQuery } from './useTraceMetricsQuery';
+import { formatTimestampForTraceMetrics } from '../utils/chartUtils';
+import { useOverviewChartContext } from '../OverviewChartContext';
+
+export interface ToolErrorRateDataPoint {
+  name: string;
+  errorRate: number;
+}
+
+export interface UseToolErrorRateChartDataResult {
+  /** Processed chart data with all time buckets filled */
+  chartData: ToolErrorRateDataPoint[];
+  /** Whether data is currently being fetched */
+  isLoading: boolean;
+  /** Error if data fetching failed */
+  error: unknown;
+  /** Whether there are any data points */
+  hasData: boolean;
+}
+
+interface UseToolErrorRateChartDataProps {
+  /** The name of the tool to fetch error rate data for */
+  toolName: string;
+}
+
+/**
+ * Custom hook that fetches and processes tool error rate data over time.
+ * Queries span metrics grouped by status and time bucket to calculate error rate.
+ * Uses OverviewChartContext to get chart props.
+ *
+ * @param props - Configuration including toolName
+ * @returns Processed chart data, loading state, and error state
+ */
+export function useToolErrorRateChartData({
+  toolName,
+}: UseToolErrorRateChartDataProps): UseToolErrorRateChartDataResult {
+  const { experimentId, startTimeMs, endTimeMs, timeIntervalSeconds, timeBuckets } = useOverviewChartContext();
+
+  // Filter for TOOL type spans with specific name
+  const toolFilters = useMemo(
+    () => [createSpanFilter(SpanFilterKey.TYPE, SpanType.TOOL), createSpanFilter(SpanFilterKey.NAME, toolName)],
+    [toolName],
+  );
+
+  // Query span counts grouped by status and time bucket
+  const { data, isLoading, error } = useTraceMetricsQuery({
+    experimentId,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.SPANS,
+    metricName: SpanMetricKey.SPAN_COUNT,
+    aggregations: [{ aggregation_type: AggregationType.COUNT }],
+    filters: toolFilters,
+    dimensions: [SpanDimensionKey.SPAN_STATUS],
+    timeIntervalSeconds,
+  });
+
+  const dataPoints = useMemo(() => data?.data_points || [], [data?.data_points]);
+
+  // Group data by time bucket and calculate error rate for each bucket
+  const errorRateByTimestamp = useMemo(() => {
+    const bucketData = new Map<number, { error: number; total: number }>();
+
+    for (const dp of dataPoints) {
+      const timeBucket = dp.dimensions?.[TIME_BUCKET_DIMENSION_KEY];
+      if (!timeBucket) continue;
+
+      const timestampMs = new Date(timeBucket).getTime();
+      const count = dp.values?.[AggregationType.COUNT] || 0;
+      const status = dp.dimensions?.[SpanDimensionKey.SPAN_STATUS];
+
+      if (!bucketData.has(timestampMs)) {
+        bucketData.set(timestampMs, { error: 0, total: 0 });
+      }
+
+      const bucket = bucketData.get(timestampMs)!;
+      bucket.total += count;
+      if (status === SpanStatus.ERROR) {
+        bucket.error += count;
+      }
+    }
+
+    // Convert to error rate map
+    const rateMap = new Map<number, number>();
+    for (const [ts, { error, total }] of bucketData) {
+      rateMap.set(ts, total > 0 ? (error / total) * 100 : 0);
+    }
+    return rateMap;
+  }, [dataPoints]);
+
+  // Build chart data with all time buckets
+  const chartData = useMemo(() => {
+    return timeBuckets.map((timestampMs) => ({
+      name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
+      errorRate: errorRateByTimestamp.get(timestampMs) || 0,
+    }));
+  }, [timeBuckets, errorRateByTimestamp, timeIntervalSeconds]);
+
+  // Check if we have actual data
+  const hasData = dataPoints.length > 0;
+
+  return {
+    chartData,
+    isLoading,
+    error,
+    hasData,
+  };
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19938/files) to review incremental changes.
- [**stack/small_improves**](https://github.com/mlflow/mlflow/pull/19938) [[Files changed](https://github.com/mlflow/mlflow/pull/19938/files)]
  - [stack/tool_cards](https://github.com/mlflow/mlflow/pull/19939) [[Files changed](https://github.com/mlflow/mlflow/pull/19939/files/62fe166dc57727e72a9ef4556c60a4ec40b71acc..5b76afd1aee1cec9833219863f8c1895530a12a7)]
    - [stack/remove_search_charts_box](https://github.com/mlflow/mlflow/pull/19940) [[Files changed](https://github.com/mlflow/mlflow/pull/19940/files/5b76afd1aee1cec9833219863f8c1895530a12a7..87e8531ab8a41a1f8cc7ca15b00a08c36ed5c46c)]
      - [stack/sort_tool_perf_summary](https://github.com/mlflow/mlflow/pull/19952) [[Files changed](https://github.com/mlflow/mlflow/pull/19952/files/87e8531ab8a41a1f8cc7ca15b00a08c36ed5c46c..b91ec2501c16c5b0170c80d2bd0a76b232aff020)]
        - [stack/add_telemetry](https://github.com/mlflow/mlflow/pull/19953) [[Files changed](https://github.com/mlflow/mlflow/pull/19953/files/b91ec2501c16c5b0170c80d2bd0a76b232aff020..a77f8d4d674a5700883e5aad8f60b1b79f257c39)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Some small refactors:
1. use constants for charts properties
2. Extract data preparing part in tool error charts

Update assessment charts to horizontal based on feedback got during bug bash, to avoid confusing that we may assume the x-axis is time (as all other charts uses x-axis as timestamps)
Before:
<img width="1632" height="1005" alt="Screenshot 2026-01-13 at 2 40 38 PM" src="https://github.com/user-attachments/assets/407436c4-5b10-47e0-97f8-a58be64c7e51" />

After:
<img width="1632" height="1005" alt="Screenshot 2026-01-13 at 2 40 44 PM" src="https://github.com/user-attachments/assets/8b781979-1714-4f78-ab1d-a02d5004aa2d" />


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
