### PR TITLE
Improve custom code judge modal UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/CustomCodeScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/CustomCodeScorerFormRenderer.tsx
@@ -128,7 +128,7 @@ mlflow.genai.evaluate(
         </Typography.Text>
         {/* Step 1: Install MLflow */}
         <div>
-          <Typography.Title level={4} css={{ marginBottom: theme.spacing.sm }}>
+          <Typography.Title level={4} css={{ marginTop: theme.spacing.sm }}>
             <FormattedMessage
               defaultMessage="Step 1: Install MLflow"
               description="Step 1 title for custom judge creation"
@@ -149,7 +149,7 @@ mlflow.genai.evaluate(
         </div>
         {/* Step 2: Define your scorer */}
         <div>
-          <Typography.Title level={4} css={{ marginBottom: theme.spacing.sm }}>
+          <Typography.Title level={4} css={{ marginTop: theme.spacing.sm }}>
             <FormattedMessage
               defaultMessage="Step 2: Define your judge function"
               description="Step 2 title for custom judge creation"
@@ -182,7 +182,7 @@ mlflow.genai.evaluate(
         </div>
         {/* Step 3: Run the scorer */}
         <div>
-          <Typography.Title level={4} css={{ marginBottom: theme.spacing.sm }}>
+          <Typography.Title level={4} css={{ marginTop: theme.spacing.sm }}>
             <FormattedMessage
               defaultMessage="Step 3: Run the judge"
               description="Step 3 title for custom judge creation"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/ScorerFormRenderer.tsx
@@ -245,19 +245,22 @@ const ScorerFormRenderer: React.FC<ScorerFormRendererProps> = ({
         >
           <FormattedMessage defaultMessage="Cancel" description="Cancel button text" />
         </Button>
-        <Button
-          componentId="codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_298"
-          type="primary"
-          htmlType="submit"
-          loading={mutation.isLoading}
-          disabled={isSubmitDisabled}
-        >
-          {mode === SCORER_FORM_MODE.EDIT ? (
-            <FormattedMessage defaultMessage="Save" description="Save judge button text" />
-          ) : (
-            <FormattedMessage defaultMessage="Create judge" description="Create judge button text" />
-          )}
-        </Button>
+        {/* Hide submit button for custom-code in create mode since it's always disabled */}
+        {!(scorerType === 'custom-code' && mode === SCORER_FORM_MODE.CREATE) && (
+          <Button
+            componentId="codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_298"
+            type="primary"
+            htmlType="submit"
+            loading={mutation.isLoading}
+            disabled={isSubmitDisabled}
+          >
+            {mode === SCORER_FORM_MODE.EDIT ? (
+              <FormattedMessage defaultMessage="Save" description="Save judge button text" />
+            ) : (
+              <FormattedMessage defaultMessage="Create judge" description="Create judge button text" />
+            )}
+          </Button>
+        )}
       </div>
     </form>
   );


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Improves the custom code judge modal experience:

1. **Removes the always-disabled "Create judge" button** - The button was always disabled for custom code scorers in create mode since creation happens via code, not the UI. Removing it reduces confusion.

2. **Adjusts step title spacing** - Changed from `marginBottom` to `marginTop` on step titles for better visual flow between sections.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="669" height="862" alt="image" src="https://github.com/user-attachments/assets/40fde15a-2e88-49b4-845f-15e631b04890" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)