### PR TITLE
[UI] Add output type selection for LLM judges

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
@@ -22,10 +22,11 @@ import { FormattedMessage, useIntl } from '@databricks/i18n';
 import { useTemplateOptions, validateInstructions } from './llmScorerUtils';
 import { type SCORER_TYPE, ScorerEvaluationScope } from './constants';
 import { COMPONENT_ID_PREFIX, type ScorerFormMode, SCORER_FORM_MODE } from './constants';
-import { LLM_TEMPLATE, isGuidelinesTemplate } from './types';
+import { LLM_TEMPLATE, isGuidelinesTemplate, type JudgeOutputTypeKind, type JudgePrimitiveOutputType } from './types';
 import { TEMPLATE_INSTRUCTIONS_MAP, EDITABLE_TEMPLATES } from './prompts';
 import EvaluateTracesSectionRenderer from './EvaluateTracesSectionRenderer';
 import { ModelSectionRenderer } from './ModelSectionRenderer';
+import OutputTypeSection from './OutputTypeSection';
 
 // Form data type that matches LLMScorer structure
 export interface LLMScorerFormData {
@@ -40,6 +41,10 @@ export interface LLMScorerFormData {
   disableMonitoring?: boolean;
   isInstructionsJudge?: boolean;
   evaluationScope?: ScorerEvaluationScope;
+  outputTypeKind?: JudgeOutputTypeKind;
+  categoricalOptions?: string;
+  dictValueType?: JudgePrimitiveOutputType;
+  listElementType?: JudgePrimitiveOutputType;
 }
 
 interface LLMScorerFormRendererProps {
@@ -544,6 +549,7 @@ const LLMScorerFormRenderer: React.FC<LLMScorerFormRendererProps> = ({ mode, con
       {!isGuidelinesTemplate(selectedTemplate) && (
         <InstructionsSection mode={mode} control={control} setValue={setValue} getValues={getValues} />
       )}
+      {EDITABLE_TEMPLATES.has(selectedTemplate) && <OutputTypeSection mode={mode} control={control} />}
       <ModelSectionRenderer mode={mode} control={control} setValue={setValue} />
       <EvaluateTracesSectionRenderer control={control} mode={mode} />
     </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/OutputTypeSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/OutputTypeSection.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import type { Control } from 'react-hook-form';
+import { Controller, useWatch } from 'react-hook-form';
+import {
+  useDesignSystemTheme,
+  FormUI,
+  Input,
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListSelectItem,
+  DialogComboboxHintRow,
+  DialogComboboxTrigger,
+  Typography,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+import { COMPONENT_ID_PREFIX, type ScorerFormMode, SCORER_FORM_MODE } from './constants';
+import type { LLMScorerFormData } from './LLMScorerFormRenderer';
+
+export interface OutputTypeSectionProps {
+  mode: ScorerFormMode;
+  control: Control<LLMScorerFormData>;
+}
+
+const OUTPUT_TYPE_KIND_OPTIONS = [
+  { value: 'default', label: 'Default', hint: 'Let the judge determine the output type automatically' },
+  { value: 'bool', label: 'Boolean', hint: 'Yes/no evaluations (pass/fail)' },
+  { value: 'int', label: 'Integer', hint: 'Integer ratings (e.g., 1-5 scale)' },
+  { value: 'float', label: 'Float', hint: 'Floating point scores (e.g., 0.0-1.0)' },
+  { value: 'str', label: 'String', hint: 'Text responses' },
+  { value: 'categorical', label: 'Categorical', hint: 'Fixed set of choices (e.g., good/bad/neutral)' },
+  { value: 'dict', label: 'Dictionary', hint: 'Key-value pairs (e.g., {"clarity": 4, "accuracy": 5})' },
+  { value: 'list', label: 'List', hint: 'List of values (e.g., ["issue1", "issue2"])' },
+] as const;
+
+const PRIMITIVE_TYPE_OPTIONS = [
+  { value: 'bool', label: 'Boolean' },
+  { value: 'int', label: 'Integer' },
+  { value: 'float', label: 'Float' },
+  { value: 'str', label: 'String' },
+] as const;
+
+const OUTPUT_TYPE_KIND_DISPLAY_MAP: Record<string, string> = {
+  default: 'Default',
+  bool: 'Boolean',
+  int: 'Integer',
+  float: 'Float',
+  str: 'String',
+  categorical: 'Categorical',
+  dict: 'Dictionary',
+  list: 'List',
+};
+
+const PRIMITIVE_TYPE_DISPLAY_MAP: Record<string, string> = {
+  bool: 'Boolean',
+  int: 'Integer',
+  float: 'Float',
+  str: 'String',
+};
+
+const OutputTypeSection: React.FC<OutputTypeSectionProps> = ({ mode, control }) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const outputTypeKind = useWatch({ control, name: 'outputTypeKind' }) ?? 'default';
+
+  const stopPropagationClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  const isReadOnly = mode === SCORER_FORM_MODE.DISPLAY;
+  const showPrimitiveSelector = outputTypeKind === 'dict' || outputTypeKind === 'list';
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+      {/* Main output type selector with inline primitive type for dict/list */}
+      <div css={{ display: 'flex', flexDirection: 'column' }}>
+        <FormUI.Label htmlFor="mlflow-experiment-scorers-output-type">
+          <FormattedMessage defaultMessage="Output type" description="Section header for judge output type selection" />
+        </FormUI.Label>
+        <FormUI.Hint>
+          <FormattedMessage
+            defaultMessage="The type of value the judge will return."
+            description="Hint text for output type selection"
+          />
+        </FormUI.Hint>
+        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm, marginTop: theme.spacing.xs }}>
+          <Controller
+            name="outputTypeKind"
+            control={control}
+            render={({ field }) => (
+              <div css={{ flex: showPrimitiveSelector ? undefined : 1 }} onClick={stopPropagationClick}>
+                <DialogCombobox
+                  componentId={`${COMPONENT_ID_PREFIX}.output-type-select`}
+                  id="mlflow-experiment-scorers-output-type"
+                  value={[field.value ?? 'default']}
+                >
+                  <DialogComboboxTrigger
+                    withInlineLabel={false}
+                    allowClear={false}
+                    disabled={isReadOnly}
+                    placeholder={intl.formatMessage({
+                      defaultMessage: 'Select output type',
+                      description: 'Placeholder for output type selection',
+                    })}
+                    renderDisplayedValue={(value) => OUTPUT_TYPE_KIND_DISPLAY_MAP[value] || value}
+                  />
+                  {!isReadOnly && (
+                    <DialogComboboxContent maxHeight={350}>
+                      <DialogComboboxOptionList>
+                        {OUTPUT_TYPE_KIND_OPTIONS.map((option) => (
+                          <DialogComboboxOptionListSelectItem
+                            key={option.value}
+                            value={option.value}
+                            onChange={() => field.onChange(option.value)}
+                            checked={
+                              field.value === option.value || (field.value === undefined && option.value === 'default')
+                            }
+                          >
+                            {option.label}
+                            <DialogComboboxHintRow>{option.hint}</DialogComboboxHintRow>
+                          </DialogComboboxOptionListSelectItem>
+                        ))}
+                      </DialogComboboxOptionList>
+                    </DialogComboboxContent>
+                  )}
+                </DialogCombobox>
+              </div>
+            )}
+          />
+
+          {outputTypeKind === 'dict' && (
+            <>
+              <Typography.Text color="secondary">
+                <FormattedMessage defaultMessage="of" description="Connector between dict and value type" />
+              </Typography.Text>
+              <Controller
+                name="dictValueType"
+                control={control}
+                render={({ field }) => (
+                  <div onClick={stopPropagationClick}>
+                    <DialogCombobox
+                      componentId={`${COMPONENT_ID_PREFIX}.dict-value-type-select`}
+                      id="mlflow-experiment-scorers-dict-value-type"
+                      value={field.value ? [field.value] : ['int']}
+                    >
+                      <DialogComboboxTrigger
+                        withInlineLabel={false}
+                        allowClear={false}
+                        disabled={isReadOnly}
+                        placeholder={intl.formatMessage({
+                          defaultMessage: 'Select value type',
+                          description: 'Placeholder for dict value type',
+                        })}
+                        renderDisplayedValue={(value) => PRIMITIVE_TYPE_DISPLAY_MAP[value] || value}
+                      />
+                      {!isReadOnly && (
+                        <DialogComboboxContent maxHeight={200}>
+                          <DialogComboboxOptionList>
+                            {PRIMITIVE_TYPE_OPTIONS.map((option) => (
+                              <DialogComboboxOptionListSelectItem
+                                key={option.value}
+                                value={option.value}
+                                onChange={() => field.onChange(option.value)}
+                                checked={field.value === option.value || (!field.value && option.value === 'int')}
+                              >
+                                {option.label}
+                              </DialogComboboxOptionListSelectItem>
+                            ))}
+                          </DialogComboboxOptionList>
+                        </DialogComboboxContent>
+                      )}
+                    </DialogCombobox>
+                  </div>
+                )}
+              />
+            </>
+          )}
+
+          {outputTypeKind === 'list' && (
+            <>
+              <Typography.Text color="secondary">
+                <FormattedMessage defaultMessage="of" description="Connector between list and element type" />
+              </Typography.Text>
+              <Controller
+                name="listElementType"
+                control={control}
+                render={({ field }) => (
+                  <div onClick={stopPropagationClick}>
+                    <DialogCombobox
+                      componentId={`${COMPONENT_ID_PREFIX}.list-element-type-select`}
+                      id="mlflow-experiment-scorers-list-element-type"
+                      value={field.value ? [field.value] : ['str']}
+                    >
+                      <DialogComboboxTrigger
+                        withInlineLabel={false}
+                        allowClear={false}
+                        disabled={isReadOnly}
+                        placeholder={intl.formatMessage({
+                          defaultMessage: 'Select element type',
+                          description: 'Placeholder for list element type',
+                        })}
+                        renderDisplayedValue={(value) => PRIMITIVE_TYPE_DISPLAY_MAP[value] || value}
+                      />
+                      {!isReadOnly && (
+                        <DialogComboboxContent maxHeight={200}>
+                          <DialogComboboxOptionList>
+                            {PRIMITIVE_TYPE_OPTIONS.map((option) => (
+                              <DialogComboboxOptionListSelectItem
+                                key={option.value}
+                                value={option.value}
+                                onChange={() => field.onChange(option.value)}
+                                checked={field.value === option.value || (!field.value && option.value === 'str')}
+                              >
+                                {option.label}
+                              </DialogComboboxOptionListSelectItem>
+                            ))}
+                          </DialogComboboxOptionList>
+                        </DialogComboboxContent>
+                      )}
+                    </DialogCombobox>
+                  </div>
+                )}
+              />
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Categorical options input */}
+      {outputTypeKind === 'categorical' && (
+        <div css={{ display: 'flex', flexDirection: 'column' }}>
+          <FormUI.Label htmlFor="mlflow-experiment-scorers-categorical-options" required>
+            <FormattedMessage defaultMessage="Options" description="Label for categorical options input" />
+          </FormUI.Label>
+          <FormUI.Hint>
+            <FormattedMessage
+              defaultMessage="Enter the allowed values, one per line."
+              description="Hint for categorical options"
+            />
+          </FormUI.Hint>
+          <Controller
+            name="categoricalOptions"
+            control={control}
+            rules={{ required: outputTypeKind === 'categorical' }}
+            render={({ field, fieldState }) => (
+              <>
+                <Input.TextArea
+                  {...field}
+                  componentId={`${COMPONENT_ID_PREFIX}.categorical-options-input`}
+                  id="mlflow-experiment-scorers-categorical-options"
+                  readOnly={isReadOnly}
+                  rows={3}
+                  placeholder={'good\nbad\nneutral'}
+                  css={{ resize: 'vertical' }}
+                  onClick={stopPropagationClick}
+                />
+                {fieldState.error && <FormUI.Message type="error" message={fieldState.error.message} />}
+              </>
+            )}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default OutputTypeSection;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/scorerCardUtils.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/scorerCardUtils.test.tsx
@@ -35,6 +35,7 @@ describe('scorerCardUtils', () => {
           disableMonitoring: undefined,
           isInstructionsJudge: undefined,
           evaluationScope: ScorerEvaluationScope.TRACES,
+          outputTypeKind: 'default',
         });
       });
 
@@ -90,6 +91,9 @@ describe('scorerCardUtils', () => {
           filterString: '',
           model: '',
           evaluationScope: ScorerEvaluationScope.TRACES,
+          disableMonitoring: undefined,
+          isInstructionsJudge: undefined,
+          outputTypeKind: 'default',
         });
       });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/scorerCardUtils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/scorerCardUtils.tsx
@@ -8,7 +8,7 @@ import type { ScheduledScorer, LLMScorer, CustomCodeScorer } from './types';
 import type { LLMScorerFormData } from './LLMScorerFormRenderer';
 import type { CustomCodeScorerFormData } from './CustomCodeScorerFormRenderer';
 import { TEMPLATE_INSTRUCTIONS_MAP } from './prompts';
-import { ScorerFormData } from './utils/scorerTransformUtils';
+import { ScorerFormData, outputTypeSpecToFormData } from './utils/scorerTransformUtils';
 import { ScorerEvaluationScope } from './constants';
 
 export const getTypeDisplayName = (scorer: ScheduledScorer, intl: IntlShape): string => {
@@ -84,6 +84,8 @@ export const getFormValuesFromScorer = (scorer: ScheduledScorer): LLMScorerFormD
     instructions = llmScorer.instructions || templateInstructions || '';
   }
 
+  const outputTypeFormFields = scorer.type === 'llm' ? outputTypeSpecToFormData((scorer as LLMScorer).outputType) : {};
+
   return {
     llmTemplate: scorer.type === 'llm' ? (scorer as LLMScorer).llmTemplate || '' : '',
     name: scorer.name || '',
@@ -97,6 +99,7 @@ export const getFormValuesFromScorer = (scorer: ScheduledScorer): LLMScorerFormD
     disableMonitoring: scorer.disableMonitoring,
     isInstructionsJudge: scorer.type === 'llm' ? (scorer as LLMScorer).is_instructions_judge : undefined,
     evaluationScope: scorer.isSessionLevelScorer ? ScorerEvaluationScope.SESSIONS : ScorerEvaluationScope.TRACES,
+    ...outputTypeFormFields,
   };
 };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
@@ -76,6 +76,26 @@ export type LLMTemplate =
   | 'UserFrustration'
   | 'ConversationalGuidelines';
 
+// Primitive types that can be used as dict values or list elements
+export type JudgePrimitiveOutputType = 'bool' | 'int' | 'float' | 'str';
+
+// Output type for LLM judges - maps to feedback_value_type in Python SDK
+// Primitive types: bool, int, float, str
+// Complex types: categorical (Literal), dict, list
+// 'default' means no explicit type - let the judge determine automatically
+export type JudgeOutputTypeKind = 'default' | JudgePrimitiveOutputType | 'categorical' | 'dict' | 'list';
+
+// Full output type specification
+export interface JudgeOutputTypeSpec {
+  kind: JudgeOutputTypeKind;
+  // For categorical (Literal) type - the list of allowed values
+  categoricalOptions?: string[];
+  // For dict type - the value type (keys are always strings)
+  dictValueType?: JudgePrimitiveOutputType;
+  // For list type - the element type
+  listElementType?: JudgePrimitiveOutputType;
+}
+
 export interface LLMScorer extends ScheduledScorerBase {
   type: 'llm';
   llmTemplate?: LLMTemplate;
@@ -85,6 +105,7 @@ export interface LLMScorer extends ScheduledScorerBase {
   // True if the scorer is an instructions-based LLM scorer that uses instructions_judge_pydantic_data
   // rather than builtin_scorer_pydantic_data.
   is_instructions_judge?: boolean;
+  outputType?: JudgeOutputTypeSpec;
 }
 
 export interface CustomCodeScorer extends ScheduledScorerBase {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/utils/scorerTransformUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/utils/scorerTransformUtils.ts
@@ -1,7 +1,164 @@
 import { type CausableError, ErrorName, PredefinedError } from '@databricks/web-shared/errors';
 import { ErrorLogType } from '@databricks/web-shared/errors';
-import type { ScheduledScorer, LLMScorer, CustomCodeScorer, ScorerConfig, LLMTemplate } from '../types';
+import type {
+  ScheduledScorer,
+  LLMScorer,
+  CustomCodeScorer,
+  ScorerConfig,
+  LLMTemplate,
+  JudgeOutputTypeSpec,
+  JudgePrimitiveOutputType,
+} from '../types';
 import { LLM_TEMPLATE, isGuidelinesTemplate } from '../types';
+
+const PRIMITIVE_TO_JSON_SCHEMA: Record<JudgePrimitiveOutputType, string> = {
+  bool: 'boolean',
+  int: 'integer',
+  float: 'number',
+  str: 'string',
+};
+
+const JSON_SCHEMA_TO_PRIMITIVE: Record<string, JudgePrimitiveOutputType> = {
+  boolean: 'bool',
+  integer: 'int',
+  number: 'float',
+  string: 'str',
+};
+
+/**
+ * Convert JudgeOutputTypeSpec to JSON Schema format for API serialization.
+ * Matches the format expected by InstructionsJudge._deserialize_feedback_value_type
+ * in mlflow/genai/judges/instructions_judge/__init__.py
+ */
+function outputTypeSpecToJsonSchema(spec: JudgeOutputTypeSpec | undefined): Record<string, unknown> | undefined {
+  if (!spec) {
+    return undefined;
+  }
+
+  switch (spec.kind) {
+    case 'bool':
+    case 'int':
+    case 'float':
+    case 'str':
+      return { type: PRIMITIVE_TO_JSON_SCHEMA[spec.kind] };
+
+    case 'categorical':
+      if (!spec.categoricalOptions || spec.categoricalOptions.length === 0) {
+        return undefined;
+      }
+      return {
+        type: 'string',
+        enum: spec.categoricalOptions,
+      };
+
+    case 'dict':
+      return {
+        type: 'object',
+        additionalProperties: {
+          type: PRIMITIVE_TO_JSON_SCHEMA[spec.dictValueType || 'int'],
+        },
+      };
+
+    case 'list':
+      return {
+        type: 'array',
+        items: {
+          type: PRIMITIVE_TO_JSON_SCHEMA[spec.listElementType || 'str'],
+        },
+      };
+
+    default:
+      return undefined;
+  }
+}
+
+function formDataToOutputTypeSpec(formData: LLMScorerFormData): JudgeOutputTypeSpec | undefined {
+  const kind = formData.outputTypeKind;
+  if (!kind || kind === 'default') {
+    return undefined;
+  }
+
+  return {
+    kind,
+    categoricalOptions: formData.categoricalOptions
+      ?.split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean),
+    dictValueType: formData.dictValueType,
+    listElementType: formData.listElementType,
+  };
+}
+
+export function outputTypeSpecToFormData(
+  spec: JudgeOutputTypeSpec | undefined,
+): Pick<LLMScorerFormData, 'outputTypeKind' | 'categoricalOptions' | 'dictValueType' | 'listElementType'> {
+  if (!spec) {
+    return { outputTypeKind: 'default' };
+  }
+
+  return {
+    outputTypeKind: spec.kind,
+    categoricalOptions: spec.categoricalOptions?.join('\n'),
+    dictValueType: spec.dictValueType,
+    listElementType: spec.listElementType,
+  };
+}
+
+/**
+ * Convert JSON Schema format back to JudgeOutputTypeSpec for loading from API.
+ * Reverse of outputTypeSpecToJsonSchema.
+ */
+function jsonSchemaToOutputTypeSpec(schema: Record<string, unknown> | undefined): JudgeOutputTypeSpec | undefined {
+  if (!schema) {
+    return undefined;
+  }
+
+  // Check for enum (Literal/categorical type)
+  if (Array.isArray(schema['enum'])) {
+    return {
+      kind: 'categorical',
+      categoricalOptions: schema['enum'] as string[],
+    };
+  }
+
+  const schemaType = schema['type'];
+  if (typeof schemaType !== 'string') {
+    return undefined;
+  }
+
+  // Check for primitive types
+  if (schemaType in JSON_SCHEMA_TO_PRIMITIVE) {
+    return {
+      kind: JSON_SCHEMA_TO_PRIMITIVE[schemaType],
+    };
+  }
+
+  // Check for object (dict) type
+  if (schemaType === 'object') {
+    const additionalProps = schema['additionalProperties'] as Record<string, unknown> | undefined;
+    if (additionalProps && typeof additionalProps['type'] === 'string') {
+      return {
+        kind: 'dict',
+        dictValueType: JSON_SCHEMA_TO_PRIMITIVE[additionalProps['type']] || 'int',
+      };
+    }
+    return { kind: 'dict', dictValueType: 'int' };
+  }
+
+  // Check for array (list) type
+  if (schemaType === 'array') {
+    const items = schema['items'] as Record<string, unknown> | undefined;
+    if (items && typeof items['type'] === 'string') {
+      return {
+        kind: 'list',
+        listElementType: JSON_SCHEMA_TO_PRIMITIVE[items['type']] || 'str',
+      };
+    }
+    return { kind: 'list', listElementType: 'str' };
+  }
+
+  return undefined;
+}
 import type { LLMScorerFormData } from '../LLMScorerFormRenderer';
 import type { CustomCodeScorerFormData } from '../CustomCodeScorerFormRenderer';
 import { ScorerEvaluationScope, type ScorerType } from '../constants';
@@ -57,6 +214,9 @@ export function transformScorerConfig(config: ScorerConfig): ScheduledScorer {
       // Instructions-based LLM scorer
       const instructions = serializedData.instructions_judge_pydantic_data.instructions || '';
       const model = serializedData.instructions_judge_pydantic_data.model;
+      const outputType = jsonSchemaToOutputTypeSpec(
+        serializedData.instructions_judge_pydantic_data.feedback_value_type,
+      );
       const result = {
         ...baseFields,
         type: 'llm',
@@ -64,6 +224,7 @@ export function transformScorerConfig(config: ScorerConfig): ScheduledScorer {
         instructions,
         model,
         is_instructions_judge: true,
+        outputType,
       } as LLMScorer;
       return result;
     } else if (isGuidelinesTemplate(serializedData.builtin_scorer_class)) {
@@ -158,6 +319,7 @@ export function transformScheduledScorer(scorer: ScheduledScorer): ScorerConfig 
       if (!llmScorer.instructions) {
         throw new ScorerTransformationError('Instructions are required for instructions-based LLM scorers');
       }
+      const feedbackValueType = outputTypeSpecToJsonSchema(llmScorer.outputType);
       config.serialized_scorer = JSON.stringify({
         ...baseSerializedScorer,
         name: llmScorer.name,
@@ -170,6 +332,7 @@ export function transformScheduledScorer(scorer: ScheduledScorer): ScorerConfig 
         instructions_judge_pydantic_data: {
           instructions: llmScorer.instructions || '',
           ...(llmScorer.model && { model: llmScorer.model }),
+          ...(feedbackValueType && { feedback_value_type: feedbackValueType }),
         },
       });
       config.custom = {};
@@ -303,6 +466,7 @@ export function convertFormDataToScheduledScorer(
         // Add model for all LLM scorers
         model: llmFormData.model || undefined,
         is_instructions_judge: llmFormData.isInstructionsJudge,
+        outputType: llmFormData.isInstructionsJudge ? formDataToOutputTypeSpec(llmFormData) : undefined,
       };
       return result;
     }
@@ -348,6 +512,7 @@ export function convertFormDataToScheduledScorer(
     // Add instructions for instructions judges (Custom, Safety, RelevanceToQuery)
     if (llmFormData.isInstructionsJudge) {
       (updatedScorer as LLMScorer).instructions = llmFormData.instructions;
+      (updatedScorer as LLMScorer).outputType = formDataToOutputTypeSpec(llmFormData);
     }
     (updatedScorer as LLMScorer).is_instructions_judge = llmFormData.isInstructionsJudge;
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -702,6 +702,10 @@
     "defaultMessage": "Enter a model name not listed above. Capabilities may not be detected.",
     "description": "Help text for custom model input"
   },
+  "3pRh9n": {
+    "defaultMessage": "The type of value the judge will return.",
+    "description": "Hint text for output type selection"
+  },
   "3vS6G9": {
     "defaultMessage": "{count, plural, one {# trace was} other {# traces were}} removed",
     "description": "Success message after deleting sessions - trace count"
@@ -1341,6 +1345,10 @@
   "8YmId5": {
     "defaultMessage": "Y axis",
     "description": "Label for Y axis in Contour chart configurator in compare runs chart config modal"
+  },
+  "8biXJJ": {
+    "defaultMessage": "Select output type",
+    "description": "Placeholder for output type selection"
   },
   "8f4/Zi": {
     "defaultMessage": "Search logged models using a simplified version of the SQL {whereBold} clause.",
@@ -1982,6 +1990,10 @@
     "defaultMessage": "Thank you for exploring the new Model Registry UI. We are dedicated to providing the best experience, and your feedback is invaluable. Please share your thoughts with us <link>here</link>.",
     "description": "Model registry > Switcher for the new model registry UI containing aliases > disable confirmation modal content"
   },
+  "DMEY+O": {
+    "defaultMessage": "Select value type",
+    "description": "Placeholder for dict value type"
+  },
   "DMKCLJ": {
     "defaultMessage": "API Key Details",
     "description": "Title for the API key details drawer"
@@ -2425,6 +2437,10 @@
   "Hk0RSH": {
     "defaultMessage": "Y-axis:",
     "description": "Label text for Y-axis in box plot comparison in MLflow"
+  },
+  "HlqAH9": {
+    "defaultMessage": "Output type",
+    "description": "Section header for judge output type selection"
   },
   "Hn1aOC": {
     "defaultMessage": "Endpoints using key: {name}",
@@ -3453,6 +3469,10 @@
     "defaultMessage": "Frequency Penalty",
     "description": "Label for frequency penalty input"
   },
+  "Qaq9vK": {
+    "defaultMessage": "Enter the allowed values, one per line.",
+    "description": "Hint for categorical options"
+  },
   "Qayyg6": {
     "defaultMessage": "Columns",
     "description": "Columns button label"
@@ -4000,6 +4020,10 @@
     "defaultMessage": "This trace is not exportable because it either contains an error or the response is not a ChatCompletionResponse.",
     "description": "Tooltip message for the export button when the trace is not exportable"
   },
+  "V1kYC+": {
+    "defaultMessage": "Select element type",
+    "description": "Placeholder for list element type"
+  },
   "V4CsL/": {
     "defaultMessage": "Unable to list artifacts stored under {artifactUri} for the current run. Please contact your tracking server administrator to notify them of this error, which can happen when the tracking server lacks permission to list artifacts under the current run's root artifact directory.",
     "description": "Error message when the artifact is unable to load. This message is displayed in the open source ML flow only"
@@ -4187,6 +4211,10 @@
   "WVUF2N": {
     "defaultMessage": "Are you sure you want to delete the prompt?",
     "description": "A content for the delete prompt confirmation modal"
+  },
+  "WWv3EQ": {
+    "defaultMessage": "Options",
+    "description": "Label for categorical options input"
   },
   "Wd8Tga": {
     "defaultMessage": "No schema. See <link>MLflow docs</link> for how to include input and output schema with your model.",
@@ -6271,6 +6299,10 @@
     "defaultMessage": "Create Model",
     "description": "Title text for creating model in the model registry"
   },
+  "mKV9T/": {
+    "defaultMessage": "of",
+    "description": "Connector between dict and value type"
+  },
   "mMR/YQ": {
     "defaultMessage": "Select a provider to configure your API key",
     "description": "Placeholder message when no provider selected"
@@ -6458,6 +6490,10 @@
   "nYSJgH": {
     "defaultMessage": "Show all parent spans",
     "description": "Checkbox label for a setting that enables showing all parent spans in the trace explorer regardless of filter conditions."
+  },
+  "naivho": {
+    "defaultMessage": "of",
+    "description": "Connector between list and element type"
   },
   "nddV+2": {
     "defaultMessage": "Show less",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/danielseong1/mlflow/pull/19997?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19997/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19997/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19997/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add ability to configure the output type (`feedback_value_type`) for instructions-based LLM judges in the scorers UI.

Key changes:
- Add `OutputTypeSection` component with dropdown for type selection
- Support primitive types (bool, int, float, str) and complex types (categorical, dict, list)
- Add "Default" option to let the judge determine type automatically
- Add transform utilities to convert between form data, `OutputTypeSpec`, and JSON Schema format for API serialization
- Integrate with existing scorer form and card rendering

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

https://github.com/user-attachments/assets/bc73c48e-c669-4fb8-b2a3-69f31d7c373c

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)