### PR TITLE
Revamp assessments and run judges directly in trace UI [Part 5/x]: Running judges

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
@@ -22,22 +22,22 @@ import {
 import { PillControl } from '@databricks/design-system/development';
 import ScorerModalRenderer from '../ScorerModalRenderer';
 import { SCORER_FORM_MODE } from '../constants';
+import { useRunSerializedScorer } from './useRunSerializedScorer';
 
 export const useRunScorerInTracesViewConfiguration = (): ModelTraceExplorerRunJudgeConfig => {
+  const [experimentId] = useExperimentIds();
+
+  const { evaluateTraces } = useRunSerializedScorer({ experimentId });
+
   const renderRunJudgeButton = useCallback<NonNullable<ModelTraceExplorerRunJudgeConfig['renderRunJudgeButton']>>(
     ({ traceId, trigger }) => {
       return (
-        <SelectJudgeDropdown
-          traceId={traceId}
-          evaluateTraces={() => {
-            // TODO: Run judges against the trace
-          }}
-        >
+        <SelectJudgeDropdown traceId={traceId} evaluateTraces={evaluateTraces}>
           {trigger}
         </SelectJudgeDropdown>
       );
     },
-    [],
+    [evaluateTraces],
   );
   return {
     renderRunJudgeButton,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunSerializedScorer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunSerializedScorer.tsx
@@ -31,6 +31,7 @@ export const useRunSerializedScorer = ({
         experimentId,
         evaluationScope: ScorerEvaluationScope.TRACES,
         serializedScorer: scorerConfig.serialized_scorer,
+        saveAssessment: true,
       };
       return evaluateTracesFn(evaluationParams);
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/types.ts
@@ -192,4 +192,6 @@ export interface EvaluateChatAssessmentsParams extends EvaluateChatParamsBase {
 /**
  * Union type for all trace evaluation parameters
  */
-export type EvaluateTracesParams = EvaluateChatCompletionsParams | EvaluateChatAssessmentsParams;
+export type EvaluateTracesParams = (EvaluateChatCompletionsParams | EvaluateChatAssessmentsParams) & {
+  saveAssessment?: boolean;
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
@@ -77,6 +77,7 @@ export const useEvaluateTracesAsync = ({ onScorerFinished }: { onScorerFinished?
         experiment_id: evaluateParams.experimentId,
         serialized_scorer: evaluateParams.serializedScorer,
         trace_ids: traceIds,
+        log_assessments: evaluateParams.saveAssessment,
       });
       return responseData;
     },


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20276/files) to review incremental changes.
- [**stack/run-judges-from-trace-ui-part5**](https://github.com/mlflow/mlflow/pull/20276) [[Files changed](https://github.com/mlflow/mlflow/pull/20276/files)]
  - [stack/run-judges-from-trace-ui-part6](https://github.com/mlflow/mlflow/pull/20312) [[Files changed](https://github.com/mlflow/mlflow/pull/20312/files/2d05df3e01ea58fb1db417026eeb61458057f2c3..8eb9a67cd0f72e5b7d15bc043474bc9b3621166f)]
    - [stack/run-judges-from-trace-ui-part7](https://github.com/mlflow/mlflow/pull/20313) [[Files changed](https://github.com/mlflow/mlflow/pull/20313/files/8eb9a67cd0f72e5b7d15bc043474bc9b3621166f..54f73e18a998e0051db1f31d54095652b22076f2)]
      - [stack/run-judges-from-trace-ui-part8](https://github.com/mlflow/mlflow/pull/20340) [[Files changed](https://github.com/mlflow/mlflow/pull/20340/files/54f73e18a998e0051db1f31d54095652b22076f2..792c2ef1f8172b9ae2b2ccebb0096f8748368cf2)]
        - [stack/run-judges-from-trace-ui-part9](https://github.com/mlflow/mlflow/pull/20360) [[Files changed](https://github.com/mlflow/mlflow/pull/20360/files/792c2ef1f8172b9ae2b2ccebb0096f8748368cf2..d04514a8c1d8da37a5cd5a7b5333705d601aaedc)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Wired up the scorer execution logic to the Run Judge dropdown, enabling users to actually run judges against traces.
Added `saveAssessment: true` to evaluation parameters so results are automatically logged as assessments on the trace

**Note: the progress/loading state is not in the scope, will be added in subsequent PRs**

https://github.com/user-attachments/assets/85b2bc1b-6e09-4eb0-9368-28648f8e501e

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
