### PR TITLE
Fix a race condition bug when using DF inputs for genai eval

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -218,8 +218,15 @@ def run(
     # all traces in the result.
     traces = mlflow.search_traces(run_id=run_id, include_spans=False, return_type="list")
 
+    # Collect trace IDs from eval results to preserve them during cleanup.
+    input_trace_ids = {
+        result.eval_item.trace.info.trace_id
+        for result in eval_results
+        if result.eval_item.trace is not None
+    }
+
     # Clean up noisy traces generated during evaluation
-    clean_up_extra_traces(traces, eval_start_time)
+    clean_up_extra_traces(traces, eval_start_time, input_trace_ids)
 
     return EvaluationResult(
         run_id=run_id,

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -760,7 +760,11 @@ def _parse_chunk(chunk: Any) -> dict[str, Any] | None:
     return doc
 
 
-def clean_up_extra_traces(traces: list[Trace], eval_start_time: int) -> list[Trace]:
+def clean_up_extra_traces(
+    traces: list[Trace],
+    eval_start_time: int,
+    input_trace_ids: set[str] | None = None,
+) -> list[Trace]:
     """
     Clean up noisy traces generated outside predict function.
 
@@ -772,6 +776,8 @@ def clean_up_extra_traces(traces: list[Trace], eval_start_time: int) -> list[Tra
     Args:
         traces: List of traces to clean up.
         eval_start_time: The start time of the evaluation run.
+        input_trace_ids: Set of trace IDs that were passed in the input DataFrame.
+            These traces should never be deleted.
 
     Returns:
         List of traces that are kept after cleaning up extra traces.
@@ -782,7 +788,7 @@ def clean_up_extra_traces(traces: list[Trace], eval_start_time: int) -> list[Tra
         extra_trace_ids = [
             trace.info.trace_id
             for trace in traces
-            if not _should_keep_trace(trace, eval_start_time)
+            if not _should_keep_trace(trace, eval_start_time, input_trace_ids)
         ]
         if extra_trace_ids:
             _logger.debug(
@@ -806,7 +812,15 @@ def clean_up_extra_traces(traces: list[Trace], eval_start_time: int) -> list[Tra
         )
 
 
-def _should_keep_trace(trace: Trace, eval_start_time: int) -> bool:
+def _should_keep_trace(
+    trace: Trace,
+    eval_start_time: int,
+    input_trace_ids: set[str] | None = None,
+) -> bool:
+    # Never delete traces that were explicitly passed in the input DataFrame.
+    if input_trace_ids and trace.info.trace_id in input_trace_ids:
+        return True
+
     # We should not delete traces that are generated before the evaluation run started.
     if trace.info.timestamp_ms < eval_start_time:
         return True


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Addresses an issue with evaluating a DF input of traces to mlflow.genai.evaluate where, due to the process of filtering out non-related traces that could occur during the execution of evaluate, if the timing is slightly off (random race condition) when cloning the traces, the discard logic can accidentally flag a trace that is part of the evaluation df input to be deleted. 

The least invasive and non-metadata impactful fix that I could determine would be to explicitly pass in the set of the trace references so that they are excluded from deletion. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
