### PR TITLE
Fix bug with max tokens using max output tokens

### DIFF
--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -259,7 +259,7 @@ def _invoke_litellm_and_handle_tools(
 
         # For direct providers, use token-counting based pruning.
         try:
-            max_context_length = litellm.get_max_tokens(model)
+            max_context_length = litellm.get_model_info(model)["max_input_tokens"]
         except Exception:
             max_context_length = None
 

--- a/mlflow/genai/judges/optimizers/memalign/utils.py
+++ b/mlflow/genai/judges/optimizers/memalign/utils.py
@@ -15,7 +15,7 @@ from mlflow.genai.judges.optimizers.memalign.prompts import (
 
 # Try to import litellm at module level
 try:
-    from litellm import get_max_tokens, token_counter
+    from litellm import get_model_info, token_counter
 
     _LITELLM_AVAILABLE = True
 except ImportError:
@@ -44,7 +44,7 @@ def _get_model_max_tokens(model: str) -> int:
         return _MAX_MODEL_TOKENS
 
     try:
-        max_tokens = get_max_tokens(model)
+        max_tokens = get_model_info(model)["max_input_tokens"]
         if max_tokens is not None:
             return max_tokens
     except Exception as e:

--- a/tests/genai/judges/adapters/test_litellm_adapter.py
+++ b/tests/genai/judges/adapters/test_litellm_adapter.py
@@ -184,7 +184,7 @@ def test_invoke_litellm_and_handle_tools_with_context_window_exceeded_direct_pro
         mock.patch(
             "mlflow.genai.judges.adapters.litellm_adapter._prune_messages_exceeding_context_window_length"
         ) as mock_prune,
-        mock.patch("litellm.get_max_tokens", return_value=8000),
+        mock.patch("litellm.get_model_info", return_value={"max_input_tokens": 8000}),
     ):
         mock_prune.return_value = [litellm.Message(role="user", content="Pruned")]
 

--- a/tests/genai/judges/optimizers/memalign/test_utils.py
+++ b/tests/genai/judges/optimizers/memalign/test_utils.py
@@ -218,7 +218,10 @@ def test_retrieve_relevant_examples_out_of_bounds_raises():
 def test_truncate_to_token_limit_no_truncation_needed(token_count, text):
     with (
         patch("mlflow.genai.judges.optimizers.memalign.utils._LITELLM_AVAILABLE", True),
-        patch("mlflow.genai.judges.optimizers.memalign.utils.get_max_tokens", return_value=100),
+        patch(
+            "mlflow.genai.judges.optimizers.memalign.utils.get_model_info",
+            return_value={"max_input_tokens": 100},
+        ),
         patch(
             "mlflow.genai.judges.optimizers.memalign.utils.token_counter",
             return_value=token_count,
@@ -231,7 +234,10 @@ def test_truncate_to_token_limit_no_truncation_needed(token_count, text):
 def test_truncate_to_token_limit_happy_path_with_truncation():
     with (
         patch("mlflow.genai.judges.optimizers.memalign.utils._LITELLM_AVAILABLE", True),
-        patch("mlflow.genai.judges.optimizers.memalign.utils.get_max_tokens", return_value=100),
+        patch(
+            "mlflow.genai.judges.optimizers.memalign.utils.get_model_info",
+            return_value={"max_input_tokens": 100},
+        ),
         patch("mlflow.genai.judges.optimizers.memalign.utils.token_counter") as mock_counter,
     ):
         mock_counter.side_effect = [150, 90]
@@ -246,7 +252,10 @@ def test_truncate_to_token_limit_happy_path_with_truncation():
 def test_truncate_to_token_limit_multiple_iterations():
     with (
         patch("mlflow.genai.judges.optimizers.memalign.utils._LITELLM_AVAILABLE", True),
-        patch("mlflow.genai.judges.optimizers.memalign.utils.get_max_tokens", return_value=100),
+        patch(
+            "mlflow.genai.judges.optimizers.memalign.utils.get_model_info",
+            return_value={"max_input_tokens": 100},
+        ),
         patch("mlflow.genai.judges.optimizers.memalign.utils.token_counter") as mock_counter,
     ):
         mock_counter.side_effect = [200, 120, 95]
@@ -261,7 +270,10 @@ def test_truncate_to_token_limit_multiple_iterations():
 def test_truncate_to_token_limit_without_litellm():
     with (
         patch("mlflow.genai.judges.optimizers.memalign.utils._LITELLM_AVAILABLE", False),
-        patch("mlflow.genai.judges.optimizers.memalign.utils.get_max_tokens", return_value=100),
+        patch(
+            "mlflow.genai.judges.optimizers.memalign.utils.get_model_info",
+            return_value={"max_input_tokens": 100},
+        ),
     ):
         text = "a" * 200
         result = truncate_to_token_limit(text, "openai/gpt-4")
@@ -271,27 +283,27 @@ def test_truncate_to_token_limit_without_litellm():
 
 
 @pytest.mark.parametrize(
-    "max_tokens_side_effect",
+    "model_info_side_effect",
     [
         Exception("API Error"),
-        None,
+        {"max_input_tokens": None},
     ],
 )
-def test_truncate_to_token_limit_get_max_tokens_fallback(max_tokens_side_effect):
+def test_truncate_to_token_limit_get_model_info_fallback(model_info_side_effect):
     with patch("mlflow.genai.judges.optimizers.memalign.utils._LITELLM_AVAILABLE", True):
-        if isinstance(max_tokens_side_effect, Exception):
-            mock_get_max = patch(
-                "mlflow.genai.judges.optimizers.memalign.utils.get_max_tokens",
-                side_effect=max_tokens_side_effect,
+        if isinstance(model_info_side_effect, Exception):
+            mock_get_model_info = patch(
+                "mlflow.genai.judges.optimizers.memalign.utils.get_model_info",
+                side_effect=model_info_side_effect,
             )
         else:
-            mock_get_max = patch(
-                "mlflow.genai.judges.optimizers.memalign.utils.get_max_tokens",
-                return_value=max_tokens_side_effect,
+            mock_get_model_info = patch(
+                "mlflow.genai.judges.optimizers.memalign.utils.get_model_info",
+                return_value=model_info_side_effect,
             )
 
         with (
-            mock_get_max,
+            mock_get_model_info,
             patch("mlflow.genai.judges.optimizers.memalign.utils.token_counter", return_value=50),
         ):
             text = "This is a short text"

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -2265,7 +2265,7 @@ def test_context_window_error_removes_tool_calls_and_retries(exception, monkeypa
 
     monkeypatch.setattr("litellm.completion", mock_completion)
     monkeypatch.setattr("litellm.token_counter", lambda model, messages: len(messages) * 20)
-    monkeypatch.setattr("litellm.get_max_tokens", lambda model: 120)
+    monkeypatch.setattr("litellm.get_model_info", lambda model: {"max_input_tokens": 120})
 
     judge = make_judge(
         name="test", instructions="test {{inputs}}", feedback_value_type=str, model="openai:/gpt-4"


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```
from litellm import get_max_tokens, get_model_info

model = "gpt-4o"

max_output = get_max_tokens(model)
model_info = get_model_info(model)
max_input = model_info["max_input_tokens"]

print(f"get_max_tokens({model}): {max_output}")
print(f"get_model_info({model})['max_input_tokens']: {max_input}")
```

returns

```
get_max_tokens(gpt-4o): 16384
get_model_info(gpt-4o)['max_input_tokens']: 128000
```

Manually tested `make_judge` works:

```
judge = make_judge(
    name="test",
    instructions="Is {{ outputs }} a valid response?",
    feedback_value_type=bool,
    model="openai:/gpt-4o-mini",
)

result = judge(outputs={"answer": "Hello world"})
print(result)
```
returns
```
Feedback(name='test', source=AssessmentSource(source_type='LLM_JUDGE', source_id='openai:/gpt-4o-mini'), trace_id=None, run_id=None, rationale="The output provided does not answer any specific query since it only provides the phrase 'Hello world', which lacks context or relevance to the expected response. Without a clear question or prompt, this output cannot be considered valid. A valid response should directly address and provide insight or information related to the query posed.", metadata={'mlflow.assessment.judgeCost': 6.81e-05}, span_id=None, create_time_ms=1768973112474, last_update_time_ms=1768973112474, assessment_id=None, error=None, expectation=None, feedback=FeedbackValue(value=False, error=None), overrides=None, valid=True)
```


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
