### PR TITLE
Rename requests chart to traces

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.test.tsx
@@ -212,7 +212,7 @@ describe('ExperimentGenAIOverviewPage', () => {
 
       // Verify all charts are rendered
       await waitFor(() => {
-        expect(screen.getByText('Requests')).toBeInTheDocument();
+        expect(screen.getByText('Traces')).toBeInTheDocument();
         expect(screen.getByText('Latency')).toBeInTheDocument();
         expect(screen.getByText('Errors')).toBeInTheDocument();
       });
@@ -234,8 +234,8 @@ describe('ExperimentGenAIOverviewPage', () => {
       renderComponent();
 
       await waitFor(() => {
-        // Requests chart should be present (full width)
-        expect(screen.getByText('Requests')).toBeInTheDocument();
+        // Traces chart should be present (full width)
+        expect(screen.getByText('Traces')).toBeInTheDocument();
         // Latency and Errors charts should be present (side by side)
         expect(screen.getByText('Latency')).toBeInTheDocument();
         expect(screen.getByText('Errors')).toBeInTheDocument();

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.test.tsx
@@ -90,7 +90,7 @@ describe('TraceRequestsChart', () => {
       renderComponent();
 
       // Check that actual chart content is not rendered during loading
-      expect(screen.queryByText('Requests')).not.toBeInTheDocument();
+      expect(screen.queryByText('Traces')).not.toBeInTheDocument();
     });
   });
 
@@ -163,13 +163,13 @@ describe('TraceRequestsChart', () => {
       });
     });
 
-    it('should display the "Requests" title', async () => {
+    it('should display the "Traces" title', async () => {
       setupTraceMetricsHandler(mockDataPoints);
 
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Requests')).toBeInTheDocument();
+        expect(screen.getByText('Traces')).toBeInTheDocument();
       });
     });
 
@@ -341,7 +341,7 @@ describe('TraceRequestsChart', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Requests')).toBeInTheDocument();
+        expect(screen.getByText('Traces')).toBeInTheDocument();
       });
 
       // Zoom Out button should not be visible when not zoomed

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceRequestsChart.tsx
@@ -42,7 +42,7 @@ export const TraceRequestsChart: React.FC = () => {
       <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
         <OverviewChartHeader
           icon={<ChartLineIcon />}
-          title={<FormattedMessage defaultMessage="Requests" description="Title for the trace requests chart" />}
+          title={<FormattedMessage defaultMessage="Traces" description="Title for the traces chart" />}
           value={totalRequests.toLocaleString()}
         />
         {isZoomed && (

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2826,6 +2826,10 @@
     "defaultMessage": "An error occurred while rendering the trace",
     "description": "Description for default error message in the Trace Explorer UI"
   },
+  "KE/zZf": {
+    "defaultMessage": "Traces",
+    "description": "Title for the traces chart"
+  },
   "KGMbzq": {
     "defaultMessage": "Commit message:",
     "description": "A label for the commit message in the prompt details page"
@@ -4191,10 +4195,6 @@
   "VGJhVI": {
     "defaultMessage": "Add New Tag",
     "description": "Add new key-value tag modal > Modal title"
-  },
-  "VLonhQ": {
-    "defaultMessage": "Requests",
-    "description": "Title for the trace requests chart"
   },
   "VMVNTR": {
     "defaultMessage": "Requested experiment was not found.",


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Rename the first chart name from `Requests` to `Traces` since it's more clearer what it represents.

<img width="1655" height="924" alt="Screenshot 2026-01-23 at 5 09 03 PM" src="https://github.com/user-attachments/assets/e5b4167a-fe6c-4e68-9789-74adc98c31b4" />

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
