### PR TITLE
Enforce `GH_TOKEN` over `GITHUB_TOKEN` for environment variable names

### DIFF
--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -11,7 +11,7 @@ This skill analyzes logs from failed GitHub Action jobs using Claude.
 
 ## Prerequisites
 
-- **GitHub Token**: Auto-detected via `gh auth token`, or set `GITHUB_TOKEN` env var
+- **GitHub Token**: Auto-detected via `gh auth token`, or set `GH_TOKEN` env var
 
 ## Usage
 

--- a/.claude/skills/fetch-diff/SKILL.md
+++ b/.claude/skills/fetch-diff/SKILL.md
@@ -21,7 +21,7 @@ Example:
 uv run skills fetch-diff https://github.com/mlflow/mlflow/pull/123
 ```
 
-Token is auto-detected from `GITHUB_TOKEN` env var or `gh auth token`.
+Token is auto-detected from `GH_TOKEN` env var or `gh auth token`.
 
 ## Output Example
 

--- a/.claude/skills/fetch-unresolved-comments/SKILL.md
+++ b/.claude/skills/fetch-unresolved-comments/SKILL.md
@@ -37,7 +37,7 @@ Uses GitHub's GraphQL API to fetch only unresolved review thread comments from a
 
    The script automatically reads the GitHub token from:
 
-   - `GITHUB_TOKEN` or `GH_TOKEN` environment variables, or
+   - `GH_TOKEN` environment variable, or
    - `gh auth token` command if environment variables are not set
 
 ## Example Output

--- a/.claude/skills/src/skills/github/utils.py
+++ b/.claude/skills/src/skills/github/utils.py
@@ -6,12 +6,12 @@ import sys
 
 
 def get_github_token() -> str:
-    if token := os.environ.get("GITHUB_TOKEN"):
+    if token := os.environ.get("GH_TOKEN"):
         return token
     try:
         return subprocess.check_output(["gh", "auth", "token"], text=True).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
-        print("Error: GITHUB_TOKEN not found (set env var or install gh CLI)", file=sys.stderr)
+        print("Error: GH_TOKEN not found (set env var or install gh CLI)", file=sys.stderr)
         sys.exit(1)
 
 

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -41,6 +41,19 @@ deny_unnecessary_github_token contains msg if {
 	msg := "Unnecessary use of github-token for actions/github-script."
 }
 
+deny_github_token_env_var contains msg if {
+	some job in input.jobs
+	some step in job.steps
+	step.env.GITHUB_TOKEN
+	msg := "Use GH_TOKEN instead of GITHUB_TOKEN for environment variable names."
+}
+
+deny_github_token_env_var contains msg if {
+	some job in input.jobs
+	job.env.GITHUB_TOKEN
+	msg := "Use GH_TOKEN instead of GITHUB_TOKEN for environment variable names."
+}
+
 deny_jobs_without_timeout contains msg if {
 	jobs := jobs_without_timeout(input.jobs)
 	count(jobs) > 0

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Check diff
         id: diff
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           changed_files="$(gh pr view --repo ${{ github.repository }} ${{ needs.check-comment.outputs.pull_number }} --json files --jq '.files.[].path')"
           protos=$([[ -z $(echo "$changed_files" | grep '^\(mlflow/protos\|tests/protos\)') ]] && echo "false" || echo "true")

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -102,7 +102,7 @@ jobs:
       - id: set-matrix
         name: Set matrix
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           EVENT_NAME="${{ github.event_name }}"
           if [ "$EVENT_NAME" = "pull_request" ]; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Check whitespace-only changes
         if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv run --no-project dev/check_whitespace_only.py \
             --repo ${{ github.repository }} \

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -52,7 +52,7 @@ jobs:
             echo "should_update_latest=false" >> $GITHUB_OUTPUT
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Gather Docker Metadata for Tracking
         id: meta

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -142,7 +142,7 @@ jobs:
         id: claude-fix
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PROMPT: ${{ needs.precheck.outputs.prompt }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Review
         id: review
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}

--- a/.github/workflows/xtest-viz.yml
+++ b/.github/workflows/xtest-viz.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Generate cross-version test visualization
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "## Cross-Version Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/dev/check_whitespace_only.py
+++ b/dev/check_whitespace_only.py
@@ -19,7 +19,7 @@ def github_api_request(url: str, accept: str) -> str:
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    if github_token := os.environ.get("GITHUB_TOKEN"):
+    if github_token := os.environ.get("GH_TOKEN"):
         headers["Authorization"] = f"Bearer {github_token}"
 
     request = urllib.request.Request(url, headers=headers)

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -795,6 +795,9 @@ class Linter(ast.NodeVisitor):
         if self._is_in_test() and rules.OsEnvironDeleteInTest.check(node, self.resolver):
             self._check(Range.from_node(node), rules.OsEnvironDeleteInTest())
 
+        if rules.UseGhToken.check(node, self.resolver):
+            self._check(Range.from_node(node), rules.UseGhToken())
+
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -49,6 +49,7 @@ from clint.rules.unknown_mlflow_arguments import UnknownMlflowArguments
 from clint.rules.unknown_mlflow_function import UnknownMlflowFunction
 from clint.rules.unnamed_thread import UnnamedThread
 from clint.rules.unparameterized_generic_type import UnparameterizedGenericType
+from clint.rules.use_gh_token import UseGhToken
 from clint.rules.use_sys_executable import UseSysExecutable
 from clint.rules.use_walrus_operator import UseWalrusOperator, WalrusOperatorVisitor
 from clint.rules.version_major_check import MajorVersionCheck
@@ -105,6 +106,7 @@ __all__ = [
     "UnnamedThread",
     "UnparameterizedGenericType",
     "AssignBeforeAppend",
+    "UseGhToken",
     "UseSysExecutable",
     "UseWalrusOperator",
     "WalrusOperatorVisitor",

--- a/dev/clint/src/clint/rules/use_gh_token.py
+++ b/dev/clint/src/clint/rules/use_gh_token.py
@@ -1,0 +1,24 @@
+import ast
+
+from clint.resolver import Resolver
+from clint.rules.base import Rule
+
+
+class UseGhToken(Rule):
+    def _message(self) -> str:
+        return "Use GH_TOKEN instead of GITHUB_TOKEN for the environment variable name."
+
+    @staticmethod
+    def check(node: ast.Call, resolver: Resolver) -> bool:
+        """
+        Returns True if the call reads the GITHUB_TOKEN environment variable.
+        Handles:
+        - os.getenv("GITHUB_TOKEN")
+        - os.environ.get("GITHUB_TOKEN")
+        """
+        match node:
+            case ast.Call(args=[ast.Constant(value="GITHUB_TOKEN"), *_]):
+                match resolver.resolve(node.func):
+                    case ["os", "getenv"] | ["os", "environ", "get"]:
+                        return True
+        return False

--- a/dev/clint/tests/rules/test_use_gh_token.py
+++ b/dev/clint/tests/rules/test_use_gh_token.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+from clint.config import Config
+from clint.linter import lint_file
+from clint.rules.use_gh_token import UseGhToken
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(
+            'import os\n\ntoken = os.getenv("GITHUB_TOKEN")',
+            id="os.getenv",
+        ),
+        pytest.param(
+            'import os\n\ntoken = os.environ.get("GITHUB_TOKEN")',
+            id="os.environ.get",
+        ),
+        pytest.param(
+            'import os\n\ntoken = os.getenv("GITHUB_TOKEN", "default")',
+            id="os.getenv with default",
+        ),
+        pytest.param(
+            'import os\n\ntoken = os.environ.get("GITHUB_TOKEN", None)',
+            id="os.environ.get with default",
+        ),
+    ],
+)
+def test_violation(code: str, index_path: Path) -> None:
+    config = Config(select={UseGhToken.name})
+    violations = lint_file(Path("file.py"), code, config, index_path)
+    assert len(violations) == 1
+    assert isinstance(violations[0].rule, UseGhToken)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(
+            'import os\n\ntoken = os.getenv("GH_TOKEN")',
+            id="os.getenv with GH_TOKEN",
+        ),
+        pytest.param(
+            'import os\n\ntoken = os.environ.get("GH_TOKEN")',
+            id="os.environ.get with GH_TOKEN",
+        ),
+        pytest.param(
+            'import os\n\ntoken = os.getenv("OTHER_VAR")',
+            id="os.getenv with other var",
+        ),
+    ],
+)
+def test_no_violation(code: str, index_path: Path) -> None:
+    config = Config(select={UseGhToken.name})
+    violations = lint_file(Path("file.py"), code, config, index_path)
+    assert len(violations) == 0

--- a/dev/list_changed_files.py
+++ b/dev/list_changed_files.py
@@ -26,7 +26,7 @@ def main():
     changed_files = []
     per_page = 100
     page = 1
-    token = os.environ.get("GITHUB_TOKEN")
+    token = os.environ.get("GH_TOKEN")
     headers = {"Authorization": f"token {token}"} if token else {}
     # Ref: https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
     url = f"https://api.github.com/repos/{args.repository}/pulls/{args.pr_num}/files"

--- a/dev/update_changelog.py
+++ b/dev/update_changelog.py
@@ -135,7 +135,7 @@ def _fetch_pr_chunk_graphql(pr_numbers: list[int]) -> list[PullRequest]:
 
     # Headers with authentication
     headers = {"Content-Type": "application/json"}
-    if token := os.getenv("GITHUB_TOKEN"):
+    if token := os.getenv("GH_TOKEN"):
         headers["Authorization"] = f"Bearer {token}"
     print(f"Batch fetching {len(pr_numbers)} PRs with GraphQL...")
     resp = requests.post(

--- a/dev/xtest_viz.py
+++ b/dev/xtest_viz.py
@@ -54,7 +54,7 @@ class JobResult:
 
 class XTestViz:
     def __init__(self, github_token: str | None = None, repo: str = "mlflow/dev"):
-        self.github_token = github_token or os.getenv("GITHUB_TOKEN")
+        self.github_token = github_token or os.getenv("GH_TOKEN")
         self.repo = repo
         self.per_page = 30
         self.headers: dict[str, str] = {}
@@ -278,16 +278,16 @@ async def main() -> None:
         default="mlflow/dev",
         help="GitHub repository in owner/repo format (default: mlflow/dev)",
     )
-    parser.add_argument("--token", help="GitHub token (default: use GITHUB_TOKEN env var)")
+    parser.add_argument("--token", help="GitHub token (default: use GH_TOKEN env var)")
 
     args = parser.parse_args()
 
-    token = args.token or os.getenv("GITHUB_TOKEN")
+    token = args.token or os.getenv("GH_TOKEN")
     if not token:
         print(
             "Warning: No GitHub token provided. API requests may be rate-limited.", file=sys.stderr
         )
-        print("Set GITHUB_TOKEN environment variable or use --token option.", file=sys.stderr)
+        print("Set GH_TOKEN environment variable or use --token option.", file=sys.stderr)
 
     visualizer = XTestViz(github_token=token, repo=args.repo)
     output = await visualizer.generate_results_table(args.days)

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -749,7 +749,7 @@ def _iter_pr_files() -> Iterator[str]:
     repo = pr_data["repository"]["full_name"]
     page = 1
     per_page = 100
-    headers = {"Authorization": token} if (token := os.environ.get("GITHUB_TOKEN")) else None
+    headers = {"Authorization": token} if (token := os.environ.get("GH_TOKEN")) else None
     while True:
         resp = requests.get(
             f"https://api.github.com/repos/{repo}/pulls/{pull_number}/files",


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Enforce using `GH_TOKEN` instead of `GITHUB_TOKEN` for environment variable names across the codebase. This standardizes the naming convention and adds automated checks to prevent future inconsistencies.

- Add clint rule (`use-gh-token`) to detect `os.getenv("GITHUB_TOKEN")` and `os.environ.get("GITHUB_TOKEN")` patterns
- Add policy.rego rule to detect `GITHUB_TOKEN` in workflow environment variables
- Update all Python files and GitHub Actions workflows to use `GH_TOKEN`

Note: `secrets.GITHUB_TOKEN` (the actual GitHub secret) and action input parameters (`github-token:`, `password:`) remain unchanged as they are dictated by GitHub/action interfaces.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)