### PR TITLE
Improve wording in quickstart installation instructions

### DIFF
--- a/docs/docs/classic-ml/getting-started/quickstart.mdx
+++ b/docs/docs/classic-ml/getting-started/quickstart.mdx
@@ -21,8 +21,7 @@ Welcome to MLflow! The purpose of this quickstart is to provide a quick guide to
 
 ## Step 1 - Set up MLflow
 
-MLflow is available on PyPI. If you don't already have it installed on your system, you can install it with:
-
+MLflow is available on PyPI. If it is not already installed, you can install it with:
 ```bash
 pip install mlflow
 ```


### PR DESCRIPTION
Simplified wording in the quickstart installation section for better clarity.