### PR TITLE
Fix duplicate status in trace explorer header, and remove filtering out session level assessments

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -730,6 +730,10 @@
     "defaultMessage": "Chart view",
     "description": "Label for the table view toggle button in the logged model list page"
   },
+  "451ETc": {
+    "defaultMessage": "Session",
+    "description": "Label for the session to which an assessment belongs"
+  },
   "46xd2Z": {
     "defaultMessage": "Compare",
     "description": "Runs charts > components > config > RunsChartsConfigureDifferenceChart > Compare config section"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -1354,6 +1354,7 @@ export const isSessionLevelAssessment = (assessment: Assessment): boolean => {
  */
 export const getTraceLevelAssessments = (assessments?: Assessment[]) =>
   assessments?.filter((assessment) => !isSessionLevelAssessment(assessment)) ?? [];
+
 export const isValidException = (
   event: ModelTraceEvent,
 ): event is ModelTraceEvent & {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerMetricSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerMetricSection.tsx
@@ -9,6 +9,7 @@ export const ModelTraceHeaderMetricSection = ({
   color,
   getTruncatedLabel,
   onCopy,
+  hideLabel = false,
 }: {
   label: React.ReactNode;
   /**
@@ -23,6 +24,7 @@ export const ModelTraceHeaderMetricSection = ({
   color?: TagColors;
   getTruncatedLabel: (label: string) => string;
   onCopy: () => void;
+  hideLabel?: boolean;
 }) => {
   const { theme } = useDesignSystemTheme();
 
@@ -36,14 +38,16 @@ export const ModelTraceHeaderMetricSection = ({
       css={{
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: hideLabel ? 'flex-start' : 'center',
         flexDirection: 'row',
         gap: theme.spacing.sm,
       }}
     >
-      <Typography.Text size="md" color="secondary">
-        {label}
-      </Typography.Text>
+      {!hideLabel && (
+        <Typography.Text size="md" color="secondary">
+          {label}
+        </Typography.Text>
+      )}
       <Tooltip componentId="shared.model-trace-explorer.header-details.tooltip" content={value} maxWidth={400}>
         <Tag
           componentId="shared.model-trace-explorer.header-details.tag"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceHeaderDetails.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceHeaderDetails.tsx
@@ -120,7 +120,6 @@ export const ModelTraceHeaderDetails = ({ modelTraceInfo }: { modelTraceInfo: Mo
             onCopy={handleCopy}
           />
         )}
-        {statusState && <ModelTraceHeaderStatusTag statusState={statusState} getTruncatedLabel={getTruncatedLabel} />}
         {sessionId && experimentId && (
           <ModelTraceHeaderSessionIdTag
             handleCopy={handleCopy}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceHeaderSessionIdTag.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceHeaderSessionIdTag.tsx
@@ -15,11 +15,13 @@ export const ModelTraceHeaderSessionIdTag = ({
   sessionId,
   traceId,
   handleCopy,
+  hideLabel = false,
 }: {
   experimentId: string;
   sessionId: string;
   traceId?: string;
   handleCopy: () => void;
+  hideLabel?: boolean;
 }) => {
   const { theme } = useDesignSystemTheme();
   const location = useLocation();
@@ -47,6 +49,7 @@ export const ModelTraceHeaderSessionIdTag = ({
         color="default"
         getTruncatedLabel={getTruncatedLabel}
         onCopy={handleCopy}
+        hideLabel={hideLabel}
       />
     );
   }
@@ -56,14 +59,16 @@ export const ModelTraceHeaderSessionIdTag = ({
       css={{
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: hideLabel ? 'flex-start' : 'center',
         flexDirection: 'row',
         gap: theme.spacing.sm,
       }}
     >
-      <Typography.Text size="md" color="secondary">
-        <FormattedMessage defaultMessage="Session ID" description="Label for the session id section" />
-      </Typography.Text>
+      {!hideLabel && (
+        <Typography.Text size="md" color="secondary">
+          <FormattedMessage defaultMessage="Session ID" description="Label for the session id section" />
+        </Typography.Text>
+      )}
       <Tooltip
         componentId="mlflow.model-trace-explorer.session-id-tag"
         content={<FormattedMessage defaultMessage="View chat session" description="Tooltip for the session id tag" />}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
@@ -13,6 +13,10 @@ import { SpanNameDetailViewLink } from './SpanNameDetailViewLink';
 import { getSourceIcon } from './utils';
 import type { ExpectationAssessment } from '../ModelTrace.types';
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
+import { ASSESSMENT_SESSION_METADATA_KEY } from '../constants';
+import { isEmpty } from 'lodash';
+import { ModelTraceHeaderSessionIdTag } from '../ModelTraceHeaderSessionIdTag';
+import { useParams } from '../RoutingUtils';
 
 export const ExpectationItem = ({ expectation }: { expectation: ExpectationAssessment }) => {
   const { theme } = useDesignSystemTheme();
@@ -20,11 +24,15 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const { nodeMap, activeView } = useModelTraceExplorerViewState();
+  const { experimentId } = useParams();
 
   const associatedSpan = expectation.span_id ? nodeMap[expectation.span_id] : null;
+  // indicate if the assessment is session-level
+  const sessionId = expectation.metadata?.[ASSESSMENT_SESSION_METADATA_KEY];
+  const showSessionTag = activeView === 'summary' && !isEmpty(sessionId);
   // the summary view displays all assessments regardless of span, so
   // we need some way to indicate which span an assessment is associated with.
-  const showAssociatedSpan = activeView === 'summary' && associatedSpan;
+  const showAssociatedSpan = activeView === 'summary' && associatedSpan && !showSessionTag;
 
   const parsedValue = getParsedExpectationValue(expectation.expectation);
   const SourceIcon = getSourceIcon(expectation.source);
@@ -110,6 +118,23 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
             <FormattedMessage defaultMessage="Span" description="Label for the associated span of an assessment" />
           </Typography.Text>
           <SpanNameDetailViewLink node={associatedSpan} />
+        </div>
+      )}
+      {showSessionTag && (
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+          <Typography.Text size="sm" color="secondary">
+            <FormattedMessage
+              defaultMessage="Session"
+              description="Label for the session to which an assessment belongs"
+            />
+          </Typography.Text>
+          <ModelTraceHeaderSessionIdTag
+            experimentId={experimentId ?? ''}
+            sessionId={sessionId ?? ''}
+            traceId={expectation.trace_id}
+            handleCopy={() => {}}
+            hideLabel
+          />
         </div>
       )}
     </div>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummaryView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummaryView.tsx
@@ -33,9 +33,6 @@ export const ModelTraceExplorerSummaryView = () => {
     [updatePaneSizeRatios],
   );
 
-  // Get only the trace-level assessments (exclude session-level assessments)
-  const displayedAssessments = useMemo(() => getTraceLevelAssessments(allAssessments), [allAssessments]);
-
   const intermediateNodes = useIntermediateNodes(rootNode);
 
   if (!rootNode) {
@@ -53,7 +50,7 @@ export const ModelTraceExplorerSummaryView = () => {
     );
   }
   const AssessmentsPaneComponent = (
-    <AssessmentsPane assessments={displayedAssessments} traceId={rootNode.traceId} activeSpanId={undefined} />
+    <AssessmentsPane assessments={allAssessments} traceId={rootNode.traceId} activeSpanId={undefined} />
   );
 
   return !isInComparisonView && assessmentsPaneEnabled && assessmentsPaneExpanded ? (


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The PR fixes a couple of things:

1. Remove duplicate status tags in trace explorer header

<img width="1571" height="796" alt="Screenshot 2026-01-22 at 5 22 50 PM" src="https://github.com/user-attachments/assets/7d46e719-9dcb-4285-974e-d59e6ae2a5e2" />

2. Show session level assessments in the trace. While this is not a bug per se (it was an intentional design decision), we received some feedback that it is confusing as after running a session-level eval, it's not visible from the trace tab. The only place to view it is the "Sessions" tab when clicking into the session itself, which is not super convenient. In this PR, we add them to the summary view, but display a little session tag to indicate it's session-level.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Detail on assessment view:

<img width="428" height="494" alt="Screenshot 2026-01-22 at 5 28 25 PM" src="https://github.com/user-attachments/assets/ffce6f5a-980e-4d2b-88da-88819870af9f" />


Overall workflow:

https://github.com/user-attachments/assets/f2b19702-e1f2-45b2-9139-5a9c3b4f28f7



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
