### PR TITLE
Ml61125/implement different sidebar tab configs based on workflow type

### DIFF
--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -1,3 +1,4 @@
+import React, { Fragment, useCallback, useMemo, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import {
   BeakerIcon,
@@ -10,7 +11,9 @@ import {
   PlusIcon,
   SegmentedControlGroup,
   SegmentedControlButton,
+  Tag,
   TextBoxIcon,
+  Tooltip,
   useDesignSystemTheme,
   DesignSystemEventProviderComponentTypes,
   DesignSystemEventProviderAnalyticsEventTypes,
@@ -22,7 +25,6 @@ import ExperimentTrackingRoutes from '../../experiment-tracking/routes';
 import { ModelRegistryRoutes } from '../../model-registry/routes';
 import GatewayRoutes from '../../gateway/routes';
 import { CreateExperimentModal } from '../../experiment-tracking/components/modals/CreateExperimentModal';
-import { useMemo, useState } from 'react';
 import { useInvalidateExperimentList } from '../../experiment-tracking/components/experiment-page/hooks/useExperimentListQuery';
 import { CreateModelModal } from '../../model-registry/components/CreateModelModal';
 import {
@@ -33,15 +35,92 @@ import Routes from '../../experiment-tracking/routes';
 import { FormattedMessage } from 'react-intl';
 import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
 import { useWorkflowType, WorkflowType } from '../contexts/WorkflowTypeContext';
+import {
+  ExperimentPageSideNavGenAIConfig,
+  ExperimentPageSideNavCustomModelConfig,
+  getExperimentPageSideNavSectionLabel,
+  type ExperimentPageSideNavSectionKey,
+} from '../../experiment-tracking/pages/experiment-page-tabs/side-nav/constants';
+import { ExperimentPageTabName } from '../../experiment-tracking/constants';
+import { ChainIcon, KeyIcon } from '@databricks/design-system';
+import { useParams } from '../utils/RoutingUtils';
 import { shouldEnableWorkflowBasedNavigation } from '../utils/FeatureUtils';
+import { AssistantSparkleIcon } from '../../assistant/AssistantIconButton';
+import { useAssistant } from '../../assistant/AssistantContext';
 
-const isHomeActive = (location: Location) => matchPath({ path: '/', end: true }, location.pathname);
+const isHomeActive = (location: Location) => Boolean(matchPath({ path: '/', end: true }, location.pathname));
 const isExperimentsActive = (location: Location) =>
-  matchPath('/experiments/*', location.pathname) || matchPath('/compare-experiments/*', location.pathname);
-const isModelsActive = (location: Location) => matchPath('/models/*', location.pathname);
-const isPromptsActive = (location: Location) => matchPath('/prompts/*', location.pathname);
-const isGatewayActive = (location: Location) => matchPath('/gateway/*', location.pathname);
-const isSettingsActive = (location: Location) => matchPath('/settings/*', location.pathname);
+  Boolean(
+    matchPath({ path: '/experiments', end: true }, location.pathname) ||
+    matchPath('/compare-experiments/*', location.pathname),
+  );
+const isModelsActive = (location: Location) => Boolean(matchPath('/models/*', location.pathname));
+const isPromptsActive = (location: Location) => Boolean(matchPath('/prompts/*', location.pathname));
+const isGatewayActive = (location: Location) => Boolean(matchPath({ path: '/gateway', end: true }, location.pathname));
+const isSettingsActive = (location: Location) => Boolean(matchPath('/settings/*', location.pathname));
+
+type MlFlowSidebarMenuDropdownComponentId =
+  | 'mlflow_sidebar.create_experiment_button'
+  | 'mlflow_sidebar.create_model_button'
+  | 'mlflow_sidebar.create_prompt_button';
+
+type NestedMenuItem = {
+  key: string;
+  icon: React.ReactNode;
+  label: React.ReactNode;
+  to: string;
+  componentId: string;
+  isActive: (location: Location) => boolean;
+};
+
+type NestedItemsGroup = {
+  sectionKey: ExperimentPageSideNavSectionKey;
+  items: NestedMenuItem[];
+};
+
+type MenuItemWithNested = {
+  key: string;
+  icon: React.ReactNode;
+  linkProps: {
+    to: string;
+    isActive: (location: Location) => boolean;
+    children: React.ReactNode;
+  };
+  componentId: string;
+  dropdownProps?: {
+    componentId: MlFlowSidebarMenuDropdownComponentId;
+    onClick: () => void;
+    children: React.ReactNode;
+  };
+  nestedItems?: NestedMenuItem[];
+  nestedItemsGroups?: NestedItemsGroup[];
+};
+
+const buildNestedItemsFromConfig = (
+  items: Array<{ tabName: ExperimentPageTabName; icon: React.ReactNode; label: React.ReactNode; componentId: string }>,
+  experimentId?: string,
+): NestedMenuItem[] => {
+  return items.map((item) => ({
+    key: `experiments-${item.tabName}`,
+    icon: item.icon,
+    label: item.label,
+    to: experimentId
+      ? Routes.getExperimentPageTabRoute(experimentId, item.tabName)
+      : ExperimentTrackingRoutes.experimentsObservatoryRoute,
+    componentId: item.componentId,
+    isActive: (loc) =>
+      Boolean(experimentId && matchPath(`/experiments/${experimentId}/${item.tabName}/*`, loc.pathname)),
+  }));
+};
+
+const NESTED_ITEMS_UL_CSS = {
+  listStyleType: 'none' as const,
+  padding: 0,
+  margin: 0,
+};
+
+const shouldShowGenAIFeatures = (enableWorkflowBasedNavigation: boolean, workflowType: WorkflowType) =>
+  !enableWorkflowBasedNavigation || (enableWorkflowBasedNavigation && workflowType === WorkflowType.GENAI);
 
 export function MlflowSidebar() {
   const location = useLocation();
@@ -49,8 +128,11 @@ export function MlflowSidebar() {
   const invalidateExperimentList = useInvalidateExperimentList();
   const navigate = useNavigate();
   const viewId = useMemo(() => uuidv4(), []);
-  const { workflowType, setWorkflowType } = useWorkflowType();
   const enableWorkflowBasedNavigation = shouldEnableWorkflowBasedNavigation();
+  // WorkflowType context is always available, but UI is guarded by feature flag
+  const { workflowType, setWorkflowType } = useWorkflowType();
+  const { experimentId } = useParams();
+  const logTelemetryEvent = useLogTelemetryEvent();
 
   const [showCreateExperimentModal, setShowCreateExperimentModal] = useState(false);
   const [showCreateModelModal, setShowCreateModelModal] = useState(false);
@@ -58,96 +140,266 @@ export function MlflowSidebar() {
     mode: CreatePromptModalMode.CreatePrompt,
     onSuccess: ({ promptName }) => navigate(Routes.getPromptDetailsPageRoute(promptName)),
   });
+  const { openPanel, closePanel, isPanelOpen } = useAssistant();
+  const [isAssistantHovered, setIsAssistantHovered] = useState(false);
 
-  type MlFlowSidebarMenuDropdownComponentId =
-    | 'mlflow_sidebar.create_experiment_button'
-    | 'mlflow_sidebar.create_model_button'
-    | 'mlflow_sidebar.create_prompt_button';
+  const handleAssistantToggle = useCallback(() => {
+    if (isPanelOpen) {
+      closePanel();
+    } else {
+      openPanel();
+    }
+    logTelemetryEvent({
+      componentId: 'mlflow.sidebar.assistant_button',
+      componentViewId: viewId,
+      componentType: DesignSystemEventProviderComponentTypes.Button,
+      componentSubType: null,
+      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+    });
+  }, [isPanelOpen, closePanel, openPanel, logTelemetryEvent, viewId]);
 
-  const menuItems = [
-    {
-      key: 'home',
-      icon: <HomeIcon />,
-      linkProps: {
-        to: ExperimentTrackingRoutes.rootRoute,
-        isActive: isHomeActive,
-        children: <FormattedMessage defaultMessage="Home" description="Sidebar link for home page" />,
-      },
-      componentId: 'mlflow.sidebar.home_tab_link',
-    },
-    {
-      key: 'experiments',
-      icon: <BeakerIcon />,
-      linkProps: {
-        to: ExperimentTrackingRoutes.experimentsObservatoryRoute,
-        isActive: isExperimentsActive,
-        children: <FormattedMessage defaultMessage="Experiments" description="Sidebar link for experiments tab" />,
-      },
-      componentId: 'mlflow.sidebar.experiments_tab_link',
-      dropdownProps: {
-        componentId: 'mlflow_sidebar.create_experiment_button' as MlFlowSidebarMenuDropdownComponentId,
-        onClick: () => setShowCreateExperimentModal(true),
-        children: (
-          <FormattedMessage
-            defaultMessage="Experiment"
-            description="Sidebar button inside the 'new' popover to create new experiment"
-          />
-        ),
-      },
-    },
-    {
-      key: 'models',
-      icon: <ModelsIcon />,
-      linkProps: {
-        to: ModelRegistryRoutes.modelListPageRoute,
-        isActive: isModelsActive,
-        children: <FormattedMessage defaultMessage="Models" description="Sidebar link for models tab" />,
-      },
-      componentId: 'mlflow.sidebar.models_tab_link',
-      dropdownProps: {
-        componentId: 'mlflow_sidebar.create_model_button' as MlFlowSidebarMenuDropdownComponentId,
-        onClick: () => setShowCreateModelModal(true),
-        children: (
-          <FormattedMessage
-            defaultMessage="Model"
-            description="Sidebar button inside the 'new' popover to create new model"
-          />
-        ),
-      },
-    },
-    {
-      key: 'prompts',
-      icon: <TextBoxIcon />,
-      linkProps: {
-        to: ExperimentTrackingRoutes.promptsPageRoute,
-        isActive: isPromptsActive,
-        children: <FormattedMessage defaultMessage="Prompts" description="Sidebar link for prompts tab" />,
-      },
-      componentId: 'mlflow.sidebar.prompts_tab_link',
-      dropdownProps: {
-        componentId: 'mlflow_sidebar.create_prompt_button' as MlFlowSidebarMenuDropdownComponentId,
-        onClick: openCreatePromptModal,
-        children: (
-          <FormattedMessage
-            defaultMessage="Prompt"
-            description="Sidebar button inside the 'new' popover to create new prompt"
-          />
-        ),
-      },
-    },
-    {
-      key: 'gateway',
-      icon: <CloudModelIcon />,
-      linkProps: {
-        to: GatewayRoutes.gatewayPageRoute,
-        isActive: isGatewayActive,
-        children: <FormattedMessage defaultMessage="AI Gateway" description="Sidebar link for gateway configuration" />,
-      },
-      componentId: 'mlflow.sidebar.gateway_tab_link',
-    },
-  ];
+  const renderNestedItemLink = useCallback(
+    (nestedItem: NestedMenuItem, isDisabled: boolean) => {
+      const isNestedActive = nestedItem.isActive(location);
+      const linkElement = (
+        <Link
+          to={nestedItem.to}
+          aria-current={isNestedActive ? 'page' : undefined}
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: theme.spacing.sm,
+            color: isDisabled ? theme.colors.textSecondary : theme.colors.textPrimary,
+            paddingInline: theme.spacing.md,
+            paddingLeft: 40,
+            paddingBlock: theme.spacing.xs,
+            borderRadius: theme.borders.borderRadiusSm,
+            cursor: isDisabled ? 'not-allowed' : 'pointer',
+            opacity: isDisabled ? 0.5 : 1,
+            '&:hover': isDisabled
+              ? {}
+              : {
+                  color: theme.colors.actionLinkHover,
+                  backgroundColor: theme.colors.actionDefaultBackgroundHover,
+                },
+            '&[aria-current="page"]': {
+              backgroundColor: theme.colors.actionDefaultBackgroundPress,
+              color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
+              fontWeight: theme.typography.typographyBoldFontWeight,
+            },
+          }}
+          onClick={(e) => {
+            if (isDisabled) {
+              e.preventDefault();
+              return;
+            }
+            logTelemetryEvent({
+              componentId: nestedItem.componentId,
+              componentViewId: viewId,
+              componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
+              componentSubType: null,
+              eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+            });
+          }}
+        >
+          {nestedItem.icon}
+          {nestedItem.label}
+        </Link>
+      );
 
-  const logTelemetryEvent = useLogTelemetryEvent();
+      if (isDisabled) {
+        return (
+          <Tooltip
+            componentId={`mlflow.sidebar.nested-item.disabled-tooltip.${nestedItem.key}`}
+            content={
+              <FormattedMessage
+                defaultMessage="Select an experiment to view this tab"
+                description="Tooltip shown when nested experiment items are disabled because no experiment is selected"
+              />
+            }
+            side="right"
+          >
+            {linkElement}
+          </Tooltip>
+        );
+      }
+      return linkElement;
+    },
+    [location, theme, logTelemetryEvent, viewId],
+  );
+
+  const experimentNestedItemsGroups = useMemo((): NestedItemsGroup[] => {
+    if (!enableWorkflowBasedNavigation) {
+      return [];
+    }
+
+    if (workflowType === WorkflowType.GENAI) {
+      const config = ExperimentPageSideNavGenAIConfig;
+      const groups: NestedItemsGroup[] = [];
+
+      if (config.observability) {
+        groups.push({
+          sectionKey: 'observability',
+          items: buildNestedItemsFromConfig(config.observability, experimentId),
+        });
+      }
+      if (config.evaluation) {
+        groups.push({
+          sectionKey: 'evaluation',
+          items: buildNestedItemsFromConfig(config.evaluation, experimentId),
+        });
+      }
+      if (config['prompts-versions']) {
+        groups.push({
+          sectionKey: 'prompts-versions',
+          items: buildNestedItemsFromConfig(config['prompts-versions'], experimentId),
+        });
+      }
+
+      return groups;
+    }
+
+    if (workflowType === WorkflowType.MACHINE_LEARNING) {
+      const config = ExperimentPageSideNavCustomModelConfig;
+      if (config['top-level']) {
+        return [
+          {
+            sectionKey: 'top-level',
+            items: buildNestedItemsFromConfig(config['top-level'], experimentId),
+          },
+        ];
+      }
+    }
+
+    return [];
+  }, [enableWorkflowBasedNavigation, workflowType, experimentId]);
+
+  const menuItems: MenuItemWithNested[] = useMemo(
+    () => [
+      {
+        key: 'home',
+        icon: <HomeIcon />,
+        linkProps: {
+          to: ExperimentTrackingRoutes.rootRoute,
+          isActive: isHomeActive,
+          children: <FormattedMessage defaultMessage="Home" description="Sidebar link for home page" />,
+        },
+        componentId: 'mlflow.sidebar.home_tab_link',
+      },
+      {
+        key: 'experiments',
+        icon: <BeakerIcon />,
+        linkProps: {
+          to: ExperimentTrackingRoutes.experimentsObservatoryRoute,
+          isActive: isExperimentsActive,
+          children: <FormattedMessage defaultMessage="Experiments" description="Sidebar link for experiments tab" />,
+        },
+        componentId: 'mlflow.sidebar.experiments_tab_link',
+        dropdownProps: {
+          componentId: 'mlflow_sidebar.create_experiment_button' as MlFlowSidebarMenuDropdownComponentId,
+          onClick: () => setShowCreateExperimentModal(true),
+          children: (
+            <FormattedMessage
+              defaultMessage="Experiment"
+              description="Sidebar button inside the 'new' popover to create new experiment"
+            />
+          ),
+        },
+        nestedItemsGroups: experimentNestedItemsGroups.length > 0 ? experimentNestedItemsGroups : undefined,
+      },
+      ...(workflowType === WorkflowType.MACHINE_LEARNING || !enableWorkflowBasedNavigation
+        ? [
+            {
+              key: 'models',
+              icon: <ModelsIcon />,
+              linkProps: {
+                to: ModelRegistryRoutes.modelListPageRoute,
+                isActive: isModelsActive,
+                children: <FormattedMessage defaultMessage="Models" description="Sidebar link for models tab" />,
+              },
+              componentId: 'mlflow.sidebar.models_tab_link',
+              dropdownProps: {
+                componentId: 'mlflow_sidebar.create_model_button' as MlFlowSidebarMenuDropdownComponentId,
+                onClick: () => setShowCreateModelModal(true),
+                children: (
+                  <FormattedMessage
+                    defaultMessage="Model"
+                    description="Sidebar button inside the 'new' popover to create new model"
+                  />
+                ),
+              },
+            },
+          ]
+        : []),
+      ...(shouldShowGenAIFeatures(enableWorkflowBasedNavigation, workflowType)
+        ? [
+            {
+              key: 'prompts',
+              icon: <TextBoxIcon />,
+              linkProps: {
+                to: ExperimentTrackingRoutes.promptsPageRoute,
+                isActive: isPromptsActive,
+                children: <FormattedMessage defaultMessage="Prompts" description="Sidebar link for prompts tab" />,
+              },
+              componentId: 'mlflow.sidebar.prompts_tab_link',
+              dropdownProps: {
+                componentId: 'mlflow_sidebar.create_prompt_button' as MlFlowSidebarMenuDropdownComponentId,
+                onClick: openCreatePromptModal,
+                children: (
+                  <FormattedMessage
+                    defaultMessage="Prompt"
+                    description="Sidebar button inside the 'new' popover to create new prompt"
+                  />
+                ),
+              },
+            },
+          ]
+        : []),
+      ...(shouldShowGenAIFeatures(enableWorkflowBasedNavigation, workflowType)
+        ? [
+            {
+              key: 'gateway',
+              icon: <CloudModelIcon />,
+              linkProps: {
+                to: GatewayRoutes.gatewayPageRoute,
+                isActive: isGatewayActive,
+                children: (
+                  <FormattedMessage defaultMessage="AI Gateway" description="Sidebar link for gateway configuration" />
+                ),
+              },
+              componentId: 'mlflow.sidebar.gateway_tab_link',
+              nestedItems:
+                enableWorkflowBasedNavigation && workflowType === WorkflowType.GENAI
+                  ? [
+                      {
+                        key: 'gateway-endpoints',
+                        icon: <ChainIcon />,
+                        label: (
+                          <FormattedMessage defaultMessage="Endpoints" description="Gateway side nav > Endpoints tab" />
+                        ),
+                        to: GatewayRoutes.gatewayPageRoute,
+                        componentId: 'mlflow.sidebar.gateway.endpoints',
+                        isActive: (loc: Location) =>
+                          Boolean(matchPath('/gateway', loc.pathname) && !matchPath('/gateway/api-keys', loc.pathname)),
+                      },
+                      {
+                        key: 'gateway-api-keys',
+                        icon: <KeyIcon />,
+                        label: (
+                          <FormattedMessage defaultMessage="API Keys" description="Gateway side nav > API Keys tab" />
+                        ),
+                        to: GatewayRoutes.apiKeysPageRoute,
+                        componentId: 'mlflow.sidebar.gateway.api-keys',
+                        isActive: (loc: Location) => Boolean(matchPath('/gateway/api-keys', loc.pathname)),
+                      },
+                    ]
+                  : undefined,
+            },
+          ]
+        : []),
+    ],
+    [enableWorkflowBasedNavigation, workflowType, experimentNestedItemsGroups, openCreatePromptModal],
+  );
 
   return (
     <aside
@@ -214,11 +466,11 @@ export function MlflowSidebar() {
             .map(({ key, icon, dropdownProps }) => (
               <DropdownMenu.Item
                 key={key}
-                componentId={dropdownProps.componentId satisfies MlFlowSidebarMenuDropdownComponentId}
-                onClick={dropdownProps.onClick}
+                componentId={(dropdownProps?.componentId ?? `${key}-dropdown-item`) as string}
+                onClick={dropdownProps?.onClick}
               >
                 <DropdownMenu.IconWrapper>{icon}</DropdownMenu.IconWrapper>
-                {dropdownProps.children}
+                {dropdownProps?.children}
               </DropdownMenu.Item>
             ))}
         </DropdownMenu.Content>
@@ -232,7 +484,7 @@ export function MlflowSidebar() {
             margin: 0,
           }}
         >
-          {menuItems.map(({ key, icon, linkProps, componentId }) => (
+          {menuItems.map(({ key, icon, linkProps, componentId, nestedItemsGroups, nestedItems }) => (
             <li key={key}>
               <Link
                 to={linkProps.to}
@@ -268,43 +520,123 @@ export function MlflowSidebar() {
                 {icon}
                 {linkProps.children}
               </Link>
+              {nestedItemsGroups && nestedItemsGroups.length > 0 && (
+                <ul css={NESTED_ITEMS_UL_CSS}>
+                  {nestedItemsGroups.map((group) => (
+                    <Fragment key={group.sectionKey}>
+                      {group.sectionKey !== 'top-level' && (
+                        <li
+                          css={{
+                            display: 'flex',
+                            marginTop: theme.spacing.xs,
+                            marginBottom: theme.spacing.xs,
+                            position: 'relative',
+                            height: theme.typography.lineHeightBase,
+                            paddingLeft: 40,
+                          }}
+                        >
+                          <Typography.Text size="sm" color="secondary">
+                            {getExperimentPageSideNavSectionLabel(group.sectionKey, [])}
+                          </Typography.Text>
+                        </li>
+                      )}
+                      {group.items.map((nestedItem) => {
+                        const isDisabled = !experimentId && key === 'experiments';
+                        return <li key={nestedItem.key}>{renderNestedItemLink(nestedItem, isDisabled)}</li>;
+                      })}
+                    </Fragment>
+                  ))}
+                </ul>
+              )}
+              {nestedItems && nestedItems.length > 0 && (
+                <ul css={NESTED_ITEMS_UL_CSS}>
+                  {nestedItems.map((nestedItem) => (
+                    <li key={nestedItem.key}>{renderNestedItemLink(nestedItem, false)}</li>
+                  ))}
+                </ul>
+              )}
             </li>
           ))}
         </ul>
-        <Link
-          to={ExperimentTrackingRoutes.settingsPageRoute}
-          aria-current={isSettingsActive(location) ? 'page' : undefined}
-          css={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: theme.spacing.sm,
-            color: theme.colors.textPrimary,
-            paddingInline: theme.spacing.md,
-            paddingBlock: theme.spacing.sm,
-            borderRadius: theme.borders.borderRadiusSm,
-            '&:hover': {
-              color: theme.colors.actionLinkHover,
-              backgroundColor: theme.colors.actionDefaultBackgroundHover,
-            },
-            '&[aria-current="page"]': {
-              backgroundColor: theme.colors.actionDefaultBackgroundPress,
-              color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
-              fontWeight: theme.typography.typographyBoldFontWeight,
-            },
-          }}
-          onClick={() =>
-            logTelemetryEvent({
-              componentId: 'mlflow.sidebar.settings_tab_link',
-              componentViewId: viewId,
-              componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
-              componentSubType: null,
-              eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
-            })
-          }
-        >
-          <GearIcon />
-          <FormattedMessage defaultMessage="Settings" description="Sidebar link for settings page" />
-        </Link>
+        <div>
+          {enableWorkflowBasedNavigation && (
+            <div
+              role="button"
+              tabIndex={0}
+              aria-pressed={isPanelOpen}
+              css={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: theme.spacing.sm,
+                padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+                borderRadius: theme.borders.borderRadiusSm,
+                cursor: 'pointer',
+                backgroundColor: isPanelOpen ? theme.colors.actionDefaultBackgroundHover : undefined,
+                color: isPanelOpen ? theme.colors.actionDefaultIconHover : theme.colors.actionDefaultIconDefault,
+                height: theme.typography.lineHeightBase,
+                boxSizing: 'content-box',
+                ':hover': { backgroundColor: theme.colors.actionDefaultBackgroundHover },
+              }}
+              onClick={handleAssistantToggle}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  handleAssistantToggle();
+                }
+              }}
+              onMouseEnter={() => setIsAssistantHovered(true)}
+              onMouseLeave={() => setIsAssistantHovered(false)}
+            >
+              <Tooltip
+                componentId="mlflow.sidebar.assistant_tooltip"
+                content={<FormattedMessage defaultMessage="Assistant" description="Tooltip for assistant button" />}
+                side="right"
+                delayDuration={0}
+              >
+                <AssistantSparkleIcon isHovered={isAssistantHovered} />
+              </Tooltip>
+              <Typography.Text bold={isPanelOpen} color="primary">
+                <FormattedMessage defaultMessage="Assistant" description="Sidebar button for AI assistant" />
+              </Typography.Text>
+              <Tag componentId="mlflow.sidebar.assistant_beta_tag" color="turquoise" css={{ marginLeft: 'auto' }}>
+                Beta
+              </Tag>
+            </div>
+          )}
+          <Link
+            to={ExperimentTrackingRoutes.settingsPageRoute}
+            aria-current={isSettingsActive(location) ? 'page' : undefined}
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+              color: theme.colors.textPrimary,
+              paddingInline: theme.spacing.md,
+              paddingBlock: theme.spacing.sm,
+              borderRadius: theme.borders.borderRadiusSm,
+              '&:hover': {
+                color: theme.colors.actionLinkHover,
+                backgroundColor: theme.colors.actionDefaultBackgroundHover,
+              },
+              '&[aria-current="page"]': {
+                backgroundColor: theme.colors.actionDefaultBackgroundPress,
+                color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
+                fontWeight: theme.typography.typographyBoldFontWeight,
+              },
+            }}
+            onClick={() =>
+              logTelemetryEvent({
+                componentId: 'mlflow.sidebar.settings_tab_link',
+                componentViewId: viewId,
+                componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
+                componentSubType: null,
+                eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+              })
+            }
+          >
+            <GearIcon />
+            <FormattedMessage defaultMessage="Settings" description="Sidebar link for settings page" />
+          </Link>
+        </div>
       </nav>
 
       <CreateExperimentModal

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -362,7 +362,7 @@ export function MlflowSidebar() {
               icon: <CloudModelIcon />,
               linkProps: {
                 to: GatewayRoutes.gatewayPageRoute,
-                isActive: isGatewayActive,
+                isActive: (location: Location) => !enableWorkflowBasedNavigation && isGatewayActive(location),
                 children: (
                   <FormattedMessage defaultMessage="AI Gateway" description="Sidebar link for gateway configuration" />
                 ),

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/constants.tsx
@@ -32,7 +32,7 @@ export type ExperimentPageSideNavConfig = {
 
 export type ExperimentPageSideNavSectionKey = 'top-level' | 'observability' | 'evaluation' | 'prompts-versions';
 
-const ExperimentPageSideNavGenAIConfig = {
+export const ExperimentPageSideNavGenAIConfig = {
   observability: [
     {
       label: (
@@ -107,7 +107,7 @@ const ExperimentPageSideNavGenAIConfig = {
   ],
 };
 
-const ExperimentPageSideNavCustomModelConfig = {
+export const ExperimentPageSideNavCustomModelConfig = {
   'top-level': [
     {
       label: (

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5183,6 +5183,10 @@
     "defaultMessage": "Select sessions",
     "description": "Button to select sessions"
   },
+  "cSEpGa": {
+    "defaultMessage": "Machine Learning",
+    "description": "Label for Machine Learning workflow type option"
+  },
   "cSSMIs": {
     "defaultMessage": "Copy artifact location",
     "description": "Copy tooltip to copy experiment artifact location from experiment runs table header"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2174,6 +2174,10 @@
     "defaultMessage": "No results",
     "description": "Experiment page > sort selector > no results after filtering by search query"
   },
+  "Emh131": {
+    "defaultMessage": "Select an experiment to view this tab",
+    "description": "Tooltip shown when nested experiment items are disabled because no experiment is selected"
+  },
   "EpFST9": {
     "defaultMessage": "No trace data recorded",
     "description": "Experiment page > traces data drawer > no trace data recorded empty state"
@@ -5182,10 +5186,6 @@
   "cSQJ9N": {
     "defaultMessage": "Select sessions",
     "description": "Button to select sessions"
-  },
-  "cSEpGa": {
-    "defaultMessage": "Machine Learning",
-    "description": "Label for Machine Learning workflow type option"
   },
   "cSSMIs": {
     "defaultMessage": "Copy artifact location",


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

This should actually be a chained PR where this branch goes into this one: https://github.com/mlflow/mlflow/pull/20158

This PR contains the entire feature: https://github.com/mlflow/mlflow/pull/20161

### Related Issues/PRs

ML-61125

### What changes are proposed in this pull request?

This PR implements dynamic sidebar navigation based on the selected workflow type. 

Key changes:
- Added nested menu items under "Experiments" based on workflow type (GenAI vs Machine Learning)
- Conditionally hide "Models" tab when GenAI workflow is selected
- Conditionally hide "Prompts" tab when Machine Learning workflow is selected
- Added nested items under "AI Gateway" (Endpoints, API Keys) for GenAI workflows
- Added tooltip for disabled nested items when no experiment is selected
- All changes gated by `shouldEnableWorkflowBasedNavigation` feature flag

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

<img width="237" height="513" alt="Screenshot 2026-01-20 at 22 16 38" src="https://github.com/user-attachments/assets/eb1a91ba-252a-4555-8afa-d05b5cd76bca" />

<img width="236" height="466" alt="Screenshot 2026-01-20 at 22 16 48" src="https://github.com/user-attachments/assets/923805b2-bb00-4688-b688-43808598c5b2" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The sidebar navigation now adapts based on the selected workflow type. When GenAI workflow is selected, the Models tab is hidden and experiment-related tabs are nested under Experiments. When Machine Learning workflow is selected, the Prompts tab is hidden and model-related tabs are nested under Experiments.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
