### PR TITLE
Validate ConversationSimulator's test_cases on reassignment

### DIFF
--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -344,11 +344,16 @@ class ConversationSimulator:
         user_model: str | None = None,
         **user_llm_params,
     ):
-        self.test_cases = self._normalize_test_cases(test_cases)
-        self._validate_test_cases()
+        self.test_cases = test_cases
         self.max_turns = max_turns
         self.user_model = user_model or get_default_model()
         self.user_llm_params = user_llm_params
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "test_cases":
+            value = self._normalize_test_cases(value)
+            self._validate_test_cases(value)
+        super().__setattr__(name, value)
 
     def _normalize_test_cases(
         self, test_cases: list[dict[str, Any]] | "DataFrame" | EvaluationDataset
@@ -369,19 +374,19 @@ class ConversationSimulator:
 
         return test_cases
 
-    def _validate_test_cases(self) -> None:
-        if not self.test_cases:
+    def _validate_test_cases(self, test_cases: list[dict[str, Any]]) -> None:
+        if not test_cases:
             raise ValueError("test_cases cannot be empty")
 
         missing_goal_indices = [
-            i for i, test_case in enumerate(self.test_cases) if not test_case.get("goal")
+            i for i, test_case in enumerate(test_cases) if not test_case.get("goal")
         ]
         if missing_goal_indices:
             raise ValueError(f"Test cases at indices {missing_goal_indices} must have 'goal' field")
 
         indices_with_extra_keys = [
             i
-            for i, test_case in enumerate(self.test_cases)
+            for i, test_case in enumerate(test_cases)
             if set(test_case.keys()) - _EXPECTED_TEST_CASE_KEYS
         ]
         if indices_with_extra_keys:


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Validating ConversationSimulator's test_cases on reassignment

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
<img width="982" height="877" alt="image" src="https://github.com/user-attachments/assets/2ef0371b-4575-48b1-ad68-e18090ce7dbb" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
