### PR TITLE
[UI] Virtualize compare run metrics table for performance at high metric count

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunMetricTable.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunMetricTable.test.tsx
@@ -1,0 +1,113 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { CompareRunMetricTable } from './CompareRunMetricTable';
+import { TestRouter, testRoute } from '../../common/utils/RoutingTestUtils';
+import type { RunInfoEntity } from '../types';
+
+const mockRunInfos: RunInfoEntity[] = [
+  { runUuid: 'run_1', experimentId: 'exp_1' } as RunInfoEntity,
+  { runUuid: 'run_2', experimentId: 'exp_1' } as RunInfoEntity,
+];
+
+const mockMetricRows = [
+  { key: 'accuracy', highlightDiff: false, values: [0.95, 0.92] },
+  { key: 'loss', highlightDiff: true, values: [0.05, 0.08] },
+];
+
+const wrapper = ({ children }: { children?: React.ReactNode }) => (
+  <IntlProvider locale="en">
+    <TestRouter routes={[testRoute(<>{children}</>)]} />
+  </IntlProvider>
+);
+
+describe('CompareRunMetricTable', () => {
+  test('renders metric rows with correct values', () => {
+    const onScroll = jest.fn();
+    render(
+      <CompareRunMetricTable
+        colWidth={200}
+        experimentIds={['exp_1']}
+        runInfos={mockRunInfos}
+        metricRows={mockMetricRows}
+        onScroll={onScroll}
+      />,
+      { wrapper },
+    );
+
+    expect(screen.getByText('accuracy')).toBeInTheDocument();
+    expect(screen.getByText('loss')).toBeInTheDocument();
+  });
+
+  test('applies highlight styling to rows with highlightDiff', () => {
+    const onScroll = jest.fn();
+    render(
+      <CompareRunMetricTable
+        colWidth={200}
+        experimentIds={['exp_1']}
+        runInfos={mockRunInfos}
+        metricRows={mockMetricRows}
+        onScroll={onScroll}
+      />,
+      { wrapper },
+    );
+
+    expect(screen.getByText('loss')).toBeInTheDocument();
+  });
+
+  test('calls onScroll when body grid is scrolled', () => {
+    const onScroll = jest.fn();
+    const { container } = render(
+      <CompareRunMetricTable
+        colWidth={200}
+        experimentIds={['exp_1']}
+        runInfos={mockRunInfos}
+        metricRows={mockMetricRows}
+        onScroll={onScroll}
+      />,
+      { wrapper },
+    );
+
+    const grids = container.querySelectorAll('[role="grid"]');
+    const bodyGrid = grids[1];
+
+    fireEvent.scroll(bodyGrid, { target: { scrollLeft: 100 } });
+    expect(onScroll).toHaveBeenCalled();
+  });
+
+  test('renders empty table when no metric rows provided', () => {
+    const onScroll = jest.fn();
+    const { container } = render(
+      <CompareRunMetricTable
+        colWidth={200}
+        experimentIds={['exp_1']}
+        runInfos={mockRunInfos}
+        metricRows={[]}
+        onScroll={onScroll}
+      />,
+      { wrapper },
+    );
+
+    expect(container.querySelector('[role="grid"]')).toBeInTheDocument();
+  });
+
+  test('setScrollLeft updates body grid scroll position', () => {
+    const onScroll = jest.fn();
+    const ref = { current: null } as any;
+
+    render(
+      <CompareRunMetricTable
+        ref={ref}
+        colWidth={200}
+        experimentIds={['exp_1']}
+        runInfos={mockRunInfos}
+        metricRows={mockMetricRows}
+        onScroll={onScroll}
+      />,
+      { wrapper },
+    );
+
+    expect(ref.current).toBeDefined();
+    expect(ref.current.setScrollLeft).toBeDefined();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunMetricTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunMetricTable.tsx
@@ -1,0 +1,300 @@
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import type { RunInfoEntity } from '@mlflow/mlflow/src/experiment-tracking/types';
+import type { ScrollParams } from 'react-virtualized';
+import { AutoSizer, Grid } from 'react-virtualized';
+import { Link } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
+import Utils from '@mlflow/mlflow/src/common/utils/Utils';
+import { LegacyTooltip, useDesignSystemTheme } from '@databricks/design-system';
+
+export type CompareRunMetricTableRef = {
+  setScrollLeft: (scrollLeft: number) => void;
+};
+
+export type CompareRunMetricTableProps = {
+  colWidth: number;
+  experimentIds: string[];
+  runInfos: RunInfoEntity[];
+  metricRows: {
+    key: string;
+    highlightDiff: boolean;
+    values: number[];
+  }[];
+  onScroll: (params: ScrollParams) => unknown;
+};
+
+export const CompareRunMetricTable = forwardRef<CompareRunMetricTableRef, CompareRunMetricTableProps>(
+  function CompareRunMetricTable(props, ref) {
+    const rowHeight = 45;
+    const tableMaxHeight = 300;
+    const headerRef = useRef<Grid | null>(null);
+    const bodyRef = useRef<Grid | null>(null);
+    const [hoveredSet, setHoveredSet] = useState<{ row: number; column: number }[]>([]);
+
+    const { tableHeight, columnCount } = useMemo(
+      () => ({
+        tableHeight: Math.min(rowHeight * props.metricRows.length, tableMaxHeight),
+        columnCount: Math.max(...props.metricRows.map((e) => e.values.length)),
+      }),
+      [rowHeight, tableMaxHeight, props.metricRows],
+    );
+
+    const isHovered = useCallback(
+      (row?: number, column?: number) => {
+        return hoveredSet.some(
+          (e) => (row === undefined || e.row === row) && (column === undefined || e.column === column),
+        );
+      },
+      [hoveredSet],
+    );
+
+    const addHoveredEntry = useCallback(
+      (row: number, column: number) => {
+        setHoveredSet((previous) => {
+          if (!isHovered(row, column)) {
+            return [...previous, { row, column }];
+          } else {
+            return previous;
+          }
+        });
+      },
+      [setHoveredSet, isHovered],
+    );
+
+    const removeHoveredEntry = useCallback(
+      (row: number, column: number) => {
+        setHoveredSet((previous) => {
+          return previous.filter((e) => e.row !== row || e.column !== column);
+        });
+      },
+      [setHoveredSet],
+    );
+
+    const synchronize = useCallback(() => {
+      if (headerRef.current && bodyRef.current) {
+        headerRef.current.scrollToPosition({
+          scrollTop: bodyRef.current.state.scrollTop,
+          scrollLeft: 0,
+        });
+      }
+    }, []);
+
+    const onScroll = useCallback(
+      (params: ScrollParams) => {
+        synchronize();
+        props.onScroll(params);
+      },
+      [props, synchronize],
+    );
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        setScrollLeft: (scrollLeft: number) => {
+          if (bodyRef.current && bodyRef.current.state.scrollLeft !== scrollLeft) {
+            bodyRef.current?.scrollToPosition({
+              scrollLeft,
+              scrollTop: bodyRef.current.state.scrollTop,
+            });
+          }
+        },
+      }),
+      [],
+    );
+
+    const headerCellRenderer = useCallback(
+      ({ rowIndex, key, style }: { rowIndex: number; key: string; style: React.CSSProperties }) => (
+        <CompareRunMetricTableHeaderCell
+          key={key}
+          style={style}
+          onMouseEnter={() => addHoveredEntry(rowIndex, 0)}
+          onMouseLeave={() => removeHoveredEntry(rowIndex, 0)}
+          highlightDiff={props.metricRows[rowIndex].highlightDiff}
+          metricRowKey={props.metricRows[rowIndex].key}
+          metricPageRoute={Routes.getMetricPageRoute(
+            props.runInfos
+              .map((info) => info.runUuid)
+              .filter((_uuid, idx) => props.metricRows[rowIndex].values[idx] !== undefined),
+            props.metricRows[rowIndex].key,
+            props.experimentIds,
+          )}
+        />
+      ),
+      [addHoveredEntry, removeHoveredEntry, props],
+    );
+
+    const bodyCellRenderer = useCallback(
+      ({
+        columnIndex,
+        rowIndex,
+        key,
+        style,
+      }: {
+        columnIndex: number;
+        rowIndex: number;
+        key: string;
+        style: React.CSSProperties;
+      }) => (
+        <CompareRunMetricTableBodyCell
+          key={key}
+          style={style}
+          onMouseEnter={() => addHoveredEntry(rowIndex, columnIndex + 1)}
+          onMouseLeave={() => removeHoveredEntry(rowIndex, columnIndex + 1)}
+          formattedMetric={Utils.formatMetric(props.metricRows[rowIndex].values[columnIndex])}
+          highlightDiff={props.metricRows[rowIndex].highlightDiff}
+          rowHovered={isHovered(rowIndex, undefined)}
+        />
+      ),
+      [addHoveredEntry, removeHoveredEntry, isHovered, props],
+    );
+
+    return (
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'row',
+        }}
+      >
+        <div
+          css={{
+            width: `${props.colWidth}px`,
+            display: 'flex',
+          }}
+        >
+          <Grid
+            ref={headerRef}
+            style={{ overflow: 'hidden' }}
+            width={props.colWidth}
+            height={tableHeight}
+            rowCount={props.metricRows.length}
+            rowHeight={rowHeight}
+            columnCount={1}
+            columnWidth={props.colWidth}
+            cellRenderer={headerCellRenderer}
+          />
+        </div>
+        <div
+          css={{
+            flex: '1',
+            display: 'flex',
+          }}
+        >
+          <AutoSizer>
+            {({ width }) => (
+              <Grid
+                ref={bodyRef}
+                onScroll={onScroll}
+                width={width}
+                height={tableHeight}
+                rowCount={props.metricRows.length}
+                rowHeight={rowHeight}
+                columnCount={columnCount}
+                columnWidth={props.colWidth}
+                cellRenderer={bodyCellRenderer}
+              />
+            )}
+          </AutoSizer>
+        </div>
+      </div>
+    );
+  },
+);
+
+interface CompareRunMetricTableHeaderCellProps {
+  key: string;
+  style: React.CSSProperties;
+  highlightDiff: boolean;
+  metricRowKey: string;
+  metricPageRoute: string;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+function CompareRunMetricTableHeaderCell({
+  key,
+  style,
+  highlightDiff,
+  metricRowKey,
+  metricPageRoute,
+  onMouseEnter,
+  onMouseLeave,
+}: CompareRunMetricTableHeaderCellProps) {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      key={key}
+      style={style}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      css={{
+        overflow: 'hidden',
+        overflowWrap: 'break-word',
+        padding: '12px 8px',
+        borderBottom: `1px solid ${theme.colors.border}`,
+        color: highlightDiff ? theme.colors.textSecondary : theme.colors.textPrimary,
+        fontWeight: 500,
+        backgroundColor: highlightDiff ? theme.colors.backgroundWarning : theme.colors.backgroundSecondary,
+        textAlign: 'left',
+      }}
+    >
+      <Link to={metricPageRoute} title="Plot chart">
+        {metricRowKey}
+        <i className="fa fa-chart-line" css={{ paddingLeft: '6px' }} />
+      </Link>
+    </div>
+  );
+}
+
+interface CompareRunMetricTableBodyCellProps {
+  key: string;
+  style: React.CSSProperties;
+  formattedMetric: string;
+  highlightDiff: boolean;
+  rowHovered: boolean;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+function CompareRunMetricTableBodyCell({
+  key,
+  style,
+  formattedMetric,
+  highlightDiff,
+  rowHovered,
+  onMouseEnter,
+  onMouseLeave,
+}: CompareRunMetricTableBodyCellProps) {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      key={key}
+      style={style}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      css={{
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        padding: '12px 8px',
+        color: highlightDiff ? theme.colors.textSecondary : undefined,
+        borderBottom: `1px solid ${theme.colors.border}`,
+        backgroundColor: highlightDiff
+          ? theme.colors.backgroundWarning
+          : rowHovered
+            ? theme.colors.backgroundSecondary
+            : undefined,
+      }}
+    >
+      <LegacyTooltip
+        title={formattedMetric}
+        // @ts-expect-error TS(2322): Type '{ children: any; title: any; color: string; ... Remove this comment to see the full error message
+        color="gray"
+        placement="topLeft"
+        overlayStyle={{ maxWidth: '400px' }}
+        // mouseEnterDelay prop is not available in DuBois design system (yet)
+        dangerouslySetAntdProps={{ mouseEnterDelay: 1 }}
+      >
+        {formattedMetric}
+      </LegacyTooltip>
+    </div>
+  );
+}

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -8,7 +8,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage, type IntlShape } from 'react-intl';
-import { Spacer, Switch, LegacyTabs, Tooltip, Typography } from '@databricks/design-system';
+import { Spacer, Switch, LegacyTabs, LegacyTooltip, Tooltip, Typography } from '@databricks/design-system';
 
 import { getExperiment, getParams, getRunInfo, getRunTags } from '../reducers/Reducers';
 import './CompareRunView.css';
@@ -25,6 +25,9 @@ import { PageHeader } from '../../shared/building_blocks/PageHeader';
 import { CollapsibleSection } from '../../common/components/CollapsibleSection';
 import type { RunInfoEntity } from '../types';
 import { CompareRunArtifactView } from './CompareRunArtifactView';
+import type { ScrollParams } from 'react-virtualized';
+import type { CompareRunMetricTableRef } from '@mlflow/mlflow/src/experiment-tracking/components/CompareRunMetricTable';
+import { CompareRunMetricTable } from '@mlflow/mlflow/src/experiment-tracking/components/CompareRunMetricTable';
 
 const { TabPane } = LegacyTabs;
 
@@ -47,6 +50,7 @@ type CompareRunViewState = any;
 class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState> {
   compareRunViewRef: any;
   runDetailsTableRef: any;
+  compareRunMetricTableRef: React.MutableRefObject<CompareRunMetricTableRef | null>;
 
   constructor(props: CompareRunViewProps) {
     super(props);
@@ -61,6 +65,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
 
     this.runDetailsTableRef = React.createRef();
     this.compareRunViewRef = React.createRef();
+    this.compareRunMetricTableRef = React.createRef();
   }
 
   onResizeHandler(e: any) {
@@ -71,14 +76,21 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
     }
   }
 
-  onCompareRunTableScrollHandler(e: any) {
-    const blocks = this.compareRunViewRef.current.querySelectorAll('.mlflow-compare-run-table');
+  updateScrollLeftForCompareTables(scrollLeft: number) {
+    const blocks = this.compareRunViewRef.current?.querySelectorAll('.mlflow-compare-run-table') || [];
     blocks.forEach((_: any, index: any) => {
       const block = blocks[index];
-      if (block !== e.target) {
-        block.scrollLeft = e.target.scrollLeft;
-      }
+      block.scrollLeft = scrollLeft;
     });
+    this.compareRunMetricTableRef.current?.setScrollLeft(scrollLeft);
+  }
+
+  onCompareRunTableScrollHandler(e: any) {
+    this.updateScrollLeftForCompareTables(e.target.scrollLeft);
+  }
+
+  onCompareRunMetricTableScrollHandler(e: ScrollParams) {
+    this.updateScrollLeftForCompareTables(e.scrollLeft);
   }
 
   componentDidMount() {
@@ -252,30 +264,13 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
   }
 
   renderMetricTable(colWidth: any, experimentIds: any) {
-    const dataRows = this.renderDataRows(
+    const preparedRows = this.prepareDataRows(
       this.props.metricLists,
-      colWidth,
       // @ts-expect-error TS(4111): Property 'onlyShowMetricDiff' comes from an index ... Remove this comment to see the full error message
       this.state.onlyShowMetricDiff,
       false,
-      (key, data) => {
-        return (
-          <Link
-            to={Routes.getMetricPageRoute(
-              this.props.runInfos.map((info) => info.runUuid).filter((uuid, idx) => data[idx] !== undefined),
-              key,
-              experimentIds,
-            )}
-            title="Plot chart"
-          >
-            {key}
-            <i className="fa fa-chart-line" css={{ paddingLeft: '6px' }} />
-          </Link>
-        );
-      },
-      Utils.formatMetric,
     );
-    if (dataRows.length === 0) {
+    if (preparedRows.length === 0) {
       return (
         <h2>
           <FormattedMessage
@@ -286,13 +281,14 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
       );
     }
     return (
-      <table
-        className="table mlflow-compare-table mlflow-compare-run-table"
-        css={{ maxHeight: '300px' }}
-        onScroll={this.onCompareRunTableScrollHandler}
-      >
-        <tbody>{dataRows}</tbody>
-      </table>
+      <CompareRunMetricTable
+        ref={this.compareRunMetricTableRef}
+        colWidth={colWidth}
+        experimentIds={experimentIds}
+        runInfos={this.props.runInfos}
+        metricRows={preparedRows}
+        onScroll={(e) => this.onCompareRunMetricTableScrollHandler(e)}
+      />
     );
   }
 
@@ -622,14 +618,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
     };
   }
 
-  renderDataRows(
-    list: any,
-    colWidth: any,
-    onlyShowDiff: any,
-    highlightDiff = false,
-    headerMap = (key: any, data: any) => key,
-    formatter = (value: any) => value,
-  ) {
+  prepareDataRows(list: any, onlyShowDiff: any, highlightDiff = false) {
     // @ts-expect-error TS(2554): Expected 2 arguments, but got 1.
     const keys = CompareRunUtil.getKeys(list);
     const data = {};
@@ -643,8 +632,6 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     keys.forEach((k) => (data[k].hasDiff = checkHasDiff(data[k].values)));
 
-    const colWidthStyle = this.genWidthStyle(colWidth);
-
     return (
       keys
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
@@ -652,32 +639,54 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
         .map((k) => {
           // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           const { values, hasDiff } = data[k];
-          const rowClass = highlightDiff && hasDiff ? 'diff-row' : undefined;
-          return (
-            <tr key={k} className={rowClass}>
-              <th scope="row" className="head-value mlflow-sticky-header" css={colWidthStyle}>
-                {headerMap(k, values)}
-              </th>
-              {values.map((value: any, i: any) => {
-                const cellText = value === undefined ? '' : formatter(value);
-                return (
-                  <td className="data-value" key={this.props.runInfos[i].runUuid} css={colWidthStyle}>
-                    <Tooltip
-                      componentId="mlflow.legacy_compare_run.data_row"
-                      content={cellText}
-                      side="top"
-                      align="end"
-                      maxWidth={400}
-                    >
-                      <span className="truncate-text single-line">{cellText}</span>
-                    </Tooltip>
-                  </td>
-                );
-              })}
-            </tr>
-          );
+          return {
+            key: k,
+            highlightDiff: highlightDiff && hasDiff,
+            values,
+          };
         })
     );
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  renderDataRows(
+    list: any,
+    colWidth: any,
+    onlyShowDiff: any,
+    highlightDiff = false,
+    headerMap = (key: any, data: any) => key,
+    formatter = (value: any) => value,
+  ) {
+    const preparedRows = this.prepareDataRows(list, onlyShowDiff, highlightDiff);
+    const colWidthStyle = this.genWidthStyle(colWidth);
+
+    return preparedRows.map((row) => {
+      const rowClass = row.highlightDiff ? 'diff-row' : undefined;
+      return (
+        <tr key={row.key} className={rowClass}>
+          <th scope="row" className="head-value mlflow-sticky-header" css={colWidthStyle}>
+            {headerMap(row.key, row.values)}
+          </th>
+          {row.values.map((value: any, i: any) => {
+            const cellText = value === undefined ? '' : formatter(value);
+            return (
+              <td className="data-value" key={this.props.runInfos[i].runUuid} css={colWidthStyle}>
+                <LegacyTooltip
+                  title={cellText}
+                  // @ts-expect-error TS(2322): Type '{ children: Element; title: any; color: stri... Remove this comment to see the full error message
+                  color="gray"
+                  placement="topLeft"
+                  overlayStyle={{ maxWidth: '400px' }}
+                  mouseEnterDelay={1.0}
+                >
+                  <span className="truncate-text single-line">{cellText}</span>
+                </LegacyTooltip>
+              </td>
+            );
+          })}
+        </tr>
+      );
+    });
   }
 }
 


### PR DESCRIPTION

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve -->

### What changes are proposed in this pull request?

We have noticed performance issues when attempting to compare runs with a large number of metrics (8000+). When selecting the runs on the experiment table and clicking the compare button, the page proceeds to show a loading spinner for minutes, consumes a lot of memory, and is sluggish once loaded.

The proposed change in the PR is to virtualize the metrics table so cells that are not visible within the scroll container are not rendered to the DOM. In testing, this reduced the loading time & memory usage, and brought page performance back to normal. 

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

https://github.com/user-attachments/assets/e7966468-5d51-495b-9477-db4277cd66b0

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Performance improvements for metrics comparison table.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
