### PR TITLE
Fix agent-as-judge for FMAPI on managed for OpenAI and Gemini

### DIFF
--- a/mlflow/genai/judges/adapters/databricks_serving_endpoint_adapter.py
+++ b/mlflow/genai/judges/adapters/databricks_serving_endpoint_adapter.py
@@ -27,7 +27,6 @@ from mlflow.genai.judges.adapters.base_adapter import (
     BaseJudgeAdapter,
 )
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
-from mlflow.genai.judges.tools import list_judge_tools
 from mlflow.genai.judges.utils.parsing_utils import _sanitize_justification
 from mlflow.genai.judges.utils.tool_calling_utils import (
     _process_tool_calls,
@@ -407,6 +406,8 @@ def _invoke_databricks_serving_endpoint_judge(
 
     tools = None
     if trace is not None:
+        from mlflow.genai.judges.tools import list_judge_tools
+
         judge_tools = list_judge_tools()
         tools = []
 

--- a/tests/genai/judges/adapters/test_databricks_adapter.py
+++ b/tests/genai/judges/adapters/test_databricks_adapter.py
@@ -580,9 +580,7 @@ def test_serving_endpoint_judge_with_tool_calling(mock_databricks_creds, mock_tr
         mock.patch(
             "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter._process_tool_calls"
         ) as mock_process,
-        mock.patch(
-            "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.list_judge_tools"
-        ) as mock_list_tools,
+        mock.patch("mlflow.genai.judges.tools.list_judge_tools") as mock_list_tools,
     ):
         mock_tool = mock.Mock()
         mock_tool.get_definition.return_value.to_dict.return_value = {"name": "get_root_span"}
@@ -645,9 +643,7 @@ def test_serving_endpoint_judge_disables_response_format_with_tools(
             "mlflow.utils.databricks_utils.get_databricks_host_creds",
             return_value=mock_databricks_creds,
         ),
-        mock.patch(
-            "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.list_judge_tools"
-        ) as mock_list_tools,
+        mock.patch("mlflow.genai.judges.tools.list_judge_tools") as mock_list_tools,
     ):
         mock_tool = mock.Mock()
         mock_tool_def = mock.Mock()
@@ -713,9 +709,7 @@ def test_serving_endpoint_judge_filters_strict_from_tools(
             "mlflow.utils.databricks_utils.get_databricks_host_creds",
             return_value=mock_databricks_creds,
         ),
-        mock.patch(
-            "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.list_judge_tools"
-        ) as mock_list_tools,
+        mock.patch("mlflow.genai.judges.tools.list_judge_tools") as mock_list_tools,
     ):
         mock_tool = mock.Mock()
         mock_tool_def = mock.Mock()
@@ -791,9 +785,7 @@ def test_serving_endpoint_judge_max_iteration_limit(mock_databricks_creds, mock_
             "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter._process_tool_calls",
             return_value=[litellm.Message(role="tool", content="{}", tool_call_id="call_123")],
         ),
-        mock.patch(
-            "mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter.list_judge_tools"
-        ) as mock_list_tools,
+        mock.patch("mlflow.genai.judges.tools.list_judge_tools") as mock_list_tools,
     ):
         mock_tool = mock.Mock()
         mock_tool_def = mock.Mock()

--- a/tests/genai/judges/utils/test_invocation_utils.py
+++ b/tests/genai/judges/utils/test_invocation_utils.py
@@ -450,7 +450,8 @@ def test_invoke_judge_model_databricks_success_not_in_databricks(
 
         mock_invoke_db.assert_called_once_with(
             model_name=expected_model_name,
-            prompt="Test prompt",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            tools=mock.ANY if with_trace else None,
             num_retries=10,
             response_format=None,
             inference_params=None,
@@ -505,7 +506,8 @@ def test_invoke_judge_model_databricks_success_in_databricks(
         )
         mock_invoke_db.assert_called_once_with(
             model_name=expected_model_name,
-            prompt="Test prompt",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            tools=None,
             num_retries=10,
             response_format=None,
             inference_params=None,
@@ -541,7 +543,8 @@ def test_invoke_judge_model_databricks_source_id(model_uri: str) -> None:
     )
     mock_invoke_db.assert_called_once_with(
         model_name=expected_model_name,
-        prompt="Test prompt",
+        messages=[{"role": "user", "content": "Test prompt"}],
+        tools=None,
         num_retries=10,
         response_format=None,
         inference_params=None,
@@ -584,7 +587,8 @@ def test_invoke_judge_model_databricks_failure_in_databricks(
         )
         mock_invoke_db.assert_called_once_with(
             model_name=expected_model_name,
-            prompt="Test prompt",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            tools=None,
             num_retries=10,
             response_format=None,
             inference_params=None,
@@ -636,7 +640,8 @@ def test_invoke_judge_model_databricks_telemetry_error_handling(
         )
         mock_invoke_db.assert_called_once_with(
             model_name=expected_model_name,
-            prompt="Test prompt",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            tools=None,
             num_retries=10,
             response_format=None,
             inference_params=None,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19961/files) to review incremental changes.
- [**stack/fix-agent-as-judge-for-fmapi-on-managed**](https://github.com/mlflow/mlflow/pull/19961) [[Files changed](https://github.com/mlflow/mlflow/pull/19961/files)]
  - [stack/fix-claude-model-tool-call-exception-with-fmapi](https://github.com/mlflow/mlflow/pull/19992) [[Files changed](https://github.com/mlflow/mlflow/pull/19992/files/2dca26f7872c9e299d5cbc89789a9d06f7472e0e..fdf738137cf4f576411f57556bd82d58668aef31)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Agent-as-judge is currently not working as expected due to the missing agentic loop and trace parsing tools `databricks_serving_endpoint_adapter`.
<img width="1338" height="1892" alt="image" src="https://github.com/user-attachments/assets/5eb51c45-4585-47ec-8c10-beab3db82685" />



This PR implements the agentic loop for `databricks_serving_endpoint_adapter` and provides the trace parsing tools and added logic to integrate with FMAPI expected formats.

With the changes in PR, we should be able to call agentic-as-judge reliably with OpenAI models.

We also resolved the `thought_signature` missing issue with `gemini-3-pro/flash` models and they are able to make agentic calls to FMAPI correctly. 

However, for anthropic models, there seems to be an issue with FMAPI tool call handling, and it still throw an exception when multiple tools are called. I will reach out to FMAPI to see the suggested way to fix/workaround this.

#### Manual Testing
**Verified most of the FMAPI OpenAI models on managed works now**
<img width="915" height="835" alt="Screenshot 2026-01-13 at 5 46 25 PM" src="https://github.com/user-attachments/assets/864ff559-b3c9-4f13-892c-2a5cb3716e0c" />
<img width="910" height="886" alt="Screenshot 2026-01-13 at 8 51 04 PM" src="https://github.com/user-attachments/assets/ebc7625c-d4d9-4974-b672-96d79927edaa" />
<img width="901" height="872" alt="Screenshot 2026-01-13 at 8 52 01 PM" src="https://github.com/user-attachments/assets/168bd164-8179-40ce-9dec-5cf2b93caf34" />
<img width="902" height="875" alt="Screenshot 2026-01-13 at 8 54 35 PM" src="https://github.com/user-attachments/assets/042ed8e1-8285-44b0-9544-593f5f1fd599" />


**Verified that Gemini 3 Pro/Flash works when instruction clearly describe the expected json format**
<img width="910" height="884" alt="Screenshot 2026-01-13 at 8 45 39 PM" src="https://github.com/user-attachments/assets/c2ff5cfe-702d-4be8-8e57-d11fcefb335a" />
<img width="912" height="885" alt="Screenshot 2026-01-13 at 8 58 14 PM" src="https://github.com/user-attachments/assets/80f15147-d5ad-41b4-b0fb-73afaeb6e111" />

### Does this PR require documentation update?

- [x]  No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
