### PR TITLE
Support get_dataset(name=...) in OSS environments

### DIFF
--- a/mlflow/genai/datasets/__init__.py
+++ b/mlflow/genai/datasets/__init__.py
@@ -12,9 +12,12 @@ import time
 from contextlib import contextmanager
 from typing import Any
 
+from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets.evaluation_dataset import EvaluationDataset
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
 from mlflow.store.tracking import SEARCH_EVALUATION_DATASETS_MAX_RESULTS
 from mlflow.tracking import get_tracking_uri
+from mlflow.tracking.client import MlflowClient
 from mlflow.utils.annotations import deprecated_parameter, experimental
 from mlflow.utils.uri import get_db_info_from_uri, is_databricks_uri
 
@@ -89,7 +92,7 @@ def _validate_non_databricks_params(
     dataset_id: str | None = None,
 ) -> None:
     """
-    Validate parameters for non-Databricks environment.
+    Validate parameters for non-Databricks environment (delete_dataset).
 
     Args:
         name: The dataset name parameter (should not be provided)
@@ -108,6 +111,51 @@ def _validate_non_databricks_params(
             "Parameter 'dataset_id' is required. "
             "Use search_datasets() to find the dataset ID by name if needed."
         )
+
+
+def _validate_non_databricks_get_params(
+    name: str | None,
+    dataset_id: str | None = None,
+) -> None:
+    if name is not None and dataset_id is not None:
+        raise ValueError("Cannot specify both 'name' and 'dataset_id'. Use only one parameter.")
+    if name is None and dataset_id is None:
+        raise ValueError("Either 'name' or 'dataset_id' must be provided.")
+
+
+def _resolve_dataset_by_name(name: str) -> str:
+    # Build filter string with appropriate quoting:
+    # - Use double quotes if name has no double quotes (handles single quotes)
+    # - Use single quotes if name has double quotes but no single quotes
+    # - Use single quotes with SQL-style escaping ('') if name has both
+    if '"' not in name:
+        filter_string = f'name = "{name}"'
+    elif "'" not in name:
+        filter_string = f"name = '{name}'"
+    else:
+        escaped_name = name.replace("'", "''")
+        filter_string = f"name = '{escaped_name}'"
+
+    results = MlflowClient().search_datasets(
+        filter_string=filter_string,
+        max_results=2,
+        order_by=["created_time DESC"],
+    )
+
+    match len(results):
+        case 0:
+            raise MlflowException(
+                f"Dataset with name '{name}' not found.",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
+        case 1:
+            return results[0].dataset_id
+        case _:
+            raise MlflowException(
+                f"Multiple datasets found with name '{name}'. "
+                "Use 'dataset_id' for unambiguous retrieval.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
 
 
 @deprecated_parameter("uc_table_name", "name")
@@ -272,22 +320,27 @@ def get_dataset(
     Get the dataset with the given name or ID.
 
     Args:
-        name: The name of the dataset (Databricks only). In Databricks, this is the UC table name.
-        dataset_id: The ID of the dataset.
+        name: The name of the dataset. In Databricks, this is the UC table name.
+            In non-Databricks environments, this will search for a dataset with the given name.
+        dataset_id: The ID of the dataset (non-Databricks only).
 
     Returns:
         An EvaluationDataset object representing the retrieved dataset.
 
     Note:
         - In Databricks environments: Use 'name' to specify the dataset.
-        - Outside of Databricks: Use 'dataset_id' to specify the dataset
+        - Outside of Databricks: Use either 'name' or 'dataset_id' to specify the dataset.
+          If using 'name', the dataset name must be unique; otherwise use 'dataset_id'.
 
     Examples:
         .. code-block:: python
 
             from mlflow.genai.datasets import get_dataset
 
-            # Get a dataset by ID (non-Databricks)
+            # Get a dataset by name
+            dataset = get_dataset(name="my_evaluation_dataset")
+
+            # Get a dataset by ID
             dataset = get_dataset(dataset_id="d-7f2e3a9b8c1d4e5f6a7b8c9d0e1f2a3b")
 
             # Access dataset properties
@@ -320,9 +373,10 @@ def get_dataset(
         except ImportError as e:
             raise ImportError(_ERROR_MSG) from e
     else:
-        _validate_non_databricks_params(name, dataset_id)
+        _validate_non_databricks_get_params(name, dataset_id)
 
-        from mlflow.tracking.client import MlflowClient
+        if name is not None:
+            dataset_id = _resolve_dataset_by_name(name)
 
         mlflow_dataset = MlflowClient().get_dataset(dataset_id)
         return EvaluationDataset(mlflow_dataset)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Resolve --> N/A - Feature enhancement

### What changes are proposed in this pull request?

This PR adds support for retrieving datasets by name in non-Databricks (OSS) environments. Previously, `get_dataset()` in OSS only accepted `dataset_id`, while Databricks environments used `name` (UC table name). Now both parameters work in OSS.

**Changes:**
- Add `_validate_non_databricks_get_params` to validate that either `name` OR `dataset_id` is provided (not both, not neither)
- Add `_resolve_dataset_by_name` helper that uses `search_datasets` to find the dataset by name
  - Uses smart quoting (double quotes for names without `"`, single quotes for names without `'`)
  - Uses pattern matching for clean result handling
  - Raises appropriate errors for not found / multiple matches
- Update `get_dataset` to resolve `name` to `dataset_id` when name is provided
- Move `MlflowClient`, `MlflowException`, and error codes to top-level imports

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added 7 new tests:
- `test_get_dataset_by_name_oss` - basic name lookup works
- `test_get_dataset_by_name_not_found` - raises when name doesn't exist
- `test_get_dataset_by_name_multiple_matches` - raises error on duplicate names
- `test_get_dataset_both_name_and_id_error` - rejects both params
- `test_get_dataset_neither_name_nor_id_error` - rejects neither
- `test_get_dataset_name_with_single_quote` - handles names with `'`
- `test_get_dataset_name_with_double_quote` - handles names with `"`

All 76 tests pass: `uv run pytest tests/genai/datasets/test_fluent.py -v`

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

The docstring for `get_dataset()` has been updated to reflect the new behavior.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`get_dataset()` now supports retrieving datasets by name in non-Databricks environments. Users can use either `get_dataset(name="my_dataset")` or `get_dataset(dataset_id="d-xxx")` to retrieve a dataset.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)