### PR TITLE
Fix AttributeError when expectations column contains None or NaN values

### DIFF
--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -82,6 +82,8 @@ class EvalItem:
 
         # Extract expectations column from the dataset.
         expectations = row.get(InputDatasetColumn.EXPECTATIONS, {})
+        if is_none_or_nan(expectations):
+            expectations = {}
 
         # Extract tags column from the dataset.
         tags = row.get(InputDatasetColumn.TAGS, {})

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1372,9 +1372,6 @@ def test_evaluate_with_conversation_simulator_calls_simulate():
         mock_simulate.assert_called_once_with(mock_predict_fn)
 
 
-# ===================== Empty/None Expectations Tests =====================
-
-
 @scorer
 def always_pass(outputs):
     return True

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1370,3 +1370,38 @@ def test_evaluate_with_conversation_simulator_calls_simulate():
 
         # Verify _simulate was called with predict_fn
         mock_simulate.assert_called_once_with(mock_predict_fn)
+
+
+# ===================== Empty/None Expectations Tests =====================
+
+
+@scorer
+def always_pass(outputs):
+    return True
+
+
+@pytest.mark.parametrize(
+    ("expectations_values", "expected_count"),
+    [
+        ([None, {}], 2),
+        ([float("nan")], 1),
+        ([{"expected": "value"}, None, {}], 3),
+    ],
+)
+def test_evaluate_handles_empty_expectations(expectations_values, expected_count):
+    data = [
+        {
+            "inputs": {"question": f"Q{i}"},
+            "outputs": f"A{i}",
+            "expectations": exp,
+        }
+        for i, exp in enumerate(expectations_values)
+    ]
+
+    result = mlflow.genai.evaluate(data=data, scorers=[always_pass])
+
+    assert result is not None
+    assert result.metrics is not None
+    assert result.result_df is not None
+    assert len(result.result_df) == expected_count
+    assert result.metrics["always_pass/mean"] == 1.0


### PR DESCRIPTION
### Related Issues/PRs

Resolves #20419

### What changes are proposed in this pull request?

Fix a bug in the GenAI evaluate harness where datasets with `None` or `NaN` values in the `expectations` column cause an `AttributeError: 'NoneType' object has no attribute 'items'`.

**Root cause:** In `EvalItem.from_dataset_row()`, the code `row.get(InputDatasetColumn.EXPECTATIONS, {})` only provides a default `{}` when the key is missing. If the key exists with a `None` or `NaN` value, that value is used, causing the later `.items()` call in `get_expectation_assessments()` to fail.

**Fix:** Normalize `expectations` to `{}` when it is `None` or `NaN` using the existing `is_none_or_nan()` utility, following the same pattern used for `trace` and `source` fields in the same method.

### How is this PR tested?

- [x] New unit/integration tests

Added parametrized test `test_evaluate_handles_empty_expectations` covering:
- Datasets with `None` expectations
- Datasets with `NaN` expectations (common from pandas)
- Datasets with mixed valid, `None`, and empty dict expectations

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where `mlflow.genai.evaluate()` failed with `AttributeError` when the input dataset contained `None` or `NaN` values in the `expectations` column.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)