### PR TITLE
Support passthrough endpoints for LiteLLM providers

### DIFF
--- a/mlflow/gateway/providers/litellm.py
+++ b/mlflow/gateway/providers/litellm.py
@@ -253,9 +253,7 @@ class LiteLLMProvider(BaseProvider):
         """Passthrough for OpenAI Response API using litellm.aresponses()."""
         import litellm
 
-        is_streaming = kwargs.pop("stream", False)
-
-        if is_streaming:
+        if kwargs.pop("stream", False):
             return self._stream_openai_responses(kwargs)
 
         response = await litellm.aresponses(**kwargs)
@@ -279,9 +277,7 @@ class LiteLLMProvider(BaseProvider):
         """Passthrough for Anthropic Messages API using litellm.anthropic.messages.acreate()."""
         import litellm
 
-        is_streaming = kwargs.pop("stream", False)
-
-        if is_streaming:
+        if kwargs.pop("stream", False):
             return self._stream_anthropic_messages(kwargs)
 
         response = await litellm.anthropic.messages.acreate(**kwargs)
@@ -331,9 +327,7 @@ class LiteLLMProvider(BaseProvider):
         """Passthrough for OpenAI Chat Completions API."""
         import litellm
 
-        is_streaming = kwargs.pop("stream", False)
-
-        if is_streaming:
+        if kwargs.pop("stream", False):
             return self._stream_openai_chat(kwargs)
 
         response = await litellm.acompletion(**kwargs)

--- a/mlflow/gateway/providers/litellm.py
+++ b/mlflow/gateway/providers/litellm.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 from typing import Any, AsyncIterable
 
 from mlflow.gateway.config import EndpointConfig, LiteLLMConfig
-from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
+from mlflow.gateway.providers.base import BaseProvider, PassthroughAction, ProviderAdapter
 from mlflow.gateway.schemas import chat, embeddings
 
 
@@ -48,6 +49,15 @@ class LiteLLMProvider(BaseProvider):
 
     NAME = "LiteLLM"
     CONFIG_TYPE = LiteLLMConfig
+
+    PASSTHROUGH_PROVIDER_PATHS = {
+        PassthroughAction.OPENAI_CHAT: "chat/completions",
+        PassthroughAction.OPENAI_EMBEDDINGS: "embeddings",
+        PassthroughAction.OPENAI_RESPONSES: "responses",
+        PassthroughAction.ANTHROPIC_MESSAGES: "messages",
+        PassthroughAction.GEMINI_GENERATE_CONTENT: "{model}:generateContent",
+        PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT: "{model}:streamGenerateContent",
+    }
 
     def __init__(self, config: EndpointConfig) -> None:
         super().__init__(config)
@@ -204,3 +214,153 @@ class LiteLLMProvider(BaseProvider):
         }
 
         return self.adapter_class.model_to_embeddings(resp_dict, self.config)
+
+    async def passthrough(
+        self,
+        action: PassthroughAction,
+        payload: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any] | AsyncIterable[bytes]:
+        """
+        Passthrough endpoint for raw API requests using LiteLLM.
+
+        Routes requests to the appropriate LiteLLM SDK method based on the action.
+        """
+        self._validate_passthrough_action(action)
+
+        model_name = self.adapter_class._get_litellm_model_name(self.config)
+        kwargs = self._build_litellm_kwargs(payload)
+        kwargs["model"] = model_name
+
+        match action:
+            case PassthroughAction.OPENAI_RESPONSES:
+                return await self._passthrough_openai_responses(kwargs)
+            case PassthroughAction.ANTHROPIC_MESSAGES:
+                return await self._passthrough_anthropic_messages(kwargs)
+            case PassthroughAction.GEMINI_GENERATE_CONTENT:
+                return await self._passthrough_gemini_generate_content(kwargs)
+            case PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT:
+                return self._passthrough_gemini_stream_generate_content(kwargs)
+            case PassthroughAction.OPENAI_CHAT:
+                return await self._passthrough_openai_chat(kwargs)
+            case PassthroughAction.OPENAI_EMBEDDINGS:
+                return await self._passthrough_openai_embeddings(kwargs)
+
+    async def _passthrough_openai_responses(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Passthrough for OpenAI Response API using litellm.aresponses()."""
+        import litellm
+
+        is_streaming = kwargs.pop("stream", False)
+
+        if is_streaming:
+            return self._stream_openai_responses(kwargs)
+
+        response = await litellm.aresponses(**kwargs)
+        return self._response_to_dict(response)
+
+    def _stream_openai_responses(self, kwargs: dict[str, Any]) -> AsyncIterable[bytes]:
+        """Stream OpenAI Response API responses."""
+
+        async def stream_generator():
+            import litellm
+
+            response = await litellm.aresponses(**kwargs, stream=True)
+            async for chunk in response:
+                data = json.dumps(self._response_to_dict(chunk))
+                yield f"data: {data}\n\n".encode()
+            yield b"data: [DONE]\n\n"
+
+        return stream_generator()
+
+    async def _passthrough_anthropic_messages(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Passthrough for Anthropic Messages API using litellm.anthropic.messages.acreate()."""
+        import litellm
+
+        is_streaming = kwargs.pop("stream", False)
+
+        if is_streaming:
+            return self._stream_anthropic_messages(kwargs)
+
+        response = await litellm.anthropic.messages.acreate(**kwargs)
+        return self._response_to_dict(response)
+
+    def _stream_anthropic_messages(self, kwargs: dict[str, Any]) -> AsyncIterable[bytes]:
+        """Stream Anthropic Messages API responses."""
+
+        async def stream_generator():
+            import litellm
+
+            response = await litellm.anthropic.messages.acreate(**kwargs, stream=True)
+            async for chunk in response:
+                data = json.dumps(self._response_to_dict(chunk))
+                yield f"data: {data}\n\n".encode()
+            yield b"data: [DONE]\n\n"
+
+        return stream_generator()
+
+    async def _passthrough_gemini_generate_content(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Passthrough for Gemini generateContent API using litellm.agenerate_content()."""
+        import litellm
+
+        response = await litellm.agenerate_content(**kwargs)
+        return self._response_to_dict(response)
+
+    def _passthrough_gemini_stream_generate_content(
+        self, kwargs: dict[str, Any]
+    ) -> AsyncIterable[bytes]:
+        """Passthrough for Gemini streamGenerateContent API."""
+
+        async def stream_generator():
+            import litellm
+
+            # Use agenerate_content with stream=True for streaming
+            response = await litellm.agenerate_content(**kwargs, stream=True)
+            async for chunk in response:
+                data = json.dumps(self._response_to_dict(chunk))
+                yield f"data: {data}\n\n".encode()
+            yield b"data: [DONE]\n\n"
+
+        return stream_generator()
+
+    async def _passthrough_openai_chat(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Passthrough for OpenAI Chat Completions API."""
+        import litellm
+
+        is_streaming = kwargs.pop("stream", False)
+
+        if is_streaming:
+            return self._stream_openai_chat(kwargs)
+
+        response = await litellm.acompletion(**kwargs)
+        return self._response_to_dict(response)
+
+    def _stream_openai_chat(self, kwargs: dict[str, Any]) -> AsyncIterable[bytes]:
+        """Stream OpenAI Chat Completions API responses."""
+
+        async def stream_generator():
+            import litellm
+
+            response = await litellm.acompletion(**kwargs, stream=True)
+            async for chunk in response:
+                data = json.dumps(self._response_to_dict(chunk))
+                yield f"data: {data}\n\n".encode()
+            yield b"data: [DONE]\n\n"
+
+        return stream_generator()
+
+    async def _passthrough_openai_embeddings(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Passthrough for OpenAI Embeddings API."""
+        import litellm
+
+        response = await litellm.aembedding(**kwargs)
+        return self._response_to_dict(response)
+
+    def _response_to_dict(self, response: Any) -> dict[str, Any]:
+        """Convert a LiteLLM response object to a dictionary."""
+        match response:
+            case dict():
+                return response
+            case _ if hasattr(response, "model_dump"):
+                return response.model_dump()
+            case _:
+                raise TypeError(f"Unexpected response type: {type(response).__name__}")

--- a/tests/gateway/providers/test_litellm.py
+++ b/tests/gateway/providers/test_litellm.py
@@ -476,7 +476,9 @@ async def test_passthrough_gemini_generate_content():
         "candidates": [{"content": {"parts": [{"text": "Generated content"}]}}],
     }
 
-    with mock.patch("litellm.agenerate_content", return_value=mock_response) as mock_agenerate:
+    with mock.patch(
+        "litellm.google_genai.agenerate_content", return_value=mock_response
+    ) as mock_agenerate:
         provider = LiteLLMProvider(EndpointConfig(**config))
         payload = {
             "contents": [{"parts": [{"text": "Generate something"}]}],
@@ -505,7 +507,7 @@ async def test_passthrough_gemini_stream_generate_content():
             yield chunk
 
     # agenerate_content is called with stream=True for streaming
-    with mock.patch("litellm.agenerate_content", return_value=mock_stream()):
+    with mock.patch("litellm.google_genai.agenerate_content", return_value=mock_stream()):
         provider = LiteLLMProvider(EndpointConfig(**config))
         payload = {
             "contents": [{"parts": [{"text": "Generate something"}]}],

--- a/tests/gateway/providers/test_litellm.py
+++ b/tests/gateway/providers/test_litellm.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.base import PassthroughAction
 from mlflow.gateway.providers.litellm import LiteLLMAdapter, LiteLLMProvider
 from mlflow.gateway.schemas import chat, embeddings
 
@@ -356,3 +357,244 @@ def test_adapter_model_to_embeddings():
     assert result.data[0].embedding == [0.1, 0.2, 0.3]
     assert result.data[0].index == 0
     assert result.usage.prompt_tokens == 5
+
+
+# Passthrough tests
+
+
+def test_passthrough_provider_paths():
+    assert PassthroughAction.OPENAI_CHAT in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
+    assert PassthroughAction.OPENAI_EMBEDDINGS in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
+    assert PassthroughAction.OPENAI_RESPONSES in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
+    assert PassthroughAction.ANTHROPIC_MESSAGES in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
+    assert PassthroughAction.GEMINI_GENERATE_CONTENT in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
+    assert (
+        PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT
+        in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
+    )
+
+
+def mock_response_with_model_dump():
+    """Create a mock response object that supports model_dump()."""
+    response = mock.MagicMock()
+    response.model_dump.return_value = {
+        "id": "test-response-id",
+        "output": "Test response output",
+        "model": "test-model",
+    }
+    return response
+
+
+@pytest.mark.asyncio
+async def test_passthrough_openai_responses():
+    config = chat_config()
+    mock_response = mock_response_with_model_dump()
+
+    with mock.patch("litellm.aresponses", return_value=mock_response) as mock_aresponses:
+        provider = LiteLLMProvider(EndpointConfig(**config))
+        payload = {"input": "Hello, world!"}
+
+        result = await provider.passthrough(
+            PassthroughAction.OPENAI_RESPONSES,
+            payload,
+            headers=None,
+        )
+
+        assert result["id"] == "test-response-id"
+        assert result["output"] == "Test response output"
+        mock_aresponses.assert_called_once()
+        call_kwargs = mock_aresponses.call_args[1]
+        assert call_kwargs["model"] == "claude-3-5-sonnet-20241022"
+        assert call_kwargs["input"] == "Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_passthrough_openai_responses_streaming():
+    config = chat_config()
+
+    async def mock_stream():
+        for i in range(2):
+            chunk = mock.MagicMock()
+            chunk.model_dump.return_value = {"chunk": i, "content": f"part{i}"}
+            yield chunk
+
+    with mock.patch("litellm.aresponses", return_value=mock_stream()):
+        provider = LiteLLMProvider(EndpointConfig(**config))
+        payload = {"input": "Hello, world!", "stream": True}
+
+        result = await provider.passthrough(
+            PassthroughAction.OPENAI_RESPONSES,
+            payload,
+            headers=None,
+        )
+
+        chunks = [chunk async for chunk in result]
+        assert len(chunks) == 3  # 2 data chunks + [DONE]
+        assert b"data:" in chunks[0]
+        assert b"[DONE]" in chunks[2]
+
+
+@pytest.mark.asyncio
+async def test_passthrough_anthropic_messages():
+    config = chat_config_with_provider()
+    mock_response = mock.MagicMock()
+    mock_response.model_dump.return_value = {
+        "id": "msg-test-id",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello!"}],
+    }
+
+    with mock.patch(
+        "litellm.anthropic.messages.acreate", return_value=mock_response
+    ) as mock_acreate:
+        provider = LiteLLMProvider(EndpointConfig(**config))
+        payload = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 100,
+        }
+
+        result = await provider.passthrough(
+            PassthroughAction.ANTHROPIC_MESSAGES,
+            payload,
+            headers=None,
+        )
+
+        assert result["id"] == "msg-test-id"
+        assert result["type"] == "message"
+        mock_acreate.assert_called_once()
+        call_kwargs = mock_acreate.call_args[1]
+        assert call_kwargs["model"] == "anthropic/claude-3-5-sonnet-20241022"
+        assert call_kwargs["max_tokens"] == 100
+
+
+@pytest.mark.asyncio
+async def test_passthrough_gemini_generate_content():
+    config = chat_config()
+    mock_response = mock.MagicMock()
+    mock_response.model_dump.return_value = {
+        "candidates": [{"content": {"parts": [{"text": "Generated content"}]}}],
+    }
+
+    with mock.patch("litellm.agenerate_content", return_value=mock_response) as mock_agenerate:
+        provider = LiteLLMProvider(EndpointConfig(**config))
+        payload = {
+            "contents": [{"parts": [{"text": "Generate something"}]}],
+        }
+
+        result = await provider.passthrough(
+            PassthroughAction.GEMINI_GENERATE_CONTENT,
+            payload,
+            headers=None,
+        )
+
+        assert "candidates" in result
+        mock_agenerate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_passthrough_gemini_stream_generate_content():
+    config = chat_config()
+
+    async def mock_stream():
+        for i in range(2):
+            chunk = mock.MagicMock()
+            chunk.model_dump.return_value = {
+                "candidates": [{"content": {"parts": [{"text": f"chunk{i}"}]}}]
+            }
+            yield chunk
+
+    # agenerate_content is called with stream=True for streaming
+    with mock.patch("litellm.agenerate_content", return_value=mock_stream()):
+        provider = LiteLLMProvider(EndpointConfig(**config))
+        payload = {
+            "contents": [{"parts": [{"text": "Generate something"}]}],
+        }
+
+        result = provider._passthrough_gemini_stream_generate_content(
+            {"model": "claude-3-5-sonnet-20241022", **payload}
+        )
+
+        chunks = [chunk async for chunk in result]
+        assert len(chunks) == 3  # 2 data chunks + [DONE]
+        assert b"data:" in chunks[0]
+        assert b"[DONE]" in chunks[2]
+
+
+@pytest.mark.asyncio
+async def test_passthrough_openai_chat():
+    config = chat_config()
+    mock_response = mock_response_with_model_dump()
+    mock_response.model_dump.return_value = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "choices": [{"message": {"role": "assistant", "content": "Hello!"}}],
+    }
+
+    with mock.patch("litellm.acompletion", return_value=mock_response) as mock_completion:
+        provider = LiteLLMProvider(EndpointConfig(**config))
+        payload = {
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+
+        result = await provider.passthrough(
+            PassthroughAction.OPENAI_CHAT,
+            payload,
+            headers=None,
+        )
+
+        assert result["id"] == "chatcmpl-test"
+        assert result["object"] == "chat.completion"
+        mock_completion.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_passthrough_openai_embeddings():
+    config = embeddings_config()
+    mock_response = mock.MagicMock()
+    mock_response.model_dump.return_value = {
+        "object": "list",
+        "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}],
+        "model": "text-embedding-3-small",
+    }
+
+    with mock.patch("litellm.aembedding", return_value=mock_response) as mock_embedding:
+        provider = LiteLLMProvider(EndpointConfig(**config))
+        payload = {"input": "Hello, world!"}
+
+        result = await provider.passthrough(
+            PassthroughAction.OPENAI_EMBEDDINGS,
+            payload,
+            headers=None,
+        )
+
+        assert result["object"] == "list"
+        assert len(result["data"]) == 1
+        mock_embedding.assert_called_once()
+
+
+def test_response_to_dict_with_model_dump():
+    config = chat_config()
+    provider = LiteLLMProvider(EndpointConfig(**config))
+
+    response = mock.MagicMock()
+    response.model_dump.return_value = {"key": "value"}
+
+    result = provider._response_to_dict(response)
+    assert result == {"key": "value"}
+
+
+def test_response_to_dict_with_dict_input():
+    config = chat_config()
+    provider = LiteLLMProvider(EndpointConfig(**config))
+
+    result = provider._response_to_dict({"key": "value"})
+    assert result == {"key": "value"}
+
+
+def test_response_to_dict_with_unknown_type_raises():
+    config = chat_config()
+    provider = LiteLLMProvider(EndpointConfig(**config))
+
+    with pytest.raises(TypeError, match="Unexpected response type"):
+        provider._response_to_dict("string value")

--- a/tests/gateway/providers/test_litellm.py
+++ b/tests/gateway/providers/test_litellm.py
@@ -362,18 +362,6 @@ def test_adapter_model_to_embeddings():
 # Passthrough tests
 
 
-def test_passthrough_provider_paths():
-    assert PassthroughAction.OPENAI_CHAT in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
-    assert PassthroughAction.OPENAI_EMBEDDINGS in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
-    assert PassthroughAction.OPENAI_RESPONSES in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
-    assert PassthroughAction.ANTHROPIC_MESSAGES in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
-    assert PassthroughAction.GEMINI_GENERATE_CONTENT in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
-    assert (
-        PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT
-        in LiteLLMProvider.PASSTHROUGH_PROVIDER_PATHS
-    )
-
-
 def mock_response_with_model_dump():
     """Create a mock response object that supports model_dump()."""
     response = mock.MagicMock()


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Support passthrough endpoints for LiteLLM providers

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
