### PR TITLE
Add progress tracking for prompt optimization job

### DIFF
--- a/mlflow/genai/optimize/optimizers/gepa_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/gepa_optimizer.py
@@ -143,7 +143,7 @@ class GepaPromptOptimizer(BasePromptOptimizer):
             import gepa
         except ImportError as e:
             raise ImportError(
-                "GEPA >= 0.0.18 is required. Please install it with: `pip install 'gepa>=0.0.18'`"
+                "GEPA >= 0.0.26 is required. Please install it with: `pip install 'gepa>=0.0.26'`"
             ) from e
 
         provider, model = _parse_model_uri(self.reflection_model)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5408,8 +5408,7 @@ def _get_prompt_optimization_job(job_id):
         if total_metric_calls is not None:
             params = json.loads(job_entity.params)
             optimizer_config = params.get("optimizer_config", {})
-            max_metric_calls = optimizer_config.get("max_metric_calls")
-            if max_metric_calls:
+            if max_metric_calls := optimizer_config.get("max_metric_calls"):
                 progress = round(min(total_metric_calls / max_metric_calls, 1.0), 2)
                 optimization_job.state.metadata["progress"] = str(progress)
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5392,18 +5392,17 @@ def _get_prompt_optimization_job(job_id):
         # "final_eval_score.<scorer_name>"
         total_metric_calls = None
         for metric_name, metric_value in run_metrics.items():
-            if metric_name == "initial_eval_score":
-                optimization_job.initial_eval_scores["aggregate"] = metric_value
-            elif metric_name == "final_eval_score":
-                optimization_job.final_eval_scores["aggregate"] = metric_value
-            elif metric_name.startswith("initial_eval_score."):
-                scorer_name = metric_name.removeprefix("initial_eval_score.")
-                optimization_job.initial_eval_scores[scorer_name] = metric_value
-            elif metric_name.startswith("final_eval_score."):
-                scorer_name = metric_name.removeprefix("final_eval_score.")
-                optimization_job.final_eval_scores[scorer_name] = metric_value
-            elif metric_name == "total_metric_calls":
-                total_metric_calls = metric_value
+            match metric_name.split(".", 1):
+                case ["initial_eval_score"]:
+                    optimization_job.initial_eval_scores["aggregate"] = metric_value
+                case ["final_eval_score"]:
+                    optimization_job.final_eval_scores["aggregate"] = metric_value
+                case ["initial_eval_score", scorer_name]:
+                    optimization_job.initial_eval_scores[scorer_name] = metric_value
+                case ["final_eval_score", scorer_name]:
+                    optimization_job.final_eval_scores[scorer_name] = metric_value
+                case ["total_metric_calls"]:
+                    total_metric_calls = metric_value
 
         if total_metric_calls is not None:
             params = json.loads(job_entity.params)

--- a/tests/genai/optimize/optimizers/test_gepa_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_gepa_optimizer.py
@@ -257,7 +257,7 @@ def test_gepa_optimizer_import_error(
     with patch.dict("sys.modules", {"gepa": None}):
         optimizer = GepaPromptOptimizer(reflection_model="openai:/gpt-4o")
 
-        with pytest.raises(ImportError, match="GEPA >= 0.0.18 is required"):
+        with pytest.raises(ImportError, match="GEPA >= 0.0.26 is required"):
             optimizer.optimize(
                 eval_fn=mock_eval_fn,
                 train_data=sample_train_data,


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add progress tracking for prompt optimization job. 

In GEPA 0.0.26 we added `total_metric_calls` which tracks how many metric calls have been made: https://github.com/gepa-ai/gepa/pull/171. 

Also bumping the minimum gepa version to 0.0.26, before which version the mlflow metrics logging hits errors.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
