### PR TITLE
[Session Grouping][1/9] Add feature flag and placeholder state for testing

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -96,6 +96,7 @@ const RunViewEvaluationsTabInner = ({
   const intl = useIntl();
   const makeHtmlFromMarkdown = useMarkdownConverter();
   const [compareToRunUuid, setCompareToRunUuid] = useCompareToRunUuid();
+  const [isGroupedBySession, setIsGroupedBySession] = useState(false);
 
   const traceLocations = useMemo(() => [createTraceLocationForExperiment(experimentId)], [experimentId]);
   const getTrace = getTraceV3;
@@ -348,6 +349,7 @@ const RunViewEvaluationsTabInner = ({
                 compareToTraceInfoV3={compareToRunData}
                 onTraceTagsEdit={showEditTagsModalForTrace}
                 displayLoadingOverlay={displayLoadingOverlay}
+                isGroupedBySession={isGroupedBySession}
               />
             </ContextProviders>
           )

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -98,6 +98,10 @@ const RunViewEvaluationsTabInner = ({
   const [compareToRunUuid, setCompareToRunUuid] = useCompareToRunUuid();
   const [isGroupedBySession, setIsGroupedBySession] = useState(false);
 
+  const onToggleSessionGrouping = useCallback(() => {
+    setIsGroupedBySession(!isGroupedBySession);
+  }, [isGroupedBySession]);
+
   const traceLocations = useMemo(() => [createTraceLocationForExperiment(experimentId)], [experimentId]);
   const getTrace = getTraceV3;
   const isQueryDisabled = false;
@@ -321,6 +325,8 @@ const RunViewEvaluationsTabInner = ({
               tableFilterOptions={tableFilterOptions}
               onRefresh={showRefreshButton ? refetchMlflowTraces : undefined}
               isRefreshing={showRefreshButton ? traceInfosFetching : undefined}
+              isGroupedBySession={isGroupedBySession}
+              onToggleSessionGrouping={onToggleSessionGrouping}
             />
             {
               // prettier-ignore

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -95,6 +95,10 @@ const TracesV3LogsImpl = React.memo(
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
     useRegisterSelectedIds('selectedTraceIds', rowSelection);
 
+    const onToggleSessionGrouping = useCallback(() => {
+      setIsGroupedBySession(!isGroupedBySession);
+    }, [isGroupedBySession]);
+
     const traceSearchLocations = useMemo(
       () => {
         return [createTraceLocationForExperiment(experimentId)];
@@ -387,6 +391,8 @@ const TracesV3LogsImpl = React.memo(
               metadataError={metadataError}
               usesV4APIs={usesV4APIs}
               addons={toolbarAddons}
+              isGroupedBySession={isGroupedBySession}
+              onToggleSessionGrouping={onToggleSessionGrouping}
             />
             {renderMainContent()}
           </div>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -89,6 +89,7 @@ const TracesV3LogsImpl = React.memo(
     const makeHtmlFromMarkdown = useMarkdownConverter();
     const intl = useIntl();
     const enableTraceInsights = shouldEnableTraceInsights();
+    const [isGroupedBySession, setIsGroupedBySession] = useState(false);
 
     // Row selection state - lifted to provide shared state via context
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -340,6 +341,7 @@ const TracesV3LogsImpl = React.memo(
                   tableSort={tableSort}
                   onTraceTagsEdit={showEditTagsModalForTrace}
                   displayLoadingOverlay={displayLoadingOverlay}
+                  isGroupedBySession={isGroupedBySession}
                 />
               </ContextProviders>
             )}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3980,10 +3980,6 @@
     "defaultMessage": "using Prompt Engineering",
     "description": "String for creating a new run with prompt engineering modal"
   },
-  "Untjzg": {
-    "defaultMessage": "Ungroup sessions",
-    "description": "Label for the ungroup sessions button in the traces table toolbar"
-  },
   "UqGOOx": {
     "defaultMessage": "No API keys created",
     "description": "Empty state title for API keys list"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1918,6 +1918,10 @@
     "defaultMessage": "Tools",
     "description": "Section header in the chat tab that displays all tools that were available for the chat model to call during execution"
   },
+  "Ck9OnH": {
+    "defaultMessage": "Toggle session grouping",
+    "description": "Aria label for the group by session button in the traces table toolbar"
+  },
   "ClYb2e": {
     "defaultMessage": "Count",
     "description": "Label for the count in the tooltip for the numeric aggregate chart."
@@ -3976,6 +3980,10 @@
     "defaultMessage": "using Prompt Engineering",
     "description": "String for creating a new run with prompt engineering modal"
   },
+  "Untjzg": {
+    "defaultMessage": "Ungroup sessions",
+    "description": "Label for the ungroup sessions button in the traces table toolbar"
+  },
   "UqGOOx": {
     "defaultMessage": "No API keys created",
     "description": "Empty state title for API keys list"
@@ -5074,6 +5082,10 @@
   "d4foU0": {
     "defaultMessage": "Learn more about configuring judges",
     "description": "Link text for configuring judges documentation"
+  },
+  "d72zLS": {
+    "defaultMessage": "Toggle session grouping",
+    "description": "Tooltip for the group by session button in the traces table toolbar"
   },
   "d8I3cy": {
     "defaultMessage": "Show only visible",
@@ -7586,6 +7598,10 @@
   "wtpLvY": {
     "defaultMessage": "Load more",
     "description": "Run page > Overview > Child runs load more"
+  },
+  "wuqL/Y": {
+    "defaultMessage": "Group by session",
+    "description": "Label for the group by session button in the traces table toolbar"
   },
   "wusz4l": {
     "defaultMessage": "Input",

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.intg.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.intg.test.tsx
@@ -115,6 +115,7 @@ describe('GenAITracesTableBodyContainer - integration test', () => {
       getRunColor: jest
         .fn<NonNullable<ComponentProps<typeof GenAITracesTableBodyContainer>['getRunColor']>>()
         .mockReturnValue('#000000'),
+      isGroupedBySession: false,
       ...additionalProps,
     };
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.tsx
@@ -57,6 +57,11 @@ interface GenAITracesTableBodyContainerProps {
    * Whether to display a loading overlay over the table
    */
   displayLoadingOverlay?: boolean;
+
+  /**
+   * Whether to group traces by session
+   */
+  isGroupedBySession: boolean;
 }
 
 const GenAITracesTableBodyContainerImpl: React.FC<React.PropsWithChildren<GenAITracesTableBodyContainerProps>> =
@@ -81,6 +86,7 @@ const GenAITracesTableBodyContainerImpl: React.FC<React.PropsWithChildren<GenAIT
       getRunColor,
       enableRowSelection = true,
       displayLoadingOverlay = false,
+      isGroupedBySession,
     } = props;
     const { theme } = useDesignSystemTheme();
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
@@ -10,6 +10,7 @@ import {
   WarningIcon,
   Button,
   RefreshIcon,
+  ToggleButton,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from '@databricks/i18n';
 
@@ -188,27 +189,20 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
                 description: 'Tooltip for the group by session button in the traces table toolbar',
               })}
             >
-              <Button
+              <ToggleButton
                 componentId="mlflow.traces-table.group-by-session-button"
-                onClick={onToggleSessionGrouping}
-                type={isGroupedBySession ? 'primary' : undefined}
+                onPressedChange={onToggleSessionGrouping}
+                pressed={isGroupedBySession}
                 aria-label={intl.formatMessage({
                   defaultMessage: 'Toggle session grouping',
                   description: 'Aria label for the group by session button in the traces table toolbar',
                 })}
               >
-                {isGroupedBySession ? (
-                  <FormattedMessage
-                    defaultMessage="Ungroup sessions"
-                    description="Label for the ungroup sessions button in the traces table toolbar"
-                  />
-                ) : (
-                  <FormattedMessage
-                    defaultMessage="Group by session"
-                    description="Label for the group by session button in the traces table toolbar"
-                  />
-                )}
-              </Button>
+                <FormattedMessage
+                  defaultMessage="Group by session"
+                  description="Label for the group by session button in the traces table toolbar"
+                />
+              </ToggleButton>
             </Tooltip>
           )}
           {onRefresh && (

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
@@ -26,7 +26,7 @@ import type {
   TableFilter,
   TableFilterOptions,
 } from './types';
-import { shouldEnableTagGrouping } from './utils/FeatureUtils';
+import { shouldEnableSessionGrouping, shouldEnableTagGrouping } from './utils/FeatureUtils';
 import type { ModelTraceInfoV3 } from '../model-trace-explorer';
 
 interface CountInfo {
@@ -82,6 +82,10 @@ interface GenAITracesTableToolbarProps {
 
   // Additional elements to render in the toolbar
   addons?: React.ReactNode;
+
+  // Session grouping
+  isGroupedBySession?: boolean;
+  onToggleSessionGrouping?: () => void;
 }
 
 export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITracesTableToolbarProps>> = React.memo(
@@ -110,6 +114,8 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
       onRefresh,
       isRefreshing,
       addons,
+      isGroupedBySession,
+      onToggleSessionGrouping,
     } = props;
     const { theme } = useDesignSystemTheme();
     const intl = useIntl();
@@ -192,6 +198,30 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
                   description: 'Aria label for the refresh traces button in the traces table toolbar',
                 })}
               />
+            </Tooltip>
+          )}
+          {shouldEnableSessionGrouping() && onToggleSessionGrouping && (
+            <Tooltip
+              componentId="mlflow.traces-table.group-by-session-button.tooltip"
+              content={intl.formatMessage({
+                defaultMessage: 'Toggle session grouping',
+                description: 'Tooltip for the group by session button in the traces table toolbar',
+              })}
+            >
+              <Button
+                componentId="mlflow.traces-table.group-by-session-button"
+                onClick={onToggleSessionGrouping}
+                type="primary"
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Toggle session grouping',
+                  description: 'Aria label for the group by session button in the traces table toolbar',
+                })}
+              >
+                {intl.formatMessage({
+                  defaultMessage: 'Group by session',
+                  description: 'Label for the group by session button in the traces table toolbar',
+                })}
+              </Button>
             </Tooltip>
           )}
           {addons}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
@@ -11,7 +11,7 @@ import {
   Button,
   RefreshIcon,
 } from '@databricks/design-system';
-import { useIntl } from '@databricks/i18n';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
 
 import { GenAITracesTableActions } from './GenAITracesTableActions';
 import { GenAiTracesTableFilter } from './GenAiTracesTableFilter';
@@ -180,6 +180,30 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
               // prettier-ignore
             />
           )}
+          {shouldEnableSessionGrouping() && onToggleSessionGrouping && (
+            <Tooltip
+              componentId="mlflow.traces-table.group-by-session-button.tooltip"
+              content={intl.formatMessage({
+                defaultMessage: 'Toggle session grouping',
+                description: 'Tooltip for the group by session button in the traces table toolbar',
+              })}
+            >
+              <Button
+                componentId="mlflow.traces-table.group-by-session-button"
+                onClick={onToggleSessionGrouping}
+                type="primary"
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Toggle session grouping',
+                  description: 'Aria label for the group by session button in the traces table toolbar',
+                })}
+              >
+                <FormattedMessage
+                  defaultMessage="Group by session"
+                  description="Label for the group by session button in the traces table toolbar"
+                />
+              </Button>
+            </Tooltip>
+          )}
           {onRefresh && (
             <Tooltip
               componentId="mlflow.traces-table.refresh-button.tooltip"
@@ -198,30 +222,6 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
                   description: 'Aria label for the refresh traces button in the traces table toolbar',
                 })}
               />
-            </Tooltip>
-          )}
-          {shouldEnableSessionGrouping() && onToggleSessionGrouping && (
-            <Tooltip
-              componentId="mlflow.traces-table.group-by-session-button.tooltip"
-              content={intl.formatMessage({
-                defaultMessage: 'Toggle session grouping',
-                description: 'Tooltip for the group by session button in the traces table toolbar',
-              })}
-            >
-              <Button
-                componentId="mlflow.traces-table.group-by-session-button"
-                onClick={onToggleSessionGrouping}
-                type="primary"
-                aria-label={intl.formatMessage({
-                  defaultMessage: 'Toggle session grouping',
-                  description: 'Aria label for the group by session button in the traces table toolbar',
-                })}
-              >
-                {intl.formatMessage({
-                  defaultMessage: 'Group by session',
-                  description: 'Label for the group by session button in the traces table toolbar',
-                })}
-              </Button>
             </Tooltip>
           )}
           {addons}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
@@ -191,16 +191,23 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
               <Button
                 componentId="mlflow.traces-table.group-by-session-button"
                 onClick={onToggleSessionGrouping}
-                type="primary"
+                type={isGroupedBySession ? 'primary' : undefined}
                 aria-label={intl.formatMessage({
                   defaultMessage: 'Toggle session grouping',
                   description: 'Aria label for the group by session button in the traces table toolbar',
                 })}
               >
-                <FormattedMessage
-                  defaultMessage="Group by session"
-                  description="Label for the group by session button in the traces table toolbar"
-                />
+                {isGroupedBySession ? (
+                  <FormattedMessage
+                    defaultMessage="Ungroup sessions"
+                    description="Label for the ungroup sessions button in the traces table toolbar"
+                  />
+                ) : (
+                  <FormattedMessage
+                    defaultMessage="Group by session"
+                    description="Label for the group by session button in the traces table toolbar"
+                  />
+                )}
               </Button>
             </Tooltip>
           )}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
@@ -31,3 +31,7 @@ export const getEvalTabTotalTracesLimit = () => {
 export const shouldUseTracesV4API = () => {
   return false;
 };
+
+export const shouldEnableSessionGrouping = () => {
+  return false;
+};


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19971/files) to review incremental changes.
- [**stack/session-group-part-1**](https://github.com/mlflow/mlflow/pull/19971) [[Files changed](https://github.com/mlflow/mlflow/pull/19971/files)]
  - [stack/session-group-part-2](https://github.com/mlflow/mlflow/pull/19973) [[Files changed](https://github.com/mlflow/mlflow/pull/19973/files/a85fbe3f7d7429ab0be992494aa32db7a7a6f469..1f18d46beb46dfed05b0900c8df71363e12ce617)]
    - [stack/session-group-part-3](https://github.com/mlflow/mlflow/pull/19974) [[Files changed](https://github.com/mlflow/mlflow/pull/19974/files/1f18d46beb46dfed05b0900c8df71363e12ce617..ea27d53ff5bbcf0f76f3733dc9f29d2e474561b7)]
      - [stack/session-group-part-4](https://github.com/mlflow/mlflow/pull/19975) [[Files changed](https://github.com/mlflow/mlflow/pull/19975/files/ea27d53ff5bbcf0f76f3733dc9f29d2e474561b7..b7ea9538ed09b192667a3c91403ebaf0364003cc)]
        - [stack/session-group-part-5](https://github.com/mlflow/mlflow/pull/19976) [[Files changed](https://github.com/mlflow/mlflow/pull/19976/files/b7ea9538ed09b192667a3c91403ebaf0364003cc..b80273a2ab962350a9e49249c6ab5dc94952d522)]
          - [stack/session-group-part-6](https://github.com/mlflow/mlflow/pull/19998) [[Files changed](https://github.com/mlflow/mlflow/pull/19998/files/b80273a2ab962350a9e49249c6ab5dc94952d522..b0887b6d5ac34ea62802d4c8b64d543b587ac942)]
            - [stack/session-group-part-7](https://github.com/mlflow/mlflow/pull/19999) [[Files changed](https://github.com/mlflow/mlflow/pull/19999/files/b0887b6d5ac34ea62802d4c8b64d543b587ac942..386c6a27f9a79f10a7117396bb3336fc02ba8480)]
              - [stack/session-group-part-8](https://github.com/mlflow/mlflow/pull/20009) [[Files changed](https://github.com/mlflow/mlflow/pull/20009/files/386c6a27f9a79f10a7117396bb3336fc02ba8480..544d49fef5b3e23b5baa516d20c665dd11077ea0)]
                - [stack/session-group-part-9](https://github.com/mlflow/mlflow/pull/20010) [[Files changed](https://github.com/mlflow/mlflow/pull/20010/files/544d49fef5b3e23b5baa516d20c665dd11077ea0..1295b23a61b1b9d040d38c5f46ab7361fcc5a9b8)]
                  - stack/session-group-part-10

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

#### Stack context

This stack implements an alternate grouped view of `GenAITracesTable`, which allows for grouping by session.

The grouped session rows are expandable to show/hide the session's contained traces, and the session rows display aggregations of the trace assessments.

This is a fairly large change, but we are mainly just forking the row component so we don't affect the main render path much when grouping is turned off.

#### PR Context

This PR adds some placeholder state and a button for testing. It does not currently do anything.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Might not be the way the final button looks (also may not be included in the trace tab):

https://github.com/user-attachments/assets/b9410cbb-3d75-4c7a-9437-356188400c5b



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
