### PR TITLE
Use different component ids between global prompt page and experiment prompt page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
@@ -17,6 +17,7 @@ import { useDebounce } from 'use-debounce';
 const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
   const [searchFilter, setSearchFilter] = useState('');
   const navigate = useNavigate();
+  const pageScope = experimentId ? 'experiment' : 'global';
 
   const [debouncedSearchFilter] = useDebounce(searchFilter, 500);
 
@@ -36,7 +37,11 @@ const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
       <Header
         title={<FormattedMessage defaultMessage="Prompts" description="Header title for the registered prompts page" />}
         buttons={
-          <Button componentId="mlflow.prompts.list.create" type="primary" onClick={openCreateVersionModal}>
+          <Button
+            componentId={`mlflow.prompts.${pageScope}.list.create`}
+            type="primary"
+            onClick={openCreateVersionModal}
+          >
             <FormattedMessage
               defaultMessage="Create prompt"
               description="Label for the create prompt button on the registered prompts page"
@@ -46,10 +51,15 @@ const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
       />
       <Spacer shrinks={false} />
       <div css={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-        <PromptsListFilters searchFilter={searchFilter} onSearchFilterChange={setSearchFilter} />
+        <PromptsListFilters searchFilter={searchFilter} onSearchFilterChange={setSearchFilter} pageScope={pageScope} />
         {error?.message && (
           <>
-            <Alert type="error" message={error.message} componentId="mlflow.prompts.list.error" closable={false} />
+            <Alert
+              type="error"
+              message={error.message}
+              componentId={`mlflow.prompts.${pageScope}.list.error`}
+              closable={false}
+            />
             <Spacer />
           </>
         )}
@@ -64,6 +74,7 @@ const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
           onPreviousPage={onPreviousPage}
           onEditTags={showEditPromptTagsModal}
           experimentId={experimentId}
+          pageScope={pageScope}
         />
       </div>
       {EditTagsModal}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
@@ -14,10 +14,46 @@ import ErrorUtils from '../../../common/utils/ErrorUtils';
 import { PromptPageErrorHandler } from './components/PromptPageErrorHandler';
 import { useDebounce } from 'use-debounce';
 
+export type PromptsListComponentId =
+  | 'mlflow.prompts.global.list.create'
+  | 'mlflow.prompts.global.list.error'
+  | 'mlflow.prompts.global.list.search'
+  | 'mlflow.prompts.global.list.pagination'
+  | 'mlflow.prompts.global.list.table.header'
+  | 'mlflow.prompts.experiment.list.create'
+  | 'mlflow.prompts.experiment.list.error'
+  | 'mlflow.prompts.experiment.list.search'
+  | 'mlflow.prompts.experiment.list.pagination'
+  | 'mlflow.prompts.experiment.list.table.header';
+
+export interface PromptsListComponentIds {
+  create: PromptsListComponentId;
+  error: PromptsListComponentId;
+  search: PromptsListComponentId;
+  pagination: PromptsListComponentId;
+  tableHeader: PromptsListComponentId;
+}
+
+const GLOBAL_COMPONENT_IDS: PromptsListComponentIds = {
+  create: 'mlflow.prompts.global.list.create',
+  error: 'mlflow.prompts.global.list.error',
+  search: 'mlflow.prompts.global.list.search',
+  pagination: 'mlflow.prompts.global.list.pagination',
+  tableHeader: 'mlflow.prompts.global.list.table.header',
+};
+
+const EXPERIMENT_COMPONENT_IDS: PromptsListComponentIds = {
+  create: 'mlflow.prompts.experiment.list.create',
+  error: 'mlflow.prompts.experiment.list.error',
+  search: 'mlflow.prompts.experiment.list.search',
+  pagination: 'mlflow.prompts.experiment.list.pagination',
+  tableHeader: 'mlflow.prompts.experiment.list.table.header',
+};
+
 const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
   const [searchFilter, setSearchFilter] = useState('');
   const navigate = useNavigate();
-  const pageScope = experimentId ? 'experiment' : 'global';
+  const componentIds = experimentId ? EXPERIMENT_COMPONENT_IDS : GLOBAL_COMPONENT_IDS;
 
   const [debouncedSearchFilter] = useDebounce(searchFilter, 500);
 
@@ -37,11 +73,7 @@ const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
       <Header
         title={<FormattedMessage defaultMessage="Prompts" description="Header title for the registered prompts page" />}
         buttons={
-          <Button
-            componentId={`mlflow.prompts.${pageScope}.list.create`}
-            type="primary"
-            onClick={openCreateVersionModal}
-          >
+          <Button componentId={componentIds.create} type="primary" onClick={openCreateVersionModal}>
             <FormattedMessage
               defaultMessage="Create prompt"
               description="Label for the create prompt button on the registered prompts page"
@@ -51,15 +83,14 @@ const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
       />
       <Spacer shrinks={false} />
       <div css={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-        <PromptsListFilters searchFilter={searchFilter} onSearchFilterChange={setSearchFilter} pageScope={pageScope} />
+        <PromptsListFilters
+          searchFilter={searchFilter}
+          onSearchFilterChange={setSearchFilter}
+          componentId={componentIds.search}
+        />
         {error?.message && (
           <>
-            <Alert
-              type="error"
-              message={error.message}
-              componentId={`mlflow.prompts.${pageScope}.list.error`}
-              closable={false}
-            />
+            <Alert type="error" message={error.message} componentId={componentIds.error} closable={false} />
             <Spacer />
           </>
         )}
@@ -74,7 +105,8 @@ const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
           onPreviousPage={onPreviousPage}
           onEditTags={showEditPromptTagsModal}
           experimentId={experimentId}
-          pageScope={pageScope}
+          paginationComponentId={componentIds.pagination}
+          tableHeaderComponentId={componentIds.tableHeader}
         />
       </div>
       {EditTagsModal}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListFilters.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListFilters.tsx
@@ -5,15 +5,17 @@ import { ModelSearchInputHelpTooltip } from '../../../../model-registry/componen
 export const PromptsListFilters = ({
   searchFilter,
   onSearchFilterChange,
+  pageScope,
 }: {
   searchFilter: string;
   onSearchFilterChange: (searchFilter: string) => void;
+  pageScope: 'global' | 'experiment';
 }) => {
   return (
     <TableFilterLayout>
       <TableFilterInput
         placeholder="Search prompts by name or tags"
-        componentId="mlflow.prompts.list.search"
+        componentId={`mlflow.prompts.${pageScope}.list.search`}
         value={searchFilter}
         onChange={(e) => onSearchFilterChange(e.target.value)}
         suffix={<ModelSearchInputHelpTooltip exampleEntityName="my-prompt-name" />}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListFilters.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListFilters.tsx
@@ -1,21 +1,22 @@
 import { TableFilterInput, TableFilterLayout } from '@databricks/design-system';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { ModelSearchInputHelpTooltip } from '../../../../model-registry/components/model-list/ModelListFilters';
+import type { PromptsListComponentId } from '../PromptsPage';
 
 export const PromptsListFilters = ({
   searchFilter,
   onSearchFilterChange,
-  pageScope,
+  componentId,
 }: {
   searchFilter: string;
   onSearchFilterChange: (searchFilter: string) => void;
-  pageScope: 'global' | 'experiment';
+  componentId: PromptsListComponentId;
 }) => {
   return (
     <TableFilterLayout>
       <TableFilterInput
         placeholder="Search prompts by name or tags"
-        componentId={`mlflow.prompts.${pageScope}.list.search`}
+        componentId={componentId}
         value={searchFilter}
         onChange={(e) => onSearchFilterChange(e.target.value)}
         suffix={<ModelSearchInputHelpTooltip exampleEntityName="my-prompt-name" />}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTable.tsx
@@ -20,6 +20,7 @@ import { PromptsListTableNameCell } from './PromptsListTableNameCell';
 import Utils from '../../../../common/utils/Utils';
 import { PromptsListTableVersionCell } from './PromptsListTableVersionCell';
 import type { PromptsTableMetadata } from '../utils';
+import type { PromptsListComponentId } from '../PromptsPage';
 import { first, isEmpty } from 'lodash';
 
 type PromptsTableColumnDef = ColumnDef<RegisteredPrompt>;
@@ -79,7 +80,8 @@ export const PromptsListTable = ({
   onPreviousPage,
   onEditTags,
   experimentId,
-  pageScope,
+  paginationComponentId,
+  tableHeaderComponentId,
 }: {
   prompts?: RegisteredPrompt[];
   error?: Error;
@@ -91,7 +93,8 @@ export const PromptsListTable = ({
   onPreviousPage: () => void;
   onEditTags: (editedEntity: RegisteredPrompt) => void;
   experimentId?: string;
-  pageScope: 'global' | 'experiment';
+  paginationComponentId: PromptsListComponentId;
+  tableHeaderComponentId: PromptsListComponentId;
 }) => {
   const { theme } = useDesignSystemTheme();
   const columns = usePromptsTableColumns();
@@ -152,14 +155,14 @@ export const PromptsListTable = ({
           hasPreviousPage={hasPreviousPage}
           onNextPage={onNextPage}
           onPreviousPage={onPreviousPage}
-          componentId={`mlflow.prompts.${pageScope}.list.pagination`}
+          componentId={paginationComponentId}
         />
       }
       empty={getEmptyState()}
     >
       <TableRow isHeader>
         {table.getLeafHeaders().map((header) => (
-          <TableHeader componentId={`mlflow.prompts.${pageScope}.list.table.header`} key={header.id}>
+          <TableHeader componentId={tableHeaderComponentId} key={header.id}>
             {flexRender(header.column.columnDef.header, header.getContext())}
           </TableHeader>
         ))}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTable.tsx
@@ -79,6 +79,7 @@ export const PromptsListTable = ({
   onPreviousPage,
   onEditTags,
   experimentId,
+  pageScope,
 }: {
   prompts?: RegisteredPrompt[];
   error?: Error;
@@ -90,6 +91,7 @@ export const PromptsListTable = ({
   onPreviousPage: () => void;
   onEditTags: (editedEntity: RegisteredPrompt) => void;
   experimentId?: string;
+  pageScope: 'global' | 'experiment';
 }) => {
   const { theme } = useDesignSystemTheme();
   const columns = usePromptsTableColumns();
@@ -150,14 +152,14 @@ export const PromptsListTable = ({
           hasPreviousPage={hasPreviousPage}
           onNextPage={onNextPage}
           onPreviousPage={onPreviousPage}
-          componentId="mlflow.prompts.list.pagination"
+          componentId={`mlflow.prompts.${pageScope}.list.pagination`}
         />
       }
       empty={getEmptyState()}
     >
       <TableRow isHeader>
         {table.getLeafHeaders().map((header) => (
-          <TableHeader componentId="mlflow.prompts.list.table.header" key={header.id}>
+          <TableHeader componentId={`mlflow.prompts.${pageScope}.list.table.header`} key={header.id}>
             {flexRender(header.column.columnDef.header, header.getContext())}
           </TableHeader>
         ))}


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Use different component ids between global prompt page and experiment prompt page for better understanding of usage pattern

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
