### PR TITLE
Open Assistant by default and persist open/close between sessions

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -244,55 +244,6 @@ const PromptSuggestions = ({ onSelect }: { onSelect: (prompt: string) => void })
 };
 
 /**
- * Empty state when no experiment is selected.
- */
-const NoExperimentState = () => {
-  const { theme } = useDesignSystemTheme();
-
-  return (
-    <div
-      css={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: theme.spacing.lg * 2,
-        gap: theme.spacing.lg,
-      }}
-    >
-      <WrenchSparkleIcon color="ai" css={{ fontSize: 64, opacity: 0.75 }} />
-
-      <Typography.Text
-        color="secondary"
-        css={{
-          fontSize: theme.typography.fontSizeMd,
-          textAlign: 'center',
-          maxWidth: 400,
-        }}
-      >
-        <FormattedMessage
-          defaultMessage="Assistant is only available within an experiment. Please select or create an experiment to get started."
-          description="Message shown when assistant is opened outside of an experiment context"
-        />
-      </Typography.Text>
-
-      <Button
-        componentId={`${COMPONENT_ID}.create_experiment`}
-        icon={<InfoBookIcon />}
-        href="https://mlflow.org/docs/latest/genai/tracing/quickstart/#create-a-mlflow-experiment"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <FormattedMessage
-          defaultMessage="View docs"
-          description="Button text for link to create experiment documentation"
-        />
-      </Button>
-    </div>
-  );
-};
-
-/**
  * Chat panel content component.
  */
 const ChatPanelContent = () => {
@@ -332,24 +283,6 @@ const ChatPanelContent = () => {
     },
     [sendMessage],
   );
-
-  // Show no experiment state when outside experiment context
-  if (!hasExperimentContext) {
-    return (
-      <div
-        css={{
-          display: 'flex',
-          flexDirection: 'column',
-          flex: 1,
-          minHeight: 0,
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
-        <NoExperimentState />
-      </div>
-    );
-  }
 
   return (
     <div

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Card,
   CloseIcon,
+  InfoBookIcon,
   PlusIcon,
   RefreshIcon,
   SparkleDoubleIcon,
@@ -23,6 +24,7 @@ import {
 import { FormattedMessage } from '@databricks/i18n';
 
 import { useAssistant } from './AssistantContext';
+import { useAssistantPageContext } from './AssistantPageContext';
 import { AssistantContextTags } from './AssistantContextTags';
 import type { ChatMessage, ToolUseInfo } from './types';
 import { GenAIMarkdownRenderer } from '../shared/web-shared/genai-markdown-renderer';
@@ -242,11 +244,62 @@ const PromptSuggestions = ({ onSelect }: { onSelect: (prompt: string) => void })
 };
 
 /**
+ * Empty state when no experiment is selected.
+ */
+const NoExperimentState = () => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: theme.spacing.lg * 2,
+        gap: theme.spacing.lg,
+      }}
+    >
+      <WrenchSparkleIcon color="ai" css={{ fontSize: 64, opacity: 0.75 }} />
+
+      <Typography.Text
+        color="secondary"
+        css={{
+          fontSize: theme.typography.fontSizeMd,
+          textAlign: 'center',
+          maxWidth: 400,
+        }}
+      >
+        <FormattedMessage
+          defaultMessage="Assistant is only available within an experiment. Please select or create an experiment to get started."
+          description="Message shown when assistant is opened outside of an experiment context"
+        />
+      </Typography.Text>
+
+      <Button
+        componentId={`${COMPONENT_ID}.create_experiment`}
+        icon={<InfoBookIcon />}
+        href="https://mlflow.org/docs/latest/genai/tracing/quickstart/#create-a-mlflow-experiment"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FormattedMessage
+          defaultMessage="View docs"
+          description="Button text for link to create experiment documentation"
+        />
+      </Button>
+    </div>
+  );
+};
+
+/**
  * Chat panel content component.
  */
 const ChatPanelContent = () => {
   const { theme } = useDesignSystemTheme();
   const { messages, isStreaming, error, activeTools, sendMessage, regenerateLastMessage } = useAssistant();
+  const pageContext = useAssistantPageContext();
+  const hasExperimentContext = Boolean(pageContext['experimentId']);
 
   const [inputValue, setInputValue] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -279,6 +332,24 @@ const ChatPanelContent = () => {
     },
     [sendMessage],
   );
+
+  // Show no experiment state when outside experiment context
+  if (!hasExperimentContext) {
+    return (
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          minHeight: 0,
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <NoExperimentState />
+      </div>
+    );
+  }
 
   return (
     <div

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -7,6 +7,7 @@ import { createContext, useCallback, useContext, useRef, useState, type ReactNod
 
 import type { AssistantAgentContextType, ChatMessage, ToolUseInfo } from './types';
 import { sendMessageStream } from './AssistantService';
+import { useLocalStorage } from '../shared/web-shared/hooks/useLocalStorage';
 import { useAssistantPageContextActions } from './AssistantPageContext';
 
 const AssistantReactContext = createContext<AssistantAgentContextType | null>(null);
@@ -16,8 +17,12 @@ const generateMessageId = (): string => {
 };
 
 export const AssistantProvider = ({ children }: { children: ReactNode }) => {
-  // Panel state
-  const [isPanelOpen, setIsPanelOpen] = useState(false);
+  // Panel state - persisted to localStorage, open by default on first visit
+  const [isPanelOpen, setIsPanelOpen] = useLocalStorage({
+    key: 'mlflow.assistant.panelOpen',
+    version: 1,
+    initialValue: true,
+  });
 
   // Chat state
   const [sessionId, setSessionId] = useState<string | null>(null);

--- a/mlflow/server/js/src/assistant/AssistantIconButton.tsx
+++ b/mlflow/server/js/src/assistant/AssistantIconButton.tsx
@@ -1,0 +1,120 @@
+import { useMemo, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+  SparkleFillIcon,
+  SparkleIcon,
+  Tooltip,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { useAssistant } from './AssistantContext';
+import { useLogTelemetryEvent } from '../telemetry/hooks/useLogTelemetryEvent';
+
+/**
+ * Animated sparkle icon that rotates and fills on hover.
+ * Use this when you need the icon as part of a larger clickable area.
+ */
+interface AssistantSparkleIconProps {
+  isHovered: boolean;
+  iconSize?: number;
+  className?: string;
+}
+
+export const AssistantSparkleIcon = ({ isHovered, iconSize, className }: AssistantSparkleIconProps) => {
+  const iconCss = iconSize ? { fontSize: iconSize } : undefined;
+
+  return (
+    <span
+      className={className}
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        transform: isHovered ? 'rotate(-90deg)' : 'rotate(0deg)',
+        transition: 'transform 0.3s ease',
+      }}
+    >
+      {isHovered ? <SparkleFillIcon color="ai" css={iconCss} /> : <SparkleIcon color="ai" css={iconCss} />}
+    </span>
+  );
+};
+
+/**
+ * Standalone icon button for the assistant.
+ * Use this for icon-only buttons (e.g., in the header).
+ */
+interface AssistantIconButtonProps {
+  componentId: string;
+  tooltipSide?: 'top' | 'bottom' | 'left' | 'right';
+  iconSize?: number;
+  className?: string;
+}
+
+export const AssistantIconButton = ({
+  componentId,
+  tooltipSide = 'bottom',
+  iconSize,
+  className,
+}: AssistantIconButtonProps) => {
+  const { theme } = useDesignSystemTheme();
+  const { openPanel, closePanel, isPanelOpen } = useAssistant();
+  const logTelemetryEvent = useLogTelemetryEvent();
+  const viewId = useMemo(() => uuidv4(), []);
+  const [isHovered, setIsHovered] = useState(false);
+
+  const togglePanel = () => {
+    if (isPanelOpen) {
+      closePanel();
+    } else {
+      openPanel();
+    }
+    logTelemetryEvent({
+      componentId,
+      componentViewId: viewId,
+      componentType: DesignSystemEventProviderComponentTypes.Button,
+      componentSubType: null,
+      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      togglePanel();
+    }
+  };
+
+  return (
+    <Tooltip
+      componentId={`${componentId}.tooltip`}
+      content={<FormattedMessage defaultMessage="Assistant" description="Tooltip for assistant button" />}
+      side={tooltipSide}
+      delayDuration={0}
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        aria-pressed={isPanelOpen}
+        className={className}
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: theme.spacing.xs,
+          borderRadius: theme.borders.borderRadiusSm,
+          cursor: 'pointer',
+          backgroundColor: isPanelOpen ? theme.colors.actionDefaultBackgroundHover : undefined,
+          color: isPanelOpen ? theme.colors.actionDefaultIconHover : theme.colors.actionDefaultIconDefault,
+          ':hover': { backgroundColor: theme.colors.actionDefaultBackgroundHover },
+        }}
+        onClick={togglePanel}
+        onKeyDown={handleKeyDown}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <AssistantSparkleIcon isHovered={isHovered} iconSize={iconSize} />
+      </div>
+    </Tooltip>
+  );
+};

--- a/mlflow/server/js/src/common/components/MlflowHeader.tsx
+++ b/mlflow/server/js/src/common/components/MlflowHeader.tsx
@@ -3,6 +3,7 @@ import { Link } from '../utils/RoutingUtils';
 import { HomePageDocsUrl, Version } from '../constants';
 import { DarkThemeSwitch } from '@mlflow/mlflow/src/common/components/DarkThemeSwitch';
 import { Button, MenuIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { AssistantIconButton } from '../../assistant/AssistantIconButton';
 import { MlflowLogo } from './MlflowLogo';
 
 export const MlflowHeader = ({
@@ -17,6 +18,7 @@ export const MlflowHeader = ({
   toggleSidebar: () => void;
 }) => {
   const { theme } = useDesignSystemTheme();
+
   return (
     <header
       css={{
@@ -65,7 +67,8 @@ export const MlflowHeader = ({
         </span>
       </div>
       <div css={{ flex: 1 }} />
-      <div css={{ display: 'flex', gap: theme.spacing.lg, alignItems: 'center' }}>
+      <div css={{ display: 'flex', gap: theme.spacing.md, alignItems: 'center' }}>
+        <AssistantIconButton componentId="mlflow.header.assistant_button" tooltipSide="bottom" iconSize={18} />
         <DarkThemeSwitch isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />
         <a href="https://github.com/mlflow/mlflow">GitHub</a>
         <a href={HomePageDocsUrl}>Docs</a>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavAssistantButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavAssistantButton.tsx
@@ -3,24 +3,38 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   DesignSystemEventProviderAnalyticsEventTypes,
   DesignSystemEventProviderComponentTypes,
-  SparkleFillIcon,
-  SparkleIcon,
   Tag,
   Tooltip,
   Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
+import { AssistantSparkleIcon } from '../../../../assistant/AssistantIconButton';
 import { useAssistant } from '../../../../assistant/AssistantContext';
 import { useLogTelemetryEvent } from '../../../../telemetry/hooks/useLogTelemetryEvent';
 import { COLLAPSED_CLASS_NAME, FULL_WIDTH_CLASS_NAME } from './constants';
 
 export const ExperimentPageSideNavAssistantButton = () => {
   const { theme } = useDesignSystemTheme();
-  const { openPanel, isPanelOpen } = useAssistant();
+  const { openPanel, closePanel, isPanelOpen } = useAssistant();
   const logTelemetryEvent = useLogTelemetryEvent();
   const viewId = useMemo(() => uuidv4(), []);
   const [isHovered, setIsHovered] = useState(false);
+
+  const togglePanel = () => {
+    if (isPanelOpen) {
+      closePanel();
+    } else {
+      openPanel();
+    }
+    logTelemetryEvent({
+      componentId: 'mlflow.experiment_side_nav.assistant_button',
+      componentViewId: viewId,
+      componentType: DesignSystemEventProviderComponentTypes.Button,
+      componentSubType: null,
+      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+    });
+  };
 
   return (
     <div
@@ -41,19 +55,10 @@ export const ExperimentPageSideNavAssistantButton = () => {
         boxSizing: 'content-box',
         ':hover': { backgroundColor: theme.colors.actionDefaultBackgroundHover },
       }}
-      onClick={() => {
-        openPanel();
-        logTelemetryEvent({
-          componentId: 'mlflow.experiment_side_nav.assistant_button',
-          componentViewId: viewId,
-          componentType: DesignSystemEventProviderComponentTypes.Button,
-          componentSubType: null,
-          eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
-        });
-      }}
+      onClick={togglePanel}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
-          openPanel();
+          togglePanel();
         }
       }}
       onMouseEnter={() => setIsHovered(true)}
@@ -65,31 +70,9 @@ export const ExperimentPageSideNavAssistantButton = () => {
         side="right"
         delayDuration={0}
       >
-        <span
-          className={COLLAPSED_CLASS_NAME}
-          css={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            transform: isHovered ? 'rotate(-90deg)' : 'rotate(0deg)',
-            transition: 'transform 0.3s ease',
-          }}
-        >
-          {isHovered ? <SparkleFillIcon color="ai" /> : <SparkleIcon color="ai" />}
-        </span>
+        <AssistantSparkleIcon isHovered={isHovered} className={COLLAPSED_CLASS_NAME} />
       </Tooltip>
-      <span
-        className={FULL_WIDTH_CLASS_NAME}
-        css={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          transform: isHovered ? 'rotate(-90deg)' : 'rotate(0deg)',
-          transition: 'transform 0.3s ease',
-        }}
-      >
-        {isHovered ? <SparkleFillIcon color="ai" /> : <SparkleIcon color="ai" />}
-      </span>
+      <AssistantSparkleIcon isHovered={isHovered} className={FULL_WIDTH_CLASS_NAME} />
       <Typography.Text className={FULL_WIDTH_CLASS_NAME} bold={isPanelOpen} color="primary">
         <FormattedMessage defaultMessage="Assistant" description="Sidebar button for AI assistant" />
       </Typography.Text>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3705,10 +3705,6 @@
     "defaultMessage": "Resources using this endpoint ({count})",
     "description": "Gateway > Delete endpoint modal > Bindings list header"
   },
-  "SGVNf8": {
-    "defaultMessage": "View docs",
-    "description": "Button text for link to create experiment documentation"
-  },
   "SI6n4L": {
     "defaultMessage": "Compare",
     "description": "Label for the compare mode on the registered prompt details page"
@@ -7554,10 +7550,6 @@
   "w/sljb": {
     "defaultMessage": "Sort descending",
     "description": "Label for the sort descending button in the logged model list page"
-  },
-  "w0ZK3+": {
-    "defaultMessage": "Assistant is only available within an experiment. Please select or create an experiment to get started.",
-    "description": "Message shown when assistant is opened outside of an experiment context"
   },
   "w2+rkp": {
     "defaultMessage": "Search metrics",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3705,6 +3705,10 @@
     "defaultMessage": "Resources using this endpoint ({count})",
     "description": "Gateway > Delete endpoint modal > Bindings list header"
   },
+  "SGVNf8": {
+    "defaultMessage": "View docs",
+    "description": "Button text for link to create experiment documentation"
+  },
   "SI6n4L": {
     "defaultMessage": "Compare",
     "description": "Label for the compare mode on the registered prompt details page"
@@ -7550,6 +7554,10 @@
   "w/sljb": {
     "defaultMessage": "Sort descending",
     "description": "Label for the sort descending button in the logged model list page"
+  },
+  "w0ZK3+": {
+    "defaultMessage": "Assistant is only available within an experiment. Please select or create an experiment to get started.",
+    "description": "Message shown when assistant is opened outside of an experiment context"
   },
   "w2+rkp": {
     "defaultMessage": "Search metrics",


### PR DESCRIPTION
### What changes are proposed in this pull request?

Open the Assistant panel by default when user visit UI first time. Then persist close/open state between sessions (local storage) so that we don't annoy users by always open it.

Also showing Assistant button on the header too for better visibility. If the page is outside experiment, the Assistant asks users to select one, because we haven't implemented context propagation outside an experiment.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
