### PR TITLE
Revamp assessments and run judges directly in trace UI [Part 3/x]: Type indication

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3398,6 +3398,10 @@
     "defaultMessage": "No models registered yet. <link>Learn more about registering models</link>.",
     "description": "Models table > no models present yet"
   },
+  "OjWQ39": {
+    "defaultMessage": "Human feedback",
+    "description": "Tooltip content for human feedback"
+  },
   "OlytgO": {
     "defaultMessage": "Field",
     "description": "Label for the column field in the GenAI Traces Table Filter form"
@@ -3873,6 +3877,10 @@
     "defaultMessage": "Save",
     "description": "Default text for save button on editable notes in MLflow"
   },
+  "SihD1a": {
+    "defaultMessage": "LLM judge feedback",
+    "description": "Tooltip content for LLM judge feedback"
+  },
   "Sm0bXt": {
     "defaultMessage": "None",
     "description": "Label for a user_frustration assessment with 'none' value"
@@ -3896,6 +3904,10 @@
   "SrXYrV": {
     "defaultMessage": "Previewing the first {numRows} rows",
     "description": "Title for showing the number of rows in the parsed data preview"
+  },
+  "SuVsDp": {
+    "defaultMessage": "Custom code judge feedback",
+    "description": "Tooltip content for custom code judge feedback"
   },
   "SwvkMI": {
     "defaultMessage": "Is the summary faithful, complete, and concise?",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/FeatureUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/FeatureUtils.ts
@@ -51,3 +51,10 @@ export const shouldUseUnifiedModelTraceComparisonUI = () => {
   }
   return true;
 };
+
+/**
+ * Determines if running scorers from trace details drawer is enabled
+ */
+export const isEvaluatingTracesInDetailsViewEnabled = () => {
+  return false;
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -1,4 +1,4 @@
-import { partition, uniqBy } from 'lodash';
+import { cloneDeep, partition, uniqBy } from 'lodash';
 import { useMemo } from 'react';
 
 import { Button, CloseIcon, Spacer, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -5,7 +5,7 @@ import { Button, CloseIcon, Spacer, Tooltip, Typography, useDesignSystemTheme } 
 import { FormattedMessage } from '@databricks/i18n';
 
 import { ASSESSMENT_PANE_MIN_WIDTH } from './AssessmentsPane.utils';
-import { shouldUseTracesV4API } from '../FeatureUtils';
+import { isEvaluatingTracesInDetailsViewEnabled, shouldUseTracesV4API } from '../FeatureUtils';
 import type { Assessment } from '../ModelTrace.types';
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
 import { useTraceCachedActions } from '../hooks/useTraceCachedActions';
@@ -19,6 +19,7 @@ export const AssessmentsPane = ({
   className,
   assessmentsTitleOverride,
   disableCloseButton,
+  enableRunScorer = true,
 }: {
   assessments: Assessment[];
   traceId: string;
@@ -26,6 +27,7 @@ export const AssessmentsPane = ({
   className?: string;
   assessmentsTitleOverride?: (count?: number) => JSX.Element;
   disableCloseButton?: boolean;
+  enableRunScorer?: boolean;
 }) => {
   const reconstructAssessments = useTraceCachedActions((state) => state.reconstructAssessments);
   const cachedActions = useTraceCachedActions((state) => state.assessmentActions[traceId]);
@@ -102,7 +104,12 @@ export const AssessmentsPane = ({
           </Tooltip>
         )}
       </div>
-      <AssessmentsPaneFeedbackSection feedbacks={feedbacks} activeSpanId={activeSpanId} traceId={traceId} />
+      <AssessmentsPaneFeedbackSection
+        enableRunScorer={enableRunScorer && isEvaluatingTracesInDetailsViewEnabled()}
+        feedbacks={feedbacks}
+        activeSpanId={activeSpanId}
+        traceId={traceId}
+      />
       <Spacer size="sm" shrinks={false} />
       <AssessmentsPaneExpectationsSection expectations={expectations} activeSpanId={activeSpanId} traceId={traceId} />
     </div>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -3,7 +3,7 @@ import { FeedbackAssessment } from '../ModelTrace.types';
 import { FeedbackGroup } from './FeedbackGroup';
 import { useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { isEmpty, isNil } from 'lodash';
+import { isEmpty, isNil, partition, some } from 'lodash';
 import { AssessmentCreateForm } from './AssessmentCreateForm';
 
 type GroupedFeedbacksByValue = { [value: string]: FeedbackAssessment[] };
@@ -48,24 +48,22 @@ const AddFeedbackButton = ({ onClick }: { onClick: () => void }) => (
     icon={<PlusIcon />}
     onClick={onClick}
   >
-    {/* {TODO(next PR): Rename to "Add human feedback" when auto LLM judge feedback is implemented */}
     <FormattedMessage defaultMessage="Add feedback" description="Label for the button to add a new feedback" />
   </Button>
 );
 
 export const AssessmentsPaneFeedbackSection = ({
+  enableRunScorer,
   feedbacks,
   activeSpanId,
   traceId,
 }: {
+  enableRunScorer: boolean;
   feedbacks: FeedbackAssessment[];
   activeSpanId?: string;
   traceId: string;
 }) => {
-  const groupedFeedbacks = useMemo(() => {
-    // TODO(next PR): Extract LLM judge feedback groups to a separate section
-    return groupFeedbacks(feedbacks);
-  }, [feedbacks]);
+  const groupedFeedbacks = useMemo(() => groupFeedbacks(feedbacks), [feedbacks]);
 
   const [createFormVisible, setCreateFormVisible] = useState(false);
 
@@ -95,6 +93,7 @@ export const AssessmentsPaneFeedbackSection = ({
           <AddFeedbackButton onClick={() => setCreateFormVisible(true)} />
         </div>
       )}
+
       {groupedFeedbacks.map(([name, valuesMap]) => (
         <FeedbackGroup key={name} name={name} valuesMap={valuesMap} traceId={traceId} activeSpanId={activeSpanId} />
       ))}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -3,7 +3,7 @@ import { FeedbackAssessment } from '../ModelTrace.types';
 import { FeedbackGroup } from './FeedbackGroup';
 import { useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { isEmpty, isNil, partition, some } from 'lodash';
+import { first, isEmpty, isNil, partition, some } from 'lodash';
 import { AssessmentCreateForm } from './AssessmentCreateForm';
 
 type GroupedFeedbacksByValue = { [value: string]: FeedbackAssessment[] };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackGroup.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackGroup.tsx
@@ -13,11 +13,13 @@ export const FeedbackGroup = ({
   valuesMap,
   traceId,
   activeSpanId,
+  feedbackTypeTag,
 }: {
   name: string;
   valuesMap: { [value: string]: FeedbackAssessment[] };
   traceId: string;
   activeSpanId?: string;
+  feedbackTypeTag?: React.ReactNode;
 }) => {
   const { theme } = useDesignSystemTheme();
   const displayName = getAssessmentDisplayName(name);
@@ -39,6 +41,7 @@ export const FeedbackGroup = ({
         gap: theme.spacing.sm,
       }}
     >
+      {feedbackTypeTag}
       <div
         css={{
           display: 'flex',

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackValueGroupSourceCounts.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackValueGroupSourceCounts.tsx
@@ -1,8 +1,17 @@
 import { countBy } from 'lodash';
 
-import { CodeIcon, SparkleIcon, Tag, Typography, useDesignSystemTheme, UserIcon } from '@databricks/design-system';
+import {
+  CodeIcon,
+  SparkleIcon,
+  Tag,
+  Tooltip,
+  Typography,
+  useDesignSystemTheme,
+  UserIcon,
+} from '@databricks/design-system';
 
 import type { AssessmentSourceType, FeedbackAssessment } from '../ModelTrace.types';
+import { FormattedMessage } from 'react-intl';
 
 const getSourceTypeIcon = (sourceType: AssessmentSourceType) => {
   const smallIconStyles = {
@@ -23,29 +32,63 @@ const getSourceTypeIcon = (sourceType: AssessmentSourceType) => {
   }
 };
 
+const getSourceTypeTooltipContent = (sourceType: AssessmentSourceType) => {
+  switch (sourceType) {
+    case 'HUMAN':
+      return <FormattedMessage defaultMessage="Human feedback" description="Tooltip content for human feedback" />;
+    case 'LLM_JUDGE':
+      return (
+        <FormattedMessage defaultMessage="LLM judge feedback" description="Tooltip content for LLM judge feedback" />
+      );
+    case 'CODE':
+      return (
+        <FormattedMessage
+          defaultMessage="Custom code judge feedback"
+          description="Tooltip content for custom code judge feedback"
+        />
+      );
+  }
+  return null;
+};
+
 export const FeedbackValueGroupSourceCounts = ({ feedbacks }: { feedbacks: FeedbackAssessment[] }) => {
   const { theme } = useDesignSystemTheme();
 
-  if (feedbacks.length < 2) {
+  if (feedbacks.length < 1) {
     return null;
   }
 
   const sourceCounts = countBy(feedbacks, (feedback) => feedback.source.source_type);
   return (
-    <div css={{ display: 'flex', gap: theme.spacing.xs, alignItems: 'center', marginLeft: theme.spacing.xs }}>
+    <div
+      css={{
+        display: 'flex',
+        gap: theme.spacing.xs,
+        alignItems: 'center',
+        marginLeft: theme.spacing.xs,
+      }}
+    >
       {Object.entries(sourceCounts).map(([sourceType, count]) => (
-        <Tag
-          componentId="shared.model-trace-explorer.feedback-source-count"
-          css={{
-            margin: 0,
-          }}
-          key={sourceType}
+        <Tooltip
+          componentId="shared.model-trace-explorer.feedback-source-tooltip"
+          content={getSourceTypeTooltipContent(sourceType as AssessmentSourceType)}
         >
-          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
-            {getSourceTypeIcon(sourceType as AssessmentSourceType)}
-            <Typography.Text>{count}</Typography.Text>
-          </div>
-        </Tag>
+          <Tag
+            componentId="shared.model-trace-explorer.feedback-source-count"
+            css={{
+              margin: 0,
+              '&>*': {
+                cursor: 'default',
+              },
+            }}
+            key={sourceType}
+          >
+            <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+              {getSourceTypeIcon(sourceType as AssessmentSourceType)}
+              {count > 1 && <Typography.Text>{count}</Typography.Text>}
+            </div>
+          </Tag>
+        </Tooltip>
       ))}
     </div>
   );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
@@ -171,6 +171,7 @@ function ModelTraceExplorerRightPaneTabsImpl({
       assessments={displayedAssessments}
       traceId={activeSpan.traceId}
       activeSpanId={activeSpan.parentId ? String(activeSpan.key) : undefined}
+      enableRunScorer={!activeSpan.parentId}
     />
   );
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20261/files) to review incremental changes.
- [**stack/run-judges-from-trace-ui-part3**](https://github.com/mlflow/mlflow/pull/20261) [[Files changed](https://github.com/mlflow/mlflow/pull/20261/files)]
  - [stack/run-judges-from-trace-ui-part4](https://github.com/mlflow/mlflow/pull/20275) [[Files changed](https://github.com/mlflow/mlflow/pull/20275/files/229baa81ba7a5f3c985222580f222fe3b0bd2065..ed99e5880f22ae667290d89d56e61e9eae77381b)]
    - [stack/run-judges-from-trace-ui-part5](https://github.com/mlflow/mlflow/pull/20276) [[Files changed](https://github.com/mlflow/mlflow/pull/20276/files/ed99e5880f22ae667290d89d56e61e9eae77381b..4acd6b70ce8f5115682b2f99bc0e8f79ccab65ce)]
      - [stack/run-judges-from-trace-ui-part6](https://github.com/mlflow/mlflow/pull/20312) [[Files changed](https://github.com/mlflow/mlflow/pull/20312/files/4acd6b70ce8f5115682b2f99bc0e8f79ccab65ce..d613514324f798a700475ff91aa9dc60ab2d8e49)]
        - [stack/run-judges-from-trace-ui-part7](https://github.com/mlflow/mlflow/pull/20313) [[Files changed](https://github.com/mlflow/mlflow/pull/20313/files/d613514324f798a700475ff91aa9dc60ab2d8e49..9b7725ad09b7c7ba2d3213fde932be04065085dd)]
          - [stack/run-judges-from-trace-ui-part8](https://github.com/mlflow/mlflow/pull/20340) [[Files changed](https://github.com/mlflow/mlflow/pull/20340/files/9b7725ad09b7c7ba2d3213fde932be04065085dd..4d9f366e767821a7619d78e6055b8c18a82a3b70)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds type indicators to assessment sections, based on contained assessment's type. 
Based on https://www.figma.com/design/eudql8szHU8Az1nqfcQ8hf/MLflow-3---Judges-and-assessments?node-id=7582-69124&t=Pzn9FaKkLB0DakuK-0

#### Demo

https://github.com/user-attachments/assets/a45b760a-1078-462d-a037-2317713a20b8

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
