### PR TITLE
[UI] Show Request and Response columns by default in traces table

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -185,8 +185,8 @@ const TracesV3LogsImpl = React.memo(
           (col) =>
             col.type === TracesTableColumnType.ASSESSMENT ||
             col.type === TracesTableColumnType.EXPECTATION ||
-            (inputHasContent && col.type === TracesTableColumnType.INPUT) ||
-            (responseHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === RESPONSE_COLUMN_ID) ||
+            col.type === TracesTableColumnType.INPUT ||
+            (col.type === TracesTableColumnType.TRACE_INFO && col.id === RESPONSE_COLUMN_ID) ||
             (tokensHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === TOKENS_COLUMN_ID) ||
             (col.type === TracesTableColumnType.TRACE_INFO &&
               [TRACE_ID_COLUMN_ID, EXECUTION_DURATION_COLUMN_ID, REQUEST_TIME_COLUMN_ID, STATE_COLUMN_ID].includes(

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useGenAITracesUIState.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useGenAITracesUIState.tsx
@@ -25,7 +25,7 @@ export interface GenAITracesUIState {
 const DEFAULT_MAX_VISIBLE_COLUMNS = 10;
 
 const LOCAL_STORAGE_KEY = 'genaiTracesUIState-columns';
-const LOCAL_STORAGE_VERSION = 1;
+const LOCAL_STORAGE_VERSION = 2;
 
 const toVisibleColumnsFromHiddenColumns = (hiddenColumns: string[], allColumns: TracesTableColumn[]) => {
   return allColumns.filter((col) => !hiddenColumns.includes(col.id));


### PR DESCRIPTION
### Related Issues/PRs

<!-- This PR improves the default column visibility in the traces table -->

### What changes are proposed in this pull request?

This PR improves the traces table user experience by making the Request and Response columns visible by default.

**Changes:**
- Updated default column selection logic in `TracesV3Logs.tsx` to always show Request (INPUT) and Response columns
- Previously, these columns were only shown conditionally if they contained data
- Incremented localStorage version from 1 to 2 in `useGenAITracesUIState.tsx` to invalidate cached column preferences
- This ensures all users see the updated default columns after upgrading

**User Impact:**
- Request and Response columns are now immediately visible when viewing traces
- Users no longer need to manually enable these columns to see trace inputs/outputs
- The Trace ID column remains visible alongside the new default columns
- All default columns: Trace ID, Request, Response, Execution time, Request time, State

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual testing performed:
- Verified Request and Response columns appear by default in traces table
- Confirmed localStorage version increment clears old cached preferences
- Tested that columns display correctly with trace data
- Verified column selection still works via the Columns dropdown

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The traces table now shows Request and Response columns by default, making it easier to view trace inputs and outputs without manual configuration.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)