### PR TITLE
Add telemetry for execution of online scorers

### DIFF
--- a/mlflow/genai/scorers/job.py
+++ b/mlflow/genai/scorers/job.py
@@ -35,6 +35,10 @@ from mlflow.tracing.constant import TraceMetadataKey
 
 _logger = logging.getLogger(__name__)
 
+# Job name constants for online scoring jobs
+ONLINE_TRACE_SCORER_JOB_NAME = "run_online_trace_scorer"
+ONLINE_SESSION_SCORER_JOB_NAME = "run_online_session_scorer"
+
 
 @dataclass
 class ScorerFailure:
@@ -60,7 +64,7 @@ def _extract_failures_from_feedbacks(feedbacks: list[Any]) -> list[ScorerFailure
 
 
 @job(
-    name="run_online_trace_scorer",
+    name=ONLINE_TRACE_SCORER_JOB_NAME,
     max_workers=MLFLOW_SERVER_ONLINE_SCORING_MAX_WORKERS.get(),
     exclusive=["experiment_id"],
 )
@@ -94,7 +98,7 @@ def run_online_trace_scorer_job(
 
 
 @job(
-    name="run_online_session_scorer",
+    name=ONLINE_SESSION_SCORER_JOB_NAME,
     max_workers=MLFLOW_SERVER_ONLINE_SCORING_MAX_WORKERS.get(),
     exclusive=["experiment_id"],
 )

--- a/mlflow/genai/scorers/job.py
+++ b/mlflow/genai/scorers/job.py
@@ -35,7 +35,7 @@ from mlflow.tracing.constant import TraceMetadataKey
 
 _logger = logging.getLogger(__name__)
 
-# Job name constants for job names that are referenced in multiple locations
+# Constants for job names that are referenced in multiple locations
 ONLINE_TRACE_SCORER_JOB_NAME = "run_online_trace_scorer"
 ONLINE_SESSION_SCORER_JOB_NAME = "run_online_session_scorer"
 

--- a/mlflow/genai/scorers/job.py
+++ b/mlflow/genai/scorers/job.py
@@ -35,7 +35,7 @@ from mlflow.tracing.constant import TraceMetadataKey
 
 _logger = logging.getLogger(__name__)
 
-# Job name constants for online scoring jobs
+# Job name constants for job names that are referenced in multiple locations
 ONLINE_TRACE_SCORER_JOB_NAME = "run_online_trace_scorer"
 ONLINE_SESSION_SCORER_JOB_NAME = "run_online_session_scorer"
 

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -149,6 +149,7 @@ def _exec_job_in_subproc(
     tmpdir: str,
     job_store: "AbstractJobStore",
     job_id: str,
+    job_name: str,
 ) -> JobResult | None:
     """
     Executes the job function in a subprocess,
@@ -211,6 +212,7 @@ def _exec_job_in_subproc(
         job_cmd,
         env={
             **os.environ,
+            "_MLFLOW_SERVER_JOB_NAME": job_name,
             "_MLFLOW_SERVER_JOB_PARAMS": json.dumps(params),
             "_MLFLOW_SERVER_JOB_FUNCTION_FULLNAME": function_fullname,
             "_MLFLOW_SERVER_JOB_RESULT_DUMP_PATH": result_file,
@@ -323,6 +325,7 @@ def _exec_job(
                 tmpdir,
                 job_store,
                 job_id,
+                job_name,
             )
 
         if job_result is None:

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -38,6 +38,9 @@ _logger = logging.getLogger(__name__)
 # Reserved Huey instance key for periodic tasks
 HUEY_PERIODIC_TASKS_INSTANCE_KEY = "periodic_tasks"
 
+# Environment variable name for the job name set in job subprocesses
+MLFLOW_SERVER_JOB_NAME_ENV_VAR = "_MLFLOW_SERVER_JOB_NAME"
+
 # Number of worker threads for the periodic tasks consumer
 PERIODIC_TASKS_WORKER_COUNT = 5
 
@@ -212,7 +215,7 @@ def _exec_job_in_subproc(
         job_cmd,
         env={
             **os.environ,
-            "_MLFLOW_SERVER_JOB_NAME": job_name,
+            MLFLOW_SERVER_JOB_NAME_ENV_VAR: job_name,
             "_MLFLOW_SERVER_JOB_PARAMS": json.dumps(params),
             "_MLFLOW_SERVER_JOB_FUNCTION_FULLNAME": function_fullname,
             "_MLFLOW_SERVER_JOB_RESULT_DUMP_PATH": result_file,

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -636,8 +636,9 @@ class ScorerCallEvent(Event):
             ONLINE_SESSION_SCORER_JOB_NAME,
             ONLINE_TRACE_SCORER_JOB_NAME,
         )
+        from mlflow.server.jobs.utils import MLFLOW_SERVER_JOB_NAME_ENV_VAR
 
-        job_name = os.environ.get("_MLFLOW_SERVER_JOB_NAME")
+        job_name = os.environ.get(MLFLOW_SERVER_JOB_NAME_ENV_VAR)
         if job_name in (ONLINE_TRACE_SCORER_JOB_NAME, ONLINE_SESSION_SCORER_JOB_NAME):
             callsite = "online_scoring"
         else:

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import sys
 from enum import Enum
 from typing import TYPE_CHECKING, Any
@@ -629,17 +630,28 @@ class ScorerCallEvent(Event):
         if not isinstance(scorer_instance, Scorer):
             return None
 
-        callsite = "direct_scorer_call"
-        for frame_info in inspect.stack()[:10]:
-            frame_filename = frame_info.filename
-            frame_function = frame_info.function
+        # Check if running inside an online scoring job
+        # Import here to avoid circular import
+        from mlflow.genai.scorers.job import (
+            ONLINE_SESSION_SCORER_JOB_NAME,
+            ONLINE_TRACE_SCORER_JOB_NAME,
+        )
 
-            if (
-                GENAI_SCORERS_PATH in frame_filename.replace("\\", "/")
-                and frame_function == SCORER_RUN_FUNCTION
-            ):
-                callsite = "genai_evaluate"
-                break
+        job_name = os.environ.get("_MLFLOW_SERVER_JOB_NAME", "")
+        if job_name in (ONLINE_TRACE_SCORER_JOB_NAME, ONLINE_SESSION_SCORER_JOB_NAME):
+            callsite = "online_scoring"
+        else:
+            callsite = "direct_scorer_call"
+            for frame_info in inspect.stack()[:10]:
+                frame_filename = frame_info.filename
+                frame_function = frame_info.function
+
+                if (
+                    GENAI_SCORERS_PATH in frame_filename.replace("\\", "/")
+                    and frame_function == SCORER_RUN_FUNCTION
+                ):
+                    callsite = "genai_evaluate"
+                    break
 
         return {
             "scorer_class": _get_scorer_class_name_for_tracking(scorer_instance),

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -631,7 +631,7 @@ class ScorerCallEvent(Event):
             return None
 
         # Check if running inside an online scoring job
-        # Import here to avoid circular import
+        # Import here to avoid circular imports
         from mlflow.genai.scorers.job import (
             ONLINE_SESSION_SCORER_JOB_NAME,
             ONLINE_TRACE_SCORER_JOB_NAME,

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -637,7 +637,7 @@ class ScorerCallEvent(Event):
             ONLINE_TRACE_SCORER_JOB_NAME,
         )
 
-        job_name = os.environ.get("_MLFLOW_SERVER_JOB_NAME", "")
+        job_name = os.environ.get("_MLFLOW_SERVER_JOB_NAME")
         if job_name in (ONLINE_TRACE_SCORER_JOB_NAME, ONLINE_SESSION_SCORER_JOB_NAME):
             callsite = "online_scoring"
         else:

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -512,15 +512,13 @@ def test_submit_job_bad_call(monkeypatch, tmp_path):
 def check_python_env_fn():
     import openai
 
+    from mlflow.server.jobs.utils import MLFLOW_SERVER_JOB_NAME_ENV_VAR
     from mlflow.utils import PYTHON_VERSION
 
     assert PYTHON_VERSION == "3.11.9"
     assert openai.__version__ == "1.108.2"
 
-    # Verify job env vars are set correctly
-    # Job name from @job(name=...) decorator - different from function name
-    assert os.environ.get("_MLFLOW_SERVER_JOB_NAME") == "python_env_checker"
-    # Full module path to the job function
+    assert os.environ.get(MLFLOW_SERVER_JOB_NAME_ENV_VAR) == "python_env_checker"
     assert (
         os.environ.get("_MLFLOW_SERVER_JOB_FUNCTION_FULLNAME")
         == "tests.server.jobs.test_jobs.check_python_env_fn"

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -1556,8 +1556,6 @@ def test_scorer_call_online_scoring_callsite(
         },
     )
 
-    mock_requests.clear()
-
 
 def test_scorer_call_tracks_feedback_errors(mock_requests, mock_telemetry_client: TelemetryClient):
     error_judge = make_judge(

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -1530,8 +1530,10 @@ def test_scorer_call_from_genai_evaluate(mock_requests, mock_telemetry_client: T
 def test_scorer_call_online_scoring_callsite(
     mock_requests, mock_telemetry_client: TelemetryClient, monkeypatch, job_name
 ):
+    from mlflow.server.jobs.utils import MLFLOW_SERVER_JOB_NAME_ENV_VAR
+
     # Set the env var that indicates we're in an online scoring job
-    monkeypatch.setenv("_MLFLOW_SERVER_JOB_NAME", job_name)
+    monkeypatch.setenv(MLFLOW_SERVER_JOB_NAME_ENV_VAR, job_name)
 
     @scorer
     def custom_scorer(outputs: str) -> bool:


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add telemetry for execution of online scorers

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
