### PR TITLE
Support querying span metrics (cost)

### DIFF
--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -93,15 +93,24 @@ SPANS_METRICS_CONFIGS: dict[SpanMetricKey, TraceMetricsConfig] = {
     ),
     SpanMetricKey.INPUT_COST: TraceMetricsConfig(
         aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
-        dimensions={SpanMetricDimensionKey.SPAN_MODEL_NAME},
+        dimensions={
+            SpanMetricDimensionKey.SPAN_MODEL_NAME,
+            SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+        },
     ),
     SpanMetricKey.OUTPUT_COST: TraceMetricsConfig(
         aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
-        dimensions={SpanMetricDimensionKey.SPAN_MODEL_NAME},
+        dimensions={
+            SpanMetricDimensionKey.SPAN_MODEL_NAME,
+            SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+        },
     ),
     SpanMetricKey.TOTAL_COST: TraceMetricsConfig(
         aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
-        dimensions={SpanMetricDimensionKey.SPAN_MODEL_NAME},
+        dimensions={
+            SpanMetricDimensionKey.SPAN_MODEL_NAME,
+            SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+        },
     ),
 }
 
@@ -372,6 +381,10 @@ def _apply_dimension_to_query(
                     # Extract model name from span_metrics metric_metadata JSON column
                     model_name = SqlSpanMetrics.metric_metadata[SpanAttributeKey.MODEL]
                     return query, model_name.label(SpanMetricDimensionKey.SPAN_MODEL_NAME)
+                case SpanMetricDimensionKey.SPAN_MODEL_PROVIDER:
+                    # Extract model provider from span_metrics metric_metadata JSON column
+                    model_provider = SqlSpanMetrics.metric_metadata[SpanAttributeKey.MODEL_PROVIDER]
+                    return query, model_provider.label(SpanMetricDimensionKey.SPAN_MODEL_PROVIDER)
         case MetricViewType.ASSESSMENTS:
             match dimension:
                 case AssessmentMetricDimensionKey.ASSESSMENT_NAME:

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -378,12 +378,12 @@ def _apply_dimension_to_query(
                 case SpanMetricDimensionKey.SPAN_STATUS:
                     return query, SqlSpan.status.label(SpanMetricDimensionKey.SPAN_STATUS)
                 case SpanMetricDimensionKey.SPAN_MODEL_NAME:
-                    # Extract model name from span_metadata JSON column on SqlSpan
-                    model_name = SqlSpan.span_metadata[SpanAttributeKey.MODEL]
+                    # Extract model name from dimension_attributes JSON column on SqlSpan
+                    model_name = SqlSpan.dimension_attributes[SpanAttributeKey.MODEL]
                     return query, model_name.label(SpanMetricDimensionKey.SPAN_MODEL_NAME)
                 case SpanMetricDimensionKey.SPAN_MODEL_PROVIDER:
-                    # Extract model provider from span_metadata JSON column on SqlSpan
-                    model_provider = SqlSpan.span_metadata[SpanAttributeKey.MODEL_PROVIDER]
+                    # Extract model provider from dimension_attributes JSON column on SqlSpan
+                    model_provider = SqlSpan.dimension_attributes[SpanAttributeKey.MODEL_PROVIDER]
                     return query, model_provider.label(SpanMetricDimensionKey.SPAN_MODEL_PROVIDER)
         case MetricViewType.ASSESSMENTS:
             match dimension:

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -378,12 +378,12 @@ def _apply_dimension_to_query(
                 case SpanMetricDimensionKey.SPAN_STATUS:
                     return query, SqlSpan.status.label(SpanMetricDimensionKey.SPAN_STATUS)
                 case SpanMetricDimensionKey.SPAN_MODEL_NAME:
-                    # Extract model name from span_metrics metric_metadata JSON column
-                    model_name = SqlSpanMetrics.metric_metadata[SpanAttributeKey.MODEL]
+                    # Extract model name from span_metadata JSON column on SqlSpan
+                    model_name = SqlSpan.span_metadata[SpanAttributeKey.MODEL]
                     return query, model_name.label(SpanMetricDimensionKey.SPAN_MODEL_NAME)
                 case SpanMetricDimensionKey.SPAN_MODEL_PROVIDER:
-                    # Extract model provider from span_metrics metric_metadata JSON column
-                    model_provider = SqlSpanMetrics.metric_metadata[SpanAttributeKey.MODEL_PROVIDER]
+                    # Extract model provider from span_metadata JSON column on SqlSpan
+                    model_provider = SqlSpan.span_metadata[SpanAttributeKey.MODEL_PROVIDER]
                     return query, model_provider.label(SpanMetricDimensionKey.SPAN_MODEL_PROVIDER)
         case MetricViewType.ASSESSMENTS:
             match dimension:

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -226,6 +226,7 @@ class SpanMetricDimensionKey:
     SPAN_TYPE = "span_type"
     SPAN_STATUS = "span_status"
     SPAN_MODEL_NAME = "span_model_name"
+    SPAN_MODEL_PROVIDER = "span_model_provider"
 
 
 class AssessmentMetricKey:

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -208,6 +208,13 @@ class SpanMetricKey:
 
     SPAN_COUNT = "span_count"
     LATENCY = "latency"
+    INPUT_COST = "input_cost"
+    OUTPUT_COST = "output_cost"
+    TOTAL_COST = "total_cost"
+
+    @classmethod
+    def cost_keys(cls) -> list[str]:
+        return [cls.INPUT_COST, cls.OUTPUT_COST, cls.TOTAL_COST]
 
 
 class SpanMetricDimensionKey:
@@ -218,6 +225,7 @@ class SpanMetricDimensionKey:
     SPAN_NAME = "span_name"
     SPAN_TYPE = "span_type"
     SPAN_STATUS = "span_status"
+    MODEL_NAME = "span_model_name"
 
 
 class AssessmentMetricKey:

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -225,7 +225,7 @@ class SpanMetricDimensionKey:
     SPAN_NAME = "span_name"
     SPAN_TYPE = "span_type"
     SPAN_STATUS = "span_status"
-    MODEL_NAME = "span_model_name"
+    SPAN_MODEL_NAME = "span_model_name"
 
 
 class AssessmentMetricKey:

--- a/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
@@ -3720,7 +3720,7 @@ def test_query_span_metrics_cost_sum(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1000000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.001,
                     "output_cost": 0.002,
                     "total_cost": 0.003,
@@ -3735,7 +3735,7 @@ def test_query_span_metrics_cost_sum(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.002,
                     "output_cost": 0.003,
                     "total_cost": 0.005,
@@ -3750,7 +3750,7 @@ def test_query_span_metrics_cost_sum(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1200000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.003,
                     "output_cost": 0.004,
                     "total_cost": 0.007,
@@ -3797,7 +3797,7 @@ def test_query_span_metrics_cost_by_model_name(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1000000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.01,
                     "output_cost": 0.02,
                     "total_cost": 0.03,
@@ -3812,7 +3812,7 @@ def test_query_span_metrics_cost_by_model_name(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.01,
                     "output_cost": 0.02,
                     "total_cost": 0.03,
@@ -3827,7 +3827,7 @@ def test_query_span_metrics_cost_by_model_name(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1200000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.005,
                     "output_cost": 0.015,
                     "total_cost": 0.02,
@@ -3880,7 +3880,7 @@ def test_query_span_metrics_cost_avg_by_model_name(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1000000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.01,
                     "output_cost": 0.02,
                     "total_cost": 0.03,
@@ -3895,7 +3895,7 @@ def test_query_span_metrics_cost_avg_by_model_name(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.02,
                     "output_cost": 0.03,
                     "total_cost": 0.05,
@@ -3943,7 +3943,7 @@ def test_query_span_metrics_cost_multiple_aggregations(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1000000000 + i * 100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.01 * i,
                     "output_cost": 0.01 * i,
                     "total_cost": 0.02 * i,
@@ -3994,7 +3994,7 @@ def test_query_span_metrics_input_output_cost(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1000000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.01,
                     "output_cost": 0.03,
                     "total_cost": 0.04,
@@ -4009,7 +4009,7 @@ def test_query_span_metrics_input_output_cost(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.02,
                     "output_cost": 0.04,
                     "total_cost": 0.06,
@@ -4069,7 +4069,7 @@ def test_query_span_metrics_cost_across_multiple_traces(store: SqlAlchemyStore):
                 span_type="LLM",
                 start_ns=1000000000,
                 attributes={
-                    SpanAttributeKey.CHAT_COST: {
+                    SpanAttributeKey.LLM_COST: {
                         "input_cost": 0.01,
                         "output_cost": 0.02,
                         "total_cost": 0.03,
@@ -4118,7 +4118,7 @@ def test_query_span_metrics_cost_percentiles(store: SqlAlchemyStore, percentile_
             span_type="LLM",
             start_ns=1000000000 + i * 100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.005 * i,
                     "output_cost": 0.005 * i,
                     "total_cost": 0.01 * i,

--- a/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
@@ -3843,18 +3843,18 @@ def test_query_span_metrics_cost_by_model_name(store: SqlAlchemyStore):
         view_type=MetricViewType.SPANS,
         metric_name=SpanMetricKey.TOTAL_COST,
         aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
-        dimensions=[SpanMetricDimensionKey.MODEL_NAME],
+        dimensions=[SpanMetricDimensionKey.SPAN_MODEL_NAME],
     )
 
     assert len(result) == 2
     assert asdict(result[0]) == {
         "metric_name": SpanMetricKey.TOTAL_COST,
-        "dimensions": {SpanMetricDimensionKey.MODEL_NAME: "claude-3"},
+        "dimensions": {SpanMetricDimensionKey.SPAN_MODEL_NAME: "claude-3"},
         "values": {"SUM": 0.02},
     }
     assert asdict(result[1]) == {
         "metric_name": SpanMetricKey.TOTAL_COST,
-        "dimensions": {SpanMetricDimensionKey.MODEL_NAME: "gpt-4"},
+        "dimensions": {SpanMetricDimensionKey.SPAN_MODEL_NAME: "gpt-4"},
         "values": {"SUM": 0.06},
     }
 
@@ -3911,13 +3911,13 @@ def test_query_span_metrics_cost_avg_by_model_name(store: SqlAlchemyStore):
         view_type=MetricViewType.SPANS,
         metric_name=SpanMetricKey.TOTAL_COST,
         aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
-        dimensions=[SpanMetricDimensionKey.MODEL_NAME],
+        dimensions=[SpanMetricDimensionKey.SPAN_MODEL_NAME],
     )
 
     assert len(result) == 1
     assert asdict(result[0]) == {
         "metric_name": SpanMetricKey.TOTAL_COST,
-        "dimensions": {SpanMetricDimensionKey.MODEL_NAME: "gpt-4"},
+        "dimensions": {SpanMetricDimensionKey.SPAN_MODEL_NAME: "gpt-4"},
         "values": {"AVG": 0.04},
     }
 
@@ -4085,13 +4085,13 @@ def test_query_span_metrics_cost_across_multiple_traces(store: SqlAlchemyStore):
         view_type=MetricViewType.SPANS,
         metric_name=SpanMetricKey.TOTAL_COST,
         aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
-        dimensions=[SpanMetricDimensionKey.MODEL_NAME],
+        dimensions=[SpanMetricDimensionKey.SPAN_MODEL_NAME],
     )
 
     assert len(result) == 1
     assert asdict(result[0]) == {
         "metric_name": SpanMetricKey.TOTAL_COST,
-        "dimensions": {SpanMetricDimensionKey.MODEL_NAME: "gpt-4"},
+        "dimensions": {SpanMetricDimensionKey.SPAN_MODEL_NAME: "gpt-4"},
         "values": {"SUM": 0.09},
     }
 

--- a/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
@@ -17,7 +17,11 @@ from mlflow.entities import (
 )
 from mlflow.entities.assessment import AssessmentError
 from mlflow.entities.trace_info import TraceInfo
-from mlflow.entities.trace_metrics import AggregationType, MetricAggregation, MetricViewType
+from mlflow.entities.trace_metrics import (
+    AggregationType,
+    MetricAggregation,
+    MetricViewType,
+)
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
 from mlflow.genai.judges import CategoricalRating
@@ -3944,9 +3948,9 @@ def test_query_span_metrics_cost_multiple_aggregations(store: SqlAlchemyStore):
             start_ns=1000000000 + i * 100000000,
             attributes={
                 SpanAttributeKey.LLM_COST: {
-                    "input_cost": 0.01 * i,
-                    "output_cost": 0.01 * i,
-                    "total_cost": 0.02 * i,
+                    "input_cost": i,
+                    "output_cost": i,
+                    "total_cost": 2 * i,
                 },
                 SpanAttributeKey.MODEL: "gpt-4",
             },
@@ -3969,7 +3973,7 @@ def test_query_span_metrics_cost_multiple_aggregations(store: SqlAlchemyStore):
     assert asdict(result[0]) == {
         "metric_name": SpanMetricKey.TOTAL_COST,
         "dimensions": {},
-        "values": {"SUM": 0.30, "AVG": 0.06},
+        "values": {"SUM": 30.0, "AVG": 6.0},
     }
 
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20403/files) to review incremental changes.
- [**stack/span_cost_metrics_query**](https://github.com/mlflow/mlflow/pull/20403) [[Files changed](https://github.com/mlflow/mlflow/pull/20403/files)]
  - [stack/cost_chart](https://github.com/mlflow/mlflow/pull/20404) [[Files changed](https://github.com/mlflow/mlflow/pull/20404/files/0962cf5f6a39b4a1e95c47ffb04a237c075fb486..de423d53c419353705f6de3d30038e715bcd93a2)]
    - [stack/cost_chart_over_time](https://github.com/mlflow/mlflow/pull/20440) [[Files changed](https://github.com/mlflow/mlflow/pull/20440/files/de423d53c419353705f6de3d30038e715bcd93a2..e5fcb98bb07668a3e39ba91aae37d2eead1d4195)]
      - [stack/cost_chart_model_selection](https://github.com/mlflow/mlflow/pull/20455) [[Files changed](https://github.com/mlflow/mlflow/pull/20455/files/e5fcb98bb07668a3e39ba91aae37d2eead1d4195..2f8551082285a20cecf73e66d4bf0bcf67ab1410)]
        - [stack/span_count_dimensions](https://github.com/mlflow/mlflow/pull/20565) [[Files changed](https://github.com/mlflow/mlflow/pull/20565/files/2f8551082285a20cecf73e66d4bf0bcf67ab1410..8ac3b8c3153202c1ade0dae45d92804fe6f4f9f7)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Support querying span cost, grouping by model name.
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
