### PR TITLE
[Session grouping followups][5/5] Use separate localstorage key for session view vs traces view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -84,6 +84,7 @@ const TracesV3LogsImpl = React.memo(
     customDefaultSelectedColumns,
     toolbarAddons,
     forceGroupBySession = false,
+    columnStorageKeyPrefix,
   }: {
     experimentId: string;
     endpointName?: string;
@@ -95,6 +96,11 @@ const TracesV3LogsImpl = React.memo(
     customDefaultSelectedColumns?: (column: TracesTableColumn) => boolean;
     toolbarAddons?: React.ReactNode;
     forceGroupBySession?: boolean;
+    /**
+     * Optional prefix for the localStorage key used to persist column selection.
+     * Use this to separate column selection state between different views.
+     */
+    columnStorageKeyPrefix?: string;
   }) => {
     const makeHtmlFromMarkdown = useMarkdownConverter();
     const intl = useIntl();
@@ -184,6 +190,8 @@ const TracesV3LogsImpl = React.memo(
       experimentId,
       allColumns,
       defaultSelectedColumns,
+      undefined, // runUuid
+      columnStorageKeyPrefix,
     );
 
     const [tableSort, setTableSort] = useTableSort(selectedColumns, {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
@@ -108,6 +108,7 @@ const ExperimentChatSessionsPageImpl = () => {
           timeRange={timeRange}
           customDefaultSelectedColumns={defaultCustomDefaultSelectedColumns}
           forceGroupBySession
+          columnStorageKeyPrefix="chat-sessions"
         />
       ) : (
         <GenAIChatSessionsTable

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useGenAITracesUIState.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useGenAITracesUIState.tsx
@@ -75,14 +75,19 @@ export const useGenAITracesUIStateColumns = (
   allColumns: TracesTableColumn[],
   defaultSelectedColumns?: (allColumns: TracesTableColumn[]) => TracesTableColumn[],
   runUuid?: string,
+  storageKeyPrefix?: string,
 ): {
   hiddenColumns: string[];
   toggleColumns: (cols: TracesTableColumn[]) => void;
 } => {
   const enableURLPersistence = shoudlEnableURLPersistenceForSortAndColumns();
 
+  const storageKey = storageKeyPrefix
+    ? `${LOCAL_STORAGE_KEY}-${storageKeyPrefix}-${experimentId}-${runUuid}`
+    : `${LOCAL_STORAGE_KEY}-${experimentId}-${runUuid}`;
+
   const [columnState, setColumnState] = useLocalStorage<GenAITracesUIState | undefined>({
-    key: `${LOCAL_STORAGE_KEY}-${experimentId}-${runUuid}`,
+    key: storageKey,
     version: LOCAL_STORAGE_VERSION,
     initialValue: undefined,
   });
@@ -189,12 +194,14 @@ export const useSelectedColumns = (
   allColumns: TracesTableColumn[],
   defaultSelectedColumns?: (cols: TracesTableColumn[]) => TracesTableColumn[],
   runUuid?: string,
+  storageKeyPrefix?: string,
 ) => {
   const { hiddenColumns, toggleColumns } = useGenAITracesUIStateColumns(
     experimentId,
     allColumns,
     defaultSelectedColumns,
     runUuid,
+    storageKeyPrefix,
   );
 
   const selectedColumns = useMemo(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20255/files) to review incremental changes.
- [**stack/separate-colstate**](https://github.com/mlflow/mlflow/pull/20255) [[Files changed](https://github.com/mlflow/mlflow/pull/20255/files)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Now that we are reusing TracesV3Logs for the session page, we want to make sure they actually have separate localstorage states. Currently without this PR, they use the same one meaning changes in the sessions tab will affect the traces tab, which is not good UX.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/71acfdd9-e3ca-4b6a-98b6-c6fa58bd567c




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
