### PR TITLE
Add log_none_params option to xgboost.autolog()

### DIFF
--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -463,6 +463,7 @@ def autolog(
     registered_model_name=None,
     model_format="ubj",
     extra_tags=None,
+    log_none_params=True,
 ):
     """
     Enables (or disables) and configures autologging from XGBoost to MLflow. Logs the following:
@@ -514,6 +515,9 @@ def autolog(
             which is the recommended format for optimal performance and cross-platform
             compatibility. Also supports "json" and "xgb" formats.
         extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
+        log_none_params: If ``True`` (default), parameters with ``None`` values are logged.
+            If ``False``, parameters with ``None`` values are excluded from logging,
+            resulting in cleaner parameter views.
     """
     import numpy as np
     import xgboost
@@ -683,6 +687,11 @@ def autolog(
         params_to_log_for_fn = get_mlflow_run_params_for_fn_args(
             original, args, kwargs, unlogged_params
         )
+        # Filter out None-valued parameters if log_none_params is False
+        if not log_none_params:
+            params_to_log_for_fn = {
+                k: v for k, v in params_to_log_for_fn.items() if v is not None
+            }
         autologging_client.log_params(
             run_id=mlflow.active_run().info.run_id, params=params_to_log_for_fn
         )

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -687,7 +687,7 @@ def autolog(
         params_to_log_for_fn = get_mlflow_run_params_for_fn_args(
             original, args, kwargs, unlogged_params
         )
-        # Filter out None-valued parameters if log_none_params is False
+       
         if not log_none_params:
             params_to_log_for_fn = {
                 k: v for k, v in params_to_log_for_fn.items() if v is not None


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

Resolves #18060

### What changes are proposed in this pull request?

Add a new [log_none_params](cci:1://file:///f:/New%20folder%20%283%29/mlflow/tests/xgboost/test_xgboost_autolog.py:796:0-814:43) parameter to `mlflow.xgboost.autolog()` that allows users to exclude parameters with `None` values from being logged.

- `log_none_params=True` (default): All parameters are logged including those with `None` values
- `log_none_params=False`: Parameters with `None` values are excluded from logging

### How is this PR tested?

- [x] New unit/integration tests

Added 2 new test functions in [tests/xgboost/test_xgboost_autolog.py](cci:7://file:///f:/New%20folder%20%283%29/mlflow/tests/xgboost/test_xgboost_autolog.py:0:0-0:0):
- [test_xgb_autolog_log_none_params_configuration](cci:1://file:///f:/New%20folder%20%283%29/mlflow/tests/xgboost/test_xgboost_autolog.py:796:0-814:43)
- [test_xgb_autolog_log_none_params_default_is_true](cci:1://file:///f:/New%20folder%20%283%29/mlflow/tests/xgboost/test_xgboost_autolog.py:817:0-830:43)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add [log_none_params](cci:1://file:///f:/New%20folder%20%283%29/mlflow/tests/xgboost/test_xgboost_autolog.py:796:0-814:43) parameter to `mlflow.xgboost.autolog()` to optionally exclude `None`-valued parameters from logging.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)