### PR TITLE
Fix HuggingFace Dataset standardization issue

### DIFF
--- a/tests/data/test_huggingface_dataset_and_source.py
+++ b/tests/data/test_huggingface_dataset_and_source.py
@@ -49,8 +49,8 @@ def mock_datasets_load_dataset():
 
 
 def test_from_huggingface_dataset_constructs_expected_dataset():
-    ds = datasets.load_dataset("rotten_tomatoes", split="train")
-    mlflow_ds = mlflow.data.from_huggingface(ds, path="rotten_tomatoes")
+    ds = datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
+    mlflow_ds = mlflow.data.from_huggingface(ds, path="cornell-movie-review-data/rotten_tomatoes")
 
     assert isinstance(mlflow_ds, HuggingFaceDataset)
     assert mlflow_ds.ds == ds
@@ -74,7 +74,9 @@ def test_from_huggingface_dataset_constructs_expected_dataset():
     assert reloaded_ds.split == ds.split == "train"
     assert reloaded_ds.num_rows == ds.num_rows
 
-    reloaded_mlflow_ds = mlflow.data.from_huggingface(reloaded_ds, path="rotten_tomatoes")
+    reloaded_mlflow_ds = mlflow.data.from_huggingface(
+        reloaded_ds, path="cornell-movie-review-data/rotten_tomatoes"
+    )
     assert reloaded_mlflow_ds.digest == mlflow_ds.digest
 
 
@@ -90,7 +92,10 @@ def test_from_huggingface_dataset_constructs_expected_dataset_with_revision():
     )
 
     mlflow_ds_new = mlflow.data.from_huggingface(
-        ds, path="rotten_tomatoes", revision=revision, trust_remote_code=True
+        ds,
+        path="cornell-movie-review-data/rotten_tomatoes",
+        revision=revision,
+        trust_remote_code=True,
     )
 
     ds = mlflow_ds_new.source.load()
@@ -156,9 +161,9 @@ def test_from_huggingface_dataset_constructs_expected_dataset_with_data_dir(tmp_
 
 
 def test_from_huggingface_dataset_respects_user_specified_name_and_digest():
-    ds = datasets.load_dataset("rotten_tomatoes", split="train")
+    ds = datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
     mlflow_ds = mlflow.data.from_huggingface(
-        ds, path="rotten_tomatoes", name="myname", digest="mydigest"
+        ds, path="cornell-movie-review-data/rotten_tomatoes", name="myname", digest="mydigest"
     )
     assert mlflow_ds.name == "myname"
     assert mlflow_ds.digest == "mydigest"
@@ -186,17 +191,17 @@ def test_from_huggingface_dataset_digest_is_consistent_for_large_ordered_dataset
 
 
 def test_from_huggingface_dataset_throws_for_dataset_dict():
-    ds = datasets.load_dataset("rotten_tomatoes")
+    ds = datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes")
     assert isinstance(ds, datasets.DatasetDict)
 
     with pytest.raises(
         MlflowException, match="must be an instance of `datasets.Dataset`.*DatasetDict"
     ):
-        mlflow.data.from_huggingface(ds, path="rotten_tomatoes")
+        mlflow.data.from_huggingface(ds, path="cornell-movie-review-data/rotten_tomatoes")
 
 
 def test_from_huggingface_dataset_no_source_specified():
-    ds = datasets.load_dataset("rotten_tomatoes", split="train")
+    ds = datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
     mlflow_ds = mlflow.data.from_huggingface(ds)
 
     assert isinstance(mlflow_ds, HuggingFaceDataset)
@@ -206,8 +211,8 @@ def test_from_huggingface_dataset_no_source_specified():
 
 
 def test_dataset_conversion_to_json():
-    ds = datasets.load_dataset("rotten_tomatoes", split="train")
-    mlflow_ds = mlflow.data.from_huggingface(ds, path="rotten_tomatoes")
+    ds = datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
+    mlflow_ds = mlflow.data.from_huggingface(ds, path="cornell-movie-review-data/rotten_tomatoes")
 
     dataset_json = mlflow_ds.to_json()
     parsed_json = json.loads(dataset_json)
@@ -224,13 +229,13 @@ def test_dataset_conversion_to_json():
 
 def test_dataset_source_conversion_to_json():
     ds = datasets.load_dataset(
-        "rotten_tomatoes",
+        "cornell-movie-review-data/rotten_tomatoes",
         split="train",
         revision="c33cbf965006dba64f134f7bef69c53d5d0d285d",
     )
     mlflow_ds = mlflow.data.from_huggingface(
         ds,
-        path="rotten_tomatoes",
+        path="cornell-movie-review-data/rotten_tomatoes",
         revision="c33cbf965006dba64f134f7bef69c53d5d0d285d",
     )
     source = mlflow_ds.source
@@ -240,7 +245,7 @@ def test_dataset_source_conversion_to_json():
     assert parsed_source["revision"] == "c33cbf965006dba64f134f7bef69c53d5d0d285d"
     assert parsed_source["split"] == "train"
     assert parsed_source["config_name"] == "default"
-    assert parsed_source["path"] == "rotten_tomatoes"
+    assert parsed_source["path"] == "cornell-movie-review-data/rotten_tomatoes"
     assert not parsed_source["data_dir"]
     assert not parsed_source["data_files"]
 
@@ -258,8 +263,10 @@ def test_dataset_source_conversion_to_json():
 def test_to_evaluation_dataset():
     import numpy as np
 
-    ds = datasets.load_dataset("rotten_tomatoes", split="train")
-    dataset = mlflow.data.from_huggingface(ds, path="rotten_tomatoes", targets="label")
+    ds = datasets.load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
+    dataset = mlflow.data.from_huggingface(
+        ds, path="cornell-movie-review-data/rotten_tomatoes", targets="label"
+    )
 
     evaluation_dataset = dataset.to_evaluation_dataset()
     assert isinstance(evaluation_dataset, EvaluationDataset)


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fixes the dataset definition to the fully qualified path for huggingface dataset names.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
