### PR TITLE
[UI] Add cost breakdown chart on usage tab

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -12,6 +12,7 @@ import { LazyTraceLatencyChart } from './components/LazyTraceLatencyChart';
 import { LazyTraceErrorsChart } from './components/LazyTraceErrorsChart';
 import { LazyTraceTokenUsageChart } from './components/LazyTraceTokenUsageChart';
 import { LazyTraceTokenStatsChart } from './components/LazyTraceTokenStatsChart';
+import { LazyTraceCostBreakdownChart } from './components/LazyTraceCostBreakdownChart';
 import { AssessmentChartsSection } from './components/AssessmentChartsSection';
 import { ToolCallStatistics } from './components/ToolCallStatistics';
 import { ToolCallChartsSection } from './components/ToolCallChartsSection';
@@ -171,6 +172,9 @@ const ExperimentGenAIOverviewPageImpl = () => {
                 <LazyTraceTokenUsageChart />
                 <LazyTraceTokenStatsChart />
               </ChartGrid>
+
+              {/* Cost Breakdown chart */}
+              <LazyTraceCostBreakdownChart />
             </TabContentContainer>
           </Tabs.Content>
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/LazyTraceCostBreakdownChart.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { LegacySkeleton } from '@databricks/design-system';
+
+const TraceCostBreakdownChart = React.lazy(() =>
+  import('./TraceCostBreakdownChart').then((module) => ({ default: module.TraceCostBreakdownChart })),
+);
+
+export const LazyTraceCostBreakdownChart: React.FC = () => (
+  <React.Suspense fallback={<LegacySkeleton active />}>
+    <TraceCostBreakdownChart />
+  </React.Suspense>
+);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.test.tsx
@@ -1,0 +1,266 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithIntl } from '../../../../common/utils/TestUtils.react18';
+import { TraceCostBreakdownChart } from './TraceCostBreakdownChart';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import {
+  MetricViewType,
+  AggregationType,
+  SpanMetricKey,
+  SpanDimensionKey,
+} from '@databricks/web-shared/model-trace-explorer';
+import { setupServer } from '../../../../common/utils/setup-msw';
+import { rest } from 'msw';
+import { OverviewChartProvider } from '../OverviewChartContext';
+
+// Helper to create a cost breakdown data point
+const createCostDataPoint = (modelName: string, totalCost: number) => ({
+  metric_name: SpanMetricKey.TOTAL_COST,
+  dimensions: { [SpanDimensionKey.MODEL_NAME]: modelName },
+  values: { [AggregationType.SUM]: totalCost },
+});
+
+describe('TraceCostBreakdownChart', () => {
+  const testExperimentId = 'test-experiment-123';
+  const startTimeMs = new Date('2025-12-22T10:00:00Z').getTime();
+  const endTimeMs = new Date('2025-12-22T12:00:00Z').getTime();
+  const timeIntervalSeconds = 3600;
+
+  const timeBuckets = [
+    new Date('2025-12-22T10:00:00Z').getTime(),
+    new Date('2025-12-22T11:00:00Z').getTime(),
+    new Date('2025-12-22T12:00:00Z').getTime(),
+  ];
+
+  const defaultContextProps = {
+    experimentId: testExperimentId,
+    startTimeMs,
+    endTimeMs,
+    timeIntervalSeconds,
+    timeBuckets,
+  };
+
+  const server = setupServer();
+
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+  const renderComponent = (contextOverrides: Partial<typeof defaultContextProps> = {}) => {
+    const queryClient = createQueryClient();
+    const contextProps = { ...defaultContextProps, ...contextOverrides };
+    return renderWithIntl(
+      <QueryClientProvider client={queryClient}>
+        <DesignSystemProvider>
+          <OverviewChartProvider {...contextProps}>
+            <TraceCostBreakdownChart />
+          </OverviewChartProvider>
+        </DesignSystemProvider>
+      </QueryClientProvider>,
+    );
+  };
+
+  const setupTraceMetricsHandler = (dataPoints: any[]) => {
+    server.use(
+      rest.post('ajax-api/3.0/mlflow/traces/metrics', async (_req, res, ctx) => {
+        return res(ctx.json({ data_points: dataPoints }));
+      }),
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupTraceMetricsHandler([]);
+  });
+
+  describe('loading state', () => {
+    it('should render loading skeleton while data is being fetched', async () => {
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', (_req, res, ctx) => {
+          return res(ctx.delay('infinite'));
+        }),
+      );
+
+      renderComponent();
+
+      // Check that actual chart content is not rendered during loading
+      expect(screen.queryByText('Cost Breakdown')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('should render error message when API call fails', async () => {
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', (_req, res, ctx) => {
+          return res(ctx.status(500), ctx.json({ error_code: 'INTERNAL_ERROR', message: 'API Error' }));
+        }),
+      );
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load chart data')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('empty data state', () => {
+    it('should render empty state when no data points are returned', async () => {
+      setupTraceMetricsHandler([]);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('No cost data available')).toBeInTheDocument();
+      });
+    });
+
+    it('should render empty state when all costs are zero', async () => {
+      setupTraceMetricsHandler([createCostDataPoint('gpt-4', 0), createCostDataPoint('gpt-3.5', 0)]);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('No cost data available')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('with data', () => {
+    const mockDataPoints = [
+      createCostDataPoint('gpt-4', 0.05),
+      createCostDataPoint('gpt-3.5-turbo', 0.03),
+      createCostDataPoint('claude-3', 0.02),
+    ];
+
+    it('should render the chart title', async () => {
+      setupTraceMetricsHandler(mockDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Cost Breakdown')).toBeInTheDocument();
+      });
+    });
+
+    it('should render the subtitle', async () => {
+      setupTraceMetricsHandler(mockDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Total Cost')).toBeInTheDocument();
+      });
+    });
+
+    it('should display total cost formatted as USD', async () => {
+      setupTraceMetricsHandler(mockDataPoints);
+
+      renderComponent();
+
+      // Total = 0.05 + 0.03 + 0.02 = 0.10
+      await waitFor(() => {
+        expect(screen.getByText('$0.10')).toBeInTheDocument();
+      });
+    });
+
+    it('should render pie chart component', async () => {
+      setupTraceMetricsHandler(mockDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+      });
+    });
+
+    it('should render pie with correct number of data points', async () => {
+      setupTraceMetricsHandler(mockDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('pie')).toHaveAttribute('data-count', '3');
+      });
+    });
+
+    it('should render legend component', async () => {
+      setupTraceMetricsHandler(mockDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('legend')).toBeInTheDocument();
+      });
+    });
+
+    it('should format large costs correctly', async () => {
+      setupTraceMetricsHandler([createCostDataPoint('gpt-4', 1234.56)]);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('$1,234.56')).toBeInTheDocument();
+      });
+    });
+
+    it('should format small costs with proper precision', async () => {
+      setupTraceMetricsHandler([createCostDataPoint('gpt-4', 0.000123)]);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('$0.000123')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('API call parameters', () => {
+    it('should call API with correct parameters for cost breakdown', async () => {
+      let capturedRequest: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedRequest = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(capturedRequest).toMatchObject({
+          experiment_ids: [testExperimentId],
+          view_type: MetricViewType.SPANS,
+          metric_name: SpanMetricKey.TOTAL_COST,
+          aggregations: [{ aggregation_type: AggregationType.SUM }],
+          dimensions: [SpanDimensionKey.MODEL_NAME],
+        });
+      });
+    });
+
+    it('should include time range in API request', async () => {
+      let capturedRequest: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedRequest = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(capturedRequest?.start_time_ms).toBe(startTimeMs);
+        expect(capturedRequest?.end_time_ms).toBe(endTimeMs);
+      });
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -1,0 +1,226 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useDesignSystemTheme, PieChartIcon, DesignSystemThemeInterface } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Sector } from 'recharts';
+import { formatCostUSD } from '@databricks/web-shared/model-trace-explorer';
+import { useTraceCostBreakdownChartData } from '../hooks/useTraceCostBreakdownChartData';
+import {
+  OverviewChartLoadingState,
+  OverviewChartErrorState,
+  OverviewChartEmptyState,
+  OverviewChartHeader,
+  OverviewChartContainer,
+  DEFAULT_CHART_CONTENT_HEIGHT,
+} from './OverviewChartComponents';
+import { useChartColors } from '../utils/chartUtils';
+
+interface ActiveShapeProps {
+  cx: number;
+  cy: number;
+  innerRadius: number;
+  outerRadius: number;
+  startAngle: number;
+  endAngle: number;
+  fill: string;
+  name: string;
+  value: number;
+  percentage: number;
+  midAngle: number;
+}
+
+const RADIAN = Math.PI / 180;
+
+// Pie chart sizing constants
+const PIE_INNER_RADIUS = 50;
+const PIE_OUTER_RADIUS = 70;
+const PIE_PADDING_ANGLE = 2;
+
+/**
+ * Renders the active (hovered) pie slice with an outer arc and external label.
+ */
+const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) => (props: unknown) => {
+  const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill, name, value, percentage, midAngle } =
+    props as ActiveShapeProps;
+
+  // Calculate direction from center based on slice's midpoint angle
+  const sin = Math.sin(-RADIAN * midAngle);
+  const cos = Math.cos(-RADIAN * midAngle);
+
+  // Line start point (just outside the pie slice)
+  const sx = cx + (outerRadius + theme.spacing.sm) * cos;
+  const sy = cy + (outerRadius + theme.spacing.sm) * sin;
+
+  // Line bend point (further out, creates an elbow in the line)
+  const mx = cx + (outerRadius + theme.spacing.md) * cos;
+  const my = cy + (outerRadius + theme.spacing.md) * sin;
+
+  // Line end point (horizontal offset from bend, direction based on left/right side)
+  const ex = mx + (cos >= 0 ? 1 : -1) * theme.spacing.md;
+  const ey = my;
+  const textAnchor = cos >= 0 ? 'start' : 'end';
+
+  return (
+    <g>
+      {/* Model name in donut center */}
+      <text
+        x={cx}
+        y={cy}
+        textAnchor="middle"
+        fill={theme.colors.textPrimary}
+        fontSize={theme.typography.fontSizeSm}
+        fontWeight={500}
+      >
+        {name}
+      </text>
+      {/* Main pie sector */}
+      <Sector
+        cx={cx}
+        cy={cy}
+        innerRadius={innerRadius}
+        outerRadius={outerRadius}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        fill={fill}
+      />
+      {/* Outer highlight arc (selection indicator) */}
+      <Sector
+        cx={cx}
+        cy={cy}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        innerRadius={outerRadius + theme.spacing.xs}
+        outerRadius={outerRadius + theme.spacing.sm}
+        fill={fill}
+      />
+      {/* Connecting line: radial segment -> horizontal segment */}
+      <path d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`} stroke={fill} fill="none" />
+      {/* Dot at line end */}
+      <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
+      {/* Cost label */}
+      <text
+        x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
+        y={ey}
+        textAnchor={textAnchor}
+        fill={theme.colors.textSecondary}
+        fontSize={theme.typography.fontSizeSm}
+      >
+        {formatCostUSD(value)}
+      </text>
+      {/* Percentage label */}
+      <text
+        x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
+        y={ey + theme.spacing.md}
+        textAnchor={textAnchor}
+        fill={theme.colors.textSecondary}
+        fontSize={theme.typography.fontSizeSm}
+      >
+        {percentage.toFixed(2)}%
+      </text>
+    </g>
+  );
+};
+
+export const TraceCostBreakdownChart: React.FC = () => {
+  const { theme } = useDesignSystemTheme();
+  const { chartData, totalCost, isLoading, error, hasData } = useTraceCostBreakdownChartData();
+  const { getChartColor } = useChartColors();
+  const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
+
+  const renderActiveShape = useMemo(() => createActiveShapeRenderer(theme), [theme]);
+
+  const onPieEnter = useCallback((_: unknown, index: number) => {
+    setActiveIndex(index);
+  }, []);
+
+  const onPieLeave = useCallback(() => {
+    setActiveIndex(undefined);
+  }, []);
+
+  const legendFormatter = useCallback(
+    (value: string, entry: unknown) => {
+      const typedEntry = entry as { payload?: { percentage?: number } };
+      return (
+        <span
+          css={{
+            color: theme.colors.textPrimary,
+            fontSize: theme.typography.fontSizeSm,
+          }}
+        >
+          {value}
+          <span css={{ color: theme.colors.textSecondary, marginLeft: theme.spacing.xs }}>
+            {typedEntry.payload?.percentage?.toFixed(0)}%
+          </span>
+        </span>
+      );
+    },
+    [theme],
+  );
+
+  if (isLoading) {
+    return <OverviewChartLoadingState />;
+  }
+
+  if (error) {
+    return <OverviewChartErrorState />;
+  }
+
+  return (
+    <OverviewChartContainer componentId="mlflow.charts.trace_cost_breakdown">
+      <OverviewChartHeader
+        icon={<PieChartIcon />}
+        title={<FormattedMessage defaultMessage="Cost Breakdown" description="Title for the cost breakdown chart" />}
+        value={formatCostUSD(totalCost)}
+        subtitle={
+          <FormattedMessage defaultMessage="Total Cost" description="Subtitle for the cost breakdown chart total" />
+        }
+      />
+
+      <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT, marginTop: theme.spacing.sm }}>
+        {hasData ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                innerRadius={PIE_INNER_RADIUS}
+                outerRadius={PIE_OUTER_RADIUS}
+                paddingAngle={PIE_PADDING_ANGLE}
+                dataKey="value"
+                nameKey="name"
+                activeIndex={activeIndex}
+                activeShape={renderActiveShape}
+                onMouseEnter={onPieEnter}
+                onMouseLeave={onPieLeave}
+              >
+                {chartData.map((_, index) => (
+                  <Cell key={`cell-${index}`} fill={getChartColor(index)} />
+                ))}
+              </Pie>
+              <Legend
+                layout="vertical"
+                align="right"
+                verticalAlign="middle"
+                formatter={legendFormatter}
+                wrapperStyle={{
+                  fontSize: theme.typography.fontSizeSm,
+                  maxHeight: DEFAULT_CHART_CONTENT_HEIGHT,
+                  overflowY: 'auto',
+                }}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        ) : (
+          <OverviewChartEmptyState
+            message={
+              <FormattedMessage
+                defaultMessage="No cost data available"
+                description="Message shown when there is no cost data to display"
+              />
+            }
+          />
+        )}
+      </div>
+    </OverviewChartContainer>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceCostBreakdownChartData.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceCostBreakdownChartData.test.tsx
@@ -1,0 +1,457 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { useTraceCostBreakdownChartData } from './useTraceCostBreakdownChartData';
+import {
+  AggregationType,
+  SpanMetricKey,
+  SpanDimensionKey,
+  MetricViewType,
+} from '@databricks/web-shared/model-trace-explorer';
+import type { ReactNode } from 'react';
+import { setupServer } from '../../../../common/utils/setup-msw';
+import { rest } from 'msw';
+import { OverviewChartProvider } from '../OverviewChartContext';
+
+// Helper to create a cost breakdown data point
+const createCostDataPoint = (modelName: string, totalCost: number) => ({
+  metric_name: SpanMetricKey.TOTAL_COST,
+  dimensions: { [SpanDimensionKey.MODEL_NAME]: modelName },
+  values: { [AggregationType.SUM]: totalCost },
+});
+
+describe('useTraceCostBreakdownChartData', () => {
+  const testExperimentId = 'test-experiment-123';
+  const startTimeMs = new Date('2025-12-22T10:00:00Z').getTime();
+  const endTimeMs = new Date('2025-12-22T12:00:00Z').getTime();
+  const timeIntervalSeconds = 3600;
+
+  const timeBuckets = [
+    new Date('2025-12-22T10:00:00Z').getTime(),
+    new Date('2025-12-22T11:00:00Z').getTime(),
+    new Date('2025-12-22T12:00:00Z').getTime(),
+  ];
+
+  const contextProps = {
+    experimentId: testExperimentId,
+    startTimeMs,
+    endTimeMs,
+    timeIntervalSeconds,
+    timeBuckets,
+  };
+
+  const server = setupServer();
+
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+  const createWrapper = (contextOverrides: Partial<typeof contextProps> = {}) => {
+    const queryClient = createQueryClient();
+    const mergedContextProps = { ...contextProps, ...contextOverrides };
+    return ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <OverviewChartProvider {...mergedContextProps}>{children}</OverviewChartProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  const setupTraceMetricsHandler = (dataPoints: any[]) => {
+    server.use(
+      rest.post('ajax-api/3.0/mlflow/traces/metrics', (_req, res, ctx) => {
+        return res(ctx.json({ data_points: dataPoints }));
+      }),
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupTraceMetricsHandler([]);
+  });
+
+  describe('loading state', () => {
+    it('should return isLoading true while fetching', async () => {
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', (_req, res, ctx) => {
+          return res(ctx.delay('infinite'));
+        }),
+      );
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.chartData).toHaveLength(0);
+      expect(result.current.totalCost).toBe(0);
+      expect(result.current.hasData).toBe(false);
+    });
+  });
+
+  describe('error state', () => {
+    it('should return error when API call fails', async () => {
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', (_req, res, ctx) => {
+          return res(ctx.status(500), ctx.json({ error: 'API Error' }));
+        }),
+      );
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
+    });
+  });
+
+  describe('empty data', () => {
+    it('should return hasData false when no data points', async () => {
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasData).toBe(false);
+      expect(result.current.chartData).toHaveLength(0);
+      expect(result.current.totalCost).toBe(0);
+    });
+
+    it('should return hasData false when all costs are zero', async () => {
+      setupTraceMetricsHandler([createCostDataPoint('gpt-4', 0), createCostDataPoint('gpt-3.5', 0)]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasData).toBe(false);
+      expect(result.current.chartData).toHaveLength(0);
+    });
+  });
+
+  describe('data transformation', () => {
+    it('should calculate total cost correctly', async () => {
+      setupTraceMetricsHandler([
+        createCostDataPoint('gpt-4', 0.05),
+        createCostDataPoint('gpt-3.5-turbo', 0.03),
+        createCostDataPoint('claude-3', 0.02),
+      ]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Total = 0.05 + 0.03 + 0.02 = 0.10
+      expect(result.current.totalCost).toBeCloseTo(0.1, 10);
+    });
+
+    it('should calculate percentages correctly', async () => {
+      setupTraceMetricsHandler([
+        createCostDataPoint('gpt-4', 0.5), // 50%
+        createCostDataPoint('gpt-3.5', 0.3), // 30%
+        createCostDataPoint('claude-3', 0.2), // 20%
+      ]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.chartData).toHaveLength(3);
+      expect(result.current.chartData[0].percentage).toBeCloseTo(50, 1);
+      expect(result.current.chartData[1].percentage).toBeCloseTo(30, 1);
+      expect(result.current.chartData[2].percentage).toBeCloseTo(20, 1);
+    });
+
+    it('should sort models by cost descending', async () => {
+      setupTraceMetricsHandler([
+        createCostDataPoint('cheap-model', 0.01),
+        createCostDataPoint('expensive-model', 0.1),
+        createCostDataPoint('medium-model', 0.05),
+      ]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.chartData[0].name).toBe('expensive-model');
+      expect(result.current.chartData[1].name).toBe('medium-model');
+      expect(result.current.chartData[2].name).toBe('cheap-model');
+    });
+
+    it('should filter out models with zero cost', async () => {
+      setupTraceMetricsHandler([createCostDataPoint('active-model', 0.05), createCostDataPoint('zero-cost-model', 0)]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.chartData).toHaveLength(1);
+      expect(result.current.chartData[0].name).toBe('active-model');
+    });
+
+    it('should use "Unknown" for missing model name', async () => {
+      setupTraceMetricsHandler([
+        {
+          metric_name: SpanMetricKey.TOTAL_COST,
+          dimensions: {}, // Missing model name
+          values: { [AggregationType.SUM]: 0.05 },
+        },
+      ]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.chartData[0].name).toBe('Unknown');
+    });
+
+    it('should handle missing values as zero cost', async () => {
+      setupTraceMetricsHandler([
+        {
+          metric_name: SpanMetricKey.TOTAL_COST,
+          dimensions: { [SpanDimensionKey.MODEL_NAME]: 'gpt-4' },
+          values: {}, // Missing SUM value
+        },
+      ]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Zero cost items are filtered out
+      expect(result.current.chartData).toHaveLength(0);
+      expect(result.current.hasData).toBe(false);
+    });
+
+    it('should return correct data structure for each model', async () => {
+      setupTraceMetricsHandler([createCostDataPoint('gpt-4', 0.1)]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const dataPoint = result.current.chartData[0];
+      expect(dataPoint).toHaveProperty('name', 'gpt-4');
+      expect(dataPoint).toHaveProperty('value', 0.1);
+      expect(dataPoint).toHaveProperty('percentage', 100);
+    });
+
+    it('should handle single model with 100% percentage', async () => {
+      setupTraceMetricsHandler([createCostDataPoint('only-model', 1.23)]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.chartData).toHaveLength(1);
+      expect(result.current.chartData[0].percentage).toBe(100);
+      expect(result.current.totalCost).toBe(1.23);
+    });
+
+    it('should handle very small costs correctly', async () => {
+      setupTraceMetricsHandler([createCostDataPoint('gpt-4', 0.000001), createCostDataPoint('gpt-3.5', 0.000002)]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.totalCost).toBeCloseTo(0.000003, 10);
+      expect(result.current.chartData[0].percentage).toBeCloseTo(66.67, 1);
+      expect(result.current.chartData[1].percentage).toBeCloseTo(33.33, 1);
+    });
+
+    it('should handle large costs correctly', async () => {
+      setupTraceMetricsHandler([createCostDataPoint('gpt-4', 1000.5), createCostDataPoint('gpt-3.5', 500.25)]);
+
+      const { result } = renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.totalCost).toBeCloseTo(1500.75, 2);
+      expect(result.current.chartData[0].name).toBe('gpt-4');
+      expect(result.current.chartData[0].value).toBe(1000.5);
+    });
+  });
+
+  describe('API request', () => {
+    it('should request SUM aggregation', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.aggregations).toContainEqual({ aggregation_type: AggregationType.SUM });
+    });
+
+    it('should request MODEL_NAME dimension', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.dimensions).toContain(SpanDimensionKey.MODEL_NAME);
+    });
+
+    it('should use SPANS view type', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.view_type).toBe(MetricViewType.SPANS);
+    });
+
+    it('should request TOTAL_COST metric', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.metric_name).toBe(SpanMetricKey.TOTAL_COST);
+    });
+
+    it('should include time range in API call', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.start_time_ms).toBe(startTimeMs);
+      expect(capturedBody.end_time_ms).toBe(endTimeMs);
+    });
+
+    it('should include experiment ID in API call', async () => {
+      let capturedBody: any = null;
+
+      server.use(
+        rest.post('ajax-api/3.0/mlflow/traces/metrics', async (req, res, ctx) => {
+          capturedBody = await req.json();
+          return res(ctx.json({ data_points: [] }));
+        }),
+      );
+
+      renderHook(() => useTraceCostBreakdownChartData(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(capturedBody).not.toBeNull();
+      });
+
+      expect(capturedBody.experiment_ids).toContain(testExperimentId);
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceCostBreakdownChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceCostBreakdownChartData.ts
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import {
+  MetricViewType,
+  AggregationType,
+  SpanMetricKey,
+  SpanDimensionKey,
+} from '@databricks/web-shared/model-trace-explorer';
+import { useTraceMetricsQuery } from './useTraceMetricsQuery';
+import { useOverviewChartContext } from '../OverviewChartContext';
+
+export interface CostBreakdownDataPoint {
+  name: string;
+  value: number;
+  percentage: number;
+}
+
+export interface UseTraceCostBreakdownChartDataResult {
+  chartData: CostBreakdownDataPoint[];
+  totalCost: number;
+  isLoading: boolean;
+  error: unknown;
+  hasData: boolean;
+}
+
+export function useTraceCostBreakdownChartData(): UseTraceCostBreakdownChartDataResult {
+  const { experimentId, startTimeMs, endTimeMs } = useOverviewChartContext();
+
+  // Fetch total cost grouped by model name
+  const { data, isLoading, error } = useTraceMetricsQuery({
+    experimentId,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.SPANS,
+    metricName: SpanMetricKey.TOTAL_COST,
+    aggregations: [{ aggregation_type: AggregationType.SUM }],
+    dimensions: [SpanDimensionKey.MODEL_NAME],
+  });
+
+  const dataPoints = useMemo(() => data?.data_points || [], [data?.data_points]);
+
+  // Calculate total cost and percentages
+  const { chartData, totalCost } = useMemo(() => {
+    const total = dataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0);
+
+    const items: CostBreakdownDataPoint[] = dataPoints
+      .map((dp) => {
+        const value = dp.values?.[AggregationType.SUM] || 0;
+        const modelName = dp.dimensions?.[SpanDimensionKey.MODEL_NAME] || 'Unknown';
+        return {
+          name: modelName,
+          value,
+          percentage: total > 0 ? (value / total) * 100 : 0,
+        };
+      })
+      .filter((item) => item.value > 0)
+      .sort((a, b) => b.value - a.value);
+
+    return { chartData: items, totalCost: total };
+  }, [dataPoints]);
+
+  return {
+    chartData,
+    totalCost,
+    isLoading,
+    error,
+    hasData: chartData.length > 0,
+  };
+}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -383,6 +383,10 @@
     "defaultMessage": "Make the line between points \"smoother\" based on Exponential Moving Average. Smoothing can be useful for displaying the overall trend when the logging frequency is high.",
     "description": "Helpful tooltip message to help with line smoothness for the metrics plot"
   },
+  "0iR7OV": {
+    "defaultMessage": "Total Cost",
+    "description": "Subtitle for the cost breakdown chart total"
+  },
   "0ja5l/": {
     "defaultMessage": "No tags found.",
     "description": "Text for no tags found in editable form table in MLflow"
@@ -3542,6 +3546,10 @@
     "defaultMessage": "Cost breakdown",
     "description": "Header for span cost breakdown"
   },
+  "PAUNgq": {
+    "defaultMessage": "Cost Breakdown",
+    "description": "Title for the cost breakdown chart"
+  },
   "PBeZnP": {
     "defaultMessage": "You can start logging traces to this logged model by calling {code} first:",
     "description": "Introductory text for the code example for logging traces to an existing logged model. The code contains reference to \"mlflow.set_active_model\" function call"
@@ -6222,6 +6230,10 @@
   "iRNZkJ": {
     "defaultMessage": "Failed to delete assessment. Error: {error}",
     "description": "Error message when deleting an assessment fails."
+  },
+  "iRs4JD": {
+    "defaultMessage": "No cost data available",
+    "description": "Message shown when there is no cost data to display"
   },
   "iT2I8i": {
     "defaultMessage": "The name is used in the endpoint URL. Only letters, numbers, underscores, hyphens, and dots are allowed.",

--- a/mlflow/server/js/src/setupTests.js
+++ b/mlflow/server/js/src/setupTests.js
@@ -80,6 +80,14 @@ jest.mock('recharts', () => ({
       {children}
     </div>
   ),
+  PieChart: ({ children }) => <div data-testid="pie-chart">{children}</div>,
+  Pie: ({ children, data }) => (
+    <div data-testid="pie" data-count={data?.length || 0}>
+      {children}
+    </div>
+  ),
+  Cell: () => <div data-testid="cell" />,
+  Sector: () => <div data-testid="sector" />,
   Line: ({ name }) => <div data-testid={name ? `line-${name}` : 'line'} />,
   Bar: ({ name }) => <div data-testid={name ? `bar-${name}` : 'bar'} />,
   Area: ({ name, dataKey }) => <div data-testid={`area-${dataKey}`} data-name={name} />,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/TraceMetrics.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/TraceMetrics.types.ts
@@ -135,6 +135,12 @@ export enum SpanMetricKey {
   SPAN_COUNT = 'span_count',
   /** Span latency in milliseconds */
   LATENCY = 'latency',
+  /** Input cost in USD */
+  INPUT_COST = 'input_cost',
+  /** Output cost in USD */
+  OUTPUT_COST = 'output_cost',
+  /** Total cost in USD */
+  TOTAL_COST = 'total_cost',
 }
 
 /**
@@ -207,6 +213,8 @@ export enum SpanDimensionKey {
   SPAN_TYPE = 'span_type',
   /** Span status dimension */
   SPAN_STATUS = 'span_status',
+  /** Model name dimension */
+  MODEL_NAME = 'span_model_name',
 }
 
 /**

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -82,3 +82,4 @@ export {
   type DrawerComponentType,
 } from './ModelTraceExplorerContext';
 export { ModelTraceExplorerDrawer, type ModelTraceExplorerDrawerProps } from './ModelTraceExplorerDrawer';
+export { formatCostUSD } from './CostUtils';

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -93,15 +93,24 @@ SPANS_METRICS_CONFIGS: dict[SpanMetricKey, TraceMetricsConfig] = {
     ),
     SpanMetricKey.INPUT_COST: TraceMetricsConfig(
         aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
-        dimensions={SpanMetricDimensionKey.SPAN_MODEL_NAME},
+        dimensions={
+            SpanMetricDimensionKey.SPAN_MODEL_NAME,
+            SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+        },
     ),
     SpanMetricKey.OUTPUT_COST: TraceMetricsConfig(
         aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
-        dimensions={SpanMetricDimensionKey.SPAN_MODEL_NAME},
+        dimensions={
+            SpanMetricDimensionKey.SPAN_MODEL_NAME,
+            SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+        },
     ),
     SpanMetricKey.TOTAL_COST: TraceMetricsConfig(
         aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
-        dimensions={SpanMetricDimensionKey.SPAN_MODEL_NAME},
+        dimensions={
+            SpanMetricDimensionKey.SPAN_MODEL_NAME,
+            SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+        },
     ),
 }
 
@@ -372,6 +381,10 @@ def _apply_dimension_to_query(
                     # Extract model name from span_metrics metric_metadata JSON column
                     model_name = SqlSpanMetrics.metric_metadata[SpanAttributeKey.MODEL]
                     return query, model_name.label(SpanMetricDimensionKey.SPAN_MODEL_NAME)
+                case SpanMetricDimensionKey.SPAN_MODEL_PROVIDER:
+                    # Extract model provider from span_metrics metric_metadata JSON column
+                    model_provider = SqlSpanMetrics.metric_metadata[SpanAttributeKey.MODEL_PROVIDER]
+                    return query, model_provider.label(SpanMetricDimensionKey.SPAN_MODEL_PROVIDER)
         case MetricViewType.ASSESSMENTS:
             match dimension:
                 case AssessmentMetricDimensionKey.ASSESSMENT_NAME:

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -378,12 +378,12 @@ def _apply_dimension_to_query(
                 case SpanMetricDimensionKey.SPAN_STATUS:
                     return query, SqlSpan.status.label(SpanMetricDimensionKey.SPAN_STATUS)
                 case SpanMetricDimensionKey.SPAN_MODEL_NAME:
-                    # Extract model name from span_metadata JSON column on SqlSpan
-                    model_name = SqlSpan.span_metadata[SpanAttributeKey.MODEL]
+                    # Extract model name from dimension_attributes JSON column on SqlSpan
+                    model_name = SqlSpan.dimension_attributes[SpanAttributeKey.MODEL]
                     return query, model_name.label(SpanMetricDimensionKey.SPAN_MODEL_NAME)
                 case SpanMetricDimensionKey.SPAN_MODEL_PROVIDER:
-                    # Extract model provider from span_metadata JSON column on SqlSpan
-                    model_provider = SqlSpan.span_metadata[SpanAttributeKey.MODEL_PROVIDER]
+                    # Extract model provider from dimension_attributes JSON column on SqlSpan
+                    model_provider = SqlSpan.dimension_attributes[SpanAttributeKey.MODEL_PROVIDER]
                     return query, model_provider.label(SpanMetricDimensionKey.SPAN_MODEL_PROVIDER)
         case MetricViewType.ASSESSMENTS:
             match dimension:

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -378,12 +378,12 @@ def _apply_dimension_to_query(
                 case SpanMetricDimensionKey.SPAN_STATUS:
                     return query, SqlSpan.status.label(SpanMetricDimensionKey.SPAN_STATUS)
                 case SpanMetricDimensionKey.SPAN_MODEL_NAME:
-                    # Extract model name from span_metrics metric_metadata JSON column
-                    model_name = SqlSpanMetrics.metric_metadata[SpanAttributeKey.MODEL]
+                    # Extract model name from span_metadata JSON column on SqlSpan
+                    model_name = SqlSpan.span_metadata[SpanAttributeKey.MODEL]
                     return query, model_name.label(SpanMetricDimensionKey.SPAN_MODEL_NAME)
                 case SpanMetricDimensionKey.SPAN_MODEL_PROVIDER:
-                    # Extract model provider from span_metrics metric_metadata JSON column
-                    model_provider = SqlSpanMetrics.metric_metadata[SpanAttributeKey.MODEL_PROVIDER]
+                    # Extract model provider from span_metadata JSON column on SqlSpan
+                    model_provider = SqlSpan.span_metadata[SpanAttributeKey.MODEL_PROVIDER]
                     return query, model_provider.label(SpanMetricDimensionKey.SPAN_MODEL_PROVIDER)
         case MetricViewType.ASSESSMENTS:
             match dimension:

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -226,6 +226,7 @@ class SpanMetricDimensionKey:
     SPAN_TYPE = "span_type"
     SPAN_STATUS = "span_status"
     SPAN_MODEL_NAME = "span_model_name"
+    SPAN_MODEL_PROVIDER = "span_model_provider"
 
 
 class AssessmentMetricKey:

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -208,6 +208,13 @@ class SpanMetricKey:
 
     SPAN_COUNT = "span_count"
     LATENCY = "latency"
+    INPUT_COST = "input_cost"
+    OUTPUT_COST = "output_cost"
+    TOTAL_COST = "total_cost"
+
+    @classmethod
+    def cost_keys(cls) -> list[str]:
+        return [cls.INPUT_COST, cls.OUTPUT_COST, cls.TOTAL_COST]
 
 
 class SpanMetricDimensionKey:
@@ -218,6 +225,7 @@ class SpanMetricDimensionKey:
     SPAN_NAME = "span_name"
     SPAN_TYPE = "span_type"
     SPAN_STATUS = "span_status"
+    MODEL_NAME = "span_model_name"
 
 
 class AssessmentMetricKey:

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -225,7 +225,7 @@ class SpanMetricDimensionKey:
     SPAN_NAME = "span_name"
     SPAN_TYPE = "span_type"
     SPAN_STATUS = "span_status"
-    MODEL_NAME = "span_model_name"
+    SPAN_MODEL_NAME = "span_model_name"
 
 
 class AssessmentMetricKey:

--- a/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
@@ -3720,7 +3720,7 @@ def test_query_span_metrics_cost_sum(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1000000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.001,
                     "output_cost": 0.002,
                     "total_cost": 0.003,
@@ -3735,7 +3735,7 @@ def test_query_span_metrics_cost_sum(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.002,
                     "output_cost": 0.003,
                     "total_cost": 0.005,
@@ -3750,7 +3750,7 @@ def test_query_span_metrics_cost_sum(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1200000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.003,
                     "output_cost": 0.004,
                     "total_cost": 0.007,
@@ -3797,7 +3797,7 @@ def test_query_span_metrics_cost_by_model_name(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1000000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.01,
                     "output_cost": 0.02,
                     "total_cost": 0.03,
@@ -3812,7 +3812,7 @@ def test_query_span_metrics_cost_by_model_name(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.01,
                     "output_cost": 0.02,
                     "total_cost": 0.03,
@@ -3827,7 +3827,7 @@ def test_query_span_metrics_cost_by_model_name(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1200000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.005,
                     "output_cost": 0.015,
                     "total_cost": 0.02,
@@ -3880,7 +3880,7 @@ def test_query_span_metrics_cost_avg_by_model_name(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1000000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.01,
                     "output_cost": 0.02,
                     "total_cost": 0.03,
@@ -3895,7 +3895,7 @@ def test_query_span_metrics_cost_avg_by_model_name(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.02,
                     "output_cost": 0.03,
                     "total_cost": 0.05,
@@ -3943,7 +3943,7 @@ def test_query_span_metrics_cost_multiple_aggregations(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1000000000 + i * 100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.01 * i,
                     "output_cost": 0.01 * i,
                     "total_cost": 0.02 * i,
@@ -3994,7 +3994,7 @@ def test_query_span_metrics_input_output_cost(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1000000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.01,
                     "output_cost": 0.03,
                     "total_cost": 0.04,
@@ -4009,7 +4009,7 @@ def test_query_span_metrics_input_output_cost(store: SqlAlchemyStore):
             span_type="LLM",
             start_ns=1100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.02,
                     "output_cost": 0.04,
                     "total_cost": 0.06,
@@ -4069,7 +4069,7 @@ def test_query_span_metrics_cost_across_multiple_traces(store: SqlAlchemyStore):
                 span_type="LLM",
                 start_ns=1000000000,
                 attributes={
-                    SpanAttributeKey.CHAT_COST: {
+                    SpanAttributeKey.LLM_COST: {
                         "input_cost": 0.01,
                         "output_cost": 0.02,
                         "total_cost": 0.03,
@@ -4118,7 +4118,7 @@ def test_query_span_metrics_cost_percentiles(store: SqlAlchemyStore, percentile_
             span_type="LLM",
             start_ns=1000000000 + i * 100000000,
             attributes={
-                SpanAttributeKey.CHAT_COST: {
+                SpanAttributeKey.LLM_COST: {
                     "input_cost": 0.005 * i,
                     "output_cost": 0.005 * i,
                     "total_cost": 0.01 * i,

--- a/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
@@ -3843,18 +3843,18 @@ def test_query_span_metrics_cost_by_model_name(store: SqlAlchemyStore):
         view_type=MetricViewType.SPANS,
         metric_name=SpanMetricKey.TOTAL_COST,
         aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
-        dimensions=[SpanMetricDimensionKey.MODEL_NAME],
+        dimensions=[SpanMetricDimensionKey.SPAN_MODEL_NAME],
     )
 
     assert len(result) == 2
     assert asdict(result[0]) == {
         "metric_name": SpanMetricKey.TOTAL_COST,
-        "dimensions": {SpanMetricDimensionKey.MODEL_NAME: "claude-3"},
+        "dimensions": {SpanMetricDimensionKey.SPAN_MODEL_NAME: "claude-3"},
         "values": {"SUM": 0.02},
     }
     assert asdict(result[1]) == {
         "metric_name": SpanMetricKey.TOTAL_COST,
-        "dimensions": {SpanMetricDimensionKey.MODEL_NAME: "gpt-4"},
+        "dimensions": {SpanMetricDimensionKey.SPAN_MODEL_NAME: "gpt-4"},
         "values": {"SUM": 0.06},
     }
 
@@ -3911,13 +3911,13 @@ def test_query_span_metrics_cost_avg_by_model_name(store: SqlAlchemyStore):
         view_type=MetricViewType.SPANS,
         metric_name=SpanMetricKey.TOTAL_COST,
         aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
-        dimensions=[SpanMetricDimensionKey.MODEL_NAME],
+        dimensions=[SpanMetricDimensionKey.SPAN_MODEL_NAME],
     )
 
     assert len(result) == 1
     assert asdict(result[0]) == {
         "metric_name": SpanMetricKey.TOTAL_COST,
-        "dimensions": {SpanMetricDimensionKey.MODEL_NAME: "gpt-4"},
+        "dimensions": {SpanMetricDimensionKey.SPAN_MODEL_NAME: "gpt-4"},
         "values": {"AVG": 0.04},
     }
 
@@ -4085,13 +4085,13 @@ def test_query_span_metrics_cost_across_multiple_traces(store: SqlAlchemyStore):
         view_type=MetricViewType.SPANS,
         metric_name=SpanMetricKey.TOTAL_COST,
         aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
-        dimensions=[SpanMetricDimensionKey.MODEL_NAME],
+        dimensions=[SpanMetricDimensionKey.SPAN_MODEL_NAME],
     )
 
     assert len(result) == 1
     assert asdict(result[0]) == {
         "metric_name": SpanMetricKey.TOTAL_COST,
-        "dimensions": {SpanMetricDimensionKey.MODEL_NAME: "gpt-4"},
+        "dimensions": {SpanMetricDimensionKey.SPAN_MODEL_NAME: "gpt-4"},
         "values": {"SUM": 0.09},
     }
 

--- a/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
@@ -17,7 +17,11 @@ from mlflow.entities import (
 )
 from mlflow.entities.assessment import AssessmentError
 from mlflow.entities.trace_info import TraceInfo
-from mlflow.entities.trace_metrics import AggregationType, MetricAggregation, MetricViewType
+from mlflow.entities.trace_metrics import (
+    AggregationType,
+    MetricAggregation,
+    MetricViewType,
+)
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
 from mlflow.genai.judges import CategoricalRating
@@ -3944,9 +3948,9 @@ def test_query_span_metrics_cost_multiple_aggregations(store: SqlAlchemyStore):
             start_ns=1000000000 + i * 100000000,
             attributes={
                 SpanAttributeKey.LLM_COST: {
-                    "input_cost": 0.01 * i,
-                    "output_cost": 0.01 * i,
-                    "total_cost": 0.02 * i,
+                    "input_cost": i,
+                    "output_cost": i,
+                    "total_cost": 2 * i,
                 },
                 SpanAttributeKey.MODEL: "gpt-4",
             },
@@ -3969,7 +3973,7 @@ def test_query_span_metrics_cost_multiple_aggregations(store: SqlAlchemyStore):
     assert asdict(result[0]) == {
         "metric_name": SpanMetricKey.TOTAL_COST,
         "dimensions": {},
-        "values": {"SUM": 0.30, "AVG": 0.06},
+        "values": {"SUM": 30.0, "AVG": 6.0},
     }
 
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20404/files/0962cf5f6a39b4a1e95c47ffb04a237c075fb486..de423d53c419353705f6de3d30038e715bcd93a2) to review incremental changes.
- [stack/span_cost_metrics_query](https://github.com/mlflow/mlflow/pull/20403) [[Files changed](https://github.com/mlflow/mlflow/pull/20403/files)]
  - [**stack/cost_chart**](https://github.com/mlflow/mlflow/pull/20404) [[Files changed](https://github.com/mlflow/mlflow/pull/20404/files/0962cf5f6a39b4a1e95c47ffb04a237c075fb486..de423d53c419353705f6de3d30038e715bcd93a2)]
    - [stack/cost_chart_over_time](https://github.com/mlflow/mlflow/pull/20440) [[Files changed](https://github.com/mlflow/mlflow/pull/20440/files/de423d53c419353705f6de3d30038e715bcd93a2..e5fcb98bb07668a3e39ba91aae37d2eead1d4195)]
      - [stack/cost_chart_model_selection](https://github.com/mlflow/mlflow/pull/20455) [[Files changed](https://github.com/mlflow/mlflow/pull/20455/files/e5fcb98bb07668a3e39ba91aae37d2eead1d4195..2f8551082285a20cecf73e66d4bf0bcf67ab1410)]
        - [stack/span_count_dimensions](https://github.com/mlflow/mlflow/pull/20565) [[Files changed](https://github.com/mlflow/mlflow/pull/20565/files/2f8551082285a20cecf73e66d4bf0bcf67ab1410..8ac3b8c3153202c1ade0dae45d92804fe6f4f9f7)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Add cost breakdown chart on usage tab. This is the initial pie chart showing the overall cost and breakdown by model name.


https://github.com/user-attachments/assets/03e8f14a-e358-4846-892c-2d98d4f73eda


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
