### PR TITLE
[Session Grouping][7/9] Initial commit for session-level assessment columns

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -297,6 +297,7 @@ const RunViewEvaluationsTabInner = ({
           experimentId={experimentId}
           getTrace={getTrace}
           renderExportTracesToDatasetsModal={renderCustomExportTracesToDatasetsModal}
+          isGroupedBySession={isGroupedBySession}
         >
           <div
             css={{

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
@@ -89,7 +89,7 @@ const renderComponent = (props = {}) => {
           <IntlProvider locale="en">
             <QueryClientProvider client={queryClient}>
               <DesignSystemProvider>
-                <GenAITracesTableProvider>
+                <GenAITracesTableProvider isGroupedBySession={false}>
                   <TracesV3Logs experimentId="test-experiment" endpointName="test-endpoint" {...props} />
                 </GenAITracesTableProvider>
               </DesignSystemProvider>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -367,6 +367,7 @@ const TracesV3LogsImpl = React.memo(
         experimentId={experimentId}
         getTrace={getTrace}
         renderExportTracesToDatasetsModal={renderCustomExportTracesToDatasetsModal}
+        isGroupedBySession={isGroupedBySession}
       >
         <div
           css={{

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableContext.tsx
@@ -18,6 +18,9 @@ export interface GenAITracesTableContextValue<T> {
   /** Grandchild updates this on every selection change */
   setSelectedRowIds: (rowIds: string[]) => void;
 
+  /** Whether traces are grouped by session */
+  isGroupedBySession: boolean;
+
   /**
    * Function to show the "Add to Evaluation Dataset" modal.
    * Provide traces to be added to the dataset. If `undefined` is passed, the modal is closed.
@@ -51,6 +54,7 @@ export const GenAITracesTableContext = createContext<GenAITracesTableContextValu
   setTable: () => {},
   selectedRowIds: [],
   setSelectedRowIds: () => {},
+  isGroupedBySession: false,
   renderExportTracesToDatasetsModal: () => null,
 });
 
@@ -58,6 +62,7 @@ interface GenAITracesTableProviderProps {
   children: React.ReactNode;
   experimentId?: string;
   getTrace?: GetTraceFunction;
+  isGroupedBySession: boolean;
 
   /**
    * Provide a custom function to render the "Export Traces to Datasets" modal.
@@ -79,6 +84,7 @@ export const GenAITracesTableProvider: React.FC<React.PropsWithChildren<GenAITra
   children,
   experimentId,
   getTrace,
+  isGroupedBySession,
   renderExportTracesToDatasetsModal,
 }) => {
   const [table, setTable] = useState<Table<TraceRow> | undefined>();
@@ -97,6 +103,7 @@ export const GenAITracesTableProvider: React.FC<React.PropsWithChildren<GenAITra
       setTable,
       selectedRowIds,
       setSelectedRowIds,
+      isGroupedBySession,
       showAddToEvaluationDatasetModal,
       renderExportTracesToDatasetsModal,
     }),
@@ -104,6 +111,7 @@ export const GenAITracesTableProvider: React.FC<React.PropsWithChildren<GenAITra
     [
       table,
       selectedRowIds,
+      isGroupedBySession,
       showAddToEvaluationDatasetModal,
       renderExportTracesToDatasetsModal,
     ],

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.utils.tsx
@@ -7,7 +7,7 @@ import type { IntlShape } from '@databricks/i18n';
 
 import { traceInfoSortingFn } from './GenAiTracesTable.utils';
 import {
-  assessmentCellRenderer,
+  AssessmentCell,
   expectationCellRenderer,
   inputColumnCellRenderer,
   traceInfoCellRenderer,
@@ -209,7 +209,15 @@ export const getColumnConfig = (
             assessmentInfo: AssessmentInfo;
             comparisonEntry: EvalTraceComparisonEntry;
           };
-          return assessmentCellRenderer(theme, intl, isComparing, assessmentInfo, comparisonEntry);
+          return (
+            <AssessmentCell
+              theme={theme}
+              intl={intl}
+              isComparing={isComparing}
+              assessmentInfo={assessmentInfo}
+              comparisonEntry={comparisonEntry}
+            />
+          );
         },
       };
     case TracesTableColumnType.EXPECTATION:

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.utils.tsx
@@ -211,8 +211,6 @@ export const getColumnConfig = (
           };
           return (
             <AssessmentCell
-              theme={theme}
-              intl={intl}
               isComparing={isComparing}
               assessmentInfo={assessmentInfo}
               comparisonEntry={comparisonEntry}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -13,6 +13,7 @@ import {
 import { useIntl } from '@databricks/i18n';
 import {
   ASSESSMENT_SESSION_METADATA_KEY,
+  FeedbackAssessment,
   TOKEN_USAGE_METADATA_KEY,
   MLFLOW_TRACE_USER_KEY,
   type ModelTraceInfoV3,
@@ -35,7 +36,13 @@ import {
 } from '../hooks/useTableColumns';
 import { TracesTableColumnType, type TracesTableColumn } from '../types';
 import { escapeCssSpecialCharacters } from '../utils/DisplayUtils';
-import { getTraceInfoInputs, getTraceInfoOutputs } from '../utils/TraceUtils';
+import {
+  convertFeedbackAssessmentToRunEvalAssessment,
+  getTraceInfoInputs,
+  getTraceInfoOutputs,
+} from '../utils/TraceUtils';
+import { compact } from 'lodash';
+import { getUniqueValueCountsBySourceId } from '../utils/AggregationUtils';
 import { TokenComponent } from './TokensCell';
 
 interface SessionHeaderCellProps {
@@ -184,57 +191,58 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({ column, se
     );
   } else if (
     column.type === TracesTableColumnType.ASSESSMENT &&
+    column.assessmentInfo &&
     column.assessmentInfo?.isSessionLevelAssessment &&
     traces.length > 0
   ) {
     // Session-level assessment column - find the assessment with session metadata
-    const assessmentName = column.assessmentInfo.name;
+    const assessmentInfo = column.assessmentInfo;
+    const assessmentName = assessmentInfo.name;
+    const allFeedback = traces.flatMap((trace) =>
+      compact(
+        trace.assessments?.filter(
+          (a): a is FeedbackAssessment =>
+            a.assessment_name === assessmentName &&
+            Boolean(a.metadata?.[ASSESSMENT_SESSION_METADATA_KEY]) &&
+            'feedback' in a,
+        ),
+      ),
+    );
 
-    // Search through all traces to find the assessment with session metadata
-    for (const trace of traces) {
-      const assessment = trace.assessments?.find(
-        (a) => a.assessment_name === assessmentName && a.metadata?.[ASSESSMENT_SESSION_METADATA_KEY],
-      );
-      if (assessment && 'feedback' in assessment) {
-        const feedbackValue = assessment.feedback.value;
-        // Map source_type to AssessmentType
-        const sourceType =
-          assessment.source.source_type === 'LLM_JUDGE'
-            ? 'AI_JUDGE'
-            : assessment.source.source_type === 'CODE'
-              ? 'CODE'
-              : 'HUMAN';
-        cellContent = (
-          <EvaluationsReviewAssessmentTag
-            showRationaleInTooltip
-            disableJudgeTypeIcon
-            hideAssessmentName
-            assessment={{
-              name: assessment.assessment_name,
-              stringValue: typeof feedbackValue === 'string' ? feedbackValue : null,
-              booleanValue: typeof feedbackValue === 'boolean' ? feedbackValue : null,
-              numericValue: typeof feedbackValue === 'number' ? feedbackValue : null,
-              rationale: assessment.rationale ?? null,
-              source: {
-                sourceId: assessment.source.source_id,
-                sourceType,
-                metadata: {},
-              },
-              rootCauseAssessment: null,
-              timestamp: assessment.create_time ? new Date(assessment.create_time).getTime() : null,
-              metadata: assessment.metadata ?? {},
-            }}
-            assessmentInfo={column.assessmentInfo}
-            type="value"
-          />
-        );
-        break;
-      }
-    }
+    const entries = allFeedback.map(convertFeedbackAssessmentToRunEvalAssessment);
+    const uniqueValueCounts = getUniqueValueCountsBySourceId(assessmentInfo, entries);
 
-    if (!cellContent) {
-      cellContent = <NullCell />;
-    }
+    cellContent = (
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.sm,
+        }}
+      >
+        {uniqueValueCounts.map((uniqueValueCount) => {
+          const assessment = uniqueValueCount.latestAssessment;
+          const count = uniqueValueCount.count;
+          return (
+            <EvaluationsReviewAssessmentTag
+              key={`tag_${uniqueValueCount.latestAssessment.name}_${uniqueValueCount.value}`}
+              showRationaleInTooltip
+              disableJudgeTypeIcon
+              hideAssessmentName
+              assessment={assessment}
+              isRootCauseAssessment={false}
+              assessmentInfo={assessmentInfo}
+              type="value"
+              count={count}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (!cellContent) {
+    cellContent = <NullCell />;
   }
 
   return (

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -17,6 +17,7 @@ import {
   TOKEN_USAGE_METADATA_KEY,
   MLFLOW_TRACE_USER_KEY,
   type ModelTraceInfoV3,
+  isFeedbackAssessment,
 } from '@databricks/web-shared/model-trace-explorer';
 
 import { NullCell } from './NullCell';
@@ -202,9 +203,7 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({ column, se
       compact(
         trace.assessments?.filter(
           (a): a is FeedbackAssessment =>
-            a.assessment_name === assessmentName &&
-            Boolean(a.metadata?.[ASSESSMENT_SESSION_METADATA_KEY]) &&
-            'feedback' in a,
+            Boolean(a.metadata?.[ASSESSMENT_SESSION_METADATA_KEY]) && isFeedbackAssessment(a),
         ),
       ),
     );

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
@@ -4,8 +4,8 @@ import React, { useContext } from 'react';
 import type { FormatDateOptions } from 'react-intl';
 
 import type { ThemeType } from '@databricks/design-system';
-import { ArrowRightIcon, Tag, Tooltip, Typography, UserIcon } from '@databricks/design-system';
-import { type IntlShape } from '@databricks/i18n';
+import { ArrowRightIcon, Tag, Tooltip, Typography, useDesignSystemTheme, UserIcon } from '@databricks/design-system';
+import { useIntl, type IntlShape } from '@databricks/i18n';
 import type { ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
 import { ExpectationValuePreview } from '@databricks/web-shared/model-trace-explorer';
 
@@ -269,12 +269,12 @@ export const assessmentCellRenderer = (
  * Hides session-level assessments in regular rows when grouped by session.
  */
 export const AssessmentCell: React.FC<{
-  theme: ThemeType;
-  intl: IntlShape;
   isComparing: boolean;
   assessmentInfo: AssessmentInfo;
   comparisonEntry: EvalTraceComparisonEntry;
-}> = ({ theme, intl, isComparing, assessmentInfo, comparisonEntry }) => {
+}> = ({ isComparing, assessmentInfo, comparisonEntry }) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const { isGroupedBySession } = useContext(GenAITracesTableContext);
 
   // Hide session-level assessments in regular rows when grouped by session

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
@@ -1,5 +1,6 @@
 import type { CellContext } from '@tanstack/react-table';
 import { first, isNil } from 'lodash';
+import React, { useContext } from 'react';
 import type { FormatDateOptions } from 'react-intl';
 
 import type { ThemeType } from '@databricks/design-system';
@@ -7,6 +8,8 @@ import { ArrowRightIcon, Tag, Tooltip, Typography, UserIcon } from '@databricks/
 import { type IntlShape } from '@databricks/i18n';
 import type { ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
 import { ExpectationValuePreview } from '@databricks/web-shared/model-trace-explorer';
+
+import { GenAITracesTableContext } from '../GenAITracesTableContext';
 
 import { LoggedModelCell } from './LoggedModelCell';
 import { NullCell } from './NullCell';
@@ -259,6 +262,27 @@ export const assessmentCellRenderer = (
       )}
     </div>
   );
+};
+
+/**
+ * Wrapper component for assessment cells that checks the context for session grouping.
+ * Hides session-level assessments in regular rows when grouped by session.
+ */
+export const AssessmentCell: React.FC<{
+  theme: ThemeType;
+  intl: IntlShape;
+  isComparing: boolean;
+  assessmentInfo: AssessmentInfo;
+  comparisonEntry: EvalTraceComparisonEntry;
+}> = ({ theme, intl, isComparing, assessmentInfo, comparisonEntry }) => {
+  const { isGroupedBySession } = useContext(GenAITracesTableContext);
+
+  // Hide session-level assessments in regular rows when grouped by session
+  if (isGroupedBySession && assessmentInfo.isSessionLevelAssessment) {
+    return <NullCell />;
+  }
+
+  return assessmentCellRenderer(theme, intl, isComparing, assessmentInfo, comparisonEntry);
 };
 
 export const expectationCellRenderer = (

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
@@ -33,5 +33,5 @@ export const shouldUseTracesV4API = () => {
 };
 
 export const shouldEnableSessionGrouping = () => {
-  return true;
+  return false;
 };

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FeatureUtils.ts
@@ -33,5 +33,5 @@ export const shouldUseTracesV4API = () => {
 };
 
 export const shouldEnableSessionGrouping = () => {
-  return false;
+  return true;
 };

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.ts
@@ -218,7 +218,7 @@ const convertAssessmentV3Source = (assessment: Assessment): RunEvaluationResultA
   };
 };
 
-const convertFeedbackAssessmentToRunEvalAssessment = (
+export const convertFeedbackAssessmentToRunEvalAssessment = (
   assessment: FeedbackAssessment,
 ): RunEvaluationResultAssessment => {
   const assessmentValue = assessment.feedback?.value;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/utils.tsx
@@ -1,6 +1,6 @@
 import { SparkleIcon, UserIcon, CodeIcon } from '@databricks/design-system';
 
-import type { Assessment } from '../ModelTrace.types';
+import type { Assessment, ExpectationAssessment, FeedbackAssessment } from '../ModelTrace.types';
 
 export const getAssessmentValue = (assessment: Assessment) => {
   if ('feedback' in assessment && assessment.feedback) {
@@ -15,6 +15,14 @@ export const getAssessmentValue = (assessment: Assessment) => {
   }
 
   return undefined;
+};
+
+export const isFeedbackAssessment = (assessment: Assessment): assessment is FeedbackAssessment => {
+  return 'feedback' in assessment && Boolean(assessment.feedback);
+};
+
+export const isExpectationAssessment = (assessment: Assessment): assessment is ExpectationAssessment => {
+  return 'expectation' in assessment && Boolean(assessment.expectation);
 };
 
 export const getSourceIcon = (source: Assessment['source']) => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -44,7 +44,7 @@ export * from './ModelTrace.types';
 export * from './TraceMetrics.types';
 export * from './oss-notebook-renderer/mlflow-fetch-utils';
 
-export { getAssessmentValue } from './assessments-pane/utils';
+export { getAssessmentValue, isFeedbackAssessment, isExpectationAssessment } from './assessments-pane/utils';
 export { TracesServiceV3, TracesServiceV4 } from './api';
 export { shouldUseTracesV4API } from './FeatureUtils';
 export { useUnifiedTraceTagsModal } from './hooks/useUnifiedTraceTagsModal';


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19999/files) to review incremental changes.
- [**stack/session-group-part-7**](https://github.com/mlflow/mlflow/pull/19999) [[Files changed](https://github.com/mlflow/mlflow/pull/19999/files)]
  - [stack/session-group-part-8](https://github.com/mlflow/mlflow/pull/20009) [[Files changed](https://github.com/mlflow/mlflow/pull/20009/files/02f978eda28f20235d9a1699aed57824f28c9b86..4c3e3ebdfe273490e4bcbbf5335c947059636443)]
    - [stack/session-group-part-9](https://github.com/mlflow/mlflow/pull/20010) [[Files changed](https://github.com/mlflow/mlflow/pull/20010/files/4c3e3ebdfe273490e4bcbbf5335c947059636443..cad6b0ed8ce18f907875d136e6e7323ddc2e6897)]
      - stack/session-group-part-10

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds a renderer for session level assessment columns. When the table is grouped by session, we show session level assessments in the session row, and remove them from the individual trace rows to prevent confusion.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Looks like this:

<img width="1915" height="967" alt="Screenshot 2026-01-16 at 4 43 36 PM" src="https://github.com/user-attachments/assets/6f6f8f8a-ec33-4747-9973-13c8fdd08f1d" />



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
