### PR TITLE
Otel translation support for model and cost tracking

### DIFF
--- a/.github/workflows/tracing.yaml
+++ b/.github/workflows/tracing.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-asyncio pytest-timeout
+          pip install pytest pytest-asyncio pytest-timeout litellm
 
       - name: Run core tracing tests
         # NB: OTLP exporter includes large dependencies, so we want to test it in a separate job

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -82,6 +82,7 @@ class SpanAttributeKey:
     LLM_COST = "mlflow.llm.cost"
     # This attribute stores the model name extracted from span inputs/attributes.
     MODEL = "mlflow.llm.model"
+    MODEL_PROVIDER = "mlflow.model.provider"
     # This attribute indicates which flavor/format generated the LLM span. This is
     # used by downstream (e.g., UI) to determine the message format for parsing.
     MESSAGE_FORMAT = "mlflow.message.format"

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -82,7 +82,7 @@ class SpanAttributeKey:
     LLM_COST = "mlflow.llm.cost"
     # This attribute stores the model name extracted from span inputs/attributes.
     MODEL = "mlflow.llm.model"
-    MODEL_PROVIDER = "mlflow.model.provider"
+    MODEL_PROVIDER = "mlflow.llm.provider"
     # This attribute indicates which flavor/format generated the LLM span. This is
     # used by downstream (e.g., UI) to determine the message format for parsing.
     MESSAGE_FORMAT = "mlflow.message.format"

--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -97,7 +97,7 @@ def translate_span_when_storing(span: Span) -> dict[str, Any]:
 
     # Calculate cost if both token usage and model are available
     if (
-        SpanAttributeKey.CHAT_COST not in attributes
+        SpanAttributeKey.LLM_COST not in attributes
         and SpanAttributeKey.CHAT_USAGE in attributes
         and SpanAttributeKey.MODEL in attributes
     ):
@@ -112,7 +112,7 @@ def translate_span_when_storing(span: Span) -> dict[str, Any]:
             if cost := calculate_cost_by_model_and_token_usage(
                 model_name, token_usage, model_provider
             ):
-                attributes[SpanAttributeKey.CHAT_COST] = dump_span_attribute_value(cost)
+                attributes[SpanAttributeKey.LLM_COST] = dump_span_attribute_value(cost)
         except Exception:
             _logger.debug("Failed to calculate cost during OTEL translation", exc_info=True)
 

--- a/mlflow/tracing/otel/translation/base.py
+++ b/mlflow/tracing/otel/translation/base.py
@@ -27,6 +27,8 @@ class OtelSchemaTranslator:
     TOTAL_TOKEN_KEY: str | None = None
     INPUT_VALUE_KEYS: list[str] | None = None
     OUTPUT_VALUE_KEYS: list[str] | None = None
+    MODEL_NAME_KEYS: list[str] | None = None
+    LLM_PROVIDER_KEY: str | None = None
 
     def get_message_format(self, attributes: dict[str, Any]) -> str | None:
         """
@@ -108,6 +110,32 @@ class OtelSchemaTranslator:
         """
         if self.TOTAL_TOKEN_KEY:
             return attributes.get(self.TOTAL_TOKEN_KEY)
+
+    def get_model_name(self, attributes: dict[str, Any]) -> str | None:
+        """
+        Get model name from OTEL attributes.
+
+        Args:
+            attributes: Dictionary of span attributes
+
+        Returns:
+            Model name string or None if not found
+        """
+        return self.get_attribute_value(attributes, self.MODEL_NAME_KEYS)
+
+    def get_model_provider(self, attributes: dict[str, Any]) -> str | None:
+        """
+        Get model provider from OTEL attributes.
+
+        Args:
+            attributes: Dictionary of span attributes
+
+        Returns:
+            Model provider string or None if not found
+        """
+
+        if self.LLM_PROVIDER_KEY:
+            return self._get_and_check_attribute_value(attributes, self.LLM_PROVIDER_KEY)
 
     def get_input_value(self, attributes: dict[str, Any]) -> Any:
         """

--- a/mlflow/tracing/otel/translation/genai_semconv.py
+++ b/mlflow/tracing/otel/translation/genai_semconv.py
@@ -43,3 +43,8 @@ class GenAiTranslator(OtelSchemaTranslator):
     # Reference: https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-input-messages
     INPUT_VALUE_KEYS = ["gen_ai.input.messages", "gen_ai.tool.call.arguments"]
     OUTPUT_VALUE_KEYS = ["gen_ai.output.messages", "gen_ai.tool.call.result"]
+
+    # Model name attribute keys from OTEL GenAI semantic conventions
+    # Reference: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+    MODEL_NAME_KEYS = ["gen_ai.response.model", "gen_ai.request.model"]
+    LLM_PROVIDER_KEY = "gen_ai.provider.name"

--- a/mlflow/tracing/otel/translation/open_inference.py
+++ b/mlflow/tracing/otel/translation/open_inference.py
@@ -44,3 +44,9 @@ class OpenInferenceTranslator(OtelSchemaTranslator):
     # Reference: https://github.com/Arize-ai/openinference/blob/c80c81b8d6fa564598bd359cdd7313f4472ceca8/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
     INPUT_VALUE_KEYS = ["input.value"]
     OUTPUT_VALUE_KEYS = ["output.value"]
+
+    # Model name attribute key
+    # Reference: https://github.com/Arize-ai/openinference/blob/c80c81b8d6fa564598bd359cdd7313f4472ceca8/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L45
+    MODEL_NAME_KEYS = ["llm.model_name", "embedding.model_name"]
+    # https://github.com/Arize-ai/openinference/blob/c80c81b8d6fa564598bd359cdd7313f4472ceca8/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L49
+    LLM_PROVIDER_KEY = "llm.provider"

--- a/mlflow/tracing/otel/translation/traceloop.py
+++ b/mlflow/tracing/otel/translation/traceloop.py
@@ -49,6 +49,9 @@ class TraceloopTranslator(OtelSchemaTranslator):
     ]
     OUTPUT_VALUE_KEYS = ["traceloop.entity.output", re.compile(r"gen_ai\.completion\.\d+\.content")]
 
+    # https://github.com/traceloop/openllmetry/blob/e66894fd7f8324bd7b2972d7f727da39e7d93181/packages/opentelemetry-semantic-conventions-ai/opentelemetry/semconv_ai/__init__.py#L70
+    LLM_PROVIDER_KEY = "gen_ai.system"
+
     def get_attribute_value(
         self, attributes: dict[str, Any], valid_keys: list[str | re.Pattern] | None = None
     ) -> Any:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -278,12 +278,13 @@ def calculate_cost_by_model_and_token_usage(
                 _logger.debug(
                     f"Failed to calculate cost for model {model_name}: {e}", exc_info=True
                 )
-                return
+                return None
         else:
             _logger.debug(
                 f"Failed to calculate cost for model {model_name} without provider: {e}",
                 exc_info=True,
             )
+            return None
 
     return {
         CostKey.INPUT_COST: input_cost_usd,

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -20,11 +20,13 @@ from mlflow.tracing.constant import (
     ASSESSMENT_ID_PREFIX,
     TRACE_ID_V4_PREFIX,
     TRACE_REQUEST_ID_PREFIX,
-    CostKey,
     SpanAttributeKey,
     TokenUsageKey,
     TraceMetadataKey,
     TraceSizeStatsKey,
+)
+from mlflow.tracing.constant import (
+    CostKey as CostKey,
 )
 from mlflow.utils.mlflow_tags import IMMUTABLE_TAGS
 from mlflow.version import IS_TRACING_SDK_ONLY
@@ -235,37 +237,59 @@ def calculate_span_cost(span: LiveSpan) -> dict[str, float] | None:
         Dictionary with input_cost, output_cost, and total_cost in USD,
         or None if cost cannot be calculated.
     """
+    model_name = span.get_attribute(SpanAttributeKey.MODEL)
+    usage = span.get_attribute(SpanAttributeKey.CHAT_USAGE)
+    model_provider = span.get_attribute(SpanAttributeKey.MODEL_PROVIDER)
+    return calculate_cost_by_model_and_token_usage(model_name, usage, model_provider)
+
+
+def calculate_cost_by_model_and_token_usage(
+    model_name: str | None, usage: dict[str, int] | None, model_provider: str | None = None
+) -> dict[str, float] | None:
+    if not model_name or not usage:
+        return None
+
     try:
         from litellm import cost_per_token
     except ImportError:
         _logger.debug("LiteLLM not available for cost calculation")
         return None
 
-    model_name = span.get_attribute(SpanAttributeKey.MODEL)
-    usage = span.get_attribute(SpanAttributeKey.CHAT_USAGE)
+    prompt_tokens = usage.get(TokenUsageKey.INPUT_TOKENS, 0)
+    completion_tokens = usage.get(TokenUsageKey.OUTPUT_TOKENS, 0)
 
-    if not model_name or not usage:
+    if prompt_tokens == 0 and completion_tokens == 0:
         return None
 
     try:
-        prompt_tokens = usage.get(TokenUsageKey.INPUT_TOKENS, 0)
-        completion_tokens = usage.get(TokenUsageKey.OUTPUT_TOKENS, 0)
-
-        if prompt_tokens == 0 and completion_tokens == 0:
-            return None
-
         input_cost_usd, output_cost_usd = cost_per_token(
             model=model_name, prompt_tokens=prompt_tokens, completion_tokens=completion_tokens
         )
-
-        return {
-            CostKey.INPUT_COST: input_cost_usd,
-            CostKey.OUTPUT_COST: output_cost_usd,
-            CostKey.TOTAL_COST: input_cost_usd + output_cost_usd,
-        }
     except Exception as e:
-        _logger.debug(f"Failed to calculate cost for span {span.span_id}: {e}", exc_info=True)
-        return None
+        if model_provider:
+            try:
+                model_name = f"{json.loads(model_provider)}/{json.loads(model_name)}"
+                input_cost_usd, output_cost_usd = cost_per_token(
+                    model=model_name,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                )
+            except Exception as e:
+                _logger.debug(
+                    f"Failed to calculate cost for model {model_name}: {e}", exc_info=True
+                )
+                return
+        else:
+            _logger.debug(
+                f"Failed to calculate cost for model {model_name} without provider: {e}",
+                exc_info=True,
+            )
+
+    return {
+        CostKey.INPUT_COST: input_cost_usd,
+        CostKey.OUTPUT_COST: output_cost_usd,
+        CostKey.TOTAL_COST: input_cost_usd + output_cost_usd,
+    }
 
 
 def get_otel_attribute(span: trace_api.Span, key: str) -> str | None:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -267,12 +267,15 @@ def calculate_cost_by_model_and_token_usage(
         )
     except Exception as e:
         if model_provider:
+            # pass model_provider only in exception case to avoid invalid model_provider
+            # being used when model_name itself is enough to calculate cost, since model_provider
+            # field can be with any value and litellm may not support it.
             try:
-                model_name = f"{json.loads(model_provider)}/{json.loads(model_name)}"
                 input_cost_usd, output_cost_usd = cost_per_token(
                     model=model_name,
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
+                    custom_llm_provider=model_provider,
                 )
             except Exception as e:
                 _logger.debug(

--- a/tests/agno/test_agno_tracing.py
+++ b/tests/agno/test_agno_tracing.py
@@ -81,6 +81,7 @@ def test_run_simple_autolog(simple_agent):
     assert spans[1].name == "Claude.invoke"
     assert spans[1].inputs["messages"][-1]["content"] == "Capital of France?"
     assert spans[1].outputs["content"][0]["text"] == "Paris"
+    assert spans[1].model_name == "claude-sonnet-4-20250514"
 
     purge_traces()
 
@@ -143,6 +144,7 @@ async def test_arun_simple_autolog(simple_agent):
     assert spans[1].name == "Claude.ainvoke"
     assert spans[1].inputs["messages"][-1]["content"] == "Capital of France?"
     assert spans[1].outputs["content"][0]["text"] == "Paris"
+    assert spans[1].model_name == "claude-sonnet-4-20250514"
 
 
 @pytest.mark.skipif(IS_AGNO_V2, reason="Test uses V1 patching behavior")

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -379,7 +379,7 @@ def test_translate_model_name_from_otel(translator: OtelSchemaTranslator, model_
     span.parent_id = "parent_123"
     # Test with the first MODEL_NAME_KEY from the translator
     model_attr_key = translator.MODEL_NAME_KEYS[0]
-    span_dict = {"attributes": {model_attr_key: model_value}}
+    span_dict = {"attributes": {model_attr_key: json.dumps(model_value)}}
     span.to_dict.return_value = span_dict
 
     result = translate_span_when_storing(span)
@@ -400,7 +400,7 @@ def test_translate_model_name_from_otel(translator: OtelSchemaTranslator, model_
 def test_translate_model_provider_from_otel(translator: OtelSchemaTranslator, provider_value: str):
     span = mock.Mock(spec=Span)
     span.parent_id = "parent_123"
-    span_dict = {"attributes": {translator.LLM_PROVIDER_KEY: provider_value}}
+    span_dict = {"attributes": {translator.LLM_PROVIDER_KEY: json.dumps(provider_value)}}
     span.to_dict.return_value = span_dict
 
     result = translate_span_when_storing(span)
@@ -440,7 +440,7 @@ def test_translate_model_name_from_inputs_outputs(
     [
         (
             {
-                "gen_ai.response.model": "gpt-4o-mini",
+                "gen_ai.response.model": '"gpt-4o-mini"',
                 SpanAttributeKey.INPUTS: json.dumps({"model": "different-model"}),
             },
             "gpt-4o-mini",
@@ -448,7 +448,7 @@ def test_translate_model_name_from_inputs_outputs(
         (
             {
                 SpanAttributeKey.MODEL: json.dumps("existing-model"),
-                "gen_ai.response.model": "new-model",
+                "gen_ai.response.model": '"new-model"',
             },
             "existing-model",
         ),
@@ -487,7 +487,7 @@ def test_translate_cost_from_otel(translator: OtelSchemaTranslator, mock_litellm
         "attributes": {
             translator.INPUT_TOKEN_KEY: 10,
             translator.OUTPUT_TOKEN_KEY: 20,
-            model_attr_key: "gpt-4o-mini",
+            model_attr_key: '"gpt-4o-mini"',
         }
     }
     span.to_dict.return_value = span_dict
@@ -515,8 +515,8 @@ def test_translate_cost_with_model_provider(translator: OtelSchemaTranslator, mo
         "attributes": {
             translator.INPUT_TOKEN_KEY: 10,
             translator.OUTPUT_TOKEN_KEY: 20,
-            model_attr_key: "gpt-4o-mini",
-            translator.LLM_PROVIDER_KEY: "openai",
+            model_attr_key: '"gpt-4o-mini"',
+            translator.LLM_PROVIDER_KEY: '"openai"',
         }
     }
     span.to_dict.return_value = span_dict
@@ -548,7 +548,7 @@ def test_translate_cost_with_model_provider(translator: OtelSchemaTranslator, mo
             {
                 "gen_ai.usage.input_tokens": 5,
                 "gen_ai.usage.output_tokens": 10,
-                "gen_ai.response.model": "claude-3-5-sonnet-20241022",
+                "gen_ai.response.model": '"claude-3-5-sonnet-20241022"',
             },
             True,
         ),
@@ -561,7 +561,7 @@ def test_translate_cost_with_model_provider(translator: OtelSchemaTranslator, mo
         ),
         (
             {
-                "gen_ai.response.model": "gpt-4o-mini",
+                "gen_ai.response.model": '"gpt-4o-mini"',
             },
             False,
         ),

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -365,3 +365,228 @@ def test_translate_inputs_outputs_edge_cases(
 def test_sanitize_attributes(attributes: dict[str, Any], expected_attributes: dict[str, Any]):
     result = sanitize_attributes(attributes)
     assert result == expected_attributes
+
+
+@pytest.mark.parametrize(
+    ("translator", "model_value"),
+    [
+        (GenAiTranslator, "gpt-4o-mini"),
+        (OpenInferenceTranslator, "claude-3-5-sonnet-20241022"),
+    ],
+)
+def test_translate_model_name_from_otel(translator: OtelSchemaTranslator, model_value: str):
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    # Test with the first MODEL_NAME_KEY from the translator
+    model_attr_key = translator.MODEL_NAME_KEYS[0]
+    span_dict = {"attributes": {model_attr_key: model_value}}
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    assert SpanAttributeKey.MODEL in result["attributes"]
+    model = json.loads(result["attributes"][SpanAttributeKey.MODEL])
+    assert model == model_value
+
+
+@pytest.mark.parametrize(
+    ("translator", "provider_value"),
+    [
+        (GenAiTranslator, "openai"),
+        (OpenInferenceTranslator, "anthropic"),
+        (TraceloopTranslator, "azure"),
+    ],
+)
+def test_translate_model_provider_from_otel(translator: OtelSchemaTranslator, provider_value: str):
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {"attributes": {translator.LLM_PROVIDER_KEY: provider_value}}
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    assert SpanAttributeKey.MODEL_PROVIDER in result["attributes"]
+    provider = json.loads(result["attributes"][SpanAttributeKey.MODEL_PROVIDER])
+    assert provider == provider_value
+
+
+@pytest.mark.parametrize(
+    ("inputs_outputs_key", "model_value"),
+    [
+        (
+            SpanAttributeKey.INPUTS,
+            {"model": "mistral-large-latest", "temperature": 0.7, "messages": []},
+        ),
+        (SpanAttributeKey.OUTPUTS, {"model": "gpt-3.5-turbo", "choices": []}),
+    ],
+)
+def test_translate_model_name_from_inputs_outputs(
+    inputs_outputs_key: str, model_value: dict[str, Any]
+):
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {"attributes": {inputs_outputs_key: json.dumps(model_value)}}
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    assert SpanAttributeKey.MODEL in result["attributes"]
+    model = json.loads(result["attributes"][SpanAttributeKey.MODEL])
+    assert model == model_value["model"]
+
+
+@pytest.mark.parametrize(
+    ("attributes", "expected_model"),
+    [
+        (
+            {
+                "gen_ai.response.model": "gpt-4o-mini",
+                SpanAttributeKey.INPUTS: json.dumps({"model": "different-model"}),
+            },
+            "gpt-4o-mini",
+        ),
+        (
+            {
+                SpanAttributeKey.MODEL: json.dumps("existing-model"),
+                "gen_ai.response.model": "new-model",
+            },
+            "existing-model",
+        ),
+        (
+            {SpanAttributeKey.INPUTS: json.dumps({"temperature": 0.7, "messages": []})},
+            None,
+        ),
+        ({}, None),
+    ],
+)
+def test_translate_model_name_edge_cases(attributes: dict[str, Any], expected_model: str | None):
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {"attributes": attributes}
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    if expected_model:
+        assert SpanAttributeKey.MODEL in result["attributes"]
+        model = json.loads(result["attributes"][SpanAttributeKey.MODEL])
+        assert model == expected_model
+    else:
+        assert SpanAttributeKey.MODEL not in result["attributes"]
+
+
+@pytest.mark.parametrize(
+    "translator",
+    [OpenInferenceTranslator, GenAiTranslator],
+)
+def test_translate_cost_from_otel(translator: OtelSchemaTranslator, mock_litellm_cost):
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    model_attr_key = translator.MODEL_NAME_KEYS[0]
+    span_dict = {
+        "attributes": {
+            translator.INPUT_TOKEN_KEY: 10,
+            translator.OUTPUT_TOKEN_KEY: 20,
+            model_attr_key: "gpt-4o-mini",
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    assert SpanAttributeKey.CHAT_COST in result["attributes"]
+    cost = json.loads(result["attributes"][SpanAttributeKey.CHAT_COST])
+    assert cost == {
+        "input_cost": 10.0,
+        "output_cost": 40.0,
+        "total_cost": 50.0,
+    }
+
+
+@pytest.mark.parametrize(
+    "translator",
+    [OpenInferenceTranslator, GenAiTranslator],
+)
+def test_translate_cost_with_model_provider(translator: OtelSchemaTranslator, mock_litellm_cost):
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    model_attr_key = translator.MODEL_NAME_KEYS[0]
+    span_dict = {
+        "attributes": {
+            translator.INPUT_TOKEN_KEY: 10,
+            translator.OUTPUT_TOKEN_KEY: 20,
+            model_attr_key: "gpt-4o-mini",
+            translator.LLM_PROVIDER_KEY: "openai",
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    # Both model and provider should be stored separately
+    assert SpanAttributeKey.MODEL in result["attributes"]
+    assert SpanAttributeKey.MODEL_PROVIDER in result["attributes"]
+    model = json.loads(result["attributes"][SpanAttributeKey.MODEL])
+    provider = json.loads(result["attributes"][SpanAttributeKey.MODEL_PROVIDER])
+    assert model == "gpt-4o-mini"
+    assert provider == "openai"
+
+    # Cost should still be calculated
+    assert SpanAttributeKey.CHAT_COST in result["attributes"]
+    cost = json.loads(result["attributes"][SpanAttributeKey.CHAT_COST])
+    assert cost == {
+        "input_cost": 10.0,
+        "output_cost": 40.0,
+        "total_cost": 50.0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("attributes", "should_have_cost"),
+    [
+        (
+            {
+                "gen_ai.usage.input_tokens": 5,
+                "gen_ai.usage.output_tokens": 10,
+                "gen_ai.response.model": "claude-3-5-sonnet-20241022",
+            },
+            True,
+        ),
+        (
+            {
+                "gen_ai.usage.input_tokens": 5,
+                "gen_ai.usage.output_tokens": 10,
+            },
+            False,
+        ),
+        (
+            {
+                "gen_ai.response.model": "gpt-4o-mini",
+            },
+            False,
+        ),
+        ({}, False),
+    ],
+)
+def test_translate_cost_edge_cases(
+    attributes: dict[str, Any], should_have_cost: bool, mock_litellm_cost
+):
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {"attributes": attributes}
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    if should_have_cost:
+        assert SpanAttributeKey.CHAT_COST in result["attributes"]
+        cost = json.loads(result["attributes"][SpanAttributeKey.CHAT_COST])
+        input_cost = attributes.get("gen_ai.usage.input_tokens", 0) * 1.0
+        output_cost = attributes.get("gen_ai.usage.output_tokens", 0) * 2.0
+        assert cost == {
+            "input_cost": input_cost,
+            "output_cost": output_cost,
+            "total_cost": input_cost + output_cost,
+        }
+    else:
+        assert SpanAttributeKey.CHAT_COST not in result["attributes"]

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -494,8 +494,8 @@ def test_translate_cost_from_otel(translator: OtelSchemaTranslator, mock_litellm
 
     result = translate_span_when_storing(span)
 
-    assert SpanAttributeKey.CHAT_COST in result["attributes"]
-    cost = json.loads(result["attributes"][SpanAttributeKey.CHAT_COST])
+    assert SpanAttributeKey.LLM_COST in result["attributes"]
+    cost = json.loads(result["attributes"][SpanAttributeKey.LLM_COST])
     assert cost == {
         "input_cost": 10.0,
         "output_cost": 40.0,
@@ -532,8 +532,8 @@ def test_translate_cost_with_model_provider(translator: OtelSchemaTranslator, mo
     assert provider == "openai"
 
     # Cost should still be calculated
-    assert SpanAttributeKey.CHAT_COST in result["attributes"]
-    cost = json.loads(result["attributes"][SpanAttributeKey.CHAT_COST])
+    assert SpanAttributeKey.LLM_COST in result["attributes"]
+    cost = json.loads(result["attributes"][SpanAttributeKey.LLM_COST])
     assert cost == {
         "input_cost": 10.0,
         "output_cost": 40.0,
@@ -579,8 +579,8 @@ def test_translate_cost_edge_cases(
     result = translate_span_when_storing(span)
 
     if should_have_cost:
-        assert SpanAttributeKey.CHAT_COST in result["attributes"]
-        cost = json.loads(result["attributes"][SpanAttributeKey.CHAT_COST])
+        assert SpanAttributeKey.LLM_COST in result["attributes"]
+        cost = json.loads(result["attributes"][SpanAttributeKey.LLM_COST])
         input_cost = attributes.get("gen_ai.usage.input_tokens", 0) * 1.0
         output_cost = attributes.get("gen_ai.usage.output_tokens", 0) * 2.0
         assert cost == {
@@ -589,4 +589,4 @@ def test_translate_cost_edge_cases(
             "total_cost": input_cost + output_cost,
         }
     else:
-        assert SpanAttributeKey.CHAT_COST not in result["attributes"]
+        assert SpanAttributeKey.LLM_COST not in result["attributes"]


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20331/files) to review incremental changes.
- [**stack/span_model_cost_otel_translation**](https://github.com/mlflow/mlflow/pull/20331) [[Files changed](https://github.com/mlflow/mlflow/pull/20331/files)]
  - [stack/trace_total_cost](https://github.com/mlflow/mlflow/pull/20337) [[Files changed](https://github.com/mlflow/mlflow/pull/20337/files/6b1b04129ee09ed315a77c7516496c32ae0250ec..397717813875e697761e3922d56385665b19fb6b)]
    - [stack/trace_cost_ui](https://github.com/mlflow/mlflow/pull/20338) [[Files changed](https://github.com/mlflow/mlflow/pull/20338/files/397717813875e697761e3922d56385665b19fb6b..f095d98e5cdbcdc98cfc5b7beae5c2f57378bac4)]
      - [stack/trace_cost_for_otel_translation](https://github.com/mlflow/mlflow/pull/20339) [[Files changed](https://github.com/mlflow/mlflow/pull/20339/files/f095d98e5cdbcdc98cfc5b7beae5c2f57378bac4..ef9a01340eb727a2ca44a120d6dc24e796504bba)]
        - [stack/cost_metrics](https://github.com/mlflow/mlflow/pull/20402) [[Files changed](https://github.com/mlflow/mlflow/pull/20402/files/ef9a01340eb727a2ca44a120d6dc24e796504bba..93e1cde58a7eb0ded3fda39c17443360cb8e8591)]
          - [stack/span_cost_metrics_query](https://github.com/mlflow/mlflow/pull/20403) [[Files changed](https://github.com/mlflow/mlflow/pull/20403/files/93e1cde58a7eb0ded3fda39c17443360cb8e8591..5f568f909ed733a345faadacb496ca72ebc52e05)]
            - [stack/cost_chart](https://github.com/mlflow/mlflow/pull/20404) [[Files changed](https://github.com/mlflow/mlflow/pull/20404/files/5f568f909ed733a345faadacb496ca72ebc52e05..854464e79ac7ee82a28a0492b08b1a911b5e5e2b)]
              - [stack/cost_chart_over_time](https://github.com/mlflow/mlflow/pull/20440) [[Files changed](https://github.com/mlflow/mlflow/pull/20440/files/854464e79ac7ee82a28a0492b08b1a911b5e5e2b..7811ba3fd3644f87fbeaf2c1e586b57f94a6eae2)]
                - [stack/cost_chart_model_selection](https://github.com/mlflow/mlflow/pull/20455) [[Files changed](https://github.com/mlflow/mlflow/pull/20455/files/7811ba3fd3644f87fbeaf2c1e586b57f94a6eae2..f927e1d5e04ed01be743b7ae7e6ffca82d922e0c)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Support model name, model provider and cost tracking translation for 3p otel libs.
We need to extract model provider because sometimes the model_name only doesn't work with litellm's cost calculation process, it causes error like:
```
Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers
Traceback (most recent call last):
  File "/Users/serena.ruan/Documents/repos/mlflow/mlflow/tracing/utils/__init__.py", line 265, in calculate_cost_by_model_and_token_usage
    input_cost_usd, output_cost_usd = cost_per_token(
  File "/Users/serena.ruan/miniconda3/envs/mlflow/lib/python3.10/site-packages/litellm/cost_calculator.py", line 218, in cost_per_token
    _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
  File "/Users/serena.ruan/miniconda3/envs/mlflow/lib/python3.10/site-packages/litellm/litellm_core_utils/get_llm_provider_logic.py", line 391, in get_llm_provider
    raise e
  File "/Users/serena.ruan/miniconda3/envs/mlflow/lib/python3.10/site-packages/litellm/litellm_core_utils/get_llm_provider_logic.py", line 368, in get_llm_provider
    raise litellm.exceptions.BadRequestError(  # type: ignore
litellm.exceptions.BadRequestError: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model="gpt-4.1-2025-04-14"
```
So in this case we should try to extract model provider from the attributes and modify the model_name to add provider as a prefix.

Verified this works with three types of 3p instrumentation, more tests will be done for the rest support

https://github.com/user-attachments/assets/3ab6ed7c-6ed9-4503-8b2e-fb9a0105e8f1


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
