### PR TITLE
Allow MLSERVER_MODEL_IMPLEMENTATION env var to take precedence

### DIFF
--- a/mlflow/pyfunc/mlserver.py
+++ b/mlflow/pyfunc/mlserver.py
@@ -40,7 +40,10 @@ def get_cmd(
     if model_version and not cmd_env.get("MLSERVER_MODEL_VERSION"):
         cmd_env["MLSERVER_MODEL_VERSION"] = model_version
 
-    cmd_env["MLSERVER_MODEL_IMPLEMENTATION"] = MLServerMLflowRuntime
+    # give precedence to user env var input
+    cmd_env["MLSERVER_MODEL_IMPLEMENTATION"] = (
+        cmd_env.get("MLSERVER_MODEL_IMPLEMENTATION") or MLServerMLflowRuntime
+    )
     cmd_env["MLSERVER_MODEL_URI"] = model_uri
 
     return cmd, cmd_env

--- a/tests/pyfunc/test_mlserver.py
+++ b/tests/pyfunc/test_mlserver.py
@@ -60,3 +60,14 @@ def test_get_cmd(params: dict[str, Any], expected: dict[str, Any]):
         **expected,
         **os.environ.copy(),
     }
+
+
+def test_get_cmd_respects_env_var_model_implementation(monkeypatch):
+    """Test that MLSERVER_MODEL_IMPLEMENTATION env var takes precedence over the default."""
+    custom_implementation = "custom.runtime.CustomRuntime"
+    monkeypatch.setenv("MLSERVER_MODEL_IMPLEMENTATION", custom_implementation)
+
+    model_uri = "/foo/bar"
+    _, cmd_env = get_cmd(model_uri=model_uri)
+
+    assert cmd_env["MLSERVER_MODEL_IMPLEMENTATION"] == custom_implementation


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR modifies the `get_cmd` function in `mlflow/pyfunc/mlserver.py` to give precedence to user-provided `MLSERVER_MODEL_IMPLEMENTATION` environment variables over the default `MLServerMLflowRuntime`. 

Previously, the `MLSERVER_MODEL_IMPLEMENTATION` was always set to `MLServerMLflowRuntime`, ignoring any user-configured environment variable. This behavior was inconsistent with how `MLSERVER_MODEL_NAME` is handled (which already respects user env vars).

This change allows users to specify a custom MLServer runtime implementation via the `MLSERVER_MODEL_IMPLEMENTATION` environment variable, enabling scenarios where users need to use a custom runtime (e.g., for serving models with non-standard preprocessing/postprocessing).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

A new test `test_get_cmd_respects_env_var_model_implementation` has been added to `tests/pyfunc/test_mlserver.py` that verifies the `MLSERVER_MODEL_IMPLEMENTATION` environment variable takes precedence over the default value.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Allow users to override `MLSERVER_MODEL_IMPLEMENTATION` via environment variable when serving models with MLServer, enabling custom runtime implementations.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)