### PR TITLE
Add documentation for judge alignment with GEPA

### DIFF
--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/alignment.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/alignment.mdx
@@ -184,6 +184,7 @@ else:
 MLflow provides multiple alignment optimizers:
 
 - [**SIMBA**](/genai/eval-monitor/scorers/llm-judge/simba) (default) - Uses DSPy's SIMBA algorithm for prompt optimization
+- [**GEPA**](/genai/eval-monitor/scorers/llm-judge/gepa) - Uses DSPy's GEPA algorithm with LLM-driven reflection for iterative refinement
 - [**MemAlign**](/genai/eval-monitor/scorers/llm-judge/memalign) (experimental) - Uses a dual-memory system for fast and cheap few-shot alignment
 
 You can also [create custom optimizers](/genai/eval-monitor/scorers/llm-judge/custom-optimizers) to implement domain-specific alignment strategies.

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/gepa.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/gepa.mdx
@@ -1,0 +1,71 @@
+# GEPA Alignment Optimizer
+
+MLflow provides the **GEPA alignment optimizer** using [DSPy's implementation of GEPA](https://dspy.ai/api/optimizers/GEPA/overview/) (Genetic-Pareto). GEPA uses LLM-driven reflection to analyze execution traces and iteratively propose improved judge instructions based on human feedback.
+
+## Requirements
+
+For alignment to work:
+
+- Traces must contain human assessments (labels) with the same name as the judge
+- Natural language feedback (rationale) is highly recommended for better alignment
+- Minimum of 10 traces with human assessments required
+- A mix of positive and negative labels is recommended
+
+## Basic Usage
+
+See [make_judge documentation](/genai/eval-monitor/scorers/llm-judge/make-judge) for details on creating judges.
+
+```python
+import mlflow
+from mlflow.genai.judges import make_judge
+from mlflow.genai.judges.optimizers import GEPAAlignmentOptimizer
+
+judge = make_judge(
+    name="politeness",
+    instructions=(
+        "Given a user question, evaluate if the chatbot's response is polite and respectful. "
+        "Consider the tone, language, and context of the response.\n\n"
+        "Question: {{ inputs }}\n"
+        "Response: {{ outputs }}"
+    ),
+    feedback_value_type=bool,
+    model="openai:/gpt-5-mini",
+)
+
+traces_with_feedback = mlflow.search_traces(return_type="list")
+
+optimizer = GEPAAlignmentOptimizer(
+    model="openai:/gpt-5-mini",
+    max_metric_calls=100,
+)
+aligned_judge = judge.align(traces_with_feedback, optimizer)
+```
+
+## Parameters
+
+| Parameter          | Type   | Default | Description                                                                                                     |
+| ------------------ | ------ | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `model`            | `str`  | `None`  | Model used for reflection. If None, uses the default model.                                                     |
+| `max_metric_calls` | `int`  | `None`  | Maximum evaluation calls during optimization. If None, automatically set to 4x the number of training examples. |
+| `gepa_kwargs`      | `dict` | `None`  | Additional keyword arguments passed directly to `dspy.GEPA()` for advanced configuration.                       |
+
+## When to Use GEPA
+
+GEPA is particularly effective when:
+
+- **Complex evaluation criteria**: Your judge needs to understand nuanced, context-dependent quality standards
+- **Rich textual feedback**: Human reviewers provide detailed explanations for their assessments
+- **Iterative refinement**: You want the optimizer to learn from failures and propose targeted improvements
+
+For simpler alignment tasks, consider using the default [SIMBA optimizer](/genai/eval-monitor/scorers/llm-judge/simba).
+
+## Debugging
+
+To debug the optimization process, enable DEBUG logging:
+
+```python
+import logging
+
+logging.getLogger("mlflow.genai.judges.optimizers.gepa").setLevel(logging.DEBUG)
+aligned_judge = judge.align(traces_with_feedback, optimizer)
+```


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
