### PR TITLE
Prevent empty inputs for conversational datasets

### DIFF
--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -11,7 +11,9 @@ import mlflow
 from mlflow.data import Dataset
 from mlflow.data.pyfunc_dataset_mixin import PyFuncConvertibleDatasetMixin
 from mlflow.entities.dataset_record_source import DatasetRecordSourceType
-from mlflow.entities.evaluation_dataset import EvaluationDataset as EntityEvaluationDataset
+from mlflow.entities.evaluation_dataset import (
+    EvaluationDataset as EntityEvaluationDataset,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import (
     EvaluationDataset,
@@ -228,7 +230,8 @@ def test_delete_dataset_missing_id():
 
 def test_delete_dataset_databricks(mock_databricks_environment):
     with mock.patch.dict(
-        "sys.modules", {"databricks.agents.datasets": mock.Mock(delete_dataset=mock.Mock())}
+        "sys.modules",
+        {"databricks.agents.datasets": mock.Mock(delete_dataset=mock.Mock())},
     ):
         delete_dataset(name="catalog.schema.table")
 
@@ -406,7 +409,8 @@ def test_databricks_profile_uri_support():
     mock_dataset = mock.Mock()
     with (
         mock.patch(
-            "mlflow.genai.datasets.get_tracking_uri", return_value="databricks://profilename"
+            "mlflow.genai.datasets.get_tracking_uri",
+            return_value="databricks://profilename",
         ),
         mock.patch.dict(
             "sys.modules",
@@ -1031,7 +1035,10 @@ def test_trace_to_dataset_with_assessments(client, experiment):
             },
         },
         {
-            "inputs": {"question": "What is Python?", "context": "programming languages"},
+            "inputs": {
+                "question": "What is Python?",
+                "context": "programming languages",
+            },
             "outputs": {"answer": "Python is a high-level programming language"},
             "expectations": {
                 "correctness": True,
@@ -1452,7 +1459,8 @@ def test_dataset_experiment_associations(tracking_uri, experiments):
 
     with mock.patch("mlflow.store.tracking.sqlalchemy_store._logger.warning") as mock_warning:
         idempotent = remove_dataset_from_experiments(
-            dataset_id=dataset.dataset_id, experiment_ids=[experiments[1], experiments[2]]
+            dataset_id=dataset.dataset_id,
+            experiment_ids=[experiments[1], experiments[2]],
         )
         assert mock_warning.call_count == 2
         assert "was not associated" in mock_warning.call_args_list[0][0][0]
@@ -1795,7 +1803,9 @@ def test_create_dataset_none_uses_active_experiment(tracking_uri):
 def test_source_type_inference():
     exp = mlflow.create_experiment("test_source_inference")
     dataset = create_dataset(
-        name="test_source_inference", experiment_id=exp, tags={"test": "source_inference"}
+        name="test_source_inference",
+        experiment_id=exp,
+        tags={"test": "source_inference"},
     )
 
     human_records = [
@@ -1893,7 +1903,9 @@ def test_trace_source_type_detection():
                     )
 
     dataset = create_dataset(
-        name="test_trace_sources", experiment_id=exp, tags={"test": "trace_source_detection"}
+        name="test_trace_sources",
+        experiment_id=exp,
+        tags={"test": "trace_source_detection"},
     )
 
     client = mlflow.MlflowClient()
@@ -1909,7 +1921,9 @@ def test_trace_source_type_detection():
         assert len(matching_records) == 1
 
     dataset2 = create_dataset(
-        name="test_trace_sources_df", experiment_id=exp, tags={"test": "trace_source_df"}
+        name="test_trace_sources_df",
+        experiment_id=exp,
+        tags={"test": "trace_source_df"},
     )
 
     traces_df = mlflow.search_traces(locations=[exp])
@@ -1921,7 +1935,9 @@ def test_trace_source_type_detection():
     assert len(trace_sources2) == len(traces_df)
 
     dataset3 = create_dataset(
-        name="test_trace_sources_list", experiment_id=exp, tags={"test": "trace_source_list"}
+        name="test_trace_sources_list",
+        experiment_id=exp,
+        tags={"test": "trace_source_list"},
     )
 
     traces_list = mlflow.search_traces(locations=[exp], return_type="list")
@@ -1938,34 +1954,6 @@ def test_trace_source_type_detection():
     delete_dataset(dataset_id=dataset.dataset_id)
     delete_dataset(dataset_id=dataset2.dataset_id)
     delete_dataset(dataset_id=dataset3.dataset_id)
-
-
-def test_create_dataset_explicit_overrides_active_experiment(tracking_uri):
-    active_exp = mlflow.create_experiment("active_exp")
-    explicit_exp = mlflow.create_experiment("explicit_exp")
-
-    mlflow.set_experiment(experiment_id=active_exp)
-
-    dataset = create_dataset(name="test_explicit_override", experiment_id=explicit_exp)
-
-    assert dataset.experiment_ids == [explicit_exp]
-
-    from mlflow.tracking import fluent
-
-    fluent._active_experiment_id = None
-
-
-def test_create_dataset_none_uses_active_experiment(tracking_uri):
-    exp_id = mlflow.create_experiment("test_none_experiment")
-    mlflow.set_experiment(experiment_id=exp_id)
-
-    dataset = create_dataset(name="test_none_exp", experiment_id=None)
-
-    assert dataset.experiment_ids == [exp_id]
-
-    from mlflow.tracking import fluent
-
-    fluent._active_experiment_id = None
 
 
 def test_create_dataset_empty_list_stays_empty(tracking_uri):
@@ -2137,7 +2125,13 @@ def test_wrapper_isinstance_checks_for_dataset_interfaces(tracking_uri, experime
     [
         [
             {"inputs": {"persona": "Student", "goal": "Find articles"}},
-            {"inputs": {"persona": "Researcher", "goal": "Review", "context": {"dept": "CS"}}},
+            {
+                "inputs": {
+                    "persona": "Researcher",
+                    "goal": "Review",
+                    "context": {"dept": "CS"},
+                }
+            },
             {"inputs": {"goal": "Single goal"}, "expectations": {"output": "expected"}},
         ],
     ],
@@ -2162,7 +2156,15 @@ def test_multiturn_valid_formats(tracking_uri, experiments, records):
         ),
         # Mixed fields in inputs
         (
-            [{"inputs": {"persona": "Student", "goal": "Find", "custom_field": "value"}}],
+            [
+                {
+                    "inputs": {
+                        "persona": "Student",
+                        "goal": "Find",
+                        "custom_field": "value",
+                    }
+                }
+            ],
             "Invalid input schema.*cannot mix session fields",
         ),
         # Inconsistent batch schema
@@ -2172,6 +2174,14 @@ def test_multiturn_valid_formats(tracking_uri, experiments, records):
                 {"inputs": {"question": "What is MLflow?"}},
             ],
             "must use the same granularity.*Found",
+        ),
+        # Empty inputs in batch with session records
+        (
+            [
+                {"inputs": {"goal": "Find articles"}},
+                {"inputs": {}},
+            ],
+            "Empty inputs are not allowed for session records.*'goal' field is required",
         ),
     ],
 )


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> 

https://github.com/mlflow/mlflow/pull/19686

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Preventing conversational dataset `merge_records` from having empty inputs: https://github.com/mlflow/mlflow/pull/19686/changes#r2673619680

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

<img width="959" height="781" alt="image" src="https://github.com/user-attachments/assets/a262a4d2-b8a3-4fe1-981b-fb16725ad58f" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
https://github.com/mlflow/mlflow/pull/19686

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
