### PR TITLE
Fix infinite loop in clint `_resolve_import` caused by circular imports

### DIFF
--- a/dev/clint/src/clint/index.py
+++ b/dev/clint/src/clint/index.py
@@ -195,7 +195,12 @@ class SymbolIndex:
 
     def _resolve_import(self, target: str) -> str:
         resolved = target
+        seen = {resolved}
         while v := self.import_mapping.get(resolved):
+            if v in seen:
+                # Circular import detected, break to avoid infinite loop
+                break
+            seen.add(v)
             resolved = v
         return resolved
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Fix an infinite loop in `clint`'s `_resolve_import` method that occurs when there are circular import mappings. The method now tracks seen values and breaks out of the loop when a cycle is detected.

### How is this PR tested?

- [x] Manual tests

Verified by running `uv run clint docs/docs/genai/eval-monitor/scorers/llm-judge/rag/context-sufficiency.mdx` which was previously hanging.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)