### PR TITLE
Add telemetry for get prompt

### DIFF
--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -183,6 +183,11 @@ For events with None in the `Tracked Parameters` column, only the event name is 
       <td>`{"uses_alias": True}`</td>
     </tr>
     <tr>
+      <td>get_prompt</td>
+      <td>Number of experiments linked to the prompt</td>
+      <td>`{"num_linked_experiments": 1}`</td>
+    </tr>
+    <tr>
       <td>start_trace</td>
       <td>None</td>
       <td>None</td>

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -96,7 +96,8 @@ def model_version_to_prompt_version(
 
     Args:
         model_version: The ModelVersion object to convert to a PromptVersion.
-        prompt_tags: The prompt-level tags. Optional.
+        prompt_tags: The prompt-level tags (from RegisteredModel). These are merged with
+            model version tags, with model version tags taking precedence. Optional.
 
     Returns:
         PromptVersion: The converted PromptVersion object.
@@ -122,13 +123,16 @@ def model_version_to_prompt_version(
     else:
         response_format = None
 
+    # Merge prompt-level tags with model version tags (model version tags take precedence)
+    merged_tags = {**(prompt_tags or {}), **model_version.tags}
+
     return PromptVersion(
         name=model_version.name,
         version=int(model_version.version),
         template=template,
         commit_message=model_version.description,
         creation_timestamp=model_version.creation_timestamp,
-        tags=model_version.tags,
+        tags=merged_tags,
         aliases=model_version.aliases,
         last_updated_timestamp=model_version.last_updated_timestamp,
         user_id=model_version.user_id,

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -88,16 +88,12 @@ class PromptCacheKey(NamedTuple):
             return cls.from_parts(prompt_name, version=prompt_version)
 
 
-def model_version_to_prompt_version(
-    model_version: ModelVersion, prompt_tags: dict[str, str] | None = None
-) -> PromptVersion:
+def model_version_to_prompt_version(model_version: ModelVersion) -> PromptVersion:
     """
     Create a PromptVersion object from a ModelVersion object.
 
     Args:
         model_version: The ModelVersion object to convert to a PromptVersion.
-        prompt_tags: The prompt-level tags (from RegisteredModel). These are merged with
-            model version tags, with model version tags taking precedence. Optional.
 
     Returns:
         PromptVersion: The converted PromptVersion object.
@@ -123,16 +119,13 @@ def model_version_to_prompt_version(
     else:
         response_format = None
 
-    # Merge prompt-level tags with model version tags (model version tags take precedence)
-    merged_tags = {**(prompt_tags or {}), **model_version.tags}
-
     return PromptVersion(
         name=model_version.name,
         version=int(model_version.version),
         template=template,
         commit_message=model_version.description,
         creation_timestamp=model_version.creation_timestamp,
-        tags=merged_tags,
+        tags=model_version.tags,
         aliases=model_version.aliases,
         last_updated_timestamp=model_version.last_updated_timestamp,
         user_id=model_version.user_id,

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -820,14 +820,7 @@ class AbstractStore:
             description=description,
         )
 
-        # Get prompt-level tags from registered model
-        rm = self.get_registered_model(name)
-        if isinstance(rm.tags, dict):
-            prompt_tags = rm.tags.copy()
-        else:
-            prompt_tags = {tag.key: tag.value for tag in rm.tags}
-
-        return model_version_to_prompt_version(mv, prompt_tags=prompt_tags)
+        return model_version_to_prompt_version(mv)
 
     def get_prompt_version(self, name: str, version: str | int) -> PromptVersion | None:
         """
@@ -873,13 +866,7 @@ class AbstractStore:
             if not has_prompt_tag(mv.tags):
                 return None
 
-            # Get user-visible tags from registered model
-            if isinstance(rm.tags, dict):
-                prompt_tags = rm.tags.copy()
-            else:
-                prompt_tags = {tag.key: tag.value for tag in rm.tags}
-
-            return model_version_to_prompt_version(mv, prompt_tags=prompt_tags)
+            return model_version_to_prompt_version(mv)
 
         except MlflowException:
             raise  # Re-raise MlflowExceptions (including our custom one above)

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -78,6 +78,10 @@ class LoadPromptEvent(Event):
         uses_alias = "@" in name_or_uri
         return {"uses_alias": uses_alias}
 
+
+class GetPromptEvent(Event):
+    name: str = "get_prompt"
+
     @classmethod
     def parse_result(cls, result: Any) -> dict[str, Any] | None:
         from mlflow.prompt.constants import PROMPT_EXPERIMENT_IDS_TAG_KEY

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -78,6 +78,22 @@ class LoadPromptEvent(Event):
         uses_alias = "@" in name_or_uri
         return {"uses_alias": uses_alias}
 
+    @classmethod
+    def parse_result(cls, result: Any) -> dict[str, Any] | None:
+        from mlflow.prompt.constants import PROMPT_EXPERIMENT_IDS_TAG_KEY
+
+        if result is None:
+            return {}
+
+        tags = getattr(result, "tags", None)
+        if tags and isinstance(tags, dict):
+            experiment_ids = tags.get(PROMPT_EXPERIMENT_IDS_TAG_KEY, "")
+            # Experiment IDs are stored as comma-separated list: ",id1,id2,"
+            ids_list = [eid for eid in experiment_ids.strip(",").split(",") if eid.strip()]
+            return {"num_linked_experiments": len(ids_list)}
+
+        return {"num_linked_experiments": 0}
+
 
 class StartTraceEvent(Event):
     name: str = "start_trace"

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -39,6 +39,7 @@ from mlflow.telemetry.events import (
     CreatePromptEvent,
     CreateRegisteredModelEvent,
     CreateWebhookEvent,
+    GetPromptEvent,
 )
 from mlflow.telemetry.track import record_usage_event
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS, utils
@@ -497,6 +498,7 @@ class ModelRegistryClient:
         """
         return self.store.create_prompt(name, description, tags)
 
+    @record_usage_event(GetPromptEvent)
     def get_prompt(self, name: str) -> Prompt | None:
         """
         Get prompt metadata by name.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -688,13 +688,10 @@ class MlflowClient:
                 registry_client.delete_registered_model(name)
             raise
 
-        # Fetch the prompt-level tags from the registered model
-        prompt_tags = registry_client.get_registered_model(name)._tags
-
         # Invalidate "latest" cache entry since we just created a new version
         PromptCache.get_instance().delete(name, alias="latest")
 
-        prompt_version = model_version_to_prompt_version(mv, prompt_tags=prompt_tags)
+        prompt_version = model_version_to_prompt_version(mv)
 
         if experiment_id := MLFLOW_EXPERIMENT_ID.get():
             self._link_prompt_to_experiment(prompt_version, experiment_id)

--- a/tests/entities/test_prompt.py
+++ b/tests/entities/test_prompt.py
@@ -11,7 +11,7 @@ from mlflow.entities.model_registry.prompt_version import (
     PromptVersion,
 )
 from mlflow.exceptions import MlflowException
-from mlflow.prompt.constants import PROMPT_EXPERIMENT_IDS_TAG_KEY, PROMPT_MODEL_CONFIG_TAG_KEY
+from mlflow.prompt.constants import PROMPT_MODEL_CONFIG_TAG_KEY
 from mlflow.prompt.registry_utils import model_version_to_prompt_version
 from mlflow.protos.model_registry_pb2 import ModelVersionTag
 
@@ -179,29 +179,6 @@ def test_prompt_from_model_version():
 
     with pytest.raises(MlflowException, match="Prompt `my-prompt` does not contain a prompt text"):
         model_version_to_prompt_version(invalid_model_version)
-
-
-def test_model_version_to_prompt_version_merges_prompt_tags():
-    model_version = ModelVersion(
-        name="my-prompt",
-        version=1,
-        description="test",
-        creation_timestamp=123,
-        tags=[
-            ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true"),
-            ModelVersionTag(key=PROMPT_TEXT_TAG_KEY, value="Hello, {{name}}!"),
-        ],
-    )
-
-    prompt_tags = {
-        PROMPT_EXPERIMENT_IDS_TAG_KEY: ",exp1,exp2,",
-    }
-
-    prompt = model_version_to_prompt_version(model_version, prompt_tags=prompt_tags)
-
-    assert prompt._tags[PROMPT_EXPERIMENT_IDS_TAG_KEY] == ",exp1,exp2,"
-    assert prompt._tags[IS_PROMPT_TAG_KEY] == "true"
-    assert prompt._tags[PROMPT_TEXT_TAG_KEY] == "Hello, {{name}}!"
 
 
 def test_prompt_with_model_config_dict():


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Add a telemetry attribute for the prompt<>experiment linkage

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
