### PR TITLE
[Session grouping followups][3/5] Replace sessions table with force grouped TracesV3Logs

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -405,6 +405,7 @@ const TracesV3LogsImpl = React.memo(
               usesV4APIs={usesV4APIs}
               addons={toolbarAddons}
               isGroupedBySession={forceGroupBySession || isGroupedBySession}
+              forceGroupBySession={forceGroupBySession}
               onToggleSessionGrouping={onToggleSessionGrouping}
             />
             {renderMainContent()}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -83,6 +83,7 @@ const TracesV3LogsImpl = React.memo(
     disableActions = false,
     customDefaultSelectedColumns,
     toolbarAddons,
+    forceGroupBySession = false,
   }: {
     experimentId: string;
     endpointName?: string;
@@ -93,6 +94,7 @@ const TracesV3LogsImpl = React.memo(
     disableActions?: boolean;
     customDefaultSelectedColumns?: (column: TracesTableColumn) => boolean;
     toolbarAddons?: React.ReactNode;
+    forceGroupBySession?: boolean;
   }) => {
     const makeHtmlFromMarkdown = useMarkdownConverter();
     const intl = useIntl();
@@ -357,7 +359,7 @@ const TracesV3LogsImpl = React.memo(
                   tableSort={tableSort}
                   onTraceTagsEdit={showEditTagsModalForTrace}
                   displayLoadingOverlay={displayLoadingOverlay}
-                  isGroupedBySession={isGroupedBySession}
+                  isGroupedBySession={forceGroupBySession || isGroupedBySession}
                 />
               </ContextProviders>
             )}
@@ -402,7 +404,7 @@ const TracesV3LogsImpl = React.memo(
               metadataError={metadataError}
               usesV4APIs={usesV4APIs}
               addons={toolbarAddons}
-              isGroupedBySession={isGroupedBySession}
+              isGroupedBySession={forceGroupBySession || isGroupedBySession}
               onToggleSessionGrouping={onToggleSessionGrouping}
             />
             {renderMainContent()}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
@@ -1,3 +1,6 @@
+import { FormattedMessage } from '@databricks/i18n';
+import ErrorUtils from '@mlflow/mlflow/src/common/utils/ErrorUtils';
+import { withErrorBoundary } from '@mlflow/mlflow/src/common/utils/withErrorBoundary';
 import { TracesV3Toolbar } from '../../components/experiment-page/components/traces-v3/TracesV3Toolbar';
 import invariant from 'invariant';
 import { useParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
@@ -5,16 +8,26 @@ import { useCallback, useMemo, useState } from 'react';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
 import {
-  SESSION_COLUMN_ID,
-  TracesTableColumnType,
+  CUSTOM_METADATA_COLUMN_ID,
+  GenAIChatSessionsTable,
   INPUTS_COLUMN_ID,
   RESPONSE_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  TracesTableColumnType,
+  createTraceLocationForExperiment,
+  createTraceLocationForUCSchema,
+  useSearchMlflowTraces,
+  shouldEnableSessionGrouping,
 } from '@databricks/web-shared/genai-traces-table';
-import type { TracesTableColumn } from '@databricks/web-shared/genai-traces-table';
+import type { GetTraceFunction, TracesTableColumn } from '@databricks/web-shared/genai-traces-table';
 import { MonitoringConfigProvider, useMonitoringConfig } from '../../hooks/useMonitoringConfig';
 import { useMonitoringFiltersTimeRange } from '../../hooks/useMonitoringFilters';
+import { SESSION_ID_METADATA_KEY, shouldUseTracesV4API } from '@databricks/web-shared/model-trace-explorer';
+import { useGetExperimentQuery } from '../../hooks/useExperimentQuery';
 import { getChatSessionsFilter } from './utils';
 import { ExperimentChatSessionsPageWrapper } from './ExperimentChatSessionsPageWrapper';
+import { useGetDeleteTracesAction } from '../../components/experiment-page/components/traces-v3/hooks/useGetDeleteTracesAction';
+import { getTrace as getTraceV3 } from '@mlflow/mlflow/src/experiment-tracking/utils/TraceUtils';
 import { TracesV3Logs } from '../../components/experiment-page/components/traces-v3/TracesV3Logs';
 import { useDesignSystemTheme } from '@databricks/design-system';
 
@@ -27,11 +40,13 @@ const defaultCustomDefaultSelectedColumns = (column: TracesTableColumn) => {
 
 const ExperimentChatSessionsPageImpl = () => {
   const { experimentId } = useParams();
+  const { theme } = useDesignSystemTheme();
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   useRegisterSelectedIds('selectedSessionIds', rowSelection);
   invariant(experimentId, 'Experiment ID must be defined');
 
+  const monitoringConfig = useMonitoringConfig();
   const { loading: isLoadingExperiment } = useGetExperimentQuery({
     experimentId,
   });
@@ -50,20 +65,60 @@ const ExperimentChatSessionsPageImpl = () => {
 
   const filters = useMemo(() => getChatSessionsFilter({ sessionId: null }), []);
 
+  const {
+    data: traces,
+    isLoading,
+    isFetching,
+  } = useSearchMlflowTraces({
+    locations: traceSearchLocations,
+    timeRange,
+    filters,
+    searchQuery,
+    disabled: false,
+  });
+
+  const deleteTracesAction = useGetDeleteTracesAction({ traceSearchLocations });
+
+  const traceActions = useMemo(
+    () => ({
+      deleteTracesAction,
+    }),
+    [deleteTracesAction],
+  );
+
   return (
-    <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, gap: theme.spacing.sm }}>
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: 0,
+        gap: theme.spacing.sm,
+      }}
+    >
       <TracesV3Toolbar
         // prettier-ignore
         viewState="sessions"
       />
-      <TracesV3Logs
-        experimentId={experimentId}
-        additionalFilters={filters}
-        endpointName=""
-        timeRange={timeRange}
-        customDefaultSelectedColumns={defaultCustomDefaultSelectedColumns}
-        forceGroupBySession
-      />
+      {shouldEnableSessionGrouping() ? (
+        <TracesV3Logs
+          experimentId={experimentId}
+          additionalFilters={filters}
+          endpointName=""
+          timeRange={timeRange}
+          customDefaultSelectedColumns={defaultCustomDefaultSelectedColumns}
+          forceGroupBySession
+        />
+      ) : (
+        <GenAIChatSessionsTable
+          experimentId={experimentId}
+          traces={traces ?? []}
+          isLoading={isLoading}
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          traceActions={traceActions}
+        />
+      )}
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
@@ -1,6 +1,3 @@
-import { FormattedMessage } from '@databricks/i18n';
-import ErrorUtils from '@mlflow/mlflow/src/common/utils/ErrorUtils';
-import { withErrorBoundary } from '@mlflow/mlflow/src/common/utils/withErrorBoundary';
 import { TracesV3Toolbar } from '../../components/experiment-page/components/traces-v3/TracesV3Toolbar';
 import invariant from 'invariant';
 import { useParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
@@ -8,21 +5,25 @@ import { useCallback, useMemo, useState } from 'react';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
 import {
-  CUSTOM_METADATA_COLUMN_ID,
-  GenAIChatSessionsTable,
-  createTraceLocationForExperiment,
-  createTraceLocationForUCSchema,
-  useSearchMlflowTraces,
+  SESSION_COLUMN_ID,
+  TracesTableColumnType,
+  INPUTS_COLUMN_ID,
+  RESPONSE_COLUMN_ID,
 } from '@databricks/web-shared/genai-traces-table';
-import type { GetTraceFunction } from '@databricks/web-shared/genai-traces-table';
+import type { TracesTableColumn } from '@databricks/web-shared/genai-traces-table';
 import { MonitoringConfigProvider, useMonitoringConfig } from '../../hooks/useMonitoringConfig';
 import { useMonitoringFiltersTimeRange } from '../../hooks/useMonitoringFilters';
-import { SESSION_ID_METADATA_KEY, shouldUseTracesV4API } from '@databricks/web-shared/model-trace-explorer';
-import { useGetExperimentQuery } from '../../hooks/useExperimentQuery';
 import { getChatSessionsFilter } from './utils';
 import { ExperimentChatSessionsPageWrapper } from './ExperimentChatSessionsPageWrapper';
-import { useGetDeleteTracesAction } from '../../components/experiment-page/components/traces-v3/hooks/useGetDeleteTracesAction';
-import { getTrace as getTraceV3 } from '@mlflow/mlflow/src/experiment-tracking/utils/TraceUtils';
+import { TracesV3Logs } from '../../components/experiment-page/components/traces-v3/TracesV3Logs';
+import { useDesignSystemTheme } from '@databricks/design-system';
+
+const defaultCustomDefaultSelectedColumns = (column: TracesTableColumn) => {
+  if (column.type === TracesTableColumnType.ASSESSMENT || column.type === TracesTableColumnType.EXPECTATION) {
+    return true;
+  }
+  return [SESSION_COLUMN_ID, INPUTS_COLUMN_ID, RESPONSE_COLUMN_ID].includes(column.id);
+};
 
 const ExperimentChatSessionsPageImpl = () => {
   const { experimentId } = useParams();
@@ -49,41 +50,19 @@ const ExperimentChatSessionsPageImpl = () => {
 
   const filters = useMemo(() => getChatSessionsFilter({ sessionId: null }), []);
 
-  const {
-    data: traces,
-    isLoading,
-    isFetching,
-  } = useSearchMlflowTraces({
-    locations: traceSearchLocations,
-    timeRange,
-    filters,
-    searchQuery,
-    disabled: false,
-  });
-
-  const deleteTracesAction = useGetDeleteTracesAction({ traceSearchLocations });
-
-  const traceActions = useMemo(
-    () => ({
-      deleteTracesAction,
-    }),
-    [deleteTracesAction],
-  );
-
   return (
-    <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+    <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, gap: theme.spacing.sm }}>
       <TracesV3Toolbar
         // prettier-ignore
         viewState="sessions"
       />
-      <GenAIChatSessionsTable
+      <TracesV3Logs
         experimentId={experimentId}
-        traces={traces ?? []}
-        isLoading={isLoading}
-        searchQuery={searchQuery}
-        setSearchQuery={setSearchQuery}
-        traceActions={traceActions}
-        onRowSelectionChange={setRowSelection}
+        additionalFilters={filters}
+        endpointName=""
+        timeRange={timeRange}
+        customDefaultSelectedColumns={defaultCustomDefaultSelectedColumns}
+        forceGroupBySession
       />
     </div>
   );

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableToolbar.tsx
@@ -86,6 +86,7 @@ interface GenAITracesTableToolbarProps {
 
   // Session grouping
   isGroupedBySession?: boolean;
+  forceGroupBySession?: boolean;
   onToggleSessionGrouping?: () => void;
 }
 
@@ -116,6 +117,7 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
       isRefreshing,
       addons,
       isGroupedBySession,
+      forceGroupBySession,
       onToggleSessionGrouping,
     } = props;
     const { theme } = useDesignSystemTheme();
@@ -181,7 +183,7 @@ export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITrac
               // prettier-ignore
             />
           )}
-          {shouldEnableSessionGrouping() && onToggleSessionGrouping && (
+          {shouldEnableSessionGrouping() && onToggleSessionGrouping && !forceGroupBySession && (
             <Tooltip
               componentId="mlflow.traces-table.group-by-session-button.tooltip"
               content={intl.formatMessage({

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
@@ -56,8 +56,18 @@ const assessmentColumnRank: Record<string, number> = Object.fromEntries(
   ASSESSMENT_COLUMN_PRIORITY.map((id, idx) => [id, idx]),
 );
 
-export function sortGroupedColumns(columns: TracesTableColumn[], isComparing?: boolean): TracesTableColumn[] {
+export function sortGroupedColumns(
+  columns: TracesTableColumn[],
+  isComparing?: boolean,
+  isGroupedBySession?: boolean,
+): TracesTableColumn[] {
   return [...columns].sort((colA, colB) => {
+    // If grouped by session, always put session column first
+    if (isGroupedBySession) {
+      if (colA.id === SESSION_COLUMN_ID) return -1;
+      if (colB.id === SESSION_COLUMN_ID) return 1;
+    }
+
     // If comparing, always put request time column first
     if (isComparing) {
       if (colA.id === INPUTS_COLUMN_ID) return -1;

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -135,8 +135,8 @@ export const GenAiTracesTableBody = React.memo(
     );
 
     const sortedGroupedColumns = useMemo(
-      () => sortGroupedColumns(selectedColumns, isComparing),
-      [selectedColumns, isComparing],
+      () => sortGroupedColumns(selectedColumns, isComparing, isGroupedBySession),
+      [selectedColumns, isComparing, isGroupedBySession],
     );
 
     const { columns } = useMemo(() => {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -48,6 +48,7 @@ import { TokenComponent } from './TokensCell';
 import { SessionHeaderPassFailAggregatedCell } from './SessionHeaderPassFailAggregatedCell';
 import { SessionHeaderNumericAggregatedCell } from './SessionHeaderNumericAggregatedCell';
 import { SessionHeaderStringAggregatedCell } from './SessionHeaderStringAggregatedCell';
+import { calculateSessionDuration } from '../sessions-table/utils';
 
 interface SessionHeaderCellProps {
   column: TracesTableColumn;
@@ -185,13 +186,23 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({ column, se
       }
     });
 
-    cellContent = cellContent = (
+    cellContent = (
       <TokenComponent
         inputTokens={totalInputTokens}
         outputTokens={totalOutputTokens}
         totalTokens={totalTokens}
         isComparing={false}
       />
+    );
+  } else if (column.id === EXECUTION_DURATION_COLUMN_ID && traces.length > 0) {
+    // Duration - sum all execution durations
+    const duration = calculateSessionDuration(traces);
+    cellContent = duration ? (
+      <div css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={duration}>
+        {duration}
+      </div>
+    ) : (
+      <NullCell />
     );
   } else if (
     column.type === TracesTableColumnType.ASSESSMENT &&

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -70,7 +70,7 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({ column, se
   let cellContent: React.ReactNode = null;
 
   // Render specific columns with data from the first trace
-  if (column.id === TRACE_ID_COLUMN_ID) {
+  if (column.id === SESSION_COLUMN_ID) {
     // Session ID column - render as a tag with link to session view
     cellContent = (
       <div css={{ overflow: 'hidden', minWidth: 0, maxWidth: '100%' }}>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
@@ -87,6 +87,8 @@ export {
   TOKENS_COLUMN_ID,
   TRACE_ID_COLUMN_ID,
   CUSTOM_METADATA_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  INPUTS_COLUMN_ID,
 } from './hooks/useTableColumns';
 
 // Test utilities

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
@@ -28,7 +28,7 @@ export {
   searchMlflowTracesQueryFn,
   SEARCH_MLFLOW_TRACES_QUERY_KEY,
 } from './hooks/useMlflowTraces';
-export { getEvalTabTotalTracesLimit } from './utils/FeatureUtils';
+export { getEvalTabTotalTracesLimit, shouldEnableSessionGrouping } from './utils/FeatureUtils';
 export { GenAITracesTableToolbar } from './GenAITracesTableToolbar';
 export { GenAiTracesTableSearchInput } from './GenAiTracesTableSearchInput';
 export { GenAITracesTableBodyContainer } from './GenAITracesTableBodyContainer';

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
@@ -242,7 +242,6 @@ export const GenAIChatSessionsTable = ({
         flex: 1,
         minHeight: 0,
         position: 'relative',
-        marginTop: theme.spacing.sm,
       }}
     >
       <GenAIChatSessionsToolbar

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/utils.tsx
@@ -58,7 +58,7 @@ export const getSessionTableRows = (experimentId: string, traces: ModelTraceInfo
   );
 };
 
-const calculateSessionDuration = (traces: ModelTraceInfoV3[]) => {
+export const calculateSessionDuration = (traces: ModelTraceInfoV3[]) => {
   const durations = traces.map((trace) => trace.execution_duration);
 
   if (durations.some((duration) => isNil(duration))) {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20253/files/9673d67d33211e9f43d0113be0265eb21b9b93f9..2f8bb9617169506e7b9ec63536cda0837f44e965) to review incremental changes.
- [stack/sort-session-cols](https://github.com/mlflow/mlflow/pull/20247) [[Files changed](https://github.com/mlflow/mlflow/pull/20247/files)]
  - [stack/execution-time](https://github.com/mlflow/mlflow/pull/20248) [[Files changed](https://github.com/mlflow/mlflow/pull/20248/files/d5df2673d6e6fe075f5f4d906847c1b92f08a954..9673d67d33211e9f43d0113be0265eb21b9b93f9)]
    - [**stack/integrate-sessions**](https://github.com/mlflow/mlflow/pull/20253) [[Files changed](https://github.com/mlflow/mlflow/pull/20253/files/9673d67d33211e9f43d0113be0265eb21b9b93f9..2f8bb9617169506e7b9ec63536cda0837f44e965)]
      - [stack/edit-turn-rendering](https://github.com/mlflow/mlflow/pull/20254) [[Files changed](https://github.com/mlflow/mlflow/pull/20254/files/2f8bb9617169506e7b9ec63536cda0837f44e965..ed574dfe6596e9783bd8834538f803ce7a85228b)]
        - [stack/separate-colstate](https://github.com/mlflow/mlflow/pull/20255) [[Files changed](https://github.com/mlflow/mlflow/pull/20255/files/ed574dfe6596e9783bd8834538f803ce7a85228b..fe39451252689e0706aaefda911115916f82803c)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR finally integrates the new session-grouped table into the sessions page, replacing the old one.

Once we decide that this experience is good, we can delete the flag and all old code.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Flag off, unchanged:

<img width="1724" height="993" alt="Screenshot 2026-01-23 at 6 33 21 PM" src="https://github.com/user-attachments/assets/d82fdd4a-9188-4b5d-83e4-cb3a498cef6a" />

Flag on, new view:


https://github.com/user-attachments/assets/3877b261-d9bf-48ba-a964-8a80cab920e2



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
