### PR TITLE
feat(typescript-anthropic): add streaming support

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
@@ -125,7 +125,7 @@ MLflow supports automatic tracing for the following Anthropic APIs:
 
 | Chat Completion | Function Calling | Streaming |  Async   | Image | Batch |
 | :-------------: | :--------------: | :-------: | :------: | :---: | :---: |
-|       ✅        |        ✅        |     -     | ✅ (\*1) |   -   |   -   |
+|       ✅        |        ✅        |    ✅     | ✅ (\*1) |   -   |   -   |
 
 <div style={{ fontSize: '0.9em', marginTop: '10px' }}>
 

--- a/libs/typescript/integrations/anthropic/src/index.ts
+++ b/libs/typescript/integrations/anthropic/src/index.ts
@@ -2,10 +2,19 @@
  * Main tracedAnthropic wrapper function for MLflow tracing integration
  */
 
-import { withSpan, LiveSpan, SpanAttributeKey, SpanType, TokenUsage } from 'mlflow-tracing';
+import {
+  startSpan,
+  getCurrentActiveSpan,
+  SpanAttributeKey,
+  SpanType,
+  SpanStatusCode,
+  TokenUsage,
+  LiveSpan,
+  withSpan,
+} from 'mlflow-tracing';
 
 const SUPPORTED_MODULES = ['Messages'];
-const SUPPORTED_METHODS = ['create'];
+const SUPPORTED_METHODS = ['create', 'stream'];
 
 /**
  * Create a traced version of Anthropic client with MLflow tracing
@@ -20,6 +29,11 @@ export function tracedAnthropic<T = any>(anthropicClient: T): T {
 
       if (typeof original === 'function') {
         if (shouldTraceMethod(moduleName, String(prop))) {
+          const methodName = String(prop);
+          if (methodName === 'stream') {
+            // eslint-disable-next-line @typescript-eslint/ban-types
+            return wrapStreamWithTracing(original as Function, moduleName) as T;
+          }
           // eslint-disable-next-line @typescript-eslint/ban-types
           return wrapWithTracing(original as Function, moduleName) as T;
         }
@@ -61,6 +75,15 @@ function wrapWithTracing(fn: Function, moduleName: string): Function {
       return fn.apply(this, args);
     }
 
+    // Skip tracing for create() calls with stream: true
+    // The Anthropic SDK's stream() method internally calls create() with stream: true,
+    // and we don't want to create a duplicate trace - the streaming wrapper handles it
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (args[0]?.stream === true) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return fn.apply(this, args);
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return withSpan(
       async (span: LiveSpan) => {
@@ -95,6 +118,171 @@ function getSpanType(moduleName: string): SpanType | undefined {
       return SpanType.LLM;
     default:
       return undefined;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+function wrapStreamWithTracing(fn: Function, moduleName: string): Function {
+  const spanType = getSpanType(moduleName);
+  const name = moduleName;
+
+  return function (this: any, ...args: any[]) {
+    if (!spanType) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return fn.apply(this, args);
+    }
+
+    // Create the stream (synchronous call)
+    const stream = fn.apply(this, args);
+
+    // Return a proxy that wraps the stream with tracing
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return wrapMessageStream(stream, args[0], name, spanType);
+  };
+}
+
+function wrapMessageStream(stream: any, inputs: any, name: string, spanType: SpanType): any {
+  // Use a flag that is set synchronously on first access to prevent duplicate spans.
+  // It is claimed either when the async iterator getter is invoked or when the wrapped
+  // finalMessage function is called, before any asynchronous work begins, so only one
+  // of these access paths will perform tracing for a given stream instance.
+  let tracingClaimed = false;
+
+  return new Proxy(stream, {
+    get(target, prop, receiver) {
+      const original = Reflect.get(target, prop, receiver);
+
+      // Wrap finalMessage() to add tracing
+      if (prop === 'finalMessage') {
+        return async function () {
+          if (tracingClaimed) {
+            // Already traced via async iteration, just return the message
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+            return target.finalMessage();
+          }
+          tracingClaimed = true;
+
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+          return withSpan(
+            async (span: LiveSpan) => {
+              span.setInputs(inputs);
+
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              const message = await target.finalMessage();
+
+              span.setOutputs(message);
+
+              try {
+                const usage = extractTokenUsage(message);
+                if (usage) {
+                  span.setAttribute(SpanAttributeKey.TOKEN_USAGE, usage);
+                }
+              } catch (error) {
+                console.debug('Error extracting token usage', error);
+              }
+
+              span.setAttribute(SpanAttributeKey.MESSAGE_FORMAT, 'anthropic');
+
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+              return message;
+            },
+            { name, spanType },
+          );
+        };
+      }
+
+      // Wrap async iterator for `for await (const event of stream)` pattern
+      if (prop === Symbol.asyncIterator) {
+        return function () {
+          if (tracingClaimed) {
+            // In practice, MessageStreams are typically consumed once and iterating again would
+            // yield no events, so this may not be a real issue but for completeness we return the
+            // unwrapped iterator in this case.
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+            return target[Symbol.asyncIterator]();
+          }
+          tracingClaimed = true;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          return wrapAsyncIterator(target[Symbol.asyncIterator](), target, inputs, name, spanType);
+        };
+      }
+
+      if (typeof original === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+        return original.bind(target);
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return original;
+    },
+  });
+}
+
+async function* wrapAsyncIterator(
+  iterator: AsyncIterator<any>,
+  stream: any,
+  inputs: any,
+  name: string,
+  spanType: SpanType,
+): AsyncGenerator<any> {
+  // Use startSpan for manual lifecycle management since withSpan doesn't support async generators
+  const parentSpan = getCurrentActiveSpan();
+  const span = startSpan({ name, spanType, parent: parentSpan ?? undefined });
+  span.setInputs(inputs);
+
+  let iterationError: Error | undefined;
+
+  try {
+    while (true) {
+      const { value, done } = await iterator.next();
+      if (done) break;
+      yield value;
+    }
+  } catch (error) {
+    iterationError = error as Error;
+    throw error;
+  } finally {
+    if (iterationError) {
+      span.setAttribute(SpanAttributeKey.MESSAGE_FORMAT, 'anthropic');
+      span.setStatus(SpanStatusCode.ERROR, iterationError.message);
+      span.end();
+    } else {
+      // After iteration completes (or early termination via break/return),
+      // get the final message for outputs and token usage
+      try {
+        // Prefer a proxy-aware finalMessage if available on the iterator, and fall back to the stream.
+        let finalMessage: any | undefined;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        const iteratorAny = iterator as any;
+        if (iteratorAny && typeof iteratorAny.finalMessage === 'function') {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+          finalMessage = await iteratorAny.finalMessage();
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        } else if (stream && typeof stream.finalMessage === 'function') {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+          finalMessage = await stream.finalMessage();
+        }
+
+        if (finalMessage !== undefined) {
+          span.setOutputs(finalMessage);
+
+          const usage = extractTokenUsage(finalMessage);
+          if (usage) {
+            span.setAttribute(SpanAttributeKey.TOKEN_USAGE, usage);
+          }
+        }
+      } catch (e) {
+        // Stream may have completed without finalMessage available
+        console.debug('Could not get final message from stream', e);
+        span.setAttribute('mlflow.tracing.token_usage_capture_failed', true);
+        span.setAttribute(
+          'mlflow.tracing.token_usage_capture_error',
+          e instanceof Error ? e.message : String(e),
+        );
+      }
+
+      span.setAttribute(SpanAttributeKey.MESSAGE_FORMAT, 'anthropic');
+      span.end();
+    }
   }
 }
 

--- a/libs/typescript/integrations/anthropic/tests/index.test.ts
+++ b/libs/typescript/integrations/anthropic/tests/index.test.ts
@@ -7,7 +7,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { tracedAnthropic } from '../src';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { anthropicMockHandlers } from './mockAnthropicServer';
+import { anthropicMockHandlers, createStreamingErrorHandler } from './mockAnthropicServer';
 import { createAuthProvider } from 'mlflow-tracing/src/auth';
 
 const TEST_TRACKING_URI = 'http://localhost:5000';
@@ -175,6 +175,252 @@ describe('tracedAnthropic', () => {
     expect(childSpan.outputs).toBeDefined();
 
     const messageFormat = childSpan.attributes[mlflow.SpanAttributeKey.MESSAGE_FORMAT];
+    expect(messageFormat).toBe('anthropic');
+  });
+
+  it('should trace messages.stream() with async iteration', async () => {
+    const anthropic = new Anthropic({ apiKey: 'test-key' });
+    const wrappedAnthropic = tracedAnthropic(anthropic);
+
+    const events: any[] = [];
+    const stream = wrappedAnthropic.messages.stream({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'Hello streaming!' }],
+    });
+
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect(events.length).toBeGreaterThan(0);
+
+    const trace = await getLastActiveTrace();
+    expect(trace.info.state).toBe('OK');
+
+    const span = trace.data.spans[0];
+    expect(span.name).toBe('Messages');
+    expect(span.spanType).toBe(mlflow.SpanType.LLM);
+    expect(span.status.statusCode).toBe(mlflow.SpanStatusCode.OK);
+    expect(span.inputs).toMatchObject({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'Hello streaming!' }],
+    });
+
+    // Verify outputs contain actual message content, not a stream object
+    expect(span.outputs).toBeDefined();
+    expect(span.outputs).toHaveProperty('id');
+    expect(span.outputs).toHaveProperty('type', 'message');
+    expect(span.outputs).toHaveProperty('content');
+    expect(span.outputs.content[0]).toHaveProperty('type', 'text');
+
+    // Verify token usage is captured for streaming
+    const spanTokenUsage = span.attributes[mlflow.SpanAttributeKey.TOKEN_USAGE];
+    expect(spanTokenUsage).toBeDefined();
+    expect(typeof spanTokenUsage[mlflow.TokenUsageKey.INPUT_TOKENS]).toBe('number');
+    expect(typeof spanTokenUsage[mlflow.TokenUsageKey.OUTPUT_TOKENS]).toBe('number');
+
+    const messageFormat = span.attributes[mlflow.SpanAttributeKey.MESSAGE_FORMAT];
+    expect(messageFormat).toBe('anthropic');
+  });
+
+  it('should trace messages.stream() with finalMessage()', async () => {
+    const anthropic = new Anthropic({ apiKey: 'test-key' });
+    const wrappedAnthropic = tracedAnthropic(anthropic);
+
+    const stream = wrappedAnthropic.messages.stream({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'Hello finalMessage!' }],
+    });
+
+    const finalMessage = await stream.finalMessage();
+
+    expect(finalMessage).toBeDefined();
+    expect(finalMessage.content).toBeDefined();
+
+    const trace = await getLastActiveTrace();
+    expect(trace.info.state).toBe('OK');
+
+    const span = trace.data.spans[0];
+    expect(span.name).toBe('Messages');
+    expect(span.spanType).toBe(mlflow.SpanType.LLM);
+    expect(span.status.statusCode).toBe(mlflow.SpanStatusCode.OK);
+    expect(span.inputs).toEqual({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'Hello finalMessage!' }],
+    });
+    expect(span.outputs).toEqual(finalMessage);
+
+    const messageFormat = span.attributes[mlflow.SpanAttributeKey.MESSAGE_FORMAT];
+    expect(messageFormat).toBe('anthropic');
+  });
+
+  it('should handle errors during streaming async iteration', async () => {
+    server.use(createStreamingErrorHandler());
+
+    const anthropic = new Anthropic({ apiKey: 'test-key', maxRetries: 0 });
+    const wrappedAnthropic = tracedAnthropic(anthropic);
+
+    const stream = wrappedAnthropic.messages.stream({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'Hello streaming error!' }],
+    });
+
+    await expect(async () => {
+      for await (const _event of stream) {
+        // consume events until error
+      }
+    }).rejects.toThrow();
+
+    const trace = await getLastActiveTrace();
+    expect(trace.info.state).toBe('ERROR');
+
+    const span = trace.data.spans[0];
+    expect(span.status.statusCode).toBe(mlflow.SpanStatusCode.ERROR);
+    expect(span.inputs).toMatchObject({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'Hello streaming error!' }],
+    });
+  });
+
+  it('should handle errors during streaming finalMessage()', async () => {
+    server.use(createStreamingErrorHandler());
+
+    const anthropic = new Anthropic({ apiKey: 'test-key', maxRetries: 0 });
+    const wrappedAnthropic = tracedAnthropic(anthropic);
+
+    const stream = wrappedAnthropic.messages.stream({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'Hello finalMessage error!' }],
+    });
+
+    await expect(stream.finalMessage()).rejects.toThrow();
+
+    const trace = await getLastActiveTrace();
+    expect(trace.info.state).toBe('ERROR');
+
+    const span = trace.data.spans[0];
+    expect(span.status.statusCode).toBe(mlflow.SpanStatusCode.ERROR);
+    expect(span.inputs).toEqual({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'Hello finalMessage error!' }],
+    });
+  });
+
+  it('should create only one span when async iteration is followed by finalMessage()', async () => {
+    const anthropic = new Anthropic({ apiKey: 'test-key' });
+    const wrappedAnthropic = tracedAnthropic(anthropic);
+
+    const stream = wrappedAnthropic.messages.stream({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'Hello dedup!' }],
+    });
+
+    // First consume via async iteration (claims tracing)
+    for await (const _event of stream) {
+      // consume all events
+    }
+
+    // Then call finalMessage() on the same stream — should NOT create a second span
+    const finalMessage = await stream.finalMessage();
+    expect(finalMessage).toBeDefined();
+
+    const trace = await getLastActiveTrace();
+    expect(trace.info.state).toBe('OK');
+
+    // Only one LLM span should exist (no duplicate from finalMessage)
+    const llmSpans = trace.data.spans.filter((s) => s.spanType === mlflow.SpanType.LLM);
+    expect(llmSpans.length).toBe(1);
+  });
+
+  it('should not trace messages.create() when stream: true is passed directly', async () => {
+    const anthropic = new Anthropic({ apiKey: 'test-key' });
+    const wrappedAnthropic = tracedAnthropic(anthropic);
+
+    // Calling create() with stream: true is skipped by the tracing wrapper
+    // because the SDK's stream() method internally calls create({ stream: true }),
+    // and tracing is handled by the stream wrapper instead.
+    // Users should use messages.stream() for traced streaming.
+    const response = await wrappedAnthropic.messages.create({
+      model: 'claude-3-7-sonnet-20250219',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'Hello direct stream!' }],
+      stream: true,
+    });
+
+    // The SDK returns a Stream object when stream: true
+    expect(response).toBeDefined();
+
+    // Consume the stream to completion
+    for await (const _event of response as any) {
+      // consume
+    }
+
+    // No traced span should have been created by the create() wrapper
+    await mlflow.flushTraces();
+    const traceId = mlflow.getLastActiveTraceId();
+    // The last active trace should be from a previous test, not this call,
+    // OR if it is from this call, it should not have a Messages LLM span
+    // created by wrapWithTracing (since create with stream:true is skipped).
+    if (traceId) {
+      const trace = await client.getTrace(traceId);
+      const matchingSpans = trace.data.spans.filter(
+        (s) =>
+          s.spanType === mlflow.SpanType.LLM &&
+          s.inputs?.messages?.[0]?.content === 'Hello direct stream!',
+      );
+      expect(matchingSpans.length).toBe(0);
+    }
+  });
+
+  it('should trace streaming request wrapped in a parent span', async () => {
+    const anthropic = new Anthropic({ apiKey: 'test-key' });
+    const wrappedAnthropic = tracedAnthropic(anthropic);
+
+    const result = await mlflow.withSpan(
+      async (_span) => {
+        const stream = wrappedAnthropic.messages.stream({
+          model: 'claude-3-7-sonnet-20250219',
+          max_tokens: 128,
+          messages: [{ role: 'user', content: 'Hello streaming parent!' }],
+        });
+
+        const message = await stream.finalMessage();
+        return message.content[0];
+      },
+      {
+        name: 'streaming-predict',
+        spanType: mlflow.SpanType.CHAIN,
+        inputs: 'Hello streaming parent!',
+      },
+    );
+
+    const trace = await getLastActiveTrace();
+    expect(trace.info.state).toBe('OK');
+    // At least 2 spans: parent chain span and child LLM span
+    expect(trace.data.spans.length).toBeGreaterThanOrEqual(2);
+
+    const parentSpan = trace.data.spans[0];
+    expect(parentSpan.name).toBe('streaming-predict');
+    expect(parentSpan.spanType).toBe(mlflow.SpanType.CHAIN);
+    expect(parentSpan.outputs).toEqual(result);
+
+    // Find child spans with LLM type
+    const llmSpans = trace.data.spans.filter((s) => s.spanType === mlflow.SpanType.LLM);
+    expect(llmSpans.length).toBeGreaterThanOrEqual(1);
+
+    const llmSpan = llmSpans[0];
+    expect(llmSpan.outputs).toBeDefined();
+
+    const messageFormat = llmSpan.attributes[mlflow.SpanAttributeKey.MESSAGE_FORMAT];
     expect(messageFormat).toBe('anthropic');
   });
 });

--- a/libs/typescript/integrations/anthropic/tests/mockAnthropicServer.ts
+++ b/libs/typescript/integrations/anthropic/tests/mockAnthropicServer.ts
@@ -12,6 +12,7 @@ interface MessagesCreateRequest {
   }>;
   max_tokens?: number;
   system?: string | Array<{ type: string; text: string }>;
+  stream?: boolean;
 }
 
 function createMessageResponse(request: MessagesCreateRequest) {
@@ -36,9 +37,149 @@ function createMessageResponse(request: MessagesCreateRequest) {
   };
 }
 
+function createStreamingEvents(request: MessagesCreateRequest): string[] {
+  const messageId = `msg_${Math.random().toString(36).slice(2)}`;
+  const responseText = 'This is a mocked streaming response.';
+
+  return [
+    `event: message_start\ndata: ${JSON.stringify({
+      type: 'message_start',
+      message: {
+        id: messageId,
+        type: 'message',
+        role: 'assistant',
+        model: request.model,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 128,
+          output_tokens: 0,
+        },
+      },
+    })}\n\n`,
+    `event: content_block_start\ndata: ${JSON.stringify({
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'text',
+        text: '',
+      },
+    })}\n\n`,
+    `event: content_block_delta\ndata: ${JSON.stringify({
+      type: 'content_block_delta',
+      index: 0,
+      delta: {
+        type: 'text_delta',
+        text: responseText,
+      },
+    })}\n\n`,
+    `event: content_block_stop\ndata: ${JSON.stringify({
+      type: 'content_block_stop',
+      index: 0,
+    })}\n\n`,
+    `event: message_delta\ndata: ${JSON.stringify({
+      type: 'message_delta',
+      delta: {
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+      },
+      usage: {
+        output_tokens: 256,
+      },
+    })}\n\n`,
+    `event: message_stop\ndata: ${JSON.stringify({
+      type: 'message_stop',
+    })}\n\n`,
+  ];
+}
+
+export function createStreamingErrorHandler() {
+  return http.post('https://api.anthropic.com/v1/messages', async ({ request }) => {
+    const body = (await request.json()) as MessagesCreateRequest;
+
+    if (body.stream) {
+      // Send a partial stream that ends with an error event
+      const messageId = `msg_${Math.random().toString(36).slice(2)}`;
+      const events = [
+        `event: message_start\ndata: ${JSON.stringify({
+          type: 'message_start',
+          message: {
+            id: messageId,
+            type: 'message',
+            role: 'assistant',
+            model: body.model,
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 128, output_tokens: 0 },
+          },
+        })}\n\n`,
+        `event: error\ndata: ${JSON.stringify({
+          type: 'error',
+          error: {
+            type: 'overloaded_error',
+            message: 'Overloaded',
+          },
+        })}\n\n`,
+      ];
+
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        async start(controller) {
+          for (const event of events) {
+            controller.enqueue(encoder.encode(event));
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+          controller.close();
+        },
+      });
+
+      return new HttpResponse(stream, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+        },
+      });
+    }
+
+    return HttpResponse.json(
+      { error: { type: 'overloaded_error', message: 'Overloaded' } },
+      { status: 529 },
+    );
+  });
+}
+
 export const anthropicMockHandlers = [
   http.post('https://api.anthropic.com/v1/messages', async ({ request }) => {
     const body = (await request.json()) as MessagesCreateRequest;
+
+    // Check if streaming is requested
+    if (body.stream) {
+      const events = createStreamingEvents(body);
+      const encoder = new TextEncoder();
+
+      const stream = new ReadableStream({
+        async start(controller) {
+          for (const event of events) {
+            controller.enqueue(encoder.encode(event));
+            // Small delay to simulate streaming
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+          controller.close();
+        },
+      });
+
+      return new HttpResponse(stream, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+        },
+      });
+    }
+
     return HttpResponse.json(createMessageResponse(body));
   }),
 ];


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #20382

### What changes are proposed in this pull request?

Add tracing support for the `messages.stream()` method in the MLflow Anthropic TypeScript integration.

The `stream` method returns a `MessageStream` object that emits events as the response streams in. This implementation traces streaming by:

- Wrapping the returned `MessageStream` object in a Proxy
- Intercepting `finalMessage()` calls to create a span around the full streaming operation
- Intercepting the async iterator (`Symbol.asyncIterator`) to trace `for await` loops
- Extracting token usage from the final message after streaming completes
- Setting appropriate span attributes (`MESSAGE_FORMAT: 'anthropic'`, token usage, etc.)

- `libs/typescript/integrations/anthropic/src/index.ts` - Main implementation
- `libs/typescript/integrations/anthropic/tests/index.test.ts` - Tests
- `libs/typescript/integrations/anthropic/tests/mockAnthropicServer.ts` - Mock SSE endpoint
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
<img width="1260" height="908" alt="tracing-screenshot" src="https://github.com/user-attachments/assets/314145e0-2669-4c97-98a0-0b93a845395f" />

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Add support for `@anthropic-ai/sdk`'s [streaming responses](https://github.com/anthropics/anthropic-sdk-typescript?tab=readme-ov-file#streaming-responses)

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
