### PR TITLE
Fix refresh button on traces tab

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3DateSelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3DateSelector.tsx
@@ -182,7 +182,6 @@ export const TracesV3DateSelector = React.memo(function TracesV3DateSelector({
           disabled={Boolean(isFetching)}
           onClick={() => {
             monitoringConfig.refresh();
-            invalidateMlflowSearchTracesCache({ queryClient });
           }}
         >
           <RefreshIcon />

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
@@ -47,13 +47,12 @@ const TracesV3ViewImpl = ({
   isLoadingExperiment?: boolean;
 }) => {
   const { theme } = useDesignSystemTheme();
-  const monitoringConfig = useMonitoringConfig();
 
   // Traces view only works with one experiment
   const experimentId = experimentIds[0];
   const [viewState] = useMonitoringViewState();
 
-  const timeRange = useMonitoringFiltersTimeRange(monitoringConfig.dateNow);
+  const timeRange = useMonitoringFiltersTimeRange();
 
   return (
     <div

--- a/mlflow/server/js/src/experiment-tracking/hooks/useMonitoringFilters.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/useMonitoringFilters.tsx
@@ -108,17 +108,16 @@ export const useMonitoringFilters = () => {
   return [monitoringFilters, setMonitoringFilters, disableAutomaticInitialization] as const;
 };
 
-export const useMonitoringFiltersTimeRange = (referenceTime?: Date) => {
+export const useMonitoringFiltersTimeRange = () => {
   const [monitoringFilters] = useMonitoringFilters();
-  const [dateNow] = useState(() => referenceTime ?? new Date());
 
   return useMemo(() => {
-    const { startTime, endTime } = getAbsoluteStartEndTime(dateNow, monitoringFilters);
+    const { startTime, endTime } = monitoringFilters;
     return {
       startTime: startTime ? new Date(startTime).getTime().toString() : undefined,
       endTime: endTime ? new Date(endTime).getTime().toString() : undefined,
     };
-  }, [dateNow, monitoringFilters]);
+  }, [monitoringFilters]);
 };
 
 export function getAbsoluteStartEndTime(

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
@@ -27,12 +27,11 @@ const ExperimentChatSessionsPageImpl = () => {
   const [searchQuery, setSearchQuery] = useState<string>('');
   invariant(experimentId, 'Experiment ID must be defined');
 
-  const monitoringConfig = useMonitoringConfig();
   const { loading: isLoadingExperiment } = useGetExperimentQuery({
     experimentId,
   });
 
-  const timeRange = useMonitoringFiltersTimeRange(monitoringConfig.dateNow);
+  const timeRange = useMonitoringFiltersTimeRange();
 
   const traceSearchLocations = useMemo(
     () => {


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Currently the "last refreshed" state is never updated in trace filters, so the refresh button effectively does nothing.

This PR fixes it by relying on `monitoringFilters` start time and end time rather than creating a new state for it. There should be no need to do so as we should just have a single source of truth.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Validated that the refresh button now works and sends an updated end time when refresh is clicked.

Clicking refresh for custom time ranges doesn't do anything but i think that's expected? I'm not sure if it's valuable to invalidate the cache if the filter will be exactly the same.



https://github.com/user-attachments/assets/12ddf65a-2842-47cc-a22f-e0ba4af304e3


Ensured it still works in run page too:


https://github.com/user-attachments/assets/e651518b-8ea9-4c1d-a1c5-41d180aa1d40




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
