### PR TITLE
[ML-60900] AgentServer: add /responses and /agent/info routes

### DIFF
--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -158,8 +158,12 @@ class AgentServer:
         async def invocations_endpoint(request: Request):
             return await self._handle_invocations_request(request)
 
-        @self.app.post("/responses/create")
-        async def responses_create_endpoint(request: Request):
+        @self.app.post("/responses")
+        async def responses_endpoint(request: Request):
+            """
+            For compatibility with the OpenAI Client `client.responses.create(...)` method.
+            https://platform.openai.com/docs/api-reference/responses/create
+            """
             return await self._handle_invocations_request(request)
 
         @self.app.get("/agent/info")

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -158,13 +158,16 @@ class AgentServer:
         async def invocations_endpoint(request: Request):
             return await self._handle_invocations_request(request)
 
-        @self.app.post("/responses")
-        async def responses_endpoint(request: Request):
-            """
-            For compatibility with the OpenAI Client `client.responses.create(...)` method.
-            https://platform.openai.com/docs/api-reference/responses/create
-            """
-            return await self._handle_invocations_request(request)
+        # Only expose /responses endpoint for ResponsesAgent
+        if self.agent_type == "ResponsesAgent":
+
+            @self.app.post("/responses")
+            async def responses_endpoint(request: Request):
+                """
+                For compatibility with the OpenAI Client `client.responses.create(...)` method.
+                https://platform.openai.com/docs/api-reference/responses/create
+                """
+                return await self._handle_invocations_request(request)
 
         @self.app.get("/agent/info")
         async def agent_info_endpoint() -> dict[str, Any]:


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- add route for /responses and fwd requests to /invocations
- add route for /agent/info to expose metadata relevant about the hosted agent

<details>

<summary>claude's plan</summary>

# Implementation Plan: Add `/responses/create` and `/agent/info` Routes

## Overview
Add two new routes to the agent server at `/Users/bryan.qiu/mlflow/mlflow/genai/agent_server/server.py`:
1. `/responses/create` - OpenAI Responses API compatible endpoint that forwards to `/invocations`
2. `/agent/info` - Returns agent/app metadata

## Implementation Details

### 1. Add `/responses/create` Route

**Location**: In `_setup_routes()` method, after `/invocations` endpoint (line ~191)

**Implementation**:
```python
@self.app.post("/responses/create")
async def responses_create_endpoint(request: Request):
    # Capture headers (same as invocations)
    set_request_headers(dict(request.headers))

    try:
        data = await request.json()
    except Exception as e:
        raise HTTPException(status_code=400, detail=f"Invalid JSON in request body: {e!s}")

    logger.debug(
        "Request received at /responses/create",
        extra={
            "agent_type": self.agent_type,
            "request_size": len(json.dumps(data)),
            "stream_requested": data.get(STREAM_KEY, False),
        },
    )

    # Extract stream parameter
    is_streaming = data.pop(STREAM_KEY, False)

    # Validate request (handles ResponsesAgentRequest with custom_inputs and context)
    try:
        request_data = self.validator.validate_and_convert_request(data)
    except ValueError as e:
        raise HTTPException(
            status_code=400,
            detail=f"Invalid parameters for {self.agent_type}: {e}",
        )

    # Forward to existing handlers (reuses all validation, tracing, execution logic)
    if is_streaming:
        return await self._handle_stream_request(request_data)
    else:
        return await self._handle_invoke_request(request_data)
```

**Key Points**:
- Directly calls `_handle_invoke_request()` or `_handle_stream_request()` (no HTTP forwarding)
- Reuses all existing validation, tracing, and error handling logic
- `custom_inputs` and `context` are already supported in `ResponsesAgentRequest` (server.py:34-51)
- Response format is already OpenAI-compatible (no transformation needed)
- Same authentication via `set_request_headers()`

### 2. Add `/agent/info` Route

**Location**: In `_setup_routes()` method, after `/responses/create` endpoint (line ~192)

**Implementation**:
```python
@self.app.get("/agent/info")
async def agent_info_endpoint() -> dict[str, Any]:
    # Get app name from environment or use default
    app_name = os.getenv("DATABRICKS_APP_NAME", "mlflow_agent_server")

    # Base info payload
    info = {
        "name": app_name,
        "use_case": "agent",
        "mlflow_version": mlflow.__version__,
    }

    # Conditionally add agent_api field for ResponsesAgent only
    if self.agent_type == "ResponsesAgent":
        info["agent_api"] = "responses"

    return info
```

**Key Points**:
- Returns dict with app metadata (name, use_case, mlflow_version, agent_api)
- Uses `DATABRICKS_APP_NAME` env var if available, defaults to "mlflow_agent_server"
- Only includes `agent_api: "responses"` when `agent_type == "ResponsesAgent"`
- Gets version from `mlflow.__version__`
- No authentication needed (metadata endpoint)

**No new imports required** - all needed modules (`os`, `mlflow`, `typing.Any`) are already imported

## Testing

### Test File: `/Users/bryan.qiu/mlflow/tests/genai/test_agent_server.py`

Add the following test cases:

1. **Test `/responses/create` non-streaming**:
   - Verify request forwarding to `/invocations`
   - Check response format and status code
   - Validate output structure

2. **Test `/responses/create` streaming**:
   - Verify streaming response format (SSE)
   - Check content-type header
   - Validate stream events

3. **Test `/responses/create` with custom_inputs and context**:
   - Verify `custom_inputs` and `context` are passed through
   - Check request validation

4. **Test `/responses/create` validation errors**:
   - Invalid request structure
   - Malformed JSON

5. **Test `/agent/info` with ResponsesAgent**:
   - Verify `agent_api: "responses"` is included
   - Check all required fields present

6. **Test `/agent/info` without ResponsesAgent**:
   - Verify `agent_api` field is NOT included
   - Check other fields still present

7. **Test `/agent/info` with custom app name**:
   - Set `DATABRICKS_APP_NAME` env var
   - Verify custom name is used

**Run tests**:
```bash
uv run pytest /Users/bryan.qiu/mlflow/tests/genai/test_agent_server.py -v
```

## Critical Files

- **Implementation**: `/Users/bryan.qiu/mlflow/mlflow/genai/agent_server/server.py` (lines 156-195)
- **Tests**: `/Users/bryan.qiu/mlflow/tests/genai/test_agent_server.py`
- **Reference - Request types**: `/Users/bryan.qiu/mlflow/mlflow/types/responses.py` (lines 34-51)
- **Reference - Validator**: `/Users/bryan.qiu/mlflow/mlflow/genai/agent_server/validator.py`

## Verification Plan

### 1. Run Tests
```bash
# Run all agent server tests
uv run pytest /Users/bryan.qiu/mlflow/tests/genai/test_agent_server.py -v

# Run code quality checks
uv run ruff format .
uv run ruff check . --fix
```

### 2. Manual Testing (if dev server is available)
```bash
# Test /responses/create non-streaming
curl -X POST http://localhost:5000/responses/create \
  -H "Content-Type: application/json" \
  -d '{"input": [{"role": "user", "content": "Hello"}]}'

# Test /responses/create streaming
curl -X POST http://localhost:5000/responses/create \
  -H "Content-Type: application/json" \
  -d '{"input": [{"role": "user", "content": "Hello"}], "stream": true}'

# Test /responses/create with custom_inputs and context
curl -X POST http://localhost:5000/responses/create \
  -H "Content-Type: application/json" \
  -d '{
    "input": [{"role": "user", "content": "Hello"}],
    "custom_inputs": {"key": "value"},
    "context": {"user_id": "test-user", "conversation_id": "conv-123"}
  }'

# Test /agent/info
curl http://localhost:5000/agent/info
```

### 3. Integration Testing
- Test with actual ResponsesAgent model
- Verify tracing works correctly
- Check authentication headers are propagated

## Route Registration Order

After implementation, routes will be in this order:
1. `/invocations` (existing)
2. `/responses/create` (new)
3. `/agent/info` (new)
4. `/health` (existing)

## Expected Behavior

### `/responses/create` Endpoint:
- **Non-streaming**: Returns JSON dict with `output` and optional `custom_outputs`
- **Streaming**: Returns SSE stream with `text/event-stream` content type
- **Validation**: Returns 400 for invalid requests with descriptive error message
- **Authentication**: Uses same headers as `/invocations` (x-forwarded-access-token, etc.)
- **Tracing**: All requests traced with MLflow spans

### `/agent/info` Endpoint:
- **ResponsesAgent**: Returns `{"name": "<app_name>", "use_case": "agent", "agent_api": "responses", "mlflow_version": "x.y.z"}`
- **Other agents**: Returns `{"name": "<app_name>", "use_case": "agent", "mlflow_version": "x.y.z"}` (no agent_api field)
- **Custom app name**: Uses `DATABRICKS_APP_NAME` env var when available

## Notes

- Both endpoints follow existing patterns in the codebase
- No code duplication - reuses existing handlers and validators
- Maintains consistency with `/invocations` endpoint behavior
- `ResponsesAgentRequest` already supports `custom_inputs` and `context` fields
- Response format is already OpenAI-compatible (no transformation needed)

</details>

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

testing locally with a responsesagent agentserver: 
agent info works:
```bash
curl http://localhost:8000/agent/info | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   103  100   103    0     0  30563      0 --:--:-- --:--:-- --:--:-- 34333
{
  "name": "mlflow_agent_server",
  "use_case": "agent",
  "mlflow_version": "3.8.2.dev0",
  "agent_api": "responses"
}
```

agent is properly invoked and prints out output properly:
```python
import asyncio
from openai import AsyncOpenAI


async def test_responses_streaming():
    """Test the Responses API with streaming against local agent server."""
    # Create OpenAI client pointing to local server
    client = AsyncOpenAI(
        base_url="http://localhost:8000",
        api_key="dummy",  # Local server may not require auth
    )

    # Call responses.create with streaming
    response = await client.responses.create(
        input=[{"role": "user", "content": "What is the 14th Fibonacci number?"}],
        stream=True,
    )

    # Process the stream
    print("Streaming response:")
    print("-" * 50)
    async for chunk in response:
        print(chunk)
        print("-" * 50)


if __name__ == "__main__":
    asyncio.run(test_responses_streaming())
```

testing locally w/ no type agentserver:
```bash
curl http://localhost:8000/agent/info | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    79  100    79    0     0   7840      0 --:--:-- --:--:-- --:--:--  7900
{
  "name": "mlflow_agent_server",
  "use_case": "agent",
  "mlflow_version": "3.8.2.dev0"
}
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
