### PR TITLE
[UI] Render cost breakdown for trace info

### DIFF
--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -235,5 +235,27 @@ class TraceInfo(_MlflowObject):
             return json.loads(usage_json)
         return None
 
+    @property
+    def cost(self) -> dict[str, float] | None:
+        """
+        Returns the aggregated cost for the trace in USD.
+
+        Returns:
+            A dictionary containing the aggregated LLM cost for the trace.
+            - "input_cost": The total cost for input tokens.
+            - "output_cost": The total cost for output tokens.
+            - "total_cost": Sum of input and output costs.
+
+        .. note::
+
+            The cost tracking is calculated based on token usage and model pricing
+            from LiteLLM. Cost tracking is not supported for all LLM providers.
+            Refer to the MLflow Tracing documentation for which providers
+            support cost tracking.
+        """
+        if cost_json := self.trace_metadata.get(TraceMetadataKey.COST):
+            return json.loads(cost_json)
+        return None
+
     def _is_v4(self) -> bool:
         return self.trace_location.uc_schema is not None

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -998,6 +998,10 @@
     "defaultMessage": "finetuning",
     "description": "A short label for experiments focused on model finetuning"
   },
+  "62NIhn": {
+    "defaultMessage": "Cost",
+    "description": "Label for the cost section"
+  },
   "64SfR8": {
     "defaultMessage": "enter a model identifier",
     "description": "Link text to switch to direct model identifier input"
@@ -1505,6 +1509,10 @@
   "9I8EpX": {
     "defaultMessage": "Automatic evaluation",
     "description": "Accordion section header for automatic evaluation settings"
+  },
+  "9IIkwh": {
+    "defaultMessage": "Cost breakdown",
+    "description": "Header for cost breakdown"
   },
   "9IN1I8": {
     "defaultMessage": "Select as compared version",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -77,6 +77,7 @@ import {
 import { normalizeOpenAIResponsesStreamingOutput } from './chat-utils/openai';
 import {
   ASSESSMENT_SESSION_METADATA_KEY,
+  COST_METADATA_KEY,
   SPAN_ATTRIBUTE_COST_KEY,
   SPAN_ATTRIBUTE_MODEL_KEY,
   TOKEN_USAGE_METADATA_KEY,
@@ -1374,6 +1375,11 @@ export const getTraceTokenUsage = (
   traceInfo: ModelTraceInfoV3,
 ): { input_tokens?: number; output_tokens?: number; total_tokens?: number } =>
   parseJSONSafe(traceInfo?.trace_metadata?.[TOKEN_USAGE_METADATA_KEY] ?? '{}');
+
+export const getTraceCost = (
+  traceInfo: ModelTraceInfoV3,
+): { input_cost?: number; output_cost?: number; total_cost?: number } =>
+  parseJSONSafe(traceInfo?.trace_metadata?.[COST_METADATA_KEY] ?? '{}');
 
 export const isSessionLevelAssessment = (assessment: Assessment): boolean => {
   return !isEmpty(assessment.metadata?.[ASSESSMENT_SESSION_METADATA_KEY]);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerCostHoverCard.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerCostHoverCard.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DesignSystemProvider } from '@databricks/design-system';
+import { IntlProvider } from '@databricks/i18n';
+
+import { ModelTraceExplorerCostHoverCard, isTraceCostType, type TraceCost } from './ModelTraceExplorerCostHoverCard';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <IntlProvider locale="en">
+    <DesignSystemProvider>{children}</DesignSystemProvider>
+  </IntlProvider>
+);
+
+describe('isTraceCostType', () => {
+  it('should return true for valid TraceCost objects', () => {
+    const validCost: TraceCost = {
+      input_cost: 0.001,
+      output_cost: 0.002,
+      total_cost: 0.003,
+    };
+    expect(isTraceCostType(validCost)).toBe(true);
+  });
+
+  it('should return true for TraceCost with zero values', () => {
+    const zeroCost = {
+      input_cost: 0,
+      output_cost: 0,
+      total_cost: 0,
+    };
+    expect(isTraceCostType(zeroCost)).toBe(true);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isTraceCostType(undefined)).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isTraceCostType(null)).toBe(false);
+  });
+
+  it('should return false for empty object', () => {
+    expect(isTraceCostType({})).toBe(false);
+  });
+
+  it('should return false for object missing input_cost', () => {
+    expect(isTraceCostType({ output_cost: 0.002, total_cost: 0.003 })).toBe(false);
+  });
+
+  it('should return false for object missing output_cost', () => {
+    expect(isTraceCostType({ input_cost: 0.001, total_cost: 0.003 })).toBe(false);
+  });
+
+  it('should return false for object missing total_cost', () => {
+    expect(isTraceCostType({ input_cost: 0.001, output_cost: 0.002 })).toBe(false);
+  });
+
+  it('should return false for non-object values', () => {
+    expect(isTraceCostType('string')).toBe(false);
+    expect(isTraceCostType(123)).toBe(false);
+    expect(isTraceCostType([])).toBe(false);
+  });
+});
+
+describe('ModelTraceExplorerCostHoverCard', () => {
+  it('renders cost label and total cost', () => {
+    const cost: TraceCost = {
+      input_cost: 0.001,
+      output_cost: 0.002,
+      total_cost: 0.003,
+    };
+    render(<ModelTraceExplorerCostHoverCard cost={cost} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('Cost')).toBeInTheDocument();
+    expect(screen.getByText('$0.003')).toBeInTheDocument();
+  });
+
+  it('renders formatted cost with appropriate precision', () => {
+    const cost: TraceCost = {
+      input_cost: 0.000022,
+      output_cost: 0.000028,
+      total_cost: 0.00005,
+    };
+    render(<ModelTraceExplorerCostHoverCard cost={cost} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('$0.00005')).toBeInTheDocument();
+  });
+
+  it('shows cost breakdown on hover', async () => {
+    const cost: TraceCost = {
+      input_cost: 0.001234,
+      output_cost: 0.002345,
+      total_cost: 0.003579,
+    };
+    render(<ModelTraceExplorerCostHoverCard cost={cost} />, { wrapper: Wrapper });
+
+    // Hover over the cost tag to trigger the hover card
+    const costTrigger = screen.getByText('$0.003579');
+    await userEvent.hover(costTrigger);
+
+    // Check that the breakdown is shown
+    expect(await screen.findByText('Cost breakdown')).toBeInTheDocument();
+    expect(screen.getByText('Input cost')).toBeInTheDocument();
+    expect(screen.getByText('Output cost')).toBeInTheDocument();
+    expect(screen.getByText('Total')).toBeInTheDocument();
+    expect(screen.getByText('$0.001234')).toBeInTheDocument();
+    expect(screen.getByText('$0.002345')).toBeInTheDocument();
+  });
+
+  it('handles zero costs correctly', async () => {
+    const cost: TraceCost = {
+      input_cost: 0,
+      output_cost: 0,
+      total_cost: 0,
+    };
+    render(<ModelTraceExplorerCostHoverCard cost={cost} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('$0.00')).toBeInTheDocument();
+
+    // Hover to see breakdown
+    const costTrigger = screen.getByText('$0.00');
+    await userEvent.hover(costTrigger);
+
+    expect(await screen.findByText('Cost breakdown')).toBeInTheDocument();
+  });
+
+  it('handles large costs correctly', () => {
+    const cost: TraceCost = {
+      input_cost: 1.5,
+      output_cost: 2.5,
+      total_cost: 4.0,
+    };
+    render(<ModelTraceExplorerCostHoverCard cost={cost} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('$4.00')).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerCostHoverCard.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerCostHoverCard.tsx
@@ -1,0 +1,122 @@
+import { isObject } from 'lodash';
+import { useMemo } from 'react';
+
+import { HoverCard, Tag, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import { formatCostUSD } from './CostUtils';
+
+export interface TraceCost {
+  input_cost: number;
+  output_cost: number;
+  total_cost: number;
+}
+
+export const isTraceCostType = (value?: unknown): value is TraceCost => {
+  return (
+    value !== undefined && isObject(value) && 'input_cost' in value && 'output_cost' in value && 'total_cost' in value
+  );
+};
+
+export const ModelTraceExplorerCostHoverCard = ({ cost }: { cost: TraceCost }) => {
+  const { theme } = useDesignSystemTheme();
+
+  const totalCost = useMemo(() => formatCostUSD(cost.total_cost), [cost.total_cost]);
+  const inputCost = useMemo(() => formatCostUSD(cost.input_cost), [cost.input_cost]);
+  const outputCost = useMemo(() => formatCostUSD(cost.output_cost), [cost.output_cost]);
+
+  return (
+    <HoverCard
+      trigger={
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexDirection: 'row',
+            gap: theme.spacing.sm,
+          }}
+        >
+          <Typography.Text size="md" color="secondary">
+            <FormattedMessage defaultMessage="Cost" description="Label for the cost section" />
+          </Typography.Text>
+          <Tag componentId="shared.model-trace-explorer.header-details.cost.tag" color="lime">
+            <span>{totalCost}</span>
+          </Tag>
+        </div>
+      }
+      content={
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.md,
+            padding: theme.spacing.sm,
+            maxWidth: 400,
+          }}
+        >
+          <Typography.Title level={3} withoutMargins>
+            <FormattedMessage defaultMessage="Cost breakdown" description="Header for cost breakdown" />
+          </Typography.Title>
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: theme.spacing.sm,
+            }}
+          >
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
+              <Typography.Text size="md">
+                <FormattedMessage defaultMessage="Input cost" description="Label for input cost" />
+              </Typography.Text>
+              <Tag componentId="shared.model-trace-explorer.cost-hovercard.input-cost.tag">
+                <span>{inputCost}</span>
+              </Tag>
+            </div>
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
+              <Typography.Text size="md">
+                <FormattedMessage defaultMessage="Output cost" description="Label for output cost" />
+              </Typography.Text>
+              <Tag componentId="shared.model-trace-explorer.cost-hovercard.output-cost.tag">
+                <span>{outputCost}</span>
+              </Tag>
+            </div>
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                paddingTop: theme.spacing.sm,
+                borderTop: `1px solid ${theme.colors.borderDecorative}`,
+              }}
+            >
+              <Typography.Text size="md" bold>
+                <FormattedMessage defaultMessage="Total" description="Label for total cost" />
+              </Typography.Text>
+              <Tag componentId="shared.model-trace-explorer.cost-hovercard.total-cost.tag">
+                <span>{totalCost}</span>
+              </Tag>
+            </div>
+          </div>
+        </div>
+      }
+      side="bottom"
+      align="start"
+    />
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceHeaderDetails.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceHeaderDetails.tsx
@@ -16,10 +16,12 @@ import type { ModelTrace, ModelTraceInfoV3, ModelTraceState } from './ModelTrace
 import {
   createTraceV4LongIdentifier,
   doesTraceSupportV4API,
+  getTraceCost,
   getTraceTokenUsage,
   isV3ModelTraceInfo,
 } from './ModelTraceExplorer.utils';
 import { ModelTraceHeaderMetricSection } from './ModelTraceExplorerMetricSection';
+import { isTraceCostType, ModelTraceExplorerCostHoverCard, type TraceCost } from './ModelTraceExplorerCostHoverCard';
 import {
   isTokenUsageType,
   ModelTraceExplorerTokenUsageHoverCard,
@@ -52,6 +54,11 @@ export const ModelTraceHeaderDetails = ({ modelTraceInfo }: { modelTraceInfo: Mo
 
   const tokenUsage = useMemo<Partial<TokenUsage> | undefined>(
     () => getTraceTokenUsage(modelTraceInfo as ModelTraceInfoV3) as Partial<TokenUsage> | undefined,
+    [modelTraceInfo],
+  );
+
+  const cost = useMemo<Partial<TraceCost> | undefined>(
+    () => getTraceCost(modelTraceInfo as ModelTraceInfoV3) as Partial<TraceCost> | undefined,
     [modelTraceInfo],
   );
 
@@ -111,6 +118,7 @@ export const ModelTraceHeaderDetails = ({ modelTraceInfo }: { modelTraceInfo: Mo
           />
         )}
         {isTokenUsageType(tokenUsage) && <ModelTraceExplorerTokenUsageHoverCard tokenUsage={tokenUsage} />}
+        {isTraceCostType(cost) && <ModelTraceExplorerCostHoverCard cost={cost} />}
         {latency && (
           <ModelTraceHeaderMetricSection
             label={<FormattedMessage defaultMessage="Latency" description="Label for the latency section" />}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/constants.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/constants.ts
@@ -13,6 +13,7 @@ export const SESSION_ID_METADATA_KEY = 'mlflow.trace.session';
 export const SOURCE_NAME_METADATA_KEY = 'mlflow.source.name';
 export const SOURCE_TYPE_METADATA_KEY = 'mlflow.source.type';
 export const TOKEN_USAGE_METADATA_KEY = 'mlflow.trace.tokenUsage';
+export const COST_METADATA_KEY = 'mlflow.trace.cost';
 export const MLFLOW_TRACE_USER_KEY = 'mlflow.trace.user';
 
 // Span attribute keys for model and cost info

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -29,6 +29,7 @@ export {
   SOURCE_NAME_METADATA_KEY,
   SOURCE_TYPE_METADATA_KEY,
   TOKEN_USAGE_METADATA_KEY,
+  COST_METADATA_KEY,
   MLFLOW_TRACE_USER_KEY,
   SELECTED_TRACE_ID_QUERY_PARAM,
   ASSESSMENT_SESSION_METADATA_KEY,
@@ -65,7 +66,12 @@ export { SingleChatTurnMessages } from './session-view/SingleChatTurnMessages';
 export { ModelTraceExplorerChatMessage } from './right-pane/ModelTraceExplorerChatMessage';
 export { SpanModelCostBadge } from './right-pane/SpanModelCostBadge';
 export { SingleChatTurnAssessments } from './session-view/SingleChatTurnAssessments';
-export { getTraceTokenUsage, createTraceV4LongIdentifier, isSessionLevelAssessment } from './ModelTraceExplorer.utils';
+export {
+  getTraceTokenUsage,
+  getTraceCost,
+  createTraceV4LongIdentifier,
+  isSessionLevelAssessment,
+} from './ModelTraceExplorer.utils';
 export { CompareModelTraceExplorer } from './CompareModelTraceExplorer';
 export { useGetTracesById } from './hooks/useGetTracesById';
 export {

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -11,6 +11,8 @@ class TraceMetadataKey:
     SIZE_STATS = "mlflow.trace.sizeStats"
     # Aggregated token usage information in a single trace, stored as a dumped JSON string.
     TOKEN_USAGE = "mlflow.trace.tokenUsage"
+    # Aggregated cost information in a single trace, stored as a dumped JSON string (USD).
+    COST = "mlflow.trace.cost"
     # Store the user ID/name of the application request. Do not confuse this with mlflow.user
     # tag, which stores "who created the trace" i.e. developer or system name.
     TRACE_USER = "mlflow.trace.user"

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -22,6 +22,7 @@ from mlflow.tracing.constant import (
 from mlflow.tracing.processor.otel_metrics_mixin import OtelMetricsMixin
 from mlflow.tracing.trace_manager import InMemoryTraceManager, _Trace
 from mlflow.tracing.utils import (
+    aggregate_cost_from_spans,
     aggregate_usage_from_spans,
     get_otel_attribute,
     maybe_get_dependencies_schemas,
@@ -180,6 +181,10 @@ class BaseMlflowSpanProcessor(OtelMetricsMixin, SimpleSpanProcessor):
         # Aggregate token usage information from all spans
         if usage := aggregate_usage_from_spans(trace.span_dict.values()):
             trace.info.request_metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(usage)
+
+        # Aggregate cost information from all spans
+        if cost := aggregate_cost_from_spans(trace.span_dict.values()):
+            trace.info.request_metadata[TraceMetadataKey.COST] = json.dumps(cost)
 
     def _truncate_metadata(self, value: str | None) -> str:
         """Get truncated value of the attribute if it exceeds the maximum length."""

--- a/mlflow/tracing/processor/inference_table.py
+++ b/mlflow/tracing/processor/inference_table.py
@@ -20,6 +20,7 @@ from mlflow.tracing.constant import (
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import (
     _try_get_prediction_context,
+    aggregate_cost_from_spans,
     aggregate_usage_from_spans,
     generate_trace_id_v3,
     get_otel_attribute,
@@ -141,6 +142,10 @@ class InferenceTableSpanProcessor(SimpleSpanProcessor):
             # Aggregate token usage information from all spans
             if usage := aggregate_usage_from_spans(spans):
                 trace.info.request_metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(usage)
+
+            # Aggregate cost information from all spans
+            if cost := aggregate_cost_from_spans(spans):
+                trace.info.request_metadata[TraceMetadataKey.COST] = json.dumps(cost)
 
         super().on_end(span)
 

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -247,7 +247,7 @@ def aggregate_cost_from_spans(spans: list[LiveSpan]) -> dict[str, float] | None:
     def dfs(span: LiveSpan, ancestor_has_cost: bool) -> None:
         nonlocal input_cost, output_cost, total_cost, has_cost_data
 
-        cost = span.get_attribute(SpanAttributeKey.CHAT_COST)
+        cost = span.get_attribute(SpanAttributeKey.LLM_COST)
         span_has_cost = cost is not None
 
         if span_has_cost and not ancestor_has_cost:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -179,12 +179,33 @@ def build_otel_context(trace_id: int, span_id: int) -> trace_api.SpanContext:
     )
 
 
-def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
-    """Aggregate token usage information from all spans in the trace."""
-    input_tokens = 0
-    output_tokens = 0
-    total_tokens = 0
-    has_usage_data = False
+def _aggregate_from_spans(
+    spans: list[LiveSpan],
+    attribute_key: str,
+    input_key: str,
+    output_key: str,
+    total_key: str,
+    default: int | float,
+) -> dict[str, int | float] | None:
+    """Generic aggregation of data from spans using DFS traversal.
+
+    Avoids double-counting by skipping spans whose ancestors already have the data.
+
+    Args:
+        spans: List of spans to aggregate from.
+        attribute_key: The span attribute key to look up.
+        input_key: Key for extracting input value from span data.
+        output_key: Key for extracting output value from span data.
+        total_key: Key for extracting total value from span data.
+        default: Default value (0 for int, 0.0 for float) that also determines return type.
+
+    Returns:
+        Aggregated dictionary with the keys, or None if no data found.
+    """
+    input_val = default
+    output_val = default
+    total_val = default
+    has_data = False
 
     span_id_to_spans = {span.span_id: span for span in spans}
     children_map: defaultdict[str, list[LiveSpan]] = defaultdict(list)
@@ -197,81 +218,57 @@ def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
         else:
             roots.append(span)
 
-    def dfs(span: LiveSpan, ancestor_has_usage: bool) -> None:
-        nonlocal input_tokens, output_tokens, total_tokens, has_usage_data
+    def dfs(span: LiveSpan, ancestor_has_data: bool) -> None:
+        nonlocal input_val, output_val, total_val, has_data
 
-        usage = span.get_attribute(SpanAttributeKey.CHAT_USAGE)
-        span_has_usage = usage is not None
+        data = span.get_attribute(attribute_key)
+        span_has_data = data is not None
 
-        if span_has_usage and not ancestor_has_usage:
-            input_tokens += usage.get(TokenUsageKey.INPUT_TOKENS, 0)
-            output_tokens += usage.get(TokenUsageKey.OUTPUT_TOKENS, 0)
-            total_tokens += usage.get(TokenUsageKey.TOTAL_TOKENS, 0)
-            has_usage_data = True
+        if span_has_data and not ancestor_has_data:
+            input_val += data.get(input_key, default)
+            output_val += data.get(output_key, default)
+            total_val += data.get(total_key, default)
+            has_data = True
 
-        next_ancestor_has_usage = ancestor_has_usage or span_has_usage
+        next_ancestor_has_data = ancestor_has_data or span_has_data
         for child in children_map.get(span.span_id, []):
-            dfs(child, next_ancestor_has_usage)
+            dfs(child, next_ancestor_has_data)
 
     for root in roots:
         dfs(root, False)
 
-    # If none of the spans have token usage data, we shouldn't log token usage metadata.
-    if not has_usage_data:
+    if not has_data:
         return None
 
     return {
-        TokenUsageKey.INPUT_TOKENS: input_tokens,
-        TokenUsageKey.OUTPUT_TOKENS: output_tokens,
-        TokenUsageKey.TOTAL_TOKENS: total_tokens,
+        input_key: input_val,
+        output_key: output_val,
+        total_key: total_val,
     }
+
+
+def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
+    """Aggregate token usage information from all spans in the trace."""
+    return _aggregate_from_spans(
+        spans,
+        SpanAttributeKey.CHAT_USAGE,
+        TokenUsageKey.INPUT_TOKENS,
+        TokenUsageKey.OUTPUT_TOKENS,
+        TokenUsageKey.TOTAL_TOKENS,
+        0,
+    )
 
 
 def aggregate_cost_from_spans(spans: list[LiveSpan]) -> dict[str, float] | None:
-    input_cost = 0.0
-    output_cost = 0.0
-    total_cost = 0.0
-    has_cost_data = False
-
-    span_id_to_spans = {span.span_id: span for span in spans}
-    children_map: defaultdict[str, list[LiveSpan]] = defaultdict(list)
-    roots: list[LiveSpan] = []
-
-    for span in spans:
-        parent_id = span.parent_id
-        if parent_id and parent_id in span_id_to_spans:
-            children_map[parent_id].append(span)
-        else:
-            roots.append(span)
-
-    def dfs(span: LiveSpan, ancestor_has_cost: bool) -> None:
-        nonlocal input_cost, output_cost, total_cost, has_cost_data
-
-        cost = span.get_attribute(SpanAttributeKey.LLM_COST)
-        span_has_cost = cost is not None
-
-        if span_has_cost and not ancestor_has_cost:
-            input_cost += cost.get(CostKey.INPUT_COST, 0.0)
-            output_cost += cost.get(CostKey.OUTPUT_COST, 0.0)
-            total_cost += cost.get(CostKey.TOTAL_COST, 0.0)
-            has_cost_data = True
-
-        next_ancestor_has_cost = ancestor_has_cost or span_has_cost
-        for child in children_map.get(span.span_id, []):
-            dfs(child, next_ancestor_has_cost)
-
-    for root in roots:
-        dfs(root, False)
-
-    # If none of the spans have cost data, we shouldn't log cost metadata.
-    if not has_cost_data:
-        return None
-
-    return {
-        CostKey.INPUT_COST: input_cost,
-        CostKey.OUTPUT_COST: output_cost,
-        CostKey.TOTAL_COST: total_cost,
-    }
+    """Aggregate cost information from all spans in the trace."""
+    return _aggregate_from_spans(
+        spans,
+        SpanAttributeKey.LLM_COST,
+        CostKey.INPUT_COST,
+        CostKey.OUTPUT_COST,
+        CostKey.TOTAL_COST,
+        0.0,
+    )
 
 
 def calculate_span_cost(span: LiveSpan) -> dict[str, float] | None:

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -13,6 +13,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.openai.utils.chat_schema import _parse_tools
 from mlflow.tracing.constant import (
     STREAM_CHUNK_EVENT_VALUE_KEY,
+    CostKey,
     SpanAttributeKey,
     TokenUsageKey,
     TraceMetadataKey,
@@ -138,6 +139,11 @@ async def test_chat_completions_autolog(client, mock_litellm_cost):
         TokenUsageKey.INPUT_TOKENS: 9,
         TokenUsageKey.OUTPUT_TOKENS: 12,
         TokenUsageKey.TOTAL_TOKENS: 21,
+    }
+    assert trace.info.cost == {
+        CostKey.INPUT_COST: 9.0,
+        CostKey.OUTPUT_COST: 24.0,
+        CostKey.TOTAL_COST: 33.0,
     }
 
 

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -154,7 +154,7 @@ def test_aggregate_cost_from_spans():
         for i in range(3)
     ]
     spans[0].set_attribute(
-        SpanAttributeKey.CHAT_COST,
+        SpanAttributeKey.LLM_COST,
         {
             CostKey.INPUT_COST: 10,
             CostKey.OUTPUT_COST: 20,
@@ -162,11 +162,11 @@ def test_aggregate_cost_from_spans():
         },
     )
     spans[1].set_attribute(
-        SpanAttributeKey.CHAT_COST,
+        SpanAttributeKey.LLM_COST,
         {CostKey.OUTPUT_COST: 15, CostKey.TOTAL_COST: 15},
     )
     spans[2].set_attribute(
-        SpanAttributeKey.CHAT_COST,
+        SpanAttributeKey.LLM_COST,
         {
             CostKey.INPUT_COST: 5,
             CostKey.OUTPUT_COST: 10,
@@ -199,7 +199,7 @@ def test_aggregate_cost_from_spans_skips_descendant_cost():
     ]
 
     spans[0].set_attribute(
-        SpanAttributeKey.CHAT_COST,
+        SpanAttributeKey.LLM_COST,
         {
             CostKey.INPUT_COST: 10,
             CostKey.OUTPUT_COST: 20,
@@ -208,7 +208,7 @@ def test_aggregate_cost_from_spans_skips_descendant_cost():
     )
 
     spans[2].set_attribute(
-        SpanAttributeKey.CHAT_COST,
+        SpanAttributeKey.LLM_COST,
         {
             CostKey.INPUT_COST: 5,
             CostKey.OUTPUT_COST: 10,
@@ -217,7 +217,7 @@ def test_aggregate_cost_from_spans_skips_descendant_cost():
     )
 
     spans[3].set_attribute(
-        SpanAttributeKey.CHAT_COST,
+        SpanAttributeKey.LLM_COST,
         {
             CostKey.INPUT_COST: 3,
             CostKey.OUTPUT_COST: 6,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20338/files/56395e49e6a28f426fd3f51ecfae3d863527314d..080a395a0a93f1cf50a3d9965678e3dc629ae8d7) to review incremental changes.
- [stack/trace_total_cost](https://github.com/mlflow/mlflow/pull/20337) [[Files changed](https://github.com/mlflow/mlflow/pull/20337/files)]
  - [**stack/trace_cost_ui**](https://github.com/mlflow/mlflow/pull/20338) [[Files changed](https://github.com/mlflow/mlflow/pull/20338/files/56395e49e6a28f426fd3f51ecfae3d863527314d..080a395a0a93f1cf50a3d9965678e3dc629ae8d7)]
    - [stack/trace_cost_for_otel_translation](https://github.com/mlflow/mlflow/pull/20339) [[Files changed](https://github.com/mlflow/mlflow/pull/20339/files/080a395a0a93f1cf50a3d9965678e3dc629ae8d7..802599a1aa6867955bb67c2cb039593011adeddf)]
      - [stack/cost_metrics](https://github.com/mlflow/mlflow/pull/20402) [[Files changed](https://github.com/mlflow/mlflow/pull/20402/files/802599a1aa6867955bb67c2cb039593011adeddf..eb5dea40c48f597bc67a042e398ec8130302c992)]
        - [stack/span_cost_metrics_query](https://github.com/mlflow/mlflow/pull/20403) [[Files changed](https://github.com/mlflow/mlflow/pull/20403/files/eb5dea40c48f597bc67a042e398ec8130302c992..8fb5a9fe9e3a367c5c5d9b87054b789e322e1a6e)]
          - [stack/cost_chart](https://github.com/mlflow/mlflow/pull/20404) [[Files changed](https://github.com/mlflow/mlflow/pull/20404/files/8fb5a9fe9e3a367c5c5d9b87054b789e322e1a6e..8250db6080f63ae06302e667e4e2cb3c17885d97)]
            - [stack/cost_chart_over_time](https://github.com/mlflow/mlflow/pull/20440) [[Files changed](https://github.com/mlflow/mlflow/pull/20440/files/8250db6080f63ae06302e667e4e2cb3c17885d97..02c88346acbd601aa2102e51417d530b318f34c6)]
              - [stack/cost_chart_model_selection](https://github.com/mlflow/mlflow/pull/20455) [[Files changed](https://github.com/mlflow/mlflow/pull/20455/files/02c88346acbd601aa2102e51417d530b318f34c6..e3bd2cb42800702382ee7d6e1fc7ba311959a03e)]
                - stack/charts_zoom_in_out

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Add cost for trace-level breakdown.


https://github.com/user-attachments/assets/b3178374-1c36-4421-a0bf-d224f5c853b9



<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
