### PR TITLE
AgentServer: fix streaming middleware bug

### DIFF
--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -161,6 +161,9 @@ class AgentServer:
 
             The timeout for the proxy request is specified by the CHAT_PROXY_TIMEOUT_SECONDS
             environment variable (defaults to 300.0 seconds).
+
+            For streaming responses (SSE), the proxy streams chunks as they arrive
+            rather than buffering the entire response.
             """
             for route in self.app.routes:
                 if hasattr(route, "path_regex") and route.path_regex.match(request.url.path):
@@ -180,18 +183,42 @@ class AgentServer:
             try:
                 body = await request.body() if request.method in ["POST", "PUT", "PATCH"] else None
                 target_url = f"http://localhost:{self.chat_app_port}/{path}"
-                proxy_response = await self.proxy_client.request(
+
+                # Build and send request with streaming enabled
+                req = self.proxy_client.build_request(
                     method=request.method,
                     url=target_url,
                     params=dict(request.query_params),
                     headers={k: v for k, v in request.headers.items() if k.lower() != "host"},
                     content=body,
                 )
-                return Response(
-                    proxy_response.content,
-                    proxy_response.status_code,
-                    headers=dict(proxy_response.headers),
-                )
+                proxy_response = await self.proxy_client.send(req, stream=True)
+
+                # Check if this is a streaming response (SSE)
+                content_type = proxy_response.headers.get("content-type", "")
+                if "text/event-stream" in content_type:
+                    # Stream SSE responses chunk by chunk
+                    async def stream_generator():
+                        try:
+                            async for chunk in proxy_response.aiter_bytes():
+                                yield chunk
+                        finally:
+                            await proxy_response.aclose()
+
+                    return StreamingResponse(
+                        stream_generator(),
+                        status_code=proxy_response.status_code,
+                        headers=dict(proxy_response.headers),
+                    )
+                else:
+                    # Non-streaming response - read fully then close
+                    content = await proxy_response.aread()
+                    await proxy_response.aclose()
+                    return Response(
+                        content,
+                        proxy_response.status_code,
+                        headers=dict(proxy_response.headers),
+                    )
             except httpx.ConnectError:
                 return Response("Service unavailable", status_code=503, media_type="text/plain")
             except Exception as e:

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -183,13 +183,15 @@ class AgentServer:
             try:
                 body = await request.body() if request.method in ["POST", "PUT", "PATCH"] else None
                 target_url = f"http://localhost:{self.chat_app_port}/{path}"
+                headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+                params = dict(request.query_params)
 
                 # Build and send request with streaming enabled
                 req = self.proxy_client.build_request(
                     method=request.method,
                     url=target_url,
-                    params=dict(request.query_params),
-                    headers={k: v for k, v in request.headers.items() if k.lower() != "host"},
+                    params=params,
+                    headers=headers,
                     content=body,
                 )
                 proxy_response = await self.proxy_client.send(req, stream=True)
@@ -202,6 +204,9 @@ class AgentServer:
                         try:
                             async for chunk in proxy_response.aiter_bytes():
                                 yield chunk
+                        except Exception as e:
+                            logger.error(f"Error while streaming response: {e}")
+                            raise
                         finally:
                             await proxy_response.aclose()
 
@@ -211,11 +216,17 @@ class AgentServer:
                         headers=dict(proxy_response.headers),
                     )
                 else:
-                    # Non-streaming response - read fully then close
-                    content = await proxy_response.aread()
+                    # Non-streaming response - close streaming response and use simpler request()
                     await proxy_response.aclose()
+                    proxy_response = await self.proxy_client.request(
+                        method=request.method,
+                        url=target_url,
+                        params=params,
+                        headers=headers,
+                        content=body,
+                    )
                     return Response(
-                        content,
+                        proxy_response.content,
                         proxy_response.status_code,
                         headers=dict(proxy_response.headers),
                     )

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -202,6 +202,9 @@ class AgentServer:
                         try:
                             async for chunk in proxy_response.aiter_bytes():
                                 yield chunk
+                        except Exception as e:
+                            logger.error(f"Streaming error: {e}")
+                            raise
                         finally:
                             await proxy_response.aclose()
 

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -1011,13 +1011,14 @@ async def test_chat_proxy_sse_streaming(content_type, status_code, custom_header
     mock_response.aclose = AsyncMock()
 
     with (
-        patch.object(server.proxy_client, "build_request"),
+        patch.object(server.proxy_client, "build_request") as mock_build_request,
         patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
     ):
         response = client.get("/api/stream")
         assert response.status_code == status_code
         assert "text/event-stream" in response.headers["content-type"]
         assert response.content == b"data: chunk1\n\ndata: chunk2\n\n"
+        mock_build_request.assert_called_once()
         mock_response.aclose.assert_called_once()
         assert mock_send.call_args.kwargs.get("stream") is True
         for key, value in custom_headers.items():
@@ -1045,12 +1046,13 @@ async def test_chat_proxy_non_sse_responses(content_type, status_code, custom_he
     mock_response.aclose = AsyncMock()
 
     with (
-        patch.object(server.proxy_client, "build_request"),
+        patch.object(server.proxy_client, "build_request") as mock_build_request,
         patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
     ):
         response = client.get("/")
         assert response.status_code == status_code
         assert response.content == b"content"
+        mock_build_request.assert_called_once()
         mock_response.aread.assert_called_once()
         mock_response.aclose.assert_called_once()
         assert mock_send.call_args.kwargs.get("stream") is True

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -558,21 +558,32 @@ async def test_chat_proxy_forwards_allowed_paths():
     server = AgentServer("ResponsesAgent", enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = AsyncMock()
-    mock_response.status_code = 200
-    mock_response.headers = {"content-type": "application/json"}
-    mock_response.aread = AsyncMock(return_value=b'{"chat": "response"}')
-    mock_response.aclose = AsyncMock()
+    # Mock for initial streaming check (will be closed when content-type is not SSE)
+    mock_stream_response = AsyncMock()
+    mock_stream_response.status_code = 200
+    mock_stream_response.headers = {"content-type": "application/json"}
+    mock_stream_response.aclose = AsyncMock()
+
+    # Mock for the actual non-streaming request
+    mock_request_response = Mock()
+    mock_request_response.status_code = 200
+    mock_request_response.headers = {"content-type": "application/json"}
+    mock_request_response.content = b'{"chat": "response"}'
 
     with (
         patch.object(server.proxy_client, "build_request") as mock_build_request,
-        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
+        patch.object(server.proxy_client, "send", return_value=mock_stream_response) as mock_send,
+        patch.object(
+            server.proxy_client, "request", return_value=mock_request_response
+        ) as mock_request,
     ):
         response = client.get("/assets/index.js")
         assert response.status_code == 200
         assert response.content == b'{"chat": "response"}'
         mock_build_request.assert_called_once()
         mock_send.assert_called_once()
+        mock_stream_response.aclose.assert_called_once()
+        mock_request.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -639,16 +650,25 @@ async def test_chat_proxy_forwards_post_requests_with_body():
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = AsyncMock()
-    mock_response.status_code = 200
-    mock_response.headers = {"content-type": "application/json"}
-    mock_response.aread = AsyncMock(return_value=b'{"result": "success"}')
-    mock_response.aclose = AsyncMock()
+    # Mock for initial streaming check (will be closed when content-type is not SSE)
+    mock_stream_response = AsyncMock()
+    mock_stream_response.status_code = 200
+    mock_stream_response.headers = {"content-type": "application/json"}
+    mock_stream_response.aclose = AsyncMock()
+
+    # Mock for the actual non-streaming request
+    mock_request_response = Mock()
+    mock_request_response.status_code = 200
+    mock_request_response.headers = {"content-type": "application/json"}
+    mock_request_response.content = b'{"result": "success"}'
 
     # POST to root path (allowed) to test body forwarding
     with (
         patch.object(server.proxy_client, "build_request") as mock_build_request,
-        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
+        patch.object(server.proxy_client, "send", return_value=mock_stream_response) as mock_send,
+        patch.object(
+            server.proxy_client, "request", return_value=mock_request_response
+        ) as mock_request,
     ):
         response = client.post("/", json={"message": "hello"})
         assert response.status_code == 200
@@ -656,7 +676,9 @@ async def test_chat_proxy_forwards_post_requests_with_body():
 
         mock_build_request.assert_called_once()
         mock_send.assert_called_once()
-        call_args = mock_build_request.call_args
+        mock_stream_response.aclose.assert_called_once()
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
         assert call_args.kwargs["method"] == "POST"
         assert call_args.kwargs["content"] is not None
 
@@ -667,20 +689,31 @@ async def test_chat_proxy_respects_chat_app_port_env_var(monkeypatch):
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = AsyncMock()
-    mock_response.status_code = 200
-    mock_response.headers = {}
-    mock_response.aread = AsyncMock(return_value=b"test")
-    mock_response.aclose = AsyncMock()
+    # Mock for initial streaming check (will be closed when content-type is not SSE)
+    mock_stream_response = AsyncMock()
+    mock_stream_response.status_code = 200
+    mock_stream_response.headers = {}
+    mock_stream_response.aclose = AsyncMock()
+
+    # Mock for the actual non-streaming request
+    mock_request_response = Mock()
+    mock_request_response.status_code = 200
+    mock_request_response.headers = {}
+    mock_request_response.content = b"test"
 
     with (
         patch.object(server.proxy_client, "build_request") as mock_build_request,
-        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
+        patch.object(server.proxy_client, "send", return_value=mock_stream_response) as mock_send,
+        patch.object(
+            server.proxy_client, "request", return_value=mock_request_response
+        ) as mock_request,
     ):
         client.get("/assets/test.js")
         mock_build_request.assert_called_once()
         mock_send.assert_called_once()
-        call_args = mock_build_request.call_args
+        mock_stream_response.aclose.assert_called_once()
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
         assert call_args.kwargs["url"] == "http://localhost:8080/assets/test.js"
 
 
@@ -897,21 +930,32 @@ async def test_chat_proxy_forwards_allowlisted_paths(path):
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = AsyncMock()
-    mock_response.status_code = 200
-    mock_response.headers = {}
-    mock_response.aread = AsyncMock(return_value=b"response")
-    mock_response.aclose = AsyncMock()
+    # Mock for initial streaming check (will be closed when content-type is not SSE)
+    mock_stream_response = AsyncMock()
+    mock_stream_response.status_code = 200
+    mock_stream_response.headers = {}
+    mock_stream_response.aclose = AsyncMock()
+
+    # Mock for the actual non-streaming request
+    mock_request_response = Mock()
+    mock_request_response.status_code = 200
+    mock_request_response.headers = {}
+    mock_request_response.content = b"response"
 
     with (
         patch.object(server.proxy_client, "build_request") as mock_build_request,
-        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
+        patch.object(server.proxy_client, "send", return_value=mock_stream_response) as mock_send,
+        patch.object(
+            server.proxy_client, "request", return_value=mock_request_response
+        ) as mock_request,
     ):
         response = client.get(path)
         assert response.status_code == 200
         mock_build_request.assert_called_once()
         mock_send.assert_called_once()
-        assert mock_build_request.call_args.kwargs["url"] == f"http://localhost:3000{path}"
+        mock_stream_response.aclose.assert_called_once()
+        mock_request.assert_called_once()
+        assert mock_request.call_args.kwargs["url"] == f"http://localhost:3000{path}"
 
 
 @pytest.mark.asyncio
@@ -973,20 +1017,31 @@ async def test_chat_proxy_forwards_additional_paths_from_env_vars(
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = AsyncMock()
-    mock_response.status_code = 200
-    mock_response.headers = {}
-    mock_response.aread = AsyncMock(return_value=b"response")
-    mock_response.aclose = AsyncMock()
+    # Mock for initial streaming check (will be closed when content-type is not SSE)
+    mock_stream_response = AsyncMock()
+    mock_stream_response.status_code = 200
+    mock_stream_response.headers = {}
+    mock_stream_response.aclose = AsyncMock()
+
+    # Mock for the actual non-streaming request
+    mock_request_response = Mock()
+    mock_request_response.status_code = 200
+    mock_request_response.headers = {}
+    mock_request_response.content = b"response"
 
     with (
         patch.object(server.proxy_client, "build_request") as mock_build_request,
-        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
+        patch.object(server.proxy_client, "send", return_value=mock_stream_response) as mock_send,
+        patch.object(
+            server.proxy_client, "request", return_value=mock_request_response
+        ) as mock_request,
     ):
         response = client.get(test_path)
         assert response.status_code == 200
         mock_build_request.assert_called_once()
         mock_send.assert_called_once()
+        mock_stream_response.aclose.assert_called_once()
+        mock_request.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -1044,23 +1099,32 @@ async def test_chat_proxy_non_sse_responses(content_type, status_code, custom_he
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = AsyncMock()
-    mock_response.status_code = status_code
-    mock_response.headers = {"content-type": content_type, **custom_headers}
-    mock_response.aread = AsyncMock(return_value=b"content")
-    mock_response.aclose = AsyncMock()
+    # Mock for initial streaming check (will be closed when content-type is not SSE)
+    mock_stream_response = AsyncMock()
+    mock_stream_response.status_code = status_code
+    mock_stream_response.headers = {"content-type": content_type, **custom_headers}
+    mock_stream_response.aclose = AsyncMock()
+
+    # Mock for the actual non-streaming request
+    mock_request_response = Mock()
+    mock_request_response.status_code = status_code
+    mock_request_response.headers = {"content-type": content_type, **custom_headers}
+    mock_request_response.content = b"content"
 
     with (
         patch.object(server.proxy_client, "build_request") as mock_build_request,
-        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
+        patch.object(server.proxy_client, "send", return_value=mock_stream_response) as mock_send,
+        patch.object(
+            server.proxy_client, "request", return_value=mock_request_response
+        ) as mock_request,
     ):
         response = client.get("/")
         assert response.status_code == status_code
         assert response.content == b"content"
         mock_build_request.assert_called_once()
-        mock_response.aread.assert_called_once()
-        mock_response.aclose.assert_called_once()
+        mock_stream_response.aclose.assert_called_once()
         assert mock_send.call_args.kwargs.get("stream") is True
+        mock_request.assert_called_once()
         for key, value in custom_headers.items():
             assert response.headers[key] == value
 

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -648,12 +648,14 @@ async def test_chat_proxy_forwards_post_requests_with_body():
     # POST to root path (allowed) to test body forwarding
     with (
         patch.object(server.proxy_client, "build_request") as mock_build_request,
-        patch.object(server.proxy_client, "send", return_value=mock_response),
+        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
     ):
         response = client.post("/", json={"message": "hello"})
         assert response.status_code == 200
         assert response.content == b'{"result": "success"}'
 
+        mock_build_request.assert_called_once()
+        mock_send.assert_called_once()
         call_args = mock_build_request.call_args
         assert call_args.kwargs["method"] == "POST"
         assert call_args.kwargs["content"] is not None
@@ -673,10 +675,11 @@ async def test_chat_proxy_respects_chat_app_port_env_var(monkeypatch):
 
     with (
         patch.object(server.proxy_client, "build_request") as mock_build_request,
-        patch.object(server.proxy_client, "send", return_value=mock_response),
+        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
     ):
         client.get("/assets/test.js")
         mock_build_request.assert_called_once()
+        mock_send.assert_called_once()
         call_args = mock_build_request.call_args
         assert call_args.kwargs["url"] == "http://localhost:8080/assets/test.js"
 
@@ -902,11 +905,12 @@ async def test_chat_proxy_forwards_allowlisted_paths(path):
 
     with (
         patch.object(server.proxy_client, "build_request") as mock_build_request,
-        patch.object(server.proxy_client, "send", return_value=mock_response),
+        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
     ):
         response = client.get(path)
         assert response.status_code == 200
         mock_build_request.assert_called_once()
+        mock_send.assert_called_once()
         assert mock_build_request.call_args.kwargs["url"] == f"http://localhost:3000{path}"
 
 
@@ -977,11 +981,12 @@ async def test_chat_proxy_forwards_additional_paths_from_env_vars(
 
     with (
         patch.object(server.proxy_client, "build_request") as mock_build_request,
-        patch.object(server.proxy_client, "send", return_value=mock_response),
+        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
     ):
         response = client.get(test_path)
         assert response.status_code == 200
         mock_build_request.assert_called_once()
+        mock_send.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -1,6 +1,6 @@
 import contextvars
 from typing import AsyncGenerator
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
@@ -558,16 +558,21 @@ async def test_chat_proxy_forwards_allowed_paths():
     server = AgentServer("ResponsesAgent", enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = Mock()
-    mock_response.content = b'{"chat": "response"}'
+    mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.headers = {"content-type": "application/json"}
+    mock_response.aread = AsyncMock(return_value=b'{"chat": "response"}')
+    mock_response.aclose = AsyncMock()
 
-    with patch.object(server.proxy_client, "request", return_value=mock_response) as mock_request:
+    with (
+        patch.object(server.proxy_client, "build_request") as mock_build_request,
+        patch.object(server.proxy_client, "send", return_value=mock_response) as mock_send,
+    ):
         response = client.get("/assets/index.js")
         assert response.status_code == 200
         assert response.content == b'{"chat": "response"}'
-        mock_request.assert_called_once()
+        mock_build_request.assert_called_once()
+        mock_send.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -589,11 +594,14 @@ async def test_chat_proxy_does_not_forward_matched_routes():
     server = AgentServer("ResponsesAgent", enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    with patch.object(server.proxy_client, "request") as mock_request:
+    with (
+        patch.object(server.proxy_client, "build_request") as mock_build_request,
+        patch.object(server.proxy_client, "send"),
+    ):
         response = client.get("/health")
         assert response.status_code == 200
         assert response.json() == {"status": "healthy"}
-        mock_request.assert_not_called()
+        mock_build_request.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -601,8 +609,11 @@ async def test_chat_proxy_handles_connect_error():
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    with patch.object(
-        server.proxy_client, "request", side_effect=httpx.ConnectError("Connection failed")
+    with (
+        patch.object(server.proxy_client, "build_request"),
+        patch.object(
+            server.proxy_client, "send", side_effect=httpx.ConnectError("Connection failed")
+        ),
     ):
         response = client.get("/")
         assert response.status_code == 503
@@ -614,7 +625,10 @@ async def test_chat_proxy_handles_general_error():
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    with patch.object(server.proxy_client, "request", side_effect=Exception("Unexpected error")):
+    with (
+        patch.object(server.proxy_client, "build_request"),
+        patch.object(server.proxy_client, "send", side_effect=Exception("Unexpected error")),
+    ):
         response = client.get("/")
         assert response.status_code == 502
         assert "Proxy error: Unexpected error" in response.text
@@ -625,18 +639,22 @@ async def test_chat_proxy_forwards_post_requests_with_body():
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = Mock()
-    mock_response.content = b'{"result": "success"}'
+    mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.headers = {"content-type": "application/json"}
+    mock_response.aread = AsyncMock(return_value=b'{"result": "success"}')
+    mock_response.aclose = AsyncMock()
 
     # POST to root path (allowed) to test body forwarding
-    with patch.object(server.proxy_client, "request", return_value=mock_response) as mock_request:
+    with (
+        patch.object(server.proxy_client, "build_request") as mock_build_request,
+        patch.object(server.proxy_client, "send", return_value=mock_response),
+    ):
         response = client.post("/", json={"message": "hello"})
         assert response.status_code == 200
         assert response.content == b'{"result": "success"}'
 
-        call_args = mock_request.call_args
+        call_args = mock_build_request.call_args
         assert call_args.kwargs["method"] == "POST"
         assert call_args.kwargs["content"] is not None
 
@@ -647,15 +665,19 @@ async def test_chat_proxy_respects_chat_app_port_env_var(monkeypatch):
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = Mock()
-    mock_response.content = b"test"
+    mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.headers = {}
+    mock_response.aread = AsyncMock(return_value=b"test")
+    mock_response.aclose = AsyncMock()
 
-    with patch.object(server.proxy_client, "request", return_value=mock_response) as mock_request:
+    with (
+        patch.object(server.proxy_client, "build_request") as mock_build_request,
+        patch.object(server.proxy_client, "send", return_value=mock_response),
+    ):
         client.get("/assets/test.js")
-        mock_request.assert_called_once()
-        call_args = mock_request.call_args
+        mock_build_request.assert_called_once()
+        call_args = mock_build_request.call_args
         assert call_args.kwargs["url"] == "http://localhost:8080/assets/test.js"
 
 
@@ -872,16 +894,20 @@ async def test_chat_proxy_forwards_allowlisted_paths(path):
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = Mock()
-    mock_response.content = b"response"
+    mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.headers = {}
+    mock_response.aread = AsyncMock(return_value=b"response")
+    mock_response.aclose = AsyncMock()
 
-    with patch.object(server.proxy_client, "request", return_value=mock_response) as mock_request:
+    with (
+        patch.object(server.proxy_client, "build_request") as mock_build_request,
+        patch.object(server.proxy_client, "send", return_value=mock_response),
+    ):
         response = client.get(path)
         assert response.status_code == 200
-        mock_request.assert_called_once()
-        assert mock_request.call_args.kwargs["url"] == f"http://localhost:3000{path}"
+        mock_build_request.assert_called_once()
+        assert mock_build_request.call_args.kwargs["url"] == f"http://localhost:3000{path}"
 
 
 @pytest.mark.asyncio
@@ -893,11 +919,14 @@ async def test_chat_proxy_blocks_arbitrary_paths(path):
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    with patch.object(server.proxy_client, "request") as mock_request:
+    with (
+        patch.object(server.proxy_client, "build_request") as mock_build_request,
+        patch.object(server.proxy_client, "send"),
+    ):
         response = client.get(path)
         assert response.status_code == 404
         assert response.text == "Not found"
-        mock_request.assert_not_called()
+        mock_build_request.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -909,11 +938,14 @@ async def test_chat_proxy_blocks_path_traversal_attempts(path):
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    with patch.object(server.proxy_client, "request") as mock_request:
+    with (
+        patch.object(server.proxy_client, "build_request") as mock_build_request,
+        patch.object(server.proxy_client, "send"),
+    ):
         response = client.get(path)
         assert response.status_code == 404
         assert response.text == "Not found"
-        mock_request.assert_not_called()
+        mock_build_request.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -937,15 +969,19 @@ async def test_chat_proxy_forwards_additional_paths_from_env_vars(
     server = AgentServer(enable_chat_proxy=True)
     client = TestClient(server.app)
 
-    mock_response = Mock()
-    mock_response.content = b"response"
+    mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.headers = {}
+    mock_response.aread = AsyncMock(return_value=b"response")
+    mock_response.aclose = AsyncMock()
 
-    with patch.object(server.proxy_client, "request", return_value=mock_response) as mock_request:
+    with (
+        patch.object(server.proxy_client, "build_request") as mock_build_request,
+        patch.object(server.proxy_client, "send", return_value=mock_response),
+    ):
         response = client.get(test_path)
         assert response.status_code == 200
-        mock_request.assert_called_once()
+        mock_build_request.assert_called_once()
 
 
 def test_return_trace_header_invoke_responses_agent():


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

now a UI that is hosted on a diff port will stream: 

https://github.com/user-attachments/assets/3b745440-432b-465d-b9ea-02f2d125b5f6

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
