### PR TITLE
Revamp assessments and run judges directly in trace UI [Part 1/x]: rearrange UI and restyle certain elements

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -295,6 +295,10 @@
     "defaultMessage": "Select a framework and follow the instructions to log traces with MLflow.",
     "description": "Helper text shown at the top of the log traces drawer"
   },
+  "03HDrw": {
+    "defaultMessage": "Add a custom feedback to this trace.",
+    "description": "Hint message prompting user to add a new feedback"
+  },
   "050N3C": {
     "defaultMessage": "Evaluate and improve the quality, cost, latency of your GenAI app",
     "description": "Title of the empty state for the evaluation runs page"
@@ -510,10 +514,6 @@
   "2+EUFB": {
     "defaultMessage": "Cancel",
     "description": "Delete evaluation runs cancel button text"
-  },
-  "2+O4wk": {
-    "defaultMessage": "Add new assessment",
-    "description": "Label for the button to add a new assessment"
   },
   "2/B9Zg": {
     "defaultMessage": "added {when} by {user}",
@@ -3402,9 +3402,17 @@
     "defaultMessage": "Field",
     "description": "Label for the column field in the GenAI Traces Table Filter form"
   },
+  "OmK5nx": {
+    "defaultMessage": "Add feedback",
+    "description": "Label for the button to add a new feedback"
+  },
   "On3g1B": {
     "defaultMessage": "Running",
     "description": "Run page > Overview > Run status cell > Value for running state"
+  },
+  "OneX+E": {
+    "defaultMessage": "Add expectation",
+    "description": "Label for the button to add a new expectation"
   },
   "OxQK9l": {
     "defaultMessage": "Key name is required",
@@ -3572,6 +3580,10 @@
   "QK/Qyx": {
     "defaultMessage": "Total",
     "description": "Label for total token usage"
+  },
+  "QK9qFL": {
+    "defaultMessage": "Hide assessments",
+    "description": "Label for the button to hide the assessments pane"
   },
   "QPC4hV": {
     "defaultMessage": "Use other parameters or disable run grouping to continue.",
@@ -5343,6 +5355,10 @@
     "defaultMessage": "expand {title}",
     "description": "Common component > collapsible section > alternative label when collapsed"
   },
+  "dTjHiD": {
+    "defaultMessage": "Add a custom expectation to this trace.",
+    "description": "Hint message prompting user to add a new expectation"
+  },
   "dVh69l": {
     "defaultMessage": "Run name",
     "description": "Column label for run name"
@@ -6539,6 +6555,10 @@
     "defaultMessage": "of",
     "description": "Connector between dict and value type"
   },
+  "mLr9U7": {
+    "defaultMessage": "Learn more.",
+    "description": "Link text for learning more about feedback"
+  },
   "mMR/YQ": {
     "defaultMessage": "Select a provider to configure your API key",
     "description": "Placeholder message when no provider selected"
@@ -6594,6 +6614,10 @@
   "mjNFJt": {
     "defaultMessage": "Logged models",
     "description": "Run page > Overview > Run models section label"
+  },
+  "mltH0e": {
+    "defaultMessage": "Show assessments",
+    "description": "Label for the button to show the assessments pane"
   },
   "mmiHAX": {
     "defaultMessage": "Parameters",
@@ -7163,10 +7187,6 @@
     "defaultMessage": "Parameter",
     "description": "Run page > Overview > Parameters table > Key column header"
   },
-  "r/fxMt": {
-    "defaultMessage": "Assessments",
-    "description": "Label for the assessments pane of the model trace explorer."
-  },
   "r/mP0/": {
     "defaultMessage": "Add rationale (optional)",
     "description": "Evaluation review > assessments > rationale input placeholder"
@@ -7658,6 +7678,10 @@
   "urvfNd": {
     "defaultMessage": "Cancel",
     "description": "Add new key-value tag modal > Cancel button text"
+  },
+  "utyagz": {
+    "defaultMessage": "Feedback",
+    "description": "Label for the feedback section in the assessments pane"
   },
   "uyx2Bd": {
     "defaultMessage": "search_traces syntax",
@@ -8226,6 +8250,10 @@
   "zMhOr3": {
     "defaultMessage": "Cancel",
     "description": "Cancel button text for model version deletion modal in model versions view page"
+  },
+  "zMv2ev": {
+    "defaultMessage": "Learn more.",
+    "description": "Link text for learning more about expectations"
   },
   "zNWzj6": {
     "defaultMessage": "Search traces by request",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test.tsx
@@ -359,7 +359,7 @@ describe('ModelTraceExplorer', () => {
 
     expect(screen.getByTestId('assessments-pane')).toBeInTheDocument();
 
-    const createButton = screen.getByText('Add new assessment');
+    const createButton = screen.getByText('Add feedback');
     await userEvent.click(createButton);
 
     // expect that the default assessment input type is boolean

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
@@ -34,6 +34,7 @@ const ComponentMap: Record<AssessmentFormInputDataType, React.ComponentType<Asse
 
 type AssessmentCreateFormProps = {
   assessmentName?: string;
+  initialAssessmentType?: 'feedback' | 'expectation';
   spanId?: string;
   traceId: string;
   setExpanded: (expanded: boolean) => void;
@@ -44,6 +45,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
   (
     {
       assessmentName,
+      initialAssessmentType,
       spanId,
       traceId,
       // used to close the form
@@ -56,7 +58,9 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
     const { schemas } = useAssessmentSchemas();
 
     const [name, setName] = useState('');
-    const [assessmentType, setAssessmentType] = useState<'feedback' | 'expectation'>('feedback');
+    const [assessmentType, setAssessmentType] = useState<'feedback' | 'expectation'>(
+      initialAssessmentType ?? 'feedback',
+    );
     const [dataType, setDataType] = useState<AssessmentFormInputDataType>('boolean');
     const [value, setValue] = useState<string | boolean | number>(true);
     const [rationale, setRationale] = useState('');
@@ -139,7 +143,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
         // clear the form back to defaults
         if (!schema) {
           setName('');
-          setAssessmentType('feedback');
+          setAssessmentType(initialAssessmentType ?? 'feedback');
           setDataType('boolean');
           setValue(true);
           setRationale('');
@@ -176,7 +180,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
             break;
         }
       },
-      [schemas],
+      [schemas, initialAssessmentType],
     );
 
     return (
@@ -186,7 +190,6 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
           display: 'flex',
           flexDirection: 'column',
           gap: theme.spacing.xs,
-          marginTop: theme.spacing.sm,
           border: `1px solid ${theme.colors.border}`,
           padding: theme.spacing.sm,
           borderRadius: theme.borders.borderRadiusSm,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentPaneToggle.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentPaneToggle.tsx
@@ -1,4 +1,4 @@
-import { GavelIcon, SegmentedControlGroup, SegmentedControlButton } from '@databricks/design-system';
+import { useDesignSystemTheme, SidebarExpandIcon, Button, SidebarCollapseIcon } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
@@ -12,32 +12,25 @@ export const AssessmentPaneToggle = () => {
   }
 
   return (
-    <SegmentedControlGroup
-      css={{ display: 'block' }}
-      name="shared.model-trace-explorer.assessments-pane-toggle"
+    <Button
+      disabled={!assessmentsPaneEnabled}
+      type="primary"
       componentId="shared.model-trace-explorer.assessments-pane-toggle"
-      value={assessmentsPaneExpanded}
       size="small"
+      icon={assessmentsPaneExpanded ? <SidebarExpandIcon /> : <SidebarCollapseIcon />}
+      onClick={() => setAssessmentsPaneExpanded?.(!assessmentsPaneExpanded)}
     >
-      <SegmentedControlButton
-        value
-        disabled={!assessmentsPaneEnabled}
-        icon={<GavelIcon />}
-        onClick={() => setAssessmentsPaneExpanded?.(!assessmentsPaneExpanded)}
-        css={{
-          '& > span': {
-            display: 'flex',
-            alignItems: 'center',
-          },
-        }}
-      >
-        {!assessmentsPaneExpanded && (
-          <FormattedMessage
-            defaultMessage="Assessments"
-            description="Label for the assessments pane of the model trace explorer."
-          />
-        )}
-      </SegmentedControlButton>
-    </SegmentedControlGroup>
+      {assessmentsPaneExpanded ? (
+        <FormattedMessage
+          defaultMessage="Hide assessments"
+          description="Label for the button to hide the assessments pane"
+        />
+      ) : (
+        <FormattedMessage
+          defaultMessage="Show assessments"
+          description="Label for the button to show the assessments pane"
+        />
+      )}
+    </Button>
   );
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneExpectationsSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneExpectationsSection.tsx
@@ -1,0 +1,105 @@
+import { Button, PlusIcon, Spacer, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { ExpectationAssessment } from '../ModelTrace.types';
+import { ExpectationItem } from './ExpectationItem';
+import { useMemo, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { isEmpty } from 'lodash';
+import { AssessmentCreateForm } from './AssessmentCreateForm';
+
+const AddExpectationButton = ({ onClick }: { onClick: () => void }) => (
+  <Button componentId="shared.model-trace-explorer.add-expectation" size="small" icon={<PlusIcon />} onClick={onClick}>
+    <FormattedMessage defaultMessage="Add expectation" description="Label for the button to add a new expectation" />
+  </Button>
+);
+
+export const AssessmentsPaneExpectationsSection = ({
+  expectations,
+  activeSpanId,
+  traceId,
+}: {
+  expectations: ExpectationAssessment[];
+  activeSpanId?: string;
+  traceId: string;
+}) => {
+  const sortedExpectations = useMemo(
+    () => expectations.toSorted((left, right) => left.assessment_name.localeCompare(right.assessment_name)),
+    [expectations],
+  );
+
+  const [createFormVisible, setCreateFormVisible] = useState(false);
+
+  const { theme } = useDesignSystemTheme();
+  return (
+    <>
+      <div
+        css={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          height: theme.spacing.lg,
+          flexShrink: 0,
+        }}
+      >
+        <Typography.Text bold>
+          <FormattedMessage
+            defaultMessage="Expectations"
+            description="Label for the expectations section in the assessments pane"
+          />{' '}
+          {!isEmpty(sortedExpectations) && <>({sortedExpectations?.length})</>}
+        </Typography.Text>
+      </div>
+      <div css={{ display: 'flex', justifyContent: 'flex-end', marginBottom: theme.spacing.sm }}>
+        {!isEmpty(sortedExpectations) && <AddExpectationButton onClick={() => setCreateFormVisible(true)} />}
+      </div>
+      {sortedExpectations.length > 0 ? (
+        <>
+          <div
+            css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm, marginBottom: theme.spacing.sm }}
+          >
+            {sortedExpectations.map((expectation) => (
+              <ExpectationItem expectation={expectation} key={expectation.assessment_id} />
+            ))}
+          </div>
+        </>
+      ) : (
+        !createFormVisible && (
+          <div
+            css={{
+              textAlign: 'center',
+              borderRadius: theme.spacing.xs,
+              border: `1px dashed ${theme.colors.border}`,
+              padding: `${theme.spacing.md}px ${theme.spacing.md}px`,
+            }}
+          >
+            <Typography.Hint>
+              <FormattedMessage
+                defaultMessage="Add a custom expectation to this trace."
+                description="Hint message prompting user to add a new expectation"
+              />{' '}
+              <Typography.Link
+                componentId="shared.model-trace-explorer.expectation-learn-more-link"
+                openInNewTab
+                href="https://www.mlflow.org/docs/latest/genai/assessments/expectations/"
+              >
+                <FormattedMessage
+                  defaultMessage="Learn more."
+                  description="Link text for learning more about expectations"
+                />
+              </Typography.Link>
+            </Typography.Hint>
+            <Spacer size="sm" />
+            <AddExpectationButton onClick={() => setCreateFormVisible(true)} />
+          </div>
+        )
+      )}
+      {createFormVisible && (
+        <AssessmentCreateForm
+          spanId={activeSpanId}
+          traceId={traceId}
+          initialAssessmentType="expectation"
+          setExpanded={() => setCreateFormVisible(false)}
+        />
+      )}
+    </>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -1,0 +1,139 @@
+import { Button, PlusIcon, Spacer, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FeedbackAssessment } from '../ModelTrace.types';
+import { FeedbackGroup } from './FeedbackGroup';
+import { useMemo, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { isEmpty, isNil } from 'lodash';
+import { AssessmentCreateForm } from './AssessmentCreateForm';
+
+type GroupedFeedbacksByValue = { [value: string]: FeedbackAssessment[] };
+
+type GroupedFeedbacks = [assessmentName: string, feedbacks: GroupedFeedbacksByValue][];
+
+const groupFeedbacks = (feedbacks: FeedbackAssessment[]): GroupedFeedbacks => {
+  const aggregated: Record<string, GroupedFeedbacksByValue> = {};
+  feedbacks.forEach((feedback) => {
+    if (feedback.valid === false) {
+      return;
+    }
+
+    let value = null;
+    if (feedback.feedback.value !== '') {
+      value = JSON.stringify(feedback.feedback.value);
+    }
+
+    const { assessment_name } = feedback;
+    if (!aggregated[assessment_name]) {
+      aggregated[assessment_name] = {};
+    }
+
+    const group = aggregated[assessment_name];
+    if (!isNil(value)) {
+      if (!group[value]) {
+        group[value] = [];
+      }
+      group[value].push(feedback);
+    }
+  });
+
+  // Filter out LLM judge feedback groups
+  return Object.entries(aggregated);
+};
+
+const AddFeedbackButton = ({ onClick }: { onClick: () => void }) => (
+  <Button
+    type="primary"
+    componentId="shared.model-trace-explorer.add-feedback"
+    size="small"
+    icon={<PlusIcon />}
+    onClick={onClick}
+  >
+    {/* {TODO(next PR): Rename to "Add human feedback" when auto LLM judge feedback is implemented */}
+    <FormattedMessage defaultMessage="Add feedback" description="Label for the button to add a new feedback" />
+  </Button>
+);
+
+export const AssessmentsPaneFeedbackSection = ({
+  feedbacks,
+  activeSpanId,
+  traceId,
+}: {
+  feedbacks: FeedbackAssessment[];
+  activeSpanId?: string;
+  traceId: string;
+}) => {
+  const groupedFeedbacks = useMemo(() => {
+    // TODO(next PR): Extract LLM judge feedback groups to a separate section
+    return groupFeedbacks(feedbacks);
+  }, [feedbacks]);
+
+  const [createFormVisible, setCreateFormVisible] = useState(false);
+
+  const { theme } = useDesignSystemTheme();
+  return (
+    <>
+      <div
+        css={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: theme.spacing.sm,
+          height: theme.spacing.lg,
+          flexShrink: 0,
+        }}
+      >
+        <Typography.Text bold>
+          <FormattedMessage
+            defaultMessage="Feedback"
+            description="Label for the feedback section in the assessments pane"
+          />{' '}
+          {!isEmpty(groupedFeedbacks) && <>({feedbacks?.length})</>}
+        </Typography.Text>
+      </div>
+      {!isEmpty(groupedFeedbacks) && (
+        <div css={{ display: 'flex', justifyContent: 'flex-end', marginBottom: theme.spacing.sm }}>
+          <AddFeedbackButton onClick={() => setCreateFormVisible(true)} />
+        </div>
+      )}
+      {groupedFeedbacks.map(([name, valuesMap]) => (
+        <FeedbackGroup key={name} name={name} valuesMap={valuesMap} traceId={traceId} activeSpanId={activeSpanId} />
+      ))}
+      {isEmpty(groupedFeedbacks) && !createFormVisible && (
+        <div
+          css={{
+            textAlign: 'center',
+            borderRadius: theme.spacing.xs,
+            border: `1px dashed ${theme.colors.border}`,
+            padding: `${theme.spacing.md}px ${theme.spacing.md}px`,
+          }}
+        >
+          <Typography.Hint>
+            <FormattedMessage
+              defaultMessage="Add a custom feedback to this trace."
+              description="Hint message prompting user to add a new feedback"
+            />{' '}
+            <Typography.Link
+              componentId="shared.model-trace-explorer.feedback-learn-more-link"
+              openInNewTab
+              href="https://www.mlflow.org/docs/latest/genai/assessments/feedback/"
+            >
+              <FormattedMessage defaultMessage="Learn more." description="Link text for learning more about feedback" />
+            </Typography.Link>
+          </Typography.Hint>
+          <Spacer size="sm" />
+          <div css={{ display: 'flex', gap: 4, justifyContent: 'center' }}>
+            <AddFeedbackButton onClick={() => setCreateFormVisible(true)} />
+          </div>
+        </div>
+      )}
+      {createFormVisible && (
+        <AssessmentCreateForm
+          spanId={activeSpanId}
+          traceId={traceId}
+          initialAssessmentType="feedback"
+          setExpanded={() => setCreateFormVisible(false)}
+        />
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20233/files) to review incremental changes.
- [**stack/run-judges-from-trace-ui-part1**](https://github.com/mlflow/mlflow/pull/20233) [[Files changed](https://github.com/mlflow/mlflow/pull/20233/files)]
  - [stack/run-judges-from-trace-ui-part2](https://github.com/mlflow/mlflow/pull/20234) [[Files changed](https://github.com/mlflow/mlflow/pull/20234/files/d1089ba99ebef1cccae84e3d0e413ad8f7190b66..fa6fe75c565e5943d27857871cc1730834a00ee6)]
    - [stack/run-judges-from-trace-ui-part3](https://github.com/mlflow/mlflow/pull/20261) [[Files changed](https://github.com/mlflow/mlflow/pull/20261/files/fa6fe75c565e5943d27857871cc1730834a00ee6..0e50b1b21ad814ea82780d5e2c811a4968facf99)]
      - [stack/run-judges-from-trace-ui-part4](https://github.com/mlflow/mlflow/pull/20275) [[Files changed](https://github.com/mlflow/mlflow/pull/20275/files/0e50b1b21ad814ea82780d5e2c811a4968facf99..db5db42f201594e49ef3c0b2c66d9a51b823acb4)]
        - [stack/run-judges-from-trace-ui-part5](https://github.com/mlflow/mlflow/pull/20276) [[Files changed](https://github.com/mlflow/mlflow/pull/20276/files/db5db42f201594e49ef3c0b2c66d9a51b823acb4..8e047796d8ab1c116e52f254063a7ad54958171b)]
          - [stack/run-judges-from-trace-ui-part6](https://github.com/mlflow/mlflow/pull/20312) [[Files changed](https://github.com/mlflow/mlflow/pull/20312/files/8e047796d8ab1c116e52f254063a7ad54958171b..3c2f1fd9ccb5c23aae142b5dbd6d32415057a7e5)]
            - [stack/run-judges-from-trace-ui-part7](https://github.com/mlflow/mlflow/pull/20313) [[Files changed](https://github.com/mlflow/mlflow/pull/20313/files/3c2f1fd9ccb5c23aae142b5dbd6d32415057a7e5..f081935028a65baaa94403e5d07c02de28b14ae0)]
              - [stack/run-judges-from-trace-ui-part8](https://github.com/mlflow/mlflow/pull/20340) [[Files changed](https://github.com/mlflow/mlflow/pull/20340/files/f081935028a65baaa94403e5d07c02de28b14ae0..53c55b4047f6d6833fbeb8d6904b4a2c635e5a05)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?


Rearranges assessments UI according to https://www.figma.com/design/eudql8szHU8Az1nqfcQ8hf/MLflow-3---Judges-and-assessments?node-id=7582-69124&t=Pzn9FaKkLB0DakuK-0

- Assessments toggle now uses primary type and new icons now
- Feedback and expectations are housed in clearly separated sections
- Improve CTA buttons and the inviting text

https://github.com/user-attachments/assets/91437c3c-d12b-4281-b440-f16329f8f931



### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
