### PR TITLE
Revamp assessments and run judges directly in trace UI [Part 7/x]: Loading states in assessments pane

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useGetScheduledScorers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useGetScheduledScorers.tsx
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryResult } from '@databricks/web-shared/query-client';
+import { useQuery, UseQueryOptions, type UseQueryResult } from '@databricks/web-shared/query-client';
 import { UnknownError, type PredefinedError } from '@databricks/web-shared/errors';
 import type { ScheduledScorer, ScorerConfig } from '../types';
 import { convertMLflowScorerToConfig, transformScorerConfig } from '../utils/scorerTransformUtils';
@@ -19,6 +19,7 @@ export interface ScheduledScorersResponse {
 
 export function useGetScheduledScorers(
   experimentId?: string,
+  options?: UseQueryOptions<ScheduledScorersResponse, PredefinedError>,
 ): UseQueryResult<ScheduledScorersResponse, PredefinedError> {
   return useQuery<ScheduledScorersResponse, PredefinedError>({
     queryKey: ['mlflow', 'scheduled-scorers', experimentId],
@@ -74,8 +75,9 @@ export function useGetScheduledScorers(
         scheduledScorers,
       };
     },
-    enabled: !!experimentId,
     staleTime: 5 * 60 * 1000, // 5 minutes
     refetchOnWindowFocus: true,
+    ...options,
+    enabled: Boolean(experimentId) && (options?.enabled ?? true),
   });
 }

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
@@ -12,6 +12,7 @@ import {
   PlusIcon,
   Radio,
   SearchIcon,
+  TableSkeleton,
   Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
@@ -79,7 +80,7 @@ const RunJudgeModalImpl = ({
   onClose: () => void;
 }) => {
   const [experimentId] = useExperimentIds();
-  const { data } = useGetScheduledScorers(experimentId);
+  const { data, isLoading: loadingScorers } = useGetScheduledScorers(experimentId, { enabled: visible });
   const intl = useIntl();
 
   const { theme } = useDesignSystemTheme();
@@ -187,6 +188,7 @@ const RunJudgeModalImpl = ({
             ...getShadowScrollStyles(theme, { orientation: 'vertical' }),
           }}
         >
+          {loadingScorers && <TableSkeleton lines={3} />}
           {displayedLLMScorers?.map((scorer) => (
             <ScorerOption
               scorer={scorer}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
@@ -2,19 +2,16 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { LLMScorer } from '../types';
 import { useGetScheduledScorers } from './useGetScheduledScorers';
 import { useExperimentIds } from '../../../components/experiment-page/hooks/useExperimentIds';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import {
   Alert,
   Button,
-  DialogCombobox,
-  DialogComboboxContent,
-  DialogComboboxCustomButtonTriggerWrapper,
-  DialogComboboxFooter,
-  DialogComboboxOptionList,
-  DialogComboboxOptionListSearch,
-  DialogComboboxOptionListSelectItem,
   getShadowScrollStyles,
+  Input,
+  Modal,
   PlusIcon,
+  Radio,
+  SearchIcon,
   Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
@@ -22,14 +19,14 @@ import { PillControl } from '@databricks/design-system/development';
 import ScorerModalRenderer from '../ScorerModalRenderer';
 import { SCORER_FORM_MODE } from '../constants';
 import { useRunSerializedScorer } from './useRunSerializedScorer';
-import {
-  isEvaluatingTracesInDetailsViewEnabled,
-  ModelTraceExplorerRunJudgeConfig,
-  ModelTraceExplorerRunJudgesContextProvider,
-} from '@databricks/web-shared/model-trace-explorer';
+import { ModelTraceExplorerRunJudgeConfig } from '@databricks/web-shared/model-trace-explorer';
 import { ScorerFinishedEvent } from '../useEvaluateTracesAsync';
 
-export const useRunScorerInTracesViewConfiguration = (): ModelTraceExplorerRunJudgeConfig => {
+interface UseRunScorerInTracesViewConfigurationReturnType extends ModelTraceExplorerRunJudgeConfig {
+  RunJudgeModalElement: React.ReactNode;
+}
+
+export const useRunScorerInTracesViewConfiguration = (): UseRunScorerInTracesViewConfigurationReturnType => {
   const [experimentId] = useExperimentIds();
 
   const scorerFinishSubscribers = useRef<((event: ScorerFinishedEvent) => void)[]>([]);
@@ -49,44 +46,44 @@ export const useRunScorerInTracesViewConfiguration = (): ModelTraceExplorerRunJu
 
   const { evaluateTraces, allEvaluations } = useRunSerializedScorer({ experimentId, onScorerFinished });
 
-  const renderRunJudgeButton = useCallback<NonNullable<ModelTraceExplorerRunJudgeConfig['renderRunJudgeButton']>>(
-    ({ traceId, trigger }) => {
+  const renderRunJudgeModal = useCallback<NonNullable<ModelTraceExplorerRunJudgeConfig['renderRunJudgeModal']>>(
+    ({ traceId, onClose, visible }) => {
       return (
-        <SelectJudgeDropdown traceId={traceId} evaluateTraces={evaluateTraces}>
-          {trigger}
-        </SelectJudgeDropdown>
+        <RunJudgeModalImpl visible={visible} traceId={traceId} evaluateTraces={evaluateTraces} onClose={onClose} />
       );
     },
     [evaluateTraces],
   );
 
   return {
-    renderRunJudgeButton,
+    renderRunJudgeModal,
     evaluations: allEvaluations,
     subscribeToScorerFinished,
-  } as ModelTraceExplorerRunJudgeConfig;
+  } as UseRunScorerInTracesViewConfigurationReturnType;
 };
 
 /**
  * Dropdown for selecting a judge to run against a trace.
  */
-const SelectJudgeDropdown = ({
+const RunJudgeModalImpl = ({
   traceId,
   onScorerStarted,
   evaluateTraces,
-  children,
+  visible,
+  onClose,
 }: {
   traceId: string;
   onScorerStarted?: (scorerName: string) => void;
   evaluateTraces: (scorer: LLMScorer, traceIds: string[]) => void;
-  children: React.ReactNode;
+  visible: boolean;
+  onClose: () => void;
 }) => {
   const [experimentId] = useExperimentIds();
   const { data } = useGetScheduledScorers(experimentId);
+  const intl = useIntl();
 
   const { theme } = useDesignSystemTheme();
   const [searchValue, setSearchValue] = useState<string>('');
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isCreateScorerModalVisible, setIsCreateScorerModalVisible] = useState(false);
 
   const displayedLLMScorers = useMemo(() => {
@@ -96,92 +93,110 @@ const SelectJudgeDropdown = ({
   }, [data?.scheduledScorers, searchValue]);
 
   const [error, setError] = useState<Error | undefined>(undefined);
+  const [selectedJudge, setSelectedJudge] = useState<LLMScorer | undefined>(undefined);
 
-  const handleLLMScorerClick = async (scorer: LLMScorer) => {
+  const handleModalConfirm = async () => {
+    if (!selectedJudge) {
+      return;
+    }
     setError(undefined);
     try {
-      evaluateTraces(scorer, [traceId]);
-      setDropdownOpen(false);
-      onScorerStarted?.(scorer.name);
+      evaluateTraces(selectedJudge, [traceId]);
+      onClose();
+      onScorerStarted?.(selectedJudge.name);
     } catch (error) {
       setError(error as Error);
     }
   };
-
+  if (!visible) {
+    return null;
+  }
   return (
     <>
-      <DialogCombobox
-        id="traces-view-judge-select-dropdown"
-        componentId="mlflow.experiment-scorers.traces-view-judge-select-dropdown"
-        open={dropdownOpen}
-        onOpenChange={setDropdownOpen}
+      <Modal
+        componentId="mlflow.experiment-scorers.traces-view-judge-select-modal"
+        visible
+        onCancel={onClose}
+        title={<FormattedMessage defaultMessage="Run judge on trace" description="Title for run judge modal" />}
+        cancelText={intl.formatMessage({
+          defaultMessage: 'Cancel',
+          description: 'Button text for canceling a judge run',
+        })}
+        okText={intl.formatMessage({
+          defaultMessage: 'Run judge',
+          description: 'Button text for running a judge',
+        })}
+        okButtonProps={{ disabled: !selectedJudge }}
+        onOk={handleModalConfirm}
       >
-        <DialogComboboxCustomButtonTriggerWrapper asChild>{children}</DialogComboboxCustomButtonTriggerWrapper>
-        <DialogComboboxContent align="end" css={{ minWidth: 450 }}>
-          <DialogComboboxOptionList
-            css={{
-              borderTop: `1px solid ${theme.colors.border}`,
-            }}
+        <div css={{ display: 'flex', gap: theme.spacing.sm, marginBottom: theme.spacing.sm }}>
+          <Input
+            componentId="mlflow.experiment-scorers.traces-view-judge-search"
+            prefix={<SearchIcon />}
+            value={searchValue}
+            onChange={(e) => setSearchValue(e.target.value)}
+            placeholder={intl.formatMessage({
+              defaultMessage: 'Search judges',
+              description: 'Placeholder for scorer search input',
+            })}
+          />
+          <Button
+            componentId="mlflow.experiment-scorers.traces-view-create-judge"
+            icon={<PlusIcon />}
+            onClick={() => setIsCreateScorerModalVisible(true)}
           >
-            <DialogComboboxOptionListSearch controlledValue={searchValue} setControlledValue={setSearchValue}>
-              <div css={{ padding: `${theme.spacing.xs}px ${theme.spacing.md}px`, marginBottom: theme.spacing.sm }}>
-                {error && (
-                  <Alert
-                    message={error.message}
-                    type="error"
-                    componentId="mlflow.experiment-scorers.traces-view-judge-error"
-                    css={{ marginBottom: theme.spacing.sm }}
-                    closable={false}
-                  />
-                )}
-                <PillControl.Root
-                  size="small"
-                  componentId="mlflow.experiment-scorers.traces-view-judge-type-filter"
-                  value="llm"
-                >
-                  <PillControl.Item value="llm">
-                    <FormattedMessage
-                      defaultMessage="Custom LLM-as-a-judge"
-                      description="Label for custom LLM judge type filter option"
-                    />
-                  </PillControl.Item>
-                  {/* TODO: Add support for pre-built LLM-as-a-judge when default gateway is available */}
-                  <PillControl.Item value="template" disabled>
-                    <FormattedMessage
-                      defaultMessage="Pre-built LLM-as-a-judge"
-                      description="Label for pre-built LLM judge type filter option"
-                    />
-                  </PillControl.Item>
-                </PillControl.Root>
-              </div>
-              <div
-                css={{
-                  height: 240,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  overflowY: 'auto',
-                  ...getShadowScrollStyles(theme, { orientation: 'vertical' }),
-                }}
-              >
-                {displayedLLMScorers?.map((scorer) => (
-                  <ScorerOption scorer={scorer} key={scorer.name} onClick={handleLLMScorerClick} />
-                ))}
-              </div>
-            </DialogComboboxOptionListSearch>
-          </DialogComboboxOptionList>
-          <DialogComboboxFooter css={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <Button
-              type="tertiary"
-              componentId="mlflow.experiment-scorers.traces-view-create-judge"
-              icon={<PlusIcon />}
-              css={{ flex: 1 }}
-              onClick={() => setIsCreateScorerModalVisible(true)}
-            >
-              <FormattedMessage defaultMessage="Create judge" description="Button to create a new judge" />
-            </Button>
-          </DialogComboboxFooter>
-        </DialogComboboxContent>
-      </DialogCombobox>
+            <FormattedMessage defaultMessage="Create judge" description="Button to create a new judge" />
+          </Button>
+        </div>
+        <div css={{ marginBottom: theme.spacing.md }}>
+          {error && (
+            <Alert
+              message={error.message}
+              type="error"
+              componentId="mlflow.experiment-scorers.traces-view-judge-error"
+              css={{ marginBottom: theme.spacing.sm }}
+              closable={false}
+            />
+          )}
+          <PillControl.Root
+            size="small"
+            componentId="mlflow.experiment-scorers.traces-view-judge-type-filter"
+            value="llm"
+          >
+            <PillControl.Item value="llm">
+              <FormattedMessage
+                defaultMessage="Custom LLM-as-a-judge"
+                description="Label for custom LLM judge type filter option"
+              />
+            </PillControl.Item>
+            {/* TODO: Add support for pre-built LLM-as-a-judge when default gateway is available */}
+            <PillControl.Item value="template" disabled>
+              <FormattedMessage
+                defaultMessage="Pre-built LLM-as-a-judge"
+                description="Label for pre-built LLM judge type filter option"
+              />
+            </PillControl.Item>
+          </PillControl.Root>
+        </div>
+        <div
+          css={{
+            height: 240,
+            display: 'flex',
+            flexDirection: 'column',
+            overflowY: 'auto',
+            ...getShadowScrollStyles(theme, { orientation: 'vertical' }),
+          }}
+        >
+          {displayedLLMScorers?.map((scorer) => (
+            <ScorerOption
+              scorer={scorer}
+              key={scorer.name}
+              onClick={() => setSelectedJudge(scorer)}
+              selected={selectedJudge?.name === scorer.name}
+            />
+          ))}
+        </div>
+      </Modal>
       {isCreateScorerModalVisible && (
         <ScorerModalRenderer
           visible
@@ -195,26 +210,31 @@ const SelectJudgeDropdown = ({
   );
 };
 
-const ScorerOption = ({ scorer, onClick }: { scorer: LLMScorer; onClick: (scorer: LLMScorer) => void }) => {
+const ScorerOption = ({
+  scorer,
+  onClick,
+  selected,
+}: {
+  scorer: LLMScorer;
+  onClick: (scorer: LLMScorer) => void;
+  selected: boolean;
+}) => {
   const { theme } = useDesignSystemTheme();
   return (
-    <DialogComboboxOptionListSelectItem
-      value={scorer.name}
-      css={{
-        alignItems: 'center',
-        height: theme.general.buttonHeight,
-        '&>label': { flex: 1 },
-        flexShrink: 0,
-      }}
-      key={scorer.name}
-      onChange={() => onClick(scorer)}
+    <div
+      role="radio"
+      aria-checked={selected}
+      css={{ cursor: 'pointer', height: 48, flexShrink: 0 }}
+      onClick={() => onClick(scorer)}
     >
-      <div css={{ display: 'flex', flexDirection: 'column' }}>
-        <Typography.Text css={{ flex: 1 }}>{scorer.name}</Typography.Text>
-        <Typography.Hint>
-          <FormattedMessage defaultMessage="Custom judge" description="Label indicating a custom judge scorer" />
-        </Typography.Hint>
-      </div>
-    </DialogComboboxOptionListSelectItem>
+      <Radio componentId={`mlflow.experiment-scorers.traces-view-judge-${scorer.name}`} checked={selected}>
+        <div css={{ display: 'flex', flexDirection: 'column', marginLeft: theme.spacing.xs }}>
+          <Typography.Text css={{ flex: 1 }}>{scorer.name}</Typography.Text>
+          <Typography.Hint>
+            <FormattedMessage defaultMessage="Custom judge" description="Label indicating a custom judge scorer" />
+          </Typography.Hint>
+        </div>
+      </Radio>
+    </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunSerializedScorer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunSerializedScorer.tsx
@@ -1,8 +1,9 @@
 import { useCallback } from 'react';
 import { useEvaluateTraces } from '../useEvaluateTraces';
-import { EvaluateTracesParams, LLM_TEMPLATE, LLMScorer, ScheduledScorer } from '../types';
-import { ASSESSMENT_NAME_TEMPLATE_MAPPING, ScorerEvaluationScope } from '../constants';
+import { EvaluateTracesParams, LLMScorer } from '../types';
+import { ScorerEvaluationScope } from '../constants';
 import { transformScheduledScorer } from '../utils/scorerTransformUtils';
+import { ScorerFinishedEvent } from '../useEvaluateTracesAsync';
 
 /**
  * Runs a known serialized scorer on a set of traces.
@@ -12,9 +13,9 @@ export const useRunSerializedScorer = ({
   onScorerFinished,
 }: {
   experimentId?: string;
-  onScorerFinished?: () => void;
+  onScorerFinished?: (event: ScorerFinishedEvent) => void;
 }) => {
-  const [evaluateTracesFn, { latestEvaluation, isLoading }] = useEvaluateTraces({ onScorerFinished });
+  const [evaluateTracesFn, { latestEvaluation, isLoading, allEvaluations }] = useEvaluateTraces({ onScorerFinished });
 
   const evaluateTraces = useCallback(
     (scorer: LLMScorer, traceIds: string[]) => {
@@ -42,5 +43,6 @@ export const useRunSerializedScorer = ({
     evaluateTraces,
     latestEvaluation,
     isLoading,
+    allEvaluations,
   };
 };

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -794,6 +794,10 @@
     "defaultMessage": "Large trace",
     "description": "Modal title for when a trace is very large. The modal warns the user that the trace may cause UI slowness, but allows them to attempt to display it anyway by clicking a button."
   },
+  "4J7jtY": {
+    "defaultMessage": "Run judge",
+    "description": "Button text for running a judge"
+  },
   "4Jyn2b": {
     "defaultMessage": "Add/Edit alias for model version {version}",
     "description": "Model registry > model version alias editor > Title of the update alias modal"
@@ -3498,6 +3502,10 @@
     "defaultMessage": "A GraphQL error occurred.",
     "description": "Generic message for a GraphQL error, typically due to query parsing or validation issues"
   },
+  "PQRoqw": {
+    "defaultMessage": "Run judge on trace",
+    "description": "Title for run judge modal"
+  },
   "PRCcZe": {
     "defaultMessage": "Select ({count})",
     "description": "Confirm button in the select traces modal showing number of selected traces"
@@ -4802,10 +4810,6 @@
   "Za9+Cg": {
     "defaultMessage": "Pass",
     "description": "Evaluation results > overall assessment > pass value label. Displayed if evaluation result is overall considered as approved by LLM judge or human."
-  },
-  "Zah+D4": {
-    "defaultMessage": "Run judge",
-    "description": "Label for the button to add a new feedback"
   },
   "Zb6BqS": {
     "defaultMessage": "Relative Time",
@@ -7619,6 +7623,10 @@
     "defaultMessage": "Back to providers",
     "description": "Navigation back to main provider list"
   },
+  "tsYxhE": {
+    "defaultMessage": "Search judges",
+    "description": "Placeholder for scorer search input"
+  },
   "ttyLD4": {
     "defaultMessage": "Okay",
     "description": "Experiment page > new notebook run modal > okay button label"
@@ -8118,6 +8126,10 @@
   "xq0Rde": {
     "defaultMessage": "New",
     "description": "Sidebar create popover button to create new experiment, model or prompt"
+  },
+  "xqc4yl": {
+    "defaultMessage": "Cancel",
+    "description": "Button text for canceling a judge run"
   },
   "xwe7WH": {
     "defaultMessage": "Default rendering",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2490,6 +2490,10 @@
     "defaultMessage": "Status",
     "description": "Label for the status section"
   },
+  "HSMagB": {
+    "defaultMessage": "Error evaluating \"{label}\"",
+    "description": "Error evaluating label"
+  },
   "HTQZeI": {
     "defaultMessage": "Evaluate trace",
     "description": "A call to action button to add assessments to a model trace in the single chat turn view"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -110,7 +110,7 @@ export const AssessmentsPane = ({
         enableRunScorer={
           enableRunScorer &&
           isEvaluatingTracesInDetailsViewEnabled() &&
-          Boolean(runJudgeConfiguration.renderRunJudgeButton)
+          Boolean(runJudgeConfiguration.renderRunJudgeModal)
         }
         feedbacks={feedbacks}
         activeSpanId={activeSpanId}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackGroup.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackGroup.tsx
@@ -1,7 +1,15 @@
 import { isNil } from 'lodash';
 import { useState } from 'react';
 
-import { useDesignSystemTheme, Typography, Button, PlusIcon, Tooltip, DangerIcon } from '@databricks/design-system';
+import {
+  useDesignSystemTheme,
+  Typography,
+  Button,
+  PlusIcon,
+  Tooltip,
+  DangerIcon,
+  TableSkeleton,
+} from '@databricks/design-system';
 
 import { AssessmentCreateForm } from './AssessmentCreateForm';
 import { getAssessmentDisplayName } from './AssessmentsPane.utils';
@@ -14,12 +22,14 @@ export const FeedbackGroup = ({
   traceId,
   activeSpanId,
   feedbackTypeTag,
+  loading,
 }: {
   name: string;
   valuesMap: { [value: string]: FeedbackAssessment[] };
   traceId: string;
   activeSpanId?: string;
   feedbackTypeTag?: React.ReactNode;
+  loading?: boolean;
 }) => {
   const { theme } = useDesignSystemTheme();
   const displayName = getAssessmentDisplayName(name);
@@ -70,6 +80,7 @@ export const FeedbackGroup = ({
       {Object.entries(valuesMap).map(([jsonValue, feedbacks]) => (
         <FeedbackValueGroup jsonValue={jsonValue} feedbacks={feedbacks} key={jsonValue} />
       ))}
+      {loading && <TableSkeleton lines={2} />}
       {showCreateForm && (
         <AssessmentCreateForm
           assessmentName={name}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/RunJudgesContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/RunJudgesContext.tsx
@@ -22,7 +22,15 @@ export interface ScorerFinishedEvent {
 }
 
 export interface ModelTraceExplorerRunJudgeConfig {
-  renderRunJudgeButton?: ({ traceId, trigger }: { traceId: string; trigger: React.ReactNode }) => React.ReactNode;
+  renderRunJudgeModal?: ({
+    traceId,
+    visible,
+    onClose,
+  }: {
+    traceId: string;
+    visible: boolean;
+    onClose: () => void;
+  }) => React.ReactNode;
   /** Current state of all active evaluations */
   evaluations?: Record<
     string,
@@ -40,7 +48,7 @@ export interface ModelTraceExplorerRunJudgeConfig {
 }
 
 const ModelTraceExplorerRunJudgesContext = React.createContext<ModelTraceExplorerRunJudgeConfig>({
-  renderRunJudgeButton: undefined,
+  renderRunJudgeModal: undefined,
   evaluations: undefined,
   subscribeToScorerFinished: undefined,
 });
@@ -54,15 +62,15 @@ const ModelTraceExplorerRunJudgesContext = React.createContext<ModelTraceExplore
  */
 export const ModelTraceExplorerRunJudgesContextProvider = ({
   children,
-  renderRunJudgeButton,
+  renderRunJudgeModal,
   evaluations,
   subscribeToScorerFinished,
 }: ModelTraceExplorerRunJudgeConfig & {
   children: React.ReactNode;
 }) => {
   const contextValue = useMemo(
-    () => ({ renderRunJudgeButton, evaluations, subscribeToScorerFinished }),
-    [renderRunJudgeButton, evaluations, subscribeToScorerFinished],
+    () => ({ renderRunJudgeModal, evaluations, subscribeToScorerFinished }),
+    [renderRunJudgeModal, evaluations, subscribeToScorerFinished],
   );
   return (
     <ModelTraceExplorerRunJudgesContext.Provider value={contextValue}>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/RunJudgesContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/RunJudgesContext.tsx
@@ -1,26 +1,69 @@
 import React, { useMemo } from 'react';
+import { FeedbackAssessment, ModelTrace } from '../ModelTrace.types';
+
+interface TraceScorerJudgeEvaluationResult {
+  trace: ModelTrace | null;
+  results: FeedbackAssessment[];
+  error: string | null;
+}
+
+interface SessionScorerJudgeEvaluationResult {
+  sessionId: string;
+  traces: ModelTrace[] | null;
+  results: FeedbackAssessment[];
+  error: string | null;
+}
+
+export interface ScorerFinishedEvent {
+  requestKey: string;
+  status: string;
+  results?: (TraceScorerJudgeEvaluationResult | SessionScorerJudgeEvaluationResult)[];
+  error?: Error | null;
+}
 
 export interface ModelTraceExplorerRunJudgeConfig {
   renderRunJudgeButton?: ({ traceId, trigger }: { traceId: string; trigger: React.ReactNode }) => React.ReactNode;
+  /** Current state of all active evaluations */
+  evaluations?: Record<
+    string,
+    {
+      requestKey: string;
+      tracesData?: Record<string, ModelTrace>;
+      results?: (TraceScorerJudgeEvaluationResult | SessionScorerJudgeEvaluationResult)[];
+      isLoading: boolean;
+      label: string;
+      error?: Error | null;
+    }
+  >;
+  /** Subscribe to scorer update events. Returns unsubscribe function. */
+  subscribeToScorerFinished?: (callback: (event: ScorerFinishedEvent) => void) => () => void;
 }
 
 const ModelTraceExplorerRunJudgesContext = React.createContext<ModelTraceExplorerRunJudgeConfig>({
   renderRunJudgeButton: undefined,
+  evaluations: undefined,
+  subscribeToScorerFinished: undefined,
 });
 
 /**
  * Provides context for running judges on traces.
  * Contains:
  * - a function to render a button to run a judge on a trace
- * - TODO: logic for monitoring and updating the status of the judge runs
+ * - current state of all active evaluations
+ * - a function to subscribe to scorer update events
  */
 export const ModelTraceExplorerRunJudgesContextProvider = ({
   children,
   renderRunJudgeButton,
+  evaluations,
+  subscribeToScorerFinished,
 }: ModelTraceExplorerRunJudgeConfig & {
   children: React.ReactNode;
 }) => {
-  const contextValue = useMemo(() => ({ renderRunJudgeButton }), [renderRunJudgeButton]);
+  const contextValue = useMemo(
+    () => ({ renderRunJudgeButton, evaluations, subscribeToScorerFinished }),
+    [renderRunJudgeButton, evaluations, subscribeToScorerFinished],
+  );
   return (
     <ModelTraceExplorerRunJudgesContext.Provider value={contextValue}>
       {children}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -56,6 +56,7 @@ export {
 } from './contexts/UpdateTraceContext';
 export {
   ModelTraceExplorerRunJudgesContextProvider,
+  useModelTraceExplorerRunJudgesContext,
   type ModelTraceExplorerRunJudgeConfig,
 } from './contexts/RunJudgesContext';
 export { SingleChatTurnMessages } from './session-view/SingleChatTurnMessages';


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20313/files) to review incremental changes.
- [**stack/run-judges-from-trace-ui-part7**](https://github.com/mlflow/mlflow/pull/20313) [[Files changed](https://github.com/mlflow/mlflow/pull/20313/files)]
  - [stack/run-judges-from-trace-ui-part8](https://github.com/mlflow/mlflow/pull/20340) [[Files changed](https://github.com/mlflow/mlflow/pull/20340/files/faea7e5fc9fb78d08c8aaf054ff8048a9d3ab1ef..83f491fe0666f47f8bc49d0d7ccb57e6e4242f18)]
    - [stack/run-judges-from-trace-ui-part9](https://github.com/mlflow/mlflow/pull/20360) [[Files changed](https://github.com/mlflow/mlflow/pull/20360/files/83f491fe0666f47f8bc49d0d7ccb57e6e4242f18..c24aa58f984ce5c4d0d359b57adc96d8dd7de375)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds visual loading states and error displays in the feedback section when judges are running or fail.

- Loading states:
  - Shows skeleton loaders when evaluations are in progress
  - Displays scorer name and "LLM-as-a-judge" tag during loading
  - Each pending evaluation shows as a separate loading card
- Error Display: shows `Alert` component with error message when evaluations fail

### Demo (happy path)

https://github.com/user-attachments/assets/e6895f67-f4ea-4f8e-91d2-f7334ee19c48

### Demo (simulated error)

https://github.com/user-attachments/assets/0f0bfb12-b1d4-430f-a07c-87400e8e10d7

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
