### PR TITLE
Fix the trace compare tab display bug

### DIFF
--- a/mlflow/server/js/src/common/components/AssistantAwareDrawer.tsx
+++ b/mlflow/server/js/src/common/components/AssistantAwareDrawer.tsx
@@ -20,7 +20,7 @@ const ASSISTANT_OPEN_DRAWER_WIDTH = '70vw';
 function Root({
   open,
   onOpenChange,
-  modal,
+  modal = false,
   children,
 }: {
   // Matches with Drawer.Root props
@@ -30,8 +30,9 @@ function Root({
   children: ReactNode;
 }) {
   return (
-    // NB: Modal is set to false to allow clicks on the assistant chat panel to pass through
-    <Drawer.Root modal={false} open={open} onOpenChange={onOpenChange}>
+    // NB: Modal defaults to false to allow clicks on the assistant chat panel to pass through,
+    // but can be overridden when needed (e.g., for comparison drawers that need proper modal behavior)
+    <Drawer.Root modal={modal} open={open} onOpenChange={onOpenChange}>
       {children}
     </Drawer.Root>
   );

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAITraceComparisonModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAITraceComparisonModal.tsx
@@ -28,6 +28,7 @@ export const GenAITraceComparisonModal = ({
   return (
     <AssistantAwareDrawer.Root
       open
+      modal
       onOpenChange={(open) => {
         if (!open) {
           onClose?.();
@@ -55,7 +56,7 @@ export const GenAITraceComparisonModal = ({
             '&>div': {
               overflow: 'hidden',
             },
-            '&>div:first-child': {
+            '&>div:first-of-type': {
               paddingLeft: theme.spacing.md,
             },
           },


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Fix the conflicting modal state between assistant drawer and trace compare view

<img width="1728" height="959" alt="image" src="https://github.com/user-attachments/assets/578c332b-1b5b-4268-ac19-6e69a8c5e0aa" />



### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
