### PR TITLE
Revamp assessments and run judges directly in trace UI [Part 6/x]: Refactor async evaluations code

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -13,6 +13,7 @@ import {
   useUnifiedTraceTagsModal,
   ModelTraceExplorerContextProvider,
   ModelTraceExplorerRunJudgesContextProvider,
+  isEvaluatingTracesInDetailsViewEnabled,
 } from '@databricks/web-shared/model-trace-explorer';
 import {
   EXECUTION_DURATION_COLUMN_ID,
@@ -57,6 +58,15 @@ import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
 import { AssistantAwareDrawer } from '@mlflow/mlflow/src/common/components/AssistantAwareDrawer';
 import { useRunScorerInTracesViewConfiguration } from '../../../../pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration';
 
+const JudgeContextProvider = ({ children }: { children: React.ReactNode }) => {
+  const runJudgeConfiguration = useRunScorerInTracesViewConfiguration();
+  return (
+    <ModelTraceExplorerRunJudgesContextProvider {...runJudgeConfiguration}>
+      {children}
+    </ModelTraceExplorerRunJudgesContextProvider>
+  );
+};
+
 const ContextProviders = ({
   children,
   makeHtmlFromMarkdown,
@@ -66,12 +76,9 @@ const ContextProviders = ({
   experimentId?: string;
   children: React.ReactNode;
 }) => {
-  const runJudgeConfiguration = useRunScorerInTracesViewConfiguration();
   return (
     <GenAiTracesMarkdownConverterProvider makeHtml={makeHtmlFromMarkdown}>
-      <ModelTraceExplorerRunJudgesContextProvider {...runJudgeConfiguration}>
-        {children}
-      </ModelTraceExplorerRunJudgesContextProvider>
+      {isEvaluatingTracesInDetailsViewEnabled() ? <JudgeContextProvider>{children}</JudgeContextProvider> : children}
     </GenAiTracesMarkdownConverterProvider>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.test.tsx
@@ -87,7 +87,7 @@ describe('SampleScorerOutputPanelContainer', () => {
     mockedUseEvaluateTraces.mockReturnValue([
       mockEvaluateTraces,
       {
-        data: null,
+        latestEvaluation: null,
         isLoading: false,
         error: null,
         reset: jest.fn(),
@@ -125,7 +125,7 @@ describe('SampleScorerOutputPanelContainer', () => {
       mockedUseEvaluateTraces.mockReturnValue([
         mockEvaluateTraces,
         {
-          data: mockResults,
+          latestEvaluation: mockResults,
           isLoading: false,
           error: null,
           reset: jest.fn(),
@@ -148,7 +148,7 @@ describe('SampleScorerOutputPanelContainer', () => {
       mockedUseEvaluateTraces.mockReturnValue([
         mockEvaluateTraces,
         {
-          data: null,
+          latestEvaluation: null,
           isLoading: true,
           error: null,
           reset: jest.fn(),
@@ -171,7 +171,7 @@ describe('SampleScorerOutputPanelContainer', () => {
       mockedUseEvaluateTraces.mockReturnValue([
         mockEvaluateTraces,
         {
-          data: null,
+          latestEvaluation: null,
           isLoading: false,
           error: mockError,
           reset: jest.fn(),
@@ -266,7 +266,7 @@ describe('SampleScorerOutputPanelContainer', () => {
       mockedUseEvaluateTraces.mockReturnValue([
         mockEvaluateTraces,
         {
-          data: null,
+          latestEvaluation: null,
           isLoading: false,
           error: null,
           reset: jest.fn(),

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/SampleScorerOutputPanelContainer.tsx
@@ -42,7 +42,7 @@ const SampleScorerOutputPanelContainer: React.FC<SampleScorerOutputPanelContaine
 
   const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
 
-  const [evaluateTraces, { data, isLoading, error, reset }] = useEvaluateTraces({
+  const [evaluateTraces, { latestEvaluation: data, isLoading, error, reset }] = useEvaluateTraces({
     onScorerFinished,
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState } from 'react';
-import { ModelTraceExplorerRunJudgeConfig } from '../../../../shared/web-shared/model-trace-explorer';
 import { LLMScorer } from '../types';
 import { useGetScheduledScorers } from './useGetScheduledScorers';
 import { useExperimentIds } from '../../../components/experiment-page/hooks/useExperimentIds';
@@ -23,6 +22,11 @@ import { PillControl } from '@databricks/design-system/development';
 import ScorerModalRenderer from '../ScorerModalRenderer';
 import { SCORER_FORM_MODE } from '../constants';
 import { useRunSerializedScorer } from './useRunSerializedScorer';
+import {
+  isEvaluatingTracesInDetailsViewEnabled,
+  ModelTraceExplorerRunJudgeConfig,
+  ModelTraceExplorerRunJudgesContextProvider,
+} from '@databricks/web-shared/model-trace-explorer';
 
 export const useRunScorerInTracesViewConfiguration = (): ModelTraceExplorerRunJudgeConfig => {
   const [experimentId] = useExperimentIds();

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunSerializedScorer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunSerializedScorer.tsx
@@ -14,7 +14,7 @@ export const useRunSerializedScorer = ({
   experimentId?: string;
   onScorerFinished?: () => void;
 }) => {
-  const [evaluateTracesFn, { data, isLoading }] = useEvaluateTraces({ onScorerFinished });
+  const [evaluateTracesFn, { latestEvaluation, isLoading }] = useEvaluateTraces({ onScorerFinished });
 
   const evaluateTraces = useCallback(
     (scorer: LLMScorer, traceIds: string[]) => {
@@ -40,7 +40,7 @@ export const useRunSerializedScorer = ({
 
   return {
     evaluateTraces,
-    data,
+    latestEvaluation,
     isLoading,
   };
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
@@ -195,7 +195,7 @@ describe('useEvaluateTraces', () => {
 
       const [evaluateTraces, state] = result.current;
 
-      expect(state.data).toBeNull();
+      expect(state.latestEvaluation).toBeNull();
       expect(state.isLoading).toBe(false);
       expect(state.error).toBeNull();
 
@@ -222,7 +222,7 @@ describe('useEvaluateTraces', () => {
       expect(evaluationResults).toEqual([expectedResult]);
 
       await waitFor(() => {
-        expect(result.current[1].data).toEqual([expectedResult]);
+        expect(result.current[1].latestEvaluation).toEqual([expectedResult]);
         expect(result.current[1].isLoading).toBe(false);
         expect(result.current[1].error).toBeNull();
       });
@@ -694,7 +694,7 @@ describe('useEvaluateTraces', () => {
 
       await waitFor(() => {
         expect(result.current[1].error).toBeNull();
-        expect(result.current[1].data).toEqual(evaluationResults);
+        expect(result.current[1].latestEvaluation).toEqual(evaluationResults);
       });
     });
 
@@ -737,7 +737,7 @@ describe('useEvaluateTraces', () => {
 
       await waitFor(() => {
         expect(result.current[1].error).toBeNull();
-        expect(result.current[1].data).toEqual(evaluationResults);
+        expect(result.current[1].latestEvaluation).toEqual(evaluationResults);
         expect(result.current[1].isLoading).toBe(false);
       });
     });
@@ -815,7 +815,7 @@ describe('useEvaluateTraces', () => {
 
       await waitFor(() => {
         expect(result.current[1].error).toBeNull();
-        expect(result.current[1].data).toEqual(evaluationResults);
+        expect(result.current[1].latestEvaluation).toEqual(evaluationResults);
         expect(result.current[1].isLoading).toBe(false);
       });
     });
@@ -864,7 +864,7 @@ describe('useEvaluateTraces', () => {
 
       await waitFor(() => {
         expect(result.current[1].error).toBeNull();
-        expect(result.current[1].data).toEqual(evaluationResults);
+        expect(result.current[1].latestEvaluation).toEqual(evaluationResults);
       });
     });
   });
@@ -945,7 +945,7 @@ describe('useEvaluateTraces', () => {
         ]);
 
         await waitFor(() => {
-          expect(result.current[1].data).toEqual(evaluationResults);
+          expect(result.current[1].latestEvaluation).toEqual(evaluationResults);
           expect(result.current[1].isLoading).toBe(false);
           expect(result.current[1].error).toBeNull();
         });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.test.tsx
@@ -301,8 +301,10 @@ describe('useEvaluateTraces', () => {
         experimentId,
       });
 
+      // In sync mode, evaluationResults is an array
+      expect(Array.isArray(evaluationResults)).toBe(true);
       expect(evaluationResults).toHaveLength(3);
-      evaluationResults?.forEach((evalResult, index) => {
+      (evaluationResults as JudgeEvaluationResult[]).forEach((evalResult, index) => {
         expect(evalResult).toEqual({
           trace: mockTraces[index],
           results: [
@@ -1017,8 +1019,10 @@ describe('useEvaluateTraces', () => {
           experimentId,
         });
 
+        // In sync mode, evaluationResults is an array
+        expect(Array.isArray(evaluationResults)).toBe(true);
         expect(evaluationResults).toHaveLength(2);
-        evaluationResults?.forEach((evalResult, index) => {
+        (evaluationResults as JudgeEvaluationResult[]).forEach((evalResult, index) => {
           expect(evalResult).toEqual({
             trace: mockTraces[index],
             results: [

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
@@ -312,14 +312,14 @@ function parseAssessmentResponse(
  * State returned by useEvaluateTraces
  */
 export interface EvaluateTracesState {
-  data: JudgeEvaluationResult[] | null;
+  latestEvaluation: JudgeEvaluationResult[] | null;
   isLoading: boolean;
   error: Error | null;
   reset: () => void;
   /**
    * Results of all evaluations
    */
-  evaluations?: Record<string, ScorerEvaluation>;
+  allEvaluations?: Record<string, ScorerEvaluation>;
 }
 
 /**
@@ -615,7 +615,7 @@ export function useEvaluateTraces({
   return [
     evaluateTracesSync,
     {
-      data,
+      latestEvaluation: data,
       isLoading,
       error,
       reset,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTraces.tsx
@@ -25,7 +25,8 @@ import {
 import { EvaluateChatCompletionsParams, EvaluateTracesParams } from './types';
 import { useGetTraceIdsForEvaluation } from './useGetTracesForEvaluation';
 import { JudgeEvaluationResult } from './useEvaluateTraces.common';
-import { useEvaluateTracesAsync } from './useEvaluateTracesAsync';
+import { ScorerEvaluation, ScorerFinishedEvent, useEvaluateTracesAsync } from './useEvaluateTracesAsync';
+import { TrackingJobStatus } from '../../../common/hooks/useGetTrackingServerJobStatus';
 
 /**
  * Response from the chat completions API
@@ -315,6 +316,10 @@ export interface EvaluateTracesState {
   isLoading: boolean;
   error: Error | null;
   reset: () => void;
+  /**
+   * Results of all evaluations
+   */
+  evaluations?: Record<string, ScorerEvaluation>;
 }
 
 /**
@@ -329,8 +334,8 @@ export function useEvaluateTraces({
   /**
    * Callback to be called when the evaluation is finished.
    */
-  onScorerFinished?: () => void;
-} = {}): [(params: EvaluateTracesParams) => Promise<JudgeEvaluationResult[] | void>, EvaluateTracesState] {
+  onScorerFinished?: (event: ScorerFinishedEvent) => void;
+} = {}): [(params: EvaluateTracesParams) => Promise<JudgeEvaluationResult[] | string | void>, EvaluateTracesState] {
   const [isLoading, setIsLoading] = useState(false);
   const [data, setData] = useState<JudgeEvaluationResult[] | null>(null);
   const [error, setError] = useState<Error | null>(null);
@@ -346,7 +351,6 @@ export function useEvaluateTraces({
 
   const evaluateTracesSync = useCallback(
     async (params: EvaluateTracesParams): Promise<JudgeEvaluationResult[]> => {
-      // Track this invocation to ensure only the latest one calls onScorerFinished
       invocationCounterRef.current += 1;
       const currentInvocationId = invocationCounterRef.current;
 
@@ -573,8 +577,13 @@ export function useEvaluateTraces({
         setData(evaluationResults);
 
         // Only call onScorerFinished if this is still the latest invocation
-        if (currentInvocationId === invocationCounterRef.current && onScorerFinished) {
-          onScorerFinished();
+        if (currentInvocationId === invocationCounterRef.current) {
+          onScorerFinished?.({
+            // Generate a semi-unique request key for the evaluation
+            requestKey: Date.now().toString(),
+            status: TrackingJobStatus.SUCCEEDED,
+            results: evaluationResults,
+          });
         }
 
         return evaluationResults;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.test.tsx
@@ -213,8 +213,8 @@ describe('useEvaluateTracesAsync', () => {
       });
       expect(finalState.error).toBeNull();
 
-      // Verify onScorerFinished was called once
-      expect(onScorerFinished).toHaveBeenCalledTimes(1);
+      // Verify onScorerFinished was called with SUCCEEDED status
+      expect(onScorerFinished).toHaveBeenCalledWith(expect.objectContaining({ status: 'SUCCEEDED' }));
     });
   });
 
@@ -250,15 +250,7 @@ describe('useEvaluateTracesAsync', () => {
       // Setup trace fetching handlers using MSW
       setupTraceFetchHandlers(server, traces);
 
-      const onScorerFinished = jest.fn();
-
-      const { result } = renderHook(
-        () =>
-          useEvaluateTracesAsync({
-            onScorerFinished,
-          }),
-        { wrapper },
-      );
+      const { result } = renderHook(() => useEvaluateTracesAsync({}), { wrapper });
 
       await act(async () => {
         const [evaluateFunction] = result.current;
@@ -282,9 +274,6 @@ describe('useEvaluateTracesAsync', () => {
       // Should have error state
       expect(state.error).toBeTruthy();
       expect(state.isLoading).toBe(false);
-
-      // onScorerFinished should NOT be called when job creation fails (job never started)
-      expect(onScorerFinished).not.toHaveBeenCalled();
       jest.restoreAllMocks();
     });
   });
@@ -345,15 +334,7 @@ describe('useEvaluateTracesAsync', () => {
       // Setup trace fetching handlers using MSW
       setupTraceFetchHandlers(server, traces);
 
-      const onScorerFinished = jest.fn();
-
-      const { result } = renderHook(
-        () =>
-          useEvaluateTracesAsync({
-            onScorerFinished,
-          }),
-        { wrapper },
-      );
+      const { result } = renderHook(() => useEvaluateTracesAsync({}), { wrapper });
 
       // Start evaluation
       act(() => {
@@ -375,9 +356,6 @@ describe('useEvaluateTracesAsync', () => {
 
       // Verify job was polled at least 3 times
       expect(jobStatusCallCount).toBeGreaterThanOrEqual(3);
-
-      // onScorerFinished IS called when job finishes, even on failure
-      expect(onScorerFinished).toHaveBeenCalledTimes(1);
     }, 30000);
 
     it('should handle job failure with detailed error message', async () => {
@@ -636,6 +614,308 @@ describe('useEvaluateTracesAsync', () => {
     });
   });
 
+  describe('Multiple evaluations', () => {
+    it('should track multiple evaluations in evaluations and return latest evaluation', async () => {
+      const experimentId = 'exp-123';
+      const serializedScorer = 'mock-serialized-scorer';
+
+      const trace1 = createMockTrace('trace-1');
+      const traces = new Map([['trace-1', trace1]]);
+
+      // Setup handlers
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(ctx.json({ traces: [{ trace_id: 'trace-1' }], next_page_token: undefined }));
+        }),
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(ctx.json({ jobs: [{ job_id: 'job-multi' }] }));
+        }),
+        rest.get('ajax-api/3.0/jobs/job-multi', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              status: 'SUCCEEDED',
+              result: { 'trace-1': { assessments: [{ assessment_name: 'test', numeric_value: 1 }] } },
+            }),
+          );
+        }),
+      );
+
+      setupTraceFetchHandlers(server, traces);
+
+      const { result } = renderHook(() => useEvaluateTracesAsync({}), { wrapper });
+
+      // Start first evaluation
+      await act(async () => {
+        const [evaluateFunction] = result.current;
+        await evaluateFunction({
+          itemIds: ['trace-1'],
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test 1',
+          serializedScorer,
+        });
+      });
+
+      // Wait for first evaluation to complete
+      await waitFor(() => result.current[1].data !== null);
+
+      // Verify first evaluation is tracked
+      expect(Object.keys(result.current[1].evaluations).length).toBe(1);
+
+      // Start second evaluation
+      await act(async () => {
+        const [evaluateFunction] = result.current;
+        await evaluateFunction({
+          itemIds: ['trace-1'],
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test 2',
+          serializedScorer,
+        });
+      });
+
+      // Wait for second evaluation to also complete
+      await waitFor(() => {
+        const keys = Object.keys(result.current[1].evaluations);
+        return keys.length === 2;
+      });
+
+      const [, state] = result.current;
+
+      // Verify evaluations contains both evaluation requests
+      expect(Object.keys(state.evaluations).length).toBe(2);
+
+      // Verify each evaluation is tracked with its own state
+      const evaluations = Object.values(state.evaluations);
+      expect(evaluations).toHaveLength(2);
+
+      // Both evaluations should have unique request keys
+      const requestKeys = evaluations.map((ev) => ev.requestKey);
+      expect(new Set(requestKeys).size).toBe(2);
+
+      // The latest evaluation's data should be in `data`
+      expect(state.data).toBeDefined();
+    });
+  });
+
+  describe('Partial errors', () => {
+    it('should handle partial success when some jobs succeed and others fail', async () => {
+      const experimentId = 'exp-123';
+      const serializedScorer = 'mock-serialized-scorer';
+
+      const trace1 = createMockTrace('trace-1');
+      const trace2 = createMockTrace('trace-2');
+      const traces = new Map([
+        ['trace-1', trace1],
+        ['trace-2', trace2],
+      ]);
+
+      // Setup trace search handler
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              traces: [{ trace_id: 'trace-1' }, { trace_id: 'trace-2' }],
+              next_page_token: undefined,
+            }),
+          );
+        }),
+      );
+
+      // Setup scorer invoke handler - returns two jobs
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(ctx.json({ jobs: [{ job_id: 'job-success' }, { job_id: 'job-fail' }] }));
+        }),
+      );
+
+      // Setup job status handlers - one succeeds, one fails
+      server.use(
+        rest.get('ajax-api/3.0/jobs/job-success', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              status: 'SUCCEEDED',
+              result: {
+                'trace-1': { assessments: [{ assessment_name: 'scorer', numeric_value: 0.9 }] },
+              },
+            }),
+          );
+        }),
+        rest.get('ajax-api/3.0/jobs/job-fail', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              status: 'FAILED',
+              result: 'Failed to evaluate trace-2: Model endpoint unavailable',
+            }),
+          );
+        }),
+      );
+
+      setupTraceFetchHandlers(server, traces);
+
+      const onScorerFinished = jest.fn();
+      const { result } = renderHook(() => useEvaluateTracesAsync({ onScorerFinished }), { wrapper });
+
+      // Start evaluation
+      act(() => {
+        const [evaluateFunction] = result.current;
+        evaluateFunction({
+          itemIds: ['trace-1', 'trace-2'],
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test',
+          serializedScorer,
+        });
+      });
+
+      // Wait for evaluation to complete with results
+      await waitFor(() => {
+        expect(result.current[1].isLoading).toBe(false);
+        expect(result.current[1].data).not.toBeNull();
+      });
+
+      const [, state] = result.current;
+
+      // Overall status should be SUCCEEDED (at least one job succeeded)
+      expect(state.error).toBeNull();
+      expect(state.data).toHaveLength(2);
+
+      // trace-1 should have successful assessment
+      const trace1Result = state.data?.find(
+        (r) => !isSessionJudgeEvaluationResult(r) && (r.trace?.info as ModelTraceInfoV3)?.trace_id === 'trace-1',
+      );
+      expect(trace1Result).toBeDefined();
+      expect(trace1Result?.results).toHaveLength(1);
+      expect((trace1Result?.results[0] as { numeric_value?: number }).numeric_value).toBe(0.9);
+      expect(trace1Result?.error).toBeNull();
+
+      // trace-2 should have error message from failed job
+      const trace2Result = state.data?.find(
+        (r) => !isSessionJudgeEvaluationResult(r) && (r.trace?.info as ModelTraceInfoV3)?.trace_id === 'trace-2',
+      );
+      expect(trace2Result).toBeDefined();
+      expect(trace2Result?.results).toEqual([]);
+      expect(trace2Result?.error).toBe('Failed to evaluate trace-2: Model endpoint unavailable');
+
+      // Callback should report SUCCEEDED (partial success is still success)
+      expect(onScorerFinished).toHaveBeenCalledWith(expect.objectContaining({ status: 'SUCCEEDED' }));
+    });
+
+    it('should include failed job per-trace data alongside successful job results', async () => {
+      const experimentId = 'exp-123';
+      const serializedScorer = 'mock-serialized-scorer';
+
+      const trace1 = createMockTrace('trace-1');
+      const trace2 = createMockTrace('trace-2');
+      const trace3 = createMockTrace('trace-3');
+      const traces = new Map([
+        ['trace-1', trace1],
+        ['trace-2', trace2],
+        ['trace-3', trace3],
+      ]);
+
+      // Setup trace search handler
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/search', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              traces: [{ trace_id: 'trace-1' }, { trace_id: 'trace-2' }, { trace_id: 'trace-3' }],
+              next_page_token: undefined,
+            }),
+          );
+        }),
+      );
+
+      // Setup scorer invoke handler - returns two jobs
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/scorer/invoke', (_req, res, ctx) => {
+          return res(ctx.json({ jobs: [{ job_id: 'job-ok' }, { job_id: 'job-partial-fail' }] }));
+        }),
+      );
+
+      // Setup job status handlers
+      server.use(
+        // First job succeeds with trace-1 only
+        rest.get('ajax-api/3.0/jobs/job-ok', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              status: 'SUCCEEDED',
+              result: {
+                'trace-1': { assessments: [{ assessment_name: 'scorer', numeric_value: 0.95 }] },
+              },
+            }),
+          );
+        }),
+        // Second job fails but has per-trace results for trace-2 and trace-3
+        rest.get('ajax-api/3.0/jobs/job-partial-fail', (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              status: 'FAILED',
+              result: {
+                'trace-2': {
+                  assessments: [{ assessment_name: 'scorer', numeric_value: 0.8 }],
+                },
+                'trace-3': {
+                  assessments: [],
+                  failures: [{ error_code: 'SCORER_ERROR', error_message: 'Model timeout on trace-3' }],
+                },
+              },
+            }),
+          );
+        }),
+      );
+
+      setupTraceFetchHandlers(server, traces);
+
+      const { result } = renderHook(() => useEvaluateTracesAsync({}), { wrapper });
+
+      // Start evaluation
+      act(() => {
+        const [evaluateFunction] = result.current;
+        evaluateFunction({
+          itemIds: ['trace-1', 'trace-2', 'trace-3'],
+          locations: [{ mlflow_experiment: { experiment_id: experimentId }, type: 'MLFLOW_EXPERIMENT' }],
+          experimentId,
+          judgeInstructions: 'Test',
+          serializedScorer,
+        });
+      });
+
+      // Wait for evaluation to complete - status is SUCCEEDED because at least one job succeeded
+      await waitFor(() => {
+        expect(result.current[1].isLoading).toBe(false);
+        expect(result.current[1].data).not.toBeNull();
+      });
+
+      const [, state] = result.current;
+
+      // Should have results from both jobs
+      expect(state.data).toHaveLength(3);
+      expect(state.error).toBeNull();
+
+      // trace-1 should have assessment from successful job
+      const trace1Result = state.data?.find(
+        (r) => !isSessionJudgeEvaluationResult(r) && (r.trace?.info as ModelTraceInfoV3)?.trace_id === 'trace-1',
+      );
+      expect(trace1Result?.results).toHaveLength(1);
+      expect((trace1Result?.results[0] as { numeric_value?: number }).numeric_value).toBe(0.95);
+
+      // trace-2 should have assessment from failed job's per-trace data
+      const trace2Result = state.data?.find(
+        (r) => !isSessionJudgeEvaluationResult(r) && (r.trace?.info as ModelTraceInfoV3)?.trace_id === 'trace-2',
+      );
+      expect(trace2Result?.results).toHaveLength(1);
+      expect((trace2Result?.results[0] as { numeric_value?: number }).numeric_value).toBe(0.8);
+
+      // trace-3 should have error from failed job's failures array
+      const trace3Result = state.data?.find(
+        (r) => !isSessionJudgeEvaluationResult(r) && (r.trace?.info as ModelTraceInfoV3)?.trace_id === 'trace-3',
+      );
+      expect(trace3Result?.results).toEqual([]);
+      expect(trace3Result?.error).toBe('Model timeout on trace-3');
+    });
+  });
+
   describe('Session Level Evaluation', () => {
     it('should successfully evaluate traces grouped by session and return SessionJudgeEvaluationResult', async () => {
       const sessionId = 'session-123';
@@ -778,7 +1058,7 @@ describe('useEvaluateTracesAsync', () => {
       }
 
       expect(finalState.error).toBeNull();
-      expect(onScorerFinished).toHaveBeenCalledTimes(1);
+      expect(onScorerFinished).toHaveBeenCalledWith(expect.objectContaining({ status: 'SUCCEEDED' }));
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
@@ -389,11 +389,11 @@ export const useEvaluateTracesAsync = ({
   return [
     evaluateTracesAsync,
     {
-      data: latestEvaluation?.results ?? null,
+      latestEvaluation: latestEvaluation?.results ?? null,
       isLoading: isJobStarting || (latestEvaluation && !latestEvaluation.results && !latestEvaluation.error) || false,
       error: startEvaluationJobError ?? latestEvaluation?.error ?? null,
       reset,
-      evaluations,
+      allEvaluations: evaluations,
     },
   ] as const;
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
@@ -1,6 +1,6 @@
 import { fetchAPI, getAjaxUrl } from '../../../common/utils/FetchUtils';
 import { useMutation, useQueryClient } from '../../../common/utils/reactQueryHooks';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FeedbackAssessment, ModelTrace } from '../../../shared/web-shared/model-trace-explorer';
 import { EvaluateTracesParams } from './types';
 import { useGetTraceIdsForEvaluation } from './useGetTracesForEvaluation';
@@ -9,205 +9,391 @@ import {
   JudgeEvaluationResult,
   SessionJudgeEvaluationResult,
 } from './useEvaluateTraces.common';
-import {
-  TrackingJobQueryResult,
-  TrackingJobStatus,
-  useGetTrackingServerJobStatus,
-} from '../../../common/hooks/useGetTrackingServerJobStatus';
+import { TrackingJobStatus } from '../../../common/hooks/useGetTrackingServerJobStatus';
 import { compact, uniq, zipObject } from 'lodash';
 import { SessionForEvaluation, useGetSessionsForEvaluation } from './useGetSessionsForEvaluation';
 import { ScorerEvaluationScope } from './constants';
-
-type EvaluateTracesAsyncJobResult = {
-  [traceId: string]: {
-    assessments: FeedbackAssessment[];
-    failures?: {
-      error_code: string;
-      error_message: string;
-    }[];
-  };
-};
+import { parseJSONSafe } from '../../../common/utils/TagUtils';
 
 const JOB_POLLING_INTERVAL = 1500;
 
-const isJobRunning = (jobData?: TrackingJobQueryResult<EvaluateTracesAsyncJobResult>): boolean => {
-  return jobData?.status === TrackingJobStatus.RUNNING || jobData?.status === TrackingJobStatus.PENDING;
+type JobStatusMap = Record<string, { status: TrackingJobStatus; result?: unknown }>;
+
+type EvaluateTracesAsyncJobResult = Record<
+  string,
+  { assessments: FeedbackAssessment[]; failures?: { error_code: string; error_message: string }[] }
+>;
+
+/** Check if any job is still running or pending */
+const isJobsLoading = (jobStatuses: JobStatusMap, jobIds: string[]): boolean => {
+  if (!jobIds.length) return true; // No jobs yet = still loading
+  return jobIds.some((id) => {
+    const status = jobStatuses[id]?.status;
+    return !status || status === TrackingJobStatus.RUNNING || status === TrackingJobStatus.PENDING;
+  });
 };
 
-type StartEvaluationJobParams = { evaluateParams: EvaluateTracesParams; traceIds: string[] };
-type StartEvaluationJobResponse = { jobs: { job_id: string }[] };
+/**
+ * Represents a single evaluation request with its state
+ */
+export interface ScorerEvaluation {
+  requestKey: string;
+  label: string;
+  jobIds: string[];
+  jobStatuses: JobStatusMap;
+  /** Whether any job is still running or pending */
+  isLoading: boolean;
+  tracesData?: Record<string, ModelTrace>;
+  sessionsData?: SessionForEvaluation[];
+  results?: JudgeEvaluationResult[];
+  error?: Error | null;
+}
 
-export const useEvaluateTracesAsync = ({ onScorerFinished }: { onScorerFinished?: () => void }) => {
+/** Event payload for scorer state updates */
+export interface ScorerFinishedEvent {
+  requestKey: string;
+  status: TrackingJobStatus;
+  results?: JudgeEvaluationResult[];
+  error?: Error | null;
+}
+
+// Generates a unique request key for an evaluation
+const generateRequestKey = () => `eval-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+/**
+ * Derive aggregated status of entire evaluation request.
+ */
+const deriveRequestStatus = (evaluationRequest: ScorerEvaluation): TrackingJobStatus => {
+  const { jobIds, jobStatuses } = evaluationRequest;
+  if (!jobIds.length) return TrackingJobStatus.PENDING;
+  const statuses = jobIds.map((id) => jobStatuses[id]?.status);
+  if (
+    statuses.some((status) => !status || status === TrackingJobStatus.RUNNING || status === TrackingJobStatus.PENDING)
+  ) {
+    return statuses.some((status) => status === TrackingJobStatus.RUNNING)
+      ? TrackingJobStatus.RUNNING
+      : TrackingJobStatus.PENDING;
+  }
+  // All jobs are complete - check if at least one succeeded
+  return statuses.includes(TrackingJobStatus.SUCCEEDED) ? TrackingJobStatus.SUCCEEDED : TrackingJobStatus.FAILED;
+};
+
+/**
+ * Build evaluation results from job data and traces (handles partial success)
+ */
+const buildResults = (evaluationRequest: ScorerEvaluation): JudgeEvaluationResult[] | null => {
+  const { tracesData, sessionsData, jobIds, jobStatuses } = evaluationRequest;
+  if (!tracesData) return null;
+
+  // Aggregate from all completed jobs - process successful jobs first, then failed (to prioritize successful results)
+  const aggregated: EvaluateTracesAsyncJobResult = {};
+  let failedJobError: string | null = null;
+
+  for (const jobId of jobIds) {
+    const job = jobStatuses[jobId];
+    if (job?.status !== TrackingJobStatus.SUCCEEDED || typeof job.result !== 'object' || !job.result) {
+      continue;
+    }
+    Object.assign(aggregated, job.result as EvaluateTracesAsyncJobResult);
+  }
+
+  for (const jobId of jobIds) {
+    const job = jobStatuses[jobId];
+    if (job?.status !== TrackingJobStatus.FAILED) {
+      continue;
+    }
+    if (!failedJobError && typeof job.result === 'string') {
+      failedJobError = job.result;
+    }
+    if (typeof job.result === 'object' && job.result) {
+      for (const [traceId, data] of Object.entries(job.result as EvaluateTracesAsyncJobResult)) {
+        if (!aggregated[traceId]) aggregated[traceId] = data;
+      }
+    }
+  }
+
+  // Default error for traces without results when some jobs failed
+  const hasFailedJobs = jobIds.some((id) => jobStatuses[id]?.status === TrackingJobStatus.FAILED);
+  const defaultError = hasFailedJobs ? failedJobError || 'Evaluation job failed' : null;
+
+  if (sessionsData) {
+    return sessionsData.map<SessionJudgeEvaluationResult>((session) => {
+      const assessments: FeedbackAssessment[] = [];
+      const errors: string[] = [];
+      let hasMissingTraces = false;
+
+      for (const { trace_id } of session.traceInfos) {
+        if (aggregated[trace_id]) {
+          assessments.push(...(aggregated[trace_id].assessments ?? []));
+          errors.push(...(aggregated[trace_id].failures?.map((f) => f.error_message) ?? []));
+        } else {
+          hasMissingTraces = true;
+        }
+      }
+
+      // Add default error if some traces are missing and we had failed jobs
+      if (hasMissingTraces && defaultError) {
+        errors.push(defaultError);
+      }
+
+      return {
+        sessionId: session.sessionId ?? '',
+        results: assessments,
+        traces: compact(session.traceInfos.map((t) => tracesData[t.trace_id] ?? null)),
+        error: errors.join(', ') || null,
+      };
+    });
+  }
+
+  return compact(
+    Object.entries(tracesData).map(([traceId, trace]) => {
+      const traceData = aggregated[traceId];
+      const traceErrors = traceData?.failures?.map((f) => f.error_message).join(', ');
+      // If trace has no data and there were failed jobs, use the default error
+      const error = traceErrors || (!traceData && defaultError) || null;
+      return {
+        trace,
+        results: traceData?.assessments ?? [],
+        error,
+      };
+    }),
+  );
+};
+
+/** Extract error message from first failed job */
+const extractError = (jobStatuses: JobStatusMap, jobIds: string[]): Error => {
+  for (const jobId of jobIds) {
+    const job = jobStatuses[jobId];
+    if (job?.status === TrackingJobStatus.FAILED) {
+      return new Error(typeof job.result === 'string' ? job.result : 'Job failed');
+    }
+  }
+  return new Error('Unknown error');
+};
+
+export const useEvaluateTracesAsync = ({
+  onScorerFinished,
+}: {
+  onScorerFinished?: (event: ScorerFinishedEvent) => void;
+}) => {
   const queryClient = useQueryClient();
-  const [currentJobsId, setCurrentJobsId] = useState<string[] | undefined>(undefined);
   const getTraceIdsForEvaluation = useGetTraceIdsForEvaluation();
   const getSessionsForEvaluation = useGetSessionsForEvaluation();
 
-  const [tracesData, setTracesData] = useState<Record<string, ModelTrace> | undefined>();
-  const lastFinishedJobsIdRef = useRef<string[] | undefined>(undefined);
-  const [sessionsData, setSessionsData] = useState<SessionForEvaluation[] | undefined>();
+  const [evaluations, setEvaluations] = useState<Record<string, ScorerEvaluation>>({});
+  const [latestRequestKey, setLatestRequestKey] = useState<string | null>(null);
 
-  const { jobResults, areJobsRunning } = useGetTrackingServerJobStatus<EvaluateTracesAsyncJobResult>(currentJobsId, {
-    enabled: Boolean(currentJobsId),
-    refetchInterval: (data) => {
-      if (data?.some((job) => isJobRunning(job))) {
-        return JOB_POLLING_INTERVAL;
-      }
-      return false;
-    },
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
+  // Refs for stable access in polling interval (avoids stale closure issues)
+  const evaluationsRef = useRef(evaluations);
+  evaluationsRef.current = evaluations;
+  const finishedCallbackRef = useRef(onScorerFinished);
+  finishedCallbackRef.current = onScorerFinished;
 
-  // Call onScorerFinished when the job successfully completes (once per job)
+  // Track finalized evaluations (to fire callbacks only once)
+  const finalizedRef = useRef<Set<string>>(new Set());
+
+  // Always-on polling interval that checks refs for current state
   useEffect(() => {
-    if (!areJobsRunning && currentJobsId && lastFinishedJobsIdRef.current !== currentJobsId) {
-      lastFinishedJobsIdRef.current = currentJobsId;
-      onScorerFinished?.();
-    }
-  }, [areJobsRunning, currentJobsId, onScorerFinished]);
+    const poll = async () => {
+      const currentEvals = evaluationsRef.current;
+
+      // Find jobs that need polling
+      const jobsToPoll: string[] = [];
+      for (const ev of Object.values(currentEvals)) {
+        if (finalizedRef.current.has(ev.requestKey)) {
+          continue;
+        }
+        for (const jobId of ev.jobIds) {
+          const status = ev.jobStatuses[jobId]?.status;
+          if (status !== TrackingJobStatus.SUCCEEDED && status !== TrackingJobStatus.FAILED) {
+            jobsToPoll.push(jobId);
+          }
+        }
+      }
+
+      if (jobsToPoll.length === 0) {
+        return;
+      }
+
+      const results = await Promise.all(
+        jobsToPoll.map(async (jobId) => {
+          try {
+            const res = await fetchAPI(getAjaxUrl(`ajax-api/3.0/jobs/${jobId}`));
+            return { jobId, status: res.status as TrackingJobStatus, result: res.result };
+          } catch {
+            return { jobId, status: TrackingJobStatus.FAILED, result: 'Failed to fetch job status' };
+          }
+        }),
+      );
+
+      setEvaluations((prev) => {
+        const next = { ...prev };
+        // Update job statuses for each evaluation request
+        for (const { jobId, status, result } of results) {
+          for (const evaluationRequest of Object.values(next)) {
+            if (evaluationRequest.jobIds.includes(jobId)) {
+              const newJobStatuses = { ...evaluationRequest.jobStatuses, [jobId]: { status, result } };
+              next[evaluationRequest.requestKey] = {
+                ...evaluationRequest,
+                jobStatuses: newJobStatuses,
+                isLoading: isJobsLoading(newJobStatuses, evaluationRequest.jobIds),
+              };
+            }
+          }
+        }
+        // Check for completions (deriveRequestStatus returns SUCCEEDED/FAILED only when all jobs complete)
+        for (const evaluationRequest of Object.values(next)) {
+          if (finalizedRef.current.has(evaluationRequest.requestKey)) {
+            continue;
+          }
+          const status = deriveRequestStatus(evaluationRequest);
+          if (status === TrackingJobStatus.SUCCEEDED) {
+            const evalResults = buildResults(evaluationRequest);
+            if (evalResults) {
+              finalizedRef.current.add(evaluationRequest.requestKey);
+              next[evaluationRequest.requestKey] = {
+                ...next[evaluationRequest.requestKey],
+                results: evalResults,
+                isLoading: false,
+              };
+              finishedCallbackRef.current?.({ requestKey: evaluationRequest.requestKey, status, results: evalResults });
+            }
+          } else if (status === TrackingJobStatus.FAILED) {
+            const error = extractError(evaluationRequest.jobStatuses, evaluationRequest.jobIds);
+            finalizedRef.current.add(evaluationRequest.requestKey);
+            next[evaluationRequest.requestKey] = { ...next[evaluationRequest.requestKey], error, isLoading: false };
+          }
+        }
+        return next;
+      });
+    };
+
+    const intervalId = setInterval(poll, JOB_POLLING_INTERVAL);
+    return () => clearInterval(intervalId);
+  }, []);
 
   const {
     mutate: startEvaluationJob,
     isLoading: isJobStarting,
     error: startEvaluationJobError,
-  } = useMutation<StartEvaluationJobResponse, Error, StartEvaluationJobParams>({
-    mutationFn: async ({ evaluateParams, traceIds }) => {
-      const responseData = await fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/scorer/invoke`), 'POST', {
+  } = useMutation<
+    { jobs: { job_id: string }[] },
+    Error,
+    { evaluateParams: EvaluateTracesParams; traceIds: string[]; requestKey: string }
+  >({
+    mutationFn: async ({ evaluateParams, traceIds }) =>
+      fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/scorer/invoke'), 'POST', {
         experiment_id: evaluateParams.experimentId,
         serialized_scorer: evaluateParams.serializedScorer,
         trace_ids: traceIds,
         log_assessments: evaluateParams.saveAssessment,
-      });
-      return responseData;
+      }),
+    onSuccess: (data, { requestKey }) => {
+      const jobIds = data.jobs.map((j) => j.job_id);
+      setEvaluations((prev) => ({
+        ...prev,
+        [requestKey]: {
+          ...prev[requestKey],
+          jobIds,
+          isLoading: isJobsLoading(prev[requestKey]?.jobStatuses ?? {}, jobIds),
+        },
+      }));
     },
-    onSuccess: (data) => {
-      setCurrentJobsId(data.jobs.map((job) => job.job_id));
+    onError: (error, { requestKey }) => {
+      finalizedRef.current.add(requestKey);
+      setEvaluations((prev) => ({ ...prev, [requestKey]: { ...prev[requestKey], error, isLoading: false } }));
     },
   });
 
-  const isLoading = areJobsRunning || isJobStarting;
-
   const evaluateTracesAsync = useCallback(
-    async (params: EvaluateTracesParams) => {
+    async (params: EvaluateTracesParams, requestKey?: string) => {
+      const key = requestKey ?? generateRequestKey();
+      setLatestRequestKey(key);
+
+      // Use the scorer name to be saved as a user-facing label
+      const evaluationRequestLabel = params.serializedScorer
+        ? parseJSONSafe(params.serializedScorer)?.name
+        : 'Feedback';
+
+      // Initialize evaluation
+      setEvaluations((prev) => ({
+        ...prev,
+        [key]: {
+          requestKey: key,
+          jobIds: [],
+          jobStatuses: {},
+          isLoading: true,
+          label: evaluationRequestLabel,
+        },
+      }));
+
       let traceIds: string[];
+      let sessionsData: SessionForEvaluation[] | undefined;
+
       if (params.evaluationScope === ScorerEvaluationScope.SESSIONS) {
         const sessions = await getSessionsForEvaluation(params);
-        setSessionsData(sessions);
-        traceIds = uniq(sessions.flatMap((session) => session.traceInfos.map((traceInfo) => traceInfo.trace_id)));
+        sessionsData = sessions;
+        traceIds = uniq(sessions.flatMap((s) => s.traceInfos.map((t) => t.trace_id)));
       } else {
-        setSessionsData(undefined);
         traceIds = await getTraceIdsForEvaluation(params);
       }
 
-      const serializedScorer = params.serializedScorer;
-
-      if (!serializedScorer) {
-        throw new Error('The serialized scorer is malformed');
+      if (!params.serializedScorer) {
+        const error = new Error('The serialized scorer is malformed');
+        finalizedRef.current.add(key);
+        setEvaluations((prev) => ({ ...prev, [key]: { ...prev[key], error, isLoading: false } }));
+        return key;
       }
 
-      // Start the evaluation job
-      startEvaluationJob({ evaluateParams: params, traceIds });
+      startEvaluationJob({ evaluateParams: params, traceIds, requestKey: key });
 
-      // After the job is started, fetch all the traces in parallel
+      // Fetch traces in parallel
       const traces = await Promise.all(
-        traceIds.map(async (traceId) => {
-          return await queryClient.fetchQuery({
+        traceIds.map((traceId) =>
+          queryClient.fetchQuery({
             queryKey: ['GetMlflowTraceV3', traceId],
             queryFn: () => getMlflowTraceV3ForEvaluation(traceId),
             staleTime: Infinity,
             cacheTime: Infinity,
-          });
-        }),
+          }),
+        ),
       );
-      setTracesData(zipObject(traceIds, traces));
+
+      setEvaluations((prev) => ({
+        ...prev,
+        [key]: { ...prev[key], tracesData: zipObject(traceIds, traces), sessionsData },
+      }));
+
+      return key;
     },
     [startEvaluationJob, getTraceIdsForEvaluation, queryClient, getSessionsForEvaluation],
   );
 
   const reset = useCallback(() => {
-    // Cancel any running jobs on the backend (fire-and-forget)
-    // Use functional setState to access current job IDs without adding to dependency array
-    setCurrentJobsId((prevJobsId) => {
-      if (prevJobsId) {
-        for (const jobId of prevJobsId) {
-          fetchAPI(getAjaxUrl(`ajax-api/3.0/jobs/cancel/${jobId}`), 'PATCH').catch(() => {
-            // Ignore errors - job may have already completed
-          });
+    // Cancel running jobs (fire-and-forget)
+    for (const ev of Object.values(evaluationsRef.current)) {
+      if (!finalizedRef.current.has(ev.requestKey)) {
+        for (const jobId of ev.jobIds) {
+          fetchAPI(getAjaxUrl(`ajax-api/3.0/jobs/cancel/${jobId}`), 'PATCH').catch(() => {});
         }
       }
-      return undefined;
-    });
-    setTracesData(undefined);
-    lastFinishedJobsIdRef.current = undefined;
-    setSessionsData(undefined);
+    }
+    setEvaluations({});
+    setLatestRequestKey(null);
+    finalizedRef.current = new Set();
   }, []);
 
-  const error = useMemo(() => {
-    if (startEvaluationJobError) {
-      return startEvaluationJobError;
-    }
-    if (areJobsRunning) {
-      return null;
-    }
-    for (const job of Object.values(jobResults ?? {})) {
-      if (job.status === TrackingJobStatus.FAILED) {
-        return new Error(job.result);
-      }
-    }
-    return null;
-  }, [jobResults, areJobsRunning, startEvaluationJobError]);
+  // Get the latest evaluation request from the evaluations map
+  const latestEvaluation = latestRequestKey ? evaluations[latestRequestKey] : undefined;
 
-  // Combine the traces data and the evaluation job data to get the results
-  const data = useMemo<JudgeEvaluationResult[] | null>(() => {
-    if (!tracesData || isLoading || error) {
-      return null;
-    }
-    const aggregatedJobResults: EvaluateTracesAsyncJobResult = {};
-    // Get data from all successful jobs
-    for (const job of Object.values(jobResults ?? {})) {
-      if (job.status === TrackingJobStatus.SUCCEEDED) {
-        for (const traceId of Object.keys(job.result)) {
-          aggregatedJobResults[traceId] = {
-            assessments: job.result[traceId]?.assessments ?? [],
-            failures: job.result[traceId]?.failures ?? [],
-          };
-        }
-      }
-    }
-
-    if (sessionsData) {
-      return sessionsData.map<SessionJudgeEvaluationResult>((session) => {
-        const sessionResults: { assessments: FeedbackAssessment[]; errors: string[] } = { assessments: [], errors: [] };
-        // For every trace in the session, aggregate the results into the session results
-        for (const traceInfo of session.traceInfos) {
-          const traceId = traceInfo.trace_id;
-          const traceResults = aggregatedJobResults[traceId];
-          sessionResults.assessments.push(...(traceResults?.assessments ?? []));
-          sessionResults.errors.push(...(traceResults?.failures?.map((failure) => failure.error_message) ?? []));
-        }
-
-        return {
-          sessionId: session.sessionId ?? '',
-          results: sessionResults.assessments,
-          traces: compact(session.traceInfos.map((traceInfo) => tracesData[traceInfo.trace_id] ?? null)),
-          error: sessionResults.errors.join(', ') || null,
-        };
-      });
-    }
-
-    const traceEvaluationResults = Object.entries(tracesData).map(([traceId, trace]) => {
-      const results = aggregatedJobResults[traceId]?.assessments ?? [];
-      const failureString = aggregatedJobResults[traceId]?.failures?.map((failure) => failure.error_message).join(', ');
-      return {
-        trace,
-        results,
-        error: failureString || null,
-      };
-    });
-
-    return compact(traceEvaluationResults);
-  }, [tracesData, isLoading, error, jobResults, sessionsData]);
-
-  return [evaluateTracesAsync, { data, isLoading, error, reset }] as const;
+  return [
+    evaluateTracesAsync,
+    {
+      data: latestEvaluation?.results ?? null,
+      isLoading: isJobStarting || (latestEvaluation && !latestEvaluation.results && !latestEvaluation.error) || false,
+      error: startEvaluationJobError ?? latestEvaluation?.error ?? null,
+      reset,
+      evaluations,
+    },
+  ] as const;
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -38,6 +38,7 @@ export {
   shouldEnableAssessmentsInSessions,
   shouldUseModelTraceExplorerDrawerUI,
   shouldUseUnifiedModelTraceComparisonUI,
+  isEvaluatingTracesInDetailsViewEnabled,
 } from './FeatureUtils';
 export { AssessmentSchemaContextProvider, type AssessmentSchema } from './contexts/AssessmentSchemaContext';
 export * from './ModelTrace.types';


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20312/files) to review incremental changes.
- [**stack/run-judges-from-trace-ui-part6**](https://github.com/mlflow/mlflow/pull/20312) [[Files changed](https://github.com/mlflow/mlflow/pull/20312/files)]
  - [stack/run-judges-from-trace-ui-part7](https://github.com/mlflow/mlflow/pull/20313) [[Files changed](https://github.com/mlflow/mlflow/pull/20313/files/150b22662255b8ab26d9853f9af8f33b8cc263e2..d340310e38f44773f7c9f3ac779ae28381b30912)]
    - [stack/run-judges-from-trace-ui-part8](https://github.com/mlflow/mlflow/pull/20340) [[Files changed](https://github.com/mlflow/mlflow/pull/20340/files/d340310e38f44773f7c9f3ac779ae28381b30912..677f7fd5081dc5809b281e2cf04322b34861dd9e)]
      - [stack/run-judges-from-trace-ui-part9](https://github.com/mlflow/mlflow/pull/20360) [[Files changed](https://github.com/mlflow/mlflow/pull/20360/files/677f7fd5081dc5809b281e2cf04322b34861dd9e..fe030b2e0d378d659e635066f1cc7efe3b89e6cb)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Major refactor of the async trace evaluation system to support tracking multiple concurrent evaluations with improved error handling and partial success support.

### State Management Improvements
- Tracks multiple concurrent evaluations in `evaluations` record
- Returns `evaluations` from hook for external state access

### Error Handling
- Supports partial success (some jobs succeed, others fail)
- Per-trace error messages extracted from failed jobs

### Polling Refactor
- Ditches `useQuery` approach as it wasn't proper tool for complex scenarios
- Single always-on polling interval checks all active jobs

### Manual regression test: evaluating traces from judges UI


https://github.com/user-attachments/assets/8831fce3-cc0f-4060-aa1c-2ab7372c7323


### Manual regression test: simulated error

https://github.com/user-attachments/assets/a0a4e120-20ca-47d6-97ec-b15163505dad

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
