### PR TITLE
Compute simulator digest from test cases instead of traces

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -318,12 +318,17 @@ def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult
     scorers = validate_scorers(scorers)
 
     # Handle ConversationSimulator: run simulation first, then evaluate the generated traces
+    precomputed_digest = None
     if isinstance(data, ConversationSimulator):
         if predict_fn is None:
             raise MlflowException.invalid_parameter_value(
                 "predict_fn is required when using ConversationSimulator as data. "
                 "The simulator needs a predict function to generate conversations."
             )
+
+        # Compute digest from test cases BEFORE simulation. This ensures the same test cases
+        # produce the same digest regardless of LLM non-determinism in generated conversations.
+        precomputed_digest = data._compute_test_case_digest()
 
         # Wrap async predict_fn for synchronous execution during simulation
         sim_predict_fn = predict_fn
@@ -387,8 +392,9 @@ def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult
         mlflow_dataset = data
         df = data.to_df()
     else:
-        # Use default name for evaluation dataset when converting from DataFrame
-        mlflow_dataset = mlflow.data.from_pandas(df=data, name="dataset")
+        # Use default name for evaluation dataset when converting from DataFrame.
+        # Pass precomputed_digest if available (e.g., from ConversationSimulator test cases).
+        mlflow_dataset = mlflow.data.from_pandas(df=data, name="dataset", digest=precomputed_digest)
         df = data
 
     try:

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -562,6 +562,19 @@ class ConversationSimulator:
                 f"which will be ignored. Expected keys: {_EXPECTED_TEST_CASE_KEYS}."
             )
 
+    def _compute_test_case_digest(self) -> str:
+        """Compute a digest based on the test cases for consistent dataset identification.
+
+        This ensures the same test cases produce the same digest regardless of
+        simulation output variations caused by LLM non-determinism.
+        """
+        import pandas as pd
+
+        from mlflow.data.digest_utils import compute_pandas_digest
+
+        test_case_df = pd.DataFrame(self.test_cases)
+        return compute_pandas_digest(test_case_df)
+
     @experimental(version="3.10.0")
     @record_usage_event(SimulateConversationEvent)
     def simulate(self, predict_fn: Callable[..., dict[str, Any]]) -> list[list["Trace"]]:

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -510,6 +510,9 @@ class ConversationSimulator:
                 f"user_agent_class must be a subclass of BaseSimulatedUserAgent, "
                 f"got {user_agent_class.__name__}"
             )
+        # Store original dataset reference if test_cases is an EvaluationDataset, so we can
+        # preserve the dataset name when creating the evaluation dataset.
+        self._source_dataset = test_cases if isinstance(test_cases, EvaluationDataset) else None
         self.test_cases = test_cases
         self.max_turns = max_turns
         self.user_model = user_model or get_default_model()
@@ -574,6 +577,16 @@ class ConversationSimulator:
 
         test_case_df = pd.DataFrame(self.test_cases)
         return compute_pandas_digest(test_case_df)
+
+    def _get_dataset_name(self) -> str:
+        """Get the dataset name to use for the evaluation dataset.
+
+        If test_cases was an EvaluationDataset, use its name. Otherwise, use the
+        default name for conversational datasets.
+        """
+        if self._source_dataset is not None:
+            return self._source_dataset.name
+        return "conversational_dataset"
 
     @experimental(version="3.10.0")
     @record_usage_event(SimulateConversationEvent)

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -653,3 +653,20 @@ def test_conversation_simulator_digest_differs_for_different_test_cases(test_cas
     simulator2 = ConversationSimulator(test_cases=test_cases_2, max_turns=2)
 
     assert simulator1._compute_test_case_digest() != simulator2._compute_test_case_digest()
+
+
+def test_conversation_simulator_get_dataset_name_default():
+    test_cases = [{"goal": "Learn about MLflow"}]
+    simulator = ConversationSimulator(test_cases=test_cases, max_turns=2)
+
+    assert simulator._get_dataset_name() == "conversational_dataset"
+
+
+def test_conversation_simulator_get_dataset_name_from_evaluation_dataset():
+    inputs = [{"goal": "Learn about MLflow"}]
+    mock_dataset = create_mock_evaluation_dataset(inputs)
+    mock_dataset.name = "my_custom_dataset"
+
+    simulator = ConversationSimulator(test_cases=mock_dataset, max_turns=2)
+
+    assert simulator._get_dataset_name() == "my_custom_dataset"

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -617,3 +617,39 @@ def test_invalid_user_agent_class_raises_type_error(simple_test_case):
             max_turns=2,
             user_agent_class=NotAUserAgent,
         )
+
+
+def test_conversation_simulator_digest_is_deterministic():
+    test_cases = [
+        {"goal": "Learn about MLflow"},
+        {"goal": "Debug deployment", "persona": "Data scientist"},
+        {"goal": "Setup", "context": {"env": "prod"}},
+    ]
+    simulator1 = ConversationSimulator(test_cases=test_cases, max_turns=2)
+    simulator2 = ConversationSimulator(test_cases=test_cases, max_turns=2)
+
+    digest1 = simulator1._compute_test_case_digest()
+    digest2 = simulator2._compute_test_case_digest()
+
+    assert digest1 == digest2
+    assert isinstance(digest1, str)
+    assert len(digest1) == 8
+
+
+@pytest.mark.parametrize(
+    ("test_cases_1", "test_cases_2"),
+    [
+        # Different goals
+        ([{"goal": "Goal A"}], [{"goal": "Goal B"}]),
+        # Adding persona changes digest
+        ([{"goal": "Goal"}], [{"goal": "Goal", "persona": "Engineer"}]),
+        # Different order
+        ([{"goal": "A"}, {"goal": "B"}], [{"goal": "B"}, {"goal": "A"}]),
+    ],
+    ids=["different_goals", "added_persona", "different_order"],
+)
+def test_conversation_simulator_digest_differs_for_different_test_cases(test_cases_1, test_cases_2):
+    simulator1 = ConversationSimulator(test_cases=test_cases_1, max_turns=2)
+    simulator2 = ConversationSimulator(test_cases=test_cases_2, max_turns=2)
+
+    assert simulator1._compute_test_case_digest() != simulator2._compute_test_case_digest()


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Ensures digest is the same between simulator runs.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Ran eval twice with the same simulator:
<img width="334" height="167" alt="image" src="https://github.com/user-attachments/assets/afa0ac99-f0e2-4196-ac1e-697aecf02d02" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
