### PR TITLE
Add statusline script for Claude Code

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+command -v jq >/dev/null || exit 0
+
+input=$(cat)
+
+cwd=$(echo "$input" | jq -r '.workspace.current_dir')
+dir=$(basename "$cwd")
+model=$(echo "$input" | jq -r '.model.display_name // empty')
+
+cd "$cwd" 2>/dev/null || cd /
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+
+output="$dir"
+[ -n "$branch" ] && output="$output ($branch)"
+[ -n "$model" ] && output="$output | $model"
+[ -n "$used" ] && output="$output | $(printf "%.1f" "$used")%"
+
+echo "$output"

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ gunicorn.conf.py
 !.claude/hooks/
 !.claude/rules/
 !.claude/settings.json
+!.claude/statusline.sh


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a minimal statusline script for Claude Code that displays helpful session information (current directory, git branch, model name, and context window usage).

<img width="428" height="73" alt="Screenshot 2026-01-14 at 16 05 56" src="https://github.com/user-attachments/assets/d016f30e-cfa0-40f1-bb78-b09c0fbbd931" />


### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)