### PR TITLE
Update tqdm bar to distinguish predict_fn from simulator latency

### DIFF
--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -56,8 +56,7 @@ _EXPECTED_TEST_CASE_KEYS = {"goal", "persona", "context", "expectations"}
 _REQUIRED_TEST_CASE_KEYS = {"goal"}
 
 PGBAR_FORMAT = (
-    "{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt} "
-    "[Elapsed: {elapsed}, Remaining: {remaining}]{postfix}"
+    "{l_bar}{bar}| {n_fmt}/{total_fmt} [Elapsed: {elapsed}, Remaining: {remaining}] {postfix}"
 )
 
 
@@ -77,7 +76,12 @@ class SimulationTimingTracker:
     def format_postfix(self) -> str:
         with self._lock:
             simulator_time = self.generate_message + self.check_goal
-            return f" (predict: {self.predict_fn:.1f}s, simulator: {simulator_time:.1f}s)"
+            total = self.predict_fn + simulator_time
+            if total == 0:
+                return "(predict: 0%, simulator: 0%)"
+            predict_pct = 100 * self.predict_fn / total
+            simulator_pct = 100 * simulator_time / total
+            return f"(predict: {predict_pct:.1f}%, simulator: {simulator_pct:.1f}%)"
 
 
 _MODEL_API_DOC = {

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
+from dataclasses import dataclass, field
+from threading import Lock
 from typing import TYPE_CHECKING, Any, Callable
 
 import pydantic
@@ -51,6 +54,31 @@ _logger = logging.getLogger(__name__)
 _MAX_METADATA_LENGTH = 250
 _EXPECTED_TEST_CASE_KEYS = {"goal", "persona", "context", "expectations"}
 _REQUIRED_TEST_CASE_KEYS = {"goal"}
+
+PGBAR_FORMAT = (
+    "{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt} "
+    "[Elapsed: {elapsed}, Remaining: {remaining}]{postfix}"
+)
+
+
+@dataclass
+class SimulationTimingTracker:
+    _lock: Lock = field(default_factory=Lock, repr=False)
+    predict_fn: float = 0.0
+    generate_message: float = 0.0
+    check_goal: float = 0.0
+
+    def add(self, predict_fn: float = 0, generate_message: float = 0, check_goal: float = 0):
+        with self._lock:
+            self.predict_fn += predict_fn
+            self.generate_message += generate_message
+            self.check_goal += check_goal
+
+    def format_postfix(self) -> str:
+        with self._lock:
+            simulator_time = self.generate_message + self.check_goal
+            return f" (predict: {self.predict_fn:.1f}s, simulator: {simulator_time:.1f}s)"
+
 
 _MODEL_API_DOC = {
     "model": """Model to use for generating user messages. Must be one of:
@@ -395,12 +423,14 @@ class ConversationSimulator:
         num_test_cases = len(self.test_cases)
         all_trace_ids: list[list[str]] = [[] for _ in range(num_test_cases)]
         max_workers = min(num_test_cases, MLFLOW_GENAI_EVAL_MAX_WORKERS.get())
+        timings = SimulationTimingTracker()
 
         progress_bar = (
             tqdm(
                 total=num_test_cases,
                 desc="Simulating conversations",
-                unit="conversation",
+                bar_format=PGBAR_FORMAT,
+                postfix=timings.format_postfix(),
             )
             if tqdm
             else None
@@ -414,7 +444,7 @@ class ConversationSimulator:
             ) as executor,
         ):
             futures = {
-                executor.submit(self._run_conversation, test_case, predict_fn): i
+                executor.submit(self._run_conversation, test_case, predict_fn, timings): i
                 for i, test_case in enumerate(self.test_cases)
             }
             try:
@@ -428,6 +458,7 @@ class ConversationSimulator:
                             f"{self.test_cases[idx].get('goal')}: {e}"
                         )
                     if progress_bar:
+                        progress_bar.set_postfix_str(timings.format_postfix(), refresh=False)
                         progress_bar.update(1)
             finally:
                 if progress_bar:
@@ -436,7 +467,10 @@ class ConversationSimulator:
         return all_trace_ids
 
     def _run_conversation(
-        self, test_case: dict[str, Any], predict_fn: Callable[..., dict[str, Any]]
+        self,
+        test_case: dict[str, Any],
+        predict_fn: Callable[..., dict[str, Any]],
+        timings: SimulationTimingTracker,
     ) -> list[str]:
         goal = test_case["goal"]
         persona = test_case.get("persona")
@@ -456,12 +490,14 @@ class ConversationSimulator:
 
         for turn in range(self.max_turns):
             try:
-                # Generate a user message using the simulated user agent.
+                start_time = time.perf_counter()
                 user_message_content = user_agent.generate_message(conversation_history, turn)
+                timings.add(generate_message=time.perf_counter() - start_time)
+
                 user_message = {"role": "user", "content": user_message_content}
                 conversation_history.append(user_message)
 
-                # Invoke the predict_fn with the user message and context.
+                start_time = time.perf_counter()
                 response, trace_id = self._invoke_predict_fn(
                     predict_fn=predict_fn,
                     input_messages=conversation_history,
@@ -472,17 +508,24 @@ class ConversationSimulator:
                     expectations=expectations if turn == 0 else None,
                     turn=turn,
                 )
+                timings.add(predict_fn=time.perf_counter() - start_time)
 
                 if trace_id:
                     trace_ids.append(trace_id)
 
-                # Parse the assistant's response and check if the goal has been achieved.
                 assistant_content = parse_outputs_to_str(response)
                 if not assistant_content or not assistant_content.strip():
                     _logger.debug(f"Stopping conversation: empty response at turn {turn}")
                     break
                 conversation_history.append({"role": "assistant", "content": assistant_content})
-                if self._check_goal_achieved(conversation_history, assistant_content, goal):
+
+                start_time = time.perf_counter()
+                goal_achieved = self._check_goal_achieved(
+                    conversation_history, assistant_content, goal
+                )
+                timings.add(check_goal=time.perf_counter() - start_time)
+
+                if goal_achieved:
                     _logger.debug(f"Stopping conversation: goal achieved at turn {turn}")
                     break
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Output of a simulator now:
```
Simulating conversations: 100%|██████████████████| 3/3 [Elapsed: 00:42, Remaining: 00:00] , (predict: 57%, simulator: 43%)
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
