### PR TITLE
 Revamp assessments and run judges directly in trace UI [Part 4/x]: Judge selector

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -12,6 +12,7 @@ import {
   shouldUseTracesV4API,
   useUnifiedTraceTagsModal,
   ModelTraceExplorerContextProvider,
+  ModelTraceExplorerRunJudgesContextProvider,
 } from '@databricks/web-shared/model-trace-explorer';
 import {
   EXECUTION_DURATION_COLUMN_ID,
@@ -54,6 +55,7 @@ import { useGetDeleteTracesAction } from './hooks/useGetDeleteTracesAction';
 import { ExportTracesToDatasetModal } from '../../../../pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal';
 import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
 import { AssistantAwareDrawer } from '@mlflow/mlflow/src/common/components/AssistantAwareDrawer';
+import { useRunScorerInTracesViewConfiguration } from '../../../../pages/experiment-scorers/hooks/useRunScorerInTracesView';
 
 const ContextProviders = ({
   children,
@@ -64,9 +66,12 @@ const ContextProviders = ({
   experimentId?: string;
   children: React.ReactNode;
 }) => {
+  const runJudgeConfiguration = useRunScorerInTracesViewConfiguration();
   return (
     <GenAiTracesMarkdownConverterProvider makeHtml={makeHtmlFromMarkdown}>
-      {children}
+      <ModelTraceExplorerRunJudgesContextProvider renderRunJudgeButton={runJudgeConfiguration.renderRunJudgeButton}>
+        {children}
+      </ModelTraceExplorerRunJudgesContextProvider>
     </GenAiTracesMarkdownConverterProvider>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -55,7 +55,7 @@ import { useGetDeleteTracesAction } from './hooks/useGetDeleteTracesAction';
 import { ExportTracesToDatasetModal } from '../../../../pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal';
 import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
 import { AssistantAwareDrawer } from '@mlflow/mlflow/src/common/components/AssistantAwareDrawer';
-import { useRunScorerInTracesViewConfiguration } from '../../../../pages/experiment-scorers/hooks/useRunScorerInTracesView';
+import { useRunScorerInTracesViewConfiguration } from '../../../../pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration';
 
 const ContextProviders = ({
   children,
@@ -69,7 +69,7 @@ const ContextProviders = ({
   const runJudgeConfiguration = useRunScorerInTracesViewConfiguration();
   return (
     <GenAiTracesMarkdownConverterProvider makeHtml={makeHtmlFromMarkdown}>
-      <ModelTraceExplorerRunJudgesContextProvider renderRunJudgeButton={runJudgeConfiguration.renderRunJudgeButton}>
+      <ModelTraceExplorerRunJudgesContextProvider {...runJudgeConfiguration}>
         {children}
       </ModelTraceExplorerRunJudgesContextProvider>
     </GenAiTracesMarkdownConverterProvider>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesView.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useMemo, useState } from 'react';
+import { ModelTraceExplorerRunJudgeConfig } from '../../../../shared/web-shared/model-trace-explorer';
+import { LLMScorer } from '../types';
+import { useGetScheduledScorers } from './useGetScheduledScorers';
+import { useExperimentIds } from '../../../components/experiment-page/hooks/useExperimentIds';
+import { FormattedMessage } from 'react-intl';
+import {
+  Button,
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxCustomButtonTriggerWrapper,
+  DialogComboboxFooter,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListSearch,
+  DialogComboboxOptionListSelectItem,
+  getShadowScrollStyles,
+  PlusIcon,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { PillControl } from '@databricks/design-system/development';
+import ScorerModalRenderer from '../ScorerModalRenderer';
+import { SCORER_FORM_MODE } from '../constants';
+
+export const useRunScorerInTracesViewConfiguration = (): ModelTraceExplorerRunJudgeConfig => {
+  const renderRunJudgeButton = useCallback<NonNullable<ModelTraceExplorerRunJudgeConfig['renderRunJudgeButton']>>(
+    ({ traceId, trigger }) => {
+      return (
+        <SelectJudgeDropdown
+          traceId={traceId}
+          evaluateTraces={() => {
+            // TODO: Run judges against the trace
+          }}
+        >
+          {trigger}
+        </SelectJudgeDropdown>
+      );
+    },
+    [],
+  );
+  return {
+    renderRunJudgeButton,
+  };
+};
+
+/**
+ * Dropdown for selecting a judge to run against a trace.
+ */
+const SelectJudgeDropdown = ({
+  traceId,
+  onScorerStarted,
+  evaluateTraces,
+  children,
+}: {
+  traceId: string;
+  onScorerStarted?: (scorerName: string) => void;
+  evaluateTraces: (scorer: LLMScorer, traceIds: string[]) => void;
+  children: React.ReactNode;
+}) => {
+  const [experimentId] = useExperimentIds();
+  const { data } = useGetScheduledScorers(experimentId);
+
+  const { theme } = useDesignSystemTheme();
+  const [searchValue, setSearchValue] = useState<string>('');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [isCreateScorerModalVisible, setIsCreateScorerModalVisible] = useState(false);
+
+  const displayedLLMScorers = useMemo(() => {
+    return data?.scheduledScorers.filter(
+      (scorer) => scorer.type === 'llm' && scorer.name.toLowerCase().includes(searchValue.toLowerCase()),
+    ) as LLMScorer[];
+  }, [data?.scheduledScorers, searchValue]);
+
+  const handleLLMScorerClick = (scorer: LLMScorer) => {
+    evaluateTraces(scorer, [traceId]);
+    setDropdownOpen(false);
+    onScorerStarted?.(scorer.name);
+  };
+
+  return (
+    <>
+      <DialogCombobox
+        id="traces-view-judge-select-dropdown"
+        componentId="mlflow.experiment-scorers.traces-view-judge-select-dropdown"
+        open={dropdownOpen}
+        onOpenChange={setDropdownOpen}
+      >
+        <DialogComboboxCustomButtonTriggerWrapper asChild>{children}</DialogComboboxCustomButtonTriggerWrapper>
+        <DialogComboboxContent align="end" css={{ minWidth: 400 }}>
+          <DialogComboboxOptionList
+            css={{
+              borderTop: `1px solid ${theme.colors.border}`,
+            }}
+          >
+            <DialogComboboxOptionListSearch controlledValue={searchValue} setControlledValue={setSearchValue}>
+              <div css={{ padding: `${theme.spacing.xs}px ${theme.spacing.md}px`, marginBottom: theme.spacing.sm }}>
+                <PillControl.Root
+                  size="small"
+                  componentId="mlflow.experiment-scorers.traces-view-judge-type-filter"
+                  value="llm"
+                >
+                  <PillControl.Item value="llm">
+                    <FormattedMessage
+                      defaultMessage="Custom LLM-as-a-judge"
+                      description="Label for custom LLM judge type filter option"
+                    />
+                  </PillControl.Item>
+                  {/* TODO: Add support for pre-built LLM-as-a-judge when default gateway is available */}
+                  <PillControl.Item value="template" disabled>
+                    <FormattedMessage
+                      defaultMessage="Pre-built LLM-as-a-judge"
+                      description="Label for pre-built LLM judge type filter option"
+                    />
+                  </PillControl.Item>
+                  {/* TODO: Add support for custom code judges */}
+                  <PillControl.Item value="custom-code" disabled>
+                    <FormattedMessage
+                      defaultMessage="Custom code"
+                      description="Label for custom code judge type filter option"
+                    />
+                  </PillControl.Item>
+                </PillControl.Root>
+              </div>
+              <div
+                css={{
+                  height: 240,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  overflowY: 'auto',
+                  ...getShadowScrollStyles(theme, { orientation: 'vertical' }),
+                }}
+              >
+                {displayedLLMScorers?.map((scorer) => (
+                  <ScorerOption scorer={scorer} key={scorer.name} onClick={handleLLMScorerClick} />
+                ))}
+              </div>
+            </DialogComboboxOptionListSearch>
+          </DialogComboboxOptionList>
+          <DialogComboboxFooter css={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Button
+              type="tertiary"
+              componentId="mlflow.experiment-scorers.traces-view-create-judge"
+              icon={<PlusIcon />}
+              css={{ flex: 1 }}
+              onClick={() => setIsCreateScorerModalVisible(true)}
+            >
+              {/* TODO: Add support for creating judges ad-hoc in traces view */}
+              <FormattedMessage defaultMessage="Create judge" description="Button to create a new judge" />
+            </Button>
+          </DialogComboboxFooter>
+        </DialogComboboxContent>
+      </DialogCombobox>
+      {isCreateScorerModalVisible && (
+        <ScorerModalRenderer
+          visible
+          onClose={() => setIsCreateScorerModalVisible(false)}
+          experimentId={experimentId}
+          mode={SCORER_FORM_MODE.CREATE}
+          initialScorerType="llm"
+        />
+      )}
+    </>
+  );
+};
+
+const ScorerOption = ({ scorer, onClick }: { scorer: LLMScorer; onClick: (scorer: LLMScorer) => void }) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <DialogComboboxOptionListSelectItem
+      value={scorer.name}
+      css={{
+        alignItems: 'center',
+        height: theme.general.buttonHeight,
+        '&>label': { flex: 1 },
+        flexShrink: 0,
+      }}
+      key={scorer.name}
+      onChange={() => onClick(scorer)}
+    >
+      <div css={{ display: 'flex', flexDirection: 'column' }}>
+        <Typography.Text css={{ flex: 1 }}>{scorer.name}</Typography.Text>
+        <Typography.Hint>
+          <FormattedMessage defaultMessage="Custom judge" description="Label indicating a custom judge scorer" />
+        </Typography.Hint>
+      </div>
+    </DialogComboboxOptionListSelectItem>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunSerializedScorer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunSerializedScorer.tsx
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import { useEvaluateTraces } from '../useEvaluateTraces';
+import { EvaluateTracesParams, LLM_TEMPLATE, LLMScorer, ScheduledScorer } from '../types';
+import { ASSESSMENT_NAME_TEMPLATE_MAPPING, ScorerEvaluationScope } from '../constants';
+import { transformScheduledScorer } from '../utils/scorerTransformUtils';
+
+/**
+ * Runs a known serialized scorer on a set of traces.
+ */
+export const useRunSerializedScorer = ({
+  experimentId,
+  onScorerFinished,
+}: {
+  experimentId?: string;
+  onScorerFinished?: () => void;
+}) => {
+  const [evaluateTracesFn, { data, isLoading }] = useEvaluateTraces({ onScorerFinished });
+
+  const evaluateTraces = useCallback(
+    (scorer: LLMScorer, traceIds: string[]) => {
+      if (!experimentId) {
+        throw new Error('Experiment ID is required');
+      }
+      const scorerConfig = transformScheduledScorer(scorer);
+      // Prepare evaluation parameters based on mode
+      const evaluationParams: EvaluateTracesParams = {
+        itemCount: undefined,
+        itemIds: traceIds,
+        locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' as const }],
+        judgeInstructions: scorer.instructions || '',
+        experimentId,
+        evaluationScope: ScorerEvaluationScope.TRACES,
+        serializedScorer: scorerConfig.serialized_scorer,
+      };
+      return evaluateTracesFn(evaluationParams);
+    },
+    [evaluateTracesFn, experimentId],
+  );
+
+  return {
+    evaluateTraces,
+    data,
+    isLoading,
+  };
+};

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1918,6 +1918,10 @@
     "defaultMessage": "No prompts",
     "description": "No results message for linked prompts table on logged model details page"
   },
+  "CAzD7g": {
+    "defaultMessage": "Custom judge",
+    "description": "Label indicating a custom judge scorer"
+  },
   "CBnbqy": {
     "defaultMessage": "Next",
     "description": "Evaluation review > assessments > next button"
@@ -3817,6 +3821,10 @@
     "defaultMessage": "Resources using this endpoint ({count})",
     "description": "Gateway > Delete endpoint modal > Bindings list header"
   },
+  "SFYixb": {
+    "defaultMessage": "Custom code",
+    "description": "Label for custom code judge type filter option"
+  },
   "SI6n4L": {
     "defaultMessage": "Compare",
     "description": "Label for the compare mode on the registered prompt details page"
@@ -4199,6 +4207,10 @@
   "VAUHXW": {
     "defaultMessage": "No chart data available for the currently visible runs. Select other runs or <link>hide empty charts.</link>",
     "description": "Experiment tracking > runs charts > indication displayed when no corresponding data is found to be used in chart-based run comparison"
+  },
+  "VD7haA": {
+    "defaultMessage": "Custom LLM-as-a-judge",
+    "description": "Label for custom LLM judge type filter option"
   },
   "VDf1X1": {
     "defaultMessage": "Quality Summary",
@@ -5650,6 +5662,10 @@
   "fcIHyN": {
     "defaultMessage": "Medium",
     "description": "Medium row size"
+  },
+  "fdfi96": {
+    "defaultMessage": "Create judge",
+    "description": "Button to create a new judge"
   },
   "ffIouW": {
     "defaultMessage": "Retrieval sufficiency assessment is missing. This is likely because your agent is not returning retrieved_context.",
@@ -8146,6 +8162,10 @@
   "yM9S/n": {
     "defaultMessage": "Please select a model to run the judge",
     "description": "Tooltip message when model is not selected"
+  },
+  "yO/HAZ": {
+    "defaultMessage": "Pre-built LLM-as-a-judge",
+    "description": "Label for pre-built LLM judge type filter option"
   },
   "yPdr5F": {
     "defaultMessage": "Does app's response directly address the user's input?",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1086,10 +1086,6 @@
     "defaultMessage": "Create endpoint",
     "description": "Gateway > Endpoints page > Create endpoint button"
   },
-  "6eYtIQ": {
-    "defaultMessage": "Add categorized feedback",
-    "description": "Label for the button to add a new human feedback"
-  },
   "6fP+8o": {
     "defaultMessage": "See more",
     "description": "A button label in a message renderer that expands truncated content when clicked."
@@ -4782,6 +4778,10 @@
   "Za9+Cg": {
     "defaultMessage": "Pass",
     "description": "Evaluation results > overall assessment > pass value label. Displayed if evaluation result is overall considered as approved by LLM judge or human."
+  },
+  "Zah+D4": {
+    "defaultMessage": "Run judge",
+    "description": "Label for the button to add a new feedback"
   },
   "Zb6BqS": {
     "defaultMessage": "Relative Time",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1086,6 +1086,10 @@
     "defaultMessage": "Create endpoint",
     "description": "Gateway > Endpoints page > Create endpoint button"
   },
+  "6eYtIQ": {
+    "defaultMessage": "Add categorized feedback",
+    "description": "Label for the button to add a new human feedback"
+  },
   "6fP+8o": {
     "defaultMessage": "See more",
     "description": "A button label in a message renderer that expands truncated content when clicked."
@@ -3820,10 +3824,6 @@
   "SDClGN": {
     "defaultMessage": "Resources using this endpoint ({count})",
     "description": "Gateway > Delete endpoint modal > Bindings list header"
-  },
-  "SFYixb": {
-    "defaultMessage": "Custom code",
-    "description": "Label for custom code judge type filter option"
   },
   "SI6n4L": {
     "defaultMessage": "Compare",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -11,6 +11,7 @@ import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateCo
 import { useTraceCachedActions } from '../hooks/useTraceCachedActions';
 import { AssessmentsPaneExpectationsSection } from './AssessmentsPaneExpectationsSection';
 import { AssessmentsPaneFeedbackSection } from './AssessmentsPaneFeedbackSection';
+import { useModelTraceExplorerRunJudgesContext } from '../contexts/RunJudgesContext';
 
 export const AssessmentsPane = ({
   assessments,
@@ -48,6 +49,7 @@ export const AssessmentsPane = ({
     () => partition(allAssessments, (assessment) => 'feedback' in assessment),
     [allAssessments],
   );
+  const runJudgeConfiguration = useModelTraceExplorerRunJudgesContext();
 
   return (
     <div
@@ -105,7 +107,11 @@ export const AssessmentsPane = ({
         )}
       </div>
       <AssessmentsPaneFeedbackSection
-        enableRunScorer={enableRunScorer && isEvaluatingTracesInDetailsViewEnabled()}
+        enableRunScorer={
+          enableRunScorer &&
+          isEvaluatingTracesInDetailsViewEnabled() &&
+          Boolean(runJudgeConfiguration.renderRunJudgeButton)
+        }
         feedbacks={feedbacks}
         activeSpanId={activeSpanId}
         traceId={traceId}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -1,10 +1,19 @@
-import { Button, PlusIcon, Spacer, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import {
+  Button,
+  DropdownMenu,
+  GavelIcon,
+  PlusIcon,
+  Spacer,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 import { FeedbackAssessment } from '../ModelTrace.types';
 import { FeedbackGroup } from './FeedbackGroup';
 import { useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { first, isEmpty, isNil, partition, some } from 'lodash';
 import { AssessmentCreateForm } from './AssessmentCreateForm';
+import { useModelTraceExplorerRunJudgesContext } from '../contexts/RunJudgesContext';
 
 type GroupedFeedbacksByValue = { [value: string]: FeedbackAssessment[] };
 
@@ -52,6 +61,22 @@ const AddFeedbackButton = ({ onClick }: { onClick: () => void }) => (
   </Button>
 );
 
+const RunJudgeButton = ({ traceId }: { traceId: string }) => {
+  const runJudgeConfiguration = useModelTraceExplorerRunJudgesContext();
+
+  if (!runJudgeConfiguration.renderRunJudgeButton) {
+    return null;
+  }
+
+  const trigger = (
+    <Button type="primary" componentId="shared.model-trace-explorer.add-feedback" size="small" icon={<GavelIcon />}>
+      <FormattedMessage defaultMessage="Run judge" description="Label for the button to add a new feedback" />
+    </Button>
+  );
+
+  return <>{runJudgeConfiguration.renderRunJudgeButton({ traceId, trigger })}</>;
+};
+
 export const AssessmentsPaneFeedbackSection = ({
   enableRunScorer,
   feedbacks,
@@ -89,8 +114,11 @@ export const AssessmentsPaneFeedbackSection = ({
         </Typography.Text>
       </div>
       {!isEmpty(groupedFeedbacks) && (
-        <div css={{ display: 'flex', justifyContent: 'flex-end', marginBottom: theme.spacing.sm }}>
+        <div
+          css={{ display: 'flex', justifyContent: 'flex-end', marginBottom: theme.spacing.sm, gap: theme.spacing.xs }}
+        >
           <AddFeedbackButton onClick={() => setCreateFormVisible(true)} />
+          {enableRunScorer && <RunJudgeButton traceId={traceId} />}
         </div>
       )}
 
@@ -122,6 +150,7 @@ export const AssessmentsPaneFeedbackSection = ({
           <Spacer size="sm" />
           <div css={{ display: 'flex', gap: 4, justifyContent: 'center' }}>
             <AddFeedbackButton onClick={() => setCreateFormVisible(true)} />
+            {enableRunScorer && <RunJudgeButton traceId={traceId} />}
           </div>
         </div>
       )}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/RunJudgesContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/RunJudgesContext.tsx
@@ -1,0 +1,31 @@
+import React, { useMemo } from 'react';
+
+export interface ModelTraceExplorerRunJudgeConfig {
+  renderRunJudgeButton?: ({ traceId, trigger }: { traceId: string; trigger: React.ReactNode }) => React.ReactNode;
+}
+
+const ModelTraceExplorerRunJudgesContext = React.createContext<ModelTraceExplorerRunJudgeConfig>({
+  renderRunJudgeButton: undefined,
+});
+
+/**
+ * Provides context for running judges on traces.
+ * Contains:
+ * - a function to render a button to run a judge on a trace
+ * - TODO: logic for monitoring and updating the status of the judge runs
+ */
+export const ModelTraceExplorerRunJudgesContextProvider = ({
+  children,
+  renderRunJudgeButton,
+}: ModelTraceExplorerRunJudgeConfig & {
+  children: React.ReactNode;
+}) => {
+  const contextValue = useMemo(() => ({ renderRunJudgeButton }), [renderRunJudgeButton]);
+  return (
+    <ModelTraceExplorerRunJudgesContext.Provider value={contextValue}>
+      {children}
+    </ModelTraceExplorerRunJudgesContext.Provider>
+  );
+};
+
+export const useModelTraceExplorerRunJudgesContext = () => React.useContext(ModelTraceExplorerRunJudgesContext);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -53,6 +53,10 @@ export {
   ModelTraceExplorerUpdateTraceContextProvider,
   useModelTraceExplorerUpdateTraceContext,
 } from './contexts/UpdateTraceContext';
+export {
+  ModelTraceExplorerRunJudgesContextProvider,
+  type ModelTraceExplorerRunJudgeConfig,
+} from './contexts/RunJudgesContext';
 export { SingleChatTurnMessages } from './session-view/SingleChatTurnMessages';
 export { ModelTraceExplorerChatMessage } from './right-pane/ModelTraceExplorerChatMessage';
 export { SingleChatTurnAssessments } from './session-view/SingleChatTurnAssessments';


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20275/files) to review incremental changes.
- [**stack/run-judges-from-trace-ui-part4**](https://github.com/mlflow/mlflow/pull/20275) [[Files changed](https://github.com/mlflow/mlflow/pull/20275/files)]
  - [stack/run-judges-from-trace-ui-part5](https://github.com/mlflow/mlflow/pull/20276) [[Files changed](https://github.com/mlflow/mlflow/pull/20276/files/f0a3996980df80b0048a35de260d37928d162e57..da33b269a9194930d78d3849013168ee3b9720bc)]
    - [stack/run-judges-from-trace-ui-part6](https://github.com/mlflow/mlflow/pull/20312) [[Files changed](https://github.com/mlflow/mlflow/pull/20312/files/da33b269a9194930d78d3849013168ee3b9720bc..9376d524b9cb8ee767d3bbad9320e51e9fe1321a)]
      - [stack/run-judges-from-trace-ui-part7](https://github.com/mlflow/mlflow/pull/20313) [[Files changed](https://github.com/mlflow/mlflow/pull/20313/files/9376d524b9cb8ee767d3bbad9320e51e9fe1321a..ee5447130f56e967fdd1ef31094db51bc412603b)]
        - [stack/run-judges-from-trace-ui-part8](https://github.com/mlflow/mlflow/pull/20340) [[Files changed](https://github.com/mlflow/mlflow/pull/20340/files/ee5447130f56e967fdd1ef31094db51bc412603b..851524b18b06219398bb22d623059fd67406bfe9)]
          - [stack/run-judges-from-trace-ui-part9](https://github.com/mlflow/mlflow/pull/20360) [[Files changed](https://github.com/mlflow/mlflow/pull/20360/files/851524b18b06219398bb22d623059fd67406bfe9..299c83313a2618a49b10362ae954e29c607b284a)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Implemented judge selector dropdown triggered by "Run judge" button in trace details view, based on [the design](https://www.figma.com/design/eudql8szHU8Az1nqfcQ8hf/MLflow-3---Judges-and-assessments?node-id=7582-69124&t=Pzn9FaKkLB0DakuK-0).
**Note:** only registered judges are supported now, predefined templates are added in [part 8](https://github.com/mlflow/mlflow/pull/20340)

<img width="698" height="617" alt="Screenshot 2026-01-23 at 18 08 49" src="https://github.com/user-attachments/assets/bf737a3a-85d2-46aa-9535-6083b3cc0680" />

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
