### PR TITLE
Fix flaky TypeScript SDK integration tests

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -62,8 +62,4 @@ jobs:
         run: npm run test:core
 
       - name: Run tests for integrations
-        run: |
-          for i in {1..10}; do
-            echo "=== Run $i/10 ==="
-            npm run test:integrations
-          done
+        run: npm run test:integrations

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -62,4 +62,8 @@ jobs:
         run: npm run test:core
 
       - name: Run tests for integrations
-        run: npm run test:integrations
+        run: |
+          for i in {1..10}; do
+            echo "=== Run $i/10 ==="
+            npm run test:integrations
+          done

--- a/libs/typescript/jest.global-server-setup.ts
+++ b/libs/typescript/jest.global-server-setup.ts
@@ -37,7 +37,7 @@ module.exports = async () => {
       detached: true,
       env: {
         ...process.env,
-        // Disable job execution to avoid timing issues in tests (no database backend anyway)
+        // Disable job execution to avoid timing issues in tests
         MLFLOW_SERVER_ENABLE_JOB_EXECUTION: 'false'
       }
     }

--- a/libs/typescript/jest.global-server-setup.ts
+++ b/libs/typescript/jest.global-server-setup.ts
@@ -34,7 +34,12 @@ module.exports = async () => {
       cwd: tempDir,
       stdio: 'inherit',
       // Create a new process group so we can kill the entire group
-      detached: true
+      detached: true,
+      env: {
+        ...process.env,
+        // Disable job execution to avoid timing issues in tests (no database backend anyway)
+        MLFLOW_SERVER_ENABLE_JOB_EXECUTION: 'false'
+      }
     }
   );
 


### PR DESCRIPTION
### Related Issues/PRs

#19850

### What changes are proposed in this pull request?

Fix flaky TypeScript SDK integration tests by explicitly disabling job execution when starting the MLflow server for tests.

**Investigation Summary:**

After #19850 changed `MLFLOW_SERVER_ENABLE_JOB_EXECUTION` to default to `True`, the TypeScript SDK integration tests started failing intermittently with HTTP 404 errors when retrieving traces.

**Evidence:**
- First CI failure occurred at 21:52 UTC on Jan 14 - just 3 minutes after #19850 was merged at 21:49 UTC
- All 8 failures in the last 100 runs occurred after this PR
- Before #19850: 0 failures
- After #19850: 8 failures out of 21 runs (~40% failure rate)

**Root cause:**
When the test server starts, it now tries to enable job execution by default. Even though it fails gracefully (no database backend configured), this adds startup overhead and introduces timing issues that cause occasional 404 errors when retrieving traces immediately after export.

**Fix:**
Set `MLFLOW_SERVER_ENABLE_JOB_EXECUTION=false` in the test server environment to restore the previous behavior. The tests don't need job execution anyway since they use a file-based backend.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)