### PR TITLE
Fix DATABRICKS_CONFIG_PROFILE env var detection when fetching databricks credentials

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1202,6 +1202,7 @@ def _get_databricks_creds_config(tracking_uri):
     # configuration providers defined in legacy Databricks CLI python library to
     # read token values.
     profile, key_prefix = get_db_info_from_uri(tracking_uri)
+    profile = profile or os.environ.get("DATABRICKS_CONFIG_PROFILE")
 
     config = None
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -957,6 +957,7 @@ def test_get_sgc_job_run_id_widget_takes_precedence_over_env_var(monkeypatch):
             "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"
         )
 
+
 def test_databricks_config_profile_env_var_is_respected(tmp_path, monkeypatch):
     file_name = f"{tmp_path}/.databrickscfg"
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
@@ -965,15 +966,15 @@ def test_databricks_config_profile_env_var_is_respected(tmp_path, monkeypatch):
 
     with open(file_name, "w") as f:
         f.write("""[DEFAULT]
-host = "http://default-workspace.databricks.com"
-token = "default-token"
+host = http://default-workspace.databricks.com
+token = default-token
 
 [test]
-host = "https://test-workspace.databricks.com"
-token = "test-token"
+host = https://test-workspace.databricks.com
+token = test-token
 """)
 
     # the resulting config should be the one from the [test] section
     result = get_databricks_host_creds("databricks")
-    assert result.host == '"https://test-workspace.databricks.com"'
-    assert result.token == '"test-token"'
+    assert result.host == "https://test-workspace.databricks.com"
+    assert result.token == "test-token"

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -959,13 +959,12 @@ def test_get_sgc_job_run_id_widget_takes_precedence_over_env_var(monkeypatch):
 
 
 def test_databricks_config_profile_env_var_is_respected(tmp_path, monkeypatch):
-    file_name = f"{tmp_path}/.databrickscfg"
+    file_path = tmp_path / "/.databrickscfg"
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
-    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", file_name)
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(file_path))
     monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "test")
 
-    with open(file_name, "w") as f:
-        f.write("""[DEFAULT]
+    file_path.write_text("""[DEFAULT]
 host = http://default-workspace.databricks.com
 token = default-token
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -57,8 +57,7 @@ def test_databricks_registry_profile():
     mock_dbutils.secrets.get.return_value = "random"
     with (
         mock.patch(
-            "mlflow.utils.databricks_utils.ProfileConfigProvider",
-            return_value=mock_provider,
+            "mlflow.utils.databricks_utils.ProfileConfigProvider", return_value=mock_provider
         ),
         mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils),
     ):
@@ -77,8 +76,7 @@ def test_databricks_no_creds_found():
 def test_databricks_no_creds_found_in_model_serving(monkeypatch):
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
     with pytest.raises(
-        MlflowException,
-        match="Reading Databricks credential configuration in model serving failed",
+        MlflowException, match="Reading Databricks credential configuration in model serving failed"
     ):
         databricks_utils.get_databricks_host_creds()
 
@@ -99,8 +97,7 @@ def oauth_file(tmp_path):
 
 def test_get_model_dependency_token(oauth_file):
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
-        str(oauth_file),
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
     ):
         token = databricks_utils.get_model_dependency_oauth_token()
         assert token == "token2"
@@ -128,8 +125,7 @@ def test_databricks_params_model_serving_oauth_cache_databricks(
     # oauth file still needs to be present for should_fetch_model_serving_environment_oauth()
     #  to evaluate true
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
-        str(oauth_file),
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
     ):
         params = databricks_utils.get_databricks_host_creds()
         assert params.host == "host"
@@ -143,8 +139,7 @@ def test_databricks_params_model_serving_oauth_cache_expired(monkeypatch, oauth_
     monkeypatch.setenv("DB_DEPENDENCY_OAUTH_CACHE", "token")
     monkeypatch.setenv("DB_DEPENDENCY_OAUTH_CACHE_EXPIRY_TS", str(time.time() - 5))
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
-        str(oauth_file),
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
     ):
         params = databricks_utils.get_databricks_host_creds()
         # cache should get updated with new token
@@ -159,8 +154,7 @@ def test_databricks_params_model_serving_read_oauth(monkeypatch, oauth_file):
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("DATABRICKS_MODEL_SERVING_HOST_URL", "host")
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
-        str(oauth_file),
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
     ):
         params = databricks_utils.get_databricks_host_creds()
         assert os.environ["DB_DEPENDENCY_OAUTH_CACHE"] == "token2"
@@ -177,8 +171,7 @@ def test_databricks_params_env_var_overrides_model_serving_oauth(monkeypatch, oa
     # oauth file still needs to be present for should_fetch_model_serving_environment_oauth()
     #  to evaluate true
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
-        str(oauth_file),
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
     ):
         params = databricks_utils.get_databricks_host_creds()
         # should use token and host from envvar, rather than token from oauthfile
@@ -212,9 +205,7 @@ def test_get_workspace_info_from_dbutils():
     mock_dbutils = mock.MagicMock()
     methods = ["notebook.entry_point.getDbutils", "notebook", "getContext"]
     mock_method_chain(
-        mock_dbutils,
-        methods + ["browserHostName", "get"],
-        return_value="mlflow.databricks.com",
+        mock_dbutils, methods + ["browserHostName", "get"], return_value="mlflow.databricks.com"
     )
     mock_method_chain(mock_dbutils, methods + ["workspaceId", "get"], return_value="1111")
 
@@ -229,9 +220,7 @@ def test_get_workspace_info_from_dbutils_no_browser_host_name():
     methods = ["notebook.entry_point.getDbutils", "notebook", "getContext"]
     mock_method_chain(mock_dbutils, methods + ["browserHostName", "get"], return_value=None)
     mock_method_chain(
-        mock_dbutils,
-        methods + ["apiUrl", "get"],
-        return_value="https://mlflow.databricks.com",
+        mock_dbutils, methods + ["apiUrl", "get"], return_value="https://mlflow.databricks.com"
     )
     mock_method_chain(mock_dbutils, methods + ["workspaceId", "get"], return_value="1111")
     with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
@@ -249,9 +238,7 @@ def test_get_workspace_info_from_dbutils_old_runtimes():
         return_value='{"tags": {"orgId" : "1111", "browserHostName": "mlflow.databricks.com"}}',
     )
     mock_method_chain(
-        mock_dbutils,
-        methods + ["browserHostName", "get"],
-        return_value="mlflow.databricks.com",
+        mock_dbutils, methods + ["browserHostName", "get"], return_value="mlflow.databricks.com"
     )
 
     # Mock out workspace ID tag
@@ -305,8 +292,7 @@ def test_databricks_params_throws_errors():
         None, "user", "pass", insecure=True
     )
     with mock.patch(
-        "mlflow.utils.databricks_utils.ProfileConfigProvider",
-        return_value=mock_provider,
+        "mlflow.utils.databricks_utils.ProfileConfigProvider", return_value=mock_provider
     ):
         with pytest.raises(
             Exception, match="Reading Databricks credential configuration failed with"
@@ -319,8 +305,7 @@ def test_databricks_params_throws_errors():
         "host", None, None, insecure=True
     )
     with mock.patch(
-        "mlflow.utils.databricks_utils.ProfileConfigProvider",
-        return_value=mock_provider,
+        "mlflow.utils.databricks_utils.ProfileConfigProvider", return_value=mock_provider
     ):
         with pytest.raises(
             Exception, match="Reading Databricks credential configuration failed with"
@@ -352,8 +337,7 @@ def test_should_fetch_model_serving_environment_oauth(monkeypatch, oauth_file):
     assert not databricks_utils.should_fetch_model_serving_environment_oauth()
 
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
-        str(oauth_file),
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
     ):
         # both file mount and env var exist, both values should return true
         assert databricks_utils.should_fetch_model_serving_environment_oauth()
@@ -400,8 +384,7 @@ def test_use_repl_context_if_available(tmp_path, monkeypatch):
     command_context_mock.jobId().get.return_value = "job_id"
     command_context_mock.tags().get("jobType").get.return_value = "NORMAL"
     with mock.patch(
-        "mlflow.utils.databricks_utils._get_command_context",
-        return_value=command_context_mock,
+        "mlflow.utils.databricks_utils._get_command_context", return_value=command_context_mock
     ) as mock_get_command_context:
         assert databricks_utils.get_job_id() == "job_id"
         mock_get_command_context.assert_called_once()
@@ -424,8 +407,7 @@ def get_context():
             return_value=None,
         ) as mock_get_context,
         mock.patch(
-            "mlflow.utils.databricks_utils._get_command_context",
-            return_value=command_context_mock,
+            "mlflow.utils.databricks_utils._get_command_context", return_value=command_context_mock
         ) as mock_get_command_context,
     ):
         assert databricks_utils.get_job_id() == "job_id"
@@ -498,8 +480,7 @@ def test_is_running_in_ipython_environment_works(get_ipython):
 def test_get_mlflow_credential_context_by_run_id():
     with (
         mock.patch(
-            "mlflow.tracking.artifact_utils.get_artifact_uri",
-            return_value="dbfs:/path/to/artifact",
+            "mlflow.tracking.artifact_utils.get_artifact_uri", return_value="dbfs:/path/to/artifact"
         ) as mock_get_artifact_uri,
         mock.patch(
             "mlflow.utils.uri.get_databricks_profile_uri_from_artifact_uri",
@@ -703,10 +684,7 @@ def test_print_databricks_deployment_job_url():
 
     with (
         mock.patch("mlflow.utils.databricks_utils.eprint") as mock_eprint,
-        mock.patch(
-            "mlflow.utils.databricks_utils.get_workspace_url",
-            return_value=workspace_url,
-        ),
+        mock.patch("mlflow.utils.databricks_utils.get_workspace_url", return_value=workspace_url),
     ):
         # Test case with a workspace ID
         with mock.patch(
@@ -863,10 +841,7 @@ def test_get_databricks_workspace_client_config_env_profile(monkeypatch):
     mock_client_instance.config = mock_config
 
     with (
-        mock.patch(
-            "mlflow.utils.databricks_utils.get_db_info_from_uri",
-            return_value=(None, None),
-        ),
+        mock.patch("mlflow.utils.databricks_utils.get_db_info_from_uri", return_value=(None, None)),
         mock.patch(
             "databricks.sdk.WorkspaceClient", return_value=mock_client_instance
         ) as mock_workspace_client,
@@ -881,12 +856,10 @@ def test_get_databricks_workspace_client_config_env_profile(monkeypatch):
 def test_get_databricks_workspace_client_config_client_creation_error():
     with (
         mock.patch(
-            "mlflow.utils.databricks_utils.get_db_info_from_uri",
-            return_value=("profile", None),
+            "mlflow.utils.databricks_utils.get_db_info_from_uri", return_value=("profile", None)
         ),
         mock.patch(
-            "databricks.sdk.WorkspaceClient",
-            side_effect=Exception("Client creation failed"),
+            "databricks.sdk.WorkspaceClient", side_effect=Exception("Client creation failed")
         ),
     ):
         with pytest.raises(Exception, match="Client creation failed"):
@@ -983,7 +956,6 @@ def test_get_sgc_job_run_id_widget_takes_precedence_over_env_var(monkeypatch):
         mock_dbutils.widgets.get.assert_called_once_with(
             "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"
         )
-
 
 def test_databricks_config_profile_env_var_is_respected(tmp_path, monkeypatch):
     file_name = f"{tmp_path}/.databrickscfg"

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -959,7 +959,7 @@ def test_get_sgc_job_run_id_widget_takes_precedence_over_env_var(monkeypatch):
 
 
 def test_databricks_config_profile_env_var_is_respected(tmp_path, monkeypatch):
-    file_path = tmp_path / "/.databrickscfg"
+    file_path = tmp_path / ".databrickscfg"
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
     monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(file_path))
     monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "test")

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -57,7 +57,8 @@ def test_databricks_registry_profile():
     mock_dbutils.secrets.get.return_value = "random"
     with (
         mock.patch(
-            "mlflow.utils.databricks_utils.ProfileConfigProvider", return_value=mock_provider
+            "mlflow.utils.databricks_utils.ProfileConfigProvider",
+            return_value=mock_provider,
         ),
         mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils),
     ):
@@ -76,7 +77,8 @@ def test_databricks_no_creds_found():
 def test_databricks_no_creds_found_in_model_serving(monkeypatch):
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
     with pytest.raises(
-        MlflowException, match="Reading Databricks credential configuration in model serving failed"
+        MlflowException,
+        match="Reading Databricks credential configuration in model serving failed",
     ):
         databricks_utils.get_databricks_host_creds()
 
@@ -97,7 +99,8 @@ def oauth_file(tmp_path):
 
 def test_get_model_dependency_token(oauth_file):
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
+        str(oauth_file),
     ):
         token = databricks_utils.get_model_dependency_oauth_token()
         assert token == "token2"
@@ -125,7 +128,8 @@ def test_databricks_params_model_serving_oauth_cache_databricks(
     # oauth file still needs to be present for should_fetch_model_serving_environment_oauth()
     #  to evaluate true
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
+        str(oauth_file),
     ):
         params = databricks_utils.get_databricks_host_creds()
         assert params.host == "host"
@@ -139,7 +143,8 @@ def test_databricks_params_model_serving_oauth_cache_expired(monkeypatch, oauth_
     monkeypatch.setenv("DB_DEPENDENCY_OAUTH_CACHE", "token")
     monkeypatch.setenv("DB_DEPENDENCY_OAUTH_CACHE_EXPIRY_TS", str(time.time() - 5))
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
+        str(oauth_file),
     ):
         params = databricks_utils.get_databricks_host_creds()
         # cache should get updated with new token
@@ -154,7 +159,8 @@ def test_databricks_params_model_serving_read_oauth(monkeypatch, oauth_file):
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("DATABRICKS_MODEL_SERVING_HOST_URL", "host")
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
+        str(oauth_file),
     ):
         params = databricks_utils.get_databricks_host_creds()
         assert os.environ["DB_DEPENDENCY_OAUTH_CACHE"] == "token2"
@@ -171,7 +177,8 @@ def test_databricks_params_env_var_overrides_model_serving_oauth(monkeypatch, oa
     # oauth file still needs to be present for should_fetch_model_serving_environment_oauth()
     #  to evaluate true
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
+        str(oauth_file),
     ):
         params = databricks_utils.get_databricks_host_creds()
         # should use token and host from envvar, rather than token from oauthfile
@@ -205,7 +212,9 @@ def test_get_workspace_info_from_dbutils():
     mock_dbutils = mock.MagicMock()
     methods = ["notebook.entry_point.getDbutils", "notebook", "getContext"]
     mock_method_chain(
-        mock_dbutils, methods + ["browserHostName", "get"], return_value="mlflow.databricks.com"
+        mock_dbutils,
+        methods + ["browserHostName", "get"],
+        return_value="mlflow.databricks.com",
     )
     mock_method_chain(mock_dbutils, methods + ["workspaceId", "get"], return_value="1111")
 
@@ -220,7 +229,9 @@ def test_get_workspace_info_from_dbutils_no_browser_host_name():
     methods = ["notebook.entry_point.getDbutils", "notebook", "getContext"]
     mock_method_chain(mock_dbutils, methods + ["browserHostName", "get"], return_value=None)
     mock_method_chain(
-        mock_dbutils, methods + ["apiUrl", "get"], return_value="https://mlflow.databricks.com"
+        mock_dbutils,
+        methods + ["apiUrl", "get"],
+        return_value="https://mlflow.databricks.com",
     )
     mock_method_chain(mock_dbutils, methods + ["workspaceId", "get"], return_value="1111")
     with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
@@ -238,7 +249,9 @@ def test_get_workspace_info_from_dbutils_old_runtimes():
         return_value='{"tags": {"orgId" : "1111", "browserHostName": "mlflow.databricks.com"}}',
     )
     mock_method_chain(
-        mock_dbutils, methods + ["browserHostName", "get"], return_value="mlflow.databricks.com"
+        mock_dbutils,
+        methods + ["browserHostName", "get"],
+        return_value="mlflow.databricks.com",
     )
 
     # Mock out workspace ID tag
@@ -292,7 +305,8 @@ def test_databricks_params_throws_errors():
         None, "user", "pass", insecure=True
     )
     with mock.patch(
-        "mlflow.utils.databricks_utils.ProfileConfigProvider", return_value=mock_provider
+        "mlflow.utils.databricks_utils.ProfileConfigProvider",
+        return_value=mock_provider,
     ):
         with pytest.raises(
             Exception, match="Reading Databricks credential configuration failed with"
@@ -305,7 +319,8 @@ def test_databricks_params_throws_errors():
         "host", None, None, insecure=True
     )
     with mock.patch(
-        "mlflow.utils.databricks_utils.ProfileConfigProvider", return_value=mock_provider
+        "mlflow.utils.databricks_utils.ProfileConfigProvider",
+        return_value=mock_provider,
     ):
         with pytest.raises(
             Exception, match="Reading Databricks credential configuration failed with"
@@ -337,7 +352,8 @@ def test_should_fetch_model_serving_environment_oauth(monkeypatch, oauth_file):
     assert not databricks_utils.should_fetch_model_serving_environment_oauth()
 
     with mock.patch(
-        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
+        "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
+        str(oauth_file),
     ):
         # both file mount and env var exist, both values should return true
         assert databricks_utils.should_fetch_model_serving_environment_oauth()
@@ -384,7 +400,8 @@ def test_use_repl_context_if_available(tmp_path, monkeypatch):
     command_context_mock.jobId().get.return_value = "job_id"
     command_context_mock.tags().get("jobType").get.return_value = "NORMAL"
     with mock.patch(
-        "mlflow.utils.databricks_utils._get_command_context", return_value=command_context_mock
+        "mlflow.utils.databricks_utils._get_command_context",
+        return_value=command_context_mock,
     ) as mock_get_command_context:
         assert databricks_utils.get_job_id() == "job_id"
         mock_get_command_context.assert_called_once()
@@ -407,7 +424,8 @@ def get_context():
             return_value=None,
         ) as mock_get_context,
         mock.patch(
-            "mlflow.utils.databricks_utils._get_command_context", return_value=command_context_mock
+            "mlflow.utils.databricks_utils._get_command_context",
+            return_value=command_context_mock,
         ) as mock_get_command_context,
     ):
         assert databricks_utils.get_job_id() == "job_id"
@@ -480,7 +498,8 @@ def test_is_running_in_ipython_environment_works(get_ipython):
 def test_get_mlflow_credential_context_by_run_id():
     with (
         mock.patch(
-            "mlflow.tracking.artifact_utils.get_artifact_uri", return_value="dbfs:/path/to/artifact"
+            "mlflow.tracking.artifact_utils.get_artifact_uri",
+            return_value="dbfs:/path/to/artifact",
         ) as mock_get_artifact_uri,
         mock.patch(
             "mlflow.utils.uri.get_databricks_profile_uri_from_artifact_uri",
@@ -684,7 +703,10 @@ def test_print_databricks_deployment_job_url():
 
     with (
         mock.patch("mlflow.utils.databricks_utils.eprint") as mock_eprint,
-        mock.patch("mlflow.utils.databricks_utils.get_workspace_url", return_value=workspace_url),
+        mock.patch(
+            "mlflow.utils.databricks_utils.get_workspace_url",
+            return_value=workspace_url,
+        ),
     ):
         # Test case with a workspace ID
         with mock.patch(
@@ -841,7 +863,10 @@ def test_get_databricks_workspace_client_config_env_profile(monkeypatch):
     mock_client_instance.config = mock_config
 
     with (
-        mock.patch("mlflow.utils.databricks_utils.get_db_info_from_uri", return_value=(None, None)),
+        mock.patch(
+            "mlflow.utils.databricks_utils.get_db_info_from_uri",
+            return_value=(None, None),
+        ),
         mock.patch(
             "databricks.sdk.WorkspaceClient", return_value=mock_client_instance
         ) as mock_workspace_client,
@@ -856,10 +881,12 @@ def test_get_databricks_workspace_client_config_env_profile(monkeypatch):
 def test_get_databricks_workspace_client_config_client_creation_error():
     with (
         mock.patch(
-            "mlflow.utils.databricks_utils.get_db_info_from_uri", return_value=("profile", None)
+            "mlflow.utils.databricks_utils.get_db_info_from_uri",
+            return_value=("profile", None),
         ),
         mock.patch(
-            "databricks.sdk.WorkspaceClient", side_effect=Exception("Client creation failed")
+            "databricks.sdk.WorkspaceClient",
+            side_effect=Exception("Client creation failed"),
         ),
     ):
         with pytest.raises(Exception, match="Client creation failed"):
@@ -956,3 +983,25 @@ def test_get_sgc_job_run_id_widget_takes_precedence_over_env_var(monkeypatch):
         mock_dbutils.widgets.get.assert_called_once_with(
             "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"
         )
+
+
+def test_databricks_config_profile_env_var_is_respected(tmp_path, monkeypatch):
+    file_name = f"{tmp_path}/.databrickscfg"
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", file_name)
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "test")
+
+    with open(file_name, "w") as f:
+        f.write("""[DEFAULT]
+host = "http://default-workspace.databricks.com"
+token = "default-token"
+
+[test]
+host = "https://test-workspace.databricks.com"
+token = "test-token"
+""")
+
+    # the resulting config should be the one from the [test] section
+    result = get_databricks_host_creds("databricks")
+    assert result.host == '"https://test-workspace.databricks.com"'
+    assert result.token == '"test-token"'


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

We support setting the `DATABRICKS_CONFIG_PROFILE` env var to specify the profile to use as an alternative to the uri format (e.g. `databricks://<profile>`). Currently we check the env var here:

https://github.com/mlflow/mlflow/blob/79525dff72b0750b6ee704b6c1fef7017484e30e/mlflow/utils/databricks_utils.py#L765

But then this profile is not actually used when getting the config here:

https://github.com/mlflow/mlflow/blob/79525dff72b0750b6ee704b6c1fef7017484e30e/mlflow/utils/databricks_utils.py#L812

This results in the default profile being used.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added a new test (confirmed it fails on previous versions) and manually tested to make sure this works:

```python
# test-auth.py
# ensure DEFAULT profile is not present, and "test" profile is set in ~/.databrickscfg
# you should get an error despite setting profile to "test" via env var here
import os

from mlflow import get_experiment

os.environ["DATABRICKS_CONFIG_PROFILE"] = "test"
os.environ["MLFLOW_TRACKING_URI"] = "databricks"
get_experiment(experiment_id="3363486573189371")  # <-- doesn't use the profile
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
