### PR TITLE
Allow skills permission and pass tracking URI explciitly

### DIFF
--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -8,6 +8,7 @@ enabling AI-powered trace analysis through the Claude Code CLI.
 import asyncio
 import json
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -36,6 +37,7 @@ _logger = logging.getLogger(__name__)
 # Restrict to only Bash commands that use MLflow CLI
 BASE_ALLOWED_TOOLS = [
     "Bash(mlflow:*)",
+    "Skill",  # Skill tool needs to be explicitly allowed
 ]
 FILE_EDIT_TOOLS = [
     "Edit(*)",
@@ -65,14 +67,8 @@ The MLflow tracking server is running at: `{tracking_uri}`
 
 **CRITICAL**:
 - The server is ALREADY RUNNING. Never ask the user to start or set up the MLflow server.
-- ALL MLflow operations MUST target this server. Set the tracking URI before any MLflow commands:
-```bash
-export MLFLOW_TRACKING_URI={tracking_uri}
-```
-```python
-import mlflow
-mlflow.set_tracking_uri("{tracking_uri}")
-```
+- ALL MLflow operations MUST target this server. You must assume MLFLOW_TRACKING_URI env var is.
+  always set. DO NOT try to override it or set custom env var to the bash command.
 - Assume the server is available and operational at all times, unless you have good reason
   to believe otherwise (e.g. an error that seems likely caused by server unavailability).
 
@@ -100,8 +96,6 @@ where the user wants to log (write) or update information.
 
 For querying and reading MLflow data (experiments, runs, traces, metrics, etc.):
 * STRONGLY PREFER MLflow CLI commands directly.
-* When running CLI commands, ALWAYS prefix with `MLFLOW_TRACKING_URI="{tracking_uri}"`
-  to ensure commands target the correct server.
 * When using MLflow CLI, always use `--help` to discover all available options.
   Do not skip this step or you will not get the correct command.
 * Trust that MLflow CLI commands will work. Do not add error handling or fallbacks to Python.
@@ -379,7 +373,11 @@ class ClaudeCodeProvider(AssistantProvider):
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
                 # Increase buffer limit from default 64KB to handle large JSON responses
-                limit=1024 * 1024,  # 1 MB
+                limit=1024 * 1024,  # 1 MB,
+                # Specify tracking URI to let Claude Code CLI inherit it
+                # NB: `env` arg in `create_subprocess_exec` does not merge with the parent process's
+                # environment so we need to copy the parent process's environment explicitly.
+                env={**os.environ.copy(), "MLFLOW_TRACKING_URI": tracking_uri},
             )
 
             async for line in process.stdout:


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. `Skill` tool needs to be explicitly allowed to execute skills.
2. Set `MLFLOW_TRACKING_URI` env var in subprocess to inherit it to Claude Code CLI.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
