### PR TITLE
Add an SDK for distillation from conversation to goal/persona

### DIFF
--- a/mlflow/genai/simulators/__init__.py
+++ b/mlflow/genai/simulators/__init__.py
@@ -1,3 +1,4 @@
+from mlflow.genai.simulators.distillation import generate_test_cases
 from mlflow.genai.simulators.simulator import (
     BaseSimulatedUserAgent,
     ConversationSimulator,
@@ -10,4 +11,5 @@ __all__ = [
     "ConversationSimulator",
     "SimulatedUserAgent",
     "SimulatorContext",
+    "generate_test_cases",
 ]

--- a/mlflow/genai/simulators/distillation.py
+++ b/mlflow/genai/simulators/distillation.py
@@ -10,7 +10,6 @@ from mlflow.genai.simulators.prompts import DEFAULT_PERSONA, DISTILL_GOAL_AND_PE
 from mlflow.genai.simulators.simulator import _MODEL_API_DOC
 from mlflow.genai.simulators.utils import format_history, invoke_model_without_tracing
 from mlflow.genai.utils.trace_utils import resolve_conversation_from_session
-from mlflow.types.llm import ChatMessage
 from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import format_docstring
 
@@ -31,6 +30,8 @@ def _distill_goal_and_persona(
         return None
 
     prompt = DISTILL_GOAL_AND_PERSONA_PROMPT.format(conversation=format_history(messages))
+
+    from mlflow.types.llm import ChatMessage
 
     response = invoke_model_without_tracing(
         model_uri=model,

--- a/mlflow/genai/simulators/distillation.py
+++ b/mlflow/genai/simulators/distillation.py
@@ -108,6 +108,16 @@ def generate_test_cases(
 
             # Use the generated test cases with ConversationSimulator
             simulator = ConversationSimulator(test_cases=test_cases)
+
+        To save test cases as an evaluation dataset for reuse:
+
+        .. code-block:: python
+
+            from mlflow.genai.datasets import create_dataset
+
+            # Create a dataset and save the test cases
+            dataset = create_dataset(name="my_test_cases")
+            dataset.merge_records([{"inputs": tc} for tc in test_cases])
     """
     model = model or get_default_simulation_model()
     num_sessions = len(sessions)

--- a/mlflow/genai/simulators/distillation.py
+++ b/mlflow/genai/simulators/distillation.py
@@ -39,15 +39,16 @@ def _distill_goal_and_persona(
     cleaned_response = _strip_markdown_code_blocks(response)
     try:
         result = json.loads(cleaned_response)
-        goal = result.get("goal", "")
-        if not goal:
+        goal = result.get("goal")
+        if goal is None:
+            _logger.debug(f"Failed to extract goal from response: {cleaned_response}")
             return None
         return {
             "goal": goal,
             "persona": result.get("persona", DEFAULT_PERSONA),
         }
-    except Exception as e:
-        _logger.warning(f"Failed to parse response from model: {e}")
+    except json.JSONDecodeError as e:
+        _logger.debug(f"Failed to parse response as JSON: {cleaned_response}\nError: {e}")
         return None
 
 

--- a/mlflow/genai/simulators/distillation.py
+++ b/mlflow/genai/simulators/distillation.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from mlflow.genai.judges.utils import get_default_model
+from mlflow.genai.judges.utils.parsing_utils import _strip_markdown_code_blocks
+from mlflow.genai.simulators.prompts import DEFAULT_PERSONA, DISTILL_GOAL_AND_PERSONA_PROMPT
+from mlflow.genai.simulators.simulator import _MODEL_API_DOC
+from mlflow.genai.simulators.utils import format_history, invoke_model_without_tracing
+from mlflow.genai.utils.trace_utils import resolve_conversation_from_session
+from mlflow.types.llm import ChatMessage
+from mlflow.utils.annotations import experimental
+from mlflow.utils.docstring_utils import format_docstring
+
+if TYPE_CHECKING:
+    from mlflow.entities import Trace
+
+    Session = list[Trace]
+
+_logger = logging.getLogger(__name__)
+
+
+def _distill_goal_and_persona(
+    session: Session,
+    model: str,
+) -> dict[str, str] | None:
+    messages = resolve_conversation_from_session(session)
+    if not messages:
+        return None
+
+    prompt = DISTILL_GOAL_AND_PERSONA_PROMPT.format(conversation=format_history(messages))
+
+    response = invoke_model_without_tracing(
+        model_uri=model,
+        messages=[ChatMessage(role="user", content=prompt)],
+    )
+    cleaned_response = _strip_markdown_code_blocks(response)
+    try:
+        result = json.loads(cleaned_response)
+        goal = result.get("goal", "")
+        if not goal:
+            return None
+        return {
+            "goal": goal,
+            "persona": result.get("persona", DEFAULT_PERSONA),
+        }
+    except Exception as e:
+        _logger.warning(f"Failed to parse response from model: {e}")
+        return None
+
+
+@experimental(version="3.10.0")
+@format_docstring(_MODEL_API_DOC)
+def generate_seed_conversations(
+    sessions: list[Session],
+    *,
+    model: str | None = None,
+) -> list[dict[str, str]]:
+    """
+    Generate seed test cases by distilling goals and personas from existing sessions.
+
+    This function analyzes sessions and uses an LLM to infer the user's goal and
+    persona from each session. This is useful for generating test cases from existing
+    conversation data rather than manually writing goals and personas.
+
+    Args:
+        sessions: A list of sessions, where each session is a list of traces.
+        model: {{ model }}
+
+    Returns:
+        A list of dicts with "goal" and "persona" keys, suitable for use with ConversationSimulator.
+
+    Example:
+        .. code-block:: python
+
+            import mlflow
+            from mlflow.genai.simulators import generate_seed_conversations
+            from mlflow.genai.simulators import ConversationSimulator
+
+            # Get existing sessions
+            sessions = mlflow.search_sessions(...)  # clint: disable=unknown-mlflow-function
+
+            # Generate seed test cases
+            test_cases = generate_seed_conversations(sessions)
+
+            # Use the generated test cases with ConversationSimulator
+            simulator = ConversationSimulator(test_cases=test_cases)
+    """
+    model = model or get_default_model()
+    results = [_distill_goal_and_persona(session, model=model) for session in sessions]
+    return [r for r in results if r is not None]

--- a/mlflow/genai/simulators/distillation.py
+++ b/mlflow/genai/simulators/distillation.py
@@ -7,10 +7,13 @@ from typing import TYPE_CHECKING
 import pydantic
 
 from mlflow.environment_variables import MLFLOW_GENAI_EVAL_MAX_WORKERS
-from mlflow.genai.judges.utils import get_default_model
 from mlflow.genai.simulators.prompts import DEFAULT_PERSONA, DISTILL_GOAL_AND_PERSONA_PROMPT
 from mlflow.genai.simulators.simulator import _MODEL_API_DOC, PGBAR_FORMAT
-from mlflow.genai.simulators.utils import format_history, invoke_model_without_tracing
+from mlflow.genai.simulators.utils import (
+    format_history,
+    get_default_simulation_model,
+    invoke_model_without_tracing,
+)
 from mlflow.genai.utils.trace_utils import resolve_conversation_from_session
 from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import format_docstring
@@ -78,6 +81,10 @@ def generate_test_cases(
     persona from each session. This is useful for generating test cases from existing
     conversation data rather than manually writing goals and personas.
 
+    .. note::
+        This task benefits from a powerful model. We recommend using ``openai:/gpt-5``
+        or a model of similar capability for best results.
+
     Args:
         sessions: A list of sessions, where each session is a list of traces.
         model: {{ model }}
@@ -102,7 +109,7 @@ def generate_test_cases(
             # Use the generated test cases with ConversationSimulator
             simulator = ConversationSimulator(test_cases=test_cases)
     """
-    model = model or get_default_model()
+    model = model or get_default_simulation_model()
     num_sessions = len(sessions)
     results: list[dict[str, str] | None] = [None] * num_sessions
     max_workers = min(num_sessions, MLFLOW_GENAI_EVAL_MAX_WORKERS.get())

--- a/mlflow/genai/simulators/distillation.py
+++ b/mlflow/genai/simulators/distillation.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import pydantic
 
 from mlflow.environment_variables import MLFLOW_GENAI_EVAL_MAX_WORKERS
-from mlflow.genai.simulators.prompts import DEFAULT_PERSONA, DISTILL_GOAL_AND_PERSONA_PROMPT
+from mlflow.genai.simulators.prompts import DISTILL_GOAL_AND_PERSONA_PROMPT
 from mlflow.genai.simulators.simulator import _MODEL_API_DOC, PGBAR_FORMAT
 from mlflow.genai.simulators.utils import (
     format_history,
@@ -33,8 +33,8 @@ _logger = logging.getLogger(__name__)
 
 class _GoalAndPersona(pydantic.BaseModel):
     goal: str = pydantic.Field(description="The user's underlying goal in the conversation")
-    persona: str = pydantic.Field(
-        default=DEFAULT_PERSONA,
+    persona: str | None = pydantic.Field(
+        default=None,
         description="A description of the user's communication style and personality",
     )
 
@@ -61,7 +61,10 @@ def _distill_goal_and_persona(
         if not result.goal:
             _logger.debug(f"Empty goal extracted from response: {response}")
             return None
-        return {"goal": result.goal, "persona": result.persona}
+        test_case = {"goal": result.goal}
+        if result.persona:
+            test_case["persona"] = result.persona
+        return test_case
     except pydantic.ValidationError as e:
         _logger.debug(f"Failed to validate response: {e}")
         return None

--- a/mlflow/genai/simulators/distillation.py
+++ b/mlflow/genai/simulators/distillation.py
@@ -43,6 +43,7 @@ def _distill_goal_and_persona(
     model: str,
 ) -> dict[str, str] | None:
     from mlflow.entities.session import Session
+    from mlflow.types.llm import ChatMessage
 
     traces = session.traces if isinstance(session, Session) else session
     messages = resolve_conversation_from_session(traces)
@@ -50,8 +51,6 @@ def _distill_goal_and_persona(
         return None
 
     prompt = DISTILL_GOAL_AND_PERSONA_PROMPT.format(conversation=format_history(messages))
-
-    from mlflow.types.llm import ChatMessage
 
     try:
         response = invoke_model_without_tracing(

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -105,12 +105,4 @@ authentication issue").
 2. **Persona**: How does the user communicate? Describe their communication style, expertise \
 level, and personality in 1-2 sentences. Start with "You are..." (e.g., "You are a data \
 scientist who asks detailed technical questions" or "You are a beginner who needs step-by-step \
-guidance").
-
-You must output your response as a valid JSON object with the following format:
-{{
-  "goal": "...",
-  "persona": "..."
-}}
-
-Do not include any markdown formatting or output additional lines."""
+guidance")."""

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -88,3 +88,29 @@ You must output your response as a valid JSON object with the following format:
   "result": "yes|no"
 }}"""
 # NB: We include "rationale" to invoke chain-of-thought reasoning for better results.
+
+DISTILL_GOAL_AND_PERSONA_PROMPT = """Analyze the following conversation and extract the user's \
+underlying goal and persona.
+
+<conversation>
+{conversation}
+</conversation>
+
+Based on this conversation, identify:
+
+1. **Goal**: What is the user trying to accomplish? Describe their objective in one clear \
+sentence, written as an instruction (e.g., "Learn how to deploy a model" or "Debug an \
+authentication issue").
+
+2. **Persona**: How does the user communicate? Describe their communication style, expertise \
+level, and personality in 1-2 sentences. Start with "You are..." (e.g., "You are a data \
+scientist who asks detailed technical questions" or "You are a beginner who needs step-by-step \
+guidance").
+
+You must output your response as a valid JSON object with the following format:
+{{
+  "goal": "...",
+  "persona": "..."
+}}
+
+Do not include any markdown formatting or output additional lines."""

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -89,8 +89,8 @@ You must output your response as a valid JSON object with the following format:
 }}"""
 # NB: We include "rationale" to invoke chain-of-thought reasoning for better results.
 
-DISTILL_GOAL_AND_PERSONA_PROMPT = """Analyze the following conversation and extract the user's \
-underlying goal and persona.
+DISTILL_GOAL_AND_PERSONA_PROMPT = """Analyze the following conversation between a user and an \
+AI assistant. Extract the user's underlying goal and persona.
 
 <conversation>
 {conversation}
@@ -98,9 +98,9 @@ underlying goal and persona.
 
 Based on this conversation, identify:
 
-1. **Goal**: What is the user trying to accomplish? Describe their objective in one clear \
-sentence, written as an instruction (e.g., "Learn how to deploy a model" or "Debug an \
-authentication issue").
+1. **Goal**: What is the user trying to accomplish by talking to the assistant? Describe their \
+objective in one clear sentence from the user's perspective (e.g., "Learn how to deploy a model", \
+"Get help debugging an authentication issue", or "Understand how experiment tracking works").
 
 2. **Persona**: How does the user communicate? Describe their communication style, expertise \
 level, and personality in 1-2 sentences. Start with "You are..." (e.g., "You are a data \

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -27,8 +27,6 @@ from mlflow.genai.simulators.utils import (
     get_default_simulation_model,
     invoke_model_without_tracing,
 )
-from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
-from mlflow.genai.utils.message_utils import serialize_messages_to_databricks_prompts
 from mlflow.genai.utils.trace_utils import parse_outputs_to_str
 from mlflow.telemetry.events import SimulateConversationEvent
 from mlflow.telemetry.track import record_usage_event

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import time
 import uuid
@@ -17,21 +16,17 @@ import mlflow
 from mlflow.environment_variables import MLFLOW_GENAI_SIMULATOR_MAX_WORKERS
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import EvaluationDataset
-from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
-    call_chat_completions,
-    create_litellm_message_from_databricks_response,
-)
-from mlflow.genai.judges.constants import (
-    _DATABRICKS_AGENTIC_JUDGE_MODEL,
-    _DATABRICKS_DEFAULT_JUDGE_MODEL,
-)
 from mlflow.genai.simulators.prompts import (
     CHECK_GOAL_PROMPT,
     DEFAULT_PERSONA,
     FOLLOWUP_USER_PROMPT,
     INITIAL_USER_PROMPT,
 )
-from mlflow.genai.simulators.utils import get_default_simulation_model
+from mlflow.genai.simulators.utils import (
+    format_history,
+    get_default_simulation_model,
+    invoke_model_without_tracing,
+)
 from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
 from mlflow.genai.utils.message_utils import serialize_messages_to_databricks_prompts
 from mlflow.genai.utils.trace_utils import parse_outputs_to_str
@@ -50,7 +45,6 @@ if TYPE_CHECKING:
     from pandas import DataFrame
 
     from mlflow.entities import Trace
-    from mlflow.types.llm import ChatMessage
 
 _logger = logging.getLogger(__name__)
 
@@ -143,99 +137,6 @@ def _suppress_tracing_logging():
         fluent_logger.setLevel(original_fluent_level)
 
 
-@contextmanager
-def _delete_trace_if_created():
-    """Delete any trace created within this context to avoid polluting user traces."""
-    trace_id_before = mlflow.get_last_active_trace_id(thread_local=True)
-    try:
-        yield
-    finally:
-        trace_id_after = mlflow.get_last_active_trace_id(thread_local=True)
-        if trace_id_after and trace_id_after != trace_id_before:
-            try:
-                mlflow.delete_trace(trace_id_after)
-            except Exception as e:
-                _logger.debug(f"Failed to delete trace {trace_id_after}: {e}")
-
-
-# TODO: Refactor judges adapters to support returning raw responses, then use them here
-#       instead of reimplementing the invocation logic.
-def _invoke_model_without_tracing(
-    model_uri: str,
-    messages: list["ChatMessage"],
-    num_retries: int = 3,
-    inference_params: dict[str, Any] | None = None,
-) -> str:
-    """
-    Invoke a model without tracing. This method will delete the last trace created by the
-    invocation, if any.
-    """
-    import litellm
-
-    from mlflow.metrics.genai.model_utils import _parse_model_uri
-
-    with _delete_trace_if_created():
-        # Use Databricks managed endpoint with agentic model for the default "databricks" URI
-        if model_uri == _DATABRICKS_DEFAULT_JUDGE_MODEL:
-            user_prompt, system_prompt = serialize_messages_to_databricks_prompts(messages)
-
-            result = call_chat_completions(
-                user_prompt=user_prompt,
-                # NB: We cannot use an empty system prompt here so we use a period.
-                system_prompt=system_prompt or ".",
-                model=_DATABRICKS_AGENTIC_JUDGE_MODEL,
-            )
-            if getattr(result, "error_code", None):
-                raise MlflowException(
-                    f"Failed to get chat completions result from Databricks managed endpoint: "
-                    f"[{result.error_code}] {result.error_message}"
-                )
-
-            output_json = result.output_json
-            if not output_json:
-                raise MlflowException("Empty response from Databricks managed endpoint")
-
-            parsed_json = json.loads(output_json) if isinstance(output_json, str) else output_json
-            return create_litellm_message_from_databricks_response(parsed_json).content
-
-        provider, model_name = _parse_model_uri(model_uri)
-
-        # Use LiteLLM for other providers (including Databricks served models)
-        litellm_messages = [litellm.Message(role=msg.role, content=msg.content) for msg in messages]
-
-        kwargs = {
-            "messages": litellm_messages,
-            "max_retries": num_retries,
-            # Drop unsupported params (e.g., temperature=0 for certain models)
-            "drop_params": True,
-        }
-
-        if provider == "gateway":
-            config = get_gateway_litellm_config(model_name)
-            kwargs["api_base"] = config.api_base
-            kwargs["api_key"] = config.api_key
-            kwargs["model"] = config.model
-        else:
-            kwargs["model"] = f"{provider}/{model_name}"
-
-        if inference_params:
-            kwargs.update(inference_params)
-
-        try:
-            response = litellm.completion(**kwargs)
-            return response.choices[0].message.content
-        except Exception as e:
-            # Check if error is about unsupported temperature parameter:
-            # "Unsupported value: 'temperature' does not support 0.0 with this model"
-            error_str = str(e)
-            if inference_params and "Unsupported value: 'temperature'" in error_str:
-                kwargs.pop("temperature", None)
-                response = litellm.completion(**kwargs)
-                return response.choices[0].message.content
-            else:
-                raise
-
-
 def _get_last_response(conversation_history: list[dict[str, Any]]) -> str | None:
     if not conversation_history:
         return None
@@ -250,17 +151,6 @@ def _get_last_response(conversation_history: list[dict[str, Any]]) -> str | None
         return result
 
     return str(last_msg)
-
-
-def _format_history(history: list[dict[str, Any]]) -> str | None:
-    if not history:
-        return None
-    formatted = []
-    for msg in history:
-        role = msg.get("role") or "unknown"
-        content = msg.get("content") or ""
-        formatted.append(f"{role}: {content}")
-    return "\n".join(formatted)
 
 
 def _fetch_traces(all_trace_ids: list[list[str]]) -> list[list["Trace"]]:
@@ -318,7 +208,7 @@ class SimulatorContext:
 
     @property
     def formatted_history(self) -> str | None:
-        return _format_history(self.conversation_history)
+        return format_history(self.conversation_history)
 
     @property
     def last_assistant_response(self) -> str | None:
@@ -389,7 +279,7 @@ class BaseSimulatedUserAgent(ABC):
             messages.append(ChatMessage(role="system", content=system_prompt))
         messages.append(ChatMessage(role="user", content=prompt))
 
-        return _invoke_model_without_tracing(
+        return invoke_model_without_tracing(
             model_uri=self.model,
             messages=messages,
             num_retries=3,
@@ -419,7 +309,7 @@ class SimulatedUserAgent(BaseSimulatedUserAgent):
             prompt = INITIAL_USER_PROMPT.format(persona=context.persona, goal=context.goal)
         else:
             history_without_last = context.conversation_history[:-1]
-            history_str = _format_history(history_without_last)
+            history_str = format_history(history_without_last)
             prompt = FOLLOWUP_USER_PROMPT.format(
                 persona=context.persona,
                 goal=context.goal,
@@ -815,7 +705,7 @@ class ConversationSimulator:
     ) -> bool:
         from mlflow.types.llm import ChatMessage
 
-        history_str = _format_history(conversation_history)
+        history_str = format_history(conversation_history)
         eval_prompt = CHECK_GOAL_PROMPT.format(
             goal=goal,
             conversation_history=history_str if history_str is not None else "",
@@ -824,7 +714,7 @@ class ConversationSimulator:
         messages = [ChatMessage(role="user", content=eval_prompt)]
 
         try:
-            text_result = _invoke_model_without_tracing(
+            text_result = invoke_model_without_tracing(
                 model_uri=self.user_model,
                 messages=messages,
                 num_retries=3,

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -25,13 +25,13 @@ from mlflow.genai.judges.constants import (
     _DATABRICKS_AGENTIC_JUDGE_MODEL,
     _DATABRICKS_DEFAULT_JUDGE_MODEL,
 )
-from mlflow.genai.judges.utils import get_default_model
 from mlflow.genai.simulators.prompts import (
     CHECK_GOAL_PROMPT,
     DEFAULT_PERSONA,
     FOLLOWUP_USER_PROMPT,
     INITIAL_USER_PROMPT,
 )
+from mlflow.genai.simulators.utils import get_default_simulation_model
 from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
 from mlflow.genai.utils.message_utils import serialize_messages_to_databricks_prompts
 from mlflow.genai.utils.trace_utils import parse_outputs_to_str
@@ -365,7 +365,7 @@ class BaseSimulatedUserAgent(ABC):
         model: str | None = None,
         **inference_params,
     ):
-        self.model = model or get_default_model()
+        self.model = model or get_default_simulation_model()
         self.inference_params = inference_params
 
     @abstractmethod
@@ -542,7 +542,7 @@ class ConversationSimulator:
         self._source_dataset = test_cases if isinstance(test_cases, EvaluationDataset) else None
         self.test_cases = test_cases
         self.max_turns = max_turns
-        self.user_model = user_model or get_default_model()
+        self.user_model = user_model or get_default_simulation_model()
         self.user_agent_class = user_agent_class or SimulatedUserAgent
         self.user_llm_params = user_llm_params
 

--- a/mlflow/genai/simulators/utils.py
+++ b/mlflow/genai/simulators/utils.py
@@ -16,11 +16,21 @@ from mlflow.genai.judges.constants import (
     _DATABRICKS_AGENTIC_JUDGE_MODEL,
     _DATABRICKS_DEFAULT_JUDGE_MODEL,
 )
+from mlflow.tracking import get_tracking_uri
+from mlflow.utils.uri import is_databricks_uri
 
 if TYPE_CHECKING:
     from mlflow.types.llm import ChatMessage
 
 _logger = logging.getLogger(__name__)
+
+_DEFAULT_SIMULATION_MODEL = "openai:/gpt-5"
+
+
+def get_default_simulation_model() -> str:
+    if is_databricks_uri(get_tracking_uri()):
+        return _DATABRICKS_AGENTIC_JUDGE_MODEL
+    return _DEFAULT_SIMULATION_MODEL
 
 
 @contextmanager

--- a/mlflow/genai/simulators/utils.py
+++ b/mlflow/genai/simulators/utils.py
@@ -43,10 +43,18 @@ def invoke_model_without_tracing(
     messages: list[ChatMessage],
     num_retries: int = 3,
     inference_params: dict[str, Any] | None = None,
+    response_format: type | None = None,
 ) -> str:
     """
     Invoke a model without tracing. This method will delete the last trace created by the
     invocation, if any.
+
+    Args:
+        model_uri: The model URI.
+        messages: List of ChatMessage objects.
+        num_retries: Number of retries on transient failures.
+        inference_params: Optional inference parameters.
+        response_format: Optional pydantic model class for structured output.
     """
     import litellm
 
@@ -85,6 +93,8 @@ def invoke_model_without_tracing(
         }
         if inference_params:
             kwargs.update(inference_params)
+        if response_format is not None:
+            kwargs["response_format"] = response_format
 
         litellm.drop_params = True
         response = litellm.completion(**kwargs)

--- a/mlflow/genai/simulators/utils.py
+++ b/mlflow/genai/simulators/utils.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
+    call_chat_completions,
+    create_litellm_message_from_databricks_response,
+    serialize_messages_to_databricks_prompts,
+)
+from mlflow.genai.judges.constants import (
+    _DATABRICKS_AGENTIC_JUDGE_MODEL,
+    _DATABRICKS_DEFAULT_JUDGE_MODEL,
+)
+
+if TYPE_CHECKING:
+    from mlflow.types.llm import ChatMessage
+
+_logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _delete_trace_if_created():
+    """Delete any trace created within this context to avoid polluting user traces."""
+    trace_id_before = mlflow.get_last_active_trace_id(thread_local=True)
+    try:
+        yield
+    finally:
+        trace_id_after = mlflow.get_last_active_trace_id(thread_local=True)
+        if trace_id_after and trace_id_after != trace_id_before:
+            try:
+                mlflow.delete_trace(trace_id_after)
+            except Exception as e:
+                _logger.debug(f"Failed to delete trace {trace_id_after}: {e}")
+
+
+def invoke_model_without_tracing(
+    model_uri: str,
+    messages: list[ChatMessage],
+    num_retries: int = 3,
+    inference_params: dict[str, Any] | None = None,
+) -> str:
+    """
+    Invoke a model without tracing. This method will delete the last trace created by the
+    invocation, if any.
+    """
+    import litellm
+
+    from mlflow.metrics.genai.model_utils import _parse_model_uri
+
+    with _delete_trace_if_created():
+        if model_uri == _DATABRICKS_DEFAULT_JUDGE_MODEL:
+            user_prompt, system_prompt = serialize_messages_to_databricks_prompts(messages)
+
+            result = call_chat_completions(
+                user_prompt=user_prompt,
+                system_prompt=system_prompt or ".",
+                model=_DATABRICKS_AGENTIC_JUDGE_MODEL,
+            )
+            if getattr(result, "error_code", None):
+                raise MlflowException(
+                    f"Failed to get chat completions result from Databricks managed endpoint: "
+                    f"[{result.error_code}] {result.error_message}"
+                )
+
+            output_json = result.output_json
+            if not output_json:
+                raise MlflowException("Empty response from Databricks managed endpoint")
+
+            parsed_json = json.loads(output_json) if isinstance(output_json, str) else output_json
+            return create_litellm_message_from_databricks_response(parsed_json).content
+
+        provider, model_name = _parse_model_uri(model_uri)
+
+        litellm_messages = [litellm.Message(role=msg.role, content=msg.content) for msg in messages]
+
+        kwargs = {
+            "model": f"{provider}/{model_name}",
+            "messages": litellm_messages,
+            "max_retries": num_retries,
+        }
+        if inference_params:
+            kwargs.update(inference_params)
+
+        litellm.drop_params = True
+        response = litellm.completion(**kwargs)
+        return response.choices[0].message.content
+
+
+def format_history(history: list[dict[str, Any]]) -> str | None:
+    if not history:
+        return None
+    formatted = []
+    for msg in history:
+        role = msg.get("role") or "unknown"
+        content = msg.get("content") or ""
+        formatted.append(f"{role}: {content}")
+    return "\n".join(formatted)

--- a/mlflow/genai/simulators/utils.py
+++ b/mlflow/genai/simulators/utils.py
@@ -35,7 +35,7 @@ def get_default_simulation_model() -> str:
 
 @contextmanager
 def _delete_trace_if_created():
-    """Delete any trace created within this context to avoid polluting user traces."""
+    """Delete at most one trace created within this context to avoid polluting user traces."""
     trace_id_before = mlflow.get_last_active_trace_id(thread_local=True)
     try:
         yield

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1304,7 +1304,7 @@ def test_evaluate_with_conversation_simulator_empty_simulation_error():
     )
 
     with mock.patch(
-        "mlflow.genai.simulators.simulator.invoke_model_without_tracing"
+        "mlflow.genai.simulators.simulator._invoke_model_without_tracing"
     ) as mock_invoke:
         # Simulate a failure that produces no traces
         mock_invoke.side_effect = Exception("LLM call failed")

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1304,7 +1304,7 @@ def test_evaluate_with_conversation_simulator_empty_simulation_error():
     )
 
     with mock.patch(
-        "mlflow.genai.simulators.simulator._invoke_model_without_tracing"
+        "mlflow.genai.simulators.simulator.invoke_model_without_tracing"
     ) as mock_invoke:
         # Simulate a failure that produces no traces
         mock_invoke.side_effect = Exception("LLM call failed")

--- a/tests/genai/simulators/conftest.py
+++ b/tests/genai/simulators/conftest.py
@@ -12,7 +12,7 @@ def mock_trace():
 def simulation_mocks(mock_trace):
     """Fixture providing common mocks for conversation simulation tests."""
     with (
-        patch("mlflow.genai.simulators.simulator._invoke_model_without_tracing") as mock_invoke,
+        patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke,
         patch("mlflow.trace") as mock_trace_decorator,
         patch("mlflow.get_last_active_trace_id") as mock_get_trace_id,
         patch("mlflow.update_current_trace") as mock_update_trace,

--- a/tests/genai/simulators/test_distillation.py
+++ b/tests/genai/simulators/test_distillation.py
@@ -1,0 +1,154 @@
+from unittest import mock
+
+import pydantic
+import pytest
+
+from mlflow.genai.simulators.distillation import (
+    _distill_goal_and_persona,
+    _GoalAndPersona,
+    generate_test_cases,
+)
+
+
+@pytest.fixture
+def mock_session():
+    trace = mock.MagicMock()
+    return [trace]
+
+
+def test_goal_and_persona_model_goal_required():
+    with pytest.raises(pydantic.ValidationError, match="goal"):
+        _GoalAndPersona.model_validate({})
+
+
+@pytest.mark.parametrize(
+    ("input_data", "expected_goal", "expected_persona"),
+    [
+        ({"goal": "Test goal"}, "Test goal", None),
+        ({"goal": "Test goal", "persona": "Friendly user"}, "Test goal", "Friendly user"),
+    ],
+)
+def test_goal_and_persona_model_validation(input_data, expected_goal, expected_persona):
+    result = _GoalAndPersona.model_validate(input_data)
+    assert result.goal == expected_goal
+    assert result.persona == expected_persona
+
+
+def test_distill_returns_none_for_empty_conversation(mock_session):
+    with mock.patch(
+        "mlflow.genai.simulators.distillation.resolve_conversation_from_session",
+        return_value=[],
+    ):
+        result = _distill_goal_and_persona(mock_session, model="openai:/gpt-4o")
+        assert result is None
+
+
+@pytest.mark.parametrize(
+    ("llm_response", "expected"),
+    [
+        (
+            '{"goal": "Get help", "persona": "Data scientist"}',
+            {"goal": "Get help", "persona": "Data scientist"},
+        ),
+        ('{"goal": "Get help"}', {"goal": "Get help"}),
+    ],
+)
+def test_distill_extracts_goal_and_persona(mock_session, llm_response, expected):
+    with (
+        mock.patch(
+            "mlflow.genai.simulators.distillation.resolve_conversation_from_session",
+            return_value=[{"role": "user", "content": "Hello"}],
+        ),
+        mock.patch(
+            "mlflow.genai.simulators.distillation.invoke_model_without_tracing",
+            return_value=llm_response,
+        ),
+    ):
+        result = _distill_goal_and_persona(mock_session, model="openai:/gpt-4o")
+        assert result == expected
+
+
+@pytest.mark.parametrize(
+    "llm_response",
+    [
+        '{"goal": "", "persona": "Test"}',  # empty goal
+        "invalid json",  # validation error
+    ],
+)
+def test_distill_returns_none_for_invalid_response(mock_session, llm_response):
+    with (
+        mock.patch(
+            "mlflow.genai.simulators.distillation.resolve_conversation_from_session",
+            return_value=[{"role": "user", "content": "Hello"}],
+        ),
+        mock.patch(
+            "mlflow.genai.simulators.distillation.invoke_model_without_tracing",
+            return_value=llm_response,
+        ),
+    ):
+        result = _distill_goal_and_persona(mock_session, model="openai:/gpt-4o")
+        assert result is None
+
+
+def test_generate_test_cases_processes_multiple_sessions():
+    sessions = [mock.MagicMock(), mock.MagicMock()]
+
+    with mock.patch(
+        "mlflow.genai.simulators.distillation._distill_goal_and_persona",
+        side_effect=[
+            {"goal": "Goal 1", "persona": "Persona 1"},
+            {"goal": "Goal 2"},
+        ],
+    ) as mock_distill:
+        result = generate_test_cases(sessions, model="openai:/gpt-4o")
+
+        assert len(result) == 2
+        assert result[0] == {"goal": "Goal 1", "persona": "Persona 1"}
+        assert result[1] == {"goal": "Goal 2"}
+        assert mock_distill.call_count == 2
+
+
+def test_generate_test_cases_filters_out_none_results():
+    sessions = [mock.MagicMock(), mock.MagicMock(), mock.MagicMock()]
+
+    with mock.patch(
+        "mlflow.genai.simulators.distillation._distill_goal_and_persona",
+        side_effect=[{"goal": "Goal 1"}, None, {"goal": "Goal 3"}],
+    ):
+        result = generate_test_cases(sessions, model="openai:/gpt-4o")
+
+        assert len(result) == 2
+        assert result[0] == {"goal": "Goal 1"}
+        assert result[1] == {"goal": "Goal 3"}
+
+
+def test_generate_test_cases_uses_default_model_when_not_specified():
+    sessions = [mock.MagicMock()]
+
+    with (
+        mock.patch(
+            "mlflow.genai.simulators.distillation.get_default_simulation_model",
+            return_value="openai:/gpt-5",
+        ) as mock_get_model,
+        mock.patch(
+            "mlflow.genai.simulators.distillation._distill_goal_and_persona",
+            return_value={"goal": "Test"},
+        ) as mock_distill,
+    ):
+        generate_test_cases(sessions)
+
+        mock_get_model.assert_called_once()
+        mock_distill.assert_called_once_with(sessions[0], "openai:/gpt-5")
+
+
+def test_generate_test_cases_handles_exceptions_gracefully():
+    sessions = [mock.MagicMock(), mock.MagicMock()]
+
+    with mock.patch(
+        "mlflow.genai.simulators.distillation._distill_goal_and_persona",
+        side_effect=[Exception("Test error"), {"goal": "Goal 2"}],
+    ):
+        result = generate_test_cases(sessions, model="openai:/gpt-4o")
+
+        assert len(result) == 1
+        assert result[0] == {"goal": "Goal 2"}

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -22,7 +22,7 @@ def create_mock_evaluation_dataset(inputs: list[dict[str, object]]) -> Mock:
 
 
 def test_simulated_user_agent_generate_initial_message():
-    with patch("mlflow.genai.simulators.simulator._invoke_model_without_tracing") as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.return_value = "Hello, I have a question about ML."
 
         agent = SimulatedUserAgent()
@@ -47,7 +47,7 @@ def test_simulated_user_agent_generate_initial_message():
 
 
 def test_simulated_user_agent_generate_followup_message():
-    with patch("mlflow.genai.simulators.simulator._invoke_model_without_tracing") as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.return_value = "Can you tell me more?"
 
         agent = SimulatedUserAgent()
@@ -74,7 +74,7 @@ def test_simulated_user_agent_generate_followup_message():
 
 
 def test_simulated_user_agent_default_persona():
-    with patch("mlflow.genai.simulators.simulator._invoke_model_without_tracing") as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.return_value = "Test message"
 
         agent = SimulatedUserAgent()
@@ -525,7 +525,7 @@ def test_conversation_simulator_sets_span_attributes(mock_predict_fn_with_contex
     long_persona = "B" * 500
     context = {"user_id": "U001", "session_id": "S001"}
 
-    with patch("mlflow.genai.simulators.simulator._invoke_model_without_tracing") as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.side_effect = [
             "Test message",
             '{"rationale": "Not achieved", "result": "no"}',
@@ -555,7 +555,7 @@ def test_conversation_simulator_sets_span_attributes(mock_predict_fn_with_contex
 
 
 def test_conversation_simulator_uses_default_persona_and_empty_context(mock_predict_fn):
-    with patch("mlflow.genai.simulators.simulator._invoke_model_without_tracing") as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.side_effect = [
             "Test message",
             '{"rationale": "Goal achieved!", "result": "yes"}',
@@ -579,7 +579,7 @@ def test_conversation_simulator_uses_default_persona_and_empty_context(mock_pred
 def test_conversation_simulator_logs_expectations_to_first_trace(mock_predict_fn):
     expectations = {"expected_topic": "MLflow", "expected_sentiment": "positive"}
 
-    with patch("mlflow.genai.simulators.simulator._invoke_model_without_tracing") as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.side_effect = [
             "Test message",
             '{"rationale": "Not achieved", "result": "no"}',
@@ -616,7 +616,7 @@ def test_conversation_simulator_logs_expectations_to_first_trace(mock_predict_fn
 
 
 def test_invoke_llm_with_prompt_only():
-    with patch("mlflow.genai.simulators.simulator._invoke_model_without_tracing") as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.return_value = "LLM response"
 
         agent = SimulatedUserAgent()
@@ -632,7 +632,7 @@ def test_invoke_llm_with_prompt_only():
 
 
 def test_invoke_llm_with_system_prompt():
-    with patch("mlflow.genai.simulators.simulator._invoke_model_without_tracing") as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.return_value = "LLM response with system"
 
         agent = SimulatedUserAgent()

--- a/tests/genai/simulators/test_utils.py
+++ b/tests/genai/simulators/test_utils.py
@@ -2,7 +2,11 @@ from unittest import mock
 
 import pytest
 
-from mlflow.genai.simulators.utils import format_history, invoke_model_without_tracing
+from mlflow.genai.simulators.utils import (
+    format_history,
+    get_default_simulation_model,
+    invoke_model_without_tracing,
+)
 
 
 @pytest.mark.parametrize(
@@ -88,3 +92,15 @@ def test_invoke_model_without_tracing_with_databricks():
 
         assert result == "Hi from Databricks"
         mock_call.assert_called_once()
+
+
+def test_get_default_simulation_model_non_databricks():
+    with mock.patch("mlflow.genai.simulators.utils.is_databricks_uri", return_value=False):
+        model = get_default_simulation_model()
+        assert model == "openai:/gpt-5"
+
+
+def test_get_default_simulation_model_databricks():
+    with mock.patch("mlflow.genai.simulators.utils.is_databricks_uri", return_value=True):
+        model = get_default_simulation_model()
+        assert model == "gpt-oss-120b"

--- a/tests/genai/simulators/test_utils.py
+++ b/tests/genai/simulators/test_utils.py
@@ -1,0 +1,90 @@
+from unittest import mock
+
+import pytest
+
+from mlflow.genai.simulators.utils import format_history, invoke_model_without_tracing
+
+
+@pytest.mark.parametrize(
+    ("history", "expected"),
+    [
+        ([], None),
+        ([{"role": "user", "content": "Hello"}], "user: Hello"),
+        (
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+                {"role": "user", "content": "How are you?"},
+            ],
+            "user: Hello\nassistant: Hi there!\nuser: How are you?",
+        ),
+        ([{"content": "Hello"}], "unknown: Hello"),
+        ([{"role": "user"}], "user: "),
+        ([{"role": None, "content": None}], "unknown: "),
+    ],
+)
+def test_format_history(history, expected):
+    assert format_history(history) == expected
+
+
+@pytest.mark.parametrize(
+    "model_uri",
+    [
+        "openai:/gpt-4o-mini",
+        "anthropic:/claude-3-haiku",
+    ],
+)
+def test_invoke_model_without_tracing_with_litellm(model_uri):
+    from mlflow.types.llm import ChatMessage
+
+    messages = [ChatMessage(role="user", content="Hello")]
+
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = mock.MagicMock(
+            choices=[mock.MagicMock(message=mock.MagicMock(content="Hi there!"))]
+        )
+
+        result = invoke_model_without_tracing(model_uri=model_uri, messages=messages)
+
+        assert result == "Hi there!"
+        mock_completion.assert_called_once()
+
+
+def test_invoke_model_without_tracing_with_inference_params():
+    from mlflow.types.llm import ChatMessage
+
+    messages = [ChatMessage(role="user", content="Hello")]
+
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = mock.MagicMock(
+            choices=[mock.MagicMock(message=mock.MagicMock(content="Response"))]
+        )
+
+        invoke_model_without_tracing(
+            model_uri="openai:/gpt-4o-mini",
+            messages=messages,
+            inference_params={"temperature": 0.5},
+        )
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["temperature"] == 0.5
+
+
+def test_invoke_model_without_tracing_with_databricks():
+    from mlflow.types.llm import ChatMessage
+
+    messages = [ChatMessage(role="user", content="Hello")]
+
+    with (
+        mock.patch("mlflow.genai.simulators.utils.call_chat_completions") as mock_call,
+        mock.patch(
+            "mlflow.genai.simulators.utils.create_litellm_message_from_databricks_response"
+        ) as mock_create,
+    ):
+        mock_call.return_value = mock.MagicMock(error_code=None, output_json='{"content": "Hi"}')
+        mock_create.return_value = mock.MagicMock(content="Hi from Databricks")
+
+        result = invoke_model_without_tracing(model_uri="databricks", messages=messages)
+
+        assert result == "Hi from Databricks"
+        mock_call.assert_called_once()

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -671,7 +671,7 @@ def test_simulate_conversation(mock_requests, mock_telemetry_client: TelemetryCl
     mock_trace = mock.Mock()
     with (
         mock.patch(
-            "mlflow.genai.simulators.simulator.invoke_model_without_tracing",
+            "mlflow.genai.simulators.simulator._invoke_model_without_tracing",
             return_value="Mock user message",
         ),
         mock.patch(
@@ -720,7 +720,7 @@ def test_simulate_conversation_from_genai_evaluate(
 
     with (
         mock.patch(
-            "mlflow.genai.simulators.simulator.invoke_model_without_tracing",
+            "mlflow.genai.simulators.simulator._invoke_model_without_tracing",
             return_value="Mock user message",
         ),
         mock.patch(

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -671,7 +671,7 @@ def test_simulate_conversation(mock_requests, mock_telemetry_client: TelemetryCl
     mock_trace = mock.Mock()
     with (
         mock.patch(
-            "mlflow.genai.simulators.simulator._invoke_model_without_tracing",
+            "mlflow.genai.simulators.simulator.invoke_model_without_tracing",
             return_value="Mock user message",
         ),
         mock.patch(
@@ -720,7 +720,7 @@ def test_simulate_conversation_from_genai_evaluate(
 
     with (
         mock.patch(
-            "mlflow.genai.simulators.simulator._invoke_model_without_tracing",
+            "mlflow.genai.simulators.simulator.invoke_model_without_tracing",
             return_value="Mock user message",
         ),
         mock.patch(


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR introduces 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
import mlflow
from mlflow.genai.simulators import generate_seed_conversations_df

mlflow.set_experiment("distillation-test")

# Create two conversation sessions with traces
sessions = []
for i, (user_msg, assistant_msg) in enumerate([
    ("How do I track experiments?", "Use mlflow.start_run() and mlflow.log_metric()."),
    ("My model deployment is failing!", "Check your model signature matches the input format."),
]):
    session_id = f"session-{i}"
    with mlflow.start_span(name="turn") as span:
        mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
        span.set_inputs(user_msg)
        span.set_outputs(assistant_msg)

    traces = mlflow.search_traces(
        filter_string=f"metadata.`mlflow.trace.session` = '{session_id}'",
        return_type="list",
    )
    sessions.append(traces)

# Generate seed conversations
df = generate_test_cases(sessions)
print(df.to_string())
```

Results:
```
  goal: Learn how to track machine learning experiments using MLflow.
  persona: You are a technical user with some familiarity in machine learning...
  ────────────────────────────────────────
  goal: Debug a model deployment failure
  persona: You are a user with some technical knowledge who communicates concisely...
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Add an SDK to distill conversations into goal/persona to use in the conversation simulator.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
