### PR TITLE
Online scoring: Create env var for session completion buffer

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1192,7 +1192,7 @@ MLFLOW_SERVER_ONLINE_SCORING_MAX_WORKERS = _EnvironmentVariable(
     "MLFLOW_SERVER_ONLINE_SCORING_MAX_WORKERS", int, 5
 )
 
-#: Buffer time in seconds to wait before considering a session complete for online scoring.
+#: Default buffer time in seconds to wait before considering a session complete for online scoring.
 #: Sessions with no new traces for this duration are considered complete and ready for scoring.
 #: (default: ``300`` (5 minutes))
 MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS = _EnvironmentVariable(

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1192,6 +1192,13 @@ MLFLOW_SERVER_ONLINE_SCORING_MAX_WORKERS = _EnvironmentVariable(
     "MLFLOW_SERVER_ONLINE_SCORING_MAX_WORKERS", int, 5
 )
 
+#: Buffer time in seconds to wait before considering a session complete for online scoring.
+#: Sessions with no new traces for this duration are considered complete and ready for scoring.
+#: (default: ``300`` (5 minutes))
+MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS = _EnvironmentVariable(
+    "MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS", int, 5 * 60
+)
+
 
 #: Specifies the maximum number of completion iterations allowed when invoking
 #: judge models. This prevents infinite loops in case of complex traces or

--- a/mlflow/genai/scorers/online/constants.py
+++ b/mlflow/genai/scorers/online/constants.py
@@ -5,10 +5,6 @@ from mlflow.tracing.constant import TraceMetadataKey
 # Maximum lookback period to prevent getting stuck on old failing traces (1 hour)
 MAX_LOOKBACK_MS = 60 * 60 * 1000
 
-# Buffer time to wait before considering a session complete (5 minutes)
-# Sessions with no new traces for this duration are considered complete
-SESSION_COMPLETION_BUFFER_MS = 5 * 60 * 1000
-
 # Maximum traces to include in a single scoring job
 MAX_TRACES_PER_JOB = 500
 

--- a/mlflow/genai/scorers/online/session_checkpointer.py
+++ b/mlflow/genai/scorers/online/session_checkpointer.py
@@ -6,10 +6,10 @@ import time
 from dataclasses import asdict, dataclass
 
 from mlflow.entities.experiment_tag import ExperimentTag
-from mlflow.genai.scorers.online.constants import (
-    MAX_LOOKBACK_MS,
-    SESSION_COMPLETION_BUFFER_MS,
+from mlflow.environment_variables import (
+    MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS,
 )
+from mlflow.genai.scorers.online.constants import MAX_LOOKBACK_MS
 from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.utils.mlflow_tags import MLFLOW_LATEST_ONLINE_SCORING_SESSION_CHECKPOINT
 
@@ -94,7 +94,10 @@ class OnlineSessionCheckpointManager:
             checkpoint.timestamp_ms if checkpoint else 0, min_lookback_time_ms
         )
 
-        max_last_trace_timestamp_ms = current_time_ms - SESSION_COMPLETION_BUFFER_MS
+        buffer_seconds = max(
+            0, MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS.get()
+        )
+        max_last_trace_timestamp_ms = current_time_ms - buffer_seconds * 1000
 
         return OnlineSessionScoringTimeWindow(
             min_last_trace_timestamp_ms=min_last_trace_timestamp_ms,

--- a/tests/genai/scorers/online/test_session_checkpointer.py
+++ b/tests/genai/scorers/online/test_session_checkpointer.py
@@ -131,11 +131,12 @@ def test_calculate_time_window_old_checkpoint(checkpoint_manager, mock_store, mo
 
 
 def test_calculate_time_window_with_custom_buffer(checkpoint_manager, mock_store, monkeypatch):
+    # Empty tags simulates no existing checkpoint
     experiment = MagicMock()
     experiment.tags = {}
     mock_store.get_experiment.return_value = experiment
     fixed_time = 1000000
-    custom_buffer_seconds = 60  # 1 minute
+    custom_buffer_seconds = 60
     monkeypatch.setattr(time, "time", lambda: fixed_time)
     monkeypatch.setenv(
         "MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS",
@@ -153,6 +154,7 @@ def test_calculate_time_window_with_custom_buffer(checkpoint_manager, mock_store
 def test_calculate_time_window_with_negative_buffer_defaults_to_zero(
     checkpoint_manager, mock_store, monkeypatch
 ):
+    # Empty tags simulates no existing checkpoint
     experiment = MagicMock()
     experiment.tags = {}
     mock_store.get_experiment.return_value = experiment

--- a/tests/genai/scorers/online/test_session_checkpointer.py
+++ b/tests/genai/scorers/online/test_session_checkpointer.py
@@ -3,10 +3,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from mlflow.genai.scorers.online.constants import (
-    MAX_LOOKBACK_MS,
-    SESSION_COMPLETION_BUFFER_MS,
+from mlflow.environment_variables import (
+    MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS,
 )
+from mlflow.genai.scorers.online.constants import MAX_LOOKBACK_MS
 from mlflow.genai.scorers.online.session_checkpointer import (
     OnlineSessionCheckpointManager,
     OnlineSessionScoringCheckpoint,
@@ -86,7 +86,9 @@ def test_calculate_time_window_no_checkpoint(checkpoint_manager, mock_store, mon
     result = checkpoint_manager.calculate_time_window()
 
     expected_min = (fixed_time * 1000) - MAX_LOOKBACK_MS
-    expected_max = (fixed_time * 1000) - SESSION_COMPLETION_BUFFER_MS
+    expected_max = (
+        fixed_time * 1000
+    ) - MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS.get() * 1000
     assert result.min_last_trace_timestamp_ms == expected_min
     assert result.max_last_trace_timestamp_ms == expected_max
 
@@ -102,7 +104,9 @@ def test_calculate_time_window_recent_checkpoint(checkpoint_manager, mock_store,
 
     result = checkpoint_manager.calculate_time_window()
 
-    expected_max = (fixed_time * 1000) - SESSION_COMPLETION_BUFFER_MS
+    expected_max = (
+        fixed_time * 1000
+    ) - MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS.get() * 1000
     assert result.min_last_trace_timestamp_ms == recent_checkpoint_time
     assert result.max_last_trace_timestamp_ms == expected_max
 
@@ -119,6 +123,46 @@ def test_calculate_time_window_old_checkpoint(checkpoint_manager, mock_store, mo
     result = checkpoint_manager.calculate_time_window()
 
     expected_min = (fixed_time * 1000) - MAX_LOOKBACK_MS
-    expected_max = (fixed_time * 1000) - SESSION_COMPLETION_BUFFER_MS
+    expected_max = (
+        fixed_time * 1000
+    ) - MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS.get() * 1000
+    assert result.min_last_trace_timestamp_ms == expected_min
+    assert result.max_last_trace_timestamp_ms == expected_max
+
+
+def test_calculate_time_window_with_custom_buffer(checkpoint_manager, mock_store, monkeypatch):
+    experiment = MagicMock()
+    experiment.tags = {}
+    mock_store.get_experiment.return_value = experiment
+    fixed_time = 1000000
+    custom_buffer_seconds = 60  # 1 minute
+    monkeypatch.setattr(time, "time", lambda: fixed_time)
+    monkeypatch.setenv(
+        "MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS",
+        str(custom_buffer_seconds),
+    )
+
+    result = checkpoint_manager.calculate_time_window()
+
+    expected_min = (fixed_time * 1000) - MAX_LOOKBACK_MS
+    expected_max = (fixed_time * 1000) - (custom_buffer_seconds * 1000)
+    assert result.min_last_trace_timestamp_ms == expected_min
+    assert result.max_last_trace_timestamp_ms == expected_max
+
+
+def test_calculate_time_window_with_negative_buffer_defaults_to_zero(
+    checkpoint_manager, mock_store, monkeypatch
+):
+    experiment = MagicMock()
+    experiment.tags = {}
+    mock_store.get_experiment.return_value = experiment
+    fixed_time = 1000000
+    monkeypatch.setattr(time, "time", lambda: fixed_time)
+    monkeypatch.setenv("MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS", "-100")
+
+    result = checkpoint_manager.calculate_time_window()
+
+    expected_min = (fixed_time * 1000) - MAX_LOOKBACK_MS
+    expected_max = fixed_time * 1000  # buffer is 0, so max = current_time
     assert result.min_last_trace_timestamp_ms == expected_min
     assert result.max_last_trace_timestamp_ms == expected_max


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Online scoring: Create env var for session completion buffer

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
