### PR TITLE
UI: Improve empty states for Traces and Sessions tabs

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Toolbar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Toolbar.tsx
@@ -21,7 +21,7 @@ export const TracesV3Toolbar = ({
         display: 'flex',
         alignItems: 'center',
         width: '100%',
-        borderBottom: `1px solid ${theme.colors.grey100}`,
+        borderBottom: `1px solid ${theme.colors.borderDecorative}`,
         paddingBottom: `${theme.spacing.sm}px`,
       }}
       className={className}

--- a/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableGenericQuickstart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableGenericQuickstart.tsx
@@ -1,5 +1,6 @@
-import { Typography, useDesignSystemTheme } from '@databricks/design-system';
-import { CodeSnippet, SnippetCopyAction } from '@databricks/web-shared/snippet';
+import { CopyIcon, Typography, useDesignSystemTheme, Alert } from '@databricks/design-system';
+import { CodeSnippet } from '@databricks/web-shared/snippet';
+import { CopyButton } from '@mlflow/mlflow/src/shared/building_blocks/CopyButton';
 
 import { QUICKSTART_CONTENT } from './TraceTableQuickstart.utils';
 
@@ -15,17 +16,19 @@ export const TraceTableGenericQuickstart = ({
   const content = getContent(baseComponentId);
   const code = getCodeSource();
   return (
-    <div>
-      <Typography.Paragraph color="secondary" css={{ maxWidth: 600 }}>
+    <div css={{ maxWidth: 600 }}>
+      <Typography.Text color="secondary">
         {content}
-      </Typography.Paragraph>
-      <div css={{ position: 'relative' }}>
-        <SnippetCopyAction
-          componentId="mlflow.traces.empty_state.example_code_copy"
-          css={{ position: 'absolute', top: theme.spacing.xs, right: theme.spacing.xs }}
+      </Typography.Text>
+      <div css={{ position: 'relative', maxWidth: '100%' }}>
+        <CopyButton
+          componentId="codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablegenericquickstart_25"
+          css={{ zIndex: 1, position: 'absolute', top: theme.spacing.xs, right: theme.spacing.xs }}
+          showLabel={false}
           copyText={code}
+          icon={<CopyIcon />}
         />
-        <CodeSnippet language="python" showLineNumbers>
+        <CodeSnippet showLineNumbers language="python" theme={theme.isDarkMode ? 'duotoneDark' : 'light'}>
           {code}
         </CodeSnippet>
       </div>

--- a/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableGenericQuickstart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableGenericQuickstart.tsx
@@ -17,9 +17,7 @@ export const TraceTableGenericQuickstart = ({
   const code = getCodeSource();
   return (
     <div css={{ maxWidth: 600 }}>
-      <Typography.Text color="secondary">
-        {content}
-      </Typography.Text>
+      <Typography.Text color="secondary">{content}</Typography.Text>
       <div css={{ position: 'relative', maxWidth: '100%' }}>
         <CopyButton
           componentId="codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablegenericquickstart_25"

--- a/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableGenericQuickstart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableGenericQuickstart.tsx
@@ -20,7 +20,7 @@ export const TraceTableGenericQuickstart = ({
       <Typography.Text color="secondary">{content}</Typography.Text>
       <div css={{ position: 'relative', maxWidth: '100%' }}>
         <CopyButton
-          componentId="codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablegenericquickstart_25"
+          componentId="mlflow.traces.empty_state_generic_quickstart.copy"
           css={{ zIndex: 1, position: 'absolute', top: theme.spacing.xs, right: theme.spacing.xs }}
           showLabel={false}
           copyText={code}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsEmptyState.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsEmptyState.tsx
@@ -30,7 +30,7 @@ export const GenAIChatSessionsEmptyState = () => {
 
   return (
     <div css={{ flex: 1, flexDirection: 'column', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-      <Typography.Title level={3} color="secondary">
+      <Typography.Title level={3}>
         <FormattedMessage
           defaultMessage="Group traces from the same chat session together"
           description="Empty state title for the chat sessions table"

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsEmptyState.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsEmptyState.tsx
@@ -53,13 +53,13 @@ export const GenAIChatSessionsEmptyState = () => {
           />
         </Typography.Link>
       </Typography.Paragraph>
-      <div css={{ position: 'relative' }}>
+      <div css={{ position: 'relative', maxWidth: 600 }}>
         <SnippetCopyAction
           componentId="mlflow.chat_sessions.empty_state.example_code_copy"
           css={{ position: 'absolute', top: theme.spacing.xs, right: theme.spacing.xs }}
           copyText={EXAMPLE_CODE}
         />
-        <CodeSnippet language="python" showLineNumbers>
+        <CodeSnippet language="python" showLineNumbers theme={theme.isDarkMode ? 'duotoneDark' : 'light'}>
           {EXAMPLE_CODE}
         </CodeSnippet>
       </div>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
@@ -264,35 +264,37 @@ export const GenAIChatSessionsTable = ({
           enableRowSelection ? table.getIsAllRowsSelected() || table.getIsSomeRowsSelected() : undefined
         }
       >
-        <TableRow isHeader>
-          {enableRowSelection && (
-            <div css={{ display: 'flex', overflow: 'hidden', flexShrink: 0 }}>
-              <TableRowSelectCell
-                componentId="mlflow.chat-sessions.table-header-checkbox"
-                checked={table.getIsAllRowsSelected()}
-                indeterminate={table.getIsSomeRowsSelected()}
-                onChange={table.getToggleAllRowsSelectedHandler()}
-              />
-            </div>
-          )}
-          {table.getLeafHeaders().map((header) => (
-            <TableHeader
-              key={header.id}
-              componentId="mlflow.chat-sessions.table-header"
-              header={header}
-              column={header.column}
-              sortable={header.column.getCanSort()}
-              css={{
-                cursor: header.column.getCanSort() ? 'pointer' : 'default',
-                flex: `calc(var(--col-${header.id}-size) / 100)`,
-              }}
-              sortDirection={header.column.getIsSorted() || 'none'}
-              onToggleSort={header.column.getToggleSortingHandler()}
-            >
-              {flexRender(header.column.columnDef.header, header.getContext())}
-            </TableHeader>
-          ))}
-        </TableRow>
+        {sessionTableRows.length > 0 && (
+          <TableRow isHeader>
+            {enableRowSelection && (
+              <div css={{ display: 'flex', overflow: 'hidden', flexShrink: 0 }}>
+                <TableRowSelectCell
+                  componentId="mlflow.chat-sessions.table-header-checkbox"
+                  checked={table.getIsAllRowsSelected()}
+                  indeterminate={table.getIsSomeRowsSelected()}
+                  onChange={table.getToggleAllRowsSelectedHandler()}
+                />
+              </div>
+            )}
+            {table.getLeafHeaders().map((header) => (
+              <TableHeader
+                key={header.id}
+                componentId="mlflow.chat-sessions.table-header"
+                header={header}
+                column={header.column}
+                sortable={header.column.getCanSort()}
+                css={{
+                  cursor: header.column.getCanSort() ? 'pointer' : 'default',
+                  flex: `calc(var(--col-${header.id}-size) / 100)`,
+                }}
+                sortDirection={header.column.getIsSorted() || 'none'}
+                onToggleSort={header.column.getToggleSortingHandler()}
+              >
+                {flexRender(header.column.columnDef.header, header.getContext())}
+              </TableHeader>
+            ))}
+          </TableRow>
+        )}
 
         {!isLoading &&
           table


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/abe82b73-d489-4d2c-8c01-c8ef90662528

After


https://github.com/user-attachments/assets/8e7f9e82-7b89-4080-b9bd-eed9c14f738a






<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR improves the UI consistency and readability of empty states in the Traces and Sessions tabs:

- **Centered layout**: Traces empty state now matches the Sessions tab with proper centering
- **Content width constraint**: Both empty states constrained to 600px max-width for better readability
- **Updated heading**: Changed Traces heading to 'Log traces to this experiment' with H3 styling
- **Proper text colors**: Using design system colors (primary for headings, secondary for body text)
- **Dark mode fix**: Code snippets now use proper duotoneDark theme in dark mode
- **Code snippet width**: Code blocks respect the 600px max-width constraint with horizontal scrolling
- **Clean empty state**: Column headers hidden in Sessions tab when table is empty
- **Consistent heading colors**: Both Traces and Sessions use text-primary color for headings
- **Design system border**: Toolbar border now uses borderDecorative token instead of hardcoded grey100

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Manual testing:**
- Manually tested in both light and dark modes
- Verified layout consistency between Traces and Sessions empty states
- Confirmed all text uses proper design system colors
- Verified code snippets display correctly and respect width constraints
- Confirmed toolbar border uses design system token

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved the visual consistency and readability of empty states in the Traces and Sessions tabs with proper centering, width constraints, updated heading text, correct design system colors, and fixed dark mode theming for code snippets.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)