### PR TITLE
Support stateful agents in conversation simulation

### DIFF
--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -435,6 +435,9 @@ class ConversationSimulator:
     - It must accept an ``input`` parameter containing the conversation history
       as a list of message dictionaries (e.g., ``[{"role": "user", "content": "..."}]``)
     - It may accept additional keyword arguments from the test case's ``context`` field
+    - It receives an ``mlflow_session_id`` parameter that uniquely identifies the conversation
+      session. This ID is consistent across all turns in the same conversation, allowing you
+      to associate related traces or maintain stateful context (e.g., for thread-based agents).
     - It should return a response (the assistant's message content will be extracted)
 
     Args:
@@ -465,6 +468,13 @@ class ConversationSimulator:
 
 
             def predict_fn(input: list[dict], **kwargs) -> dict:
+                # The mlflow_session_id uniquely identifies this conversation session.
+                # All turns in the same conversation share the same session ID.
+                session_id = kwargs.get("mlflow_session_id")
+
+                # You can use this to maintain state across turns, e.g.:
+                # thread = get_or_create_thread(session_id)
+
                 response = client.chat.completions.create(
                     model="gpt-4o-mini",
                     messages=input,
@@ -737,7 +747,9 @@ class ConversationSimulator:
                 )
             return predict_fn(input=input, **ctx)
 
-        response = traced_predict(input=input_messages, **context)
+        response = traced_predict(
+            input=input_messages, mlflow_session_id=trace_session_id, **context
+        )
         trace_id = mlflow.get_last_active_trace_id(thread_local=True)
 
         # Log expectations to the first trace of the session

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -466,7 +466,7 @@ class ConversationSimulator:
             from mlflow.genai.simulators import ConversationSimulator
             from mlflow.genai.scorers import ConversationalSafety, Safety
 
-            # Cache to store conversation threads by session ID
+            # Dummy cache to store conversation threads by session ID
             conversation_threads = {}
 
 

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -466,14 +466,20 @@ class ConversationSimulator:
             from mlflow.genai.simulators import ConversationSimulator
             from mlflow.genai.scorers import ConversationalSafety, Safety
 
+            # Cache to store conversation threads by session ID
+            conversation_threads = {}
+
 
             def predict_fn(input: list[dict], **kwargs) -> dict:
                 # The mlflow_session_id uniquely identifies this conversation session.
                 # All turns in the same conversation share the same session ID.
                 session_id = kwargs.get("mlflow_session_id")
 
-                # You can use this to maintain state across turns, e.g.:
-                # thread = get_or_create_thread(session_id)
+                # Use the session ID to maintain state across turns - for example,
+                # storing conversation context, user preferences, or agent memory
+                if session_id not in conversation_threads:
+                    conversation_threads[session_id] = {"turn_count": 0}
+                conversation_threads[session_id]["turn_count"] += 1
 
                 response = client.chat.completions.create(
                     model="gpt-4o-mini",

--- a/tests/genai/simulators/conftest.py
+++ b/tests/genai/simulators/conftest.py
@@ -40,7 +40,7 @@ def mock_llm_response():
 
 @pytest.fixture
 def mock_predict_fn():
-    def predict_fn(input=None, messages=None, context=None):
+    def predict_fn(input=None, messages=None, context=None, **kwargs):
         return {
             "output": [
                 {


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Supports stateful agents in conversation simulation by adding `mlflow_session_id` to `predict_fn` `kwargs` in simulator.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
