### PR TITLE
[UI] Improve LLM judge creation modal UX and variable ordering

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
@@ -11,8 +11,6 @@ import {
   ChevronDownIcon,
   DialogCombobox,
   DialogComboboxContent,
-  DialogComboboxAddButton,
-  DialogComboboxFooter,
   DialogComboboxOptionList,
   DialogComboboxOptionListSelectItem,
   DialogComboboxHintRow,
@@ -86,13 +84,13 @@ const LLMTemplateSection: React.FC<LLMTemplateSectionProps> = ({ mode, control, 
   return (
     <div css={{ display: 'flex', flexDirection: 'column' }}>
       <FormUI.Label aria-required={!isReadOnly} htmlFor="mlflow-experiment-scorers-built-in-scorer">
-        <FormattedMessage defaultMessage="LLM template" description="Section header for LLM template selection" />
+        <FormattedMessage defaultMessage="LLM judge" description="Section header for LLM judge selection" />
       </FormUI.Label>
       {!isReadOnly && (
         <FormUI.Hint>
           <FormattedMessage
-            defaultMessage="Start with a built-in LLM judge template or create your own."
-            description="Hint text for LLM template selection with documentation link"
+            defaultMessage="Select a built-in judge or create a custom one."
+            description="Hint text for LLM judge selection"
           />
         </FormUI.Hint>
       )}
@@ -111,8 +109,8 @@ const LLMTemplateSection: React.FC<LLMTemplateSectionProps> = ({ mode, control, 
                 allowClear={false}
                 disabled={isReadOnly}
                 placeholder={intl.formatMessage({
-                  defaultMessage: 'Select an LLM template',
-                  description: 'Placeholder for LLM template selection',
+                  defaultMessage: 'Select an LLM judge',
+                  description: 'Placeholder for LLM judge selection',
                 })}
                 renderDisplayedValue={(value) => (
                   <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
@@ -124,6 +122,25 @@ const LLMTemplateSection: React.FC<LLMTemplateSectionProps> = ({ mode, control, 
               {!isReadOnly && (
                 <DialogComboboxContent maxHeight={350}>
                   <DialogComboboxOptionList>
+                    {/* Custom template option first with PlusIcon */}
+                    {templateOptions
+                      .filter((option) => option.value === LLM_TEMPLATE.CUSTOM)
+                      .map((option) => (
+                        <DialogComboboxOptionListSelectItem
+                          key={option.value}
+                          value={option.value}
+                          onChange={() => {
+                            field.onChange(option.value);
+                            handleTemplateChange(option.value);
+                          }}
+                          checked={field.value === option.value}
+                          icon={<PlusIcon />}
+                        >
+                          {option.label}
+                          <DialogComboboxHintRow>{option.hint}</DialogComboboxHintRow>
+                        </DialogComboboxOptionListSelectItem>
+                      ))}
+                    {/* Built-in templates */}
                     {templateOptions
                       .filter((option) => option.value !== LLM_TEMPLATE.CUSTOM)
                       .map((option) => (
@@ -142,16 +159,6 @@ const LLMTemplateSection: React.FC<LLMTemplateSectionProps> = ({ mode, control, 
                         </DialogComboboxOptionListSelectItem>
                       ))}
                   </DialogComboboxOptionList>
-                  <DialogComboboxFooter>
-                    <DialogComboboxAddButton
-                      onClick={() => {
-                        field.onChange(LLM_TEMPLATE.CUSTOM);
-                        handleTemplateChange(LLM_TEMPLATE.CUSTOM);
-                      }}
-                    >
-                      {templateOptions.find((option) => option.value === LLM_TEMPLATE.CUSTOM)?.label}
-                    </DialogComboboxAddButton>
-                  </DialogComboboxFooter>
                 </DialogComboboxContent>
               )}
             </DialogCombobox>
@@ -262,21 +269,6 @@ const InstructionsSection: React.FC<InstructionsSectionProps> = ({ mode, control
         </DropdownMenu.HintRow>
       </DropdownMenu.Item>
       <DropdownMenu.Item
-        componentId={`${COMPONENT_ID_PREFIX}.add-variable-expectations`}
-        onClick={(e) => {
-          e.stopPropagation();
-          appendVariable('{{ expectations }}');
-        }}
-      >
-        <FormattedMessage defaultMessage="Expectations" description="Label for expectations variable option" />
-        <DropdownMenu.HintRow>
-          <FormattedMessage
-            defaultMessage="Expectations added for a trace"
-            description="Description for expectations variable"
-          />
-        </DropdownMenu.HintRow>
-      </DropdownMenu.Item>
-      <DropdownMenu.Item
         componentId={`${COMPONENT_ID_PREFIX}.add-variable-trace`}
         onClick={(e) => {
           e.stopPropagation();
@@ -288,6 +280,21 @@ const InstructionsSection: React.FC<InstructionsSectionProps> = ({ mode, control
           <FormattedMessage
             defaultMessage="Full trace with an agent using the right part of the trace to use to judge"
             description="Description for trace variable"
+          />
+        </DropdownMenu.HintRow>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item
+        componentId={`${COMPONENT_ID_PREFIX}.add-variable-expectations`}
+        onClick={(e) => {
+          e.stopPropagation();
+          appendVariable('{{ expectations }}');
+        }}
+      >
+        <FormattedMessage defaultMessage="Expectations" description="Label for expectations variable option" />
+        <DropdownMenu.HintRow>
+          <FormattedMessage
+            defaultMessage="Expectations added for a trace"
+            description="Description for expectations variable"
           />
         </DropdownMenu.HintRow>
       </DropdownMenu.Item>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/llmScorerUtils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/llmScorerUtils.tsx
@@ -96,12 +96,12 @@ export const useTemplateOptions = (scope?: ScorerEvaluationScope) => {
       {
         value: LLM_TEMPLATE.CUSTOM,
         label: intl.formatMessage({
-          defaultMessage: 'Create custom LLM template',
-          description: 'LLM template option',
+          defaultMessage: 'Custom judge',
+          description: 'LLM judge option for creating a custom judge',
         }),
         hint: intl.formatMessage({
           defaultMessage: 'Define custom instructions for LLM evaluation',
-          description: 'Hint for Custom template',
+          description: 'Hint for Custom judge',
         }),
       },
     ],

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -55,10 +55,6 @@
     "defaultMessage": "No sessions found",
     "description": "Title for the empty sessions list in the select sessions modal"
   },
-  "+Oupsq": {
-    "defaultMessage": "Start with a built-in LLM judge template or create your own.",
-    "description": "Hint text for LLM template selection with documentation link"
-  },
   "+SBxBK": {
     "defaultMessage": "Assessment Type",
     "description": "Field label for assessment type in a creation form"
@@ -510,6 +506,10 @@
   "25VTYi": {
     "defaultMessage": "Cancel",
     "description": "Cancellation button text on the model version stage transition request/approval modal"
+  },
+  "268j5O": {
+    "defaultMessage": "LLM judge",
+    "description": "Section header for LLM judge selection"
   },
   "27XMby": {
     "defaultMessage": "Missing",
@@ -1953,10 +1953,6 @@
   "D2svqS": {
     "defaultMessage": "overall error rate",
     "description": "Subtitle for overall tool error rate"
-  },
-  "D4rcC+": {
-    "defaultMessage": "Define custom instructions for LLM evaluation",
-    "description": "Hint for Custom template"
   },
   "D7SSDK": {
     "defaultMessage": "Automatically log traces for LiteLLM API calls by calling the {code} function. For example:",
@@ -4064,6 +4060,10 @@
     "defaultMessage": "Description",
     "description": "Column title text for description in model version table"
   },
+  "VmDLSS": {
+    "defaultMessage": "Select a built-in judge or create a custom one.",
+    "description": "Hint text for LLM judge selection"
+  },
   "Vn+uJi": {
     "defaultMessage": "Version",
     "description": "Header for the version column in the registered prompts table"
@@ -4370,10 +4370,6 @@
   "Y9ZFyN": {
     "defaultMessage": "Download artifact",
     "description": "Link to download the artifact of the experiment"
-  },
-  "YCYIaY": {
-    "defaultMessage": "Create custom LLM template",
-    "description": "LLM template option"
   },
   "YECxws": {
     "defaultMessage": "Compare",
@@ -4931,10 +4927,6 @@
     "defaultMessage": "Delete API key",
     "description": "Gateway > API key details drawer > Delete API key button aria label"
   },
-  "cHDnV/": {
-    "defaultMessage": "LLM template",
-    "description": "Section header for LLM template selection"
-  },
   "cHV5jh": {
     "defaultMessage": "Resources using this key via endpoints",
     "description": "Gateway > Bindings using key drawer > Subtitle"
@@ -4994,6 +4986,10 @@
   "cmYzGP": {
     "defaultMessage": "Dismiss",
     "description": "A label for the button to dismiss the modal with the usage example of the prompt"
+  },
+  "cn52sr": {
+    "defaultMessage": "Select an LLM judge",
+    "description": "Placeholder for LLM judge selection"
   },
   "cniMRT": {
     "defaultMessage": "Direct access to OpenAI's Responses API for multi-turn conversations with vision and audio capabilities.",
@@ -5102,6 +5098,10 @@
   "dcoaGS": {
     "defaultMessage": "No experiments created",
     "description": "A header for the empty state in the experiments table"
+  },
+  "dd8i7f": {
+    "defaultMessage": "Define custom instructions for LLM evaluation",
+    "description": "Hint for Custom judge"
   },
   "ddAFCW": {
     "defaultMessage": "500: Internal server error",
@@ -5846,10 +5846,6 @@
   "jA7Y1x": {
     "defaultMessage": "Edit API key",
     "description": "Gateway > API keys list > Edit API key button aria label"
-  },
-  "jGHQgn": {
-    "defaultMessage": "Select an LLM template",
-    "description": "Placeholder for LLM template selection"
   },
   "jH0+gA": {
     "defaultMessage": "Metrics",
@@ -7218,6 +7214,10 @@
   "tzA/LZ": {
     "defaultMessage": "Name",
     "description": "Header for the name column in the registered prompts table"
+  },
+  "u13xKF": {
+    "defaultMessage": "Custom judge",
+    "description": "LLM judge option for creating a custom judge"
   },
   "uABFy0": {
     "defaultMessage": "AI Gateway",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/danielseong1/mlflow/pull/19963?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19963/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19963/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19963/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Improve the scorer (LLM judge) creation modal with better naming and UX:

- Rename "LLM template" dropdown label to "LLM judge" for clearer terminology
- Rename "Custom LLM template" option to "Custom judge"  
- Update hint text from "Start with a built-in LLM judge template or create your own." to "Select a built-in judge or create a custom one."
- Move "Custom judge" option to first position in dropdown (with + icon)
- Move `{{ expectations }}` variable to last position in the "Add variable" dropdown for trace-level scorers

These changes make the mental model clearer - users are selecting *which judge* to use, not a "template".

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="1715" height="859" alt="image" src="https://github.com/user-attachments/assets/34c0eaf8-d818-40d1-aef6-a55e46853ef2" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved LLM judge creation modal UX with clearer naming ("LLM judge" instead of "LLM template") and better dropdown ordering.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)