### PR TITLE
[Session grouping followups][1/5] Sort session column to start when grouping by sessions

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
@@ -56,8 +56,18 @@ const assessmentColumnRank: Record<string, number> = Object.fromEntries(
   ASSESSMENT_COLUMN_PRIORITY.map((id, idx) => [id, idx]),
 );
 
-export function sortGroupedColumns(columns: TracesTableColumn[], isComparing?: boolean): TracesTableColumn[] {
+export function sortGroupedColumns(
+  columns: TracesTableColumn[],
+  isComparing?: boolean,
+  isGroupedBySession?: boolean,
+): TracesTableColumn[] {
   return [...columns].sort((colA, colB) => {
+    // If grouped by session, always put session column first
+    if (isGroupedBySession) {
+      if (colA.id === SESSION_COLUMN_ID) return -1;
+      if (colB.id === SESSION_COLUMN_ID) return 1;
+    }
+
     // If comparing, always put request time column first
     if (isComparing) {
       if (colA.id === INPUTS_COLUMN_ID) return -1;

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -135,8 +135,8 @@ export const GenAiTracesTableBody = React.memo(
     );
 
     const sortedGroupedColumns = useMemo(
-      () => sortGroupedColumns(selectedColumns, isComparing),
-      [selectedColumns, isComparing],
+      () => sortGroupedColumns(selectedColumns, isComparing, isGroupedBySession),
+      [selectedColumns, isComparing, isGroupedBySession],
     );
 
     const { columns } = useMemo(() => {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -70,7 +70,7 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({ column, se
   let cellContent: React.ReactNode = null;
 
   // Render specific columns with data from the first trace
-  if (column.id === TRACE_ID_COLUMN_ID) {
+  if (column.id === SESSION_COLUMN_ID) {
     // Session ID column - render as a tag with link to session view
     cellContent = (
       <div css={{ overflow: 'hidden', minWidth: 0, maxWidth: '100%' }}>


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20247/files) to review incremental changes.
- [**stack/sort-session-cols**](https://github.com/mlflow/mlflow/pull/20247) [[Files changed](https://github.com/mlflow/mlflow/pull/20247/files)]
  - [stack/execution-time](https://github.com/mlflow/mlflow/pull/20248) [[Files changed](https://github.com/mlflow/mlflow/pull/20248/files/d5df2673d6e6fe075f5f4d906847c1b92f08a954..9673d67d33211e9f43d0113be0265eb21b9b93f9)]
    - [stack/integrate-sessions](https://github.com/mlflow/mlflow/pull/20253) [[Files changed](https://github.com/mlflow/mlflow/pull/20253/files/9673d67d33211e9f43d0113be0265eb21b9b93f9..2f8bb9617169506e7b9ec63536cda0837f44e965)]
      - [stack/edit-turn-rendering](https://github.com/mlflow/mlflow/pull/20254) [[Files changed](https://github.com/mlflow/mlflow/pull/20254/files/2f8bb9617169506e7b9ec63536cda0837f44e965..ed574dfe6596e9783bd8834538f803ce7a85228b)]
        - [stack/separate-colstate](https://github.com/mlflow/mlflow/pull/20255) [[Files changed](https://github.com/mlflow/mlflow/pull/20255/files/ed574dfe6596e9783bd8834538f803ce7a85228b..fe39451252689e0706aaefda911115916f82803c)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

UX fix for session-grouped trace table:

Previously, we rendered the session ID in the trace ID column. However I felt this was a little hacky as there is an existing session ID column which will be left blank

This PR just changes it such that session ID will be sorted to the start when grouping by sessions.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/88148519-3e0c-4b09-811e-f6fa607f761a



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
