### PR TITLE
Upgrade pytest to 9.0.2 and migrate to native TOML config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,7 @@ lint = [
   "pytest",
 ]
 test = [
-  "pytest==8.4.0",
+  "pytest==9.0.2",
   "pytest-asyncio",
   "pytest-repeat",
   "pytest-cov",
@@ -509,8 +509,16 @@ extend-ignore-re = [
   "livin'",
 ]
 
-[tool.pytest.ini_options]
-addopts = "-p no:legacypath --strict-markers --color=yes --durations=10 --showlocals -v"
+[tool.pytest]
+addopts = [
+  "-p",
+  "no:legacypath",
+  "--strict-markers",
+  "--color=yes",
+  "--durations=10",
+  "--showlocals",
+  "-v",
+]
 filterwarnings = [
   # Prevent deprecated numpy type aliases from being used
   "error:^`np\\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow",
@@ -529,7 +537,8 @@ filterwarnings = [
   # Prevent deprecated generator.throw(type, value, tb) signature from being used (Python 3.12+)
   "error:the \\(type, exc, tb\\) signature of throw\\(\\) is deprecated:DeprecationWarning",
 ]
-timeout = 1200
+# Use string for pytest-timeout compatibility (https://github.com/pytest-dev/pytest-timeout/issues/194)
+timeout = "1200"
 
 # Currently, type checking is only enabled for `dev/clint` and `.claude/skills`.
 [tool.mypy]

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,4 +1,4 @@
-pytest==8.4.0
+pytest==9.0.2
 # transformers 4.51.0 has this issue:
 # https://github.com/huggingface/transformers/issues/37326
 transformers!=4.51.0

--- a/requirements/lint-requirements.txt
+++ b/requirements/lint-requirements.txt
@@ -4,6 +4,6 @@ blacken-docs==1.18.0
 pre-commit==4.0.1
 toml==0.10.2
 mypy==1.17.1
-pytest==8.4.0
+pytest==9.0.2
 pydantic==2.11.7
 -e ./dev/clint

--- a/uv.lock
+++ b/uv.lock
@@ -4453,7 +4453,7 @@ dev = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyspark" },
     { name = "pytest" },
-    { name = "pytest", specifier = "==8.4.0" },
+    { name = "pytest", specifier = "==9.0.2" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-repeat" },
@@ -4518,7 +4518,7 @@ test = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "psutil" },
     { name = "pyspark" },
-    { name = "pytest", specifier = "==8.4.0" },
+    { name = "pytest", specifier = "==9.0.2" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-repeat" },
@@ -6757,7 +6757,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/ae/40/1414582f16c1d7b05
 
 [[package]]
 name = "pytest"
-version = "8.4.0"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -6768,9 +6768,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/19980?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19980/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19980/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19980/merge
```

</p>
</details>

### Related Issues/PRs

#xxx

### What changes are proposed in this pull request?

Upgrade pytest from 8.4.0 to 9.0.2 and migrate pytest config to the new native TOML format (`[tool.pytest]` instead of `[tool.pytest.ini_options]`).

Key changes:
- Convert `addopts` from string to array (required by new format)
- Keep `timeout` as string for pytest-timeout compatibility (https://github.com/pytest-dev/pytest-timeout/issues/194)

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)