### PR TITLE
Improve scorer trace picker UX and validation

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
@@ -59,7 +59,7 @@ function TestWrapper({ defaultValues, onScorerFinished }: TestWrapperProps) {
       llmTemplate: LLM_TEMPLATE.CUSTOM,
       sampleRate: 100,
       scorerType: 'llm',
-      model: 'provider:/some-model',
+      model: 'gateway:/some-model',
       ...defaultValues,
     },
   });
@@ -108,11 +108,12 @@ describe('SampleScorerOutputPanelContainer', () => {
       expect(mockedRenderer).toHaveBeenCalledWith(
         expect.objectContaining({
           isLoading: false,
-          isRunScorerDisabled: false,
+          // Button is disabled initially because no traces are selected
+          isRunScorerDisabled: true,
           error: null,
           currentEvalResultIndex: 0,
           totalTraces: 0,
-          itemsToEvaluate: { itemCount: 1, itemIds: [] },
+          selectedItemIds: [],
         }),
         expect.anything(),
       );
@@ -198,7 +199,6 @@ describe('SampleScorerOutputPanelContainer', () => {
 
       expect(mockEvaluateTraces).toHaveBeenCalledWith({
         evaluationScope: ScorerEvaluationScope.TRACES,
-        itemCount: 1,
         itemIds: [],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions: 'Test instructions',

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelRenderer.tsx
@@ -15,7 +15,6 @@ import { FormattedMessage } from '@databricks/i18n';
 import { SimplifiedModelTraceExplorer } from '@databricks/web-shared/model-trace-explorer';
 import type { Assessment, ModelTrace } from '@databricks/web-shared/model-trace-explorer';
 import { COMPONENT_ID_PREFIX, BUTTON_VARIANT, type ButtonVariant, ScorerEvaluationScope } from './constants';
-import { EvaluateTracesParams } from './types';
 import { SampleScorerTracesToEvaluatePicker } from './SampleScorerTracesToEvaluatePicker';
 import { useFormContext } from 'react-hook-form';
 import { ScorerFormData } from './utils/scorerTransformUtils';
@@ -78,8 +77,8 @@ interface SampleScorerOutputPanelRendererProps {
   handlePrevious: () => void;
   handleNext: () => void;
   totalTraces: number;
-  itemsToEvaluate: Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>;
-  onItemsToEvaluateChange: (itemsToEvaluate: Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>) => void;
+  selectedItemIds: string[];
+  onSelectedItemIdsChange: (selectedItemIds: string[]) => void;
 }
 
 const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererProps> = ({
@@ -95,8 +94,8 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
   handlePrevious,
   handleNext,
   totalTraces,
-  itemsToEvaluate,
-  onItemsToEvaluateChange,
+  selectedItemIds,
+  onSelectedItemIdsChange,
 }) => {
   const { theme } = useDesignSystemTheme();
 
@@ -168,8 +167,8 @@ const SampleScorerOutputPanelRenderer: React.FC<SampleScorerOutputPanelRendererP
         </Typography.Text>
         <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
           <SampleScorerTracesToEvaluatePicker
-            itemsToEvaluate={itemsToEvaluate}
-            onItemsToEvaluateChange={onItemsToEvaluateChange}
+            selectedItemIds={selectedItemIds}
+            onSelectedItemIdsChange={onSelectedItemIdsChange}
           />
           {!isInitialScreen && (
             <Tooltip

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerTracesToEvaluatePicker.tsx
@@ -1,15 +1,7 @@
-import {
-  Button,
-  DialogComboboxOptionList,
-  DialogComboboxContent,
-  DialogComboboxOptionListSelectItem,
-} from '@databricks/design-system';
+import { Button } from '@databricks/design-system';
 
-import { ChevronDownIcon, DialogCombobox, DialogComboboxCustomButtonTriggerWrapper } from '@databricks/design-system';
-import { defineMessage, FormattedMessage } from 'react-intl';
-import { EvaluateTracesParams } from './types';
-import { isEmpty } from 'lodash';
-import { useMemo, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { useState } from 'react';
 import { coerceToEnum } from '../../../shared/web-shared/utils';
 import { SelectTracesModal } from '../../components/SelectTracesModal';
 import { ScorerFormData } from './utils/scorerTransformUtils';
@@ -17,139 +9,74 @@ import { useFormContext } from 'react-hook-form';
 import { MAX_SELECTED_ITEM_COUNT, ScorerEvaluationScope } from './constants';
 import { SelectSessionsModal } from '../../components/SelectSessionsModal';
 
-enum PickerOption {
-  'LAST_TRACE_OR_SESSION' = '1',
-  'CUSTOM' = 'custom',
-}
-
-const PickerOptionsLabelsForTraces = {
-  [PickerOption.LAST_TRACE_OR_SESSION]: defineMessage({
-    defaultMessage: 'Last trace',
-    description: 'Option for last trace',
-  }),
-  [PickerOption.CUSTOM]: defineMessage({
-    defaultMessage: 'Select traces',
-    description: 'Option for selecting custom traces',
-  }),
-};
-
-const PickerOptionsLabelsForSessions = {
-  [PickerOption.LAST_TRACE_OR_SESSION]: defineMessage({
-    defaultMessage: 'Last session',
-    description: 'Option for last session',
-  }),
-  [PickerOption.CUSTOM]: defineMessage({
-    defaultMessage: 'Select sessions',
-    description: 'Option for selecting custom traces',
-  }),
-};
-
 export const SampleScorerTracesToEvaluatePicker = ({
-  onItemsToEvaluateChange,
-  itemsToEvaluate,
+  selectedItemIds,
+  onSelectedItemIdsChange,
 }: {
-  itemsToEvaluate: Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>;
-  onItemsToEvaluateChange: (itemsToEvaluate: Pick<EvaluateTracesParams, 'itemCount' | 'itemIds'>) => void;
+  selectedItemIds: string[];
+  onSelectedItemIdsChange: (selectedItemIds: string[]) => void;
 }) => {
   const { watch } = useFormContext<ScorerFormData>();
 
   const evaluationScope = coerceToEnum(ScorerEvaluationScope, watch('evaluationScope'), ScorerEvaluationScope.TRACES);
 
-  const PickerOptionsLabels =
-    evaluationScope === ScorerEvaluationScope.TRACES ? PickerOptionsLabelsForTraces : PickerOptionsLabelsForSessions;
-
   const [displayPickCustomTracesModal, setDisplayPickCustomTracesModal] = useState(false);
-  const itemsToEvaluateDropdownValue = useMemo(() => {
-    if (!isEmpty(itemsToEvaluate.itemIds)) {
-      return PickerOption.CUSTOM;
-    }
-    return coerceToEnum(PickerOption, String(itemsToEvaluate.itemCount), PickerOption.LAST_TRACE_OR_SESSION);
-  }, [itemsToEvaluate]);
+  const hasSelectedItems = selectedItemIds.length > 0;
 
   return (
     <>
-      <DialogCombobox
-        componentId="mlflow.experiment-scorers.form.traces-picker"
-        id="mlflow.experiment-scorers.form.traces-picker"
-        value={[itemsToEvaluateDropdownValue]}
+      <Button
+        componentId="mlflow.experiment-scorers.form.traces-picker.trigger"
+        size="small"
+        onClick={() => setDisplayPickCustomTracesModal(true)}
       >
-        <DialogComboboxCustomButtonTriggerWrapper>
-          <Button
-            componentId="mlflow.experiment-scorers.form.traces-picker.trigger"
-            size="small"
-            endIcon={<ChevronDownIcon />}
-          >
-            {itemsToEvaluateDropdownValue === PickerOption.CUSTOM ? (
-              evaluationScope === ScorerEvaluationScope.TRACES ? (
-                <FormattedMessage
-                  defaultMessage="{count, plural, one {1 trace selected} other {# traces selected}}"
-                  description="Label for the number of traces selected"
-                  values={{ count: itemsToEvaluate.itemIds?.length }}
-                />
-              ) : (
-                <FormattedMessage
-                  defaultMessage="{count, plural, one {1 session selected} other {# sessions selected}}"
-                  description="Label for the number of sessions selected"
-                  values={{ count: itemsToEvaluate.itemIds?.length }}
-                />
-              )
-            ) : (
-              <FormattedMessage {...PickerOptionsLabels[itemsToEvaluateDropdownValue]} />
-            )}
-          </Button>
-        </DialogComboboxCustomButtonTriggerWrapper>
-        <DialogComboboxContent align="end">
-          <DialogComboboxOptionList>
-            <DialogComboboxOptionListSelectItem
-              value={PickerOption.LAST_TRACE_OR_SESSION}
-              checked={itemsToEvaluateDropdownValue === PickerOption.LAST_TRACE_OR_SESSION}
-              onChange={() => {
-                onItemsToEvaluateChange({ itemCount: Number(PickerOption.LAST_TRACE_OR_SESSION), itemIds: undefined });
-              }}
-            >
-              <FormattedMessage {...PickerOptionsLabels[PickerOption.LAST_TRACE_OR_SESSION]} />
-            </DialogComboboxOptionListSelectItem>
-            <DialogComboboxOptionListSelectItem
-              value={PickerOption.CUSTOM}
-              checked={itemsToEvaluateDropdownValue === PickerOption.CUSTOM}
-              onChange={() => {
-                setDisplayPickCustomTracesModal(true);
-              }}
-            >
-              <FormattedMessage {...PickerOptionsLabels[PickerOption.CUSTOM]} />
-            </DialogComboboxOptionListSelectItem>
-          </DialogComboboxOptionList>
-        </DialogComboboxContent>
-      </DialogCombobox>
+        {hasSelectedItems ? (
+          evaluationScope === ScorerEvaluationScope.TRACES ? (
+            <FormattedMessage
+              defaultMessage="{count, plural, one {1 trace selected} other {# traces selected}}"
+              description="Label for the number of traces selected"
+              values={{ count: selectedItemIds.length }}
+            />
+          ) : (
+            <FormattedMessage
+              defaultMessage="{count, plural, one {1 session selected} other {# sessions selected}}"
+              description="Label for the number of sessions selected"
+              values={{ count: selectedItemIds.length }}
+            />
+          )
+        ) : evaluationScope === ScorerEvaluationScope.TRACES ? (
+          <FormattedMessage defaultMessage="Select traces" description="Button to select traces" />
+        ) : (
+          <FormattedMessage defaultMessage="Select sessions" description="Button to select sessions" />
+        )}
+      </Button>
       {displayPickCustomTracesModal && evaluationScope === ScorerEvaluationScope.TRACES && (
         <SelectTracesModal
           onClose={() => {
-            onItemsToEvaluateChange({ ...itemsToEvaluate });
             setDisplayPickCustomTracesModal(false);
           }}
           onSuccess={(traceIds) => {
-            if (!isEmpty(traceIds)) {
-              onItemsToEvaluateChange({ itemCount: undefined, itemIds: traceIds });
+            if (traceIds.length > 0) {
+              onSelectedItemIdsChange(traceIds);
             }
             setDisplayPickCustomTracesModal(false);
           }}
-          initialTraceIdsSelected={itemsToEvaluate.itemIds}
+          initialTraceIdsSelected={selectedItemIds}
           maxTraceCount={MAX_SELECTED_ITEM_COUNT}
         />
       )}
       {displayPickCustomTracesModal && evaluationScope === ScorerEvaluationScope.SESSIONS && (
         <SelectSessionsModal
           onClose={() => {
-            onItemsToEvaluateChange({ ...itemsToEvaluate });
             setDisplayPickCustomTracesModal(false);
           }}
-          onSuccess={(traceIds) => {
-            if (!isEmpty(traceIds)) {
-              onItemsToEvaluateChange({ itemCount: undefined, itemIds: traceIds });
+          onSuccess={(sessionIds) => {
+            if (sessionIds.length > 0) {
+              onSelectedItemIdsChange(sessionIds);
             }
             setDisplayPickCustomTracesModal(false);
           }}
-          initialSessionIdsSelected={itemsToEvaluate.itemIds}
+          initialSessionIdsSelected={selectedItemIds}
           maxSessionCount={MAX_SELECTED_ITEM_COUNT}
         />
       )}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
@@ -200,7 +200,7 @@ describe('useEvaluateTraces', () => {
       expect(state.error).toBeNull();
 
       const evaluationResults = await evaluateTraces({
-        itemCount: 1,
+        itemIds: [traceId],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -249,13 +249,13 @@ describe('useEvaluateTraces', () => {
       const experimentId = 'exp-123';
       const judgeInstructions = 'Evaluate the quality';
 
-      const mockTraces: ModelTrace[] = traceIds.map((traceId) => ({
-        info: { trace_id: traceId } as any,
+      const mockTraces: ModelTrace[] = traceIds.map((id) => ({
+        info: { trace_id: id } as any,
         data: {
           spans: [
             {
-              trace_id: traceId,
-              span_id: `span-${traceId}`,
+              trace_id: id,
+              span_id: `span-${id}`,
               name: 'root',
               trace_state: '',
               parent_span_id: null,
@@ -263,8 +263,8 @@ describe('useEvaluateTraces', () => {
               end_time_unix_nano: '1000000',
               status: { code: 'STATUS_CODE_UNSET' },
               attributes: {
-                'mlflow.spanInputs': `input-${traceId}`,
-                'mlflow.spanOutputs': `output-${traceId}`,
+                'mlflow.spanInputs': `input-${id}`,
+                'mlflow.spanOutputs': `output-${id}`,
               },
             },
           ],
@@ -286,8 +286,8 @@ describe('useEvaluateTraces', () => {
       );
 
       // Verify initial cache state
-      traceIds.forEach((traceId) => {
-        const initialCache = queryClient.getQueryData(['GetMlflowTraceV3', traceId]);
+      traceIds.forEach((id) => {
+        const initialCache = queryClient.getQueryData(['GetMlflowTraceV3', id]);
         expect(initialCache).toBeUndefined();
       });
 
@@ -295,7 +295,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: traceIds.length,
+        itemIds: traceIds,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -370,7 +370,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: 1,
+        itemIds: [traceId],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -423,7 +423,7 @@ describe('useEvaluateTraces', () => {
 
       // First call - should fetch from API
       await evaluateTraces({
-        itemCount: 1,
+        itemIds: [traceId],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -434,7 +434,7 @@ describe('useEvaluateTraces', () => {
       // Second call with same traceId - traces should use cache, so no additional trace API calls
       // but chat completions will be called again (not cached by design)
       await evaluateTraces({
-        itemCount: 1,
+        itemIds: [traceId],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -475,7 +475,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: 1,
+        itemIds: [traceId],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -509,7 +509,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: 0,
+        itemIds: [],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -546,7 +546,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: 1,
+        itemIds: [traceId],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -574,8 +574,8 @@ describe('useEvaluateTraces', () => {
       const experimentId = 'exp-123';
       const judgeInstructions = 'Evaluate';
 
-      const mockTraces: ModelTrace[] = traceIds.map((traceId) => ({
-        info: { trace_id: traceId } as any,
+      const mockTraces: ModelTrace[] = traceIds.map((id) => ({
+        info: { trace_id: id } as any,
         data: { spans: [] },
       }));
 
@@ -602,7 +602,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: traceIds.length,
+        itemIds: traceIds,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -676,7 +676,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: 1,
+        itemIds: [traceId],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -719,7 +719,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: 1,
+        itemIds: [traceId],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -759,7 +759,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: 1,
+        itemIds: [traceId],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -797,7 +797,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: 1,
+        itemIds: [traceId],
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -823,8 +823,8 @@ describe('useEvaluateTraces', () => {
       const experimentId = 'exp-123';
       const judgeInstructions = 'Evaluate';
 
-      const mockTraces: ModelTrace[] = traceIds.map((traceId) => ({
-        info: { trace_id: traceId } as any,
+      const mockTraces: ModelTrace[] = traceIds.map((id) => ({
+        info: { trace_id: id } as any,
         data: { spans: [] },
       }));
 
@@ -841,7 +841,7 @@ describe('useEvaluateTraces', () => {
       const [evaluateTraces] = result.current;
 
       const evaluationResults = await evaluateTraces({
-        itemCount: traceIds.length,
+        itemIds: traceIds,
         locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
         judgeInstructions,
         experimentId,
@@ -921,7 +921,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          itemCount: 1,
+          itemIds: [traceId],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -965,13 +965,13 @@ describe('useEvaluateTraces', () => {
         const experimentId = 'exp-123';
         const requestedAssessments = [{ assessment_name: 'groundedness' }];
 
-        const mockTraces: ModelTrace[] = traceIds.map((traceId) => ({
-          info: { trace_id: traceId } as any,
+        const mockTraces: ModelTrace[] = traceIds.map((id) => ({
+          info: { trace_id: id } as any,
           data: {
             spans: [
               {
-                trace_id: traceId,
-                span_id: `span-${traceId}`,
+                trace_id: id,
+                span_id: `span-${id}`,
                 name: 'root',
                 trace_state: '',
                 parent_span_id: null,
@@ -979,8 +979,8 @@ describe('useEvaluateTraces', () => {
                 end_time_unix_nano: '1000000',
                 status: { code: 'STATUS_CODE_UNSET' },
                 attributes: {
-                  'mlflow.spanInputs': `input-${traceId}`,
-                  'mlflow.spanOutputs': `output-${traceId}`,
+                  'mlflow.spanInputs': `input-${id}`,
+                  'mlflow.spanOutputs': `output-${id}`,
                 },
               },
             ],
@@ -1011,7 +1011,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          itemCount: traceIds.length,
+          itemIds: traceIds,
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1102,7 +1102,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         await evaluateTraces({
-          itemCount: 1,
+          itemIds: [traceId],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1147,7 +1147,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          itemCount: 1,
+          itemIds: [traceId],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1213,7 +1213,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          itemCount: 1,
+          itemIds: [traceId],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1239,7 +1239,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          itemCount: 0,
+          itemIds: [],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1284,7 +1284,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          itemCount: 1,
+          itemIds: [traceId],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,
@@ -1304,13 +1304,13 @@ describe('useEvaluateTraces', () => {
         const experimentId = 'exp-123';
         const requestedAssessments = [{ assessment_name: 'correctness' }];
 
-        const mockTraces: ModelTrace[] = traceIds.map((traceId) => ({
-          info: { trace_id: traceId } as any,
+        const mockTraces: ModelTrace[] = traceIds.map((id) => ({
+          info: { trace_id: id } as any,
           data: {
             spans: [
               {
-                trace_id: traceId,
-                span_id: `span-${traceId}`,
+                trace_id: id,
+                span_id: `span-${id}`,
                 name: 'root',
                 trace_state: '',
                 parent_span_id: null,
@@ -1318,7 +1318,7 @@ describe('useEvaluateTraces', () => {
                 end_time_unix_nano: '1000000',
                 status: { code: 'STATUS_CODE_UNSET' },
                 attributes: {
-                  'mlflow.spanInputs': `input-${traceId}`,
+                  'mlflow.spanInputs': `input-${id}`,
                 },
               },
             ],
@@ -1354,7 +1354,7 @@ describe('useEvaluateTraces', () => {
         const [evaluateTraces] = result.current;
 
         const evaluationResults = await evaluateTraces({
-          itemCount: traceIds.length,
+          itemIds: traceIds,
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           requestedAssessments,
           experimentId,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
@@ -14,18 +14,17 @@ import {
   extractTemplateVariables,
 } from '../../utils/evaluationUtils';
 import { searchMlflowTracesQueryFn, SEARCH_MLFLOW_TRACES_QUERY_KEY } from '@databricks/web-shared/genai-traces-table';
-import { DEFAULT_TRACE_COUNT, RETRIEVAL_ASSESSMENTS, ScorerEvaluationScope } from './constants';
+import { RETRIEVAL_ASSESSMENTS } from './constants';
 import {
   extractInputs,
   extractOutputs,
   extractRetrievalContext,
   extractExpectations,
-  type TraceRetrievalContexts,
   type RetrievalContext,
 } from '../../utils/TraceUtils';
 import { EvaluateChatCompletionsParams, EvaluateTracesParams } from './types';
 import { useGetTraceIdsForEvaluation } from './useGetTracesForEvaluation';
-import { getMlflowTraceV3ForEvaluation, JudgeEvaluationResult } from './useEvaluateTraces.common';
+import { JudgeEvaluationResult } from './useEvaluateTraces.common';
 import { useEvaluateTracesAsync } from './useEvaluateTracesAsync';
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx
@@ -182,7 +182,7 @@ describe('useEvaluateTracesAsync', () => {
       act(() => {
         const [evaluateFunction] = result.current;
         evaluateFunction({
-          itemCount: 1,
+          itemIds: ['trace-1'],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test instructions',
@@ -263,7 +263,7 @@ describe('useEvaluateTracesAsync', () => {
       await act(async () => {
         const [evaluateFunction] = result.current;
         evaluateFunction({
-          itemCount: 1,
+          itemIds: ['trace-1'],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test instructions',
@@ -359,7 +359,7 @@ describe('useEvaluateTracesAsync', () => {
       act(() => {
         const [evaluateTracesFn] = result.current;
         evaluateTracesFn({
-          itemCount: 1,
+          itemIds: ['trace-1'],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test instructions',
@@ -421,7 +421,7 @@ describe('useEvaluateTracesAsync', () => {
       act(() => {
         const [evaluateTracesFn] = result.current;
         evaluateTracesFn({
-          itemCount: 1,
+          itemIds: ['trace-1'],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test',
@@ -475,7 +475,7 @@ describe('useEvaluateTracesAsync', () => {
       await act(async () => {
         const [evaluateTracesFn] = result.current;
         evaluateTracesFn({
-          itemCount: 1,
+          itemIds: ['trace-1'],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test',
@@ -542,7 +542,7 @@ describe('useEvaluateTracesAsync', () => {
       act(() => {
         const [evaluateTracesFn] = result.current;
         evaluateTracesFn({
-          itemCount: 1,
+          itemIds: ['trace-1'],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test',
@@ -611,7 +611,7 @@ describe('useEvaluateTracesAsync', () => {
       await act(async () => {
         const [evaluateTracesFn] = result.current;
         evaluateTracesFn({
-          itemCount: 1,
+          itemIds: ['trace-1'],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Test',
@@ -723,7 +723,7 @@ describe('useEvaluateTracesAsync', () => {
       act(() => {
         const [evaluateFunction] = result.current;
         evaluateFunction({
-          itemCount: 1,
+          itemIds: [sessionId],
           locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
           experimentId,
           judgeInstructions: 'Evaluate the session',

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1390,10 +1390,6 @@
     "defaultMessage": "No API keys found",
     "description": "Empty state title when filter returns no results"
   },
-  "8nHnwU": {
-    "defaultMessage": "Select sessions",
-    "description": "Option for selecting custom traces"
-  },
   "8qJt7/": {
     "defaultMessage": "Experimental",
     "description": "Experimental badge shown for features which are experimental"
@@ -3777,10 +3773,6 @@
     "defaultMessage": "Description",
     "description": "Header for the description column in the experiments table"
   },
-  "SUmLKb": {
-    "defaultMessage": "Last session",
-    "description": "Option for last session"
-  },
   "SVNXvf": {
     "defaultMessage": "Create LLM judge",
     "description": "Title for new LLM judge modal"
@@ -3923,6 +3915,10 @@
   "TeN9hs": {
     "defaultMessage": "Traces",
     "description": "Label for the traces tab on the logged model details page"
+  },
+  "Tf8grA": {
+    "defaultMessage": "Select traces",
+    "description": "Button to select traces"
   },
   "TfuAgs": {
     "defaultMessage": "Hide group",
@@ -4679,6 +4675,10 @@
     "defaultMessage": "Not grounded",
     "description": "Evaluation results > grounded assessment > negative value label. Displayed if evaluation result is considered as not grounded."
   },
+  "Zg0h0m": {
+    "defaultMessage": "Please select traces to run the judge",
+    "description": "Tooltip message when no traces are selected"
+  },
   "ZgAOhX": {
     "defaultMessage": "Chart name",
     "description": "Runs charts > components > config > RunsChartsConfigureDifferenceChart > Chart name config section"
@@ -5107,6 +5107,10 @@
     "defaultMessage": "Hide assessments",
     "description": "Tooltip for a button that closes the assessments pane"
   },
+  "cSQJ9N": {
+    "defaultMessage": "Select sessions",
+    "description": "Button to select sessions"
+  },
   "cSSMIs": {
     "defaultMessage": "Copy artifact location",
     "description": "Copy tooltip to copy experiment artifact location from experiment runs table header"
@@ -5486,6 +5490,10 @@
   "faLIN+": {
     "defaultMessage": "Timestamp",
     "description": "Run page > Charts tab > Chart tooltip > Timestamp label"
+  },
+  "fb6ZYV": {
+    "defaultMessage": "Running the judge from the UI is only supported with gateway endpoints",
+    "description": "Tooltip message when model is not a gateway endpoint"
   },
   "fcIHyN": {
     "defaultMessage": "Medium",
@@ -6859,10 +6867,6 @@
     "defaultMessage": "Metric",
     "description": "Run page > Overview > Metrics table > Key column header"
   },
-  "pjluqu": {
-    "defaultMessage": "Select traces",
-    "description": "Option for selecting custom traces"
-  },
   "pl1bdY": {
     "defaultMessage": "Registered Models",
     "description": "Text for link back to models page under the header on the model version\n             view page"
@@ -6974,6 +6978,10 @@
   "qVQYZH": {
     "defaultMessage": "Show less",
     "description": "Button to close alert description"
+  },
+  "qcYoo4": {
+    "defaultMessage": "Please select sessions to run the judge",
+    "description": "Tooltip message when no sessions are selected"
   },
   "qkRBUr": {
     "defaultMessage": "Line smoothing",
@@ -7494,10 +7502,6 @@
   "uq6CTI": {
     "defaultMessage": "No profile available",
     "description": "Text for no profile available in the experiment run dataset drawer"
-  },
-  "urVshe": {
-    "defaultMessage": "Last trace",
-    "description": "Option for last trace"
   },
   "urvfNd": {
     "defaultMessage": "Cancel",


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR makes two adjustments to the scorer evaluation UI based on UX feedback:

1. **Remove "Last trace/session" dropdown option** - Users must now explicitly select traces/sessions via the modal picker. This simplifies the UI and makes trace selection more intentional.

2. **Disable "Run judge" button for non-gateway models** - Direct model endpoints are not supported for running judges from the UI, so the button is now disabled with an explanatory tooltip.

Key changes:
- Simplified `itemsToEvaluate` state from `{ itemCount, itemIds }` to just `selectedItemIds: string[]`
- Replaced dropdown with a simple button that opens the selection modal
- Added validation to disable run button when no traces are selected
- Added validation to disable run button for direct (non-gateway) models

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Updated existing unit tests to reflect the simplified state shape. Manually verified the UI changes work correctly.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)