### PR TITLE
Refactor check_patch_prs.py to use GitHub API instead of git clone

### DIFF
--- a/dev/check_patch_prs.py
+++ b/dev/check_patch_prs.py
@@ -28,7 +28,7 @@ class Commit:
 
 def get_commits(branch: str) -> list[Commit]:
     """
-    Get the commits in the release branch via GitHub API (last 3 months).
+    Get the commits in the release branch via GitHub API (last 90 days).
     """
     commits = []
     per_page = 100
@@ -57,7 +57,7 @@ def get_commits(branch: str) -> list[Commit]:
             msg = item["commit"]["message"].split("\n")[0]
             if m := pr_rgx.search(msg):
                 commits.append(Commit(sha=item["sha"], pr_num=int(m.group(1))))
-        if len(data) < per_page:
+        if not data or len(data) < per_page:
             break
         page += 1
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Refactor `dev/check_patch_prs.py` to use the GitHub REST API instead of cloning the repository. This avoids the overhead of a git clone operation and is consistent with how `fetch_patch_prs` already fetches PR data.

Changes:
- Replace `git clone` + `git log` with GitHub commits API
- Add `GH_TOKEN` environment variable support for authentication (avoids rate limiting)
- Limit commits to last 90 days using `since` parameter

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)