### PR TITLE
Drop unsupported params for litellm models

### DIFF
--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -182,6 +182,8 @@ def _invoke_model_without_tracing(
         if inference_params:
             kwargs.update(inference_params)
 
+        # Drop unsupported params (e.g., temperature=0 for gpt-5)
+        litellm.drop_params = True
         response = litellm.completion(**kwargs)
         return response.choices[0].message.content
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Drop unsupported params for litellm models

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
import mlflow
from mlflow.genai.simulators import ConversationSimulator
from mlflow.genai.scorers import ConversationCompleteness, UserFrustration
import openai

client = openai.OpenAI()


# Define your agent's predict function - see below for predict function requirements
def my_chatbot(input: list[dict], **kwargs) -> dict:
    return client.chat.completions.create(
        model="gpt-5-mini",
        messages=input,
    )


# Define test cases with user goals and personas
test_cases = [
    {
        "goal": "Learn how to track experiments in MLflow",
        "persona": "A data scientist new to MLflow",
    },
    {
        "goal": "Troubleshoot a deployment issue with model serving",
        "persona": "An ML engineer with production issues",
    },
    {
        "goal": "Set up model registry for team collaboration",
        "persona": "A technical lead planning MLOps infrastructure",
    },
]

# Create simulator
simulator = ConversationSimulator(
    test_cases=test_cases,
    max_turns=8,  # Maximum conversation length
    user_model="openai:/gpt-5-mini",
)

# Evaluate - the simulator generates conversations and evaluates them
results = mlflow.genai.evaluate(
    data=simulator,
    predict_fn=my_chatbot,
    scorers=[
        ConversationCompleteness(),
        UserFrustration(),
    ],
)
```

Before:
``2026/01/13 21:50:27 WARNING mlflow.genai.simulators.simulator: Goal achievement check failed: litellm.UnsupportedParamsError: gpt-5 models (including gpt-5-codex) don't support temperature=0.0. Only temperature=1 is supported. For gpt-5.1, temperature is supported when reasoning_effort='none' (or not specified, as it defaults to 'none'). To drop unsupported params set `litellm.drop_params = True` ``

<img width="1531" height="744" alt="image" src="https://github.com/user-attachments/assets/29ec3238-b439-4fe0-a945-9addf8a20ecb" />


After:
<img width="1549" height="440" alt="image" src="https://github.com/user-attachments/assets/eaaf88ca-3e6e-4705-83d2-e73b4874678b" />

<img width="958" height="174" alt="image" src="https://github.com/user-attachments/assets/3a413346-0f02-4e41-a520-e7e1c9cc24d7" />



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
