### PR TITLE
Prevent spurious 404 requests for relative image URLs in markdown

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.test.tsx
@@ -107,6 +107,13 @@ describe('GenAIMarkdownRenderer', () => {
         expect(screen.getByText('[test image](../images/test.png)')).toBeInTheDocument();
       });
 
+      it('renders relative URL without prefix as text instead of img', () => {
+        const screen = render(<GenAIMarkdownRenderer>{`![test image](images/test.png)`}</GenAIMarkdownRenderer>);
+
+        expect(screen.queryByRole('img')).not.toBeInTheDocument();
+        expect(screen.getByText('[test image](images/test.png)')).toBeInTheDocument();
+      });
+
       it('renders data: URL as img element', () => {
         const dataUrl =
           'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';

--- a/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.test.tsx
@@ -74,6 +74,49 @@ describe('GenAIMarkdownRenderer', () => {
         expect(screen.container.querySelector('#user-content-fn-3')).toHaveTextContent('My reference 3.');
       });
     });
+
+    describe('Image', () => {
+      it('renders absolute URL as img element', () => {
+        const screen = render(
+          <GenAIMarkdownRenderer>{`![test image](https://example.com/image.png)`}</GenAIMarkdownRenderer>,
+        );
+
+        const img = screen.getByRole('img');
+        expect(img).toHaveAttribute('src', 'https://example.com/image.png');
+        expect(img).toHaveAttribute('alt', 'test image');
+      });
+
+      it('renders relative URL starting with / as text instead of img', () => {
+        const screen = render(<GenAIMarkdownRenderer>{`![test image](/foo/bar/test.png)`}</GenAIMarkdownRenderer>);
+
+        expect(screen.queryByRole('img')).not.toBeInTheDocument();
+        expect(screen.getByText('[test image](/foo/bar/test.png)')).toBeInTheDocument();
+      });
+
+      it('renders relative URL starting with ./ as text instead of img', () => {
+        const screen = render(<GenAIMarkdownRenderer>{`![test image](./images/test.png)`}</GenAIMarkdownRenderer>);
+
+        expect(screen.queryByRole('img')).not.toBeInTheDocument();
+        expect(screen.getByText('[test image](./images/test.png)')).toBeInTheDocument();
+      });
+
+      it('renders relative URL starting with ../ as text instead of img', () => {
+        const screen = render(<GenAIMarkdownRenderer>{`![test image](../images/test.png)`}</GenAIMarkdownRenderer>);
+
+        expect(screen.queryByRole('img')).not.toBeInTheDocument();
+        expect(screen.getByText('[test image](../images/test.png)')).toBeInTheDocument();
+      });
+
+      it('renders data: URL as img element', () => {
+        const dataUrl =
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+        const screen = render(<GenAIMarkdownRenderer>{`![pixel](${dataUrl})`}</GenAIMarkdownRenderer>);
+
+        const img = screen.getByRole('img');
+        expect(img).toHaveAttribute('src', dataUrl);
+        expect(img).toHaveAttribute('alt', 'pixel');
+      });
+    });
   });
 });
 

--- a/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.tsx
@@ -21,6 +21,11 @@ const urlTransform: UrlTransform = (value) => {
   return defaultUrlTransform(value);
 };
 
+const isRelativeUrl = (url: string | undefined): boolean => {
+  if (!url) return false;
+  return url.startsWith('/') || url.startsWith('./') || url.startsWith('../');
+};
+
 export const GenAIMarkdownRenderer = (props: { children: string; components?: ExtendedComponents }) => {
   const components: Components = useMemo(
     () => getMarkdownComponents({ extensions: props.components }),
@@ -138,7 +143,8 @@ export const getMarkdownComponents = (props: { extensions?: ExtendedComponents }
     // Design system's table does not use thead and tbody elements
     thead: ({ children }) => <>{children}</>,
     tbody: ({ children }) => <>{children}</>,
-    img: ({ src, alt }) => <img src={src} alt={alt} css={{ maxWidth: '100%' }} />,
+    img: ({ src, alt }) =>
+      isRelativeUrl(src) ? <span>{`[${alt}](${src})`}</span> : <img src={src} alt={alt} css={{ maxWidth: '100%' }} />,
   }) satisfies ReactMarkdownComponents;
 
 const isCodeSnippetLanguage = (languageString: string): languageString is CodeSnippetLanguage => {

--- a/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.tsx
@@ -23,7 +23,8 @@ const urlTransform: UrlTransform = (value) => {
 
 const isRelativeUrl = (url: string | undefined): boolean => {
   if (!url) return false;
-  return url.startsWith('/') || url.startsWith('./') || url.startsWith('../');
+  // Check if URL has a protocol (absolute URL)
+  return !/^[a-z][a-z0-9+.-]*:/i.test(url);
 };
 
 export const GenAIMarkdownRenderer = (props: { children: string; components?: ExtendedComponents }) => {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/20003?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/20003/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/20003/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/20003/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When markdown content contains relative image URLs like `![alt](/foo/bar/test.png)`, the `GenAIMarkdownRenderer` component renders them as `<img>` tags, causing the browser to make spurious HTTP requests that result in 404 errors.

This PR renders relative image URLs as text (e.g., `[alt](/foo/bar/test.png)`) instead of `<img>` tags to prevent these unnecessary network requests.

Before:

<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/8b82960d-7cc3-4cbd-bf89-28c40548df97" />

After:

<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/a47fbbf8-cbb9-4512-a47e-8e10c4784eb1" />

### How is this PR tested?

- [x] Manual tests

Tested with a Playwright script that creates a trace with markdown containing a relative image URL and verifies no 404 requests are made.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed spurious 404 errors caused by relative image URLs in markdown content displayed in the trace detail panel.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)