### PR TITLE
[Session Grouping][4/9] Initial renderers for simple columns

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -433,7 +433,8 @@ export const GenAiTracesTableBody = React.memo(
                 virtualizerTotalSize={virtualizerTotalSize}
                 virtualizerMeasureElement={rowVirtualizer.measureElement}
                 rowSelectionState={rowSelection}
-                selectedColumns={selectedColumns}
+                selectedColumns={sortedGroupedColumns}
+                expandedSessions={expandedSessions}
                 toggleSessionExpanded={toggleSessionExpanded}
                 experimentId={experimentId}
               />

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -130,6 +130,11 @@ export const GenAiTracesTableBody = React.memo(
 
     const evaluationInputs = selectedColumns.filter((col) => col.type === TracesTableColumnType.INPUT);
 
+    const sortedGroupedColumns = useMemo(
+      () => sortGroupedColumns(selectedColumns, isComparing),
+      [selectedColumns, isComparing],
+    );
+
     const { columns } = useMemo(() => {
       if (!enableGrouping) {
         // Return flat columns without grouping
@@ -150,7 +155,6 @@ export const GenAiTracesTableBody = React.memo(
 
       // Create a map of group IDs to their column arrays
       const groupColumns = new Map<TracesTableColumnGroup, ColumnDef<EvalTraceComparisonEntry>[]>();
-      const sortedGroupedColumns = sortGroupedColumns(selectedColumns, isComparing);
 
       sortedGroupedColumns.forEach((col) => {
         // Get the group for this column, defaulting to 'Info' if not specified
@@ -192,6 +196,7 @@ export const GenAiTracesTableBody = React.memo(
 
       return { columns: topLevelColumns };
     }, [
+      sortedGroupedColumns,
       selectedColumns,
       evaluationInputs,
       isComparing,

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -427,6 +427,7 @@ export const GenAiTracesTableBody = React.memo(
                 virtualItems={virtualItems}
                 virtualizerTotalSize={virtualizerTotalSize}
                 virtualizerMeasureElement={rowVirtualizer.measureElement}
+                rowSelectionState={rowSelection}
                 selectedColumns={selectedColumns}
                 toggleSessionExpanded={toggleSessionExpanded}
                 experimentId={experimentId}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -427,9 +427,9 @@ export const GenAiTracesTableBody = React.memo(
                 virtualItems={virtualItems}
                 virtualizerTotalSize={virtualizerTotalSize}
                 virtualizerMeasureElement={rowVirtualizer.measureElement}
-                rowSelectionState={rowSelection}
                 selectedColumns={selectedColumns}
                 toggleSessionExpanded={toggleSessionExpanded}
+                experimentId={experimentId}
               />
             ) : (
               <MemoizedGenAiTracesTableBodyRows

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -128,7 +128,10 @@ export const GenAiTracesTableBody = React.memo(
 
     const isComparing = !isNil(compareToRunUuid);
 
-    const evaluationInputs = selectedColumns.filter((col) => col.type === TracesTableColumnType.INPUT);
+    const evaluationInputs = useMemo(
+      () => selectedColumns.filter((col) => col.type === TracesTableColumnType.INPUT),
+      [selectedColumns],
+    );
 
     const sortedGroupedColumns = useMemo(
       () => sortGroupedColumns(selectedColumns, isComparing),

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
@@ -28,7 +28,7 @@ interface SessionHeaderRowProps {
   sessionId: string;
   traceCount: number;
   traces: any[];
-  visibleColumns: TracesTableColumn[];
+  selectedColumns: TracesTableColumn[];
   enableRowSelection?: boolean;
   sessionRows: Row<EvalTraceComparisonEntry>[];
   isComparing: boolean;
@@ -56,19 +56,6 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
       map.set(row.original, row);
     });
     return map;
-  }, [rows]);
-
-  // Get visible columns from the first row to match table rendering
-  const visibleColumns = useMemo(() => {
-    if (rows.length === 0) return [];
-    const firstRow = rows[0];
-    const cells = firstRow.getVisibleCells();
-    return cells.map((cell) => ({
-      id: cell.column.id,
-      label: cell.column.columnDef.header as string,
-      type: (cell.column.columnDef.meta as any)?.type,
-      group: (cell.column.columnDef.meta as any)?.group,
-    })) as TracesTableColumn[];
   }, [rows]);
 
   return (
@@ -104,7 +91,7 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
                 sessionId={groupedRow.sessionId}
                 traceCount={groupedRow.traces.length}
                 traces={groupedRow.traces}
-                visibleColumns={visibleColumns}
+                selectedColumns={selectedColumns}
                 enableRowSelection={enableRowSelection}
                 sessionRows={rows.filter((row) => {
                   // Filter rows that belong to this session
@@ -159,7 +146,7 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
 const SessionHeaderRow = React.memo(function SessionHeaderRow({
   sessionId,
   traces,
-  visibleColumns,
+  selectedColumns,
   enableRowSelection,
   sessionRows,
   isComparing,
@@ -209,7 +196,7 @@ const SessionHeaderRow = React.memo(function SessionHeaderRow({
         </div>
       )}
       {/* Render a cell for each visible column from the table */}
-      {visibleColumns.map((column) => (
+      {selectedColumns.map((column) => (
         <SessionHeaderCell
           key={column.id}
           column={column}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
@@ -1,9 +1,11 @@
 import type { Row, RowSelectionState } from '@tanstack/react-table';
 import type { VirtualItem } from '@tanstack/react-virtual';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
-import { TableCell, TableRow, useDesignSystemTheme } from '@databricks/design-system';
+import { Checkbox, TableCell, TableRow, TableRowSelectCell, useDesignSystemTheme } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
 
+import { SessionHeaderCell } from './cellRenderers/SessionHeaderCellRenderers';
 import { GenAiTracesTableBodyRow } from './GenAiTracesTableBodyRows';
 import type { TracesTableColumn, EvalTraceComparisonEntry } from './types';
 import type { GroupedTraceTableRowData } from './utils/SessionGroupingUtils';
@@ -19,6 +21,18 @@ interface GenAiTracesTableSessionGroupedRowsProps {
   virtualizerMeasureElement: (node: HTMLDivElement | null) => void;
   selectedColumns: TracesTableColumn[];
   toggleSessionExpanded: (sessionId: string) => void;
+  experimentId: string;
+}
+
+interface SessionHeaderRowProps {
+  sessionId: string;
+  traceCount: number;
+  traces: any[];
+  visibleColumns: TracesTableColumn[];
+  enableRowSelection?: boolean;
+  sessionRows: Row<EvalTraceComparisonEntry>[];
+  isComparing: boolean;
+  experimentId: string;
 }
 
 export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTracesTableSessionGroupedRows({
@@ -30,6 +44,7 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
   virtualizerTotalSize,
   virtualizerMeasureElement,
   selectedColumns,
+  experimentId,
 }: GenAiTracesTableSessionGroupedRowsProps) {
   // Create a map from eval data (contained in `groupedRows`) to the
   // actual table row from the tanstack data model. When grouping by
@@ -41,6 +56,19 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
       map.set(row.original, row);
     });
     return map;
+  }, [rows]);
+
+  // Get visible columns from the first row to match table rendering
+  const visibleColumns = useMemo(() => {
+    if (rows.length === 0) return [];
+    const firstRow = rows[0];
+    const cells = firstRow.getVisibleCells();
+    return cells.map((cell) => ({
+      id: cell.column.id,
+      label: cell.column.columnDef.header as string,
+      type: (cell.column.columnDef.meta as any)?.type,
+      group: (cell.column.columnDef.meta as any)?.group,
+    })) as TracesTableColumn[];
   }, [rows]);
 
   return (
@@ -72,7 +100,21 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
                 width: '100%',
               }}
             >
-              <SessionHeaderRow sessionId={groupedRow.sessionId} traceCount={groupedRow.traces.length} />
+              <SessionHeaderRow
+                sessionId={groupedRow.sessionId}
+                traceCount={groupedRow.traces.length}
+                traces={groupedRow.traces}
+                visibleColumns={visibleColumns}
+                enableRowSelection={enableRowSelection}
+                sessionRows={rows.filter((row) => {
+                  // Filter rows that belong to this session
+                  const traceIds = groupedRow.traces.map((t) => t.trace_id).filter(Boolean);
+                  const rowTraceId = row.original.currentRunValue?.traceInfo?.trace_id;
+                  return rowTraceId && traceIds.includes(rowTraceId);
+                })}
+                isComparing={isComparing}
+                experimentId={experimentId}
+              />
             </div>
           );
         }
@@ -116,20 +158,68 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
 // Session header component
 const SessionHeaderRow = React.memo(function SessionHeaderRow({
   sessionId,
-  traceCount,
-}: {
-  sessionId: string;
-  traceCount: number;
-}) {
+  traces,
+  visibleColumns,
+  enableRowSelection,
+  sessionRows,
+  isComparing,
+  experimentId,
+}: SessionHeaderRowProps) {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  // Calculate selection state for this session
+  const { allSelected, someSelected, exportableRows } = useMemo(() => {
+    // Filter to only exportable rows (those that can be selected)
+    const exportable = sessionRows.filter((row) => row.original.currentRunValue && !isComparing);
+
+    if (exportable.length === 0) {
+      return { allSelected: false, someSelected: false, exportableRows: [] };
+    }
+
+    const selectedCount = exportable.filter((row) => row.getIsSelected()).length;
+    return {
+      allSelected: selectedCount === exportable.length && selectedCount > 0,
+      someSelected: selectedCount > 0 && selectedCount < exportable.length,
+      exportableRows: exportable,
+    };
+  }, [sessionRows, isComparing]);
+
+  // Handle toggle all rows in this session
+  const handleToggleAll = useCallback(() => {
+    const shouldSelect = !allSelected;
+    exportableRows.forEach((row) => {
+      row.toggleSelected(shouldSelect);
+    });
+  }, [allSelected, exportableRows]);
 
   return (
     <TableRow isHeader>
-      <TableCell>
-        <span>
-          Session: {sessionId} ({traceCount} {traceCount === 1 ? 'trace' : 'traces'})
-        </span>
-      </TableCell>
+      {/* Checkbox cell for session row selection */}
+      {enableRowSelection && (
+        <div css={{ display: 'flex', overflow: 'hidden', flexShrink: 0 }}>
+          <TableRowSelectCell
+            componentId="mlflow.genai-traces-table.session-select"
+            checked={allSelected}
+            indeterminate={someSelected}
+            onChange={handleToggleAll}
+            isDisabled={isComparing || exportableRows.length === 0}
+            css={{ marginRight: 0 }}
+          />
+        </div>
+      )}
+      {/* Render a cell for each visible column from the table */}
+      {visibleColumns.map((column) => (
+        <SessionHeaderCell
+          key={column.id}
+          column={column}
+          sessionId={sessionId}
+          traces={traces}
+          theme={theme}
+          intl={intl}
+          experimentId={experimentId}
+        />
+      ))}
     </TableRow>
   );
 });

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -1,7 +1,6 @@
 import { isNil } from 'lodash';
 import React from 'react';
 
-import type { ThemeType } from '@databricks/design-system';
 import {
   SpeechBubbleIcon,
   TableCell,
@@ -11,7 +10,7 @@ import {
   UserIcon,
   useDesignSystemTheme,
 } from '@databricks/design-system';
-import type { IntlShape } from '@databricks/i18n';
+import { useIntl } from '@databricks/i18n';
 import type { ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
 
 import { NullCell } from './NullCell';
@@ -32,8 +31,6 @@ interface SessionHeaderCellProps {
   sessionId: string;
   traces: ModelTraceInfoV3[];
   onChangeEvaluationId?: (evaluationId: string | undefined, traceInfo?: ModelTraceInfoV3) => void;
-  theme: ThemeType;
-  intl: IntlShape;
   experimentId: string;
 }
 
@@ -41,14 +38,9 @@ interface SessionHeaderCellProps {
  * Renders a cell in the session header row based on the column type.
  * Returns null for columns that don't have session-level representations.
  */
-export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
-  column,
-  sessionId,
-  traces,
-  theme,
-  intl,
-  experimentId,
-}) => {
+export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({ column, sessionId, traces, experimentId }) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const firstTrace = traces[0];
 
   // Default: render empty cell for columns without session-level data
@@ -66,19 +58,7 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
             css={{ maxWidth: '100%' }}
           >
             <SpeechBubbleIcon css={{ fontSize: theme.typography.fontSizeBase, marginRight: theme.spacing.xs }} />
-            <span
-              css={{
-                display: 'inline-flex',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                alignItems: 'center',
-                minWidth: 0,
-                flexShrink: 1,
-              }}
-            >
-              {sessionId}
-            </span>
+            <Typography.Text ellipsis>{sessionId}</Typography.Text>
           </Tag>
         </SessionIdLinkWrapper>
       </div>
@@ -110,7 +90,7 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
         componentId="mlflow.genai-traces-table.session-header-request-time"
         content={date.toLocaleString(navigator.language, { timeZoneName: 'short' })}
       >
-        <span css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
+        <Typography.Text ellipsis>
           {formatDateTime(date, intl, {
             year: 'numeric',
             month: '2-digit',
@@ -120,7 +100,7 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
             second: '2-digit',
             hour12: false,
           })}
-        </span>
+        </Typography.Text>
       </Tooltip>
     ) : (
       <NullCell />
@@ -140,7 +120,7 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
         title={value}
       >
         <UserIcon css={{ color: theme.colors.textSecondary, fontSize: 16, flexShrink: 0 }} />
-        <span css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>{value}</span>
+        <Typography.Text ellipsis>{value}</Typography.Text>
       </div>
     ) : (
       <NullCell />

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -11,7 +11,7 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { useIntl } from '@databricks/i18n';
-import type { ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
+import { MLFLOW_TRACE_USER_KEY, type ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
 
 import { NullCell } from './NullCell';
 import { SessionIdLinkWrapper } from './SessionIdLinkWrapper';
@@ -25,6 +25,7 @@ import {
 } from '../hooks/useTableColumns';
 import type { TracesTableColumn } from '../types';
 import { escapeCssSpecialCharacters } from '../utils/DisplayUtils';
+import { getTraceInfoInputs } from '../utils/TraceUtils';
 
 interface SessionHeaderCellProps {
   column: TracesTableColumn;
@@ -65,7 +66,7 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({ column, se
     );
   } else if (column.id === INPUTS_COLUMN_ID && firstTrace) {
     // Request/Input column - get from first trace's request_preview
-    const inputTitle = firstTrace.request_preview || '';
+    const inputTitle = getTraceInfoInputs(firstTrace);
     cellContent = inputTitle ? (
       <div
         css={{
@@ -107,7 +108,7 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({ column, se
     );
   } else if (column.id === USER_COLUMN_ID && firstTrace) {
     // User column - get from first trace's metadata or tags
-    const value = firstTrace.trace_metadata?.['mlflow.trace.user'] || firstTrace.tags?.['mlflow.user'];
+    const value = firstTrace.trace_metadata?.[MLFLOW_TRACE_USER_KEY];
     cellContent = value ? (
       <div
         css={{

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -1,0 +1,165 @@
+import { isNil } from 'lodash';
+import React from 'react';
+
+import type { ThemeType } from '@databricks/design-system';
+import {
+  SpeechBubbleIcon,
+  TableCell,
+  Tag,
+  Tooltip,
+  Typography,
+  UserIcon,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import type { IntlShape } from '@databricks/i18n';
+import type { ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
+
+import { NullCell } from './NullCell';
+import { SessionIdLinkWrapper } from './SessionIdLinkWrapper';
+import { formatDateTime } from './rendererFunctions';
+import {
+  INPUTS_COLUMN_ID,
+  REQUEST_TIME_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  TRACE_ID_COLUMN_ID,
+  USER_COLUMN_ID,
+} from '../hooks/useTableColumns';
+import type { TracesTableColumn } from '../types';
+import { escapeCssSpecialCharacters } from '../utils/DisplayUtils';
+
+interface SessionHeaderCellProps {
+  column: TracesTableColumn;
+  sessionId: string;
+  traces: ModelTraceInfoV3[];
+  onChangeEvaluationId?: (evaluationId: string | undefined, traceInfo?: ModelTraceInfoV3) => void;
+  theme: ThemeType;
+  intl: IntlShape;
+  experimentId: string;
+}
+
+/**
+ * Renders a cell in the session header row based on the column type.
+ * Returns null for columns that don't have session-level representations.
+ */
+export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
+  column,
+  sessionId,
+  traces,
+  theme,
+  intl,
+  experimentId,
+}) => {
+  const firstTrace = traces[0];
+
+  // Default: render empty cell for columns without session-level data
+  let cellContent: React.ReactNode = null;
+
+  // Render specific columns with data from the first trace
+  if (column.id === TRACE_ID_COLUMN_ID) {
+    // Session ID column - render as a tag with link to session view
+    cellContent = (
+      <div css={{ overflow: 'hidden', minWidth: 0, maxWidth: '100%' }}>
+        <SessionIdLinkWrapper sessionId={sessionId} experimentId={experimentId}>
+          <Tag
+            componentId="mlflow.genai-traces-table.session-header-session-id"
+            title={sessionId}
+            css={{ maxWidth: '100%' }}
+          >
+            <SpeechBubbleIcon css={{ fontSize: theme.typography.fontSizeBase, marginRight: theme.spacing.xs }} />
+            <span
+              css={{
+                display: 'inline-flex',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                alignItems: 'center',
+                minWidth: 0,
+                flexShrink: 1,
+              }}
+            >
+              {sessionId}
+            </span>
+          </Tag>
+        </SessionIdLinkWrapper>
+      </div>
+    );
+  } else if (column.id === INPUTS_COLUMN_ID && firstTrace) {
+    // Request/Input column - get from first trace's request_preview
+    const inputTitle = firstTrace.request_preview || '';
+    cellContent = inputTitle ? (
+      <div
+        css={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+        }}
+        title={inputTitle}
+      >
+        {inputTitle}
+      </div>
+    ) : (
+      <NullCell />
+    );
+  } else if (column.id === REQUEST_TIME_COLUMN_ID && firstTrace) {
+    // Request time - format timestamp from first trace
+    const timestamp = firstTrace[REQUEST_TIME_COLUMN_ID];
+    const date = timestamp ? new Date(timestamp) : null;
+    cellContent = date ? (
+      <Tooltip
+        componentId="mlflow.genai-traces-table.session-header-request-time"
+        content={date.toLocaleString(navigator.language, { timeZoneName: 'short' })}
+      >
+        <span css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
+          {formatDateTime(date, intl, {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false,
+          })}
+        </span>
+      </Tooltip>
+    ) : (
+      <NullCell />
+    );
+  } else if (column.id === USER_COLUMN_ID && firstTrace) {
+    // User column - get from first trace's metadata or tags
+    const value = firstTrace.trace_metadata?.['mlflow.trace.user'] || firstTrace.tags?.['mlflow.user'];
+    cellContent = value ? (
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.xs,
+          overflow: 'hidden',
+          minWidth: 0,
+        }}
+        title={value}
+      >
+        <UserIcon css={{ color: theme.colors.textSecondary, fontSize: 16, flexShrink: 0 }} />
+        <span css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>{value}</span>
+      </div>
+    ) : (
+      <NullCell />
+    );
+  }
+
+  return (
+    <TableCell
+      key={column.id}
+      style={{
+        flex: `1 1 var(--col-${escapeCssSpecialCharacters(column.id)}-size)`,
+      }}
+      css={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+      }}
+    >
+      <div css={{ display: 'flex', overflow: 'hidden', minWidth: 0 }}>{cellContent}</div>
+    </TableCell>
+  );
+};


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19975/files) to review incremental changes.
- [**stack/session-group-part-4**](https://github.com/mlflow/mlflow/pull/19975) [[Files changed](https://github.com/mlflow/mlflow/pull/19975/files)]
  - [stack/session-group-part-5](https://github.com/mlflow/mlflow/pull/19976) [[Files changed](https://github.com/mlflow/mlflow/pull/19976/files/239a8f029c1d0cc85a7352b41b6d557f4186d52b..361367a9077a4a4425e903c03d73d1b4ccb049c5)]
    - [stack/session-group-part-6](https://github.com/mlflow/mlflow/pull/19998) [[Files changed](https://github.com/mlflow/mlflow/pull/19998/files/361367a9077a4a4425e903c03d73d1b4ccb049c5..d704c037f24a87010a559cb454fa72b42aea97ea)]
      - [stack/session-group-part-7](https://github.com/mlflow/mlflow/pull/19999) [[Files changed](https://github.com/mlflow/mlflow/pull/19999/files/d704c037f24a87010a559cb454fa72b42aea97ea..533421aaa060f4536cf82d8cd9a4810bd48caf76)]
        - [stack/session-group-part-8](https://github.com/mlflow/mlflow/pull/20009) [[Files changed](https://github.com/mlflow/mlflow/pull/20009/files/533421aaa060f4536cf82d8cd9a4810bd48caf76..0bedc57690833f4efc183ece3a704d327562b33e)]
          - [stack/session-group-part-9](https://github.com/mlflow/mlflow/pull/20010) [[Files changed](https://github.com/mlflow/mlflow/pull/20010/files/0bedc57690833f4efc183ece3a704d327562b33e..78ffc0801129fd21d1c779a761cb4f90149e0265)]
            - stack/session-group-part-10

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR introduces initial renderers for a few simple columns in the session header:

1. **Checkbox column**: Instead of a checkbox to select, we render a button to expand/collapse
2. **Trace ID column**: Instead of trace ID we render the session ID (session column will be left null)
3. **Input column**: Copy input from first trace in the session
4. **Request time column**: Copy request time from first trace
5. **User column**: Copy from first trace. it is possible but unlikely that the user is different in each contained trace but i think taking it from the first trace is a good enough heuristic

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

https://github.com/user-attachments/assets/f467d499-4219-4d6c-bff9-af981c6a9211

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
