### PR TITLE
Update FileStore deprecation message to reflect February 2026 date

### DIFF
--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -134,7 +134,7 @@ class FileStore(AbstractStore):
 
         super().__init__()
         warnings.warn(
-            "The filesystem model registry backend (e.g., './mlruns') will be deprecated in "
+            "The filesystem model registry backend (e.g., './mlruns') is deprecated as of "
             "February 2026. Consider transitioning to a database backend (e.g., "
             "'sqlite:///mlflow.db') to take advantage of the latest MLflow features. "
             "See https://github.com/mlflow/mlflow/issues/18534 for more details and migration "

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -217,7 +217,7 @@ class FileStore(AbstractStore):
         """
         super().__init__()
         warnings.warn(
-            "The filesystem tracking backend (e.g., './mlruns') will be deprecated in "
+            "The filesystem tracking backend (e.g., './mlruns') is deprecated as of "
             "February 2026. Consider transitioning to a database backend (e.g., "
             "'sqlite:///mlflow.db') to take advantage of the latest MLflow features. "
             "See https://github.com/mlflow/mlflow/issues/18534 for more details and migration "

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -61,7 +61,7 @@ def rm_data(registered_model_names, tmp_path):
 
 
 def test_file_store_deprecation_warning(tmp_path):
-    with pytest.warns(FutureWarning, match="filesystem model registry backend.*will be deprecated"):
+    with pytest.warns(FutureWarning, match="filesystem model registry backend.*is deprecated"):
         FileStore(str(tmp_path / "model_registry"))
 
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -148,7 +148,7 @@ def create_experiments(store, experiment_names):
 
 
 def test_file_store_deprecation_warning(tmp_path):
-    with pytest.warns(FutureWarning, match="filesystem tracking backend.*will be deprecated"):
+    with pytest.warns(FutureWarning, match="filesystem tracking backend.*is deprecated"):
         FileStore(str(tmp_path / "mlruns"))
 
 


### PR DESCRIPTION
### Related Issues/PRs

#18534

### What changes are proposed in this pull request?

Update the FileStore deprecation warning message from "will be deprecated in February 2026" to "is deprecated as of February 2026" since MLflow 3.10 targets early February 2026.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The filesystem tracking and model registry backends are now deprecated as of February 2026. Users should transition to a database backend (e.g., `sqlite:///mlflow.db`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)