### PR TITLE
 Fix Windows path handling in artifact downloads

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import posixpath
+import re
 import tempfile
 import traceback
 import uuid
@@ -34,6 +35,7 @@ from mlflow.utils.async_logging.async_artifacts_logging_queue import (
     AsyncArtifactsLoggingQueue,
 )
 from mlflow.utils.file_utils import ArtifactProgressBar, create_tmp_dir
+from mlflow.utils.os import is_windows
 from mlflow.utils.validation import bad_path_message, path_not_unique
 
 if TYPE_CHECKING:
@@ -51,6 +53,9 @@ _NUM_DEFAULT_CPUS = _NUM_MAX_THREADS // _NUM_MAX_THREADS_PER_CPU
 _logger = logging.getLogger(__name__)
 # Chunk size for streaming artifact uploads and downloads (1 MB).
 ARTIFACT_STREAM_CHUNK_SIZE = 1024 * 1024
+
+# Precompiled regex for sanitizing Windows-invalid characters in path components (Windows only)
+_WINDOWS_INVALID_CHARS_REGEX = re.compile(r'[<>:"|?*]') if is_windows() else None
 
 
 def _truncate_error(err: str, max_length: int = 10_000) -> str:
@@ -76,6 +81,51 @@ def _retry_with_new_creds(try_func, creds_func, orig_creds=None):
         )
         new_creds = creds_func()
         return try_func(new_creds)
+
+
+def _sanitize_path_component_for_windows(component: str) -> str:
+    """
+    Sanitize a path component by replacing Windows-invalid characters with underscores.
+
+    Windows does not allow these characters in filenames: < > : " | ? *
+    (Note: / and \\ are path separators and are handled separately)
+
+    This function does not handle Windows reserved names (CON, PRN, AUX, NUL, COM1-9,
+    LPT1-9, CONIN$, CONOUT$). Artifact paths with these names are rare in practice, but
+    would cause issues if encountered on Windows.
+
+    Args:
+        component: A single path component (filename or directory name).
+
+    Returns:
+        The sanitized path component with invalid characters replaced by underscores.
+    """
+    # Replace Windows-invalid characters with underscores using precompiled regex (single pass)
+    return _WINDOWS_INVALID_CHARS_REGEX.sub("_", component)
+
+
+def _sanitize_path_for_windows(path: str) -> str:
+    """
+    Sanitize a POSIX-style path by replacing Windows-invalid characters in each component.
+
+    This function only performs sanitization on Windows. On other platforms, the path
+    is returned unchanged.
+
+    Args:
+        path: A POSIX-style path (using / as separator).
+
+    Returns:
+        The sanitized path with invalid characters replaced, or the original path if not
+        on Windows or if the path is empty.
+    """
+    if not is_windows() or not path:
+        return path
+
+    # Split by POSIX path separator and sanitize each component
+    components = path.split("/")
+    sanitized_components = [_sanitize_path_component_for_windows(comp) for comp in components]
+    # Use posixpath.join to explicitly work with POSIX paths before platform conversion
+    return posixpath.join(*sanitized_components) if sanitized_components else ""
 
 
 @developer_stable
@@ -210,6 +260,8 @@ class ArtifactRepository:
         resulting destination path is `<dst_local_dir_path>/dir1/file1.txt`. Local directories are
         created for the resulting destination location if they do not exist.
 
+        Note: On windows this method escapes/normalizes path separators and invalid characters.
+
         Args:
             src_artifact_path: A relative, POSIX-style path referring to an artifact stored
                 within the repository's artifact root location. `src_artifact_path` should be
@@ -224,9 +276,30 @@ class ArtifactRepository:
             for downloading the artifact specified by `src_artifact_path`.
         """
         src_artifact_path = src_artifact_path.rstrip("/")  # Ensure correct dirname for trailing '/'
+        # Sanitize path for Windows by replacing invalid characters (: < > " | ? *)
+        src_artifact_path = _sanitize_path_for_windows(src_artifact_path)
         dirpath = posixpath.dirname(src_artifact_path)
-        local_dir_path = os.path.join(dst_local_dir_path, dirpath)
-        local_file_path = os.path.join(dst_local_dir_path, src_artifact_path)
+        # os.path.normpath() converts forward slashes (/) to OS-specific separators (\\ on Windows)
+        if dirpath:
+            local_dir_path = os.path.join(dst_local_dir_path, os.path.normpath(dirpath))
+        else:
+            local_dir_path = dst_local_dir_path
+        local_file_path = os.path.join(dst_local_dir_path, os.path.normpath(src_artifact_path))
+
+        # Security check: Ensure the resolved path stays within the destination directory
+        abs_local_file_path = os.path.abspath(local_file_path)
+        abs_dst_path = os.path.abspath(dst_local_dir_path)
+        is_outside = (
+            not abs_local_file_path.startswith(abs_dst_path + os.sep)
+            and abs_local_file_path != abs_dst_path
+        )
+        if is_outside:
+            raise MlflowException(
+                f"Invalid artifact path: '{src_artifact_path}' resolves outside "
+                f"the destination directory",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
         if not os.path.exists(local_dir_path):
             os.makedirs(local_dir_path, exist_ok=True)
         return local_file_path
@@ -326,7 +399,9 @@ class ArtifactRepository:
         if is_dir:
             for file_info in self._iter_artifacts_recursive(artifact_path):
                 if file_info.is_dir:  # Empty directory
-                    os.makedirs(os.path.join(dst_path, file_info.path), exist_ok=True)
+                    sanitized_path = _sanitize_path_for_windows(file_info.path)
+                    normalized_path = os.path.join(dst_path, os.path.normpath(sanitized_path))
+                    os.makedirs(normalized_path, exist_ok=True)
                 else:
                     fut = _download_file(file_info.path, dst_path)
                     futures[fut] = file_info.path
@@ -373,7 +448,10 @@ class ArtifactRepository:
                 error_code=error_code,
             )
 
-        return os.path.join(dst_path, artifact_path)
+        if artifact_path:
+            sanitized_path = _sanitize_path_for_windows(artifact_path)
+            return os.path.join(dst_path, os.path.normpath(sanitized_path))
+        return dst_path
 
     @abstractmethod
     def _download_file(self, remote_file_path, local_path):

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -54,8 +54,10 @@ _logger = logging.getLogger(__name__)
 # Chunk size for streaming artifact uploads and downloads (1 MB).
 ARTIFACT_STREAM_CHUNK_SIZE = 1024 * 1024
 
-# Precompiled regex for sanitizing Windows-invalid characters in path components (Windows only)
-_WINDOWS_INVALID_CHARS_REGEX = re.compile(r'[<>:"|?*]') if is_windows() else None
+# Precompiled regex for sanitizing Windows-invalid characters in path components (Windows only).
+# Backslash is included: artifact paths are POSIX-style (only "/" separates components), so a
+# literal "\" inside a component is part of the name and is invalid in a Windows filename.
+_WINDOWS_INVALID_CHARS_REGEX = re.compile(r'[<>:"|?*\\]') if is_windows() else None
 
 
 def _truncate_error(err: str, max_length: int = 10_000) -> str:
@@ -87,8 +89,9 @@ def _sanitize_path_component_for_windows(component: str) -> str:
     """
     Sanitize a path component by replacing Windows-invalid characters with underscores.
 
-    Windows does not allow these characters in filenames: < > : " | ? *
-    (Note: / and \\ are path separators and are handled separately)
+    Windows does not allow these characters in filenames: < > : " | ? * \\
+    (Note: / is the POSIX path separator and is handled separately by splitting the path.
+    A literal \\ inside a component is not a separator here and is sanitized as invalid.)
 
     This function does not handle Windows reserved names (CON, PRN, AUX, NUL, COM1-9,
     LPT1-9, CONIN$, CONOUT$). Artifact paths with these names are rare in practice, but
@@ -100,10 +103,9 @@ def _sanitize_path_component_for_windows(component: str) -> str:
     Returns:
         The sanitized path component with invalid characters replaced by underscores.
     """
-    # On non-Windows platforms, return component unchanged
+    # A None regex means we're not on Windows, so leave the component untouched.
     if _WINDOWS_INVALID_CHARS_REGEX is None:
         return component
-    # Replace Windows-invalid characters with underscores using precompiled regex (single pass)
     return _WINDOWS_INVALID_CHARS_REGEX.sub("_", component)
 
 
@@ -124,11 +126,35 @@ def _sanitize_path_for_windows(path: str) -> str:
     if not is_windows() or not path:
         return path
 
-    # Split by POSIX path separator and sanitize each component
     components = path.split("/")
     sanitized_components = [_sanitize_path_component_for_windows(comp) for comp in components]
-    # Use posixpath.join to explicitly work with POSIX paths before platform conversion
-    return posixpath.join(*sanitized_components) if sanitized_components else ""
+    # Rejoin with "/" rather than posixpath.join, which would drop a leading empty component and
+    # turn an absolute path like "/etc/passwd" into a relative one on Windows (it stays absolute
+    # on POSIX). Preserving it keeps the containment check in _create_download_destination honest.
+    return "/".join(sanitized_components)
+
+
+def _validate_path_within_directory(candidate_path: str, dir_path: str, artifact_path: str) -> None:
+    """
+    Raise ``MlflowException`` if ``candidate_path`` is not contained within ``dir_path``.
+
+    Uses os.path.commonpath on realpath-resolved, normcase-normalized paths so the check is
+    correct on case-insensitive filesystems (Windows) and when ``dir_path`` is a filesystem
+    root (e.g. "/" or "C:\\"), and also accounts for symlinks. A plain startswith() comparison
+    mishandles all of these cases. ``commonpath`` raises ``ValueError`` for paths on different
+    drives or a mix of absolute and relative paths, which likewise means the candidate escapes.
+    """
+    abs_candidate_path = os.path.normcase(os.path.realpath(candidate_path))
+    abs_dir_path = os.path.normcase(os.path.realpath(dir_path))
+    try:
+        within = os.path.commonpath([abs_candidate_path, abs_dir_path]) == abs_dir_path
+    except ValueError:
+        within = False
+    if not within:
+        raise MlflowException(
+            f"Invalid artifact path: '{artifact_path}' resolves outside the destination directory",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
 
 
 @developer_stable
@@ -279,7 +305,6 @@ class ArtifactRepository:
             for downloading the artifact specified by `src_artifact_path`.
         """
         src_artifact_path = src_artifact_path.rstrip("/")  # Ensure correct dirname for trailing '/'
-        # Sanitize path for Windows by replacing invalid characters (: < > " | ? *)
         src_artifact_path = _sanitize_path_for_windows(src_artifact_path)
         # os.path.normpath() converts forward slashes (/) to OS-specific separators (\\ on Windows)
         if dirpath := posixpath.dirname(src_artifact_path):
@@ -288,19 +313,7 @@ class ArtifactRepository:
             local_dir_path = dst_local_dir_path
         local_file_path = os.path.join(dst_local_dir_path, os.path.normpath(src_artifact_path))
 
-        # Security check: Ensure the resolved path stays within the destination directory
-        abs_local_file_path = os.path.abspath(local_file_path)
-        abs_dst_path = os.path.abspath(dst_local_dir_path)
-        is_outside = (
-            not abs_local_file_path.startswith(abs_dst_path + os.sep)
-            and abs_local_file_path != abs_dst_path
-        )
-        if is_outside:
-            raise MlflowException(
-                f"Invalid artifact path: '{src_artifact_path}' resolves outside "
-                f"the destination directory",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
+        _validate_path_within_directory(local_file_path, dst_local_dir_path, src_artifact_path)
 
         if not os.path.exists(local_dir_path):
             os.makedirs(local_dir_path, exist_ok=True)
@@ -403,6 +416,9 @@ class ArtifactRepository:
                 if file_info.is_dir:  # Empty directory
                     sanitized_path = _sanitize_path_for_windows(file_info.path)
                     normalized_path = os.path.join(dst_path, os.path.normpath(sanitized_path))
+                    # A malicious listing with ".." segments or an absolute path must not create
+                    # directories outside the destination.
+                    _validate_path_within_directory(normalized_path, dst_path, file_info.path)
                     os.makedirs(normalized_path, exist_ok=True)
                 else:
                     fut = _download_file(file_info.path, dst_path)

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -100,6 +100,9 @@ def _sanitize_path_component_for_windows(component: str) -> str:
     Returns:
         The sanitized path component with invalid characters replaced by underscores.
     """
+    # On non-Windows platforms, return component unchanged
+    if _WINDOWS_INVALID_CHARS_REGEX is None:
+        return component
     # Replace Windows-invalid characters with underscores using precompiled regex (single pass)
     return _WINDOWS_INVALID_CHARS_REGEX.sub("_", component)
 
@@ -278,9 +281,8 @@ class ArtifactRepository:
         src_artifact_path = src_artifact_path.rstrip("/")  # Ensure correct dirname for trailing '/'
         # Sanitize path for Windows by replacing invalid characters (: < > " | ? *)
         src_artifact_path = _sanitize_path_for_windows(src_artifact_path)
-        dirpath = posixpath.dirname(src_artifact_path)
         # os.path.normpath() converts forward slashes (/) to OS-specific separators (\\ on Windows)
-        if dirpath:
+        if dirpath := posixpath.dirname(src_artifact_path):
             local_dir_path = os.path.join(dst_local_dir_path, os.path.normpath(dirpath))
         else:
             local_dir_path = dst_local_dir_path

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -36,6 +36,7 @@ from mlflow.utils.async_logging.async_artifacts_logging_queue import (
 )
 from mlflow.utils.file_utils import ArtifactProgressBar, create_tmp_dir
 from mlflow.utils.os import is_windows
+from mlflow.utils.uri import validate_path_within_directory
 from mlflow.utils.validation import bad_path_message, path_not_unique
 
 if TYPE_CHECKING:
@@ -132,29 +133,6 @@ def _sanitize_path_for_windows(path: str) -> str:
     # turn an absolute path like "/etc/passwd" into a relative one on Windows (it stays absolute
     # on POSIX). Preserving it keeps the containment check in _create_download_destination honest.
     return "/".join(sanitized_components)
-
-
-def _validate_path_within_directory(candidate_path: str, dir_path: str, artifact_path: str) -> None:
-    """
-    Raise ``MlflowException`` if ``candidate_path`` is not contained within ``dir_path``.
-
-    Uses os.path.commonpath on realpath-resolved, normcase-normalized paths so the check is
-    correct on case-insensitive filesystems (Windows) and when ``dir_path`` is a filesystem
-    root (e.g. "/" or "C:\\"), and also accounts for symlinks. A plain startswith() comparison
-    mishandles all of these cases. ``commonpath`` raises ``ValueError`` for paths on different
-    drives or a mix of absolute and relative paths, which likewise means the candidate escapes.
-    """
-    abs_candidate_path = os.path.normcase(os.path.realpath(candidate_path))
-    abs_dir_path = os.path.normcase(os.path.realpath(dir_path))
-    try:
-        within = os.path.commonpath([abs_candidate_path, abs_dir_path]) == abs_dir_path
-    except ValueError:
-        within = False
-    if not within:
-        raise MlflowException(
-            f"Invalid artifact path: '{artifact_path}' resolves outside the destination directory",
-            error_code=INVALID_PARAMETER_VALUE,
-        )
 
 
 @developer_stable
@@ -289,7 +267,9 @@ class ArtifactRepository:
         resulting destination path is `<dst_local_dir_path>/dir1/file1.txt`. Local directories are
         created for the resulting destination location if they do not exist.
 
-        Note: On windows this method escapes/normalizes path separators and invalid characters.
+        Note: This method normalizes path separators and validates that the resulting destination
+        stays within `dst_local_dir_path` on all platforms. On Windows it additionally sanitizes
+        characters that are invalid in filenames on that platform.
 
         Args:
             src_artifact_path: A relative, POSIX-style path referring to an artifact stored
@@ -313,7 +293,7 @@ class ArtifactRepository:
             local_dir_path = dst_local_dir_path
         local_file_path = os.path.join(dst_local_dir_path, os.path.normpath(src_artifact_path))
 
-        _validate_path_within_directory(local_file_path, dst_local_dir_path, src_artifact_path)
+        validate_path_within_directory(dst_local_dir_path, local_file_path)
 
         if not os.path.exists(local_dir_path):
             os.makedirs(local_dir_path, exist_ok=True)
@@ -418,7 +398,7 @@ class ArtifactRepository:
                     normalized_path = os.path.join(dst_path, os.path.normpath(sanitized_path))
                     # A malicious listing with ".." segments or an absolute path must not create
                     # directories outside the destination.
-                    _validate_path_within_directory(normalized_path, dst_path, file_info.path)
+                    validate_path_within_directory(dst_path, normalized_path)
                     os.makedirs(normalized_path, exist_ok=True)
                 else:
                     fut = _download_file(file_info.path, dst_path)

--- a/tests/store/artifact/test_artifact_repo.py
+++ b/tests/store/artifact/test_artifact_repo.py
@@ -319,8 +319,6 @@ def test_create_download_destination_sanitizes_windows_paths():
 
 
 def test_create_download_destination_prevents_path_traversal():
-    """Test that path traversal attacks are prevented."""
-
     class TestRepo(ArtifactRepository):
         def log_artifact(self, local_file, artifact_path=None):
             pass

--- a/tests/store/artifact/test_artifact_repo.py
+++ b/tests/store/artifact/test_artifact_repo.py
@@ -272,6 +272,12 @@ def test_download_artifacts_provides_traceback_info(debug, reset_logging_level):
         ("leading / space", "leading / space"),
         ("trailing/ space", "trailing/ space"),
         ("spans/Component: Name /Other", "spans/Component_ Name /Other"),
+        # A literal backslash inside a component is invalid on Windows and must be sanitized
+        # rather than treated as a separator.
+        ("we\\ird", "we_ird"),
+        ("dir/na\\me", "dir/na_me"),
+        # A leading "/" must be preserved so absolute paths stay absolute (see containment check).
+        ("/etc/passwd", "/etc/passwd"),
     ],
 )
 def test_sanitize_path_for_windows(input_path, expected_output):
@@ -349,3 +355,29 @@ def test_create_download_destination_prevents_path_traversal():
                 match="Invalid artifact path.*",
             ):
                 repo._create_download_destination(malicious_path, tmp.path())
+
+
+@pytest.mark.parametrize(
+    "malicious_dir",
+    [
+        "../../../evil",
+        "model/../../evil",
+    ],
+)
+def test_download_artifacts_prevents_empty_dir_path_traversal(malicious_dir):
+    def list_artifacts(path):
+        if path in ("", None):
+            return [FileInfo(_MODEL_DIR, True, _EMPTY_FILE_SIZE)]
+        elif path.endswith(_MODEL_DIR):
+            return [FileInfo(malicious_dir, True, _EMPTY_FILE_SIZE)]
+        else:
+            return []
+
+    with mock.patch.object(
+        ArtifactRepositoryImpl, "list_artifacts", side_effect=list_artifacts
+    ) as list_artifacts_mock:
+        repo = ArtifactRepositoryImpl("")
+        with TempDir() as tmp:
+            with pytest.raises(MlflowException, match="Invalid artifact path.*"):
+                repo.download_artifacts("", dst_path=tmp.path())
+        list_artifacts_mock.assert_called()

--- a/tests/store/artifact/test_artifact_repo.py
+++ b/tests/store/artifact/test_artifact_repo.py
@@ -352,7 +352,7 @@ def test_create_download_destination_prevents_path_traversal():
         for malicious_path in malicious_paths:
             with pytest.raises(
                 MlflowException,
-                match="Invalid artifact path.*",
+                match="Invalid path: resolved path is outside the artifact directory",
             ):
                 repo._create_download_destination(malicious_path, tmp.path())
 
@@ -378,6 +378,9 @@ def test_download_artifacts_prevents_empty_dir_path_traversal(malicious_dir):
     ) as list_artifacts_mock:
         repo = ArtifactRepositoryImpl("")
         with TempDir() as tmp:
-            with pytest.raises(MlflowException, match="Invalid artifact path.*"):
+            with pytest.raises(
+                MlflowException,
+                match="Invalid path: resolved path is outside the artifact directory",
+            ):
                 repo.download_artifacts("", dst_path=tmp.path())
         list_artifacts_mock.assert_called()

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1077,10 +1077,11 @@ def test_databricks_download_file_in_parallel_when_necessary(
             download_mock.assert_called()
 
 
-def test_databricks_download_file_get_request_fail(databricks_artifact_repo, test_file):
+def test_databricks_download_file_get_request_fail(databricks_artifact_repo):
     mock_credential_info = ArtifactCredentialInfo(
         signed_uri=MOCK_AZURE_SIGNED_URI, type=ArtifactCredentialType.AZURE_SAS_URI
     )
+    artifact_path = "test.txt"
     with (
         mock.patch(
             f"{DATABRICKS_ARTIFACT_REPOSITORY}._get_read_credential_infos",
@@ -1090,8 +1091,8 @@ def test_databricks_download_file_get_request_fail(databricks_artifact_repo, tes
         mock.patch("requests.Session.request", side_effect=MlflowException("MOCK ERROR")),
     ):
         with pytest.raises(MlflowException, match=r"MOCK ERROR"):
-            databricks_artifact_repo.download_artifacts(test_file)
-        read_credential_infos_mock.assert_called_with(test_file)
+            databricks_artifact_repo.download_artifacts(artifact_path)
+        read_credential_infos_mock.assert_called_with(artifact_path)
 
 
 def test_download_artifacts_awaits_download_completion(databricks_artifact_repo, tmp_path):

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1095,6 +1095,23 @@ def test_databricks_download_file_get_request_fail(databricks_artifact_repo):
         read_credential_infos_mock.assert_called_with(artifact_path)
 
 
+def test_databricks_download_file_rejects_absolute_artifact_path(
+    databricks_artifact_repo, tmp_path
+):
+    # Artifact paths are POSIX-style. An absolute one resolves outside the download destination
+    # and must be rejected before any download is attempted. This is why the sibling tests use
+    # relative artifact paths.
+    with mock.patch(
+        f"{DATABRICKS_ARTIFACT_REPOSITORY}.list_artifacts", return_value=[]
+    ) as list_artifacts_mock:
+        with pytest.raises(
+            MlflowException,
+            match="Invalid path: resolved path is outside the artifact directory",
+        ):
+            databricks_artifact_repo.download_artifacts("/etc/passwd", dst_path=str(tmp_path))
+        list_artifacts_mock.assert_called()
+
+
 def test_download_artifacts_awaits_download_completion(databricks_artifact_repo, tmp_path):
     """
     Verifies that all asynchronous artifact downloads are joined before `download_artifacts()`


### PR DESCRIPTION
Fixes issues when downloading artifacts on Windows, and hardens artifact download path handling against traversal on all platforms:

  1. Path separator conversion (Windows): POSIX-style forward slashes were not being converted to Windows backslashes, causing paths like 'D:\path\spans/artifact' and NotADirectoryError.

  2. Invalid character sanitization (Windows): Windows-reserved characters
     (< > : " | ? * \) in artifact names were causing download failures.

  3. Path traversal containment (all platforms): the download destination is now validated to stay within the target directory before any file/directory is created.

  Changes:
  - Add _sanitize_path_for_windows() to replace invalid characters (Windows only)
  - Apply fixes in _create_download_destination() and download_artifacts()
  - Reuse mlflow.utils.uri.validate_path_within_directory for the containment check in both the download-destination and empty-directory paths
  - Add test cases covering all of the above

  Example: 'spans/Agent: Task' now downloads correctly as 'spans\Agent_ Task'.

> [!NOTE]
> **Behavior change is not limited to Windows.** The path normalization and the containment check run on all platforms. On POSIX, an absolute or escaping `artifact_path` (e.g. `/etc/passwd` or one containing `..`) that the previous code silently accepted now raises `MlflowException`. Only the invalid-character sanitization is Windows-specific.

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Small tweaks to the artifacts download flow to handle Windows file system limitations, plus cross-platform hardening of the download path against traversal.


### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [X] Examples
  - [X] API references
  - [X] Instructions

### Release Notes

- Note for Windows users, the command `mlflow artifacts download` will now normalize file names.
- On all platforms, artifact downloads now reject paths that would resolve outside the destination directory.

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->


<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
