### PR TITLE
[MLflow Demo] Add Prompt demo data

### DIFF
--- a/mlflow/demo/base.py
+++ b/mlflow/demo/base.py
@@ -14,6 +14,7 @@ class DemoFeature(str, Enum):
 
     TRACES = "traces"
     EVALUATION = "evaluation"
+    PROMPTS = "prompts"
 
 
 @dataclass

--- a/mlflow/demo/data.py
+++ b/mlflow/demo/data.py
@@ -1,14 +1,236 @@
-"""Demo data definitions for traces.
-
-This module contains the trace data used by the demo generators.
-Each trace has v1 (baseline) and v2 (improved) responses to demonstrate
-agent improvement over time.
-"""
-
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any
+
+from mlflow.demo.base import DEMO_PROMPT_PREFIX
+from mlflow.entities.model_registry import PromptVersion
+
+# =============================================================================
+# Prompt Data Definitions
+# =============================================================================
+
+_CUSTOMER_SUPPORT_NAME = f"{DEMO_PROMPT_PREFIX}.prompts.customer-support"
+_DOCUMENT_SUMMARIZER_NAME = f"{DEMO_PROMPT_PREFIX}.prompts.document-summarizer"
+_CODE_REVIEWER_NAME = f"{DEMO_PROMPT_PREFIX}.prompts.code-reviewer"
+
+
+@dataclass
+class DemoPromptDef:
+    name: str
+    versions: list[PromptVersion]
+
+
+CUSTOMER_SUPPORT_PROMPT = DemoPromptDef(
+    name=_CUSTOMER_SUPPORT_NAME,
+    versions=[
+        PromptVersion(
+            name=_CUSTOMER_SUPPORT_NAME,
+            version=1,
+            template="You are a customer support agent. Help the user with: {{query}}",
+            commit_message="Initial customer support prompt",
+            aliases=["baseline"],
+        ),
+        PromptVersion(
+            name=_CUSTOMER_SUPPORT_NAME,
+            version=2,
+            template=(
+                "You are a friendly and professional customer support agent. "
+                "Respond in a helpful, empathetic tone.\n\n"
+                "User query: {{query}}"
+            ),
+            commit_message="Add tone and style guidance",
+            aliases=["tone-guidance"],
+        ),
+        PromptVersion(
+            name=_CUSTOMER_SUPPORT_NAME,
+            version=3,
+            template=(
+                "You are a friendly and professional customer support agent for {{company_name}}. "
+                "Respond in a helpful, empathetic tone.\n\n"
+                "Context: {{context}}\n\n"
+                "User query: {{query}}"
+            ),
+            commit_message="Add company context and conversation history",
+            aliases=["with-context"],
+        ),
+        PromptVersion(
+            name=_CUSTOMER_SUPPORT_NAME,
+            version=4,
+            template=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a friendly and professional customer support agent "
+                        "for {{company_name}}. Follow these guidelines:\n"
+                        "- Be empathetic and patient\n"
+                        "- Provide clear, actionable solutions\n"
+                        "- Escalate complex issues appropriately\n"
+                        "- Always verify customer satisfaction before closing"
+                    ),
+                },
+                {"role": "user", "content": "Context: {{context}}\n\nQuery: {{query}}"},
+            ],
+            commit_message="Convert to chat format with detailed guidelines",
+            aliases=["production"],
+        ),
+    ],
+)
+
+DOCUMENT_SUMMARIZER_PROMPT = DemoPromptDef(
+    name=_DOCUMENT_SUMMARIZER_NAME,
+    versions=[
+        PromptVersion(
+            name=_DOCUMENT_SUMMARIZER_NAME,
+            version=1,
+            template="Summarize the following document:\n\n{{document}}",
+            commit_message="Initial summarization prompt",
+            aliases=["baseline"],
+        ),
+        PromptVersion(
+            name=_DOCUMENT_SUMMARIZER_NAME,
+            version=2,
+            template=(
+                "Summarize the following document in {{max_words}} words or less:\n\n{{document}}"
+            ),
+            commit_message="Add length constraint parameter",
+            aliases=["length-constraint"],
+        ),
+        PromptVersion(
+            name=_DOCUMENT_SUMMARIZER_NAME,
+            version=3,
+            template=(
+                "Summarize the following document for a {{audience}} audience. "
+                "Keep the summary under {{max_words}} words.\n\n"
+                "Document:\n{{document}}"
+            ),
+            commit_message="Add audience targeting",
+            aliases=["audience-targeting"],
+        ),
+        PromptVersion(
+            name=_DOCUMENT_SUMMARIZER_NAME,
+            version=4,
+            template=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a document summarization expert. Create concise, accurate "
+                        "summaries that capture the essential information while maintaining "
+                        "the original meaning."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Summarize this document for a {{audience}} audience.\n"
+                        "Maximum length: {{max_words}} words.\n\n"
+                        "Include:\n"
+                        "1. Main topic/thesis\n"
+                        "2. Key points (3-5 bullets)\n"
+                        "3. Conclusion or main takeaway\n\n"
+                        "Document:\n{{document}}"
+                    ),
+                },
+            ],
+            commit_message="Add structured output format with key points",
+            aliases=["production"],
+        ),
+    ],
+)
+
+CODE_REVIEWER_PROMPT = DemoPromptDef(
+    name=_CODE_REVIEWER_NAME,
+    versions=[
+        PromptVersion(
+            name=_CODE_REVIEWER_NAME,
+            version=1,
+            template=(
+                "Review the following code and provide feedback:\n\n```{{language}}\n{{code}}\n```"
+            ),
+            commit_message="Initial code review prompt",
+            aliases=["baseline"],
+        ),
+        PromptVersion(
+            name=_CODE_REVIEWER_NAME,
+            version=2,
+            template=(
+                "Review the following {{language}} code for:\n"
+                "- Bugs and errors\n"
+                "- Performance issues\n"
+                "- Code style\n\n"
+                "```{{language}}\n{{code}}\n```"
+            ),
+            commit_message="Add specific review categories",
+            aliases=["review-categories"],
+        ),
+        PromptVersion(
+            name=_CODE_REVIEWER_NAME,
+            version=3,
+            template=(
+                "Review the following {{language}} code. For each issue found, specify:\n"
+                "- Severity: Critical, Major, Minor, or Suggestion\n"
+                "- Category: Bug, Performance, Security, Style, or Maintainability\n"
+                "- Line number (if applicable)\n"
+                "- Recommended fix\n\n"
+                "```{{language}}\n{{code}}\n```"
+            ),
+            commit_message="Add severity levels and structured feedback format",
+            aliases=["severity-levels"],
+        ),
+        PromptVersion(
+            name=_CODE_REVIEWER_NAME,
+            version=4,
+            template=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are an expert code reviewer. Analyze code for bugs, security "
+                        "vulnerabilities, performance issues, and maintainability concerns. "
+                        "Provide actionable feedback with clear explanations and suggested fixes."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Review this {{language}} code:\n\n"
+                        "```{{language}}\n{{code}}\n```\n\n"
+                        "Provide feedback in this format:\n"
+                        "## Summary\n"
+                        "Brief overview of code quality.\n\n"
+                        "## Issues Found\n"
+                        "For each issue:\n"
+                        "- **[Severity]** Category: Description\n"
+                        "  - Line: X\n"
+                        "  - Fix: Recommendation\n\n"
+                        "## Positive Aspects\n"
+                        "What the code does well."
+                    ),
+                },
+            ],
+            commit_message="Production-ready with structured markdown output",
+            aliases=["production"],
+        ),
+    ],
+)
+
+DEMO_PROMPTS: list[DemoPromptDef] = [
+    CUSTOMER_SUPPORT_PROMPT,
+    DOCUMENT_SUMMARIZER_PROMPT,
+    CODE_REVIEWER_PROMPT,
+]
+
+
+# =============================================================================
+# Trace Data Definitions
+# =============================================================================
+
+
+@dataclass
+class LinkedPromptRef:
+    """Reference to a prompt version for linking to traces."""
+
+    prompt_name: str
+    version: int
 
 
 @dataclass

--- a/mlflow/demo/generators/__init__.py
+++ b/mlflow/demo/generators/__init__.py
@@ -1,11 +1,10 @@
-"""Demo data generators."""
-
 from mlflow.demo.generators.evaluation import EvaluationDemoGenerator
+from mlflow.demo.generators.prompts import PromptsDemoGenerator
 from mlflow.demo.generators.traces import TracesDemoGenerator
 from mlflow.demo.registry import demo_registry
 
-# Register all generators
 demo_registry.register(TracesDemoGenerator)
 demo_registry.register(EvaluationDemoGenerator)
+demo_registry.register(PromptsDemoGenerator)
 
-__all__ = ["EvaluationDemoGenerator", "TracesDemoGenerator"]
+__all__ = ["EvaluationDemoGenerator", "PromptsDemoGenerator", "TracesDemoGenerator"]

--- a/mlflow/demo/generators/evaluation.py
+++ b/mlflow/demo/generators/evaluation.py
@@ -1,5 +1,3 @@
-"""Demo generator for evaluation runs and datasets."""
-
 from __future__ import annotations
 
 import hashlib
@@ -108,12 +106,20 @@ IMPROVED_PROFILE = {
 
 
 class EvaluationDemoGenerator(BaseDemoGenerator):
-    """Generates demo evaluation data comparing v1 and v2 agent outputs.
+    """Generates demo evaluation data comparing baseline (v1) and improved (v2) traces.
 
     Creates:
     - Ground truth expectations on all demo traces
-    - Two datasets: one for v1 (baseline) traces, one for v2 (improved) traces
-    - Two evaluation runs: baseline evaluation on v1, improved evaluation on v2
+    - Two datasets: baseline (v1) and improved (v2) - both include all trace types
+    - Two evaluation runs comparing the same inputs with different outputs
+
+    The baseline and improved evaluations include matching trace types:
+    - 2 RAG traces
+    - 2 agent traces
+    - 6 prompt traces (2 per prompt type)
+    - Session traces
+
+    This allows direct comparison between v1 and v2 performance.
     """
 
     name = DemoFeature.EVALUATION

--- a/mlflow/demo/generators/prompts.py
+++ b/mlflow/demo/generators/prompts.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import logging
+
+from mlflow.demo.base import (
+    DEMO_EXPERIMENT_NAME,
+    DEMO_PROMPT_PREFIX,
+    BaseDemoGenerator,
+    DemoFeature,
+    DemoResult,
+)
+from mlflow.demo.data import DEMO_PROMPTS, DemoPromptDef
+from mlflow.genai.prompts import (
+    delete_prompt_alias,
+    register_prompt,
+    search_prompts,
+    set_prompt_alias,
+)
+from mlflow.tracking.client import MlflowClient
+
+_logger = logging.getLogger(__name__)
+
+
+class PromptsDemoGenerator(BaseDemoGenerator):
+    """Generates demo prompts showing version history and alias management.
+
+    Creates:
+    - 3 prompts: customer-support, document-summarizer, code-reviewer
+    - Each with 3-4 versions showing prompt evolution
+    - Version-specific aliases (baseline, improvements, production)
+    """
+
+    name = DemoFeature.PROMPTS
+    version = 2
+
+    def generate(self) -> DemoResult:
+        import mlflow
+
+        mlflow.set_experiment(DEMO_EXPERIMENT_NAME)
+
+        prompt_names = []
+        total_versions = 0
+
+        for prompt_def in DEMO_PROMPTS:
+            versions_created = self._create_prompt_with_versions(prompt_def)
+            prompt_names.append(prompt_def.name)
+            total_versions += versions_created
+
+        entity_ids = [
+            f"prompts:{len(prompt_names)}",
+            f"versions:{total_versions}",
+        ]
+
+        return DemoResult(
+            feature=self.name,
+            entity_ids=entity_ids,
+            navigation_url="#/prompts",
+        )
+
+    def _create_prompt_with_versions(self, prompt_def: DemoPromptDef) -> int:
+        for version_num, version_def in enumerate(prompt_def.versions, start=1):
+            register_prompt(
+                name=prompt_def.name,
+                template=version_def.template,
+                commit_message=version_def.commit_message,
+                tags={"demo": "true"},
+            )
+
+            if version_def.aliases:
+                set_prompt_alias(
+                    name=prompt_def.name,
+                    alias=version_def.aliases[0],
+                    version=version_num,
+                )
+
+        return len(prompt_def.versions)
+
+    def _data_exists(self) -> bool:
+        try:
+            prompts = search_prompts(
+                filter_string=f"name LIKE '{DEMO_PROMPT_PREFIX}.%'",
+                max_results=1,
+            )
+            return len(prompts) > 0
+        except Exception:
+            _logger.debug("Failed to check if prompts demo exists", exc_info=True)
+            return False
+
+    def delete_demo(self) -> None:
+        all_aliases = set()
+        for prompt_def in DEMO_PROMPTS:
+            for version_def in prompt_def.versions:
+                all_aliases.update(version_def.aliases)
+
+        try:
+            prompts = search_prompts(
+                filter_string=f"name LIKE '{DEMO_PROMPT_PREFIX}.%'",
+                max_results=100,
+            )
+
+            client = MlflowClient()
+            for prompt in prompts:
+                try:
+                    for alias in all_aliases:
+                        try:
+                            delete_prompt_alias(name=prompt.name, alias=alias)
+                        except Exception:
+                            _logger.debug(
+                                "Failed to delete alias %s for prompt %s",
+                                alias,
+                                prompt.name,
+                                exc_info=True,
+                            )
+                    client.delete_prompt(name=prompt.name)
+                except Exception:
+                    _logger.debug("Failed to delete prompt %s", prompt.name, exc_info=True)
+        except Exception:
+            _logger.debug("Failed to delete demo prompts", exc_info=True)

--- a/tests/demo/test_evaluation_generator.py
+++ b/tests/demo/test_evaluation_generator.py
@@ -13,7 +13,10 @@ from mlflow.demo.generators.traces import TracesDemoGenerator
 
 @pytest.fixture
 def evaluation_generator():
-    return EvaluationDemoGenerator()
+    generator = EvaluationDemoGenerator()
+    original_version = generator.version
+    yield generator
+    EvaluationDemoGenerator.version = original_version
 
 
 @pytest.fixture
@@ -116,5 +119,3 @@ def test_is_generated_checks_version(evaluation_generator):
     EvaluationDemoGenerator.version = 99
     fresh_generator = EvaluationDemoGenerator()
     assert fresh_generator.is_generated() is False
-
-    EvaluationDemoGenerator.version = 1

--- a/tests/demo/test_prompts_generator.py
+++ b/tests/demo/test_prompts_generator.py
@@ -1,0 +1,140 @@
+import pytest
+
+from mlflow.demo.base import DEMO_PROMPT_PREFIX, DemoFeature, DemoResult
+from mlflow.demo.data import DEMO_PROMPTS
+from mlflow.demo.generators.prompts import PromptsDemoGenerator
+from mlflow.genai.prompts import load_prompt, search_prompts
+
+
+@pytest.fixture
+def prompts_generator():
+    generator = PromptsDemoGenerator()
+    original_version = generator.version
+    yield generator
+    PromptsDemoGenerator.version = original_version
+
+
+def test_generator_attributes():
+    generator = PromptsDemoGenerator()
+    assert generator.name == DemoFeature.PROMPTS
+    assert generator.version == 2
+
+
+def test_data_exists_false_when_no_prompts():
+    generator = PromptsDemoGenerator()
+    assert generator._data_exists() is False
+
+
+def test_generate_creates_prompts():
+    generator = PromptsDemoGenerator()
+    result = generator.generate()
+
+    assert isinstance(result, DemoResult)
+    assert result.feature == DemoFeature.PROMPTS
+    assert any("prompts:" in e for e in result.entity_ids)
+    assert any("versions:" in e for e in result.entity_ids)
+
+
+def test_generate_creates_expected_prompts():
+    generator = PromptsDemoGenerator()
+    generator.generate()
+
+    prompts = search_prompts(
+        filter_string=f"name LIKE '{DEMO_PROMPT_PREFIX}.%'",
+        max_results=100,
+    )
+
+    assert len(prompts) == len(DEMO_PROMPTS)
+
+    prompt_names = {p.name for p in prompts}
+    expected_names = {prompt_def.name for prompt_def in DEMO_PROMPTS}
+    assert prompt_names == expected_names
+
+
+def test_prompts_have_multiple_versions():
+    generator = PromptsDemoGenerator()
+    generator.generate()
+
+    for prompt_def in DEMO_PROMPTS:
+        expected_versions = len(prompt_def.versions)
+        prompt = load_prompt(prompt_def.name, version=expected_versions)
+        assert prompt is not None
+        assert prompt.version == expected_versions
+
+
+def test_prompts_have_version_aliases():
+    generator = PromptsDemoGenerator()
+    generator.generate()
+
+    for prompt_def in DEMO_PROMPTS:
+        for version_num, version_def in enumerate(prompt_def.versions, start=1):
+            if version_def.aliases:
+                prompt = load_prompt(f"prompts:/{prompt_def.name}@{version_def.aliases[0]}")
+                assert prompt.version == version_num
+
+
+def test_data_exists_true_after_generate():
+    generator = PromptsDemoGenerator()
+    assert generator._data_exists() is False
+
+    generator.generate()
+
+    assert generator._data_exists() is True
+
+
+def test_delete_demo_removes_prompts():
+    generator = PromptsDemoGenerator()
+    generator.generate()
+    assert generator._data_exists() is True
+
+    generator.delete_demo()
+
+    assert generator._data_exists() is False
+
+
+def test_prompts_have_demo_tag():
+    generator = PromptsDemoGenerator()
+    generator.generate()
+
+    for prompt_def in DEMO_PROMPTS:
+        prompt = load_prompt(prompt_def.name, version=1)
+        assert prompt.tags.get("demo") == "true"
+
+
+def test_is_generated_checks_version(prompts_generator):
+    prompts_generator.generate()
+    prompts_generator.store_version()
+
+    assert prompts_generator.is_generated() is True
+
+    PromptsDemoGenerator.version = 99
+    fresh_generator = PromptsDemoGenerator()
+    assert fresh_generator.is_generated() is False
+
+
+def test_prompt_templates_are_valid():
+    generator = PromptsDemoGenerator()
+    generator.generate()
+
+    for prompt_def in DEMO_PROMPTS:
+        latest_version = len(prompt_def.versions)
+        prompt = load_prompt(prompt_def.name, version=latest_version)
+
+        assert prompt.template is not None
+        if isinstance(prompt.template, str):
+            assert len(prompt.template) > 0
+        else:
+            assert len(prompt.template) > 0
+            for msg in prompt.template:
+                assert "role" in msg
+                assert "content" in msg
+
+
+def test_demo_prompt_definitions():
+    assert len(DEMO_PROMPTS) == 3
+    for prompt_def in DEMO_PROMPTS:
+        assert prompt_def.name.startswith(DEMO_PROMPT_PREFIX)
+        assert len(prompt_def.versions) >= 3
+        for version_def in prompt_def.versions:
+            assert version_def.template is not None
+            assert version_def.commit_message is not None

--- a/tests/demo/test_traces_generator.py
+++ b/tests/demo/test_traces_generator.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mlflow import MlflowClient, get_experiment_by_name, set_experiment
 from mlflow.demo.base import DEMO_EXPERIMENT_NAME, DemoFeature, DemoResult
 from mlflow.demo.generators.traces import (
@@ -5,6 +7,14 @@ from mlflow.demo.generators.traces import (
     DEMO_VERSION_TAG,
     TracesDemoGenerator,
 )
+
+
+@pytest.fixture
+def traces_generator():
+    generator = TracesDemoGenerator()
+    original_version = generator.version
+    yield generator
+    TracesDemoGenerator.version = original_version
 
 
 def test_generator_attributes():
@@ -130,14 +140,11 @@ def test_traces_have_type_metadata():
     assert len(session_traces) == 14
 
 
-def test_is_generated_checks_version():
-    generator = TracesDemoGenerator()
-    generator.generate()
-    generator.store_version()
+def test_is_generated_checks_version(traces_generator):
+    traces_generator.generate()
+    traces_generator.store_version()
 
-    assert generator.is_generated() is True
+    assert traces_generator.is_generated() is True
 
     TracesDemoGenerator.version = 99
-    assert generator.is_generated() is False
-
-    TracesDemoGenerator.version = 2
+    assert traces_generator.is_generated() is False


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20047/files) to review incremental changes.
- [**stack/demo/prompts**](https://github.com/mlflow/mlflow/pull/20047) [[Files changed](https://github.com/mlflow/mlflow/pull/20047/files)]
  - [stack/demo/cli](https://github.com/mlflow/mlflow/pull/20048) [[Files changed](https://github.com/mlflow/mlflow/pull/20048/files/5c2543c1afbf68c1ea7833c54fb02f22d4c54df8..30b2c83aec4ef4d72c308223106aedbccebf01c2)]
    - [stack/demo/home](https://github.com/mlflow/mlflow/pull/20162) [[Files changed](https://github.com/mlflow/mlflow/pull/20162/files/30b2c83aec4ef4d72c308223106aedbccebf01c2..66ea27786a83c7193d32ecd3b6f7b04416461d5c)]
      - [stack/demo/docs](https://github.com/mlflow/mlflow/pull/20240) [[Files changed](https://github.com/mlflow/mlflow/pull/20240/files/66ea27786a83c7193d32ecd3b6f7b04416461d5c..46bdf537a90ae13984bf98de14c2e71ba3dee81d)]
        - [stack/demo/scorers](https://github.com/mlflow/mlflow/pull/20287) [[Files changed](https://github.com/mlflow/mlflow/pull/20287/files/46bdf537a90ae13984bf98de14c2e71ba3dee81d..3c764336cef404d07a314ee0bad72e696701ab55)]
          - [stack/demo/handling](https://github.com/mlflow/mlflow/pull/20349) [[Files changed](https://github.com/mlflow/mlflow/pull/20349/files/3c764336cef404d07a314ee0bad72e696701ab55..0d9eca08f21a3339124f719238f8119f8db8f853)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds data for simulating prompt evolution, including example traces (with evaluation) on versions of prompts for 3 separate domains. 

<img width="2086" height="1453" alt="Screenshot 2026-01-15 at 8 38 33 PM" src="https://github.com/user-attachments/assets/9675ca47-3e8c-48e5-8468-1bff1b2b2130" />
<img width="2083" height="1454" alt="Screenshot 2026-01-15 at 8 38 43 PM" src="https://github.com/user-attachments/assets/469181df-ad78-4a58-8647-c0eab0023ec8" />
<img width="2085" height="1446" alt="Screenshot 2026-01-15 at 8 38 54 PM" src="https://github.com/user-attachments/assets/fdee6bbb-c06e-4e60-a3a4-7e29a0fc3545" />
<img width="2092" height="1453" alt="Screenshot 2026-01-15 at 8 39 03 PM" src="https://github.com/user-attachments/assets/fdd50ae5-3cb3-4e9d-bb17-c614527c7472" />


### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
