### PR TITLE
Telemetry to distinguish between types of dataset

### DIFF
--- a/mlflow/entities/evaluation_dataset.py
+++ b/mlflow/entities/evaluation_dataset.py
@@ -413,7 +413,8 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
         except (json.JSONDecodeError, TypeError):
             return DatasetGranularity.UNKNOWN
 
-    def _classify_input_fields(self, input_keys: set[str]) -> DatasetGranularity:
+    @staticmethod
+    def _classify_input_fields(input_keys: set[str]) -> DatasetGranularity:
         """
         Classify a set of input field names into a granularity type:
         - SESSION: Has 'goal' field, and only session fields (persona, goal, context)

--- a/mlflow/entities/evaluation_dataset.py
+++ b/mlflow/entities/evaluation_dataset.py
@@ -12,8 +12,12 @@ from mlflow.entities.dataset_record import DatasetRecord
 from mlflow.entities.dataset_record_source import DatasetRecordSourceType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.datasets_pb2 import Dataset as ProtoDataset
-from mlflow.telemetry.events import MergeRecordsEvent
-from mlflow.telemetry.track import record_usage_event
+from mlflow.telemetry.events import (
+    DatasetToDataFrameEvent,
+    DatasetType,
+    MergeRecordsEvent,
+)
+from mlflow.telemetry.track import _record_event
 from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracking.context import registry as context_registry
 from mlflow.utils.mlflow_tags import MLFLOW_USER
@@ -212,7 +216,6 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
         else:
             return df.to_dict("records")
 
-    @record_usage_event(MergeRecordsEvent)
     def merge_records(
         self, records: list[dict[str, Any]] | "pd.DataFrame" | list["Trace"]
     ) -> "EvaluationDataset":
@@ -258,11 +261,18 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
         from mlflow.entities.trace import Trace
         from mlflow.tracking._tracking_service.utils import _get_store, get_tracking_uri
 
+        input_type: str
         if isinstance(records, pd.DataFrame):
+            input_type = "pandas"
             record_dicts = self._process_dataframe_records(records)
         elif isinstance(records, list) and records and isinstance(records[0], Trace):
+            input_type = "list[trace]"
             record_dicts = self._process_trace_records(records)
+        elif isinstance(records, list):
+            input_type = "list[dict]" if records and isinstance(records[0], dict) else "list"
+            record_dicts = records
         else:
+            input_type = "other"
             record_dicts = records
 
         self._validate_record_dicts(record_dicts)
@@ -293,6 +303,18 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
 
         tracking_store.upsert_dataset_records(dataset_id=self.dataset_id, records=record_dicts)
         self._records = None
+
+        dataset_type = self._get_existing_granularity()
+        if dataset_type == DatasetGranularity.UNKNOWN and record_dicts:
+            dataset_type = self._classify_input_fields(record_dicts[0].get("inputs", {}).keys())
+        _record_event(
+            MergeRecordsEvent,
+            {
+                "record_count": len(record_dicts) if record_dicts else 0,
+                "input_type": input_type,
+                "dataset_type": dataset_type.value,
+            },
+        )
 
         return self
 
@@ -403,6 +425,8 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
             DatasetGranularity based on existing records, or UNKNOWN if empty/unparseable
         """
         if self._schema is None:
+            if self.has_records():
+                return self._classify_input_fields(set(self.records[0].inputs.keys()))
             return DatasetGranularity.UNKNOWN
         try:
             schema = json.loads(self._schema)
@@ -451,6 +475,13 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
         records = self.records
 
         if not records:
+            _record_event(
+                DatasetToDataFrameEvent,
+                {
+                    "record_count": 0,
+                    "dataset_type": DatasetType.UNKNOWN.value,
+                },
+            )
             return pd.DataFrame(
                 columns=[
                     "inputs",
@@ -479,6 +510,14 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
             }
             for record in records
         ]
+        dataset_type = self._get_existing_granularity()
+        _record_event(
+            DatasetToDataFrameEvent,
+            {
+                "record_count": len(records),
+                "dataset_type": dataset_type.value,
+            },
+        )
 
         return pd.DataFrame(data)
 

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -219,9 +219,87 @@ class CreateDatasetEvent(Event):
 class MergeRecordsEvent(Event):
     name: str = "merge_records"
 
+    @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        from mlflow.entities.evaluation_dataset import EvaluationDataset
+
+        dataset_instance = arguments.get("self")
+        if not isinstance(dataset_instance, EvaluationDataset):
+            return None
+
+        if arguments is None:
+            return None
+
+        records = arguments.get("records")
+        if records is None:
+            return None
+
+        try:
+            count = len(records)
+        except TypeError:
+            return None
+
+        if count == 0:
+            return None
+
+        input_type = type(records).__name__.lower()
+        input_keys: set[str] | None = None
+
+        if "dataframe" in input_type:
+            input_type = "pandas"
+            try:
+                if "inputs" in records.columns:
+                    if first_inputs := records.iloc[0].get("inputs", {}):
+                        input_keys = set(first_inputs.keys())
+            except Exception:
+                pass
+        elif isinstance(records, list):
+            first_elem = records[0]
+            if hasattr(first_elem, "__class__") and first_elem.__class__.__name__ == "Trace":
+                input_type = "list[trace]"
+            elif isinstance(first_elem, dict):
+                input_type = "list[dict]"
+                if first_inputs := first_elem.get("inputs", {}):
+                    input_keys = set(first_inputs.keys())
+            else:
+                input_type = "list"
+        else:
+            input_type = "other"
+
+        if input_type == "list[trace]":
+            dataset_type = DatasetType.TRACE
+        elif input_keys:
+            dataset_type = dataset_instance._classify_input_fields(input_keys)
+        else:
+            dataset_type = DatasetType.UNKNOWN
+
+        return {
+            "record_count": count,
+            "input_type": input_type,
+            "dataset_type": dataset_type.value,
+        }
+
 
 class DatasetToDataFrameEvent(Event):
     name: str = "dataset_to_df"
+
+    @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        from mlflow.entities.evaluation_dataset import EvaluationDataset
+
+        dataset_instance = arguments.get("self")
+        if not isinstance(dataset_instance, EvaluationDataset):
+            return None
+
+        granularity = dataset_instance._get_existing_granularity()
+        return {"dataset_type": granularity.value}
+
+    @classmethod
+    def parse_result(cls, result: Any) -> dict[str, Any] | None:
+        if result is None:
+            return {"record_count": 0}
+
+        return {"record_count": len(result)}
 
 
 def _is_prompt(tags: dict[str, str]) -> bool:

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -206,12 +206,6 @@ class CreateModelVersionEvent(Event):
         return {"is_prompt": _is_prompt(tags)}
 
 
-class DatasetType(str, Enum):
-    SESSION = "session"
-    TRACE = "trace"
-    UNKNOWN = "unknown"
-
-
 class CreateDatasetEvent(Event):
     name: str = "create_dataset"
 
@@ -221,11 +215,10 @@ class MergeRecordsEvent(Event):
 
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
-        from mlflow.entities.evaluation_dataset import EvaluationDataset
-
-        dataset_instance = arguments.get("self")
-        if not isinstance(dataset_instance, EvaluationDataset):
-            return None
+        from mlflow.entities.evaluation_dataset import (
+            DatasetGranularity,
+            EvaluationDataset,
+        )
 
         if arguments is None:
             return None
@@ -267,11 +260,11 @@ class MergeRecordsEvent(Event):
             input_type = "other"
 
         if input_type == "list[trace]":
-            dataset_type = DatasetType.TRACE
+            dataset_type = DatasetGranularity.TRACE
         elif input_keys:
-            dataset_type = dataset_instance._classify_input_fields(input_keys)
+            dataset_type = EvaluationDataset._classify_input_fields(input_keys)
         else:
-            dataset_type = DatasetType.UNKNOWN
+            dataset_type = DatasetGranularity.UNKNOWN
 
         return {
             "record_count": count,

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -206,6 +206,12 @@ class CreateModelVersionEvent(Event):
         return {"is_prompt": _is_prompt(tags)}
 
 
+class DatasetType(str, Enum):
+    SESSION = "session"
+    TRACE = "trace"
+    UNKNOWN = "unknown"
+
+
 class CreateDatasetEvent(Event):
     name: str = "create_dataset"
 
@@ -213,38 +219,9 @@ class CreateDatasetEvent(Event):
 class MergeRecordsEvent(Event):
     name: str = "merge_records"
 
-    @classmethod
-    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
-        if arguments is None:
-            return None
 
-        records = arguments.get("records")
-        if records is None:
-            return None
-
-        try:
-            count = len(records)
-        except TypeError:
-            return None
-
-        if count == 0:
-            return None
-
-        input_type = type(records).__name__.lower()
-        if "dataframe" in input_type:
-            input_type = "pandas"
-        elif isinstance(records, list):
-            first_elem = records[0]
-            if hasattr(first_elem, "__class__") and first_elem.__class__.__name__ == "Trace":
-                input_type = "list[trace]"
-            elif isinstance(first_elem, dict):
-                input_type = "list[dict]"
-            else:
-                input_type = "list"
-        else:
-            input_type = "other"
-
-        return {"record_count": count, "input_type": input_type}
+class DatasetToDataFrameEvent(Event):
+    name: str = "dataset_to_df"
 
 
 def _is_prompt(tags: dict[str, str]) -> bool:

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -285,14 +285,18 @@ class DatasetToDataFrameEvent(Event):
             return None
 
         callsite = "direct_call"
-        for frame_info in inspect.stack()[:10]:
-            frame_filename = frame_info.filename.replace("\\", "/")
+        frame = sys._getframe()
+        for _ in range(10):
+            if frame is None:
+                break
+            frame_filename = frame.f_code.co_filename.replace("\\", "/")
             if "mlflow/genai/evaluation" in frame_filename:
                 callsite = "genai_evaluate"
                 break
             if "mlflow/genai/simulators" in frame_filename:
                 callsite = "conversation_simulator"
                 break
+            frame = frame.f_back
 
         granularity = dataset_instance._get_existing_granularity()
         return {"dataset_type": granularity.value, "callsite": callsite}

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -284,8 +284,18 @@ class DatasetToDataFrameEvent(Event):
         if not isinstance(dataset_instance, EvaluationDataset):
             return None
 
+        callsite = "direct_call"
+        for frame_info in inspect.stack()[:10]:
+            frame_filename = frame_info.filename.replace("\\", "/")
+            if "mlflow/genai/evaluation" in frame_filename:
+                callsite = "genai_evaluate"
+                break
+            if "mlflow/genai/simulators" in frame_filename:
+                callsite = "conversation_simulator"
+                break
+
         granularity = dataset_instance._get_existing_granularity()
-        return {"dataset_type": granularity.value}
+        return {"dataset_type": granularity.value, "callsite": callsite}
 
     @classmethod
     def parse_result(cls, result: Any) -> dict[str, Any] | None:

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -155,7 +155,7 @@ def test_dataset_to_df_parse(granularity, expected_dataset_type):
     mock_dataset = _make_mock_dataset(granularity)
     arguments = {"self": mock_dataset}
     result = DatasetToDataFrameEvent.parse(arguments)
-    assert result == {"dataset_type": expected_dataset_type}
+    assert result == {"dataset_type": expected_dataset_type, "callsite": "direct_call"}
 
 
 @pytest.mark.parametrize(

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -111,22 +111,21 @@ def test_event_name():
             {"records": [{"a": 1}, {"b": 2}]},
             {"record_count": 2, "input_type": "list[dict]", "dataset_type": "unknown"},
         ),
-        # Trace records (no 'goal' field in inputs)
+        # Trace records
         (
             {"records": [{"inputs": {"question": "What is MLflow?", "context": "docs"}}]},
             {"record_count": 1, "input_type": "list[dict]", "dataset_type": "trace"},
         ),
-        # Session records (has 'goal' field in inputs)
-        (
-            {"records": [{"inputs": {"persona": "user", "goal": "test", "context": "info"}}]},
-            {"record_count": 1, "input_type": "list[dict]", "dataset_type": "session"},
-        ),
-        # Multiple trace records
         (
             {"records": [{"inputs": {"q": "a"}}, {"inputs": {"q": "b"}}]},
             {"record_count": 2, "input_type": "list[dict]", "dataset_type": "trace"},
         ),
-        # Edge cases that return None
+        # Session records
+        (
+            {"records": [{"inputs": {"persona": "user", "goal": "test", "context": "info"}}]},
+            {"record_count": 1, "input_type": "list[dict]", "dataset_type": "session"},
+        ),
+        # Edge cases
         ({"records": []}, None),
         ({"records": None}, None),
         ({}, None),

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -9,7 +9,14 @@ from click.testing import CliRunner
 
 import mlflow
 from mlflow import MlflowClient
-from mlflow.entities import EvaluationDataset, Expectation, Feedback, Metric, Param, RunTag
+from mlflow.entities import (
+    EvaluationDataset,
+    Expectation,
+    Feedback,
+    Metric,
+    Param,
+    RunTag,
+)
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.entities.trace import Trace
 from mlflow.entities.webhook import WebhookAction, WebhookEntity, WebhookEvent
@@ -27,7 +34,11 @@ from mlflow.genai.scorers.builtin_scorers import (
     UserFrustration,
 )
 from mlflow.genai.simulators import ConversationSimulator
-from mlflow.pyfunc.model import ResponsesAgent, ResponsesAgentRequest, ResponsesAgentResponse
+from mlflow.pyfunc.model import (
+    ResponsesAgent,
+    ResponsesAgentRequest,
+    ResponsesAgentResponse,
+)
 from mlflow.telemetry.client import TelemetryClient
 from mlflow.telemetry.events import (
     AiCommandRunEvent,
@@ -80,7 +91,8 @@ def mlflow_client():
 @pytest.fixture(autouse=True)
 def mock_get_telemetry_client(mock_telemetry_client: TelemetryClient):
     with mock.patch(
-        "mlflow.telemetry.track.get_telemetry_client", return_value=mock_telemetry_client
+        "mlflow.telemetry.track.get_telemetry_client",
+        return_value=mock_telemetry_client,
     ):
         yield
 
@@ -105,7 +117,10 @@ def test_create_logged_model(mock_requests, mock_telemetry_client: TelemetryClie
         python_model=TestModel(),
     )
     validate_telemetry_record(
-        mock_telemetry_client, mock_requests, event_name, {"flavor": "pyfunc.CustomPythonModel"}
+        mock_telemetry_client,
+        mock_requests,
+        event_name,
+        {"flavor": "pyfunc.CustomPythonModel"},
     )
 
     mlflow.sklearn.log_model(
@@ -141,7 +156,10 @@ def test_create_logged_model(mock_requests, mock_telemetry_client: TelemetryClie
         python_model=SimpleResponsesAgent(),
     )
     validate_telemetry_record(
-        mock_telemetry_client, mock_requests, event_name, {"flavor": "pyfunc.ResponsesAgent"}
+        mock_telemetry_client,
+        mock_requests,
+        event_name,
+        {"flavor": "pyfunc.ResponsesAgent"},
     )
 
 
@@ -420,9 +438,21 @@ def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
         expected_params = {
             "predict_fn_provided": False,
             "scorer_info": [
-                {"class": "UserDefinedScorer", "kind": "decorator", "scope": "response"},
-                {"class": "UserDefinedScorer", "kind": "instructions", "scope": "response"},
-                {"class": "UserDefinedScorer", "kind": "instructions", "scope": "session"},
+                {
+                    "class": "UserDefinedScorer",
+                    "kind": "decorator",
+                    "scope": "response",
+                },
+                {
+                    "class": "UserDefinedScorer",
+                    "kind": "instructions",
+                    "scope": "response",
+                },
+                {
+                    "class": "UserDefinedScorer",
+                    "kind": "instructions",
+                    "scope": "session",
+                },
                 {"class": "Guidelines", "kind": "guidelines", "scope": "response"},
                 {"class": "RelevanceToQuery", "kind": "builtin", "scope": "response"},
                 {"class": "UserFrustration", "kind": "builtin", "scope": "session"},
@@ -432,7 +462,10 @@ def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
             "eval_data_provided_fields": ["inputs", "outputs"],
         }
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+            mock_telemetry_client,
+            mock_requests,
+            GenAIEvaluateEvent.name,
+            expected_params,
         )
 
         # Test with predict_fn
@@ -452,7 +485,10 @@ def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
             "eval_data_provided_fields": ["inputs", "outputs"],
         }
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+            mock_telemetry_client,
+            mock_requests,
+            GenAIEvaluateEvent.name,
+            expected_params,
         )
 
 
@@ -481,14 +517,21 @@ def test_genai_evaluate_telemetry_data_fields(
         expected_params = {
             "predict_fn_provided": False,
             "scorer_info": [
-                {"class": "UserDefinedScorer", "kind": "decorator", "scope": "response"},
+                {
+                    "class": "UserDefinedScorer",
+                    "kind": "decorator",
+                    "scope": "response",
+                },
             ],
             "eval_data_type": "list[dict]",
             "eval_data_size": 2,
             "eval_data_provided_fields": ["expectations", "inputs", "outputs"],
         }
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+            mock_telemetry_client,
+            mock_requests,
+            GenAIEvaluateEvent.name,
+            expected_params,
         )
 
         # Test with pandas DataFrame
@@ -503,14 +546,21 @@ def test_genai_evaluate_telemetry_data_fields(
         expected_params = {
             "predict_fn_provided": False,
             "scorer_info": [
-                {"class": "UserDefinedScorer", "kind": "decorator", "scope": "response"},
+                {
+                    "class": "UserDefinedScorer",
+                    "kind": "decorator",
+                    "scope": "response",
+                },
             ],
             "eval_data_type": "pd.DataFrame",
             "eval_data_size": 3,
             "eval_data_provided_fields": ["inputs", "outputs"],
         }
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+            mock_telemetry_client,
+            mock_requests,
+            GenAIEvaluateEvent.name,
+            expected_params,
         )
 
         # Test with list of Traces
@@ -526,14 +576,21 @@ def test_genai_evaluate_telemetry_data_fields(
         expected_params = {
             "predict_fn_provided": False,
             "scorer_info": [
-                {"class": "UserDefinedScorer", "kind": "decorator", "scope": "response"},
+                {
+                    "class": "UserDefinedScorer",
+                    "kind": "decorator",
+                    "scope": "response",
+                },
             ],
             "eval_data_type": "list[Trace]",
             "eval_data_size": 2,
             "eval_data_provided_fields": ["inputs", "outputs", "trace"],
         }
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+            mock_telemetry_client,
+            mock_requests,
+            GenAIEvaluateEvent.name,
+            expected_params,
         )
 
         # Test with EvaluationDataset
@@ -557,14 +614,21 @@ def test_genai_evaluate_telemetry_data_fields(
         expected_params = {
             "predict_fn_provided": False,
             "scorer_info": [
-                {"class": "UserDefinedScorer", "kind": "decorator", "scope": "response"},
+                {
+                    "class": "UserDefinedScorer",
+                    "kind": "decorator",
+                    "scope": "response",
+                },
             ],
             "eval_data_type": "EvaluationDataset",
             "eval_data_size": 2,
             "eval_data_provided_fields": ["expectations", "inputs", "outputs"],
         }
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+            mock_telemetry_client,
+            mock_requests,
+            GenAIEvaluateEvent.name,
+            expected_params,
         )
 
 
@@ -720,7 +784,10 @@ def test_merge_records(mock_requests, mock_telemetry_client: TelemetryClient):
         mock_store_instance = mock.MagicMock()
         mock_store.return_value = mock_store_instance
         mock_store_instance.get_dataset.return_value = mock.MagicMock(dataset_id="test-id")
-        mock_store_instance.upsert_dataset_records.return_value = {"inserted": 2, "updated": 0}
+        mock_store_instance.upsert_dataset_records.return_value = {
+            "inserted": 2,
+            "updated": 0,
+        }
 
         evaluation_dataset = EvaluationDataset(
             dataset_id="test-id",
@@ -736,9 +803,16 @@ def test_merge_records(mock_requests, mock_telemetry_client: TelemetryClient):
         ]
         evaluation_dataset.merge_records(records)
 
-        expected_params = {"record_count": 2, "input_type": "list[dict]"}
+        expected_params = {
+            "record_count": 2,
+            "input_type": "list[dict]",
+            "dataset_type": "trace",
+        }
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, MergeRecordsEvent.name, expected_params
+            mock_telemetry_client,
+            mock_requests,
+            MergeRecordsEvent.name,
+            expected_params,
         )
 
 
@@ -760,12 +834,18 @@ def test_log_metric(mock_requests, mock_telemetry_client: TelemetryClient):
     with mlflow.start_run():
         mlflow.log_metric("test_metric", 1.0)
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, LogMetricEvent.name, {"synchronous": True}
+            mock_telemetry_client,
+            mock_requests,
+            LogMetricEvent.name,
+            {"synchronous": True},
         )
 
         mlflow.log_metric("test_metric", 1.0, synchronous=False)
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, LogMetricEvent.name, {"synchronous": False}
+            mock_telemetry_client,
+            mock_requests,
+            LogMetricEvent.name,
+            {"synchronous": False},
         )
 
         client = MlflowClient()
@@ -777,7 +857,10 @@ def test_log_metric(mock_requests, mock_telemetry_client: TelemetryClient):
             step=0,
         )
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, LogMetricEvent.name, {"synchronous": True}
+            mock_telemetry_client,
+            mock_requests,
+            LogMetricEvent.name,
+            {"synchronous": True},
         )
 
         client.log_metric(
@@ -789,7 +872,10 @@ def test_log_metric(mock_requests, mock_telemetry_client: TelemetryClient):
             synchronous=False,
         )
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, LogMetricEvent.name, {"synchronous": False}
+            mock_telemetry_client,
+            mock_requests,
+            LogMetricEvent.name,
+            {"synchronous": False},
         )
 
 
@@ -797,12 +883,18 @@ def test_log_param(mock_requests, mock_telemetry_client: TelemetryClient):
     with mlflow.start_run():
         mlflow.log_param("test_param", "test_value")
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, LogParamEvent.name, {"synchronous": True}
+            mock_telemetry_client,
+            mock_requests,
+            LogParamEvent.name,
+            {"synchronous": True},
         )
 
         mlflow.log_param("test_param", "test_value", synchronous=False)
         validate_telemetry_record(
-            mock_telemetry_client, mock_requests, LogParamEvent.name, {"synchronous": False}
+            mock_telemetry_client,
+            mock_requests,
+            LogParamEvent.name,
+            {"synchronous": False},
         )
 
         client = mlflow.MlflowClient()
@@ -894,13 +986,19 @@ def test_get_logged_model(mock_requests, mock_telemetry_client: TelemetryClient,
 
     mlflow.sklearn.load_model(model_info.model_uri)
     data = validate_telemetry_record(
-        mock_telemetry_client, mock_requests, GetLoggedModelEvent.name, check_params=False
+        mock_telemetry_client,
+        mock_requests,
+        GetLoggedModelEvent.name,
+        check_params=False,
     )
     assert "sklearn" in json.loads(data["params"])["imports"]
 
     mlflow.pyfunc.load_model(model_info.model_uri)
     data = validate_telemetry_record(
-        mock_telemetry_client, mock_requests, GetLoggedModelEvent.name, check_params=False
+        mock_telemetry_client,
+        mock_requests,
+        GetLoggedModelEvent.name,
+        check_params=False,
     )
 
     model_def = """
@@ -923,7 +1021,10 @@ set_model(TestModel())
 
     mlflow.pyfunc.load_model(model_info.model_uri)
     data = validate_telemetry_record(
-        mock_telemetry_client, mock_requests, GetLoggedModelEvent.name, check_params=False
+        mock_telemetry_client,
+        mock_requests,
+        GetLoggedModelEvent.name,
+        check_params=False,
     )
 
     # test load model after registry
@@ -932,7 +1033,10 @@ set_model(TestModel())
 
     mlflow.pyfunc.load_model("models:/test/1")
     data = validate_telemetry_record(
-        mock_telemetry_client, mock_requests, GetLoggedModelEvent.name, check_params=False
+        mock_telemetry_client,
+        mock_requests,
+        GetLoggedModelEvent.name,
+        check_params=False,
     )
 
 
@@ -1027,23 +1131,29 @@ def test_invoke_custom_judge_model(
 
     with (
         mock.patch(
-            "mlflow.genai.judges.utils._is_litellm_available", return_value=litellm_available
+            "mlflow.genai.judges.utils._is_litellm_available",
+            return_value=litellm_available,
         ),
         mock.patch(
-            "mlflow.utils.databricks_utils.get_databricks_host_creds", return_value=mock_creds
+            "mlflow.utils.databricks_utils.get_databricks_host_creds",
+            return_value=mock_creds,
         ),
     ):
         if use_native_provider:
             with (
                 mock.patch.object(
                     __import__(
-                        "mlflow.metrics.genai.model_utils", fromlist=["score_model_on_payload"]
+                        "mlflow.metrics.genai.model_utils",
+                        fromlist=["score_model_on_payload"],
                     ),
                     "score_model_on_payload",
                     return_value=mock_response,
                 ),
                 mock.patch.object(
-                    __import__("mlflow.metrics.genai.model_utils", fromlist=["get_endpoint_type"]),
+                    __import__(
+                        "mlflow.metrics.genai.model_utils",
+                        fromlist=["get_endpoint_type"],
+                    ),
                     "get_endpoint_type",
                     return_value="llm/v1/chat",
                 ),
@@ -1149,7 +1259,13 @@ def test_autologging(mock_requests, mock_telemetry_client: TelemetryClient):
         data = [record["data"] for record in mock_requests]
         params = [event["params"] for event in data if event["event_name"] == AutologgingEvent.name]
         assert (
-            json.dumps({"flavor": mlflow.openai.FLAVOR_NAME, "log_traces": True, "disable": False})
+            json.dumps(
+                {
+                    "flavor": mlflow.openai.FLAVOR_NAME,
+                    "log_traces": True,
+                    "disable": False,
+                }
+            )
             in params
         )
         assert json.dumps({"flavor": "all", "log_traces": True, "disable": False}) in params
@@ -1171,13 +1287,19 @@ def test_load_prompt(mock_requests, mock_telemetry_client: TelemetryClient):
     # Test load_prompt with version (no alias)
     mlflow.genai.load_prompt(name_or_uri="test_prompt", version=prompt.version)
     validate_telemetry_record(
-        mock_telemetry_client, mock_requests, LoadPromptEvent.name, {"uses_alias": False}
+        mock_telemetry_client,
+        mock_requests,
+        LoadPromptEvent.name,
+        {"uses_alias": False},
     )
 
     # Test load_prompt with URI and version (no alias)
     mlflow.genai.load_prompt(name_or_uri=f"prompts:/test_prompt/{prompt.version}")
     validate_telemetry_record(
-        mock_telemetry_client, mock_requests, LoadPromptEvent.name, {"uses_alias": False}
+        mock_telemetry_client,
+        mock_requests,
+        LoadPromptEvent.name,
+        {"uses_alias": False},
     )
 
     # Test load_prompt with alias


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SomtochiUmeh/mlflow/pull/19959?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19959/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19959/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19959/merge
```

</p>
</details>

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adding telemetry to distinguish between conversational and regular datasets when either `merge_records` or `to_df` is called

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
```python
import os

os.environ["_MLFLOW_TESTING_TELEMETRY"] = "true"

import pandas as pd

import mlflow
from mlflow import MlflowClient
from mlflow.genai import scorer
from mlflow.genai.datasets import create_dataset, delete_dataset
from mlflow.genai.simulators import ConversationSimulator

mlflow.set_tracking_uri("sqlite:///mlflow_telemetry_test.db")


@scorer
def always_true(outputs) -> bool:
    return True


experiment_name = "telemetry_test_experiment"
experiment = mlflow.set_experiment(experiment_name)

created_datasets = []

# TEST 1: list[dict] with TRACE inputs
print("TEST 1: merge_records with list[dict] - TRACE inputs")

trace_dataset = create_dataset(
    name="telemetry_test_trace_list_dict",
    experiment_id=experiment.experiment_id,
)
created_datasets.append(trace_dataset)

trace_records = [
    {"inputs": {"question": "What is MLflow?", "context": "docs"}},
    {"inputs": {"question": "How do I log metrics?", "context": "tutorial"}},
    {"inputs": {"question": "What is a run?", "context": "concepts"}},
]

trace_dataset.merge_records(trace_records)
df = trace_dataset.to_df()

# TEST 2: list[dict] with SESSION inputs
print("TEST 2: merge_records with list[dict] - SESSION inputs")

session_dataset = create_dataset(
    name="telemetry_test_session_list_dict",
    experiment_id=experiment.experiment_id,
)
created_datasets.append(session_dataset)

session_records = [
    {
        "inputs": {
            "persona": "A curious student learning about ML",
            "goal": "Understand how to track experiments in MLflow",
            "context": {"user_level": "beginner"},
        }
    },
    {
        "inputs": {
            "persona": "A data scientist",
            "goal": "Deploy a model to production",
            "context": {"user_level": "advanced"},
        }
    },
]

session_dataset.merge_records(session_records)
session_df = session_dataset.to_df()

# TEST 3: pandas DataFrame with TRACE inputs
print("TEST 3: merge_records with pandas DataFrame - TRACE inputs")

trace_df_dataset = create_dataset(
    name="telemetry_test_trace_pandas",
    experiment_id=experiment.experiment_id,
)
created_datasets.append(trace_df_dataset)

trace_df_records = pd.DataFrame(
    [
        {"inputs": {"question": "How to use autolog?", "topic": "tracking"}},
        {"inputs": {"question": "What are artifacts?", "topic": "storage"}},
    ]
)

trace_df_dataset.merge_records(trace_df_records)
result_df = trace_df_dataset.to_df()

# TEST 4: pandas DataFrame with SESSION inputs
print("TEST 4: merge_records with pandas DataFrame - SESSION inputs")

session_df_dataset = create_dataset(
    name="telemetry_test_session_pandas",
    experiment_id=experiment.experiment_id,
)
created_datasets.append(session_df_dataset)

session_df_records = pd.DataFrame(
    [
        {
            "inputs": {
                "goal": "Learn about model registry",
                "persona": "ML Engineer",
                "context": {"experience": "intermediate"},
            }
        },
        {
            "inputs": {
                "goal": "Set up CI/CD for ML",
                "persona": "DevOps Engineer",
                "context": {"experience": "advanced"},
            }
        },
    ]
)
session_df_dataset.merge_records(session_df_records)
result_session_df = session_df_dataset.to_df()

# TEST 5: list[Trace] inputs
print("TEST 5: merge_records with list[Trace]")

trace_list_dataset = create_dataset(
    name="telemetry_test_trace_list",
    experiment_id=experiment.experiment_id,
)
created_datasets.append(trace_list_dataset)


@mlflow.trace
def sample_function(query: str) -> str:
    return f"Response to: {query}"


traces = []
for query in ["What is MLflow?", "How do I deploy models?"]:
    sample_function(query)

client = MlflowClient()
traces = client.search_traces(locations=[experiment.experiment_id], max_results=2)
if traces:
    trace_list_dataset.merge_records(traces)
    trace_result_df = trace_list_dataset.to_df()
else:
    print("No traces found, skipping list[Trace] test")

# TEST 6: to_df() callsite detection - from mlflow.genai.evaluate
print("TEST 6: to_df() callsite - genai_evaluate")
eval_dataset = create_dataset(
    name="telemetry_test_eval_callsite",
    experiment_id=experiment.experiment_id,
)
created_datasets.append(eval_dataset)
eval_dataset.merge_records(
    [
        {"inputs": {"goal": "Q1"}, "outputs": "A1"},
        {"inputs": {"goal": "Q2"}, "outputs": "A2"},
    ]
)

try:
    mlflow.genai.evaluate(data=eval_dataset, scorers=[always_true])
except Exception:
    pass

# TEST 7: to_df() callsite detection - from mlflow.genai.simulators
print("TEST 7: to_df() callsite - conversation_simulator")
simulator = ConversationSimulator(test_cases=eval_dataset)

# CLEANUP
for ds in created_datasets:
    delete_dataset(dataset_id=ds.dataset_id)


if os.path.exists("mlflow_telemetry_test.db"):
    os.remove("mlflow_telemetry_test.db")

print("Telemetry Test Complete!")
```

```
TEST 1: merge_records with list[dict] - TRACE inputs
dataset_to_df event: {
  "dataset_type": "trace",
  "callsite": "direct_call",
  "record_count": 3,
  "mlflow_experiment_id": "1"
}
TEST 2: merge_records with list[dict] - SESSION inputs
dataset_to_df event: {
  "dataset_type": "session",
  "callsite": "direct_call",
  "record_count": 2,
  "mlflow_experiment_id": "1"
}
TEST 3: merge_records with pandas DataFrame - TRACE inputs
dataset_to_df event: {
  "dataset_type": "trace",
  "callsite": "direct_call",
  "record_count": 2,
  "mlflow_experiment_id": "1"
}
TEST 4: merge_records with pandas DataFrame - SESSION inputs
dataset_to_df event: {
  "dataset_type": "session",
  "callsite": "direct_call",
  "record_count": 2,
  "mlflow_experiment_id": "1"
}
TEST 5: merge_records with list[Trace]
dataset_to_df event: {
  "dataset_type": "trace",
  "callsite": "direct_call",
  "record_count": 2,
  "mlflow_experiment_id": "1"
}
TEST 6: to_df() callsite - genai_evaluate
dataset_to_df event: {
  "dataset_type": "session",
  "callsite": "genai_evaluate",
  "record_count": 2,
  "mlflow_experiment_id": "1"
}
dataset_to_df event: {
  "dataset_type": "session",
  "callsite": "genai_evaluate",
  "record_count": 2,
  "mlflow_experiment_id": "1"
}
Evaluating:   0%|                                                                                        | 0/2 [Elapsed: 00:02, Remaining: ?] 
TEST 7: to_df() callsite - conversation_simulator
dataset_to_df event: {
  "dataset_type": "session",
  "callsite": "conversation_simulator",
  "record_count": 2,
  "mlflow_experiment_id": "1"
}
Telemetry Test Complete!
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
