### PR TITLE
[5/x] Add Compare button to run detail page for evaluation runs

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
@@ -10,11 +10,12 @@ import { RunViewHeaderRegisterModelButton } from './RunViewHeaderRegisterModelBu
 import type { UseGetRunQueryResponseExperiment, UseGetRunQueryResponseOutputs } from './hooks/useGetRunQuery';
 import type { RunPageModelVersionSummary } from './hooks/useUnifiedRegisteredModelVersionsSummariesForRun';
 import { ExperimentKind } from '@mlflow/mlflow/src/experiment-tracking/constants';
-import { Button, Icon, useDesignSystemTheme } from '@databricks/design-system';
+import { Button, Icon, Tooltip, useDesignSystemTheme } from '@databricks/design-system';
+import { useNavigate } from '../../../common/utils/RoutingUtils';
 import { RunIcon } from './assets/RunIcon';
 import { ExperimentPageTabName } from '@mlflow/mlflow/src/experiment-tracking/constants';
 import { useExperimentKind, isGenAIExperimentKind } from '../../utils/ExperimentKindUtils';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 const RunViewHeaderIcon = () => {
   const { theme } = useDesignSystemTheme();
   return (
@@ -117,6 +118,37 @@ export const RunViewHeader = ({
     );
   }
 
+  const navigate = useNavigate();
+
+  const handleCompareClick = useCallback(() => {
+    const evaluationRunsRoute = Routes.getExperimentPageTabRoute(
+      experiment.experimentId ?? '',
+      ExperimentPageTabName.EvaluationRuns,
+    );
+    navigate(`${evaluationRunsRoute}?selectedRunUuid=${runUuid}`);
+  }, [navigate, experiment.experimentId, runUuid]);
+
+  const renderCompareButton = () => {
+    if (!shouldRouteToEvaluations) {
+      return null;
+    }
+    return (
+      <Tooltip
+        componentId="mlflow.run-view.compare-button.tooltip"
+        content={
+          <FormattedMessage
+            defaultMessage="Compare this run with other evaluation runs"
+            description="Tooltip for the compare button on the run detail page"
+          />
+        }
+      >
+        <Button componentId="mlflow.run-view.compare-button" onClick={handleCompareClick}>
+          <FormattedMessage defaultMessage="Compare" description="Compare button on run detail page" />
+        </Button>
+      </Tooltip>
+    );
+  };
+
   const renderRegisterModelButton = () => {
     return (
       <RunViewHeaderRegisterModelButton
@@ -141,6 +173,8 @@ export const RunViewHeader = ({
         breadcrumbs={breadcrumbs}
         /* prettier-ignore */
       >
+        {renderCompareButton()}
+        {renderRegisterModelButton()}
         <OverflowMenu
           menu={[
             {
@@ -163,8 +197,6 @@ export const RunViewHeader = ({
               : []),
           ]}
         />
-
-        {renderRegisterModelButton()}
       </PageHeader>
       <RunViewModeSwitch runTags={runTags} />
     </div>

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
@@ -125,7 +125,8 @@ export const RunViewHeader = ({
       experiment.experimentId ?? '',
       ExperimentPageTabName.EvaluationRuns,
     );
-    navigate(`${evaluationRunsRoute}?selectedRunUuid=${runUuid}`);
+    const searchParams = new URLSearchParams({ selectedRunUuid: runUuid });
+    navigate(`${evaluationRunsRoute}?${searchParams.toString()}`);
   }, [navigate, experiment.experimentId, runUuid]);
 
   const renderCompareButton = () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -93,15 +93,13 @@ const ExperimentEvaluationRunsPageImpl = () => {
 
   // On mount, if selectedRunUuid is in URL, pre-select it and enter comparison mode
   const hasInitializedFromUrl = useRef(false);
-  useEffect(() => {
-    if (!hasInitializedFromUrl.current && selectedRunUuid && runs?.length) {
-      hasInitializedFromUrl.current = true;
-      if (runUuids.includes(selectedRunUuid)) {
-        setRowSelection({ [selectedRunUuid]: true });
-        setIsComparisonMode(true);
-      }
+  if (!hasInitializedFromUrl.current && selectedRunUuid && runs?.length) {
+    hasInitializedFromUrl.current = true;
+    if (runUuids.includes(selectedRunUuid)) {
+      setRowSelection({ [selectedRunUuid]: true });
+      setIsComparisonMode(true);
     }
-  }, [selectedRunUuid, runs, runUuids, setRowSelection]);
+  }
 
   /**
    * Generate a list of unique data columns based on runs' metrics, params, and tags.

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -89,12 +89,19 @@ const ExperimentEvaluationRunsPageImpl = () => {
     filter: searchFilter,
   });
 
-  const runUuids = runs?.map((run) => run.info.runUuid) ?? [];
-  // In comparison mode, set the selected run to the first run if we don't already have one
-  // or if the selected run went out of scope (e.g. was deleted)
-  if (isComparisonMode && runs?.length && (!selectedRunUuid || !runUuids.includes(selectedRunUuid))) {
-    setSelectedRunUuid(runs[0].info.runUuid);
-  }
+  const runUuids = useMemo(() => runs?.map((run) => run.info.runUuid) ?? [], [runs]);
+
+  // On mount, if selectedRunUuid is in URL, pre-select it and enter comparison mode
+  const hasInitializedFromUrl = useRef(false);
+  useEffect(() => {
+    if (!hasInitializedFromUrl.current && selectedRunUuid && runs?.length) {
+      hasInitializedFromUrl.current = true;
+      if (runUuids.includes(selectedRunUuid)) {
+        setRowSelection({ [selectedRunUuid]: true });
+        setIsComparisonMode(true);
+      }
+    }
+  }, [selectedRunUuid, runs, runUuids, setRowSelection]);
 
   /**
    * Generate a list of unique data columns based on runs' metrics, params, and tags.

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2150,6 +2150,10 @@
     "defaultMessage": "Prompts & versions",
     "description": "Label for the versions section in the MLflow experiment navbar"
   },
+  "EDWwN/": {
+    "defaultMessage": "Compare",
+    "description": "Compare button on run detail page"
+  },
   "EI7moF": {
     "defaultMessage": "Last year",
     "description": "Option for the start select dropdown to filter runs since the last 1 year"
@@ -2533,6 +2537,10 @@
   "HeNa8H": {
     "defaultMessage": "All",
     "description": "Option for the start select dropdown to filter runs from the beginning of time"
+  },
+  "Hem4uh": {
+    "defaultMessage": "Compare this run with other evaluation runs",
+    "description": "Tooltip for the compare button on the run detail page"
   },
   "HfcIG/": {
     "defaultMessage": "Does the assistant follow the provided guidelines throughout the conversation?",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20284/files) to review incremental changes.
- [**stack/run-comparison-pt5**](https://github.com/mlflow/mlflow/pull/20284) [[Files changed](https://github.com/mlflow/mlflow/pull/20284/files)]
  - [stack/run-comparison-pt6](https://github.com/mlflow/mlflow/pull/20285) [[Files changed](https://github.com/mlflow/mlflow/pull/20285/files/f48a63e6e7ba42a5748787737e8559e22ed0c115..a3e19c88ce4c0a7b689bdf8feb3fd530905416c1)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Adds a comparison button to the evaluation run page - clicking on it automatically selects the run in the evaluation runs page.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
![Clipboard-20260124-042321-223](https://github.com/user-attachments/assets/baad489a-26ba-4df0-a06a-10adf4894ce0)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
