### PR TITLE
Fix Compare modal closing immediately after opening

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.tsx
@@ -106,7 +106,12 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
   }, []);
 
   const handleOpenCompare = useCallback(() => {
-    setShowCompareModal(true);
+    // Delay to allow dropdown click event to complete before drawer opens.
+    // This prevents the click from being detected as an "outside click"
+    // by the drawer's DismissableLayer, which would immediately close it.
+    requestAnimationFrame(() => {
+      setShowCompareModal(true);
+    });
   }, []);
 
   const handleCloseCompare = useCallback(() => {


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When clicking the "Compare" button in the Actions dropdown on the traces page, the comparison drawer would appear briefly and then immediately close. This was caused by the click event that opens the modal being detected as an "outside click" by the drawer's DismissableLayer (since the drawer uses `modal={false}`).

The fix delays opening the drawer using `requestAnimationFrame`, allowing the dropdown click event to complete before the drawer renders and registers its outside-click handler.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix an issue where the Compare modal on the traces page would immediately close after opening.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)