### PR TITLE
Improve Assistant chat panel UX

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -125,7 +125,7 @@ const ChatMessageBubble = ({
               }}
             >
               {activeTools && activeTools.length > 0 && activeTools[0].description
-                ? activeTools[0].description
+                ? `Tool: ${activeTools[0].description}`
                 : 'Processing'}
             </span>
           </div>
@@ -342,11 +342,10 @@ const ChatPanelContent = () => {
         >
           <div css={{ display: 'flex', alignItems: 'center' }}>
             <input
-              placeholder="Ask a question about this trace..."
+              placeholder="Ask a question..."
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
-              disabled={isStreaming}
               css={{
                 flex: 1,
                 border: 'none',
@@ -361,10 +360,6 @@ const ChatPanelContent = () => {
                 '&:focus': {
                   border: 'none',
                   outline: 'none',
-                },
-                '&:disabled': {
-                  cursor: 'not-allowed',
-                  opacity: 0.5,
                 },
               }}
             />
@@ -517,8 +512,8 @@ export const AssistantChatPanel = () => {
     return <ChatPanelContent />;
   };
 
-  // Determine if we should show the chat controls (new chat button)
-  const showChatControls = setupComplete && !isInSetupWizard;
+  // Only show chat button when setup is complete, not in wizard, and within an experiment context
+  const showChatControls = setupComplete && !isInSetupWizard && Boolean(experimentId);
 
   return (
     <div

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -43,6 +43,10 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   const { getContext: getPageContext } = useAssistantPageContextActions();
 
   const appendToStreamingMessage = useCallback((text: string) => {
+    // Add newline separator if there's already content (e.g. reasoning)
+    if (streamingMessageRef.current && !streamingMessageRef.current.endsWith('\n') && !text.startsWith('\n')) {
+      streamingMessageRef.current += '\n\n';
+    }
     streamingMessageRef.current += text;
     setMessages((prev) => {
       const lastMessage = prev[prev.length - 1];


### PR DESCRIPTION
### What changes are proposed in this pull request?

Address small UX issues identified in the bug bash:

- Hide new chat button when outside experiment context (empty state outside experiment will be added in a separate PR)
- Use generic placeholder text for input field, not specific to trace
- Add "Tool:" prefix to tool execution status to make the text like "Get Trace from MLflow..." less strange (hopefully)
- Fix missing newlines between reasoning
- Allow typing input while assistant is responding (sending is disabled)

<img width="492" height="396" alt="Screenshot 2026-01-21 at 17 54 37" src="https://github.com/user-attachments/assets/37576d26-30f7-4164-bf78-8f195c7690ce" />

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
