### PR TITLE
Fix experiment page default tab

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.test.tsx
@@ -38,6 +38,12 @@ jest.mock('../experiment-overview/ExperimentGenAIOverviewPage', () => ({
   default: () => <div>Experiment overview page</div>,
 }));
 
+jest.mock('../experiment-runs/ExperimentRunsPage', () => ({
+  // mock default export
+  __esModule: true,
+  default: () => <div>Experiment runs page</div>,
+}));
+
 describe('ExperimentLoggedModelListPage', () => {
   const { history } = setupTestRouter();
   const createTestExperiment = (
@@ -73,7 +79,7 @@ describe('ExperimentLoggedModelListPage', () => {
     rest.post('/ajax-api/2.0/mlflow/runs/search', (req, res, ctx) => res(ctx.json({ runs: [] }))),
   );
 
-  const renderTestComponent = () => {
+  const renderTestComponent = (initialPath = '/experiments/12345678/models') => {
     const queryClient = new QueryClient();
     return render(
       <TestApolloProvider disableCache>
@@ -107,11 +113,16 @@ describe('ExperimentLoggedModelListPage', () => {
                             () => import('../experiment-logged-models/ExperimentLoggedModelListPage'),
                           ),
                         },
+                        {
+                          path: RoutePaths.experimentPageTabRuns,
+                          pageId: PageId.experimentPageTabRuns,
+                          element: createLazyRouteElement(() => import('../experiment-runs/ExperimentRunsPage')),
+                        },
                       ],
                     },
                   ]}
                   history={history}
-                  initialEntries={[createMLflowRoutePath('/experiments/12345678/models')]}
+                  initialEntries={[createMLflowRoutePath(initialPath)]}
                 />
               </DesignSystemProvider>
             </QueryClientProvider>
@@ -233,5 +244,75 @@ describe('ExperimentLoggedModelListPage', () => {
         value: ExperimentKind.GENAI_DEVELOPMENT,
       });
     });
+  });
+
+  test('integration test: should redirect to overview tab when GenAI experiment kind is inferred', async () => {
+    server.resetHandlers(
+      graphql.query('MlflowGetExperimentQuery', (req, res, ctx) =>
+        res(ctx.data(createTestExperimentResponse(createTestExperiment('12345678', 'Test experiment name', [])))),
+      ),
+    );
+
+    // Simulate experiment with traces (GenAI)
+    server.use(
+      rest.get('/ajax-api/2.0/mlflow/traces', (req, res, ctx) => {
+        return res(ctx.json({ traces: [{ request_id: 'trace1' }] }));
+      }),
+      rest.post('/ajax-api/2.0/mlflow/runs/search', (req, res, ctx) => {
+        return res(ctx.json({ runs: [] }));
+      }),
+    );
+
+    // Start on experiment page WITHOUT a tab
+    renderTestComponent('/experiments/12345678');
+
+    // Should redirect to overview tab for GenAI experiments
+    expect(await screen.findByText('Experiment overview page')).toBeInTheDocument();
+  });
+
+  test('integration test: should redirect to runs tab when ML experiment kind is inferred', async () => {
+    server.resetHandlers(
+      graphql.query('MlflowGetExperimentQuery', (req, res, ctx) =>
+        res(ctx.data(createTestExperimentResponse(createTestExperiment('12345678', 'Test experiment name', [])))),
+      ),
+    );
+
+    // Simulate experiment with runs but no traces (ML)
+    server.use(
+      rest.get('/ajax-api/2.0/mlflow/traces', (req, res, ctx) => {
+        return res(ctx.json({ traces: [] }));
+      }),
+      rest.post('/ajax-api/2.0/mlflow/runs/search', (req, res, ctx) => {
+        return res(ctx.json({ runs: [{ info: { run_uuid: 'run1' } }] }));
+      }),
+    );
+
+    // Start on experiment page WITHOUT a tab
+    renderTestComponent('/experiments/12345678');
+
+    // Should redirect to runs tab for ML experiments
+    expect(await screen.findByText('Experiment runs page')).toBeInTheDocument();
+  });
+
+  test('integration test: should redirect based on existing kind tag without waiting for inference', async () => {
+    server.resetHandlers(
+      graphql.query('MlflowGetExperimentQuery', (req, res, ctx) =>
+        res(
+          ctx.data(
+            createTestExperimentResponse(
+              createTestExperiment('12345678', 'Test experiment name', [
+                { key: 'mlflow.experimentKind', value: ExperimentKind.GENAI_DEVELOPMENT },
+              ]),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Start on experiment page WITHOUT a tab
+    renderTestComponent('/experiments/12345678');
+
+    // Should redirect to overview tab based on existing tag
+    expect(await screen.findByText('Experiment overview page')).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.tsx
@@ -80,9 +80,11 @@ const ExperimentPageTabsImpl = () => {
   // Check if the user landed on the experiment page without a specific tab (sub-route)...
   const { pathname } = useLocation();
   const matchedExperimentPageWithoutTab = Boolean(matchPath(RoutePaths.experimentPage, pathname));
-  // ...if true, we want to navigate to the appropriate tab based on the experiment kind
+  // ...if true, we want to navigate to the appropriate tab based on the experiment kind.
+  // However, if experiment kind inference is enabled (no kind tag exists), we should
+  // let the inference process handle navigation instead to avoid race conditions.
   useNavigateToExperimentPageTab({
-    enabled: matchedExperimentPageWithoutTab,
+    enabled: matchedExperimentPageWithoutTab && !isExperimentKindInferenceEnabled,
     experimentId,
   });
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix the issue that an experiment falls on 'runs' tab when it's inferred as GenAI type.
Root cause is due to below race condition:
1. Experiment data loads (relatively fast): useNavigateToExperimentPageTab receives the experiment and checks no tags existing, then it falls back to `NO_INFERRED_TYPE` and navigate to `/runs` immediately
2. Trace/Run queries complete (slower): useInferExperimentKind finally gets containsTraces = true, and infer the type as GenAI and set `inferredExperimentPageTab = 'overview'`.
3. However, 2 happens after 1 so it's too late when we set the tab. Previous change in https://github.com/mlflow/mlflow/pull/19915 checks whether the URL falls on default page without sub paths, but by this time it's /experiments/exp_id/runs, then the tab navigation doesn't happen.

The fix is to rely on `useNavigateToExperimentPageTab` to handle the navigation instead.

https://github.com/user-attachments/assets/7b3c1422-a490-49fb-a9d2-067235356887


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
