### PR TITLE
[2/2][ML-61080] Unify trace drawer for chat sessions UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -21,6 +21,7 @@ import {
   getModelTraceId,
   isV3ModelTraceInfo,
   ModelTraceExplorer,
+  ModelTraceExplorerContextProvider,
   ModelTraceExplorerDrawer,
   ModelTraceExplorerUpdateTraceContextProvider,
   shouldEnableAssessmentsInSessions,
@@ -41,6 +42,8 @@ import { SELECTED_TRACE_ID_QUERY_PARAM } from '../../../constants';
 import { useExperimentSingleChatMetrics } from './useExperimentSingleChatMetrics';
 import { ExperimentSingleChatSessionMetrics } from './ExperimentSingleChatSessionMetrics';
 import { useRegisterAssistantContext } from '@mlflow/mlflow/src/assistant';
+import { ExportTracesToDatasetModal } from '../../experiment-evaluation-datasets/components/ExportTracesToDatasetModal';
+import { AssistantAwareDrawer } from '@mlflow/mlflow/src/common/components/AssistantAwareDrawer';
 
 const ContextProviders = ({
   children,
@@ -49,10 +52,18 @@ const ContextProviders = ({
   children: React.ReactNode;
   invalidateTraceQuery?: (traceId?: string) => void;
 }) => {
+  const renderCustomExportTracesToDatasetsModal = ExportTracesToDatasetModal;
+  const DrawerComponent = AssistantAwareDrawer;
+
   return (
-    <ModelTraceExplorerUpdateTraceContextProvider invalidateTraceQuery={invalidateTraceQuery}>
-      {children}
-    </ModelTraceExplorerUpdateTraceContextProvider>
+    <ModelTraceExplorerContextProvider
+      renderExportTracesToDatasetsModal={renderCustomExportTracesToDatasetsModal}
+      DrawerComponent={DrawerComponent}
+    >
+      <ModelTraceExplorerUpdateTraceContextProvider invalidateTraceQuery={invalidateTraceQuery}>
+        {children}
+      </ModelTraceExplorerUpdateTraceContextProvider>
+    </ModelTraceExplorerContextProvider>
   );
 };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -16,11 +16,12 @@ import { useGetExperimentQuery } from '../../../hooks/useExperimentQuery';
 import { useCallback, useMemo, useRef, useState, useEffect } from 'react';
 import { ExperimentSingleChatSessionScoreResults } from './ExperimentSingleChatSessionScoreResults';
 import { TracesV3Toolbar } from '../../../components/experiment-page/components/traces-v3/TracesV3Toolbar';
-import type { ModelTrace } from '@databricks/web-shared/model-trace-explorer';
+import type { ModelTrace, ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
 import {
   getModelTraceId,
   isV3ModelTraceInfo,
   ModelTraceExplorer,
+  ModelTraceExplorerDrawer,
   ModelTraceExplorerUpdateTraceContextProvider,
   shouldEnableAssessmentsInSessions,
   shouldUseTracesV4API,
@@ -35,7 +36,7 @@ import {
   ExperimentSingleChatConversation,
   ExperimentSingleChatConversationSkeleton,
 } from './ExperimentSingleChatConversation';
-import { Drawer, useDesignSystemTheme } from '@databricks/design-system';
+import { useDesignSystemTheme } from '@databricks/design-system';
 import { SELECTED_TRACE_ID_QUERY_PARAM } from '../../../constants';
 import { useExperimentSingleChatMetrics } from './useExperimentSingleChatMetrics';
 import { ExperimentSingleChatSessionMetrics } from './ExperimentSingleChatSessionMetrics';
@@ -170,19 +171,32 @@ const ExperimentSingleChatSessionPageImpl = () => {
             )}
           </div>
         )}
-        <Drawer.Root
-          open={selectedTrace !== null}
-          onOpenChange={(open) => {
-            if (!open) {
-              setSelectedTrace(null);
+        {selectedTrace !== null && selectedTurnIndex !== null && (
+          <ModelTraceExplorerDrawer
+            handleClose={() => setSelectedTrace(null)}
+            selectPreviousEval={() => {
+              if (selectedTurnIndex > 0 && traces) {
+                const prevIndex = selectedTurnIndex - 1;
+                setSelectedTurnIndex(prevIndex);
+                setSelectedTrace(traces[prevIndex]);
+              }
+            }}
+            selectNextEval={() => {
+              if (traces && selectedTurnIndex < traces.length - 1) {
+                const nextIndex = selectedTurnIndex + 1;
+                setSelectedTurnIndex(nextIndex);
+                setSelectedTrace(traces[nextIndex]);
+              }
+            }}
+            isPreviousAvailable={selectedTurnIndex > 0}
+            isNextAvailable={traces !== undefined && selectedTurnIndex < traces.length - 1}
+            renderModalTitle={() => getModelTraceId(selectedTrace)}
+            experimentId={experimentId}
+            traceInfo={
+              sortedTraceInfos?.[selectedTurnIndex] && isV3ModelTraceInfo(sortedTraceInfos[selectedTurnIndex])
+                ? (sortedTraceInfos[selectedTurnIndex] as ModelTraceInfoV3)
+                : undefined
             }
-          }}
-        >
-          <Drawer.Content
-            componentId="mlflow.experiment.chat-session.trace-drawer"
-            title={selectedTrace ? getModelTraceId(selectedTrace) : ''}
-            width="90vw"
-            expandContentToFullHeight
           >
             <div
               css={{
@@ -192,10 +206,10 @@ const ExperimentSingleChatSessionPageImpl = () => {
                 marginBottom: -theme.spacing.lg,
               }}
             >
-              {selectedTrace && <ModelTraceExplorer modelTrace={selectedTrace} collapseAssessmentPane="force-open" />}
+              <ModelTraceExplorer modelTrace={selectedTrace} collapseAssessmentPane="force-open" />
             </div>
-          </Drawer.Content>
-        </Drawer.Root>
+          </ModelTraceExplorerDrawer>
+        )}
       </div>
     </ContextProviders>
   );


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
The chat sessions UI now uses the same trace drawer, allowing for easier navigation between turns.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

https://github.com/user-attachments/assets/ac0c6987-82bb-4d1e-b620-065003e811ad




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
