### PR TITLE
Switch default Assistant prompt per page

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -29,6 +29,7 @@ import type { ChatMessage, ToolUseInfo } from './types';
 import { AssistantSetupWizard } from './setup';
 import { GenAIMarkdownRenderer } from '../shared/web-shared/genai-markdown-renderer';
 import { useCopyController } from '../shared/web-shared/snippet/hooks/useCopyController';
+import { useAssistantPrompts } from '../common/utils/RoutingUtils';
 
 type CurrentView = 'chat' | 'setup-wizard' | 'settings';
 
@@ -170,12 +171,7 @@ const ChatMessageBubble = ({
  */
 const PromptSuggestions = ({ onSelect }: { onSelect: (prompt: string) => void }) => {
   const { theme } = useDesignSystemTheme();
-
-  const suggestions = [
-    'What does this trace show?',
-    'Debug the error in this trace.',
-    'What is the performance bottleneck in this trace?',
-  ];
+  const suggestions = useAssistantPrompts();
 
   return (
     <div

--- a/mlflow/server/js/src/common/utils/RoutingUtils.tsx
+++ b/mlflow/server/js/src/common/utils/RoutingUtils.tsx
@@ -96,6 +96,18 @@ export interface DocumentTitleHandle {
   getPageTitle: (params: Params<string>) => string;
 }
 
+/**
+ * Handle for route definitions that provides context-aware assistant prompts.
+ */
+export interface AssistantPromptsHandle {
+  getAssistantPrompts?: () => string[];
+}
+
+/**
+ * Combined route handle interface for routes that support both page titles and assistant prompts.
+ */
+export type RouteHandle = DocumentTitleHandle & AssistantPromptsHandle;
+
 export const usePageTitle = () => {
   const matches = useMatches();
   if (matches.length === 0) {
@@ -107,6 +119,30 @@ export const usePageTitle = () => {
   const title = handle?.getPageTitle(lastMatch.params);
 
   return title;
+};
+
+const DEFAULT_ASSISTANT_PROMPTS = [
+  'What can you help me with?',
+  'How do I get started with MLflow?',
+  'Explain how experiment tracking works.',
+];
+
+/**
+ * Hook to get context-aware assistant prompts based on the current route.
+ * Falls back to default prompts if the route doesn't define any.
+ */
+export const useAssistantPrompts = (): string[] => {
+  const matches = useMatches();
+
+  // Find the most specific route that defines assistant prompts (search from end)
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const handle = matches[i].handle as AssistantPromptsHandle | undefined;
+    if (handle?.getAssistantPrompts) {
+      return handle.getAssistantPrompts();
+    }
+  }
+
+  return DEFAULT_ASSISTANT_PROMPTS;
 };
 
 export type { Location, NavigateFunction, Params, To, NavigateOptions };

--- a/mlflow/server/js/src/common/utils/RoutingUtils.tsx
+++ b/mlflow/server/js/src/common/utils/RoutingUtils.tsx
@@ -121,10 +121,10 @@ export const usePageTitle = () => {
   return title;
 };
 
-const DEFAULT_ASSISTANT_PROMPTS = [
-  'What can you help me with?',
+export const DEFAULT_ASSISTANT_PROMPTS = [
   'How do I get started with MLflow?',
-  'Explain how experiment tracking works.',
+  'What should I know about MLflow?',
+  'Explain how MLflow Tracing works.',
 ];
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -1,4 +1,4 @@
-import { createLazyRouteElement, RouteHandle } from '../common/utils/RoutingUtils';
+import { createLazyRouteElement, RouteHandle, DEFAULT_ASSISTANT_PROMPTS } from '../common/utils/RoutingUtils';
 
 import { PageId, RoutePaths } from './routes';
 
@@ -221,11 +221,7 @@ export const getRouteDefs = () => [
     pageId: PageId.home,
     handle: {
       getPageTitle: () => 'Home',
-      getAssistantPrompts: () => [
-        'How do I get started with MLflow?',
-        'What can MLflow help me with?',
-        'Show me how to track my first experiment.',
-      ],
+      getAssistantPrompts: () => DEFAULT_ASSISTANT_PROMPTS,
     } satisfies RouteHandle,
   },
   {

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -1,4 +1,4 @@
-import { createLazyRouteElement, DocumentTitleHandle } from '../common/utils/RoutingUtils';
+import { createLazyRouteElement, RouteHandle } from '../common/utils/RoutingUtils';
 
 import { PageId, RoutePaths } from './routes';
 
@@ -8,13 +8,27 @@ const getPromptPagesRouteDefs = () => {
       path: RoutePaths.promptsPage,
       element: createLazyRouteElement(() => import('./pages/prompts/PromptsPage')),
       pageId: PageId.promptsPage,
-      handle: { getPageTitle: () => 'Prompts' } satisfies DocumentTitleHandle,
+      handle: {
+        getPageTitle: () => 'Prompts',
+        getAssistantPrompts: () => [
+          'How do I create a new prompt?',
+          'How do I version my prompts?',
+          'How do I use prompts with my LLM application?',
+        ],
+      } satisfies RouteHandle,
     },
     {
       path: RoutePaths.promptDetailsPage,
       element: createLazyRouteElement(() => import('./pages/prompts/PromptsDetailsPage')),
       pageId: PageId.promptDetailsPage,
-      handle: { getPageTitle: (params) => `Prompt: ${params['promptName']}` } satisfies DocumentTitleHandle,
+      handle: {
+        getPageTitle: (params) => `Prompt: ${params['promptName']}`,
+        getAssistantPrompts: () => [
+          'Explain what this prompt does.',
+          'How can I improve this prompt?',
+          'Show me how to use this prompt in code.',
+        ],
+      } satisfies RouteHandle,
     },
   ];
 };
@@ -27,7 +41,14 @@ const getExperimentPageRouteDefs = () => {
         return import('./components/ExperimentListView');
       }),
       pageId: 'mlflow.experiment.list',
-      handle: { getPageTitle: () => 'Experiments' } satisfies DocumentTitleHandle,
+      handle: {
+        getPageTitle: () => 'Experiments',
+        getAssistantPrompts: () => [
+          'How do I create a new experiment?',
+          'How do I organize my experiments?',
+          'Show me my recent experiments.',
+        ],
+      } satisfies RouteHandle,
     },
     {
       path: RoutePaths.experimentPage,
@@ -35,7 +56,7 @@ const getExperimentPageRouteDefs = () => {
         return import('./pages/experiment-page-tabs/ExperimentPageTabs');
       }),
       pageId: PageId.experimentPage,
-      handle: { getPageTitle: (params) => `Experiment ${params['experimentId']}` } satisfies DocumentTitleHandle,
+      handle: { getPageTitle: (params) => `Experiment ${params['experimentId']}` } satisfies RouteHandle,
       children: [
         {
           path: RoutePaths.experimentPageTabOverview,
@@ -43,7 +64,12 @@ const getExperimentPageRouteDefs = () => {
           element: createLazyRouteElement(() => import('./pages/experiment-overview/ExperimentGenAIOverviewPage')),
           handle: {
             getPageTitle: (params) => `Overview - Experiment ${params['experimentId']}`,
-          } satisfies DocumentTitleHandle,
+            getAssistantPrompts: () => [
+              'How do I get started with MLflow GenAI?',
+              'What is the trend of token usage?',
+              'Why did the error rate spike?',
+            ],
+          } satisfies RouteHandle,
         },
         {
           path: RoutePaths.experimentPageTabRuns,
@@ -51,7 +77,12 @@ const getExperimentPageRouteDefs = () => {
           element: createLazyRouteElement(() => import('./pages/experiment-runs/ExperimentRunsPage')),
           handle: {
             getPageTitle: (params) => `Runs - Experiment ${params['experimentId']}`,
-          } satisfies DocumentTitleHandle,
+            getAssistantPrompts: () => [
+              'Compare the selected runs.',
+              'Which run performed best?',
+              'What parameters differ between runs?',
+            ],
+          } satisfies RouteHandle,
         },
         {
           path: RoutePaths.experimentPageTabTraces,
@@ -59,7 +90,12 @@ const getExperimentPageRouteDefs = () => {
           element: createLazyRouteElement(() => import('./pages/experiment-traces/ExperimentTracesPage')),
           handle: {
             getPageTitle: (params) => `Traces - Experiment ${params['experimentId']}`,
-          } satisfies DocumentTitleHandle,
+            getAssistantPrompts: () => [
+              'Debug the error in this trace.',
+              'What is the performance bottleneck in this trace?',
+              'How to measure the quality of my agent with traces?',
+            ],
+          } satisfies RouteHandle,
         },
         {
           path: RoutePaths.experimentPageTabChatSessions,
@@ -67,7 +103,12 @@ const getExperimentPageRouteDefs = () => {
           element: createLazyRouteElement(() => import('./pages/experiment-chat-sessions/ExperimentChatSessionsPage')),
           handle: {
             getPageTitle: (params) => `Chat Sessions - Experiment ${params['experimentId']}`,
-          } satisfies DocumentTitleHandle,
+            getAssistantPrompts: () => [
+              'How to group multiple traces by session?',
+              'What topics were discussed in this session?',
+              'Were there any issues in this conversation?',
+            ],
+          } satisfies RouteHandle,
         },
         {
           path: RoutePaths.experimentPageTabSingleChatSession,
@@ -75,7 +116,14 @@ const getExperimentPageRouteDefs = () => {
           element: createLazyRouteElement(
             () => import('./pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage'),
           ),
-          handle: { getPageTitle: (params) => `Chat Session ${params['sessionId']}` } satisfies DocumentTitleHandle,
+          handle: {
+            getPageTitle: (params) => `Chat Session ${params['sessionId']}`,
+            getAssistantPrompts: () => [
+              'Summarize this chat session.',
+              'What was the outcome of this conversation?',
+              'Identify any issues in this chat.',
+            ],
+          } satisfies RouteHandle,
         },
         {
           path: RoutePaths.experimentPageTabModels,
@@ -85,7 +133,12 @@ const getExperimentPageRouteDefs = () => {
           ),
           handle: {
             getPageTitle: (params) => `Logged Models - Experiment ${params['experimentId']}`,
-          } satisfies DocumentTitleHandle,
+            getAssistantPrompts: () => [
+              'Which model should I use for production?',
+              'Compare these models.',
+              'What are the differences between model versions?',
+            ],
+          } satisfies RouteHandle,
         },
         {
           path: RoutePaths.experimentPageTabEvaluationRuns,
@@ -95,7 +148,12 @@ const getExperimentPageRouteDefs = () => {
           ),
           handle: {
             getPageTitle: (params) => `Evaluation Runs - Experiment ${params['experimentId']}`,
-          } satisfies DocumentTitleHandle,
+            getAssistantPrompts: () => [
+              'Summarize the evaluation results.',
+              'Which model performed best in evaluation?',
+              'What metrics should I focus on?',
+            ],
+          } satisfies RouteHandle,
         },
         {
           path: RoutePaths.experimentPageTabScorers,
@@ -103,7 +161,12 @@ const getExperimentPageRouteDefs = () => {
           element: createLazyRouteElement(() => import('./pages/experiment-scorers/ExperimentScorersPage')),
           handle: {
             getPageTitle: (params) => `Scorers - Experiment ${params['experimentId']}`,
-          } satisfies DocumentTitleHandle,
+            getAssistantPrompts: () => [
+              'How do I create LLM judge for testing the quality of my agent?',
+              'Which built-in LLM judges should I use for my project?',
+              'How to run my judges on traces?',
+            ],
+          } satisfies RouteHandle,
         },
         {
           path: RoutePaths.experimentPageTabDatasets,
@@ -113,7 +176,12 @@ const getExperimentPageRouteDefs = () => {
           }),
           handle: {
             getPageTitle: (params) => `Datasets - Experiment ${params['experimentId']}`,
-          } satisfies DocumentTitleHandle,
+            getAssistantPrompts: () => [
+              'How to add a new record to a dataset?',
+              'How do I use this dataset for evaluation?',
+              'What format should my dataset be in?',
+            ],
+          } satisfies RouteHandle,
         },
         {
           path: RoutePaths.experimentPageTabPrompts,
@@ -121,13 +189,25 @@ const getExperimentPageRouteDefs = () => {
           element: createLazyRouteElement(() => import('./pages/prompts/ExperimentPromptsPage')),
           handle: {
             getPageTitle: (params) => `Prompts - Experiment ${params['experimentId']}`,
-          } satisfies DocumentTitleHandle,
+            getAssistantPrompts: () => [
+              'How do I create a new prompt?',
+              'Which prompt performs best for my project?',
+              'How do I use registered prompts with my LLM application?',
+            ],
+          } satisfies RouteHandle,
         },
         {
           path: RoutePaths.experimentPageTabPromptDetails,
           pageId: PageId.experimentPageTabPromptDetails,
           element: createLazyRouteElement(() => import('./pages/prompts/ExperimentPromptDetailsPage')),
-          handle: { getPageTitle: (params) => `Prompt: ${params['promptName']}` } satisfies DocumentTitleHandle,
+          handle: {
+            getPageTitle: (params) => `Prompt: ${params['promptName']}`,
+            getAssistantPrompts: () => [
+              'Explain what this prompt does.',
+              'How can I improve this prompt?',
+              'Show me how to use this prompt in code.',
+            ],
+          } satisfies RouteHandle,
         },
       ],
     },
@@ -139,26 +219,47 @@ export const getRouteDefs = () => [
     path: RoutePaths.rootRoute,
     element: createLazyRouteElement(() => import('../home/HomePage')),
     pageId: PageId.home,
-    handle: { getPageTitle: () => 'Home' } satisfies DocumentTitleHandle,
+    handle: {
+      getPageTitle: () => 'Home',
+      getAssistantPrompts: () => [
+        'How do I get started with MLflow?',
+        'What can MLflow help me with?',
+        'Show me how to track my first experiment.',
+      ],
+    } satisfies RouteHandle,
   },
   {
     path: RoutePaths.settingsPage,
     element: createLazyRouteElement(() => import('../settings/SettingsPage')),
     pageId: PageId.settingsPage,
-    handle: { getPageTitle: () => 'Settings' } satisfies DocumentTitleHandle,
+    handle: { getPageTitle: () => 'Settings' } satisfies RouteHandle,
   },
   ...getExperimentPageRouteDefs(),
   {
     path: RoutePaths.experimentLoggedModelDetailsPageTab,
     element: createLazyRouteElement(() => import('./pages/experiment-logged-models/ExperimentLoggedModelDetailsPage')),
     pageId: PageId.experimentLoggedModelDetailsPageTab,
-    handle: { getPageTitle: (params) => `Model ${params['loggedModelId']}` } satisfies DocumentTitleHandle,
+    handle: {
+      getPageTitle: (params) => `Model ${params['loggedModelId']}`,
+      getAssistantPrompts: () => [
+        'Explain this model.',
+        'How do I deploy this model?',
+        'What are the model inputs and outputs?',
+      ],
+    } satisfies RouteHandle,
   },
   {
     path: RoutePaths.experimentLoggedModelDetailsPage,
     element: createLazyRouteElement(() => import('./pages/experiment-logged-models/ExperimentLoggedModelDetailsPage')),
     pageId: PageId.experimentLoggedModelDetailsPage,
-    handle: { getPageTitle: (params) => `Model ${params['loggedModelId']}` } satisfies DocumentTitleHandle,
+    handle: {
+      getPageTitle: (params) => `Model ${params['loggedModelId']}`,
+      getAssistantPrompts: () => [
+        'Explain this model.',
+        'How do I deploy this model?',
+        'What are the model inputs and outputs?',
+      ],
+    } satisfies RouteHandle,
   },
   {
     path: RoutePaths.compareExperimentsSearch,
@@ -166,31 +267,62 @@ export const getRouteDefs = () => [
       () => import(/* webpackChunkName: "experimentPage" */ './components/experiment-page/ExperimentPage'),
     ),
     pageId: PageId.compareExperimentsSearch,
-    handle: { getPageTitle: () => 'Compare Experiments' } satisfies DocumentTitleHandle,
+    handle: {
+      getPageTitle: () => 'Compare Experiments',
+      getAssistantPrompts: () => [
+        'Compare these experiments.',
+        'Which experiment performed best?',
+        'What are the key differences?',
+      ],
+    } satisfies RouteHandle,
   },
   {
     path: RoutePaths.runPageWithTab,
     element: createLazyRouteElement(() => import('./components/run-page/RunPage')),
     pageId: PageId.runPageWithTab,
-    handle: { getPageTitle: (params) => `Run ${params['runUuid']}` } satisfies DocumentTitleHandle,
+    handle: {
+      getPageTitle: (params) => `Run ${params['runUuid']}`,
+      getAssistantPrompts: () => [
+        'Summarize this run.',
+        'What parameters were used?',
+        'How does this run compare to others?',
+      ],
+    } satisfies RouteHandle,
   },
   {
     path: RoutePaths.runPageDirect,
     element: createLazyRouteElement(() => import('./components/DirectRunPage')),
     pageId: PageId.runPageDirect,
-    handle: { getPageTitle: (params) => `Run ${params['runUuid']}` } satisfies DocumentTitleHandle,
+    handle: {
+      getPageTitle: (params) => `Run ${params['runUuid']}`,
+      getAssistantPrompts: () => [
+        'Summarize this run.',
+        'What parameters were used?',
+        'How does this run compare to others?',
+      ],
+    } satisfies RouteHandle,
   },
   {
     path: RoutePaths.compareRuns,
     element: createLazyRouteElement(() => import('./components/CompareRunPage')),
     pageId: PageId.compareRuns,
-    handle: { getPageTitle: () => 'Compare Runs' } satisfies DocumentTitleHandle,
+    handle: {
+      getPageTitle: () => 'Compare Runs',
+      getAssistantPrompts: () => [
+        'Compare these runs.',
+        'Which run performed best?',
+        'What parameters differ between runs?',
+      ],
+    } satisfies RouteHandle,
   },
   {
     path: RoutePaths.metricPage,
     element: createLazyRouteElement(() => import('./components/MetricPage')),
     pageId: PageId.metricPage,
-    handle: { getPageTitle: () => 'Metric Details' } satisfies DocumentTitleHandle,
+    handle: {
+      getPageTitle: () => 'Metric Details',
+      getAssistantPrompts: () => ['Explain this metric.', 'What trends do you see?', 'How can I improve this metric?'],
+    } satisfies RouteHandle,
   },
   ...getPromptPagesRouteDefs(),
 ];


### PR DESCRIPTION
### What changes are proposed in this pull request?

Show different prompts based on which page are users on.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
