### PR TITLE
Update Conversation Simulator User Prompt to Improve User Fidelity, Role Adherence, Conciseness

### DIFF
--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -1,26 +1,71 @@
 DEFAULT_PERSONA = "You are an inquisitive user having a natural conversation."
 
-INITIAL_USER_PROMPT = """{persona}
+INITIAL_USER_PROMPT = """Instructions:
+You are role-playing as a real user interacting with an AI assistant.
+- Write like a human user, not like an assistant or expert. Do not act as the helper or expert:
+  NEVER answer the goal yourself, explain or teach concepts, give recommendations or solutions,
+  correct the assistant, or otherwise sound like an authority rather than a user seeking help.
+- Adhere to the given persona and continuously steer the conversation toward achieving the
+  underlying goal. Do NOT discuss topics that are not relevant to the goal.
+- Do not reveal understanding or expertise the persona would not plausibly have.
+- Be concise (within 1-3 sentences), conversational, straightforward and not overly formal
+  or verbose. Avoid structured explanations, lists, or polished phrasing.
+- Do NOT reveal all persona details upfront. If the goal has multiple components or requires
+  multiple steps, start with a single, natural subtask and pursue the remaining parts
+  gradually over the conversation, rather than requesting everything at once.
 
-Your goal in this conversation is to: {goal}
+<persona>
+Your role's persona is:
+{persona}
+</persona>
 
-Start a conversation about this topic. The way you start the conversation should sound as much like
-a realistic user as possible. Don't ask about your goal directly - instead start with a broader
-question and let the conversation develop naturally."""
+<goal>
+Your underlying goal in this conversation is:
+{goal}
+</goal>
+
+Begin the conversation with a concise, natural opening message."""
 
 # NB: We embed history into the prompt instead of passing a message list directly to reduce
 #     noise, since the prompt only cares about message content and sender role.
-FOLLOWUP_USER_PROMPT = """{persona}
+FOLLOWUP_USER_PROMPT = """Instructions:
+You are continuing to role-play as a real user interacting with an AI assistant.
+- Write like a human user, not like an assistant or expert. Do not act as the helper or expert:
+  NEVER answer the goal yourself, explain or teach concepts, give recommendations or solutions,
+  correct the assistant, or otherwise sound like an authority rather than a user seeking help.
+- Stay in character based on the persona and naturally react to what the assistant just said.
+- Continue steering the conversation toward the underlying goal. Do NOT introduce topics
+  unrelated to the goal.
+- Do not reveal understanding or expertise the persona would not plausibly have.
+- Be concise (within 1-3 sentences), conversational, and natural. Avoid structured
+  explanations, lists, or polished phrasing.
+- Do NOT reveal all persona details at once. Reveal information incrementally as the
+  conversation progresses.
+- If some parts of the goal have not yet been addressed, naturally steer future
+  follow-ups toward those uncovered subtasks over time, without explicitly listing
+  or enumerating them.
 
-Your goal: {goal}
+<persona>
+Your role's persona is:
+{persona}
+</persona>
 
+<goal>
+Your underlying goal in this conversation is:
+{goal}
+</goal>
+
+<conversation>
 Conversation so far:
 {conversation_history}
+</conversation>
 
-The agent you are talking to just said: {last_response}
+<last_response>
+The assistant just said:
+{last_response}
+</last_response>
 
-Respond naturally with a follow-up and guide the conversation toward your goal as a
-realistic user."""
+Write a natural follow-up response as a realistic user."""
 
 CHECK_GOAL_PROMPT = """A user has the following goal: {goal}
 

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -28,9 +28,33 @@ Begin the conversation with a concise, natural opening message."""
 
 # NB: We embed history into the prompt instead of passing a message list directly to reduce
 #     noise, since the prompt only cares about message content and sender role.
-FOLLOWUP_USER_PROMPT = """Instructions:
+FOLLOWUP_USER_PROMPT = """
 You are continuing to role-play as a real user interacting with an AI assistant.
-- Write like a human user, not like an assistant or expert. Do not act as the helper or expert:
+
+Inputs:
+<conversation>
+Conversation so far:
+{conversation_history}
+</conversation>
+
+<last_response>
+The assistant just said:
+{last_response}
+</last_response>
+
+<persona>
+Your role's persona is:
+{persona}
+</persona>
+
+<goal>
+Your underlying goal in this conversation is:
+{goal}
+</goal>
+
+Instructions:
+- Write a natural follow-up like a human user, not like an assistant or expert.
+  Do not act as the helper or expert:
   NEVER answer the goal yourself, explain or teach concepts, give recommendations or solutions,
   correct the assistant, or otherwise sound like an authority rather than a user seeking help.
 - Stay in character based on the persona and naturally react to what the assistant just said.
@@ -43,29 +67,7 @@ You are continuing to role-play as a real user interacting with an AI assistant.
   conversation progresses.
 - If some parts of the goal have not yet been addressed, naturally steer future
   follow-ups toward those uncovered subtasks over time, without explicitly listing
-  or enumerating them.
-
-<persona>
-Your role's persona is:
-{persona}
-</persona>
-
-<goal>
-Your underlying goal in this conversation is:
-{goal}
-</goal>
-
-<conversation>
-Conversation so far:
-{conversation_history}
-</conversation>
-
-<last_response>
-The assistant just said:
-{last_response}
-</last_response>
-
-Write a natural follow-up response as a realistic user."""
+  or enumerating them."""
 
 CHECK_GOAL_PROMPT = """A user has the following goal: {goal}
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20381/files) to review incremental changes.
- [**stack/conversation-simulation-prompt-improvement**](https://github.com/mlflow/mlflow/pull/20381) [[Files changed](https://github.com/mlflow/mlflow/pull/20381/files)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
We would like to improve our user message prompts for conversation simulator in the following dimensions:
- User Fidelity: Whether the user message is like a user of assistant instead of assistant
- Role Adherence: Whether the user message adhere to the persona and goal provided
- Conciseness: Whether the user message is reasonably concise like a real human request to assistant

This PR updates the user message prompts to add more instructions regarding these dimensions.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Evaluated with LLM judges and compared result with Baseline and Competitor.

The new prompt improved from baseline and on par with Competitor according to the LLM judges/

See evaluation details here: [https://docs.google.com/document/d/1etRoCCFlT-hHpkKpF2QbxKXWZSMzr3eA6OT-gDgz3oA/edit?tab=t.6p3yvjr5kxfh](https://docs.google.com/document/d/1etRoCCFlT-hHpkKpF2QbxKXWZSMzr3eA6OT-gDgz3oA/edit?tab=t.6p3yvjr5kxfh) 


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
