### PR TITLE
Add EditableEndpointName component for editing endpoint names

### DIFF
--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditableEndpointName.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditableEndpointName.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import {
+  Alert,
+  Button,
+  Input,
+  Modal,
+  PencilIcon,
+  Tooltip,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { isValidEndpointName } from '../../utils/gatewayUtils';
+import type { Endpoint } from '../../types';
+
+interface EditableEndpointNameProps {
+  endpoint: Endpoint | undefined;
+  existingEndpoints: Endpoint[] | undefined;
+  onNameUpdate: (newName: string) => Promise<void>;
+  isSubmitting?: boolean;
+}
+
+export const EditableEndpointName = ({
+  endpoint,
+  existingEndpoints,
+  onNameUpdate,
+  isSubmitting = false,
+}: EditableEndpointNameProps) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const handleOpenModal = () => {
+    setNewName(endpoint?.name ?? '');
+    setError(null);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setNewName('');
+    setError(null);
+  };
+
+  const validateName = (name: string): string | null => {
+    if (!name.trim()) {
+      return intl.formatMessage({
+        defaultMessage: 'Endpoint name is required',
+        description: 'Error message when endpoint name is empty',
+      });
+    }
+
+    if (!isValidEndpointName(name)) {
+      return intl.formatMessage({
+        defaultMessage:
+          'Name can only contain letters, numbers, underscores, hyphens, and dots. Spaces and special characters are not allowed.',
+        description: 'Error message for invalid endpoint name format',
+      });
+    }
+
+    const otherEndpoints = existingEndpoints?.filter((e) => e.endpoint_id !== endpoint?.endpoint_id);
+    if (otherEndpoints?.some((e) => e.name === name)) {
+      return intl.formatMessage({
+        defaultMessage: 'An endpoint with this name already exists',
+        description: 'Error message when endpoint name already exists',
+      });
+    }
+
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const validationError = validateName(newName);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    if (newName === endpoint?.name) {
+      handleCloseModal();
+      return;
+    }
+
+    setIsUpdating(true);
+    try {
+      await onNameUpdate(newName);
+      handleCloseModal();
+    } catch (e: any) {
+      setError(e.message || 'Failed to update endpoint name');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNewName(e.target.value);
+    if (error) {
+      setError(null);
+    }
+  };
+
+  return (
+    <>
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+        <Typography.Title level={2} withoutMargins>
+          {endpoint?.name}
+        </Typography.Title>
+        <Tooltip
+          componentId="mlflow.gateway.edit-endpoint.name-edit-tooltip"
+          content={intl.formatMessage({
+            defaultMessage: 'Edit endpoint name',
+            description: 'Tooltip for edit endpoint name button',
+          })}
+        >
+          <Button
+            componentId="mlflow.gateway.edit-endpoint.name-edit-button"
+            size="small"
+            type="tertiary"
+            icon={<PencilIcon />}
+            onClick={handleOpenModal}
+            disabled={isSubmitting}
+            aria-label={intl.formatMessage({
+              defaultMessage: 'Edit endpoint name',
+              description: 'Aria label for edit endpoint name button',
+            })}
+          />
+        </Tooltip>
+      </div>
+
+      <Modal
+        componentId="mlflow.gateway.edit-endpoint-name-modal"
+        title={intl.formatMessage({
+          defaultMessage: 'Edit Endpoint Name',
+          description: 'Title for edit endpoint name modal',
+        })}
+        visible={isModalOpen}
+        onCancel={handleCloseModal}
+        onOk={handleSubmit}
+        okText={intl.formatMessage({
+          defaultMessage: 'Save',
+          description: 'Save button text for edit endpoint name modal',
+        })}
+        cancelText={intl.formatMessage({
+          defaultMessage: 'Cancel',
+          description: 'Cancel button text',
+        })}
+        confirmLoading={isUpdating}
+        okButtonProps={{ disabled: !newName.trim() || newName === endpoint?.name }}
+        size="normal"
+      >
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+          {error && (
+            <Alert
+              componentId="mlflow.gateway.edit-endpoint-name-modal.error"
+              type="error"
+              message={error}
+              closable={false}
+            />
+          )}
+
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+            <Typography.Text bold>
+              <FormattedMessage defaultMessage="Endpoint Name" description="Label for endpoint name input" />
+            </Typography.Text>
+            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+              <FormattedMessage
+                defaultMessage="The name is used in the endpoint URL. Only letters, numbers, underscores, hyphens, and dots are allowed."
+                description="Help text for endpoint name input"
+              />
+            </Typography.Text>
+            <Input
+              componentId="mlflow.gateway.edit-endpoint-name-modal.name-input"
+              value={newName}
+              onChange={handleNameChange}
+              placeholder={intl.formatMessage({
+                defaultMessage: 'my-endpoint',
+                description: 'Placeholder for endpoint name input',
+              })}
+              validationState={error ? 'error' : undefined}
+              autoFocus
+            />
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+};

--- a/mlflow/server/js/src/gateway/hooks/useEditEndpointForm.ts
+++ b/mlflow/server/js/src/gateway/hooks/useEditEndpointForm.ts
@@ -1,7 +1,7 @@
 import { useForm } from 'react-hook-form';
 import { useNavigate } from '../../common/utils/RoutingUtils';
 import { useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
-import { useEffect, useCallback, useMemo, useState } from 'react';
+import { useEffect, useCallback, useMemo } from 'react';
 import { useEndpointsQuery } from './useEndpointsQuery';
 import { useEndpointQuery } from './useEndpointQuery';
 import { useUpdateEndpointMutation } from './useUpdateEndpointMutation';
@@ -9,7 +9,6 @@ import { useCreateModelDefinitionMutation } from './useCreateModelDefinitionMuta
 import { useUpdateModelDefinitionMutation } from './useUpdateModelDefinitionMutation';
 import { useCreateSecret } from './useCreateSecret';
 import { getReadableErrorMessage } from '../utils/errorUtils';
-import { isValidEndpointName } from '../utils/gatewayUtils';
 import GatewayRoutes from '../routes';
 import type { Endpoint } from '../types';
 
@@ -59,13 +58,13 @@ export interface UseEditEndpointFormResult {
   isSubmitting: boolean;
   loadError: Error | null;
   mutationError: Error | null;
-  resetErrors: () => void;
   endpoint: Endpoint | undefined;
+  existingEndpoints: Endpoint[] | undefined;
   isFormComplete: boolean;
   hasChanges: boolean;
   handleSubmit: (values: EditEndpointFormData) => Promise<void>;
   handleCancel: () => void;
-  handleNameBlur: () => void;
+  handleNameUpdate: (newName: string) => Promise<void>;
 }
 
 export function useEditEndpointForm(endpointId: string): UseEditEndpointFormResult {
@@ -131,22 +130,14 @@ export function useEditEndpointForm(endpointId: string): UseEditEndpointFormResu
     mutateAsync: updateEndpoint,
     error: updateEndpointError,
     isLoading: isUpdatingEndpoint,
-    reset: resetEndpointError,
   } = useUpdateEndpointMutation();
 
   const { mutateAsync: createSecret } = useCreateSecret();
   const { mutateAsync: createModelDefinition } = useCreateModelDefinitionMutation();
   const { mutateAsync: updateModelDefinition } = useUpdateModelDefinitionMutation();
 
-  const [customError, setCustomError] = useState<Error | null>();
-
-  const resetErrors = useCallback(() => {
-    resetEndpointError();
-    setCustomError(null);
-  }, [resetEndpointError]);
-
   const isSubmitting = isUpdatingEndpoint;
-  const mutationError = (customError || updateEndpointError) as Error | null;
+  const mutationError = updateEndpointError as Error | null;
 
   const handleSubmit = useCallback(
     async (values: EditEndpointFormData) => {
@@ -277,6 +268,22 @@ export function useEditEndpointForm(endpointId: string): UseEditEndpointFormResu
     navigate(GatewayRoutes.gatewayPageRoute);
   }, [navigate]);
 
+  const handleNameUpdate = useCallback(
+    async (newName: string) => {
+      if (!endpoint) return;
+
+      await updateEndpoint({
+        endpointId: endpoint.endpoint_id,
+        name: newName,
+      });
+
+      // Invalidate the endpoint query to refetch the updated data
+      queryClient.invalidateQueries({ queryKey: ['gateway', 'endpoint', endpointId] });
+      queryClient.invalidateQueries({ queryKey: ['gateway', 'endpoints'] });
+    },
+    [endpoint, updateEndpoint, queryClient, endpointId],
+  );
+
   const trafficSplitModels = form.watch('trafficSplitModels');
   const fallbackModels = form.watch('fallbackModels');
 
@@ -386,39 +393,18 @@ export function useEditEndpointForm(endpointId: string): UseEditEndpointFormResu
 
   const { data: existingEndpoints } = useEndpointsQuery();
 
-  const handleNameBlur = useCallback(() => {
-    const name = form.getValues('name');
-    if (name) {
-      if (!isValidEndpointName(name)) {
-        form.setError('name', {
-          type: 'manual',
-          message:
-            'Name can only contain letters, numbers, underscores, hyphens, and dots. Spaces and special characters are not allowed.',
-        });
-        return;
-      }
-      const otherEndpoints = existingEndpoints?.filter((e) => e.endpoint_id !== endpointId);
-      if (otherEndpoints?.some((e) => e.name === name)) {
-        form.setError('name', {
-          type: 'manual',
-          message: 'An endpoint with this name already exists',
-        });
-      }
-    }
-  }, [form, existingEndpoints, endpointId]);
-
   return {
     form,
     isLoadingEndpoint,
     isSubmitting,
     loadError: loadError as Error | null,
     mutationError,
-    resetErrors,
     endpoint,
+    existingEndpoints,
     isFormComplete,
     hasChanges,
     handleSubmit,
     handleCancel,
-    handleNameBlur,
+    handleNameUpdate,
   };
 }

--- a/mlflow/server/js/src/gateway/pages/EndpointPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/EndpointPage.tsx
@@ -14,13 +14,13 @@ const EndpointPage = () => {
     isSubmitting,
     loadError,
     mutationError,
-    resetErrors,
     endpoint,
+    existingEndpoints,
     isFormComplete,
     hasChanges,
     handleSubmit,
     handleCancel,
-    handleNameBlur,
+    handleNameUpdate,
   } = useEditEndpointForm(endpointId ?? '');
 
   return (
@@ -32,13 +32,13 @@ const EndpointPage = () => {
         loadError={loadError}
         mutationError={mutationError}
         errorMessage={getReadableErrorMessage(mutationError)}
-        resetErrors={resetErrors}
-        endpointName={endpoint?.name}
+        endpoint={endpoint}
+        existingEndpoints={existingEndpoints}
         isFormComplete={isFormComplete}
         hasChanges={hasChanges}
         onSubmit={handleSubmit}
         onCancel={handleCancel}
-        onNameBlur={handleNameBlur}
+        onNameUpdate={handleNameUpdate}
       />
     </FormProvider>
   );

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -938,6 +938,10 @@
     "defaultMessage": "Delete",
     "description": "Delete button text"
   },
+  "5umyLP": {
+    "defaultMessage": "Edit endpoint name",
+    "description": "Aria label for edit endpoint name button"
+  },
   "5vzPok": {
     "defaultMessage": "AI Gateway",
     "description": "Sidebar link for gateway configuration"
@@ -1302,6 +1306,10 @@
     "defaultMessage": "Type a key",
     "description": "Key-value tag editor modal > Tag dropdown > Tag input placeholder"
   },
+  "8DoNdT": {
+    "defaultMessage": "Save",
+    "description": "Save button text for edit endpoint name modal"
+  },
   "8EK+SZ": {
     "defaultMessage": "Use",
     "description": "A label for a button to display the modal with the usage example of the prompt"
@@ -1609,6 +1617,10 @@
   "AanBxl": {
     "defaultMessage": "my-endpoint",
     "description": "Placeholder for endpoint name input"
+  },
+  "AawxF/": {
+    "defaultMessage": "Edit Endpoint Name",
+    "description": "Title for edit endpoint name modal"
   },
   "AdlJNW": {
     "defaultMessage": "Assessment Name",
@@ -2153,6 +2165,10 @@
   "FFe+Ug": {
     "defaultMessage": "Type a value",
     "description": "Key-value tag editor modal > Value input placeholder"
+  },
+  "FHJ1NN": {
+    "defaultMessage": "Endpoint Name",
+    "description": "Label for endpoint name input"
   },
   "FKoHx5": {
     "defaultMessage": "Security Notice: Default Passphrase in Use",
@@ -4232,10 +4248,6 @@
     "defaultMessage": "Groundedness",
     "description": "Evaluation results > known type of evaluation result assessment > groundedness assessment. Used to indicate if the result is grounded in context of LLMs evaluation. Label displayed if user provided custom value, e.g. \"Groundedness: moderately grounded\""
   },
-  "Wt644B": {
-    "defaultMessage": "Endpoint Name",
-    "description": "Section title for endpoint name"
-  },
   "WtTgz+": {
     "defaultMessage": "Tool",
     "description": "Column header for tool name"
@@ -4386,6 +4398,10 @@
   "Y6gWro": {
     "defaultMessage": "The correctness LLM judge gives a binary evaluation and written rationale on whether the agent's generated response is factually accurate and semantically similar to the provided ground-truth response or grading notes.",
     "description": "Evaluation results > known type of evaluation result assessment > description of correctness assessment."
+  },
+  "Y73UT6": {
+    "defaultMessage": "Endpoint name is required",
+    "description": "Error message when endpoint name is empty"
   },
   "Y7AIKR": {
     "defaultMessage": "MLflow Invocations API",
@@ -5167,6 +5183,10 @@
     "defaultMessage": "Are you sure you want to navigate away? Your pending text changes will be lost.",
     "description": "Prompt text for navigating away before saving changes in editable note in MLflow"
   },
+  "dzIz7c": {
+    "defaultMessage": "Name can only contain letters, numbers, underscores, hyphens, and dots. Spaces and special characters are not allowed.",
+    "description": "Error message for invalid endpoint name format"
+  },
   "dzoxyA": {
     "defaultMessage": "Reject pending request",
     "description": "Title for a model version stage transition modal when rejecting a pending request"
@@ -5535,6 +5555,10 @@
     "defaultMessage": "Tag \"{value}\" already exists.",
     "description": "Validation message for tags that already exist in tags table in MLflow"
   },
+  "gVz/1j": {
+    "defaultMessage": "An endpoint with this name already exists",
+    "description": "Error message when endpoint name already exists"
+  },
   "gYOuKs": {
     "defaultMessage": "Rationale",
     "description": "Label for the rationale of an expectation assessment"
@@ -5786,6 +5810,10 @@
   "iRNZkJ": {
     "defaultMessage": "Failed to delete assessment. Error: {error}",
     "description": "Error message when deleting an assessment fails."
+  },
+  "iT2I8i": {
+    "defaultMessage": "The name is used in the endpoint URL. Only letters, numbers, underscores, hyphens, and dots are allowed.",
+    "description": "Help text for endpoint name input"
   },
   "iT8ODo": {
     "defaultMessage": "Minimum",
@@ -6395,6 +6423,10 @@
     "defaultMessage": "Edit history",
     "description": "Title of a modal that shows the edit history of an assessment"
   },
+  "nBKx6U": {
+    "defaultMessage": "Edit endpoint name",
+    "description": "Tooltip for edit endpoint name button"
+  },
   "nC54Nf": {
     "defaultMessage": "Tags",
     "description": "Column title for model tags in the registered model page"
@@ -6534,10 +6566,6 @@
   "o8YPlv": {
     "defaultMessage": "Dataset tracking",
     "description": "Home page news card title four"
-  },
-  "o9x0Pq": {
-    "defaultMessage": "The name is used in the endpoint URL. Only letters, numbers, underscores, hyphens, and dots are allowed.",
-    "description": "Endpoint name description"
   },
   "oBJ8xc": {
     "defaultMessage": "Cost",


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Replace the endpoint name form with an icon and modal

<img width="872" height="681" alt="image" src="https://github.com/user-attachments/assets/587fb16d-7267-4d00-9629-ef584b651a92" />


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
