### PR TITLE
[DRAFT BULK CHANGE] [run judges]

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/hooks/useMonitoringFilters.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/useMonitoringFilters.tsx
@@ -14,7 +14,7 @@ export type START_TIME_LABEL =
   | 'LAST_YEAR'
   | 'ALL'
   | 'CUSTOM';
-export const DEFAULT_START_TIME_LABEL: START_TIME_LABEL = 'LAST_7_DAYS';
+export const DEFAULT_START_TIME_LABEL: START_TIME_LABEL = 'LAST_30_DAYS';
 
 export interface MonitoringFilters {
   startTimeLabel?: START_TIME_LABEL;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/RunJudgeButtonForTrace.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/RunJudgeButtonForTrace.tsx
@@ -1,0 +1,266 @@
+import {
+  Button,
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxCustomButtonTriggerWrapper,
+  DialogComboboxFooter,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListSearch,
+  DialogComboboxOptionListSelectItem,
+  DialogComboboxTrigger,
+  GavelIcon,
+  getShadowScrollStyles,
+  PlayIcon,
+  PlusIcon,
+  Popover,
+  SparkleDoubleIcon,
+  Tag,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { getTypeColor, getTypeDisplayName, getTypeIcon } from './scorerCardUtils';
+import { useGetScheduledScorers } from './hooks/useGetScheduledScorers';
+import { useExperimentIds } from '../../components/experiment-page/hooks/useExperimentIds';
+import { useIntl } from 'react-intl';
+import { LLM_TEMPLATE, LLMScorer, ScheduledScorer } from './types';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEvaluateTraces } from './useEvaluateTraces';
+import { useEvaluateTracesUsingKnownScorer } from './useEvaluateTracesUsingKnownScorer';
+import ScorerModalRenderer from './ScorerModalRenderer';
+import { SCORER_FORM_MODE, ScorerEvaluationScope } from './constants';
+import { useTemplateOptions } from './llmScorerUtils';
+import { isString } from 'lodash';
+import { RunIcon } from '../../components/run-page/assets/RunIcon';
+
+export const RunJudgeButtonForTrace = ({
+  traceId,
+  onScorerStarted,
+  evaluateTraces,
+  disabled,
+}: {
+  traceId: string;
+  onScorerStarted?: (scorerName: string) => void;
+  evaluateTraces: (scorer: LLMScorer, traceIds: string[]) => void;
+  disabled?: boolean;
+}) => {
+  const [experimentId] = useExperimentIds();
+  const { data } = useGetScheduledScorers(experimentId);
+  const { templateOptions } = useTemplateOptions(ScorerEvaluationScope.TRACES);
+
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+  const [searchValue, setSearchValue] = useState<string>('');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [isCreateScorerModalVisible, setIsCreateScorerModalVisible] = useState(false);
+
+  const displayedScorers = useMemo(() => {
+    return data?.scheduledScorers.filter((scorer) => scorer.name.toLowerCase().includes(searchValue.toLowerCase()));
+  }, [data?.scheduledScorers, searchValue]);
+
+  const displayedTemplates = useMemo(() => {
+    return templateOptions?.filter((template) => template.label.toLowerCase().includes(searchValue.toLowerCase()));
+  }, [templateOptions, searchValue]);
+
+  const handleClick = (scorerOrTemplate: ScheduledScorer | LLM_TEMPLATE) => {
+    if (isString(scorerOrTemplate)) {
+      // evaluateTraces({ llmTemplate: scorer, instructions: '', name: '', type: 'llm' }, [traceId]);
+      // evaluateTraces(scorerOrTemplate, [traceId]);
+      // setDropdownOpen(false);
+      return;
+    }
+    if ('instructions' in scorerOrTemplate) {
+      evaluateTraces(scorerOrTemplate, [traceId]);
+      setDropdownOpen(false);
+      onScorerStarted?.(scorerOrTemplate.name);
+    }
+  };
+
+  return (
+    <>
+      <DialogCombobox id="TODO" componentId="TODO" open={dropdownOpen} onOpenChange={setDropdownOpen}>
+        <DialogComboboxCustomButtonTriggerWrapper asChild>
+          <Button componentId="TODO" size="small" icon={<PlayIcon />} disabled={disabled}>
+            Run judge
+          </Button>
+        </DialogComboboxCustomButtonTriggerWrapper>
+        <DialogComboboxContent align="end" css={{ minWidth: 400 }}>
+          <DialogComboboxOptionList
+            css={{
+              height: 240,
+              display: 'flex',
+              flexDirection: 'column',
+              overflowY: 'auto',
+              ...getShadowScrollStyles(theme, { orientation: 'vertical' }),
+              borderTop: `1px solid ${theme.colors.border}`,
+            }}
+          >
+            <DialogComboboxOptionListSearch controlledValue={searchValue} setControlledValue={setSearchValue}>
+              {displayedScorers?.map((scorer) => (
+                <ScorerOption scorer={scorer} key={scorer.name} onClick={handleClick} />
+              ))}
+              {displayedTemplates?.map((template) => (
+                <TemplateOption
+                  template={template}
+                  key={template.value}
+                  onClick={(template) => handleClick(template)}
+                />
+              ))}
+            </DialogComboboxOptionListSearch>
+          </DialogComboboxOptionList>
+
+          <DialogComboboxFooter css={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Button
+              type="tertiary"
+              componentId="TODO"
+              icon={<PlusIcon />}
+              css={{ flex: 1 }}
+              onClick={() => setIsCreateScorerModalVisible(true)}
+            >
+              Create judge
+            </Button>
+          </DialogComboboxFooter>
+        </DialogComboboxContent>
+      </DialogCombobox>
+      {isCreateScorerModalVisible && (
+        <ScorerModalRenderer
+          visible
+          onClose={() => setIsCreateScorerModalVisible(false)}
+          experimentId={experimentId}
+          mode={SCORER_FORM_MODE.CREATE}
+          initialScorerType="llm"
+        />
+      )}
+    </>
+  );
+};
+
+const ScorerOption = ({ scorer, onClick }: { scorer: ScheduledScorer; onClick: (scorer: ScheduledScorer) => void }) => {
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+  return (
+    <DialogComboboxOptionListSelectItem
+      value={scorer.name}
+      icon={<GavelIcon />}
+      css={{
+        alignItems: 'center',
+        height: theme.general.buttonHeight,
+        '&>label': { flex: 1 },
+
+        flexShrink: 0,
+      }}
+      key={scorer.name}
+      hintColumn={
+        <Tag
+          componentId="codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_123"
+          color={getTypeColor(scorer)}
+          icon={getTypeIcon(scorer)}
+        >
+          {getTypeDisplayName(scorer, intl)}
+        </Tag>
+      }
+      onChange={() => onClick(scorer)}
+    >
+      <div css={{ display: 'flex', flexDirection: 'column' }}>
+        <Typography.Text css={{ flex: 1 }}>{scorer.name}</Typography.Text>
+        <Typography.Hint>Custom judge</Typography.Hint>
+      </div>
+    </DialogComboboxOptionListSelectItem>
+  );
+};
+
+const TemplateOption = ({
+  template,
+  onClick,
+}: {
+  template: {
+    value: LLM_TEMPLATE;
+    label: string;
+    hint: string;
+  };
+  onClick: (template: LLM_TEMPLATE) => void;
+}) => {
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+  return (
+    <DialogComboboxOptionListSelectItem
+      value={template.value}
+      icon={<SparkleDoubleIcon />}
+      css={{
+        alignItems: 'center',
+        height: theme.general.buttonHeight,
+        '&>label': { flex: 1 },
+
+        flexShrink: 0,
+      }}
+      key={template.value}
+      hintColumn={
+        <Tag
+          componentId="codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_123"
+          color={'pink'}
+          icon={<SparkleDoubleIcon />}
+        >
+          {intl.formatMessage({
+            defaultMessage: 'LLM-as-a-judge',
+            description: 'Label for LLM scorer type',
+          })}
+        </Tag>
+      }
+      onChange={() => onClick(template.value)}
+    >
+      <div css={{ display: 'flex', flexDirection: 'column' }}>
+        <Typography.Text css={{ flex: 1 }}>{template.label}</Typography.Text>
+        <Typography.Hint>Built-in judge</Typography.Hint>
+      </div>
+    </DialogComboboxOptionListSelectItem>
+  );
+};
+
+export const useRunJudgeButtonForTrace = ({
+  // traceId,
+  experimentId,
+  // onScorerFinished,
+  // onScorerStarted,
+}: {
+  // traceId: string;
+  experimentId?: string;
+  // onScorerFinished: () => void;
+  // onScorerStarted?: (scorerName: string) => void;
+}) => {
+  const finishedCallbackRef = useRef<(() => void) | undefined>(undefined);
+  const [scorerInProgress, setScorerInProgress] = useState<string | undefined>(undefined);
+  const { evaluateTraces, isLoading } = useEvaluateTracesUsingKnownScorer({
+    experimentId,
+    onScorerFinished: () => {
+      finishedCallbackRef.current?.();
+      setScorerInProgress(undefined);
+    },
+  });
+
+  const renderRunJudgeButton = useCallback(
+    ({
+      traceId,
+      onRunJudgeFinishedCallback,
+      disabled,
+    }: {
+      traceId: string;
+      onRunJudgeFinishedCallback: () => void;
+      disabled?: boolean;
+    }) => {
+      finishedCallbackRef.current = onRunJudgeFinishedCallback;
+      return (
+        <RunJudgeButtonForTrace
+          traceId={traceId}
+          onScorerStarted={setScorerInProgress}
+          evaluateTraces={evaluateTraces}
+          disabled={disabled}
+        />
+      );
+    },
+    [evaluateTraces],
+  );
+
+  return useMemo(
+    () => ({ renderRunJudgeButton, judgeExecutionState: { isLoading, scorerInProgress } }),
+    [renderRunJudgeButton, isLoading, scorerInProgress],
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
@@ -77,6 +77,7 @@ export const useEvaluateTracesAsync = ({ onScorerFinished }: { onScorerFinished?
         experiment_id: evaluateParams.experimentId,
         serialized_scorer: evaluateParams.serializedScorer,
         trace_ids: traceIds,
+        log_assessments: true,
       });
       return responseData;
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesUsingKnownScorer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesUsingKnownScorer.tsx
@@ -1,0 +1,53 @@
+import { useCallback } from 'react';
+import { useEvaluateTraces } from './useEvaluateTraces';
+import { EvaluateTracesParams, LLM_TEMPLATE, LLMScorer, ScheduledScorer } from './types';
+import { ASSESSMENT_NAME_TEMPLATE_MAPPING, ScorerEvaluationScope } from './constants';
+import { transformScheduledScorer } from './utils/scorerTransformUtils';
+import { isObject } from 'lodash';
+
+export const useEvaluateTracesUsingKnownScorer = ({
+  experimentId,
+  onScorerFinished,
+}: {
+  experimentId?: string;
+  onScorerFinished: () => void;
+}) => {
+  const [evaluateTracesFn, { data, isLoading }] = useEvaluateTraces({ onScorerFinished });
+
+  const evaluateTraces = useCallback(
+    async (scorer: LLMScorer, traceIds: string[]) => {
+      if (!experimentId) {
+        throw new Error('Experiment ID is required');
+      }
+      try {
+        const scorerConfig = transformScheduledScorer(scorer);
+        // Prepare evaluation parameters based on mode
+        const evaluationParams: EvaluateTracesParams = {
+          itemCount: undefined,
+          itemIds: traceIds,
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' as const }],
+          requestedAssessments: [
+            {
+              assessment_name:
+                ASSESSMENT_NAME_TEMPLATE_MAPPING[scorer.llmTemplate as keyof typeof ASSESSMENT_NAME_TEMPLATE_MAPPING],
+            },
+          ],
+          judgeInstructions: scorer.instructions || '',
+          experimentId,
+          evaluationScope: ScorerEvaluationScope.TRACES,
+          serializedScorer: scorerConfig.serialized_scorer,
+        };
+        await evaluateTracesFn(evaluationParams);
+      } catch (error) {
+        // TODO: Handle serialization error
+      }
+    },
+    [evaluateTracesFn, experimentId],
+  );
+
+  return {
+    evaluateTraces,
+    data,
+    isLoading,
+  };
+};

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useActiveEvaluation.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useActiveEvaluation.tsx
@@ -16,12 +16,23 @@ export const useActiveEvaluation = () => {
   const selectedEvaluationId = searchParams.get(QUERY_PARAM_KEY) ?? undefined;
 
   const setSelectedEvaluationId = useCallback(
-    (selectedEvaluationId: string | undefined, traceInfo?: ModelTraceInfoV3) => {
+    (
+      selectedEvaluationId: string | undefined,
+      traceInfo?: ModelTraceInfoV3,
+      additionalParams?: Record<string, string>,
+    ) => {
       setSearchParams((params) => {
         if (selectedEvaluationId === undefined) {
           params.delete(QUERY_PARAM_KEY);
           return params;
         }
+
+        if (additionalParams) {
+          Object.entries(additionalParams).forEach(([key, value]) => {
+            params.set(key, value);
+          });
+        }
+
         // If the trace supports V4 identifiers, use this format instead.
         if (traceInfo && doesTraceSupportV4API(traceInfo)) {
           const longIdentifier = createTraceV4LongIdentifier(traceInfo);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.tsx
@@ -94,7 +94,7 @@ export const ModelTraceExplorerImpl = ({
         selectedSpanIdOnRender={selectedSpanId}
         assessmentsPaneEnabled={assessmentsPaneEnabled}
         isInComparisonView={isInComparisonView}
-        initialAssessmentsPaneCollapsed={collapseAssessmentPane}
+        initialAssessmentsPaneCollapsed={'force-open'}
         isTraceInitialLoading={isTraceInitialLoading}
       >
         {showLoadingState ? (

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerViewStateContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerViewStateContext.tsx
@@ -18,7 +18,7 @@ type PaneSizeRatios = {
 // Default ratios of pane sizes in the model trace explorer.
 const getDefaultPaneSizeRatios = (): PaneSizeRatios => ({
   // Summary sidebar
-  summarySidebar: 0.75,
+  summarySidebar: 0.66,
   // Details sidebar
   detailsSidebar: 0.7,
   // Details pane (based on the window width)

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
@@ -34,6 +34,7 @@ const ComponentMap: Record<AssessmentFormInputDataType, React.ComponentType<Asse
 
 type AssessmentCreateFormProps = {
   assessmentName?: string;
+  initialAssessmentType?: 'feedback' | 'expectation';
   spanId?: string;
   traceId: string;
   setExpanded: (expanded: boolean) => void;
@@ -46,6 +47,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
       assessmentName,
       spanId,
       traceId,
+      initialAssessmentType,
       // used to close the form
       // after the assessment is created
       setExpanded,
@@ -56,7 +58,9 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
     const { schemas } = useAssessmentSchemas();
 
     const [name, setName] = useState('');
-    const [assessmentType, setAssessmentType] = useState<'feedback' | 'expectation'>('feedback');
+    const [assessmentType, setAssessmentType] = useState<'feedback' | 'expectation'>(
+      initialAssessmentType ?? 'feedback',
+    );
     const [dataType, setDataType] = useState<AssessmentFormInputDataType>('boolean');
     const [value, setValue] = useState<string | boolean | number>(true);
     const [rationale, setRationale] = useState('');

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentJudgesSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentJudgesSection.tsx
@@ -1,0 +1,129 @@
+// import {
+//   Button,
+//   ParagraphSkeleton,
+//   PlusIcon,
+//   Spacer,
+//   TableSkeleton,
+//   TableSkeletonRows,
+//   Typography,
+//   useDesignSystemTheme,
+// } from '@databricks/design-system';
+// import { FormattedMessage } from 'react-intl';
+// import { useModelTraceExplorerUpdateTraceContext } from '../contexts/UpdateTraceContext';
+// // import { useModelTraceExplorerUpdateTraceContext } from '../contexts/UpdateTraceContext';
+// import { RunJudgeButtonForTrace } from '../../../../experiment-tracking/pages/experiment-scorers/RunJudgeButtonForTrace';
+// import { FETCH_TRACE_INFO_QUERY_KEY } from '../ModelTraceExplorer.utils';
+// import { useQueryClient } from '@tanstack/react-query';
+// import { FeedbackAssessment } from '../ModelTrace.types';
+// import { FeedbackGroup } from './FeedbackGroup';
+// import { isEmpty } from 'lodash';
+// import { Link } from '../RoutingUtils';
+// import { invalidateMlflowSearchTracesCache } from '@databricks/web-shared/genai-traces-table';
+// import { useState } from 'react';
+
+// export const AssessmentJudgesSection = ({
+//   traceId,
+//   groupedFeedbacks,
+// }: {
+//   traceId: string;
+//   groupedFeedbacks: [assessmentName: string, feedbacks: { [value: string]: FeedbackAssessment[] }][];
+// }) => {
+//   const { theme } = useDesignSystemTheme();
+//   const queryClient = useQueryClient();
+//   //   const [isLoading, setIsLoading] = useState(false);
+
+//   const [scorerInProgressName, setScorerInProgressName] = useState<string | undefined>(undefined);
+
+//   const handleScorerStarted = (scorerName: string) => {
+//     setScorerInProgressName(scorerName);
+//   };
+
+//   const { useRenderRunJudgeButton, invalidateTraceQuery } = useModelTraceExplorerUpdateTraceContext();
+//   if (!useRenderRunJudgeButton) {
+//     return null;
+//   }
+
+//   return (
+//     <div css={{ display: 'flex', flexDirection: 'column', marginBottom: theme.spacing.md }}>
+//       <div
+//         css={{
+//           display: 'flex',
+//           justifyContent: 'space-between',
+//           alignItems: 'center',
+//           marginBottom: theme.spacing.sm,
+//           height: theme.spacing.lg,
+//         }}
+//       >
+//         <Typography.Text bold>
+//           <FormattedMessage
+//             defaultMessage="Judges"
+//             description="Label for the expectations section in the assessments pane"
+//           />{' '}
+//           {!isEmpty(groupedFeedbacks) && <>({groupedFeedbacks.length})</>}
+//         </Typography.Text>
+//         {!isEmpty(groupedFeedbacks) &&
+//           null
+//           // <RunJudgeButtonForTrace
+//           //   traceId={traceId}
+//           //   onScorerStarted={handleScorerStarted}
+//           //   onScorerFinished={() => {
+//           //     queryClient.invalidateQueries({ queryKey: [FETCH_TRACE_INFO_QUERY_KEY, traceId] });
+//           //     invalidateMlflowSearchTracesCache({ queryClient });
+//           //     invalidateTraceQuery?.(traceId);
+//           //     setScorerInProgressName(undefined);
+//           //   }}
+//           // />
+//         }
+//       </div>
+//       {groupedFeedbacks.map(([name, valuesMap]) => (
+//         <FeedbackGroup key={name} name={name} valuesMap={valuesMap} traceId={traceId} showAddButton={false} />
+//       ))}
+//       {scorerInProgressName && (
+//         <div
+//           css={{
+//             borderRadius: theme.spacing.sm,
+//             border: `1px solid ${theme.colors.border}`,
+//             padding: `${theme.spacing.md}px ${theme.spacing.md}px`,
+//           }}
+//         >
+//           <Typography.Text bold css={{ overflow: 'hidden', textOverflow: 'ellipsis', textWrap: 'nowrap' }}>
+//             {scorerInProgressName}
+//           </Typography.Text>
+//           <Spacer size="sm" />
+//           <TableSkeleton lines={3} />
+//         </div>
+//       )}
+//       {isEmpty(groupedFeedbacks) && (
+//         <div
+//           css={{
+//             textAlign: 'center',
+//             borderRadius: theme.spacing.sm,
+//             border: `1px solid ${theme.colors.border}`,
+//             padding: `${theme.spacing.md}px ${theme.spacing.md}px`,
+//             display: scorerInProgressName ? 'none' : 'block',
+//           }}
+//         >
+//           <>
+//             <Typography.Hint>
+//               Add a LLM-as-a-judge or Custom code scorer to this trace.{' '}
+//               <Typography.Link componentId="TODO">Learn more.</Typography.Link>
+//             </Typography.Hint>
+//             <Spacer size="sm" />
+//             {/* {renderRunJudgeButton({ traceId })} */}
+
+//             {/* <RunJudgeButtonForTrace
+//               traceId={traceId}
+//               onScorerStarted={handleScorerStarted}
+//               onScorerFinished={() => {
+//                 queryClient.invalidateQueries({ queryKey: [FETCH_TRACE_INFO_QUERY_KEY, traceId] });
+//                 invalidateMlflowSearchTracesCache({ queryClient });
+//                 invalidateTraceQuery?.(traceId);
+//                 setScorerInProgressName(undefined);
+//               }}
+//             /> */}
+//           </>
+//         </div>
+//       )}
+//     </div>
+//   );
+// };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -1,11 +1,16 @@
-import { isNil, partition, uniqBy } from 'lodash';
-import { useMemo } from 'react';
+import { isEmpty, isNil, partition, some, uniqBy } from 'lodash';
+import { useCallback, useMemo, useState } from 'react';
 
 import {
   Button,
   ChevronDownIcon,
   ChevronRightIcon,
   CloseIcon,
+  PlayIcon,
+  PlusIcon,
+  Spacer,
+  Spinner,
+  TableSkeleton,
   Tooltip,
   Typography,
   useDesignSystemTheme,
@@ -20,6 +25,12 @@ import { shouldUseTracesV4API } from '../FeatureUtils';
 import type { Assessment, FeedbackAssessment } from '../ModelTrace.types';
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
 import { useTraceCachedActions } from '../hooks/useTraceCachedActions';
+import { AssessmentCreateForm } from './AssessmentCreateForm';
+import { FETCH_TRACE_INFO_QUERY_KEY } from '../ModelTraceExplorer.utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { invalidateMlflowSearchTracesCache } from '../hooks/invalidateMlflowSearchTracesCache';
+import { useModelTraceExplorerUpdateTraceContext } from '../contexts/UpdateTraceContext';
+import { AssessmentEditForm } from './AssessmentEditForm';
 
 type GroupedFeedbacksByValue = { [value: string]: FeedbackAssessment[] };
 
@@ -51,7 +62,21 @@ const groupFeedbacks = (feedbacks: FeedbackAssessment[]): GroupedFeedbacks => {
     }
   });
 
-  return Object.entries(aggregated).toSorted(([leftName], [rightName]) => leftName.localeCompare(rightName));
+  return Object.entries(aggregated).toSorted(([leftName, leftFeedback], [rightName, rightFeedback]) => {
+    const leftIsLLMJudge = some(leftFeedback, (feedbacks) =>
+      feedbacks.some((feedback) => feedback.source.source_type === 'LLM_JUDGE'),
+    );
+    const rightIsLLMJudge = some(rightFeedback, (feedbacks) =>
+      feedbacks.some((feedback) => feedback.source.source_type === 'LLM_JUDGE'),
+    );
+    if (leftIsLLMJudge && !rightIsLLMJudge) {
+      return -1;
+    }
+    if (!leftIsLLMJudge && rightIsLLMJudge) {
+      return 1;
+    }
+    return leftName.localeCompare(rightName);
+  });
 };
 
 export const AssessmentsPane = ({
@@ -71,6 +96,14 @@ export const AssessmentsPane = ({
 }) => {
   const reconstructAssessments = useTraceCachedActions((state) => state.reconstructAssessments);
   const cachedActions = useTraceCachedActions((state) => state.assessmentActions[traceId]);
+  const { runJudgeContext, invalidateTraceQuery } = useModelTraceExplorerUpdateTraceContext();
+
+  const queryClient = useQueryClient();
+  const onRunJudgeFinishedCallback = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: [FETCH_TRACE_INFO_QUERY_KEY, traceId] });
+    invalidateTraceQuery?.(traceId);
+    invalidateMlflowSearchTracesCache({ queryClient });
+  }, [traceId, invalidateTraceQuery, queryClient]);
 
   // Combine the initial assessments with the cached actions (additions and deletions)
   const allAssessments = useMemo(() => {
@@ -88,10 +121,14 @@ export const AssessmentsPane = ({
     () => partition(allAssessments, (assessment) => 'feedback' in assessment),
     [allAssessments],
   );
-  const groupedFeedbacks = useMemo(() => groupFeedbacks(feedbacks), [feedbacks]);
+  const groupedFeedbacks = useMemo(() => {
+    return groupFeedbacks(feedbacks);
+  }, [feedbacks]);
   const sortedExpectations = expectations.toSorted((left, right) =>
     left.assessment_name.localeCompare(right.assessment_name),
   );
+
+  const [createFormDisplayMode, setCreateFormDisplayMode] = useState<null | 'feedback' | 'expectation'>(null);
 
   return (
     <div
@@ -110,7 +147,15 @@ export const AssessmentsPane = ({
       }}
       className={className}
     >
-      <div css={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: theme.spacing.sm,
+        }}
+      >
         {!isInComparisonView &&
           (assessmentsTitleOverride ? (
             assessmentsTitleOverride()
@@ -137,17 +182,132 @@ export const AssessmentsPane = ({
           </Tooltip>
         )}
       </div>
+      {/* <AssessmentJudgesSection traceId={traceId} groupedFeedbacks={groupedJudgeFeedbacks} /> */}
+      <div
+        css={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: theme.spacing.sm,
+          height: theme.spacing.lg,
+        }}
+      >
+        <Typography.Text bold>
+          <FormattedMessage
+            defaultMessage="Feedback"
+            description="Label for the feedback section in the assessments pane"
+          />{' '}
+          {!isEmpty(groupedFeedbacks) && <>({groupedFeedbacks?.length})</>}
+        </Typography.Text>
+      </div>
+      {!isEmpty(groupedFeedbacks) && (
+        <div css={{ display: 'flex', gap: 4, justifyContent: 'flex-end', marginBottom: theme.spacing.sm }}>
+          <Button
+            componentId="shared.model-trace-explorer.add-feedback"
+            size="small"
+            icon={<PlusIcon />}
+            onClick={() => setCreateFormDisplayMode('feedback')}
+          >
+            <FormattedMessage
+              defaultMessage="Add feedback"
+              description="Label for the button to add a new assessment"
+            />
+          </Button>
+          {runJudgeContext?.renderRunJudgeButton({
+            traceId,
+            onRunJudgeFinishedCallback,
+            disabled: runJudgeContext?.judgeExecutionState.isLoading,
+          })}
+        </div>
+      )}
+      {runJudgeContext?.judgeExecutionState.isLoading && (
+        <div
+          css={{
+            borderRadius: theme.spacing.sm,
+            border: `1px solid ${theme.colors.border}`,
+            padding: 12,
+            paddingTop: 8,
+            marginBottom: theme.spacing.sm,
+          }}
+        >
+          <Typography.Text bold>{runJudgeContext?.judgeExecutionState.scorerInProgress}</Typography.Text>
+          <TableSkeleton lines={4} />
+        </div>
+      )}
       {groupedFeedbacks.map(([name, valuesMap]) => (
         <FeedbackGroup key={name} name={name} valuesMap={valuesMap} traceId={traceId} activeSpanId={activeSpanId} />
       ))}
-      {sortedExpectations.length > 0 && (
-        <>
-          <Typography.Text color="secondary" css={{ marginBottom: theme.spacing.sm }}>
+      {isEmpty(groupedFeedbacks) && (
+        <div
+          css={{
+            textAlign: 'center',
+            borderRadius: theme.spacing.sm,
+            border: `1px solid ${theme.colors.border}`,
+            padding: `${theme.spacing.md}px ${theme.spacing.md}px`,
+          }}
+        >
+          <Typography.Hint>
+            Add a custom feedback to this trace. <Typography.Link componentId="TODO">Learn more.</Typography.Link>
+          </Typography.Hint>
+          <Spacer size="sm" />
+          <div css={{ display: 'flex', gap: 4, justifyContent: 'center' }}>
+            <Button
+              componentId="TODO"
+              size="small"
+              icon={<PlusIcon />}
+              onClick={() => setCreateFormDisplayMode('feedback')}
+            >
+              Add feedback
+            </Button>
+            {runJudgeContext?.renderRunJudgeButton({
+              traceId,
+              onRunJudgeFinishedCallback,
+              disabled: runJudgeContext?.judgeExecutionState.isLoading,
+            })}
+          </div>
+        </div>
+      )}
+      {createFormDisplayMode === 'feedback' && (
+        <AssessmentCreateForm
+          spanId={activeSpanId}
+          traceId={traceId}
+          initialAssessmentType="feedback"
+          setExpanded={() => setCreateFormDisplayMode(null)}
+        />
+      )}
+      <Spacer size="sm" />
+      <div
+        css={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: theme.spacing.sm,
+          height: theme.spacing.lg,
+        }}
+      >
+        <Typography.Text bold>
+          <FormattedMessage
+            defaultMessage="Expectations"
+            description="Label for the expectations section in the assessments pane"
+          />{' '}
+          {!isEmpty(sortedExpectations) && <>({sortedExpectations?.length})</>}
+        </Typography.Text>
+        {!isEmpty(sortedExpectations) && (
+          <Button
+            componentId="shared.model-trace-explorer.add-expectation"
+            size="small"
+            icon={<PlusIcon />}
+            onClick={() => setCreateFormDisplayMode('expectation')}
+          >
             <FormattedMessage
-              defaultMessage="Expectations"
-              description="Label for the expectations section in the assessments pane"
+              defaultMessage="Add expectation"
+              description="Label for the button to add a new expectation"
             />
-          </Typography.Text>
+          </Button>
+        )}
+      </div>
+      {sortedExpectations.length > 0 ? (
+        <>
           <div
             css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm, marginBottom: theme.spacing.sm }}
           >
@@ -156,17 +316,37 @@ export const AssessmentsPane = ({
             ))}
           </div>
         </>
+      ) : (
+        <div
+          css={{
+            textAlign: 'center',
+            borderRadius: theme.spacing.sm,
+            border: `1px solid ${theme.colors.border}`,
+            padding: `${theme.spacing.md}px ${theme.spacing.md}px`,
+          }}
+        >
+          <Typography.Hint>
+            Add a custom expectation to this trace. <Typography.Link componentId="TODO">Learn more.</Typography.Link>
+          </Typography.Hint>
+          <Spacer size="sm" />
+          <Button
+            componentId="TODO"
+            size="small"
+            icon={<PlusIcon />}
+            onClick={() => setCreateFormDisplayMode('expectation')}
+          >
+            Add expectation
+          </Button>
+        </div>
       )}
-      <AssessmentCreateButton
-        title={
-          <FormattedMessage
-            defaultMessage="Add new assessment"
-            description="Label for the button to add a new assessment"
-          />
-        }
-        spanId={activeSpanId}
-        traceId={traceId}
-      />
+      {createFormDisplayMode === 'expectation' && (
+        <AssessmentCreateForm
+          spanId={activeSpanId}
+          traceId={traceId}
+          initialAssessmentType="expectation"
+          setExpanded={() => setCreateFormDisplayMode(null)}
+        />
+      )}
     </div>
   );
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackGroup.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackGroup.tsx
@@ -13,11 +13,13 @@ export const FeedbackGroup = ({
   valuesMap,
   traceId,
   activeSpanId,
+  showAddButton = true,
 }: {
   name: string;
   valuesMap: { [value: string]: FeedbackAssessment[] };
   traceId: string;
   activeSpanId?: string;
+  showAddButton?: boolean;
 }) => {
   const { theme } = useDesignSystemTheme();
   const displayName = getAssessmentDisplayName(name);
@@ -54,15 +56,17 @@ export const FeedbackGroup = ({
           </Typography.Text>
           {hasError && <DangerIcon css={{ flexShrink: 0 }} color="danger" />}
         </div>
-        <Tooltip content="Add new feedback" componentId="shared.model-trace-explorer.add-feedback-in-group-tooltip">
-          <Button
-            componentId="shared.model-trace-explorer.add-feedback"
-            css={{ flexShrink: 0, marginRight: -theme.spacing.xs }}
-            size="small"
-            icon={<PlusIcon />}
-            onClick={() => setShowCreateForm(true)}
-          />
-        </Tooltip>
+        {showAddButton && (
+          <Tooltip content="Add new feedback" componentId="shared.model-trace-explorer.add-feedback-in-group-tooltip">
+            <Button
+              componentId="shared.model-trace-explorer.add-feedback"
+              css={{ flexShrink: 0, marginRight: -theme.spacing.xs }}
+              size="small"
+              icon={<PlusIcon />}
+              onClick={() => setShowCreateForm(true)}
+            />
+          </Tooltip>
+        )}
       </div>
       {Object.entries(valuesMap).map(([jsonValue, feedbacks]) => (
         <FeedbackValueGroup jsonValue={jsonValue} feedbacks={feedbacks} key={jsonValue} />

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackValueGroup.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackValueGroup.tsx
@@ -1,11 +1,19 @@
 import { useState } from 'react';
 
-import { Button, ChevronDownIcon, ChevronRightIcon, useDesignSystemTheme } from '@databricks/design-system';
+import {
+  Button,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  SparkleDoubleIcon,
+  Tag,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 
 import { AssessmentDisplayValue } from './AssessmentDisplayValue';
 import { FeedbackItem } from './FeedbackItem';
 import { FeedbackValueGroupSourceCounts } from './FeedbackValueGroupSourceCounts';
 import type { FeedbackAssessment } from '../ModelTrace.types';
+import { FormattedMessage } from 'react-intl';
 
 export const FeedbackValueGroup = ({
   jsonValue,
@@ -30,6 +38,11 @@ export const FeedbackValueGroup = ({
         />
         <AssessmentDisplayValue jsonValue={jsonValue} assessmentName={assessmentName} />
         <FeedbackValueGroupSourceCounts feedbacks={feedbacks} />
+        {feedbacks.find((x) => x.source.source_type === 'LLM_JUDGE') && (
+          <Tag componentId="TODO" color="purple" icon={<SparkleDoubleIcon />}>
+            <FormattedMessage defaultMessage="LLM-as-a-judge" description="Label for LLM scorer type" />
+          </Tag>
+        )}
       </div>
       {expanded && (
         <div

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/UpdateTraceContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/UpdateTraceContext.tsx
@@ -1,12 +1,24 @@
 import React, { useMemo } from 'react';
 
-import type { ModelTrace } from '../ModelTrace.types';
+import type { ModelTrace, ModelTraceInfoV3 } from '../ModelTrace.types';
 
 const ModelTraceExplorerUpdateTraceContext = React.createContext<{
   sqlWarehouseId?: string;
   modelTraceInfo?: ModelTrace['info'];
   invalidateTraceQuery?: (traceId?: string) => void;
   chatSessionId?: string;
+  runJudgeContext?: {
+    renderRunJudgeButton: ({
+      traceId,
+      onRunJudgeFinishedCallback,
+      disabled,
+    }: {
+      traceId: string;
+      onRunJudgeFinishedCallback: () => void;
+      disabled?: boolean;
+    }) => React.ReactNode;
+    judgeExecutionState: { isLoading: boolean; scorerInProgress: string | undefined };
+  };
 }>({
   sqlWarehouseId: undefined,
   modelTraceInfo: undefined,
@@ -26,16 +38,29 @@ export const ModelTraceExplorerUpdateTraceContextProvider = ({
   children,
   invalidateTraceQuery,
   chatSessionId,
+  runJudgeContext,
 }: {
   sqlWarehouseId?: string;
   modelTraceInfo?: ModelTrace['info'];
   children: React.ReactNode;
   invalidateTraceQuery?: (traceId?: string) => void;
   chatSessionId?: string;
+  runJudgeContext?: {
+    renderRunJudgeButton: ({
+      traceId,
+      onRunJudgeFinishedCallback,
+      disabled,
+    }: {
+      traceId: string;
+      onRunJudgeFinishedCallback: () => void;
+      disabled?: boolean;
+    }) => React.ReactNode;
+    judgeExecutionState: { isLoading: boolean; scorerInProgress: string | undefined };
+  };
 }) => {
   const contextValue = useMemo(
-    () => ({ sqlWarehouseId, modelTraceInfo, invalidateTraceQuery, chatSessionId }),
-    [sqlWarehouseId, modelTraceInfo, invalidateTraceQuery, chatSessionId],
+    () => ({ sqlWarehouseId, modelTraceInfo, invalidateTraceQuery, chatSessionId, runJudgeContext }),
+    [sqlWarehouseId, modelTraceInfo, invalidateTraceQuery, chatSessionId, runJudgeContext],
   );
   return (
     <ModelTraceExplorerUpdateTraceContext.Provider value={contextValue}>


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
