### PR TITLE
Fix Vertex AI model configuration

### DIFF
--- a/mlflow/server/js/src/gateway/utils/providerUtils.test.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.test.ts
@@ -18,16 +18,6 @@ describe('providerUtils', () => {
       expect(formatProviderName('databricks')).toBe('Databricks');
     });
 
-    it('returns display name for Vertex AI variants', () => {
-      expect(formatProviderName('vertex_ai-anthropic')).toBe('Vertex AI (Anthropic)');
-      expect(formatProviderName('vertex_ai-llama3')).toBe('Vertex AI (Llama 3)');
-      expect(formatProviderName('vertex_ai-mistral')).toBe('Vertex AI (Mistral)');
-    });
-
-    it('formats unknown Vertex AI variants', () => {
-      expect(formatProviderName('vertex_ai-some-new-model')).toBe('Vertex AI (Some New Model)');
-    });
-
     it('formats unknown providers with title case', () => {
       expect(formatProviderName('some_unknown_provider')).toBe('Some Unknown Provider');
     });

--- a/mlflow/server/js/src/gateway/utils/providerUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.ts
@@ -13,19 +13,11 @@ export const PROVIDER_GROUPS: Record<string, Omit<ProviderGroup, 'providers'>> =
     displayName: 'OpenAI / Azure OpenAI',
     defaultProvider: 'openai',
   },
-  vertex_ai: {
-    groupId: 'vertex_ai',
-    displayName: 'Google Vertex AI',
-    defaultProvider: 'vertex_ai',
-  },
 };
 
 export function getProviderGroupId(provider: string): string | null {
   if (provider === 'openai' || provider === 'azure') {
     return 'openai_azure';
-  }
-  if (provider === 'vertex_ai' || provider.startsWith('vertex_ai-')) {
-    return 'vertex_ai';
   }
   return null;
 }
@@ -67,19 +59,6 @@ export function buildProviderGroups(providers: string[]): {
     });
   }
 
-  const vertexProviders = groupedProviders.get('vertex_ai');
-  if (vertexProviders && vertexProviders.length > 0) {
-    vertexProviders.sort((a, b) => {
-      if (a === 'vertex_ai') return -1;
-      if (b === 'vertex_ai') return 1;
-      return a.localeCompare(b);
-    });
-    groups.push({
-      ...PROVIDER_GROUPS['vertex_ai'],
-      providers: vertexProviders,
-    });
-  }
-
   return { groups, ungroupedProviders };
 }
 
@@ -106,33 +85,9 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   cerebras: 'Cerebras',
 };
 
-const VERTEX_AI_VARIANT_NAMES: Record<string, string> = {
-  'vertex_ai-anthropic': 'Vertex AI (Anthropic)',
-  'vertex_ai-llama3': 'Vertex AI (Llama 3)',
-  'vertex_ai-mistral': 'Vertex AI (Mistral)',
-  'vertex_ai-ai21': 'Vertex AI (AI21)',
-  'vertex_ai-codey': 'Vertex AI (Codey)',
-  'vertex_ai-image-models': 'Vertex AI (Image)',
-  'vertex_ai-code-text-models': 'Vertex AI (Code)',
-  'vertex_ai-text-models': 'Vertex AI (Text)',
-  'vertex_ai-chat-models': 'Vertex AI (Chat)',
-  'vertex_ai-embedding-models': 'Vertex AI (Embedding)',
-  'vertex_ai-vision-models': 'Vertex AI (Vision)',
-};
-
 export function formatProviderName(provider: string): string {
   if (PROVIDER_DISPLAY_NAMES[provider]) {
     return PROVIDER_DISPLAY_NAMES[provider];
-  }
-
-  if (VERTEX_AI_VARIANT_NAMES[provider]) {
-    return VERTEX_AI_VARIANT_NAMES[provider];
-  }
-
-  if (provider.startsWith('vertex_ai-')) {
-    const variant = provider.replace('vertex_ai-', '');
-    const formattedVariant = variant.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-    return `Vertex AI (${formattedVariant})`;
   }
 
   return provider.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -224,7 +224,7 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
                     "name": "vertex_project",
                     "description": "GCP Project ID",
                     "secret": False,
-                    "required": True,
+                    "required": False,
                 },
                 {
                     "name": "vertex_location",
@@ -451,6 +451,25 @@ def get_provider_config_response(provider: str) -> ProviderConfigResponse:
 
 _EXCLUDED_PROVIDERS = {"bedrock_converse"}
 
+# Providers that should be consolidated into a single provider.
+# For example, vertex_ai-llama_models, vertex_ai-anthropic, etc. should all be
+# consolidated into vertex_ai to be used by the AI Gateway.
+_PROVIDER_CONSOLIDATION = {
+    "vertex_ai": lambda p: p == "vertex_ai" or p.startswith("vertex_ai-"),
+}
+
+
+def _normalize_provider(provider: str) -> str:
+    """
+    Normalize provider name by consolidating variants into a single provider.
+
+    For example, vertex_ai-llama_models -> vertex_ai
+    """
+    for normalized, matcher in _PROVIDER_CONSOLIDATION.items():
+        if matcher(provider):
+            return normalized
+    return provider
+
 
 def get_all_providers() -> list[str]:
     """
@@ -458,6 +477,9 @@ def get_all_providers() -> list[str]:
 
     Only returns providers that have at least one chat, completion, or embedding model,
     excluding providers that only offer image generation, audio, or other non-text services.
+
+    Provider variants are consolidated into a single provider (e.g., all vertex_ai-*
+    variants are returned as just vertex_ai).
 
     Returns:
         List of provider names that support chat/completion/embedding
@@ -472,7 +494,7 @@ def get_all_providers() -> list[str]:
         if mode in _SUPPORTED_MODEL_MODES:
             if provider := info.get("litellm_provider"):
                 if provider not in _EXCLUDED_PROVIDERS:
-                    providers.add(provider)
+                    providers.add(_normalize_provider(provider))
 
     return list(providers)
 
@@ -485,12 +507,14 @@ def get_models(provider: str | None = None) -> list[dict[str, Any]]:
     excluding image generation, audio, and other non-text services.
 
     Args:
-        provider: Optional provider name to filter by (e.g., 'openai', 'anthropic')
+        provider: Optional provider name to filter by (e.g., 'openai', 'anthropic').
+                  When filtering by a consolidated provider (e.g., 'vertex_ai'),
+                  all variant providers are included (e.g., 'vertex_ai-anthropic').
 
     Returns:
         List of model dictionaries with keys:
             - model: Model name
-            - provider: Provider name
+            - provider: Provider name (normalized, e.g., vertex_ai instead of vertex_ai-anthropic)
             - mode: Model mode (e.g., 'chat', 'completion', 'embedding')
             - supports_function_calling: Whether model supports tool/function calling
             - supports_vision: Whether model supports image/vision input
@@ -507,9 +531,14 @@ def get_models(provider: str | None = None) -> list[dict[str, Any]]:
         raise ImportError("LiteLLM is not installed. Install it with: pip install 'mlflow[genai]'")
 
     model_cost = _get_model_cost()
-    models = []
+    # Use dict to dedupe models by (provider, model_name) key
+    models_dict: dict[tuple[str, str], dict[str, Any]] = {}
     for model_name, info in model_cost.items():
-        if provider and info.get("litellm_provider") != provider:
+        litellm_provider = info.get("litellm_provider")
+        normalized_provider = _normalize_provider(litellm_provider) if litellm_provider else None
+
+        # Filter by provider (matching against the normalized provider name)
+        if provider and normalized_provider != provider:
             continue
 
         mode = info.get("mode")
@@ -517,29 +546,33 @@ def get_models(provider: str | None = None) -> list[dict[str, Any]]:
             continue
 
         # Model names sometimes include the provider prefix, e.g. "gemini/gemini-2.5-flash"
-        if provider and model_name.startswith(f"{provider}/"):
-            model_name = model_name.removeprefix(f"{provider}/")
+        # Strip the normalized provider prefix if present
+        if normalized_provider and model_name.startswith(f"{normalized_provider}/"):
+            model_name = model_name.removeprefix(f"{normalized_provider}/")
 
         # LiteLLM contains fine-tuned models with the prefix "ft:"
         if model_name.startswith("ft:"):
             continue
 
-        models.append(
-            {
-                "model": model_name,
-                "provider": info.get("litellm_provider"),
-                "mode": mode,
-                "supports_function_calling": info.get("supports_function_calling", False),
-                "supports_vision": info.get("supports_vision", False),
-                "supports_reasoning": info.get("supports_reasoning", False),
-                "supports_prompt_caching": info.get("supports_prompt_caching", False),
-                "supports_response_schema": info.get("supports_response_schema", False),
-                "max_input_tokens": info.get("max_input_tokens"),
-                "max_output_tokens": info.get("max_output_tokens"),
-                "input_cost_per_token": info.get("input_cost_per_token"),
-                "output_cost_per_token": info.get("output_cost_per_token"),
-                "deprecation_date": info.get("deprecation_date"),
-            }
-        )
+        # Dedupe by (provider, model_name) - keep the first occurrence
+        key = (normalized_provider, model_name)
+        if key in models_dict:
+            continue
 
-    return models
+        models_dict[key] = {
+            "model": model_name,
+            "provider": normalized_provider,
+            "mode": mode,
+            "supports_function_calling": info.get("supports_function_calling", False),
+            "supports_vision": info.get("supports_vision", False),
+            "supports_reasoning": info.get("supports_reasoning", False),
+            "supports_prompt_caching": info.get("supports_prompt_caching", False),
+            "supports_response_schema": info.get("supports_response_schema", False),
+            "max_input_tokens": info.get("max_input_tokens"),
+            "max_output_tokens": info.get("max_output_tokens"),
+            "input_cost_per_token": info.get("input_cost_per_token"),
+            "output_cost_per_token": info.get("output_cost_per_token"),
+            "deprecation_date": info.get("deprecation_date"),
+        }
+
+    return list(models_dict.values())

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -21,135 +21,135 @@ def test_normalize_provider_does_not_normalize_other_providers():
     assert _normalize_provider("gemini") == "gemini"
 
 
-@mock.patch("mlflow.utils.providers._get_model_cost")
-def test_get_all_providers_consolidates_vertex_ai_variants(mock_model_cost):
-    mock_model_cost.return_value = {
-        "gpt-4o": {"litellm_provider": "openai", "mode": "chat"},
-        "claude-3-5-sonnet": {"litellm_provider": "anthropic", "mode": "chat"},
-        "gemini-1.5-pro": {"litellm_provider": "vertex_ai", "mode": "chat"},
-        "vertex_ai/meta/llama-4-scout": {
-            "litellm_provider": "vertex_ai-llama_models",
-            "mode": "chat",
-        },
-        "vertex_ai/claude-3-5-sonnet": {
-            "litellm_provider": "vertex_ai-anthropic",
-            "mode": "chat",
-        },
-    }
+def test_get_all_providers_consolidates_vertex_ai_variants():
+    with mock.patch("mlflow.utils.providers._get_model_cost") as mock_model_cost:
+        mock_model_cost.return_value = {
+            "gpt-4o": {"litellm_provider": "openai", "mode": "chat"},
+            "claude-3-5-sonnet": {"litellm_provider": "anthropic", "mode": "chat"},
+            "gemini-1.5-pro": {"litellm_provider": "vertex_ai", "mode": "chat"},
+            "vertex_ai/meta/llama-4-scout": {
+                "litellm_provider": "vertex_ai-llama_models",
+                "mode": "chat",
+            },
+            "vertex_ai/claude-3-5-sonnet": {
+                "litellm_provider": "vertex_ai-anthropic",
+                "mode": "chat",
+            },
+        }
 
-    providers = get_all_providers()
+        providers = get_all_providers()
 
-    # vertex_ai-* variants should be consolidated into vertex_ai
-    assert "vertex_ai" in providers
-    assert "vertex_ai-llama_models" not in providers
-    assert "vertex_ai-anthropic" not in providers
-    assert "openai" in providers
-    assert "anthropic" in providers
-
-
-@mock.patch("mlflow.utils.providers._get_model_cost")
-def test_get_models_normalizes_vertex_ai_provider_and_strips_prefix(mock_model_cost):
-    mock_model_cost.return_value = {
-        "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas": {
-            "litellm_provider": "vertex_ai-llama_models",
-            "mode": "chat",
-            "supports_function_calling": True,
-        },
-        "vertex_ai/claude-3-5-sonnet": {
-            "litellm_provider": "vertex_ai-anthropic",
-            "mode": "chat",
-            "supports_function_calling": True,
-        },
-        "gemini-1.5-pro": {
-            "litellm_provider": "vertex_ai",
-            "mode": "chat",
-            "supports_function_calling": True,
-        },
-    }
-
-    models = get_models(provider="vertex_ai")
-
-    assert len(models) == 3
-
-    # Check that all providers are normalized to vertex_ai
-    for model in models:
-        assert model["provider"] == "vertex_ai"
-
-    # Check that vertex_ai/ prefix is stripped from model names
-    model_names = [m["model"] for m in models]
-    assert "meta/llama-4-scout-17b-16e-instruct-maas" in model_names
-    assert "claude-3-5-sonnet" in model_names
-    assert "gemini-1.5-pro" in model_names
-
-    # Ensure the original prefixed names are not present
-    assert "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas" not in model_names
-    assert "vertex_ai/claude-3-5-sonnet" not in model_names
+        # vertex_ai-* variants should be consolidated into vertex_ai
+        assert "vertex_ai" in providers
+        assert "vertex_ai-llama_models" not in providers
+        assert "vertex_ai-anthropic" not in providers
+        assert "openai" in providers
+        assert "anthropic" in providers
 
 
-@mock.patch("mlflow.utils.providers._get_model_cost")
-def test_get_models_filters_by_consolidated_provider(mock_model_cost):
-    mock_model_cost.return_value = {
-        "gpt-4o": {"litellm_provider": "openai", "mode": "chat"},
-        "vertex_ai/meta/llama-4-scout": {
-            "litellm_provider": "vertex_ai-llama_models",
-            "mode": "chat",
-        },
-    }
+def test_get_models_normalizes_vertex_ai_provider_and_strips_prefix():
+    with mock.patch("mlflow.utils.providers._get_model_cost") as mock_model_cost:
+        mock_model_cost.return_value = {
+            "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas": {
+                "litellm_provider": "vertex_ai-llama_models",
+                "mode": "chat",
+                "supports_function_calling": True,
+            },
+            "vertex_ai/claude-3-5-sonnet": {
+                "litellm_provider": "vertex_ai-anthropic",
+                "mode": "chat",
+                "supports_function_calling": True,
+            },
+            "gemini-1.5-pro": {
+                "litellm_provider": "vertex_ai",
+                "mode": "chat",
+                "supports_function_calling": True,
+            },
+        }
 
-    # Filtering by vertex_ai should include vertex_ai-* variants
-    vertex_models = get_models(provider="vertex_ai")
-    assert len(vertex_models) == 1
-    assert vertex_models[0]["model"] == "meta/llama-4-scout"
+        models = get_models(provider="vertex_ai")
 
-    # Filtering by openai should not include vertex_ai models
-    openai_models = get_models(provider="openai")
-    assert len(openai_models) == 1
-    assert openai_models[0]["model"] == "gpt-4o"
+        assert len(models) == 3
 
+        # Check that all providers are normalized to vertex_ai
+        for model in models:
+            assert model["provider"] == "vertex_ai"
 
-@mock.patch("mlflow.utils.providers._get_model_cost")
-def test_get_models_does_not_modify_other_providers(mock_model_cost):
-    mock_model_cost.return_value = {
-        "gpt-4o": {
-            "litellm_provider": "openai",
-            "mode": "chat",
-            "supports_function_calling": True,
-        },
-        "claude-3-5-sonnet": {
-            "litellm_provider": "anthropic",
-            "mode": "chat",
-            "supports_function_calling": True,
-        },
-    }
+        # Check that vertex_ai/ prefix is stripped from model names
+        model_names = [m["model"] for m in models]
+        assert "meta/llama-4-scout-17b-16e-instruct-maas" in model_names
+        assert "claude-3-5-sonnet" in model_names
+        assert "gemini-1.5-pro" in model_names
 
-    models = get_models()
-
-    openai_model = next(m for m in models if m["provider"] == "openai")
-    assert openai_model["model"] == "gpt-4o"
-
-    anthropic_model = next(m for m in models if m["provider"] == "anthropic")
-    assert anthropic_model["model"] == "claude-3-5-sonnet"
+        # Ensure the original prefixed names are not present
+        assert "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas" not in model_names
+        assert "vertex_ai/claude-3-5-sonnet" not in model_names
 
 
-@mock.patch("mlflow.utils.providers._get_model_cost")
-def test_get_models_dedupes_models_after_normalization(mock_model_cost):
-    # Same model appearing under different vertex_ai variants should be deduped
-    mock_model_cost.return_value = {
-        "gemini-3-flash-preview": {
-            "litellm_provider": "vertex_ai",
-            "mode": "chat",
-            "supports_function_calling": True,
-        },
-        "vertex_ai/gemini-3-flash-preview": {
-            "litellm_provider": "vertex_ai-chat-models",
-            "mode": "chat",
-            "supports_function_calling": True,
-        },
-    }
+def test_get_models_filters_by_consolidated_provider():
+    with mock.patch("mlflow.utils.providers._get_model_cost") as mock_model_cost:
+        mock_model_cost.return_value = {
+            "gpt-4o": {"litellm_provider": "openai", "mode": "chat"},
+            "vertex_ai/meta/llama-4-scout": {
+                "litellm_provider": "vertex_ai-llama_models",
+                "mode": "chat",
+            },
+        }
 
-    models = get_models(provider="vertex_ai")
+        # Filtering by vertex_ai should include vertex_ai-* variants
+        vertex_models = get_models(provider="vertex_ai")
+        assert len(vertex_models) == 1
+        assert vertex_models[0]["model"] == "meta/llama-4-scout"
 
-    # Should only have one gemini-3-flash-preview, not two
-    model_names = [m["model"] for m in models]
-    assert model_names.count("gemini-3-flash-preview") == 1
-    assert len(models) == 1
+        # Filtering by openai should not include vertex_ai models
+        openai_models = get_models(provider="openai")
+        assert len(openai_models) == 1
+        assert openai_models[0]["model"] == "gpt-4o"
+
+
+def test_get_models_does_not_modify_other_providers():
+    with mock.patch("mlflow.utils.providers._get_model_cost") as mock_model_cost:
+        mock_model_cost.return_value = {
+            "gpt-4o": {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "supports_function_calling": True,
+            },
+            "claude-3-5-sonnet": {
+                "litellm_provider": "anthropic",
+                "mode": "chat",
+                "supports_function_calling": True,
+            },
+        }
+
+        models = get_models()
+
+        openai_model = next(m for m in models if m["provider"] == "openai")
+        assert openai_model["model"] == "gpt-4o"
+
+        anthropic_model = next(m for m in models if m["provider"] == "anthropic")
+        assert anthropic_model["model"] == "claude-3-5-sonnet"
+
+
+def test_get_models_dedupes_models_after_normalization():
+    with mock.patch("mlflow.utils.providers._get_model_cost") as mock_model_cost:
+        # Same model appearing under different vertex_ai variants should be deduped
+        mock_model_cost.return_value = {
+            "gemini-3-flash-preview": {
+                "litellm_provider": "vertex_ai",
+                "mode": "chat",
+                "supports_function_calling": True,
+            },
+            "vertex_ai/gemini-3-flash-preview": {
+                "litellm_provider": "vertex_ai-chat-models",
+                "mode": "chat",
+                "supports_function_calling": True,
+            },
+        }
+
+        models = get_models(provider="vertex_ai")
+
+        # Should only have one gemini-3-flash-preview, not two
+        model_names = [m["model"] for m in models]
+        assert model_names.count("gemini-3-flash-preview") == 1
+        assert len(models) == 1

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -1,0 +1,155 @@
+from unittest import mock
+
+from mlflow.utils.providers import (
+    _normalize_provider,
+    get_all_providers,
+    get_models,
+)
+
+
+def test_normalize_provider_normalizes_vertex_ai_variants():
+    assert _normalize_provider("vertex_ai") == "vertex_ai"
+    assert _normalize_provider("vertex_ai-anthropic") == "vertex_ai"
+    assert _normalize_provider("vertex_ai-llama_models") == "vertex_ai"
+    assert _normalize_provider("vertex_ai-mistral") == "vertex_ai"
+
+
+def test_normalize_provider_does_not_normalize_other_providers():
+    assert _normalize_provider("openai") == "openai"
+    assert _normalize_provider("anthropic") == "anthropic"
+    assert _normalize_provider("bedrock") == "bedrock"
+    assert _normalize_provider("gemini") == "gemini"
+
+
+@mock.patch("mlflow.utils.providers._get_model_cost")
+def test_get_all_providers_consolidates_vertex_ai_variants(mock_model_cost):
+    mock_model_cost.return_value = {
+        "gpt-4o": {"litellm_provider": "openai", "mode": "chat"},
+        "claude-3-5-sonnet": {"litellm_provider": "anthropic", "mode": "chat"},
+        "gemini-1.5-pro": {"litellm_provider": "vertex_ai", "mode": "chat"},
+        "vertex_ai/meta/llama-4-scout": {
+            "litellm_provider": "vertex_ai-llama_models",
+            "mode": "chat",
+        },
+        "vertex_ai/claude-3-5-sonnet": {
+            "litellm_provider": "vertex_ai-anthropic",
+            "mode": "chat",
+        },
+    }
+
+    providers = get_all_providers()
+
+    # vertex_ai-* variants should be consolidated into vertex_ai
+    assert "vertex_ai" in providers
+    assert "vertex_ai-llama_models" not in providers
+    assert "vertex_ai-anthropic" not in providers
+    assert "openai" in providers
+    assert "anthropic" in providers
+
+
+@mock.patch("mlflow.utils.providers._get_model_cost")
+def test_get_models_normalizes_vertex_ai_provider_and_strips_prefix(mock_model_cost):
+    mock_model_cost.return_value = {
+        "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas": {
+            "litellm_provider": "vertex_ai-llama_models",
+            "mode": "chat",
+            "supports_function_calling": True,
+        },
+        "vertex_ai/claude-3-5-sonnet": {
+            "litellm_provider": "vertex_ai-anthropic",
+            "mode": "chat",
+            "supports_function_calling": True,
+        },
+        "gemini-1.5-pro": {
+            "litellm_provider": "vertex_ai",
+            "mode": "chat",
+            "supports_function_calling": True,
+        },
+    }
+
+    models = get_models(provider="vertex_ai")
+
+    assert len(models) == 3
+
+    # Check that all providers are normalized to vertex_ai
+    for model in models:
+        assert model["provider"] == "vertex_ai"
+
+    # Check that vertex_ai/ prefix is stripped from model names
+    model_names = [m["model"] for m in models]
+    assert "meta/llama-4-scout-17b-16e-instruct-maas" in model_names
+    assert "claude-3-5-sonnet" in model_names
+    assert "gemini-1.5-pro" in model_names
+
+    # Ensure the original prefixed names are not present
+    assert "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas" not in model_names
+    assert "vertex_ai/claude-3-5-sonnet" not in model_names
+
+
+@mock.patch("mlflow.utils.providers._get_model_cost")
+def test_get_models_filters_by_consolidated_provider(mock_model_cost):
+    mock_model_cost.return_value = {
+        "gpt-4o": {"litellm_provider": "openai", "mode": "chat"},
+        "vertex_ai/meta/llama-4-scout": {
+            "litellm_provider": "vertex_ai-llama_models",
+            "mode": "chat",
+        },
+    }
+
+    # Filtering by vertex_ai should include vertex_ai-* variants
+    vertex_models = get_models(provider="vertex_ai")
+    assert len(vertex_models) == 1
+    assert vertex_models[0]["model"] == "meta/llama-4-scout"
+
+    # Filtering by openai should not include vertex_ai models
+    openai_models = get_models(provider="openai")
+    assert len(openai_models) == 1
+    assert openai_models[0]["model"] == "gpt-4o"
+
+
+@mock.patch("mlflow.utils.providers._get_model_cost")
+def test_get_models_does_not_modify_other_providers(mock_model_cost):
+    mock_model_cost.return_value = {
+        "gpt-4o": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "supports_function_calling": True,
+        },
+        "claude-3-5-sonnet": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "supports_function_calling": True,
+        },
+    }
+
+    models = get_models()
+
+    openai_model = next(m for m in models if m["provider"] == "openai")
+    assert openai_model["model"] == "gpt-4o"
+
+    anthropic_model = next(m for m in models if m["provider"] == "anthropic")
+    assert anthropic_model["model"] == "claude-3-5-sonnet"
+
+
+@mock.patch("mlflow.utils.providers._get_model_cost")
+def test_get_models_dedupes_models_after_normalization(mock_model_cost):
+    # Same model appearing under different vertex_ai variants should be deduped
+    mock_model_cost.return_value = {
+        "gemini-3-flash-preview": {
+            "litellm_provider": "vertex_ai",
+            "mode": "chat",
+            "supports_function_calling": True,
+        },
+        "vertex_ai/gemini-3-flash-preview": {
+            "litellm_provider": "vertex_ai-chat-models",
+            "mode": "chat",
+            "supports_function_calling": True,
+        },
+    }
+
+    models = get_models(provider="vertex_ai")
+
+    # Should only have one gemini-3-flash-preview, not two
+    model_names = [m["model"] for m in models]
+    assert model_names.count("gemini-3-flash-preview") == 1
+    assert len(models) == 1


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Fix the Vertex AI model configuration issue that LiteLLM uses different provider name between model config (e.g., `vertex_ai-anthropic`) and actual invocation (`vertex_ai`). This PR also consolidate all Vertex variants into one. 
<img width="512" height="316" alt="image" src="https://github.com/user-attachments/assets/68c7c3fd-fec9-441a-bb13-886428cedc5e" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
