### PR TITLE
Fix infinite state update loop of NavigableCombobox

### DIFF
--- a/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
+++ b/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
@@ -278,6 +278,11 @@ export function NavigableCombobox<T = string>({
 
   setInputValueRef.current = comboboxState.setInputValue;
 
+  // Sync the input display text when the external `value` prop changes.
+  // This is needed because `initialInputValue` only sets the value on mount,
+  // so we need to update the displayed text when the value is changed externally
+  // (e.g., when the parent resets the form or updates the selection programmatically).
+  // We use a ref for setInputValue to avoid including it in the dependency array.
   const isOpen = comboboxState.isOpen;
   useEffect(() => {
     if (!isOpen) {

--- a/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
+++ b/mlflow/server/js/src/common/components/navigable-combobox/NavigableCombobox.tsx
@@ -278,11 +278,12 @@ export function NavigableCombobox<T = string>({
 
   setInputValueRef.current = comboboxState.setInputValue;
 
+  const isOpen = comboboxState.isOpen;
   useEffect(() => {
-    if (!comboboxState.isOpen) {
-      comboboxState.setInputValue(selectedDisplayName);
+    if (!isOpen) {
+      setInputValueRef.current?.(selectedDisplayName);
     }
-  }, [selectedDisplayName, comboboxState]);
+  }, [selectedDisplayName, isOpen]);
 
   const handleNavigate = useCallback((targetViewId: string, e: React.MouseEvent) => {
     e.preventDefault();


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/19965?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19965/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19965/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19965/merge
```

</p>
</details>

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Fix the following infinite loop error

```
Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render. Error Component Stack
    at NavigableCombobox (NavigableCombobox.tsx:69:1)
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
