### PR TITLE
Add telemetry for overview charts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3DateSelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3DateSelector.tsx
@@ -31,14 +31,19 @@ export interface DateRange {
   endDate: string;
 }
 
+type TracesV3DateSelectorRefreshButtonComponentId =
+  | 'mlflow.experiment-evaluation-monitoring.refresh-date-button'
+  | 'mlflow.experiment.overview.refresh-button';
+
 interface TracesV3DateSelectorProps {
   /** Optional list of time label keys to exclude from the dropdown */
   excludeOptions?: string[];
   /** Optional custom componentId for the refresh button */
-  refreshButtonComponentId?: string;
+  refreshButtonComponentId?: TracesV3DateSelectorRefreshButtonComponentId;
 }
 
-const DEFAULT_REFRESH_BUTTON_COMPONENT_ID = 'mlflow.experiment-evaluation-monitoring.refresh-date-button';
+const DEFAULT_REFRESH_BUTTON_COMPONENT_ID: TracesV3DateSelectorRefreshButtonComponentId =
+  'mlflow.experiment-evaluation-monitoring.refresh-date-button';
 
 // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
 export const TracesV3DateSelector = React.memo(function TracesV3DateSelector({

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3DateSelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3DateSelector.tsx
@@ -34,10 +34,17 @@ export interface DateRange {
 interface TracesV3DateSelectorProps {
   /** Optional list of time label keys to exclude from the dropdown */
   excludeOptions?: string[];
+  /** Optional custom componentId for the refresh button */
+  refreshButtonComponentId?: string;
 }
 
+const DEFAULT_REFRESH_BUTTON_COMPONENT_ID = 'mlflow.experiment-evaluation-monitoring.refresh-date-button';
+
 // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
-export const TracesV3DateSelector = React.memo(({ excludeOptions }: TracesV3DateSelectorProps) => {
+export const TracesV3DateSelector = React.memo(function TracesV3DateSelector({
+  excludeOptions,
+  refreshButtonComponentId = DEFAULT_REFRESH_BUTTON_COMPONENT_ID,
+}: TracesV3DateSelectorProps) {
   const intl = useIntl();
   const { theme } = useDesignSystemTheme();
   const queryClient = useQueryClient();
@@ -166,7 +173,7 @@ export const TracesV3DateSelector = React.memo(({ excludeOptions }: TracesV3Date
       >
         <Button
           type="link"
-          componentId="mlflow.experiment-evaluation-monitoring.refresh-date-button"
+          componentId={refreshButtonComponentId}
           disabled={Boolean(isFetching)}
           onClick={() => {
             monitoringConfig.refresh();

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -66,6 +66,7 @@ const ExperimentGenAIOverviewPageImpl = () => {
         componentId="mlflow.experiment.overview.tabs"
         value={activeTab}
         onValueChange={(value) => setActiveTab(value as OverviewTab)}
+        valueHasNoPii
         css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}
       >
         <Tabs.List>
@@ -101,7 +102,10 @@ const ExperimentGenAIOverviewPageImpl = () => {
            * Time range selector - exclude 'ALL' since charts require start_time_ms and end_time_ms
            * TODO: remove this once this is supported in backend
            */}
-          <TracesV3DateSelector excludeOptions={['ALL']} />
+          <TracesV3DateSelector
+            excludeOptions={['ALL']}
+            refreshButtonComponentId="mlflow.experiment.overview.refresh-button"
+          />
         </div>
 
         <OverviewChartProvider

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { TableSkeleton, TitleSkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
+import { useChartInteractionTelemetry } from '../hooks/useChartInteractionTelemetry';
 
 export const DEFAULT_CHART_HEIGHT = 280;
 export const DEFAULT_CHART_CONTENT_HEIGHT = 200;
@@ -357,13 +358,18 @@ export function useScrollableLegendProps(config?: ScrollableLegendConfig) {
  */
 interface OverviewChartContainerProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
+  /** Component ID for telemetry tracking (e.g., "mlflow.charts.trace_requests") */
+  componentId?: string;
 }
 
 /**
- * Common container styling for overview chart cards
+ * Common container styling for overview chart cards.
+ * When componentId is provided, tracks user interactions for telemetry.
  */
-export const OverviewChartContainer: React.FC<OverviewChartContainerProps> = ({ children, ...rest }) => {
+export const OverviewChartContainer: React.FC<OverviewChartContainerProps> = ({ children, componentId, ...rest }) => {
   const { theme } = useDesignSystemTheme();
+  const interactionProps = useChartInteractionTelemetry(componentId);
+
   return (
     <div
       css={{
@@ -372,6 +378,7 @@ export const OverviewChartContainer: React.FC<OverviewChartContainerProps> = ({ 
         padding: theme.spacing.lg,
         backgroundColor: theme.colors.backgroundPrimary,
       }}
+      {...interactionProps}
       {...rest}
     >
       {children}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolErrorRateChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolErrorRateChart.tsx
@@ -52,7 +52,7 @@ export const ToolErrorRateChart: React.FC<ToolErrorRateChartProps> = ({ toolName
 
   if (!hasData) {
     return (
-      <OverviewChartContainer data-testid={`tool-chart-${toolName}`}>
+      <OverviewChartContainer componentId="mlflow.charts.tool_error_rate" data-testid={`tool-chart-${toolName}`}>
         <OverviewChartHeader icon={<WrenchIcon css={{ color: chartLineColor }} />} title={toolName} />
         <OverviewChartEmptyState />
       </OverviewChartContainer>
@@ -60,7 +60,7 @@ export const ToolErrorRateChart: React.FC<ToolErrorRateChartProps> = ({ toolName
   }
 
   return (
-    <OverviewChartContainer data-testid={`tool-chart-${toolName}`}>
+    <OverviewChartContainer componentId="mlflow.charts.tool_error_rate" data-testid={`tool-chart-${toolName}`}>
       <OverviewChartHeader
         icon={<WrenchIcon css={{ color: chartLineColor }} />}
         title={toolName}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolLatencyChart.tsx
@@ -47,7 +47,7 @@ export const ToolLatencyChart: React.FC = () => {
   }
 
   return (
-    <OverviewChartContainer>
+    <OverviewChartContainer componentId="mlflow.charts.tool_latency">
       <OverviewChartHeader
         icon={<LightningIcon />}
         title={

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolPerformanceSummary.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolPerformanceSummary.tsx
@@ -117,7 +117,7 @@ export const ToolPerformanceSummary: React.FC = () => {
   );
 
   return (
-    <OverviewChartContainer>
+    <OverviewChartContainer componentId="mlflow.charts.tool_performance_summary">
       <OverviewChartHeader
         icon={<WrenchIcon />}
         title={

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/ToolUsageChart.tsx
@@ -47,7 +47,7 @@ export const ToolUsageChart: React.FC = () => {
   }
 
   return (
-    <OverviewChartContainer>
+    <OverviewChartContainer componentId="mlflow.charts.tool_usage">
       <OverviewChartHeader
         icon={<ChartLineIcon />}
         title={<FormattedMessage defaultMessage="Tool Usage Over Time" description="Title for the tool usage chart" />}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceErrorsChart.tsx
@@ -45,7 +45,7 @@ export const TraceErrorsChart: React.FC = () => {
   }
 
   return (
-    <OverviewChartContainer>
+    <OverviewChartContainer componentId="mlflow.charts.trace_errors">
       <OverviewChartHeader
         icon={<DangerIcon />}
         title={<FormattedMessage defaultMessage="Errors" description="Title for the errors chart" />}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
@@ -49,7 +49,7 @@ export const TraceLatencyChart: React.FC = () => {
   }
 
   return (
-    <OverviewChartContainer>
+    <OverviewChartContainer componentId="mlflow.charts.trace_latency">
       <OverviewChartHeader
         icon={<ClockIcon />}
         title={<FormattedMessage defaultMessage="Latency" description="Title for the latency chart" />}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
@@ -39,7 +39,7 @@ export const TraceRequestsChart: React.FC = () => {
   }
 
   return (
-    <OverviewChartContainer>
+    <OverviewChartContainer componentId="mlflow.charts.trace_requests">
       <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
         <OverviewChartHeader
           icon={<ChartLineIcon />}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenStatsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenStatsChart.tsx
@@ -49,7 +49,7 @@ export const TraceTokenStatsChart: React.FC = () => {
   }
 
   return (
-    <OverviewChartContainer>
+    <OverviewChartContainer componentId="mlflow.charts.trace_token_stats">
       <OverviewChartHeader
         icon={<BarChartIcon />}
         title={<FormattedMessage defaultMessage="Tokens per Trace" description="Title for the token stats chart" />}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -49,7 +49,7 @@ export const TraceTokenUsageChart: React.FC = () => {
   }
 
   return (
-    <OverviewChartContainer>
+    <OverviewChartContainer componentId="mlflow.charts.trace_token_usage">
       <OverviewChartHeader
         icon={<LightningIcon />}
         title={<FormattedMessage defaultMessage="Token Usage" description="Title for the token usage chart" />}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useChartInteractionTelemetry.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useChartInteractionTelemetry.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, act } from '@testing-library/react';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { useChartInteractionTelemetry } from './useChartInteractionTelemetry';
+
+// Mock the telemetry hook
+const mockLogTelemetryEvent = jest.fn();
+jest.mock('../../../../telemetry/hooks/useLogTelemetryEvent', () => ({
+  useLogTelemetryEvent: () => mockLogTelemetryEvent,
+}));
+
+describe('useChartInteractionTelemetry', () => {
+  beforeEach(() => {
+    mockLogTelemetryEvent.mockClear();
+  });
+
+  it('should return onClick handler', () => {
+    const { result } = renderHook(() => useChartInteractionTelemetry('mlflow.charts.test'));
+
+    expect(result.current.onClick).toBeDefined();
+    expect(typeof result.current.onClick).toBe('function');
+  });
+
+  it('should log telemetry event on click when componentId is provided', () => {
+    const { result } = renderHook(() => useChartInteractionTelemetry('mlflow.charts.test'));
+
+    act(() => {
+      result.current.onClick();
+    });
+
+    expect(mockLogTelemetryEvent).toHaveBeenCalledTimes(1);
+    expect(mockLogTelemetryEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        componentId: 'mlflow.charts.test',
+        componentType: 'card',
+        eventType: 'onClick',
+        value: 'chart_interaction',
+      }),
+    );
+  });
+
+  it('should not log telemetry event when componentId is undefined', () => {
+    const { result } = renderHook(() => useChartInteractionTelemetry(undefined));
+
+    act(() => {
+      result.current.onClick();
+    });
+
+    expect(mockLogTelemetryEvent).not.toHaveBeenCalled();
+  });
+
+  it('should log multiple events on multiple clicks', () => {
+    const { result } = renderHook(() => useChartInteractionTelemetry('mlflow.charts.test'));
+
+    act(() => {
+      result.current.onClick();
+      result.current.onClick();
+      result.current.onClick();
+    });
+
+    expect(mockLogTelemetryEvent).toHaveBeenCalledTimes(3);
+  });
+
+  it('should use consistent componentViewId across clicks', () => {
+    const { result } = renderHook(() => useChartInteractionTelemetry('mlflow.charts.test'));
+
+    act(() => {
+      result.current.onClick();
+    });
+
+    const firstCall = mockLogTelemetryEvent.mock.calls[0][0] as { componentViewId: string };
+
+    act(() => {
+      result.current.onClick();
+    });
+
+    const secondCall = mockLogTelemetryEvent.mock.calls[1][0] as { componentViewId: string };
+
+    expect(firstCall.componentViewId).toBe(secondCall.componentViewId);
+  });
+
+  it('should not return onMouseEnter handler (to avoid noise from scrolling)', () => {
+    const { result } = renderHook(() => useChartInteractionTelemetry('mlflow.charts.test'));
+
+    expect(result.current).not.toHaveProperty('onMouseEnter');
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useChartInteractionTelemetry.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useChartInteractionTelemetry.ts
@@ -1,0 +1,41 @@
+import { useCallback, useRef } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+} from '@databricks/design-system';
+import { useLogTelemetryEvent } from '../../../../telemetry/hooks/useLogTelemetryEvent';
+
+/**
+ * Hook for tracking chart interaction telemetry.
+ * Tracks when users click on a chart.
+ * Not tracking hover interactions to avoid noise.
+ *
+ * @param componentId - Unique identifier for the chart (e.g., "mlflow.charts.trace_requests").
+ *                      If undefined, no telemetry will be logged.
+ * @returns Object with event handlers to spread on the chart container
+ *
+ * @example
+ * const interactionProps = useChartInteractionTelemetry('mlflow.charts.trace_requests');
+ * <div {...interactionProps}>Chart content</div>
+ */
+export function useChartInteractionTelemetry(componentId: string | undefined) {
+  const componentViewId = useRef<string>(uuidv4());
+  const logTelemetryEvent = useLogTelemetryEvent();
+
+  const onClick = useCallback(() => {
+    if (!componentId) {
+      return;
+    }
+
+    logTelemetryEvent({
+      componentId,
+      componentViewId: componentViewId.current,
+      componentType: DesignSystemEventProviderComponentTypes.Card,
+      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+      value: 'chart_interaction',
+    });
+  }, [componentId, logTelemetryEvent]);
+
+  return { onClick };
+}

--- a/mlflow/server/js/src/telemetry/TelemetryClient.ts
+++ b/mlflow/server/js/src/telemetry/TelemetryClient.ts
@@ -108,6 +108,8 @@ class TelemetryClient {
         componentType: record.componentType,
         componentSubType: record.componentSubType,
         eventType: record.eventType,
+        // Include value for events, this only happens when valueHasNoPii=true
+        ...(record.value !== undefined && { value: String(record.value) }),
       },
     };
 

--- a/mlflow/server/js/src/telemetry/types.ts
+++ b/mlflow/server/js/src/telemetry/types.ts
@@ -9,4 +9,6 @@ export interface DesignSystemObservabilityEvent {
   componentType: DesignSystemEventProviderComponentTypes;
   componentSubType?: string | null;
   eventType: DesignSystemEventProviderAnalyticsEventTypes;
+  /** Value is only present when the component has valueHasNoPii=true */
+  value?: unknown;
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19953/files) to review incremental changes.
- [**stack/add_telemetry**](https://github.com/mlflow/mlflow/pull/19953) [[Files changed](https://github.com/mlflow/mlflow/pull/19953/files)]
  - [stack/add_time_unit_selection](https://github.com/mlflow/mlflow/pull/19988) [[Files changed](https://github.com/mlflow/mlflow/pull/19988/files/715d838537035b8a1c9bb9c03ed2ccaf44493572..715d838537035b8a1c9bb9c03ed2ccaf44493572)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Add telemetry for overview tab, including:
- which tab is selected (value is passed as part of params)
- what chart is clicked (hover operation is not handled since it's too noisy, it records even if we scroll on the page)
- refresh button (update the component id so it's clearer)

Verified locally, example record:
[
    {
        "timestamp_ns": 1768299392031000000,
        "event_name": "ui_event",
        "params": '{"componentId": "mlflow.charts.trace_errors", "componentViewId": "95f831e0-7096-4311-b22c-3f2a108130a2", "componentType": "card", "eventType": "onClick", "value": "chart_interaction"}',
        "status": "success",
        "duration_ms": 0,
        "installation_id": "957e04e8-f071-4fb2-9e13-c1f56f0cbe96",
        "session_id": "e1fd84fa-cabd-4a3f-8600-191d7363c70d",
    },
    {
        "timestamp_ns": 1768299338023000000,
        "event_name": "ui_event",
        "params": '{"componentId": "mlflow.experiment.overview.tabs", "componentViewId": "1ae06eb3-efc8-4e92-9044-44bd337fb97f", "componentType": "tabs", "eventType": "onValueChange", "value": "quality"}',
        "status": "success",
        "duration_ms": 0,
        "installation_id": "957e04e8-f071-4fb2-9e13-c1f56f0cbe96",
        "session_id": "e1fd84fa-cabd-4a3f-8600-191d7363c70d",
    },
]


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
