### PR TITLE
AgentServer: optionally return trace id when requested

### DIFF
--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -21,7 +21,7 @@ from mlflow.utils.annotations import experimental
 
 logger = logging.getLogger(__name__)
 STREAM_KEY = "stream"
-RETURN_TRACE_HEADER = "x-mlflow-return-trace"
+RETURN_TRACE_HEADER = "x-mlflow-return-trace-id"
 
 AgentType = Literal["ResponsesAgent"]
 
@@ -347,10 +347,10 @@ class AgentServer:
                 if self.agent_type == "ResponsesAgent":
                     span.set_attribute(SpanAttributeKey.MESSAGE_FORMAT, "openai")
                     span.set_outputs(ResponsesAgent.responses_agent_output_reducer(all_chunks))
+                    if return_trace:
+                        yield f"data: {json.dumps({'trace_id': span.trace_id})}\n\n"
                 else:
                     span.set_outputs(all_chunks)
-                if return_trace:
-                    yield f"data: {json.dumps({'trace_id': span.trace_id})}\n\n"
 
                 yield "data: [DONE]\n\n"
 

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 
 import mlflow
-from mlflow.genai.agent_server.utils import set_request_headers
+from mlflow.genai.agent_server.utils import get_request_headers, set_request_headers
 from mlflow.genai.agent_server.validator import BaseAgentValidator, ResponsesAgentValidator
 from mlflow.pyfunc import ResponsesAgent
 from mlflow.tracing.constant import SpanAttributeKey
@@ -21,6 +21,7 @@ from mlflow.utils.annotations import experimental
 
 logger = logging.getLogger(__name__)
 STREAM_KEY = "stream"
+RETURN_TRACE_HEADER = "x-mlflow-return-trace"
 
 AgentType = Literal["ResponsesAgent"]
 
@@ -259,6 +260,7 @@ class AgentServer:
         )
 
         is_streaming = data.pop(STREAM_KEY, False)
+        return_trace = bool(get_request_headers().get(RETURN_TRACE_HEADER, False))
 
         try:
             request_data = self.validator.validate_and_convert_request(data)
@@ -269,11 +271,13 @@ class AgentServer:
             )
 
         if is_streaming:
-            return await self._handle_stream_request(request_data)
+            return await self._handle_stream_request(request_data, return_trace)
         else:
-            return await self._handle_invoke_request(request_data)
+            return await self._handle_invoke_request(request_data, return_trace)
 
-    async def _handle_invoke_request(self, request: dict[str, Any]) -> dict[str, Any]:
+    async def _handle_invoke_request(
+        self, request: dict[str, Any], return_trace: bool
+    ) -> dict[str, Any]:
         if _invoke_function is None:
             raise HTTPException(status_code=500, detail="No invoke function registered")
 
@@ -291,6 +295,8 @@ class AgentServer:
                 result = self.validator.validate_and_convert_result(result)
                 if self.agent_type == "ResponsesAgent":
                     span.set_attribute(SpanAttributeKey.MESSAGE_FORMAT, "openai")
+                    if return_trace:
+                        result.metadata = (result.metadata or {}) | {"trace_id": span.trace_id}
                 span.set_outputs(result)
 
             logger.debug(
@@ -320,6 +326,7 @@ class AgentServer:
         self,
         func: Callable[..., Any],
         request: dict[str, Any],
+        return_trace: bool,
     ) -> AsyncGenerator[str, None]:
         func_name = func.__name__
         all_chunks: list[dict[str, Any]] = []
@@ -342,6 +349,8 @@ class AgentServer:
                     span.set_outputs(ResponsesAgent.responses_agent_output_reducer(all_chunks))
                 else:
                     span.set_outputs(all_chunks)
+                if return_trace:
+                    yield f"data: {json.dumps({'trace_id': span.trace_id})}\n\n"
 
                 yield "data: [DONE]\n\n"
 
@@ -368,11 +377,13 @@ class AgentServer:
             yield f"data: {json.dumps({'error': str(e)})}\n\n"
             yield "data: [DONE]\n\n"
 
-    async def _handle_stream_request(self, request: dict[str, Any]) -> StreamingResponse:
+    async def _handle_stream_request(
+        self, request: dict[str, Any], return_trace: bool = False
+    ) -> StreamingResponse:
         if _stream_function is None:
             raise HTTPException(status_code=500, detail="No stream function registered")
         return StreamingResponse(
-            self._generate(_stream_function, request), media_type="text/event-stream"
+            self._generate(_stream_function, request, return_trace), media_type="text/event-stream"
         )
 
     @staticmethod

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -260,7 +260,7 @@ class AgentServer:
         )
 
         is_streaming = data.pop(STREAM_KEY, False)
-        return_trace_id = get_request_headers().get(RETURN_TRACE_HEADER) == "true"
+        return_trace_id = (get_request_headers().get(RETURN_TRACE_HEADER) or "").lower() == "true"
 
         try:
             request_data = self.validator.validate_and_convert_request(data)

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -380,7 +380,7 @@ class AgentServer:
             yield "data: [DONE]\n\n"
 
     async def _handle_stream_request(
-        self, request: dict[str, Any], return_trace_id: bool = False
+        self, request: dict[str, Any], return_trace_id: bool
     ) -> StreamingResponse:
         if _stream_function is None:
             raise HTTPException(status_code=500, detail="No stream function registered")

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -260,7 +260,7 @@ class AgentServer:
         )
 
         is_streaming = data.pop(STREAM_KEY, False)
-        return_trace_id = bool(get_request_headers().get(RETURN_TRACE_HEADER, False))
+        return_trace_id = get_request_headers().get(RETURN_TRACE_HEADER) == "true"
 
         try:
             request_data = self.validator.validate_and_convert_request(data)

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -352,13 +352,11 @@ def test_invocations_endpoint_validation_error():
 
 
 def test_invocations_endpoint_success_invoke():
-    with patch("mlflow.start_span") as mock_span:
-        # Mock the span context manager
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span_instance.trace_id = "test-trace-id"
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    mock_span_instance.trace_id = "test-trace-id"
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @invoke()
         def test_invoke(request):
@@ -391,16 +389,15 @@ def test_invocations_endpoint_success_invoke():
         assert response.status_code == 200
         response_json = response.json()
         assert "output" in response_json
+        mock_span.assert_called_once()
 
 
 def test_invocations_endpoint_success_stream():
-    with patch("mlflow.start_span") as mock_span:
-        # Mock the span context manager
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span_instance.trace_id = "test-trace-id"
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    mock_span_instance.trace_id = "test-trace-id"
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @stream()
         def test_stream(request):
@@ -432,6 +429,7 @@ def test_invocations_endpoint_success_stream():
         response = client.post("/invocations", json=request_data)
         assert response.status_code == 200
         assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+        mock_span.assert_called_once()
 
 
 def test_health_endpoint_returns_status():
@@ -463,11 +461,10 @@ def test_request_headers_isolation():
 
 
 def test_tracing_span_creation():
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @invoke()
         def test_function(request):
@@ -482,11 +479,10 @@ def test_tracing_span_creation():
 
 
 def test_tracing_attributes_setting():
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @invoke()
         def test_function(request):
@@ -664,11 +660,10 @@ async def test_chat_proxy_respects_chat_app_port_env_var(monkeypatch):
 
 
 def test_responses_create_endpoint_invoke():
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @invoke()
         def test_invoke(request):
@@ -700,14 +695,14 @@ def test_responses_create_endpoint_invoke():
         response = client.post("/responses", json=request_data)
         assert response.status_code == 200
         assert "output" in response.json()
+        mock_span.assert_called_once()
 
 
 def test_responses_create_endpoint_stream():
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @stream()
         def test_stream(request):
@@ -739,14 +734,14 @@ def test_responses_create_endpoint_stream():
         response = client.post("/responses", json=request_data)
         assert response.status_code == 200
         assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+        mock_span.assert_called_once()
 
 
 def test_responses_create_with_custom_inputs_and_context():
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @invoke()
         def test_invoke(request):
@@ -775,6 +770,7 @@ def test_responses_create_with_custom_inputs_and_context():
 
         response = client.post("/responses", json=request_data)
         assert response.status_code == 200
+        mock_span.assert_called_once()
 
 
 def test_responses_create_validation_error():
@@ -953,12 +949,11 @@ async def test_chat_proxy_forwards_additional_paths_from_env_vars(
 
 
 def test_return_trace_header_invoke_responses_agent():
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span_instance.trace_id = "test-trace-id-123"
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    mock_span_instance.trace_id = "test-trace-id-123"
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @invoke()
         def test_invoke(request):
@@ -996,15 +991,15 @@ def test_return_trace_header_invoke_responses_agent():
         response_json = response.json()
         assert "output" in response_json
         assert response_json["metadata"] == {"trace_id": "test-trace-id-123"}
+        mock_span.assert_called_once()
 
 
 def test_return_trace_header_invoke_responses_agent_without_header():
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span_instance.trace_id = "test-trace-id-123"
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    mock_span_instance.trace_id = "test-trace-id-123"
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @invoke()
         def test_invoke(request):
@@ -1038,15 +1033,15 @@ def test_return_trace_header_invoke_responses_agent_without_header():
         response_json = response.json()
         assert "output" in response_json
         assert response_json.get("metadata") is None
+        mock_span.assert_called_once()
 
 
 def test_return_trace_header_stream_responses_agent():
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span_instance.trace_id = "test-trace-id-456"
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    mock_span_instance.trace_id = "test-trace-id-456"
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @stream()
         def test_stream(request):
@@ -1086,15 +1081,15 @@ def test_return_trace_header_stream_responses_agent():
         content = response.text
         assert 'data: {"trace_id": "test-trace-id-456"}' in content
         assert "data: [DONE]" in content
+        mock_span.assert_called_once()
 
 
 def test_return_trace_header_stream_responses_agent_without_header():
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span_instance.trace_id = "test-trace-id-456"
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    mock_span_instance.trace_id = "test-trace-id-456"
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @stream()
         def test_stream(request):
@@ -1130,15 +1125,15 @@ def test_return_trace_header_stream_responses_agent_without_header():
         content = response.text
         assert "trace_id" not in content
         assert "data: [DONE]" in content
+        mock_span.assert_called_once()
 
 
 def test_return_trace_header_stream_non_responses_agent():
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span_instance.trace_id = "test-trace-id-789"
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    mock_span_instance.trace_id = "test-trace-id-789"
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @stream()
         def test_stream(request):
@@ -1160,16 +1155,16 @@ def test_return_trace_header_stream_non_responses_agent():
         # trace_id should NOT be included for non-ResponsesAgent even with header
         assert "trace_id" not in content
         assert "data: [DONE]" in content
+        mock_span.assert_called_once()
 
 
 @pytest.mark.parametrize("header_value", ["true", "True", "TRUE", "tRuE"])
 def test_return_trace_header_case_insensitive(header_value):
-    with patch("mlflow.start_span") as mock_span:
-        mock_span_instance = Mock()
-        mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
-        mock_span_instance.__exit__ = Mock(return_value=None)
-        mock_span_instance.trace_id = "test-trace-id-123"
-        mock_span.return_value = mock_span_instance
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+    mock_span_instance.trace_id = "test-trace-id-123"
+    with patch("mlflow.start_span", return_value=mock_span_instance) as mock_span:
 
         @invoke()
         def test_invoke(request):
@@ -1207,3 +1202,4 @@ def test_return_trace_header_case_insensitive(header_value):
         response_json = response.json()
         assert "output" in response_json
         assert response_json["metadata"] == {"trace_id": "test-trace-id-123"}
+        mock_span.assert_called_once()


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
- if the "x-mlflow-return-trace-id" header is passed as any case of "true" and the agentserver is hosting a ResponsesAgent, return the trace ID
- for streaming, this is a separate SSE
- for non-streaming, this is inserted into the `metadata` field

bc this is an opt-in only change, this doesn't affect any current users and will not affect generic clients

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

non-stream
```
bbqiu: ~/app-templates [main] $ curl -X POST http://localhost:8000/responses \
-H "Content-Type: application/json" \
-H "x-mlflow-return-trace-id: true" \
-d '{
"input": [{ "role": "user", "content": "hi. respond in 3 words" }]}'
{"object":"response","output":[{"type":"message","id":"__fake_id__","content":[{"annotations":[],"text":"Hi! How can I?","type":"output_text","logprobs":[]}],"role":"assistant","status":"completed","provider_data":{"model":"databricks-gpt-5-2","response_id":"chatcmpl-D2mzoSKr6QRa8Bq2cltZJgigM9oyd"}}],"metadata":{"trace_id":"tr-b2aae5c7b4ae388c17bb430add15596c"}}
```

stream
```
bbqiu: ~/app-templates [main] $ curl -X POST http://localhost:8000/responses \
-H "Content-Type: application/json" \
-H "x-mlflow-return-trace-id: true" \
-d '{
"input": [{ "role": "user", "content": "hi. respond in 3 words" }], "stream": true}'
data: {"response": {"id": "__fake_id__", "created_at": 1769557427.654634, "error": null, "incomplete_details": null, "instructions": null, "metadata": null, "model": "databricks-gpt-5-2", "object": "response", "output": [], "parallel_tool_calls": false, "temperature": null, "tool_choice": "auto", "tools": [], "top_p": null, "background": null, "completed_at": null, "conversation": null, "max_output_tokens": null, "max_tool_calls": null, "previous_response_id": null, "prompt": null, "prompt_cache_key": null, "prompt_cache_retention": null, "reasoning": null, "safety_identifier": null, "service_tier": null, "status": null, "text": null, "top_logprobs": null, "truncation": null, "usage": null, "user": null}, "sequence_number": 0, "type": "response.created"}

data: {"item": {"id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "content": [], "role": "assistant", "status": "in_progress", "type": "message", "provider_data": {"model": "databricks-gpt-5-2", "response_id": "chatcmpl-D2n0ldSM856GH2s5bKVndop7Dft95"}}, "output_index": 0, "sequence_number": 1, "type": "response.output_item.added"}

data: {"content_index": 0, "item_id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "output_index": 0, "part": {"annotations": [], "text": "", "type": "output_text", "logprobs": []}, "sequence_number": 2, "type": "response.content_part.added"}

data: {"content_index": 0, "delta": "", "item_id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "logprobs": [], "output_index": 0, "sequence_number": 3, "type": "response.output_text.delta"}

data: {"content_index": 0, "delta": "Hi", "item_id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "logprobs": [], "output_index": 0, "sequence_number": 4, "type": "response.output_text.delta"}

data: {"content_index": 0, "delta": ".", "item_id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "logprobs": [], "output_index": 0, "sequence_number": 5, "type": "response.output_text.delta"}

data: {"content_index": 0, "delta": " How", "item_id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "logprobs": [], "output_index": 0, "sequence_number": 6, "type": "response.output_text.delta"}

data: {"content_index": 0, "delta": " can", "item_id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "logprobs": [], "output_index": 0, "sequence_number": 7, "type": "response.output_text.delta"}

data: {"content_index": 0, "delta": " I", "item_id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "logprobs": [], "output_index": 0, "sequence_number": 8, "type": "response.output_text.delta"}

data: {"content_index": 0, "delta": " help", "item_id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "logprobs": [], "output_index": 0, "sequence_number": 9, "type": "response.output_text.delta"}

data: {"content_index": 0, "delta": "?", "item_id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "logprobs": [], "output_index": 0, "sequence_number": 10, "type": "response.output_text.delta"}

data: {"content_index": 0, "item_id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "output_index": 0, "part": {"annotations": [], "text": "Hi. How can I help?", "type": "output_text", "logprobs": []}, "sequence_number": 11, "type": "response.content_part.done"}

data: {"item": {"id": "07dcd737-bfff-4af4-872b-c9adfdcac139", "content": [{"annotations": [], "text": "Hi. How can I help?", "type": "output_text", "logprobs": []}], "role": "assistant", "status": "completed", "type": "message", "provider_data": {"model": "databricks-gpt-5-2", "response_id": "chatcmpl-D2n0ldSM856GH2s5bKVndop7Dft95"}}, "output_index": 0, "sequence_number": 12, "type": "response.output_item.done"}

data: {"response": {"id": "__fake_id__", "created_at": 1769557427.654634, "error": null, "incomplete_details": null, "instructions": null, "metadata": null, "model": "databricks-gpt-5-2", "object": "response", "output": [{"id": "__fake_id__", "content": [{"annotations": [], "text": "Hi. How can I help?", "type": "output_text", "logprobs": []}], "role": "assistant", "status": "completed", "type": "message", "provider_data": {"model": "databricks-gpt-5-2", "response_id": "chatcmpl-D2n0ldSM856GH2s5bKVndop7Dft95"}}], "parallel_tool_calls": false, "temperature": null, "tool_choice": "auto", "tools": [], "top_p": null, "background": null, "completed_at": null, "conversation": null, "max_output_tokens": null, "max_tool_calls": null, "previous_response_id": null, "prompt": null, "prompt_cache_key": null, "prompt_cache_retention": null, "reasoning": null, "safety_identifier": null, "service_tier": null, "status": null, "text": null, "top_logprobs": null, "truncation": null, "usage": {"input_tokens": 238, "input_tokens_details": {"cached_tokens": 0}, "output_tokens": 10, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 248}, "user": null}, "sequence_number": 13, "type": "response.completed"}

data: {"trace_id": "tr-03c5091a0d8a8fda0ecb7e8f0a79a20e"}

data: [DONE]
```
### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
