### PR TITLE
[UI] Store ExperimentPage and RunPage UI states in indexedDB

### DIFF
--- a/mlflow/server/js/src/common/utils/IndexedDBStorageUtils.test.ts
+++ b/mlflow/server/js/src/common/utils/IndexedDBStorageUtils.test.ts
@@ -1,0 +1,153 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { IndexedDBStorage } from './IndexedDBStorageUtils';
+
+// Mock IndexedDB with proper async behavior
+const createMockIndexedDB = () => {
+  const mockStore = {
+    put: jest.fn(),
+    delete: jest.fn(),
+    openCursor: jest.fn(() => ({
+      onsuccess: null,
+      onerror: null,
+      result: null,
+    })),
+  };
+
+  const mockTransaction = {
+    objectStore: jest.fn(() => mockStore),
+    oncomplete: null as any,
+    onerror: null as any,
+    onabort: null as any,
+  };
+
+  const mockDB = {
+    objectStoreNames: { contains: jest.fn(() => false) },
+    createObjectStore: jest.fn(),
+    transaction: jest.fn(() => {
+      setTimeout(() => {
+        if (mockTransaction.oncomplete) mockTransaction.oncomplete();
+      }, 0);
+      return mockTransaction;
+    }),
+  };
+
+  global.indexedDB = {
+    open: jest.fn(() => {
+      const request = {
+        result: mockDB,
+        onupgradeneeded: null as any,
+        onsuccess: null as any,
+        onerror: null as any,
+      };
+      setTimeout(() => {
+        if (request.onupgradeneeded) request.onupgradeneeded();
+        if (request.onsuccess) request.onsuccess();
+      }, 0);
+      return request;
+    }),
+  } as any;
+};
+
+describe('IndexedDBStorage', () => {
+  beforeEach(() => {
+    createMockIndexedDB();
+  });
+
+  test('initializes successfully', async () => {
+    const storage = new IndexedDBStorage();
+    await expect(storage.initialize()).resolves.not.toThrow();
+  });
+
+  test('getItem returns null for non-existent key', async () => {
+    const storage = new IndexedDBStorage();
+    await storage.initialize();
+    expect(storage.getItem('nonexistent')).toBeNull();
+  });
+
+  test('setItem and getItem work correctly', async () => {
+    const storage = new IndexedDBStorage();
+    await storage.initialize();
+    storage.setItem('key1', 'value1');
+    expect(storage.getItem('key1')).toBe('value1');
+  });
+
+  test('setItem overwrites existing value', async () => {
+    const storage = new IndexedDBStorage();
+    await storage.initialize();
+    storage.setItem('key1', 'value1');
+    storage.setItem('key1', 'value2');
+    expect(storage.getItem('key1')).toBe('value2');
+  });
+
+  test('removeItem deletes key', async () => {
+    const storage = new IndexedDBStorage();
+    await storage.initialize();
+    storage.setItem('key1', 'value1');
+    storage.removeItem('key1');
+    expect(storage.getItem('key1')).toBeNull();
+  });
+
+  test('handles uninitialized access gracefully', () => {
+    const onError = jest.fn();
+    const storage = new IndexedDBStorage(onError);
+
+    expect(storage.getItem('key')).toBeNull();
+    storage.setItem('key', 'value');
+
+    expect(onError).toHaveBeenCalled();
+  });
+
+  test('handles errors with onError callback', async () => {
+    const onError = jest.fn();
+    const storage = new IndexedDBStorage(onError);
+    await storage.initialize();
+
+    storage.setItem('key', 'value');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('formats error with context and error message', async () => {
+    const onError = jest.fn();
+    const storage = new IndexedDBStorage(onError);
+
+    storage.getItem('key');
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const error = onError.mock.calls[0][0] as Error;
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain('Failed to get indexed db item');
+    expect(error.message).toContain('IndexedDBStorage not initialized');
+  });
+
+  test('formats error with context when error is null', async () => {
+    const onError = jest.fn();
+    const storage = new IndexedDBStorage(onError);
+
+    storage.setItem('key', 'value');
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const error = onError.mock.calls[0][0] as Error;
+    expect(error.message).toContain('Failed to set indexed db item');
+  });
+
+  test('formats error with context when error is undefined', async () => {
+    const onError = jest.fn();
+    const storage = new IndexedDBStorage(onError);
+
+    storage.removeItem('key');
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const error = onError.mock.calls[0][0] as Error;
+    expect(error.message).toContain('Failed to remove indexed db item');
+  });
+
+  test('formats error with context and string error', async () => {
+    const onError = jest.fn();
+    const storage = new IndexedDBStorage(onError);
+
+    storage.getItem('key');
+
+    const error = onError.mock.calls[0][0] as Error;
+    expect(error.message).toMatch(/Failed to get indexed db item: .+/);
+  });
+});

--- a/mlflow/server/js/src/common/utils/IndexedDBStorageUtils.ts
+++ b/mlflow/server/js/src/common/utils/IndexedDBStorageUtils.ts
@@ -1,0 +1,161 @@
+const INDEXED_DB_NAME = 'MLflow';
+const INDEXED_DB_STORE_NAME = 'IndexedDBStore';
+
+export class IndexedDBStorage {
+  private readonly dbName: string;
+  private readonly storeName: string;
+  private readonly onError?: (reason: unknown) => void;
+
+  private db: IDBDatabase | null = null;
+  private cache: Map<string, string> = new Map();
+  private dirty: Set<string> = new Set();
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private isReady = false;
+
+  public constructor(onError?: (reason: unknown) => void) {
+    this.dbName = INDEXED_DB_NAME;
+    this.storeName = INDEXED_DB_STORE_NAME;
+    this.onError = onError;
+  }
+
+  /** Call once at startup. After this resolves, getItem / setItem are synchronous. */
+  public async initialize(): Promise<void> {
+    if (this.isReady) {
+      return;
+    }
+    this.db = await this.openDB();
+    await this.loadAllIntoCache();
+    this.isReady = true;
+  }
+
+  public getItem(key: string): string | null {
+    try {
+      this.ensureReady();
+      const v = this.cache.get(key);
+      return v === undefined ? null : v;
+    } catch (error) {
+      this.handleError(error, 'Failed to get indexed db item');
+      return null;
+    }
+  }
+
+  public setItem(key: string, value: string): void {
+    try {
+      this.ensureReady();
+      this.cache.set(key, value);
+      this.dirty.add(key);
+      this.scheduleFlush();
+    } catch (error) {
+      this.handleError(error, 'Failed to set indexed db item');
+    }
+  }
+
+  // TODO implement GC logic for Indexed DB to clean up old experiment preferences
+  public removeItem(key: string): void {
+    try {
+      this.ensureReady();
+      this.cache.delete(key);
+      this.dirty.add(key);
+      this.scheduleFlush();
+    } catch (error) {
+      this.handleError(error, 'Failed to remove indexed db item');
+    }
+  }
+
+  public async flush(): Promise<void> {
+    this.ensureReady();
+    await this.flushInternal();
+  }
+
+  private ensureReady(): void {
+    if (!this.isReady || !this.db) {
+      throw new Error('IndexedDBStorage not initialized. Call await initialize() before use.');
+    }
+  }
+
+  private openDB(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(this.dbName, 1);
+
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(this.storeName)) {
+          db.createObjectStore(this.storeName);
+        }
+      };
+
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  private loadAllIntoCache(): Promise<void> {
+    if (!this.db) throw new Error('DB not open');
+
+    return new Promise((resolve, reject) => {
+      const tx = this.db!.transaction(this.storeName, 'readonly');
+      const store = tx.objectStore(this.storeName);
+      const req = store.openCursor();
+
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (!cursor) return;
+        this.cache.set(String(cursor.key), String(cursor.value));
+        cursor.continue();
+      };
+
+      req.onerror = () => reject(req.error);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      (async () => {
+        try {
+          await this.flushInternal();
+        } catch (error) {
+          this.handleError(error, 'Failed to save settings');
+        }
+      })();
+    }, 50);
+  }
+
+  private flushInternal(): Promise<void> {
+    if (!this.db) throw new Error('DB not open');
+    if (this.dirty.size === 0) return Promise.resolve();
+
+    const keys = Array.from(this.dirty);
+    this.dirty.clear();
+
+    return new Promise((resolve, reject) => {
+      const tx = this.db!.transaction(this.storeName, 'readwrite');
+      const store = tx.objectStore(this.storeName);
+
+      for (const key of keys) {
+        if (this.cache.has(key)) {
+          store.put(this.cache.get(key)!, key);
+        } else {
+          store.delete(key);
+        }
+      }
+
+      tx.oncomplete = () => resolve();
+      tx.onerror = tx.onabort = () => {
+        keys.forEach((e) => this.dirty.add(e));
+        reject(tx.error);
+      };
+    });
+  }
+
+  private handleError(error: any, context: string): void {
+    if (this.onError) {
+      this.onError(new Error(context + (error ? `: ${error}` : '')));
+    }
+  }
+}

--- a/mlflow/server/js/src/common/utils/LocalStorageUtils.test.ts
+++ b/mlflow/server/js/src/common/utils/LocalStorageUtils.test.ts
@@ -60,3 +60,9 @@ test('Session scoped storage works', () => {
     expect(otherStore.loadComponentState().searchInput).toEqual('metrics.ok');
   });
 });
+
+test('IndexedDB scoped storage falls back to localStorage when unavailable', () => {
+  const store = LocalStorageUtils.getIndexedDBScopedStoreForComponent('TestComponent', 1, false);
+  store.setItem('key', 'value');
+  expect(store.getItem('key')).toEqual('value');
+});

--- a/mlflow/server/js/src/experiment-tracking/components/contexts/IndexedDBInitializationContext.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/contexts/IndexedDBInitializationContext.test.tsx
@@ -1,0 +1,70 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  IndexedDBInitializationContextProvider,
+  IndexedDBInitializationContext,
+} from './IndexedDBInitializationContext';
+import { globalIndexedDBStorage } from '../../../common/utils/LocalStorageUtils';
+import React, { useContext } from 'react';
+
+jest.mock('../../../common/utils/LocalStorageUtils', () => ({
+  globalIndexedDBStorage: {
+    initialize: jest.fn(),
+  },
+}));
+
+jest.mock('../../../common/utils/Utils', () => ({
+  __esModule: true,
+  default: {
+    logErrorAndNotifyUser: jest.fn(),
+  },
+}));
+
+describe('IndexedDBInitializationContext', () => {
+  const TestComponent = () => {
+    const { isIndexedDBAvailable } = useContext(IndexedDBInitializationContext);
+    return <div>{isIndexedDBAvailable ? 'Available' : 'Unavailable'}</div>;
+  };
+
+  test('shows spinner while initializing', () => {
+    (globalIndexedDBStorage.initialize as jest.Mock).mockImplementation(() => new Promise(() => {}));
+
+    render(
+      <IndexedDBInitializationContextProvider>
+        <TestComponent />
+      </IndexedDBInitializationContextProvider>,
+    );
+
+    expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+
+  test('sets isIndexedDBAvailable to true on successful initialization', async () => {
+    // @ts-expect-error Argument of type 'undefined' is not assignable to parameter of type 'never'.
+    (globalIndexedDBStorage.initialize as jest.Mock).mockResolvedValue(undefined);
+
+    render(
+      <IndexedDBInitializationContextProvider>
+        <TestComponent />
+      </IndexedDBInitializationContextProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Available')).toBeInTheDocument();
+    });
+  });
+
+  test('sets isIndexedDBAvailable to false on initialization error', async () => {
+    // @ts-expect-error Argument of type 'Error' is not assignable to parameter of type 'never'.
+    (globalIndexedDBStorage.initialize as jest.Mock).mockRejectedValue(new Error('Init failed'));
+
+    render(
+      <IndexedDBInitializationContextProvider>
+        <TestComponent />
+      </IndexedDBInitializationContextProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/contexts/IndexedDBInitializationContext.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/contexts/IndexedDBInitializationContext.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useEffect, useState } from 'react';
+import { globalIndexedDBStorage } from '@mlflow/mlflow/src/common/utils/LocalStorageUtils';
+import { Spinner } from '@databricks/design-system';
+import Utils from '@mlflow/mlflow/src/common/utils/Utils';
+
+export const IndexedDBInitializationContext = createContext<{
+  isIndexedDBAvailable?: boolean;
+}>({});
+
+export function IndexedDBInitializationContextProvider(props: React.PropsWithChildren<unknown>) {
+  const [ready, setReady] = useState<boolean>(false);
+  const [isIndexedDBAvailable, setIsIndexedDBAvailable] = useState<boolean>(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        await globalIndexedDBStorage.initialize();
+        setIsIndexedDBAvailable(true);
+      } catch (error) {
+        Utils.logErrorAndNotifyUser(
+          `IndexedDB unavailable - using browser local storage instead. Your settings will still be saved. Error: ${error}`,
+        );
+        setIsIndexedDBAvailable(false);
+      } finally {
+        setReady(true);
+      }
+    })();
+  }, []);
+
+  if (!ready) {
+    return <Spinner />;
+  }
+
+  return (
+    <IndexedDBInitializationContext.Provider value={{ isIndexedDBAvailable }}>
+      {props.children}
+    </IndexedDBInitializationContext.Provider>
+  );
+}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/ExperimentPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/ExperimentPage.tsx
@@ -12,6 +12,7 @@ import { ExperimentView } from './ExperimentView';
 import { LegacySkeleton, PageWrapper, useDesignSystemTheme } from '@databricks/design-system';
 import { useNavigateToExperimentPageTab } from './hooks/useNavigateToExperimentPageTab';
 import { useExperimentIds } from './hooks/useExperimentIds';
+import { IndexedDBInitializationContextProvider } from '@mlflow/mlflow/src/experiment-tracking/components/contexts/IndexedDBInitializationContext';
 
 /**
  * Concrete actions for GetExperiments context
@@ -56,9 +57,11 @@ const ExperimentPage = () => {
   }
   return (
     <PageWrapper css={{ height: '100%', paddingTop: theme.spacing.md }}>
-      <GetExperimentsContextProvider actions={getExperimentActions}>
-        <ExperimentView />
-      </GetExperimentsContextProvider>
+      <IndexedDBInitializationContextProvider>
+        <GetExperimentsContextProvider actions={getExperimentActions}>
+          <ExperimentView />
+        </GetExperimentsContextProvider>
+      </IndexedDBInitializationContextProvider>
     </PageWrapper>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/usePersistExperimentPageViewState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/usePersistExperimentPageViewState.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 
 import { pick } from 'lodash';
 import { createExperimentPageSearchFacetsState } from '../models/ExperimentPageSearchFacetsState';
@@ -6,6 +6,7 @@ import type { ExperimentPageUIState } from '../models/ExperimentPageUIState';
 import { loadExperimentViewState, saveExperimentViewState } from '../utils/persistSearchFacets';
 import type { ExperimentQueryParamsSearchFacets } from './useExperimentPageSearchFacets';
 import { EXPERIMENT_PAGE_QUERY_PARAM_KEYS, useUpdateExperimentPageSearchFacets } from './useExperimentPageSearchFacets';
+import { IndexedDBInitializationContext } from '@mlflow/mlflow/src/experiment-tracking/components/contexts/IndexedDBInitializationContext';
 
 /**
  * Takes care of initializing the search facets from persisted view state and persisting them.
@@ -21,6 +22,8 @@ export const usePersistExperimentPageViewState = (
 
   const persistKey = useMemo(() => (experimentIds ? JSON.stringify(experimentIds.sort()) : null), [experimentIds]);
 
+  const { isIndexedDBAvailable } = useContext(IndexedDBInitializationContext);
+
   // If there are no query params visible in the address bar, either reinstantiate
   // them from persisted view state or use default values.
   useEffect(() => {
@@ -28,7 +31,7 @@ export const usePersistExperimentPageViewState = (
       return;
     }
     if (!searchFacets) {
-      const persistedViewState = persistKey ? loadExperimentViewState(persistKey) : null;
+      const persistedViewState = persistKey ? loadExperimentViewState(persistKey, isIndexedDBAvailable) : null;
       const rebuiltViewState = pick(
         { ...createExperimentPageSearchFacetsState(), ...persistedViewState },
         EXPERIMENT_PAGE_QUERY_PARAM_KEYS,
@@ -36,13 +39,13 @@ export const usePersistExperimentPageViewState = (
       setSearchFacets(rebuiltViewState, { replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchFacets, persistKey, disabled]);
+  }, [searchFacets, persistKey, disabled, isIndexedDBAvailable]);
 
   // Persist complete view state in local storage when either search facets or UI state change
   useEffect(() => {
     if (!searchFacets || !persistKey || disabled) {
       return;
     }
-    saveExperimentViewState({ ...searchFacets, ...uiState }, persistKey);
-  }, [searchFacets, uiState, persistKey, disabled]);
+    saveExperimentViewState({ ...searchFacets, ...uiState }, persistKey, isIndexedDBAvailable);
+  }, [searchFacets, uiState, persistKey, disabled, isIndexedDBAvailable]);
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/persistSearchFacets.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/persistSearchFacets.ts
@@ -9,9 +9,13 @@ import { createExperimentPageSearchFacetsState } from '../models/ExperimentPageS
 /**
  * Loads current view state (UI state, view state) in the local storage.
  */
-export function loadExperimentViewState(idKey: string) {
+export function loadExperimentViewState(idKey: string, isIndexedDBAvailable?: boolean) {
   try {
-    const localStorageInstance = LocalStorageUtils.getStoreForComponent('ExperimentPage', idKey);
+    const localStorageInstance = LocalStorageUtils.getIndexedDBScopedStoreForComponent(
+      'ExperimentPage',
+      idKey,
+      !!isIndexedDBAvailable,
+    );
     return localStorageInstance.loadComponentState();
   } catch {
     Utils.logErrorAndNotifyUser(`Error: malformed persisted search state for experiment(s) ${idKey}`);
@@ -26,7 +30,15 @@ export function loadExperimentViewState(idKey: string) {
 /**
  * Persists view state (UI state, view state) in the local storage.
  */
-export function saveExperimentViewState(data: ExperimentPageUIState & ExperimentPageSearchFacetsState, idKey: string) {
-  const localStorageInstance = LocalStorageUtils.getStoreForComponent('ExperimentPage', idKey);
+export function saveExperimentViewState(
+  data: ExperimentPageUIState & ExperimentPageSearchFacetsState,
+  idKey: string,
+  isIndexedDBAvailable?: boolean,
+) {
+  const localStorageInstance = LocalStorageUtils.getIndexedDBScopedStoreForComponent(
+    'ExperimentPage',
+    idKey,
+    !!isIndexedDBAvailable,
+  );
   localStorageInstance.saveComponentState(data);
 }

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunPage.tsx
@@ -40,6 +40,7 @@ import { getGraphQLErrorMessage } from '../../../graphql/get-graphql-error';
 import { useLoggedModelsForExperimentRun } from '../experiment-page/hooks/useLoggedModelsForExperimentRun';
 import { useLoggedModelsForExperimentRunV2 } from '../experiment-page/hooks/useLoggedModelsForExperimentRunV2';
 import { useExperimentKind } from '../../utils/ExperimentKindUtils';
+import { IndexedDBInitializationContextProvider } from '@mlflow/mlflow/src/experiment-tracking/components/contexts/IndexedDBInitializationContext';
 
 const RunPageLoadingState = () => (
   <PageContainer>
@@ -269,26 +270,28 @@ export const RunPage = () => {
   return (
     <>
       <PageContainer usesFullHeight={useFullHeightPage}>
-        {/* Header fixed on top */}
-        <RunViewHeader
-          comparedExperimentIds={comparedExperimentIds}
-          experiment={experiment}
-          handleRenameRunClick={() => setRenameModalVisible(true)}
-          handleDeleteRunClick={() => setDeleteModalVisible(true)}
-          hasComparedExperimentsBefore={hasComparedExperimentsBefore}
-          runDisplayName={Utils.getRunDisplayName(runInfo, safeRunUuid)}
-          runTags={tags}
-          runParams={params}
-          runUuid={safeRunUuid}
-          runOutputs={runOutputs}
-          artifactRootUri={runInfo?.artifactUri ?? undefined}
-          registeredModelVersionSummaries={registeredModelVersionSummaries}
-          isLoading={loading || isLoadingLoggedModels}
-        />
-        {/* Scroll tab contents independently within own container */}
-        <div css={{ flex: 1, overflow: 'auto', marginBottom: theme.spacing.sm, display: 'flex' }}>
-          {renderActiveTab()}
-        </div>
+        <IndexedDBInitializationContextProvider>
+          {/* Header fixed on top */}
+          <RunViewHeader
+            comparedExperimentIds={comparedExperimentIds}
+            experiment={experiment}
+            handleRenameRunClick={() => setRenameModalVisible(true)}
+            handleDeleteRunClick={() => setDeleteModalVisible(true)}
+            hasComparedExperimentsBefore={hasComparedExperimentsBefore}
+            runDisplayName={Utils.getRunDisplayName(runInfo, safeRunUuid)}
+            runTags={tags}
+            runParams={params}
+            runUuid={safeRunUuid}
+            runOutputs={runOutputs}
+            artifactRootUri={runInfo?.artifactUri ?? undefined}
+            registeredModelVersionSummaries={registeredModelVersionSummaries}
+            isLoading={loading || isLoadingLoggedModels}
+          />
+          {/* Scroll tab contents independently within own container */}
+          <div css={{ flex: 1, overflow: 'auto', marginBottom: theme.spacing.sm, display: 'flex' }}>
+            {renderActiveTab()}
+          </div>
+        </IndexedDBInitializationContextProvider>
       </PageContainer>
       <RenameRunModal
         runUuid={safeRunUuid}

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
@@ -1,6 +1,7 @@
 import { TableSkeleton, ToggleButton, useDesignSystemTheme } from '@databricks/design-system';
 import { compact, mapValues, values } from 'lodash';
 import type { ReactNode } from 'react';
+import { useContext } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
@@ -38,6 +39,7 @@ import type { UseGetRunQueryResponseRunInfo } from './hooks/useGetRunQuery';
 import { RunsChartsGlobalChartSettingsDropdown } from '../runs-charts/components/RunsChartsGlobalChartSettingsDropdown';
 import { RunsChartsDraggableCardsGridContextProvider } from '../runs-charts/components/RunsChartsDraggableCardsGridContext';
 import { RunsChartsFilterInput } from '../runs-charts/components/RunsChartsFilterInput';
+import { IndexedDBInitializationContext } from '@mlflow/mlflow/src/experiment-tracking/components/contexts/IndexedDBInitializationContext';
 
 interface RunViewMetricChartsProps {
   metricKeys: string[];
@@ -304,9 +306,12 @@ const RunViewMetricChartsImpl = ({
 export const RunViewMetricCharts = (props: RunViewMetricChartsProps) => {
   const persistenceIdentifier = `${props.runInfo.runUuid}-${props.mode}`;
 
+  const { isIndexedDBAvailable } = useContext(IndexedDBInitializationContext);
+
   const localStore = useMemo(
-    () => LocalStorageUtils.getStoreForComponent('RunPage', persistenceIdentifier),
-    [persistenceIdentifier],
+    () =>
+      LocalStorageUtils.getIndexedDBScopedStoreForComponent('RunPage', persistenceIdentifier, !!isIndexedDBAvailable),
+    [persistenceIdentifier, isIndexedDBAvailable],
   );
 
   const [chartUIState, updateChartsUIState] = useState<ExperimentRunsChartsUIConfiguration>(() => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-runs/ExperimentRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-runs/ExperimentRunsPage.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../actions';
 import { GetExperimentsContextProvider } from '../../components/experiment-page/contexts/GetExperimentsContext';
 import { ExperimentView } from '../../components/experiment-page/ExperimentView';
+import { IndexedDBInitializationContextProvider } from '@mlflow/mlflow/src/experiment-tracking/components/contexts/IndexedDBInitializationContext';
 
 /**
  * Concrete actions for GetExperiments context
@@ -17,9 +18,11 @@ const getExperimentActions = {
 };
 
 const ExperimentRunsPage = () => (
-  <GetExperimentsContextProvider actions={getExperimentActions}>
-    <ExperimentView showHeader={false} />
-  </GetExperimentsContextProvider>
+  <IndexedDBInitializationContextProvider>
+    <GetExperimentsContextProvider actions={getExperimentActions}>
+      <ExperimentView showHeader={false} />
+    </GetExperimentsContextProvider>
+  </IndexedDBInitializationContextProvider>
 );
 
 export default ExperimentRunsPage;


### PR DESCRIPTION

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

### What changes are proposed in this pull request?

This commit addresses the 5MB localStorage size limit that was being exceeded when ExperimentPage and RunPage stored UI state for large numbers of runs or metrics. The solution migrates UI state storage to IndexedDB, which provides significantly larger storage capacity while maintaining the same user experience. A fallback to localStorage ensures compatibility when IndexedDB is unavailable in certain browser environments.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
Configuration:
Experiment with 1 run containing 8000 metrics.

To reproduce:
Click chart view on the experiment page, wait for it to crash.

Manually verified:
Verified that with the fix, the charts page is able to load without crashing.
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
