### PR TITLE
Fix for SQLAlchemy 2.1

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -18,12 +18,17 @@ from sqlalchemy import event, sql
 from sqlalchemy.pool import (
     AssertionPool,
     AsyncAdaptedQueuePool,
-    FallbackAsyncAdaptedQueuePool,
     NullPool,
     QueuePool,
     SingletonThreadPool,
     StaticPool,
 )
+
+# FallbackAsyncAdaptedQueuePool was removed in SQLAlchemy 2.1
+try:
+    from sqlalchemy.pool import FallbackAsyncAdaptedQueuePool
+except ImportError:
+    FallbackAsyncAdaptedQueuePool = None
 
 from mlflow.environment_variables import (
     MLFLOW_MYSQL_SSL_CA,
@@ -350,12 +355,14 @@ def create_sqlalchemy_engine(db_uri):
         pool_class_map = {
             "AssertionPool": AssertionPool,
             "AsyncAdaptedQueuePool": AsyncAdaptedQueuePool,
-            "FallbackAsyncAdaptedQueuePool": FallbackAsyncAdaptedQueuePool,
             "NullPool": NullPool,
             "QueuePool": QueuePool,
             "SingletonThreadPool": SingletonThreadPool,
             "StaticPool": StaticPool,
         }
+        # FallbackAsyncAdaptedQueuePool was removed in SQLAlchemy 2.1
+        if FallbackAsyncAdaptedQueuePool is not None:
+            pool_class_map["FallbackAsyncAdaptedQueuePool"] = FallbackAsyncAdaptedQueuePool
         if poolclass not in pool_class_map:
             list_str = " ".join(pool_class_map.keys())
             err_str = (

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -24,12 +24,6 @@ from sqlalchemy.pool import (
     StaticPool,
 )
 
-# FallbackAsyncAdaptedQueuePool was removed in SQLAlchemy 2.1
-try:
-    from sqlalchemy.pool import FallbackAsyncAdaptedQueuePool
-except ImportError:
-    FallbackAsyncAdaptedQueuePool = None
-
 from mlflow.environment_variables import (
     MLFLOW_MYSQL_SSL_CA,
     MLFLOW_MYSQL_SSL_CERT,
@@ -360,9 +354,12 @@ def create_sqlalchemy_engine(db_uri):
             "SingletonThreadPool": SingletonThreadPool,
             "StaticPool": StaticPool,
         }
-        # FallbackAsyncAdaptedQueuePool was removed in SQLAlchemy 2.1
-        if FallbackAsyncAdaptedQueuePool is not None:
+        try:
+            from sqlalchemy.pool import FallbackAsyncAdaptedQueuePool
+
             pool_class_map["FallbackAsyncAdaptedQueuePool"] = FallbackAsyncAdaptedQueuePool
+        except ImportError:
+            pass
         if poolclass not in pool_class_map:
             list_str = " ".join(pool_class_map.keys())
             err_str = (

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -355,6 +355,7 @@ def create_sqlalchemy_engine(db_uri):
             "StaticPool": StaticPool,
         }
         try:
+            # FallbackAsyncAdaptedQueuePool was removed in SQLAlchemy 2.1
             from sqlalchemy.pool import FallbackAsyncAdaptedQueuePool
 
             pool_class_map["FallbackAsyncAdaptedQueuePool"] = FallbackAsyncAdaptedQueuePool


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

SQLAlchemy 2.1 made greenlet an optional dependency, which removes the public class `FallbackAsyncAdaptedQueuePool`. As this is supported directly through greenlet in the latest release, allow for a fallback import in the utils. 


### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
