### PR TITLE
Update genai evaluate databricks managed telemetry util to include build in scorer information

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -210,7 +210,7 @@ def run(
     mlflow.log_metrics(aggregated_metrics)
 
     try:
-        emit_metric_usage_event(scorers, len(eval_items), aggregated_metrics)
+        emit_metric_usage_event(scorers, len(eval_items), len(session_groups), aggregated_metrics)
     except Exception as e:
         _logger.debug(f"Failed to emit metric usage event: {e}", exc_info=True)
 

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -34,7 +34,7 @@ from mlflow.genai.evaluation.session_utils import (
     evaluate_session_level_scorers,
     group_traces_by_session,
 )
-from mlflow.genai.evaluation.telemetry import emit_custom_metric_event
+from mlflow.genai.evaluation.telemetry import emit_metric_usage_event
 from mlflow.genai.evaluation.utils import (
     PGBAR_FORMAT,
     is_none_or_nan,
@@ -210,9 +210,9 @@ def run(
     mlflow.log_metrics(aggregated_metrics)
 
     try:
-        emit_custom_metric_event(scorers, len(eval_items), aggregated_metrics)
+        emit_metric_usage_event(scorers, len(eval_items), aggregated_metrics)
     except Exception as e:
-        _logger.debug(f"Failed to emit custom metric usage event: {e}", exc_info=True)
+        _logger.debug(f"Failed to emit metric usage event: {e}", exc_info=True)
 
     # Search for all traces in the run. We need to fetch the traces from backend here to include
     # all traces in the result.

--- a/mlflow/genai/evaluation/telemetry.py
+++ b/mlflow/genai/evaluation/telemetry.py
@@ -22,50 +22,91 @@ _sessions = threading.local()
 _SESSION_KEY = "genai-eval-session"
 
 
-def emit_custom_metric_event(
+def emit_metric_usage_event(
     scorers: list[Scorer], eval_count: int | None, aggregated_metrics: dict[str, float]
 ):
-    """Emit events for custom scorers and metrics usage if running on Databricks"""
+    """Emit usage events for custom and built-in scorers when running on Databricks"""
     if not is_databricks_uri(mlflow.get_tracking_uri()):
         return
 
     custom_metrics = list(filter(_is_custom_scorer, scorers))
-    metric_name_to_hash = {m.name: _hash_metric_name(m.name) for m in custom_metrics}
+    builtin_metrics = [s for s in scorers if not _is_custom_scorer(s)]
 
-    metric_stats = {
-        hashed_name: {"average": None, "count": eval_count}
-        for hashed_name in metric_name_to_hash.values()
-    }
-    for metric_key, metric_value in aggregated_metrics.items():
-        name, aggregation = metric_key.split("/", 1)
-        hashed_name = metric_name_to_hash.get(name)
-        if hashed_name is not None and aggregation == "mean":
-            metric_stats[hashed_name]["average"] = metric_value
+    events = []
 
-    metric_stats = [
-        {
-            "name": hashed_name,
-            "average": metric_stats[hashed_name]["average"],
-            "count": metric_stats[hashed_name]["count"],
+    if custom_metrics:
+        metric_name_to_hash = {m.name: _hash_metric_name(m.name) for m in custom_metrics}
+
+        metric_stats = {
+            hashed_name: {"average": None, "count": eval_count}
+            for hashed_name in metric_name_to_hash.values()
         }
-        for hashed_name in metric_stats
-    ]
-    event_payload = {
-        "metric_names": list(metric_name_to_hash.values()),
-        "eval_count": eval_count,
-        "metrics": metric_stats,
+        for metric_key, metric_value in aggregated_metrics.items():
+            name, aggregation = metric_key.split("/", 1)
+            hashed_name = metric_name_to_hash.get(name)
+            if hashed_name is not None and aggregation == "mean":
+                metric_stats[hashed_name]["average"] = metric_value
+
+        metric_stats = [
+            {
+                "name": hashed_name,
+                "average": metric_stats[hashed_name]["average"],
+                "count": metric_stats[hashed_name]["count"],
+            }
+            for hashed_name in metric_stats
+        ]
+
+        events.append(
+            {
+                "custom_metric_usage_event": {
+                    "eval_count": eval_count,
+                    "metrics": metric_stats,
+                }
+            }
+        )
+
+    if builtin_metrics:
+        builtin_stats = [
+            {
+                "name": type(scorer).__name__,
+                "count": eval_count,
+            }
+            for scorer in builtin_metrics
+        ]
+
+        events.append(
+            {
+                "builtin_scorer_usage_event": {
+                    "metrics": builtin_stats,
+                }
+            }
+        )
+
+    if not events:
+        return
+
+    payload = {"agent_evaluation_client_usage_events": events}
+
+    extra_headers = {
+        _CLIENT_VERSION_HEADER: VERSION,
+        _SESSION_ID_HEADER: _get_or_create_session_id(),
+        _BATCH_SIZE_HEADER: str(eval_count),
+        _CLIENT_NAME_HEADER: "mlflow",
     }
+
+    try:
+        from databricks.rag_eval.utils import request_utils
+
+        extra_headers = request_utils.add_traffic_id_header(extra_headers)
+    except ImportError:
+        pass
+
     http_request(
         host_creds=get_databricks_host_creds(),
         endpoint=_EVAL_TELEMETRY_ENDPOINT,
         method="POST",
-        extra_headers={
-            _CLIENT_VERSION_HEADER: VERSION,
-            _SESSION_ID_HEADER: _get_or_create_session_id(),
-            _BATCH_SIZE_HEADER: str(eval_count),
-            _CLIENT_NAME_HEADER: "mlflow",
-        },
-        json=event_payload,
+        extra_headers=extra_headers,
+        json=payload,
     )
 
 

--- a/tests/genai/evaluate/test_telemetry.py
+++ b/tests/genai/evaluate/test_telemetry.py
@@ -36,6 +36,14 @@ class IsEmpty(Scorer):
         return outputs == ""
 
 
+from databricks.agents.evals import metric
+
+
+@metric
+def not_empty(response):
+    return response != ""
+
+
 session_level_judge = make_judge(
     name="session_quality",
     instructions="Evaluate if the {{ conversation }} is coherent and complete.",
@@ -84,7 +92,7 @@ def test_emit_metric_usage_event_custom_scorers_only(mock_http_request):
         feedback_value_type=str,
     )
     emit_metric_usage_event(
-        scorers=[is_concise, is_correct, IsEmpty(), is_kind],
+        scorers=[is_concise, is_correct, IsEmpty(), is_kind, not_empty],
         trace_count=10,
         session_count=0,
         aggregated_metrics={
@@ -92,6 +100,7 @@ def test_emit_metric_usage_event_custom_scorers_only(mock_http_request):
             "is_correct/mean": 0.2,
             "is_empty/mean": 0.3,
             "is_kind/mean": 0.4,
+            "not_empty/mean": 0.5,
         },
     )
 
@@ -108,6 +117,7 @@ def test_emit_metric_usage_event_custom_scorers_only(mock_http_request):
                         {"name": mock.ANY, "average": 0.2, "count": 10},
                         {"name": mock.ANY, "average": 0.3, "count": 10},
                         {"name": mock.ANY, "average": 0.4, "count": 10},
+                        {"name": mock.ANY, "average": 0.5, "count": 10},
                     ],
                 }
             }

--- a/tests/genai/evaluate/test_telemetry.py
+++ b/tests/genai/evaluate/test_telemetry.py
@@ -8,7 +8,7 @@ from mlflow.genai.evaluation.telemetry import (
     _CLIENT_NAME_HEADER,
     _CLIENT_VERSION_HEADER,
     _SESSION_ID_HEADER,
-    emit_custom_metric_event,
+    emit_metric_usage_event,
 )
 from mlflow.genai.judges import make_judge
 from mlflow.genai.scorers import Correctness, Guidelines
@@ -29,7 +29,6 @@ def is_correct(outputs, expectations) -> bool:
     return outputs == expectations["expected_response"]
 
 
-# Class based scorers
 class IsEmpty(Scorer):
     name: str = "is_empty"
 
@@ -37,29 +36,8 @@ class IsEmpty(Scorer):
         return outputs == ""
 
 
-def test_emit_custom_metric_event():
-    from databricks.agents.evals import metric
-
-    # Legacy custom metrics
-    @metric
-    def not_empty(response):
-        return response != ""
-
-    scorers = [
-        # Built-in
-        Correctness(),
-        Guidelines(guidelines="The answer must be concise and straight to the point."),
-        # Custom
-        is_concise,
-        is_correct,
-        IsEmpty(),
-        not_empty,
-        make_judge(
-            name="is_kind",
-            instructions="The answer must be kind. {{ outputs }}",
-            feedback_value_type=str,
-        ),
-    ]
+@pytest.fixture
+def mock_http_request():
     with (
         mock.patch("mlflow.genai.evaluation.telemetry.is_databricks_uri", return_value=True),
         mock.patch(
@@ -67,25 +45,143 @@ def test_emit_custom_metric_event():
         ) as mock_http_request,
         mock.patch("mlflow.genai.evaluation.telemetry.get_databricks_host_creds"),
     ):
-        emit_custom_metric_event(
-            scorers=scorers,
+        yield mock_http_request
+
+
+def test_emit_metric_usage_event_skip_outside_databricks():
+    with (
+        mock.patch("mlflow.genai.evaluation.telemetry.is_databricks_uri", return_value=False),
+        mock.patch(
+            "mlflow.genai.evaluation.telemetry.http_request", autospec=True
+        ) as mock_http_request,
+        mock.patch("mlflow.genai.evaluation.telemetry.get_databricks_host_creds"),
+    ):
+        emit_metric_usage_event(
+            scorers=[is_concise],
             eval_count=10,
-            aggregated_metrics={
-                "is_concise/mean": 0.1,
-                "is_concise/min": 0.2,
-                "is_concise/max": 0.3,
-                "is_correct/mean": 0.4,
-                "is_empty/mean": 0.5,
-                "not_empty/max": 0.6,
-                "correctness/mean": 0.7,
-                "guidelines/mean": 0.8,
-                "is_kind/mean": 0.9,
-            },
+            aggregated_metrics={"is_concise/mean": 0.5},
         )
+    mock_http_request.assert_not_called()
+
+
+def test_emit_metric_usage_event_skip_when_no_scorers(mock_http_request):
+    emit_metric_usage_event(scorers=[], eval_count=10, aggregated_metrics={})
+    mock_http_request.assert_not_called()
+
+
+def test_emit_metric_usage_event_custom_scorers_only(mock_http_request):
+    from databricks.agents.evals import metric
+
+    @metric
+    def not_empty(response):
+        return response != ""
+
+    is_kind = make_judge(
+        name="is_kind",
+        instructions="The answer must be kind. {{ outputs }}",
+        feedback_value_type=str,
+    )
+    emit_metric_usage_event(
+        scorers=[is_concise, is_correct, IsEmpty(), is_kind, not_empty],
+        eval_count=10,
+        aggregated_metrics={
+            "is_concise/mean": 0.1,
+            "is_correct/mean": 0.2,
+            "is_empty/mean": 0.3,
+            "is_kind/mean": 0.4,
+            "not_empty/mean": 0.5,
+        },
+    )
 
     mock_http_request.assert_called_once()
-    call_args = mock_http_request.call_args[1]
+    payload = mock_http_request.call_args[1]["json"]
 
+    assert payload == {
+        "agent_evaluation_client_usage_events": [
+            {
+                "custom_metric_usage_event": {
+                    "eval_count": 10,
+                    "metrics": [
+                        {"name": mock.ANY, "average": 0.1, "count": 10},
+                        {"name": mock.ANY, "average": 0.2, "count": 10},
+                        {"name": mock.ANY, "average": 0.3, "count": 10},
+                        {"name": mock.ANY, "average": 0.4, "count": 10},
+                        {"name": mock.ANY, "average": 0.5, "count": 10},
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def test_emit_metric_usage_event_builtin_scorers_only(mock_http_request):
+    emit_metric_usage_event(
+        scorers=[Correctness(), Guidelines(guidelines="Be concise")],
+        eval_count=5,
+        aggregated_metrics={"correctness/mean": 0.8, "guidelines/mean": 0.9},
+    )
+
+    mock_http_request.assert_called_once()
+    payload = mock_http_request.call_args[1]["json"]
+
+    assert payload == {
+        "agent_evaluation_client_usage_events": [
+            {
+                "builtin_metric_usage_event": {
+                    "eval_count": 5,
+                    "metrics": [
+                        {"name": "Correctness", "count": 5},
+                        {"name": "Guidelines", "count": 5},
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def test_emit_metric_usage_event_mixed_custom_and_builtin_scorers(mock_http_request):
+    emit_metric_usage_event(
+        scorers=[Correctness(), is_concise, Guidelines(guidelines="Be concise")],
+        eval_count=10,
+        aggregated_metrics={
+            "correctness/mean": 0.7,
+            "is_concise/mean": 0.5,
+            "guidelines/mean": 0.8,
+        },
+    )
+
+    mock_http_request.assert_called_once()
+    payload = mock_http_request.call_args[1]["json"]
+
+    assert payload == {
+        "agent_evaluation_client_usage_events": [
+            {
+                "custom_metric_usage_event": {
+                    "eval_count": 10,
+                    "metrics": [{"name": mock.ANY, "average": 0.5, "count": 10}],
+                }
+            },
+            {
+                "builtin_metric_usage_event": {
+                    "eval_count": 10,
+                    "metrics": [
+                        {"name": "Correctness", "count": 10},
+                        {"name": "Guidelines", "count": 10},
+                    ],
+                }
+            },
+        ]
+    }
+
+
+def test_emit_metric_usage_event_headers(mock_http_request):
+    emit_metric_usage_event(
+        scorers=[is_concise],
+        eval_count=10,
+        aggregated_metrics={"is_concise/mean": 0.5},
+    )
+
+    call_args = mock_http_request.call_args[1]
     assert call_args["method"] == "POST"
     assert call_args["endpoint"] == "/api/2.0/agents/evaluation-client-usage-events"
 
@@ -95,77 +191,17 @@ def test_emit_custom_metric_event():
     assert headers[_BATCH_SIZE_HEADER] == "10"
     assert headers[_CLIENT_NAME_HEADER] == "mlflow"
 
-    event = call_args["json"]
-    assert len(event["metric_names"]) == 5
-    assert all(isinstance(name, str) for name in event["metric_names"])
-    assert event["eval_count"] == 10
-    assert event["metrics"] == [
-        {
-            "name": mock.ANY,
-            "average": 0.1,
-            "count": 10,
-        },
-        {
-            "name": mock.ANY,
-            "average": 0.4,
-            "count": 10,
-        },
-        {
-            "name": mock.ANY,
-            "average": 0.5,
-            "count": 10,
-        },
-        {
-            "name": mock.ANY,
-            "average": None,
-            "count": 10,
-        },
-        {
-            "name": mock.ANY,
-            "average": 0.9,
-            "count": 10,
-        },
-    ]
-    # Metric names should be hashed
-    assert isinstance(event["metrics"][0]["name"], str)
-    assert event["metrics"][0]["name"] != "is_concise"
 
-
-def test_emit_custom_metric_usage_event_skip_outside_databricks():
-    with (
-        mock.patch("mlflow.genai.evaluation.telemetry.is_databricks_uri", return_value=False),
-        mock.patch(
-            "mlflow.genai.evaluation.telemetry.http_request", autospec=True
-        ) as mock_http_request,
-        mock.patch("mlflow.genai.evaluation.telemetry.get_databricks_host_creds"),
-    ):
-        emit_custom_metric_event(
-            scorers=[is_concise, is_correct],
+def test_emit_metric_usage_event_with_sessions(mock_http_request):
+    for _ in range(3):
+        emit_metric_usage_event(
+            scorers=[is_concise, Correctness()],
             eval_count=10,
-            aggregated_metrics={"is_concise/mean": 0.1, "is_correct/mean": 0.2},
+            aggregated_metrics={"is_concise/mean": 0.5, "correctness/mean": 0.8},
         )
-    mock_http_request.assert_not_called()
-
-
-def test_emit_custom_metric_usage_event_with_sessions():
-    with (
-        mock.patch("mlflow.genai.evaluation.telemetry.is_databricks_uri", return_value=True),
-        mock.patch(
-            "mlflow.genai.evaluation.telemetry.http_request", autospec=True
-        ) as mock_http_request,
-        mock.patch("mlflow.genai.evaluation.telemetry.get_databricks_host_creds"),
-    ):
-        for _ in range(3):
-            emit_custom_metric_event(
-                scorers=[is_concise, is_correct],
-                eval_count=10,
-                aggregated_metrics={"is_concise/mean": 0.1, "is_correct/mean": 0.2},
-            )
 
     assert mock_http_request.call_count == 3
     session_ids = [
-        call_args[1]["extra_headers"][_SESSION_ID_HEADER]
-        for call_args in mock_http_request.call_args_list
+        call[1]["extra_headers"][_SESSION_ID_HEADER] for call in mock_http_request.call_args_list
     ]
     assert len(set(session_ids)) == 1
-    assert all(session_id is not None for session_id in session_ids)

--- a/tests/genai/evaluate/test_telemetry.py
+++ b/tests/genai/evaluate/test_telemetry.py
@@ -11,7 +11,7 @@ from mlflow.genai.evaluation.telemetry import (
     emit_metric_usage_event,
 )
 from mlflow.genai.judges import make_judge
-from mlflow.genai.scorers import Correctness, Guidelines
+from mlflow.genai.scorers import Correctness, Guidelines, UserFrustration
 from mlflow.genai.scorers.validation import IS_DBX_AGENTS_INSTALLED
 from mlflow.version import VERSION
 
@@ -36,6 +36,13 @@ class IsEmpty(Scorer):
         return outputs == ""
 
 
+session_level_judge = make_judge(
+    name="session_quality",
+    instructions="Evaluate if the {{ conversation }} is coherent and complete.",
+    feedback_value_type=bool,
+)
+
+
 @pytest.fixture
 def mock_http_request():
     with (
@@ -58,38 +65,33 @@ def test_emit_metric_usage_event_skip_outside_databricks():
     ):
         emit_metric_usage_event(
             scorers=[is_concise],
-            eval_count=10,
+            trace_count=10,
+            session_count=0,
             aggregated_metrics={"is_concise/mean": 0.5},
         )
     mock_http_request.assert_not_called()
 
 
 def test_emit_metric_usage_event_skip_when_no_scorers(mock_http_request):
-    emit_metric_usage_event(scorers=[], eval_count=10, aggregated_metrics={})
+    emit_metric_usage_event(scorers=[], trace_count=10, session_count=0, aggregated_metrics={})
     mock_http_request.assert_not_called()
 
 
 def test_emit_metric_usage_event_custom_scorers_only(mock_http_request):
-    from databricks.agents.evals import metric
-
-    @metric
-    def not_empty(response):
-        return response != ""
-
     is_kind = make_judge(
         name="is_kind",
         instructions="The answer must be kind. {{ outputs }}",
         feedback_value_type=str,
     )
     emit_metric_usage_event(
-        scorers=[is_concise, is_correct, IsEmpty(), is_kind, not_empty],
-        eval_count=10,
+        scorers=[is_concise, is_correct, IsEmpty(), is_kind],
+        trace_count=10,
+        session_count=0,
         aggregated_metrics={
             "is_concise/mean": 0.1,
             "is_correct/mean": 0.2,
             "is_empty/mean": 0.3,
             "is_kind/mean": 0.4,
-            "not_empty/mean": 0.5,
         },
     )
 
@@ -106,7 +108,6 @@ def test_emit_metric_usage_event_custom_scorers_only(mock_http_request):
                         {"name": mock.ANY, "average": 0.2, "count": 10},
                         {"name": mock.ANY, "average": 0.3, "count": 10},
                         {"name": mock.ANY, "average": 0.4, "count": 10},
-                        {"name": mock.ANY, "average": 0.5, "count": 10},
                     ],
                 }
             }
@@ -117,7 +118,8 @@ def test_emit_metric_usage_event_custom_scorers_only(mock_http_request):
 def test_emit_metric_usage_event_builtin_scorers_only(mock_http_request):
     emit_metric_usage_event(
         scorers=[Correctness(), Guidelines(guidelines="Be concise")],
-        eval_count=5,
+        trace_count=5,
+        session_count=0,
         aggregated_metrics={"correctness/mean": 0.8, "guidelines/mean": 0.9},
     )
 
@@ -127,8 +129,7 @@ def test_emit_metric_usage_event_builtin_scorers_only(mock_http_request):
     assert payload == {
         "agent_evaluation_client_usage_events": [
             {
-                "builtin_metric_usage_event": {
-                    "eval_count": 5,
+                "builtin_scorer_usage_event": {
                     "metrics": [
                         {"name": "Correctness", "count": 5},
                         {"name": "Guidelines", "count": 5},
@@ -142,7 +143,8 @@ def test_emit_metric_usage_event_builtin_scorers_only(mock_http_request):
 def test_emit_metric_usage_event_mixed_custom_and_builtin_scorers(mock_http_request):
     emit_metric_usage_event(
         scorers=[Correctness(), is_concise, Guidelines(guidelines="Be concise")],
-        eval_count=10,
+        trace_count=10,
+        session_count=0,
         aggregated_metrics={
             "correctness/mean": 0.7,
             "is_concise/mean": 0.5,
@@ -162,8 +164,7 @@ def test_emit_metric_usage_event_mixed_custom_and_builtin_scorers(mock_http_requ
                 }
             },
             {
-                "builtin_metric_usage_event": {
-                    "eval_count": 10,
+                "builtin_scorer_usage_event": {
                     "metrics": [
                         {"name": "Correctness", "count": 10},
                         {"name": "Guidelines", "count": 10},
@@ -177,7 +178,8 @@ def test_emit_metric_usage_event_mixed_custom_and_builtin_scorers(mock_http_requ
 def test_emit_metric_usage_event_headers(mock_http_request):
     emit_metric_usage_event(
         scorers=[is_concise],
-        eval_count=10,
+        trace_count=10,
+        session_count=0,
         aggregated_metrics={"is_concise/mean": 0.5},
     )
 
@@ -192,11 +194,12 @@ def test_emit_metric_usage_event_headers(mock_http_request):
     assert headers[_CLIENT_NAME_HEADER] == "mlflow"
 
 
-def test_emit_metric_usage_event_with_sessions(mock_http_request):
+def test_emit_metric_usage_event_with_multiple_calls(mock_http_request):
     for _ in range(3):
         emit_metric_usage_event(
             scorers=[is_concise, Correctness()],
-            eval_count=10,
+            trace_count=10,
+            session_count=0,
             aggregated_metrics={"is_concise/mean": 0.5, "correctness/mean": 0.8},
         )
 
@@ -205,3 +208,83 @@ def test_emit_metric_usage_event_with_sessions(mock_http_request):
         call[1]["extra_headers"][_SESSION_ID_HEADER] for call in mock_http_request.call_args_list
     ]
     assert len(set(session_ids)) == 1
+
+
+def test_emit_metric_usage_event_session_level_custom_scorer(mock_http_request):
+    emit_metric_usage_event(
+        scorers=[session_level_judge],
+        trace_count=10,
+        session_count=3,
+        aggregated_metrics={"session_quality/mean": 0.7},
+    )
+
+    mock_http_request.assert_called_once()
+    payload = mock_http_request.call_args[1]["json"]
+
+    assert payload == {
+        "agent_evaluation_client_usage_events": [
+            {
+                "custom_metric_usage_event": {
+                    "eval_count": 10,
+                    "metrics": [{"name": mock.ANY, "average": 0.7, "count": 3}],
+                }
+            }
+        ]
+    }
+
+
+def test_emit_metric_usage_event_session_level_builtin_scorer(mock_http_request):
+    emit_metric_usage_event(
+        scorers=[UserFrustration()],
+        trace_count=10,
+        session_count=3,
+        aggregated_metrics={"user_frustration/mean": 0.8},
+    )
+
+    mock_http_request.assert_called_once()
+    payload = mock_http_request.call_args[1]["json"]
+
+    assert payload == {
+        "agent_evaluation_client_usage_events": [
+            {
+                "builtin_scorer_usage_event": {
+                    "metrics": [{"name": "UserFrustration", "count": 3}],
+                }
+            }
+        ]
+    }
+
+
+def test_emit_metric_usage_event_mixed_session_and_trace_level_scorers(mock_http_request):
+    emit_metric_usage_event(
+        scorers=[is_concise, session_level_judge, Correctness()],
+        trace_count=10,
+        session_count=3,
+        aggregated_metrics={
+            "is_concise/mean": 0.5,
+            "session_quality/mean": 0.7,
+            "correctness/mean": 0.8,
+        },
+    )
+
+    mock_http_request.assert_called_once()
+    payload = mock_http_request.call_args[1]["json"]
+
+    assert payload == {
+        "agent_evaluation_client_usage_events": [
+            {
+                "custom_metric_usage_event": {
+                    "eval_count": 10,
+                    "metrics": [
+                        {"name": mock.ANY, "average": 0.5, "count": 10},
+                        {"name": mock.ANY, "average": 0.7, "count": 3},
+                    ],
+                }
+            },
+            {
+                "builtin_scorer_usage_event": {
+                    "metrics": [{"name": "Correctness", "count": 10}],
+                }
+            },
+        ]
+    }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20041/files) to review incremental changes.
- [**stack/add-built-in-scorer-to-managed-telemetry**](https://github.com/mlflow/mlflow/pull/20041) [[Files changed](https://github.com/mlflow/mlflow/pull/20041/files)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
We want to have some databricks managed  backend telemetry to better understand the usages of different built in scorers. Currently, our backend telemetry only logs the custom scorer (non build in ones).

Aligned with @avesh-singh_data on the telemetry schema, I added a new `builtin_metric_usage_event` to `RagEvalClientUsage` to capture the usage patterns of different built in scorers from genai evaluation for databricks managed mlflow. 

For session-level scorer, aligned with @AveshCSingh  that we will be recording the number of sessions instead of the number of traces/rows.

This PR updates the corresponding client side http request call to provide built in scorer information.

Universe PR: https://github.com/databricks-eng/universe/pull/1571550?timeline_per_page=5

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Manual Testing
Tested the change E2E using Liteswap with changes in the universe PR:
https://github.com/databricks-eng/universe/pull/1571550?timeline_per_page=5

Databricks Notebook: https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/2221573099017867?o=6051921418418893

Python Notebook Code
```
completeness_judge = Completeness(
  name="my_completeness_judge",
)

safety_judge = Safety(
  name="my_safety_judge"
)

politeness_judge = make_judge(
    name="polite_judge",
    instructions="Analyze whether the {{outputs}} is polite or not, return a score between 1 and 5",
    feedback_value_type=int,
)

result = mlflow.genai.evaluate(
  data = traces,
  scorers = [safety_judge, completeness_judge, politeness_judge],
)
```

Client Logs
```
payload: {'agent_evaluation_client_usage_events': [{'custom_metric_usage_event': {'eval_count': 4, 'metrics': [{'name': 'cca205d5d66eac926cd2e22a63030622c710e129b195611a9a6682dc713e7aef', 'average': None, 'count': 4}]}}, {'builtin_scorer_usage_event': {'metrics': [{'name': 'Safety', 'count': 4}, {'name': 'Completeness', 'count': 4}]}}]}
```

Liteswap pod logs:
```
2026/01/30 23:37:34.781 INFO com.databricks.managedrag.ManagedRagBackend[tenant=6051921418418893 traceId=fffee3447c43699214bca3e5474b7f2a spanId=1f03ec3b79872b37 isSampled=false requestId=0c2d2843-327e-4dc7-b299-264d516aea48 serverEventId=CgwIvoH1ywYQy6S45QIYhQE6ENilden76EeOig6tXSKr0Aw= thread=armeria-worker-10-3]: xshdbg: handleEvaluationClientUsageEvents received events: Vector(custom_metric_usage_event {
  eval_count: 4
  metrics {
    name: [REDACTED]
    count: 4
  }
}
, builtin_scorer_usage_event {
  metrics {
    name: "Safety"
    count: 4
  }
  metrics {
    name: "Completeness"
    count: 4
  }
}
)

2026/01/30 23:37:34.856 INFO com.databricks.managedrag.eval.logging.AgentEvaluationLogger[tenant=6051921418418893 traceId=fffee3447c43699214bca3e5474b7f2a spanId=1f03ec3b79872b37 isSampled=false requestId=0c2d2843-327e-4dc7-b299-264d516aea48 serverEventId=CgwIvoH1ywYQy6S45QIYhQE6ENilden76EeOig6tXSKr0Aw= thread=armeria-worker-10-3]: xshdbg: logRagEvalClientUsageEvent received event: CustomMetricUsageEvent(custom_metrics {
  custom_metric_name: "cca205d5d66eac926cd2e22a63030622c710e129b195611a9a6682dc713e7aef"
  custom_metric_name_hash: "d2fbf675f1d710f00fac3e9f3887cebe5c6dc8616f943f420ac880af96b8e3cd"
  custom_metric_row_count: 4.0
}
custom_metrics_count: 1
)

2026/01/30 23:37:34.871 INFO com.databricks.managedrag.eval.logging.AgentEvaluationLogger[tenant=6051921418418893 traceId=fffee3447c43699214bca3e5474b7f2a spanId=1f03ec3b79872b37 isSampled=false requestId=0c2d2843-327e-4dc7-b299-264d516aea48 serverEventId=CgwIvoH1ywYQy6S45QIYhQE6ENilden76EeOig6tXSKr0Aw= thread=armeria-worker-10-3]: xshdbg: logRagEvalClientUsageEvent received event: BuiltinScorerUsageEvent(builtin_scorers {
  scorer_name: "Safety"
  scorer_evaluation_count: 4.0
}
builtin_scorers {
  scorer_name: "Completeness"
  scorer_evaluation_count: 4.0
}
)
```

Verified with staging query:
<img width="1453" height="623" alt="Screenshot 2026-01-30 at 3 49 47 PM" src="https://github.com/user-attachments/assets/ffb6bf06-69e4-4e1d-82f7-eed23ddbe6ad" />


Session-level scorer works as expected:

Client Code:
```
traces = mlflow.search_traces(
    experiment_ids=[experiment_id],
    filter_string=f"metadata.`mlflow.trace.session` = 'sim-424fcd62dd1749eb'",
    return_type="list",
)
mlflow.litellm.autolog()

completeness_judge = Completeness(
  name="my_completeness_judge",
)

safety_judge = Safety(
  name="my_safety_judge"
)

politeness_judge = make_judge(
    name="polite_judge",
    instructions="Analyze whether the {{outputs}} is polite or not, return a score between 1 and 5",
    feedback_value_type=int,
)

session_quality = make_judge(
    name="session_quality",
    instructions="Evaluate if the {{ conversation }} is coherent and complete.",
    feedback_value_type=bool,
)

result = mlflow.genai.evaluate(
  data = traces,
  scorers = [safety_judge, completeness_judge, politeness_judge, ConversationCompleteness(), session_quality],
)
```

Client Http Payload:
```
payload: {
    "agent_evaluation_client_usage_events": [
        {
            "custom_metric_usage_event": {
                "eval_count": 4,
                "metrics": [
                    {
                        "name": "cca205d5d66eac926cd2e22a63030622c710e129b195611a9a6682dc713e7aef",
                        "average": null,
                        "count": 4
                    },
                    {
                        "name": "ac2bdf911ea9bb32ea8d6737e50b19b9a80664abde7c6161632a61bb1f0a0723",
                        "average": null,
                        "count": 1
                    }
                ]
            }
        },
        {
            "builtin_scorer_usage_event": {
                "metrics": [
                    {
                        "name": "Safety",
                        "count": 4
                    },
                    {
                        "name": "Completeness",
                        "count": 4
                    },
                    {
                        "name": "ConversationCompleteness",
                        "count": 1
                    }
                ]
            }
        }
    ]
}
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
