### PR TITLE
Fix passthrough path validation message

### DIFF
--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -110,16 +110,17 @@ class BaseProvider(ABC):
         """
         provider_path = self.PASSTHROUGH_PROVIDER_PATHS.get(action)
         if provider_path is None:
-            route = PASSTHROUGH_ROUTES.get(action, action.value)
+            requested_route = PASSTHROUGH_ROUTES.get(action, action.value)
             supported_routes = ", ".join(
-                f"/gateway{route} (provider_path: {path})"
+                f"/gateway{supported_route} (provider_path: {path})"
                 for act in self.PASSTHROUGH_PROVIDER_PATHS.keys()
-                if (route := PASSTHROUGH_ROUTES.get(act))
+                if (supported_route := PASSTHROUGH_ROUTES.get(act))
                 and (path := self.PASSTHROUGH_PROVIDER_PATHS.get(act))
             )
             raise AIGatewayException(
                 status_code=400,
-                detail=f"Unsupported passthrough endpoint '{route}' for {self.NAME} provider. "
+                detail="Unsupported passthrough endpoint "
+                f"'{requested_route}' for {self.NAME} provider. "
                 f"Supported endpoints: {supported_routes}",
             )
         return provider_path

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -1101,6 +1101,19 @@ async def test_azure_openai_passthrough_chat_removes_model():
 
 
 @pytest.mark.asyncio
+async def test_validate_passthrough_action_error_shows_correct_endpoint():
+    config = chat_config()
+    provider = OpenAIProvider(EndpointConfig(**config))
+
+    with pytest.raises(
+        AIGatewayException,
+        match=r"Unsupported passthrough endpoint "
+        r"'/gemini/v1beta/models/\{endpoint_name\}:generateContent' for OpenAI provider",
+    ):
+        provider._validate_passthrough_action(PassthroughAction.GEMINI_GENERATE_CONTENT)
+
+
+@pytest.mark.asyncio
 async def test_chat_with_structured_output():
     config = EndpointConfig(**chat_config())
     provider = OpenAIProvider(config)


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Fix the issue that the validation error of the passthrough endpoint sometimes becomes incorrect due to the variable overwrite.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
