### PR TITLE
[BUG] Fix download_artifacts when run has no artifacts

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -290,7 +290,19 @@ class ArtifactRepository:
 
         # Submit download tasks
         futures = {}
-        if self._is_directory(artifact_path):
+        if artifact_path in ("", None):
+            root_listing = self.list_artifacts(artifact_path)
+            if not root_listing:
+                _logger.info(
+                    "No artifacts found to download at %s. Returning destination path.",
+                    self.artifact_uri,
+                )
+                return dst_path
+            is_dir = True
+        else:
+            is_dir = self._is_directory(artifact_path)
+
+        if is_dir:
             for file_info in self._iter_artifacts_recursive(artifact_path):
                 if file_info.is_dir:  # Empty directory
                     os.makedirs(os.path.join(dst_path, file_info.path), exist_ok=True)

--- a/tests/store/artifact/test_artifact_repo.py
+++ b/tests/store/artifact/test_artifact_repo.py
@@ -104,6 +104,18 @@ def test_download_artifacts_download_file():
         repo.download_artifacts(_MODEL_FILE)
 
 
+def test_download_artifacts_empty_root_returns_dst_path(tmp_path):
+    with (
+        mock.patch.object(ArtifactRepositoryImpl, "list_artifacts", return_value=[]),
+        mock.patch.object(ArtifactRepositoryImpl, "_download_file") as download_mock,
+    ):
+        repo = ArtifactRepositoryImpl(_PARENT_DIR)
+        result = repo.download_artifacts("", dst_path=tmp_path)
+
+        assert result == str(tmp_path)
+        download_mock.assert_not_called()
+
+
 def test_download_artifacts_dst_path_does_not_exist(tmp_path):
     repo = ArtifactRepositoryImpl(_PARENT_DIR)
     dst_path = tmp_path.joinpath("does_not_exist")

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -285,9 +285,7 @@ def test_log_artifacts_in_parallel_when_necessary(tmp_path, monkeypatch):
 def test_download_file_in_parallel_when_necessary(file_size, is_parallel_download):
     repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, credential=TEST_CREDENTIAL)
     remote_file_path = "file_1.txt"
-    list_artifacts_result = (
-        [FileInfo(path=remote_file_path, is_dir=False, file_size=file_size)] if file_size else []
-    )
+    list_artifacts_result = [FileInfo(path=remote_file_path, is_dir=False, file_size=file_size)]
     with (
         mock.patch(
             f"{ADLS_ARTIFACT_REPOSITORY}.list_artifacts",

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1068,9 +1068,7 @@ def test_databricks_download_file_in_parallel_when_necessary(
     databricks_artifact_repo, file_size, is_parallel_download
 ):
     remote_file_path = "file_1.txt"
-    list_artifacts_result = (
-        [FileInfo(path=remote_file_path, is_dir=False, file_size=file_size)] if file_size else []
-    )
+    list_artifacts_result = [FileInfo(path=remote_file_path, is_dir=False, file_size=file_size)]
     with (
         mock.patch(
             f"{DATABRICKS_ARTIFACT_REPOSITORY}.list_artifacts",

--- a/tests/store/artifact/test_optimized_s3_artifact_repo.py
+++ b/tests/store/artifact/test_optimized_s3_artifact_repo.py
@@ -230,9 +230,7 @@ def test_download_file_in_parallel_when_necessary(
 ):
     repo = OptimizedS3ArtifactRepository(posixpath.join(s3_artifact_root, "some/path"))
     remote_file_path = "file_1.txt"
-    list_artifacts_result = (
-        [FileInfo(path=remote_file_path, is_dir=False, file_size=file_size)] if file_size else []
-    )
+    list_artifacts_result = [FileInfo(path=remote_file_path, is_dir=False, file_size=file_size)]
     with (
         mock.patch(
             f"{S3_ARTIFACT_REPOSITORY}.list_artifacts",


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve -->#16467

### What changes are proposed in this pull request?
- If a run has no artifacts, `download_artifacts` now just returns the destination path instead of trying to download the empty root.
- Adds a simple info log saying there were no artifacts to download.
- Includes a unit test to make sure we don’t attempt any downloads in the empty-root case.

<!-- Please fill in changes proposed in this PR. -->

<!-- Attach code, screenshot, video used for manual testing here. -->
#### Before the change
```terminal
🏃 View run unruly-snipe-98 at: http://localhost:5000/#/experiments/<experiment-id>/runs/<run-id>
🧪 View experiment at: http://localhost:5000/#/experiments/<experiment-id>
Traceback (most recent call last):
  File "/Users/yashwanthkiran.g/mlflow/artifact_hang.py", line 15, in <module>
    mlflow.artifacts.download_artifacts(run_id=run_id, dst_path=tmpdir)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yashwanthkiran.g/mlflow/mlflow/artifacts/__init__.py", line 106, in download_artifacts
    return artifact_repo.download_artifacts(artifact_path, dst_path=dst_path)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yashwanthkiran.g/mlflow/mlflow/store/artifact/artifact_repo.py", line 327, in download_artifacts
    raise MlflowException(
    ...<4 lines>...
    )
mlflow.exceptions.MlflowException: The following failures occurred while downloading one or more artifacts from http://localhost:5000/api/2.0/mlflow-artifacts/artifacts/<experiment-id>/<run-id>/artifacts:
##### File  #####
API request to http://localhost:5000/api/2.0/mlflow-artifacts/artifacts/<experiment-id>/<run-id>/artifacts/ failed with exception HTTPConnectionPool(host='localhost', port=5000): Max retries exceeded with url: /api/2.0/mlflow-artifacts/artifacts/<experiment-id>/<run-id>/artifacts/ (Caused by ResponseError('too many 500 error responses'))
```
#### After the change
```terminal
🏃 View run casual-crow-841 at: http://localhost:5000/#/experiments/<experiment-id>/runs/<run-id>
🧪 View experiment at: http://localhost:5000/#/experiments/<experiment-id>
2026/01/20 00:00:45 INFO mlflow.store.artifact.artifact_repo: No artifacts found to download at http://localhost:5000/api/2.0/mlflow-artifacts/artifacts/<experiment-id>/<run-id>/artifacts. Returning destination path.
/var/folders/x2/jc3r1fkj1z18m1ws59w0yns40000gp/T/tmpwnnkb90_ os.listdir(tmpdir) = []
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
`mlflow.artifacts.download_artifacts` now returns immediately when a run has no artifacts, instead of retrying and hanging.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
