### PR TITLE
fix(tracing): Prevent HTML output in non-notebook IPython environments

### DIFF
--- a/mlflow/genai/utils/display_utils.py
+++ b/mlflow/genai/utils/display_utils.py
@@ -2,7 +2,6 @@ import sys
 
 from mlflow.entities import Run
 from mlflow.store.tracking.rest_store import RestStore
-from mlflow.tracing.display.display_handler import _is_jupyter
 from mlflow.tracking._tracking_service.utils import _get_store, get_tracking_uri
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_WORKSPACE_URL
 from mlflow.utils.uri import is_databricks_uri
@@ -131,7 +130,10 @@ open the \033[93m\033[1mTraces\033[0m tab in the Run page in the MLflow UI.\n\n"
         return
 
     uri = _resolve_evaluation_results_url(store, run)
-    if _is_jupyter():
+    # Lazy import to avoid circular dependency
+    from mlflow.tracking.context.jupyter_notebook_context import _is_in_jupyter_notebook
+
+    if _is_in_jupyter_notebook():
         from IPython.display import HTML, display
 
         display(HTML(_EVAL_OUTPUT_HTML.format(eval_results_url=uri)))

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -83,13 +83,6 @@ def _get_query_string_for_traces(traces: list["Trace"]):
     return urlencode(query_params)
 
 
-def _is_jupyter():
-    # Lazy import to avoid circular dependency
-    from mlflow.tracking.context.jupyter_notebook_context import _is_in_jupyter_notebook
-
-    return _is_in_jupyter_notebook()
-
-
 def is_using_tracking_server():
     return is_http_uri(mlflow.get_tracking_uri())
 
@@ -98,7 +91,10 @@ def is_trace_ui_available():
     # the notebook display feature only works in
     # Databricks notebooks, or in Jupyter notebooks
     # with a tracking server
-    return _is_jupyter() and (is_in_databricks_runtime() or is_using_tracking_server())
+    # Lazy import to avoid circular dependency
+    from mlflow.tracking.context.jupyter_notebook_context import _is_in_jupyter_notebook
+
+    return _is_in_jupyter_notebook() and (is_in_databricks_runtime() or is_using_tracking_server())
 
 
 class IPythonTraceDisplayHandler:
@@ -123,7 +119,10 @@ class IPythonTraceDisplayHandler:
 
     def __init__(self):
         self.traces_to_display = {}
-        if not _is_jupyter():
+        # Lazy import to avoid circular dependency
+        from mlflow.tracking.context.jupyter_notebook_context import _is_in_jupyter_notebook
+
+        if not _is_in_jupyter_notebook():
             return
 
         try:

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -84,12 +84,10 @@ def _get_query_string_for_traces(traces: list["Trace"]):
 
 
 def _is_jupyter():
-    try:
-        from IPython import get_ipython
+    # Lazy import to avoid circular dependency
+    from mlflow.tracking.context.jupyter_notebook_context import _is_in_jupyter_notebook
 
-        return get_ipython() is not None
-    except ImportError:
-        return False
+    return _is_in_jupyter_notebook()
 
 
 def is_using_tracking_server():

--- a/tests/genai/utils/test_display_utils.py
+++ b/tests/genai/utils/test_display_utils.py
@@ -15,7 +15,10 @@ def test_display_outputs_jupyter(monkeypatch):
     with (
         mock.patch("IPython.display.display") as mock_display,
         mock.patch.object(display_utils, "_get_store", return_value=mock_store),
-        mock.patch.object(display_utils, "_is_jupyter", return_value=True),
+        mock.patch(
+            "mlflow.tracking.context.jupyter_notebook_context._is_in_jupyter_notebook",
+            return_value=True,
+        ),
         mlflow.start_run() as run,
     ):
         display_utils.display_evaluation_output(run.info.run_id)
@@ -33,7 +36,10 @@ def test_display_outputs_non_ipython(capsys):
 
     with (
         mock.patch.object(display_utils, "_get_store", return_value=mock_store),
-        mock.patch.object(display_utils, "_is_jupyter", return_value=False),
+        mock.patch(
+            "mlflow.tracking.context.jupyter_notebook_context._is_in_jupyter_notebook",
+            return_value=False,
+        ),
         mlflow.start_run() as run,
     ):
         display_utils.display_evaluation_output(run.info.run_id)
@@ -58,7 +64,10 @@ def test_display_outputs_databricks(monkeypatch):
         with (
             mock.patch("IPython.display.display") as mock_display,
             mock.patch.object(display_utils, "_get_store", return_value=mock_store),
-            mock.patch.object(display_utils, "_is_jupyter", return_value=True),
+            mock.patch(
+                "mlflow.tracking.context.jupyter_notebook_context._is_in_jupyter_notebook",
+                return_value=True,
+            ),
             mock.patch.object(display_utils, "is_databricks_uri", return_value=True),
         ):
             display_utils.display_evaluation_output(run.info.run_id)

--- a/tests/tracing/display/test_ipython.py
+++ b/tests/tracing/display/test_ipython.py
@@ -31,6 +31,8 @@ class MockEventRegistry:
 class MockIPython:
     def __init__(self):
         self.events = MockEventRegistry()
+        # Mimic Jupyter notebook environment for _is_in_jupyter_notebook detection
+        self.kernel = Mock()
 
     def mock_run_cell(self):
         self.events.trigger("post_run_cell")


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Fix `_is_jupyter()` to use existing `_is_in_jupyter_notebook()` which properly detects notebooks vs plain IPython environments (e.g., Databricks jobs).

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix raw HTML being dumped to logs in Databricks jobs and other non-notebook IPython environments.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)