### PR TITLE
Fix tool name extraction for tool call correctness

### DIFF
--- a/mlflow/genai/scorers/deepeval/utils.py
+++ b/mlflow/genai/scorers/deepeval/utils.py
@@ -8,6 +8,7 @@ from mlflow.entities.span import SpanAttributeKey, SpanType
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.utils.trace_utils import (
+    _extract_tool_name_from_span,
     _to_dict,
     extract_retrieval_context_from_trace,
     parse_inputs_to_str,
@@ -65,15 +66,6 @@ def _convert_to_deepeval_tool_calls(tool_call_dicts: list[dict[str, Any]]):
         )
         for tc_dict in tool_call_dicts
     ]
-
-
-def _extract_tool_name_from_span(span) -> str:
-    inputs = span.attributes.get(SpanAttributeKey.INPUTS)
-    if isinstance(inputs, dict):
-        call_data = inputs.get("call")
-        if isinstance(call_data, dict) and "tool_name" in call_data:
-            return call_data["tool_name"]
-    return span.name
 
 
 def _extract_tool_calls_from_trace(trace: Trace):

--- a/mlflow/genai/scorers/deepeval/utils.py
+++ b/mlflow/genai/scorers/deepeval/utils.py
@@ -67,6 +67,15 @@ def _convert_to_deepeval_tool_calls(tool_call_dicts: list[dict[str, Any]]):
     ]
 
 
+def _extract_tool_name_from_span(span) -> str:
+    inputs = span.attributes.get(SpanAttributeKey.INPUTS)
+    if isinstance(inputs, dict):
+        call_data = inputs.get("call")
+        if isinstance(call_data, dict) and "tool_name" in call_data:
+            return call_data["tool_name"]
+    return span.name
+
+
 def _extract_tool_calls_from_trace(trace: Trace):
     """
     Extract tool calls from trace spans with type TOOL.
@@ -86,7 +95,7 @@ def _extract_tool_calls_from_trace(trace: Trace):
 
     return [
         DeepEvalToolCall(
-            name=span.name,
+            name=_extract_tool_name_from_span(span),
             input_parameters=span.attributes.get(SpanAttributeKey.INPUTS),
             output=span.attributes.get(SpanAttributeKey.OUTPUTS),
         )

--- a/tests/genai/scorers/deepeval/test_utils.py
+++ b/tests/genai/scorers/deepeval/test_utils.py
@@ -8,7 +8,6 @@ from mlflow.genai.scorers.deepeval.models import create_deepeval_model
 from mlflow.genai.scorers.deepeval.utils import (
     _convert_to_deepeval_tool_calls,
     _extract_tool_calls_from_trace,
-    _extract_tool_name_from_span,
     map_scorer_inputs_to_deepeval_test_case,
 )
 
@@ -92,24 +91,6 @@ def test_extract_tool_calls_from_trace_returns_none_when_no_tools():
     trace = Mock()
     trace.search_spans.return_value = []
     assert _extract_tool_calls_from_trace(trace) is None
-
-
-def test_extract_tool_name_from_span_uses_span_name_by_default():
-    span = Mock(spec=Span)
-    span.name = "my_tool"
-    span.attributes = {SpanAttributeKey.INPUTS: {"arg": "value"}}
-
-    assert _extract_tool_name_from_span(span) == "my_tool"
-
-
-def test_extract_tool_name_from_span_extracts_from_call_tool_name():
-    span = Mock(spec=Span)
-    span.name = "ToolManager.handle_call"
-    span.attributes = {
-        SpanAttributeKey.INPUTS: {"call": {"tool_name": "list_client", "args": {"param": "value"}}}
-    }
-
-    assert _extract_tool_name_from_span(span) == "list_client"
 
 
 def test_map_mlflow_to_test_case_basic():

--- a/tests/genai/scorers/deepeval/test_utils.py
+++ b/tests/genai/scorers/deepeval/test_utils.py
@@ -8,6 +8,7 @@ from mlflow.genai.scorers.deepeval.models import create_deepeval_model
 from mlflow.genai.scorers.deepeval.utils import (
     _convert_to_deepeval_tool_calls,
     _extract_tool_calls_from_trace,
+    _extract_tool_name_from_span,
     map_scorer_inputs_to_deepeval_test_case,
 )
 
@@ -91,6 +92,24 @@ def test_extract_tool_calls_from_trace_returns_none_when_no_tools():
     trace = Mock()
     trace.search_spans.return_value = []
     assert _extract_tool_calls_from_trace(trace) is None
+
+
+def test_extract_tool_name_from_span_uses_span_name_by_default():
+    span = Mock(spec=Span)
+    span.name = "my_tool"
+    span.attributes = {SpanAttributeKey.INPUTS: {"arg": "value"}}
+
+    assert _extract_tool_name_from_span(span) == "my_tool"
+
+
+def test_extract_tool_name_from_span_extracts_from_call_tool_name():
+    span = Mock(spec=Span)
+    span.name = "ToolManager.handle_call"
+    span.attributes = {
+        SpanAttributeKey.INPUTS: {"call": {"tool_name": "list_client", "args": {"param": "value"}}}
+    }
+
+    assert _extract_tool_name_from_span(span) == "list_client"
 
 
 def test_map_mlflow_to_test_case_basic():


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

https://github.com/mlflow/mlflow/issues/20043

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
 Resolve #20043 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled - fixes the tool name extraction for our judges

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
import mlflow
from mlflow.entities import SpanType
from mlflow.genai.scorers.deepeval import ToolCorrectness

mlflow.set_tracking_uri("sqlite:///test_wrapper.db")
mlflow.set_experiment("wrapper_test")


@mlflow.trace
def agent_with_wrapper_tool(query: str):
    # Simulate a wrapper tool call like FastMCPToolset creates
    with mlflow.start_span(name="ToolManager.handle_call", span_type=SpanType.TOOL) as span:
        span.set_inputs({"call": {"tool_name": "list_client", "args": {"param": query}}})
        result = {"clients": ["client_a", "client_b"]}
        span.set_outputs(result)
    return f"Found clients for: {query}"


# Create a trace
response = agent_with_wrapper_tool("test query")
print(f"Agent response: {response}\n")

# Retrieve the trace
traces = mlflow.search_traces(experiment_ids=["1"])
trace_id = traces.iloc[0]["trace_id"]
trace = mlflow.get_trace(trace_id)

# Show what's in the trace
tool_spans = trace.search_spans(span_type=SpanType.TOOL)
print("Tool spans in trace:")
for span in tool_spans:
    print(f"  span.name: '{span.name}'")
    print(f"  inputs: {span.inputs}")

# Test with ToolCorrectness scorer
print("\n--- Testing ToolCorrectness scorer ---")
scorer = ToolCorrectness()

expectations = {
    "expected_tool_calls": [{"name": "list_client"}]
}

result = scorer(
    inputs={"query": "test query"},
    outputs={"response": response},
    expectations=expectations,
    trace=trace,
)

print(f"\nScorer result:")
print(f"  {result}")
```

results:

```
Tool spans in trace:
  span.name: 'ToolManager.handle_call'
  inputs: {'call': {'tool_name': 'list_client', 'args': {'param': 'test query'}}}

--- Testing ToolCorrectness scorer ---

Scorer result:
  Feedback(name='ToolCorrectness', source=AssessmentSource(source_type='LLM_JUDGE', source_id='openai:/gpt-4.1-mini'), trace_id=None, run_id=None, rationale="[\n\t Tool Calling Reason: All expected tools ['list_client'] were called (order not considered).\n\t Tool Selection Reason: No available tools were provided to assess tool selection criteria\n]\n", metadata={'score': 1.0, 'threshold': 0.5, 'mlflow.scorer.framework': 'deepeval'}, span_id=None, create_time_ms=1769038707044, last_update_time_ms=1769038707044, assessment_id=None, error=None, expectation=None, feedback=FeedbackValue(value=<CategoricalRating.YES: 'yes'>, error=None), overrides=None, valid=True)
```

Note that before the fix, this judge returned `NO`

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fix tool name extraction which impacted the ToolCallCorrectness scorer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
