### PR TITLE
Always log otel resource attribtues for MLflow SDK

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -4,7 +4,6 @@ import logging
 from functools import lru_cache
 from typing import Any, Union
 
-from opentelemetry.proto.resource.v1.resource_pb2 import Resource as OTelProtoResource
 from opentelemetry.proto.trace.v1.trace_pb2 import Span as OTelProtoSpan
 from opentelemetry.proto.trace.v1.trace_pb2 import Status as OTelProtoStatus
 from opentelemetry.sdk.resources import Resource as _OTelResource
@@ -206,13 +205,6 @@ class Span:
             )
             for event in self._span.events
         ]
-
-    @property
-    def resource(self) -> _OTelResource:
-        """The resource associated with this span."""
-        if hasattr(self._span, "resource") and self._span.resource is not None:
-            return self._span.resource
-        return _OTelResource.get_empty()
 
     def __repr__(self):
         return (
@@ -459,20 +451,6 @@ class Span:
             otel_span.events.append(otel_event)
 
         return otel_span
-
-    def resource_to_otel_proto(self) -> OTelProtoResource:
-        """
-        Convert the span's resource to OpenTelemetry protobuf Resource format.
-
-        Returns:
-            An OpenTelemetry protobuf Resource message.
-        """
-        otel_resource = OTelProtoResource()
-        for key, value in self.resource.attributes.items():
-            attr = otel_resource.attributes.add()
-            attr.key = key
-            _set_otel_proto_anyvalue(attr.value, value)
-        return otel_resource
 
 
 def _encode_span_id_to_byte(span_id: int | None) -> bytes:

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -552,7 +552,7 @@ class DatabricksTracingRestStore(RestStore):
 
         request = ExportTraceServiceRequest()
         resource_spans = request.resource_spans.add()
-        resource_spans.resource.CopyFrom(spans[0].resource.to_otel_proto())
+        resource_spans.resource.CopyFrom(spans[0].resource_to_otel_proto())
         scope_spans = resource_spans.scope_spans.add()
         scope_spans.spans.extend(span.to_otel_proto() for span in spans)
 

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -49,7 +49,7 @@ from mlflow.store.entities import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.store.tracking.rest_store import RestStore
 from mlflow.tracing.utils import parse_trace_id_v4
-from mlflow.tracing.utils.otlp import OTLP_TRACES_PATH
+from mlflow.tracing.utils.otlp import OTLP_TRACES_PATH, resource_to_otel_proto
 from mlflow.utils.databricks_tracing_utils import (
     assessment_to_proto,
     trace_from_proto,
@@ -552,7 +552,8 @@ class DatabricksTracingRestStore(RestStore):
 
         request = ExportTraceServiceRequest()
         resource_spans = request.resource_spans.add()
-        resource_spans.resource.CopyFrom(spans[0].resource_to_otel_proto())
+        resource = getattr(spans[0]._span, "resource", None)
+        resource_spans.resource.CopyFrom(resource_to_otel_proto(resource))
         scope_spans = resource_spans.scope_spans.add()
         scope_spans.spans.extend(span.to_otel_proto() for span in spans)
 

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -552,6 +552,7 @@ class DatabricksTracingRestStore(RestStore):
 
         request = ExportTraceServiceRequest()
         resource_spans = request.resource_spans.add()
+        resource_spans.resource.CopyFrom(spans[0].resource.to_otel_proto())
         scope_spans = resource_spans.scope_spans.add()
         scope_spans.spans.extend(span.to_otel_proto() for span in spans)
 

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -1962,6 +1962,7 @@ class RestStore(RestGatewayStoreMixin, AbstractStore):
 
         request = ExportTraceServiceRequest()
         resource_spans = request.resource_spans.add()
+        resource_spans.resource.CopyFrom(spans[0].resource_to_otel_proto())
         scope_spans = resource_spans.scope_spans.add()
         scope_spans.spans.extend(span.to_otel_proto() for span in spans)
 

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -128,7 +128,11 @@ from mlflow.store.tracking import MAX_RESULTS_QUERY_TRACE_METRICS, SEARCH_TRACES
 from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.store.tracking.gateway.rest_mixin import RestGatewayStoreMixin
 from mlflow.tracing.analysis import TraceFilterCorrelationResult
-from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER, OTLP_TRACES_PATH
+from mlflow.tracing.utils.otlp import (
+    MLFLOW_EXPERIMENT_ID_HEADER,
+    OTLP_TRACES_PATH,
+    resource_to_otel_proto,
+)
 from mlflow.utils.databricks_utils import databricks_api_disabled
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import (
@@ -1962,7 +1966,8 @@ class RestStore(RestGatewayStoreMixin, AbstractStore):
 
         request = ExportTraceServiceRequest()
         resource_spans = request.resource_spans.add()
-        resource_spans.resource.CopyFrom(spans[0].resource_to_otel_proto())
+        resource = getattr(spans[0]._span, "resource", None)
+        resource_spans.resource.CopyFrom(resource_to_otel_proto(resource))
         scope_spans = resource_spans.scope_spans.add()
         scope_spans.spans.extend(span.to_otel_proto() for span in spans)
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -486,14 +486,15 @@ def _initialize_tracer_provider(disabled=False):
     else:
         # Update the env var to let otel initialize the resource with MLflow's SDK attributes
         attributes = {**_parse_otel_resource_attributes(otel_resource_attributes), **sdk_attributes}
-        os.environ["OTEL_RESOURCE_ATTRIBUTES"] = ",".join([f"{k}={v}" for k, v in attributes.items()])
+        os.environ["OTEL_RESOURCE_ATTRIBUTES"] = ",".join(
+            [f"{k}={v}" for k, v in attributes.items()]
+        )
 
     tracer_provider = TracerProvider(resource=resource, sampler=_get_trace_sampler())
     for processor in processors:
         tracer_provider.add_span_processor(processor)
 
     provider.set(tracer_provider)
-
 
 
 def _parse_otel_resource_attributes(otel_resource_attributes: str | None) -> dict:
@@ -509,7 +510,7 @@ def _parse_otel_resource_attributes(otel_resource_attributes: str | None) -> dic
             key, value = item.split("=", maxsplit=1)
             attributes[key.strip()] = value.strip()
     except ValueError:
-        _logger.warning(f"Failed to parse otel resource attributes, skipping", exc_info=True)
+        _logger.warning("Failed to parse otel resource attributes, skipping", exc_info=True)
         return {}
     return attributes
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -13,7 +13,7 @@ import json
 import logging
 import os
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Callable, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, ParamSpec, TypeVar
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
@@ -497,7 +497,7 @@ def _initialize_tracer_provider(disabled=False):
     provider.set(tracer_provider)
 
 
-def _parse_otel_resource_attributes(otel_resource_attributes: str | None) -> dict:
+def _parse_otel_resource_attributes(otel_resource_attributes: str | None) -> dict[str, Any]:
     """
     Parse the otel resource attributes from a comma separated key-value pairs string.
     """
@@ -510,7 +510,7 @@ def _parse_otel_resource_attributes(otel_resource_attributes: str | None) -> dic
             key, value = item.split("=", maxsplit=1)
             attributes[key.strip()] = value.strip()
     except ValueError:
-        _logger.warning("Failed to parse otel resource attributes, skipping", exc_info=True)
+        _logger.debug("Failed to parse otel resource attributes, skipping", exc_info=True)
         return {}
     return attributes
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -473,22 +473,45 @@ def _initialize_tracer_provider(disabled=False):
     otel_service_name = os.getenv("OTEL_SERVICE_NAME")
     otel_resource_attributes = os.getenv("OTEL_RESOURCE_ATTRIBUTES")
     resource = None
+    sdk_attributes = {
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "mlflow",
+        "telemetry.sdk.version": mlflow.__version__,
+    }
     if not otel_service_name and not otel_resource_attributes:
         # Setting an empty resource to avoid triggering resource aggregation, which causes
         # an issue in LiteLLM tracing: https://github.com/mlflow/mlflow/issues/16296
         # Add telemetry resource: https://opentelemetry.io/docs/specs/semconv/resource/#telemetry-sdk
-        resource = Resource(
-            {
-                "telemetry.sdk.language": "python",
-                "telemetry.sdk.name": "mlflow",
-                "telemetry.sdk.version": mlflow.__version__,
-            }
-        )
+        resource = Resource(sdk_attributes)
+    else:
+        # Update the env var to let otel initialize the resource with MLflow's SDK attributes
+        attributes = {**_parse_otel_resource_attributes(otel_resource_attributes), **sdk_attributes}
+        os.environ["OTEL_RESOURCE_ATTRIBUTES"] = ",".join([f"{k}={v}" for k, v in attributes.items()])
+
     tracer_provider = TracerProvider(resource=resource, sampler=_get_trace_sampler())
     for processor in processors:
         tracer_provider.add_span_processor(processor)
 
     provider.set(tracer_provider)
+
+
+
+def _parse_otel_resource_attributes(otel_resource_attributes: str | None) -> dict:
+    """
+    Parse the otel resource attributes from a comma separated key-value pairs string.
+    """
+    attributes = {}
+    if not otel_resource_attributes:
+        return attributes
+
+    try:
+        for item in otel_resource_attributes.split(","):
+            key, value = item.split("=", maxsplit=1)
+            attributes[key.strip()] = value.strip()
+    except ValueError:
+        _logger.warning(f"Failed to parse otel resource attributes, skipping", exc_info=True)
+        return {}
+    return attributes
 
 
 def _get_trace_sampler() -> TraceIdRatioBased | None:

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -509,7 +509,7 @@ def _parse_otel_resource_attributes(otel_resource_attributes: str | None) -> dic
         for item in otel_resource_attributes.split(","):
             key, value = item.split("=", maxsplit=1)
             attributes[key.strip()] = value.strip()
-    except ValueError:
+    except Exception:
         _logger.debug("Failed to parse otel resource attributes, skipping", exc_info=True)
         return {}
     return attributes

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -73,10 +73,14 @@ def create_mock_spans(diff_trace_id=False):
     mock_span1 = mock.MagicMock(spec=Span)
     mock_span1.trace_id = "trace123"
     mock_span1.to_otel_proto.return_value = otel_span1
+    mock_span1._span = mock.MagicMock()
+    mock_span1._span.resource = None
 
     mock_span2 = mock.MagicMock(spec=Span)
     mock_span2.trace_id = "trace456" if diff_trace_id else "trace123"
     mock_span2.to_otel_proto.return_value = otel_span2
+    mock_span2._span = mock.MagicMock()
+    mock_span2._span.resource = None
 
     return [mock_span1, mock_span2]
 

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -542,7 +542,6 @@ def test_metrics_export_without_otlp_trace_export(monkeypatch):
     assert processors[0]._export_metrics is True
 
 
-
 def test_otel_resource_attributes(monkeypatch):
     tracer = _get_tracer("test")
     # By default, only MLflow's SDK attributes are set on an empty resource
@@ -564,7 +563,6 @@ def test_otel_resource_attributes(monkeypatch):
         "telemetry.sdk.version": mlflow.__version__,
         "service.name": "unknown_service",
     }
-
 
     # Service name should be propagated from the env var
     mlflow.tracing.reset()


### PR DESCRIPTION
### What changes are proposed in this pull request?

Currently, Otel resource attributes for MLflow SDK is only set when there is no custom ones provided by users via `OTEL_RESOURCE_ATTRIBUTE` env var. However, the SDK telemetry should always be recorded, so this PR updates the logic to append them into the custom ones.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
