### PR TITLE
[Session Grouping][2/9] Add util to group trace data by session

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -96,6 +96,7 @@ const RunViewEvaluationsTabInner = ({
   const intl = useIntl();
   const makeHtmlFromMarkdown = useMarkdownConverter();
   const [compareToRunUuid, setCompareToRunUuid] = useCompareToRunUuid();
+  const [isGroupedBySession, setIsGroupedBySession] = useState(false);
 
   const traceLocations = useMemo(() => [createTraceLocationForExperiment(experimentId)], [experimentId]);
   const getTrace = getTraceV3;
@@ -348,6 +349,7 @@ const RunViewEvaluationsTabInner = ({
                 compareToTraceInfoV3={compareToRunData}
                 onTraceTagsEdit={showEditTagsModalForTrace}
                 displayLoadingOverlay={displayLoadingOverlay}
+                isGroupedBySession={isGroupedBySession}
               />
             </ContextProviders>
           )

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -98,6 +98,10 @@ const RunViewEvaluationsTabInner = ({
   const [compareToRunUuid, setCompareToRunUuid] = useCompareToRunUuid();
   const [isGroupedBySession, setIsGroupedBySession] = useState(false);
 
+  const onToggleSessionGrouping = useCallback(() => {
+    setIsGroupedBySession(!isGroupedBySession);
+  }, [isGroupedBySession]);
+
   const traceLocations = useMemo(() => [createTraceLocationForExperiment(experimentId)], [experimentId]);
   const getTrace = getTraceV3;
   const isQueryDisabled = false;
@@ -321,6 +325,8 @@ const RunViewEvaluationsTabInner = ({
               tableFilterOptions={tableFilterOptions}
               onRefresh={showRefreshButton ? refetchMlflowTraces : undefined}
               isRefreshing={showRefreshButton ? traceInfosFetching : undefined}
+              isGroupedBySession={isGroupedBySession}
+              onToggleSessionGrouping={onToggleSessionGrouping}
             />
             {
               // prettier-ignore

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -95,6 +95,10 @@ const TracesV3LogsImpl = React.memo(
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
     useRegisterSelectedIds('selectedTraceIds', rowSelection);
 
+    const onToggleSessionGrouping = useCallback(() => {
+      setIsGroupedBySession(!isGroupedBySession);
+    }, [isGroupedBySession]);
+
     const traceSearchLocations = useMemo(
       () => {
         return [createTraceLocationForExperiment(experimentId)];
@@ -387,6 +391,8 @@ const TracesV3LogsImpl = React.memo(
               metadataError={metadataError}
               usesV4APIs={usesV4APIs}
               addons={toolbarAddons}
+              isGroupedBySession={isGroupedBySession}
+              onToggleSessionGrouping={onToggleSessionGrouping}
             />
             {renderMainContent()}
           </div>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -89,6 +89,7 @@ const TracesV3LogsImpl = React.memo(
     const makeHtmlFromMarkdown = useMarkdownConverter();
     const intl = useIntl();
     const enableTraceInsights = shouldEnableTraceInsights();
+    const [isGroupedBySession, setIsGroupedBySession] = useState(false);
 
     // Row selection state - lifted to provide shared state via context
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -340,6 +341,7 @@ const TracesV3LogsImpl = React.memo(
                   tableSort={tableSort}
                   onTraceTagsEdit={showEditTagsModalForTrace}
                   displayLoadingOverlay={displayLoadingOverlay}
+                  isGroupedBySession={isGroupedBySession}
                 />
               </ContextProviders>
             )}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3980,10 +3980,6 @@
     "defaultMessage": "using Prompt Engineering",
     "description": "String for creating a new run with prompt engineering modal"
   },
-  "Untjzg": {
-    "defaultMessage": "Ungroup sessions",
-    "description": "Label for the ungroup sessions button in the traces table toolbar"
-  },
   "UqGOOx": {
     "defaultMessage": "No API keys created",
     "description": "Empty state title for API keys list"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1918,6 +1918,10 @@
     "defaultMessage": "Tools",
     "description": "Section header in the chat tab that displays all tools that were available for the chat model to call during execution"
   },
+  "Ck9OnH": {
+    "defaultMessage": "Toggle session grouping",
+    "description": "Aria label for the group by session button in the traces table toolbar"
+  },
   "ClYb2e": {
     "defaultMessage": "Count",
     "description": "Label for the count in the tooltip for the numeric aggregate chart."
@@ -3976,6 +3980,10 @@
     "defaultMessage": "using Prompt Engineering",
     "description": "String for creating a new run with prompt engineering modal"
   },
+  "Untjzg": {
+    "defaultMessage": "Ungroup sessions",
+    "description": "Label for the ungroup sessions button in the traces table toolbar"
+  },
   "UqGOOx": {
     "defaultMessage": "No API keys created",
     "description": "Empty state title for API keys list"
@@ -5074,6 +5082,10 @@
   "d4foU0": {
     "defaultMessage": "Learn more about configuring judges",
     "description": "Link text for configuring judges documentation"
+  },
+  "d72zLS": {
+    "defaultMessage": "Toggle session grouping",
+    "description": "Tooltip for the group by session button in the traces table toolbar"
   },
   "d8I3cy": {
     "defaultMessage": "Show only visible",
@@ -7586,6 +7598,10 @@
   "wtpLvY": {
     "defaultMessage": "Load more",
     "description": "Run page > Overview > Child runs load more"
+  },
+  "wuqL/Y": {
+    "defaultMessage": "Group by session",
+    "description": "Label for the group by session button in the traces table toolbar"
   },
   "wusz4l": {
     "defaultMessage": "Input",

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.intg.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.intg.test.tsx
@@ -115,6 +115,7 @@ describe('GenAITracesTableBodyContainer - integration test', () => {
       getRunColor: jest
         .fn<NonNullable<ComponentProps<typeof GenAITracesTableBodyContainer>['getRunColor']>>()
         .mockReturnValue('#000000'),
+      isGroupedBySession: false,
       ...additionalProps,
     };
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableBodyContainer.tsx
@@ -57,6 +57,11 @@ interface GenAITracesTableBodyContainerProps {
    * Whether to display a loading overlay over the table
    */
   displayLoadingOverlay?: boolean;
+
+  /**
+   * Whether to group traces by session
+   */
+  isGroupedBySession: boolean;
 }
 
 const GenAITracesTableBodyContainerImpl: React.FC<React.PropsWithChildren<GenAITracesTableBodyContainerProps>> =
@@ -81,6 +86,7 @@ const GenAITracesTableBodyContainerImpl: React.FC<React.PropsWithChildren<GenAIT
       getRunColor,
       enableRowSelection = true,
       displayLoadingOverlay = false,
+      isGroupedBySession,
     } = props;
     const { theme } = useDesignSystemTheme();
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
@@ -10,6 +10,7 @@ import {
   WarningIcon,
   Button,
   RefreshIcon,
+  ToggleButton,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from '@databricks/i18n';
 
@@ -188,27 +189,20 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
                 description: 'Tooltip for the group by session button in the traces table toolbar',
               })}
             >
-              <Button
+              <ToggleButton
                 componentId="mlflow.traces-table.group-by-session-button"
-                onClick={onToggleSessionGrouping}
-                type={isGroupedBySession ? 'primary' : undefined}
+                onPressedChange={onToggleSessionGrouping}
+                pressed={isGroupedBySession}
                 aria-label={intl.formatMessage({
                   defaultMessage: 'Toggle session grouping',
                   description: 'Aria label for the group by session button in the traces table toolbar',
                 })}
               >
-                {isGroupedBySession ? (
-                  <FormattedMessage
-                    defaultMessage="Ungroup sessions"
-                    description="Label for the ungroup sessions button in the traces table toolbar"
-                  />
-                ) : (
-                  <FormattedMessage
-                    defaultMessage="Group by session"
-                    description="Label for the group by session button in the traces table toolbar"
-                  />
-                )}
-              </Button>
+                <FormattedMessage
+                  defaultMessage="Group by session"
+                  description="Label for the group by session button in the traces table toolbar"
+                />
+              </ToggleButton>
             </Tooltip>
           )}
           {onRefresh && (

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
@@ -26,7 +26,7 @@ import type {
   TableFilter,
   TableFilterOptions,
 } from './types';
-import { shouldEnableTagGrouping } from './utils/FeatureUtils';
+import { shouldEnableSessionGrouping, shouldEnableTagGrouping } from './utils/FeatureUtils';
 import type { ModelTraceInfoV3 } from '../model-trace-explorer';
 
 interface CountInfo {
@@ -82,6 +82,10 @@ interface GenAITracesTableToolbarProps {
 
   // Additional elements to render in the toolbar
   addons?: React.ReactNode;
+
+  // Session grouping
+  isGroupedBySession?: boolean;
+  onToggleSessionGrouping?: () => void;
 }
 
 export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITracesTableToolbarProps>> = React.memo(
@@ -110,6 +114,8 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
       onRefresh,
       isRefreshing,
       addons,
+      isGroupedBySession,
+      onToggleSessionGrouping,
     } = props;
     const { theme } = useDesignSystemTheme();
     const intl = useIntl();
@@ -192,6 +198,30 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
                   description: 'Aria label for the refresh traces button in the traces table toolbar',
                 })}
               />
+            </Tooltip>
+          )}
+          {shouldEnableSessionGrouping() && onToggleSessionGrouping && (
+            <Tooltip
+              componentId="mlflow.traces-table.group-by-session-button.tooltip"
+              content={intl.formatMessage({
+                defaultMessage: 'Toggle session grouping',
+                description: 'Tooltip for the group by session button in the traces table toolbar',
+              })}
+            >
+              <Button
+                componentId="mlflow.traces-table.group-by-session-button"
+                onClick={onToggleSessionGrouping}
+                type="primary"
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Toggle session grouping',
+                  description: 'Aria label for the group by session button in the traces table toolbar',
+                })}
+              >
+                {intl.formatMessage({
+                  defaultMessage: 'Group by session',
+                  description: 'Label for the group by session button in the traces table toolbar',
+                })}
+              </Button>
             </Tooltip>
           )}
           {addons}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
@@ -11,7 +11,7 @@ import {
   Button,
   RefreshIcon,
 } from '@databricks/design-system';
-import { useIntl } from '@databricks/i18n';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
 
 import { GenAITracesTableActions } from './GenAITracesTableActions';
 import { GenAiTracesTableFilter } from './GenAiTracesTableFilter';
@@ -180,6 +180,30 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
               // prettier-ignore
             />
           )}
+          {shouldEnableSessionGrouping() && onToggleSessionGrouping && (
+            <Tooltip
+              componentId="mlflow.traces-table.group-by-session-button.tooltip"
+              content={intl.formatMessage({
+                defaultMessage: 'Toggle session grouping',
+                description: 'Tooltip for the group by session button in the traces table toolbar',
+              })}
+            >
+              <Button
+                componentId="mlflow.traces-table.group-by-session-button"
+                onClick={onToggleSessionGrouping}
+                type="primary"
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Toggle session grouping',
+                  description: 'Aria label for the group by session button in the traces table toolbar',
+                })}
+              >
+                <FormattedMessage
+                  defaultMessage="Group by session"
+                  description="Label for the group by session button in the traces table toolbar"
+                />
+              </Button>
+            </Tooltip>
+          )}
           {onRefresh && (
             <Tooltip
               componentId="mlflow.traces-table.refresh-button.tooltip"
@@ -198,30 +222,6 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
                   description: 'Aria label for the refresh traces button in the traces table toolbar',
                 })}
               />
-            </Tooltip>
-          )}
-          {shouldEnableSessionGrouping() && onToggleSessionGrouping && (
-            <Tooltip
-              componentId="mlflow.traces-table.group-by-session-button.tooltip"
-              content={intl.formatMessage({
-                defaultMessage: 'Toggle session grouping',
-                description: 'Tooltip for the group by session button in the traces table toolbar',
-              })}
-            >
-              <Button
-                componentId="mlflow.traces-table.group-by-session-button"
-                onClick={onToggleSessionGrouping}
-                type="primary"
-                aria-label={intl.formatMessage({
-                  defaultMessage: 'Toggle session grouping',
-                  description: 'Aria label for the group by session button in the traces table toolbar',
-                })}
-              >
-                {intl.formatMessage({
-                  defaultMessage: 'Group by session',
-                  description: 'Label for the group by session button in the traces table toolbar',
-                })}
-              </Button>
             </Tooltip>
           )}
           {addons}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
@@ -191,16 +191,23 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
               <Button
                 componentId="mlflow.traces-table.group-by-session-button"
                 onClick={onToggleSessionGrouping}
-                type="primary"
+                type={isGroupedBySession ? 'primary' : undefined}
                 aria-label={intl.formatMessage({
                   defaultMessage: 'Toggle session grouping',
                   description: 'Aria label for the group by session button in the traces table toolbar',
                 })}
               >
-                <FormattedMessage
-                  defaultMessage="Group by session"
-                  description="Label for the group by session button in the traces table toolbar"
-                />
+                {isGroupedBySession ? (
+                  <FormattedMessage
+                    defaultMessage="Ungroup sessions"
+                    description="Label for the ungroup sessions button in the traces table toolbar"
+                  />
+                ) : (
+                  <FormattedMessage
+                    defaultMessage="Group by session"
+                    description="Label for the group by session button in the traces table toolbar"
+                  />
+                )}
               </Button>
             </Tooltip>
           )}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
@@ -31,3 +31,7 @@ export const getEvalTabTotalTracesLimit = () => {
 export const shouldUseTracesV4API = () => {
   return false;
 };
+
+export const shouldEnableSessionGrouping = () => {
+  return false;
+};

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { SESSION_ID_METADATA_KEY, type ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
+
+import type { EvalTraceComparisonEntry } from '../types';
+import { groupTracesBySessionForTable } from './SessionGroupingUtils';
+
+const createMockTraceInfo = (traceId: string, sessionId: string | null, requestTime: string): ModelTraceInfoV3 => ({
+  trace_id: traceId,
+  trace_location: { type: 'MLFLOW_EXPERIMENT', mlflow_experiment: { experiment_id: 'exp-1' } },
+  request_time: requestTime,
+  state: 'OK',
+  tags: {},
+  trace_metadata: sessionId ? { [SESSION_ID_METADATA_KEY]: sessionId } : undefined,
+});
+
+const createMockEntry = (traceId: string, sessionId: string | null, requestTime: string): EvalTraceComparisonEntry => ({
+  currentRunValue: {
+    evaluationId: `eval-${traceId}`,
+    requestId: `req-${traceId}`,
+    inputs: {},
+    inputsId: `inputs-${traceId}`,
+    outputs: {},
+    targets: {},
+    overallAssessments: [],
+    responseAssessmentsByName: {},
+    metrics: {},
+    traceInfo: createMockTraceInfo(traceId, sessionId, requestTime),
+  },
+});
+
+describe('groupTracesBySessionForTable', () => {
+  it('groups traces by session and adds session headers', () => {
+    const entries: EvalTraceComparisonEntry[] = [
+      createMockEntry('trace-1', 'session-A', '2025-01-01T10:00:00.000Z'),
+      createMockEntry('trace-2', 'session-A', '2025-01-01T11:00:00.000Z'),
+      createMockEntry('trace-3', 'session-B', '2025-01-01T09:00:00.000Z'),
+    ];
+
+    const result = groupTracesBySessionForTable(entries);
+
+    // Should have 2 session headers + 3 trace rows = 5 items
+    expect(result).toHaveLength(5);
+
+    // First session header
+    expect(result[0]).toMatchObject({ type: 'sessionHeader', sessionId: 'session-A' });
+    // Then trace rows for session A
+    expect(result[1]).toMatchObject({ type: 'trace' });
+    expect(result[2]).toMatchObject({ type: 'trace' });
+
+    // Second session header
+    expect(result[3]).toMatchObject({ type: 'sessionHeader', sessionId: 'session-B' });
+    // Then trace row for session B
+    expect(result[4]).toMatchObject({ type: 'trace' });
+  });
+
+  it('sorts traces within a session by request time ascending', () => {
+    const entries: EvalTraceComparisonEntry[] = [
+      createMockEntry('trace-late', 'session-A', '2025-01-01T15:00:00.000Z'),
+      createMockEntry('trace-early', 'session-A', '2025-01-01T09:00:00.000Z'),
+      createMockEntry('trace-middle', 'session-A', '2025-01-01T12:00:00.000Z'),
+    ];
+
+    const result = groupTracesBySessionForTable(entries);
+
+    // Should have 1 session header + 3 trace rows = 4 items
+    expect(result).toHaveLength(4);
+    expect(result[0]).toMatchObject({ type: 'sessionHeader', sessionId: 'session-A' });
+
+    // Verify traces are sorted by request time ascending
+    const traceRows = result.filter(
+      (row): row is { type: 'trace'; data: EvalTraceComparisonEntry } => row.type === 'trace',
+    );
+    expect(traceRows[0].data.currentRunValue?.traceInfo?.trace_id).toBe('trace-early');
+    expect(traceRows[1].data.currentRunValue?.traceInfo?.trace_id).toBe('trace-middle');
+    expect(traceRows[2].data.currentRunValue?.traceInfo?.trace_id).toBe('trace-late');
+  });
+
+  it('places standalone traces (without session ID) at the end', () => {
+    const entries: EvalTraceComparisonEntry[] = [
+      createMockEntry('trace-standalone-1', null, '2025-01-01T08:00:00.000Z'),
+      createMockEntry('trace-session', 'session-A', '2025-01-01T10:00:00.000Z'),
+      createMockEntry('trace-standalone-2', null, '2025-01-01T12:00:00.000Z'),
+    ];
+
+    const result = groupTracesBySessionForTable(entries);
+
+    // Should have 1 session header + 1 session trace + 2 standalone traces = 4 items
+    expect(result).toHaveLength(4);
+
+    // Session content first
+    expect(result[0]).toMatchObject({ type: 'sessionHeader', sessionId: 'session-A' });
+    expect(result[1]).toMatchObject({ type: 'trace' });
+    if (result[1].type === 'trace') {
+      expect(result[1].data.currentRunValue?.traceInfo?.trace_id).toBe('trace-session');
+    }
+
+    // Standalone traces at the end
+    expect(result[2]).toMatchObject({ type: 'trace' });
+    if (result[2].type === 'trace') {
+      expect(result[2].data.currentRunValue?.traceInfo?.trace_id).toBe('trace-standalone-1');
+    }
+    expect(result[3]).toMatchObject({ type: 'trace' });
+    if (result[3].type === 'trace') {
+      expect(result[3].data.currentRunValue?.traceInfo?.trace_id).toBe('trace-standalone-2');
+    }
+  });
+
+  it('returns empty array for empty input', () => {
+    const result = groupTracesBySessionForTable([]);
+    expect(result).toEqual([]);
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.ts
@@ -70,6 +70,13 @@ export const groupTracesBySessionForTable = (
       return;
     }
 
+    // Sort entries by request time ascending within the session (first turn to last turn)
+    sessionEntries.sort((a, b) => {
+      const aTime = a.currentRunValue?.traceInfo?.request_time ?? '';
+      const bTime = b.currentRunValue?.traceInfo?.request_time ?? '';
+      return aTime.localeCompare(bTime);
+    });
+
     // Collect all traces for the session header
     const traces = collectTracesFromEntries(sessionEntries);
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.ts
@@ -36,12 +36,16 @@ const collectTracesFromEntries = (entries: EvalTraceComparisonEntry[]): ModelTra
  * Groups traces by session for display in a table.
  * Returns a flattened array where each session is represented by:
  * 1. A sessionHeader row containing all traces in that session
- * 2. Individual trace rows for each trace in the session
+ * 2. Individual trace rows for each trace in the session (only if session is expanded)
  *
  * Traces without a session ID are appended at the end as standalone trace rows.
+ *
+ * @param currentEvaluationResults - The evaluation entries to group
+ * @param expandedSessions - Set of session IDs that are expanded (show trace rows)
  */
 export const groupTracesBySessionForTable = (
   currentEvaluationResults: EvalTraceComparisonEntry[],
+  expandedSessions: Set<string>,
 ): GroupedTraceTableRowData[] => {
   const sessionMap: Record<string, EvalTraceComparisonEntry[]> = {};
   const standaloneEntries: EvalTraceComparisonEntry[] = [];
@@ -64,7 +68,7 @@ export const groupTracesBySessionForTable = (
 
   const result: GroupedTraceTableRowData[] = [];
 
-  // Process each session: add header followed by trace rows
+  // Process each session: add header followed by trace rows (if expanded)
   Object.entries(sessionMap).forEach(([sessionId, sessionEntries]) => {
     if (sessionEntries.length === 0) {
       return;
@@ -87,13 +91,15 @@ export const groupTracesBySessionForTable = (
       traces,
     });
 
-    // Add individual trace rows
-    sessionEntries.forEach((entry) => {
-      result.push({
-        type: 'trace',
-        data: entry,
+    // Add individual trace rows only if session is expanded
+    if (expandedSessions.has(sessionId)) {
+      sessionEntries.forEach((entry) => {
+        result.push({
+          type: 'trace',
+          data: entry,
+        });
       });
-    });
+    }
   });
 
   // Add standalone traces at the end

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.ts
@@ -1,0 +1,101 @@
+import { compact } from 'lodash';
+
+import { SESSION_ID_METADATA_KEY, type ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
+
+import type { EvalTraceComparisonEntry } from '../types';
+
+export type GroupedTraceTableRowData =
+  | { type: 'trace'; data: EvalTraceComparisonEntry }
+  | { type: 'sessionHeader'; sessionId: string; traces: ModelTraceInfoV3[] };
+
+/**
+ * Extract session ID from a ModelTraceInfoV3.
+ */
+const getSessionIdFromTrace = (trace: ModelTraceInfoV3): string | null => {
+  return trace.trace_metadata?.[SESSION_ID_METADATA_KEY] ?? null;
+};
+
+/**
+ * Collect all ModelTraceInfoV3 objects from a list of entries (currentRunValue only).
+ */
+const collectTracesFromEntries = (entries: EvalTraceComparisonEntry[]): ModelTraceInfoV3[] => {
+  const traces: ModelTraceInfoV3[] = [];
+
+  // for now, only checks the current run as the compare flow
+  // will soon be refactored entirely to a different component.
+  entries.forEach((entry) => {
+    if (entry.currentRunValue?.traceInfo) {
+      traces.push(entry.currentRunValue.traceInfo);
+    }
+  });
+
+  return compact(traces);
+};
+
+/**
+ * Groups traces by session for display in a table.
+ * Returns a flattened array where each session is represented by:
+ * 1. A sessionHeader row containing all traces in that session
+ * 2. Individual trace rows for each trace in the session
+ *
+ * Traces without a session ID are appended at the end as standalone trace rows.
+ */
+export const groupTracesBySessionForTable = (
+  currentEvaluationResults: EvalTraceComparisonEntry[],
+): GroupedTraceTableRowData[] => {
+  const sessionMap: Record<string, EvalTraceComparisonEntry[]> = {};
+  const standaloneEntries: EvalTraceComparisonEntry[] = [];
+
+  // Group entries by session ID
+  currentEvaluationResults.forEach((entry) => {
+    const traceInfo = entry.currentRunValue?.traceInfo;
+    if (!traceInfo) {
+      return;
+    }
+
+    const sessionId = getSessionIdFromTrace(traceInfo);
+    if (sessionId) {
+      const sessionEntries = sessionMap[sessionId] ?? [];
+      sessionMap[sessionId] = [...sessionEntries, entry];
+    } else {
+      standaloneEntries.push(entry);
+    }
+  });
+
+  const result: GroupedTraceTableRowData[] = [];
+
+  // Process each session: add header followed by trace rows
+  Object.entries(sessionMap).forEach(([sessionId, sessionEntries]) => {
+    if (sessionEntries.length === 0) {
+      return;
+    }
+
+    // Collect all traces for the session header
+    const traces = collectTracesFromEntries(sessionEntries);
+
+    // Add session header
+    result.push({
+      type: 'sessionHeader',
+      sessionId,
+      traces,
+    });
+
+    // Add individual trace rows
+    sessionEntries.forEach((entry) => {
+      result.push({
+        type: 'trace',
+        data: entry,
+      });
+    });
+  });
+
+  // Add standalone traces at the end
+  standaloneEntries.forEach((entry) => {
+    result.push({
+      type: 'trace',
+      data: entry,
+    });
+  });
+
+  return result;
+};


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19973/files/a85fbe3f7d7429ab0be992494aa32db7a7a6f469..1f18d46beb46dfed05b0900c8df71363e12ce617) to review incremental changes.
- [stack/session-group-part-1](https://github.com/mlflow/mlflow/pull/19971) [[Files changed](https://github.com/mlflow/mlflow/pull/19971/files)]
  - [**stack/session-group-part-2**](https://github.com/mlflow/mlflow/pull/19973) [[Files changed](https://github.com/mlflow/mlflow/pull/19973/files/a85fbe3f7d7429ab0be992494aa32db7a7a6f469..1f18d46beb46dfed05b0900c8df71363e12ce617)]
    - [stack/session-group-part-3](https://github.com/mlflow/mlflow/pull/19974) [[Files changed](https://github.com/mlflow/mlflow/pull/19974/files/1f18d46beb46dfed05b0900c8df71363e12ce617..ea27d53ff5bbcf0f76f3733dc9f29d2e474561b7)]
      - [stack/session-group-part-4](https://github.com/mlflow/mlflow/pull/19975) [[Files changed](https://github.com/mlflow/mlflow/pull/19975/files/ea27d53ff5bbcf0f76f3733dc9f29d2e474561b7..b7ea9538ed09b192667a3c91403ebaf0364003cc)]
        - [stack/session-group-part-5](https://github.com/mlflow/mlflow/pull/19976) [[Files changed](https://github.com/mlflow/mlflow/pull/19976/files/b7ea9538ed09b192667a3c91403ebaf0364003cc..b80273a2ab962350a9e49249c6ab5dc94952d522)]
          - [stack/session-group-part-6](https://github.com/mlflow/mlflow/pull/19998) [[Files changed](https://github.com/mlflow/mlflow/pull/19998/files/b80273a2ab962350a9e49249c6ab5dc94952d522..b0887b6d5ac34ea62802d4c8b64d543b587ac942)]
            - [stack/session-group-part-7](https://github.com/mlflow/mlflow/pull/19999) [[Files changed](https://github.com/mlflow/mlflow/pull/19999/files/b0887b6d5ac34ea62802d4c8b64d543b587ac942..386c6a27f9a79f10a7117396bb3336fc02ba8480)]
              - [stack/session-group-part-8](https://github.com/mlflow/mlflow/pull/20009) [[Files changed](https://github.com/mlflow/mlflow/pull/20009/files/386c6a27f9a79f10a7117396bb3336fc02ba8480..544d49fef5b3e23b5baa516d20c665dd11077ea0)]
                - [stack/session-group-part-9](https://github.com/mlflow/mlflow/pull/20010) [[Files changed](https://github.com/mlflow/mlflow/pull/20010/files/544d49fef5b3e23b5baa516d20c665dd11077ea0..1295b23a61b1b9d040d38c5f46ab7361fcc5a9b8)]
                  - stack/session-group-part-10

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

#### Stack context

This stack implements an alternate grouped view of `GenAITracesTable`, which allows for grouping by session.

The grouped session rows are expandable to show/hide the session's contained traces, and the session rows display aggregations of the trace assessments.

This is a fairly large change, but we are mainly just forking the row component so we don't affect the main render path much when grouping is turned off.

#### PR Context

This PR adds the util to group trace data rows by session ID. The util is not yet used but the idea is:

1. Introduce a "session header row" type which will be rendered via a separate renderer.
2. Underneath these new rows, we simply append the trace table data for the traces in that session. This data will be rendered via the existing renderer so the current render path will be as untouched as possible.



### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Util is not used in this PR but the rendered data looks like this:

https://github.com/user-attachments/assets/c1df2dc8-63dd-49b1-b726-f82313858b5a


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
