### PR TITLE
 feat[genai]: Log assessments in optimize_prompts traces

### DIFF
--- a/docs/docs/genai/prompt-registry/optimize-prompts.mdx
+++ b/docs/docs/genai/prompt-registry/optimize-prompts.mdx
@@ -520,6 +520,14 @@ print(f"Initial score: {result.initial_eval_score}")
 print(f"Final score: {result.final_eval_score}")
 ```
 
+## Tracking and Observability
+
+When `enable_tracking=True`, `optimize_prompts` automatically creates an MLflow Run to track the optimization process. This includes:
+
+- **Metrics**: Tracks `initial_eval_score` and `final_eval_score`.
+- **Traces**: Captures detailed execution traces of your `predict_fn` during the evaluation phases.
+- **Assessments**: Logs the results from your `scorers` (e.g., scores and rationales) directly to the traces as assessments. This allows you to inspect individual failures and understand the optimization decisions.
+
 ## Common Use Cases
 
 ### Improving Accuracy

--- a/mlflow/genai/optimize/optimize.py
+++ b/mlflow/genai/optimize/optimize.py
@@ -97,6 +97,7 @@ def optimize_prompts(
             - Links to the optimized prompt versions
             - The optimizer name and parameters
             - Optimization progress
+            - Traces with detailed assessments from the scorers
             If False, no MLflow run is created and no tracking occurs.
 
     Returns:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/brandonhawi/mlflow/pull/20000?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/20000/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/20000/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/20000/merge
```

</p>
</details>

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Updates `mlflow.genai.optimize_prompts` to log scorer results as assessments on evaluation traces. Previously, scorer outputs were aggregated but not persisted as trace assessments. This change ensures that optimization results are visible in the MLflow UI and available for analysis, aligning behavior with `mlflow.genai.evaluate()`. Includes a regression test in `tests/genai/optimize/test_optimize.py`.


### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Updated `mlflow.genai.optimize_prompts()` to log scorer results as assessments on evaluation traces, ensuring that optimization results are visible in the MLflow UI and available for analysis, aligning behavior with `mlflow.genai.evaluate()`. 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [X] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
- [X] Unsure 😄 
