### PR TITLE
Add simulation_guidelines field to conversation simulation

### DIFF
--- a/docs/docs/genai/datasets/conversation-simulation.mdx
+++ b/docs/docs/genai/datasets/conversation-simulation.mdx
@@ -46,6 +46,10 @@ test_cases = [
         "inputs": {
             "goal": "Understand model versioning best practices for a team environment.",
             "persona": "You are building an ML platform for your team",
+            "simulation_guidelines": [
+                "Start with a general question about model versioning",
+                "Do not mention compliance requirements until the assistant asks about your use case",
+            ],
             "context": {"team_size": "large", "compliance": "strict"},
         },
     },

--- a/docs/docs/genai/eval-monitor/running-evaluation/conversation-simulation.mdx
+++ b/docs/docs/genai/eval-monitor/running-evaluation/conversation-simulation.mdx
@@ -147,13 +147,13 @@ results = mlflow.genai.evaluate(
 
 Each test case represents a conversation scenario. Test cases support the following fields:
 
-| Field                    | Required | Description                                                          |
-| ------------------------ | -------- | -------------------------------------------------------------------- |
-| `goal`                   | Yes      | What the simulated user is trying to accomplish                      |
-| `persona`                | No       | Description of the user's personality and communication style        |
-| `simulation_guidelines`  | No       | A list of instructions controlling how the simulated user behaves    |
-| `context`                | No       | Additional kwargs passed to your predict function                    |
-| `expectations`           | No       | Expected outcomes logged to the first trace for scorer reference     |
+| Field                   | Required | Description                                                       |
+| ----------------------- | -------- | ----------------------------------------------------------------- |
+| `goal`                  | Yes      | What the simulated user is trying to accomplish                   |
+| `persona`               | No       | Description of the user's personality and communication style     |
+| `simulation_guidelines` | No       | A list of instructions controlling how the simulated user behaves |
+| `context`               | No       | Additional kwargs passed to your predict function                 |
+| `expectations`          | No       | Expected outcomes logged to the first trace for scorer reference  |
 
 ### Goal
 
@@ -283,7 +283,7 @@ simulator = ConversationSimulator(test_cases=df)
 The `generate_test_cases` API is experimental in MLflow 3.10.0. The API and behavior may change in future releases.
 :::
 
-Generate test cases from existing conversation sessions using <APILink fn="mlflow.genai.simulators.generate_test_cases">`generate_test_cases`</APILink>. This analyzes each session and extracts the user's goal, persona, and simulation guidelines that help reproduce the original conversation trajectory:
+Generate test cases from existing conversation sessions using <APILink fn="mlflow.genai.simulators.generate_test_cases">`generate_test_cases`</APILink>. This is useful for creating test cases that reflect real user behavior from production conversations:
 
 ```python
 import mlflow

--- a/docs/docs/genai/eval-monitor/running-evaluation/conversation-simulation.mdx
+++ b/docs/docs/genai/eval-monitor/running-evaluation/conversation-simulation.mdx
@@ -106,6 +106,10 @@ test_cases = [
     {
         "goal": "Set up model versioning for a production ML pipeline",
         "persona": "You are a beginner who needs step-by-step guidance",
+        "simulation_guidelines": [
+            "Start by asking about model versioning without mentioning any specific tools",
+            "Do not ask about deployment until the assistant brings it up",
+        ],
         "context": {
             "user_id": "beginner_123"
         },  # user_id is passed to predict_fn via kwargs
@@ -141,13 +145,15 @@ results = mlflow.genai.evaluate(
 
 ## Defining Test Cases
 
-Each test case represents a conversation scenario. Test cases support three fields:
+Each test case represents a conversation scenario. Test cases support the following fields:
 
-| Field     | Required | Description                                                   |
-| --------- | -------- | ------------------------------------------------------------- |
-| `goal`    | Yes      | What the simulated user is trying to accomplish               |
-| `persona` | No       | Description of the user's personality and communication style |
-| `context` | No       | Additional kwargs passed to your predict function             |
+| Field                    | Required | Description                                                          |
+| ------------------------ | -------- | -------------------------------------------------------------------- |
+| `goal`                   | Yes      | What the simulated user is trying to accomplish                      |
+| `persona`                | No       | Description of the user's personality and communication style        |
+| `simulation_guidelines`  | No       | A list of instructions controlling how the simulated user behaves    |
+| `context`                | No       | Additional kwargs passed to your predict function                    |
+| `expectations`           | No       | Expected outcomes logged to the first trace for scorer reference     |
 
 ### Goal
 
@@ -193,6 +199,34 @@ The persona shapes how the simulated user communicates. If not specified, a defa
     "persona": "You are impatient and frustrated because this is blocking a production release",
 }
 ```
+
+### Simulation Guidelines
+
+Simulation guidelines give you fine-grained control over _how_ the simulated user behaves during the conversation. While the goal defines _what_ the user wants and the persona defines _who_ the user is, guidelines specify _rules_ the simulated user must follow. They are especially useful for reproducing specific conversation patterns observed in production.
+
+Guidelines are provided as a list of strings, where each string is a specific instruction:
+
+```python
+{
+    "goal": "Get a summary of last quarter's sales data broken down by region",
+    "persona": "You are a sales manager who prefers concise answers",
+    "simulation_guidelines": [
+        "Do not provide the date range upfront; wait until the assistant asks for it",
+        "Do not explicitly ask for percentage changes; the assistant should provide them without being asked",
+        "Start with a broad request and only narrow down to specific regions after the assistant responds",
+    ],
+}
+```
+
+Guidelines can cover several categories:
+
+- **Information withholding**: Prevent the simulated user from revealing details too early (e.g., _"Do not provide the error message upfront; wait until the assistant asks for more details"_)
+- **Implicit expectations**: Things the user expects the assistant to infer without being asked (e.g., _"Do not explicitly ask for code examples; the assistant should provide them on its own"_)
+- **Pacing and ordering**: Control the order in which topics are raised (e.g., _"Start with a broad question and only narrow down after the assistant responds"_)
+
+:::tip
+Simulation guidelines are particularly valuable when using <APILink fn="mlflow.genai.simulators.generate_test_cases">`generate_test_cases`</APILink> to extract test cases from production sessions. The function automatically infers guidelines that help reproduce the original conversation trajectory.
+:::
 
 ### Context
 
@@ -249,7 +283,7 @@ simulator = ConversationSimulator(test_cases=df)
 The `generate_test_cases` API is experimental in MLflow 3.10.0. The API and behavior may change in future releases.
 :::
 
-Generate test cases from existing conversation sessions using <APILink fn="mlflow.genai.simulators.generate_test_cases">`generate_test_cases`</APILink>. This is useful for creating test cases that reflect real user behavior from production conversations:
+Generate test cases from existing conversation sessions using <APILink fn="mlflow.genai.simulators.generate_test_cases">`generate_test_cases`</APILink>. This analyzes each session and extracts the user's goal, persona, and simulation guidelines that help reproduce the original conversation trajectory:
 
 ```python
 import mlflow

--- a/mlflow/entities/evaluation_dataset.py
+++ b/mlflow/entities/evaluation_dataset.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 SESSION_IDENTIFIER_FIELDS = frozenset({"goal"})
-SESSION_INPUT_FIELDS = frozenset({"persona", "goal", "context"})
+SESSION_INPUT_FIELDS = frozenset({"persona", "goal", "context", "simulation_guidelines"})
 SESSION_ALLOWED_COLUMNS = SESSION_INPUT_FIELDS | {"expectations", "tags", "source"}
 
 

--- a/mlflow/genai/simulators/distillation.py
+++ b/mlflow/genai/simulators/distillation.py
@@ -36,9 +36,9 @@ class _GoalAndPersona(pydantic.BaseModel):
         default=None,
         description="A description of the user's communication style and personality",
     )
-    simulation_guidelines: str | None = pydantic.Field(
+    simulation_guidelines: list[str] | None = pydantic.Field(
         default=None,
-        description="Guidelines for how a simulated user should conduct this type of conversation",
+        description="List of guidelines for how a simulated user should conduct this conversation",
     )
 
 

--- a/mlflow/genai/simulators/distillation.py
+++ b/mlflow/genai/simulators/distillation.py
@@ -36,6 +36,10 @@ class _GoalAndPersona(pydantic.BaseModel):
         default=None,
         description="A description of the user's communication style and personality",
     )
+    simulation_guidelines: str | None = pydantic.Field(
+        default=None,
+        description="Guidelines for how a simulated user should conduct this type of conversation",
+    )
 
 
 def _distill_goal_and_persona(
@@ -65,6 +69,8 @@ def _distill_goal_and_persona(
         test_case = {"goal": result.goal}
         if result.persona:
             test_case["persona"] = result.persona
+        if result.simulation_guidelines:
+            test_case["simulation_guidelines"] = result.simulation_guidelines
         return test_case
     except pydantic.ValidationError as e:
         _logger.debug(f"Failed to validate response: {e}")
@@ -95,8 +101,8 @@ def generate_test_cases(
         model: {{ model }}
 
     Returns:
-        A list of dicts with "goal" and "persona" keys, suitable for use with
-        :py:class:`~mlflow.genai.simulators.ConversationSimulator`.
+        A list of dicts with "goal", "persona", and "simulation_guidelines" keys,
+        suitable for use with :py:class:`~mlflow.genai.simulators.ConversationSimulator`.
 
     Example:
         .. code-block:: python

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -23,7 +23,7 @@ Your role's persona is:
 Your underlying goal in this conversation is:
 {goal}
 </goal>
-
+{guidelines_section}
 Begin the conversation with a concise, natural opening message."""
 
 # NB: We embed history into the prompt instead of passing a message list directly to reduce
@@ -51,7 +51,7 @@ Your role's persona is:
 Your underlying goal in this conversation is:
 {goal}
 </goal>
-
+{guidelines_section}
 Instructions:
 - Write a natural follow-up like a human user, not like an assistant or expert.
   Do not act as the helper or expert:

--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -13,6 +13,9 @@ You are role-playing as a real user interacting with an AI assistant.
 - Do NOT reveal all persona details upfront. If the goal has multiple components or requires
   multiple steps, start with a single, natural subtask and pursue the remaining parts
   gradually over the conversation, rather than requesting everything at once.
+- If simulation guidelines are provided, strictly follow them as requirements for how to
+  conduct the conversation. They take precedence over default behavior. The guidelines
+  describe how YOU (the user) should behave, not how the assistant should respond.
 
 <persona>
 Your role's persona is:
@@ -67,7 +70,10 @@ Instructions:
   conversation progresses.
 - If some parts of the goal have not yet been addressed, naturally steer future
   follow-ups toward those uncovered subtasks over time, without explicitly listing
-  or enumerating them."""
+  or enumerating them.
+- If simulation guidelines are provided, strictly follow them as requirements for how to
+  conduct the conversation. They take precedence over default behavior. The guidelines
+  describe how YOU (the user) should behave, not how the assistant should respond."""
 
 CHECK_GOAL_PROMPT = """A user has the following goal: {goal}
 
@@ -90,7 +96,7 @@ You must output your response as a valid JSON object with the following format:
 # NB: We include "rationale" to invoke chain-of-thought reasoning for better results.
 
 DISTILL_GOAL_AND_PERSONA_PROMPT = """Analyze the following conversation between a user and an \
-AI assistant. Extract the user's underlying goal and persona.
+AI assistant. Extract the user's underlying goal, persona, and simulation guidelines.
 
 <conversation>
 {conversation}
@@ -105,4 +111,18 @@ objective in one clear sentence from the user's perspective (e.g., "Learn how to
 2. **Persona**: How does the user communicate? Describe their communication style, expertise \
 level, and personality in 1-2 sentences. Start with "You are..." (e.g., "You are a data \
 scientist who asks detailed technical questions" or "You are a beginner who needs step-by-step \
-guidance")."""
+guidance").
+
+3. **Simulation Guidelines**: The goal is to reproduce the original conversation trajectory as \
+closely as possible. Describe specific requirements for how a simulated user should conduct the \
+conversation. Guidelines can cover any of the following:
+- **Information withholding**: If the user only reveals a detail in a later turn, specify that \
+the simulated user must NOT reveal it earlier (e.g., "Do not provide the error message upfront; \
+wait until the assistant asks for more details").
+- **Implicit expectations**: Things the user deliberately does NOT ask for, expecting the \
+assistant to infer them on its own (e.g., "Do not explicitly ask for the percentage change; \
+the assistant should provide it without being asked", "Do not tell the assistant how to handle \
+edge cases; it should infer the correct behavior").
+- **Pacing and ordering**: The order in which topics or sub-tasks are raised (e.g., "Start \
+with a broad question and only narrow down after the assistant responds").
+Return null if the conversation is straightforward with no notable patterns."""

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -309,8 +309,7 @@ class SimulatedUserAgent(BaseSimulatedUserAgent):
     """
 
     def generate_message(self, context: SimulatorContext) -> str:
-        guidelines = context.simulation_guidelines
-        if guidelines:
+        if guidelines := context.simulation_guidelines:
             if isinstance(guidelines, list):
                 formatted = "\n".join(f"- {g}" for g in guidelines)
             else:

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -310,7 +310,11 @@ class SimulatedUserAgent(BaseSimulatedUserAgent):
 
     def generate_message(self, context: SimulatorContext) -> str:
         guidelines_section = (
-            f"\n<simulation_guidelines>\n{context.simulation_guidelines}\n</simulation_guidelines>"
+            "\n<simulation_guidelines>\n"
+            "Follow these requirements for how YOU (the user) should conduct the conversation. "
+            "Remember, you are the USER seeking help, not the assistant providing answers:\n"
+            f"{context.simulation_guidelines}\n"
+            "</simulation_guidelines>"
             if context.simulation_guidelines
             else ""
         )
@@ -710,9 +714,7 @@ class ConversationSimulator:
             metadata = {
                 TraceMetadataKey.TRACE_SESSION: trace_session_id,
                 "mlflow.simulation.goal": goal[:_MAX_METADATA_LENGTH],
-                "mlflow.simulation.persona": (persona or DEFAULT_PERSONA)[
-                    :_MAX_METADATA_LENGTH
-                ],
+                "mlflow.simulation.persona": (persona or DEFAULT_PERSONA)[:_MAX_METADATA_LENGTH],
                 "mlflow.simulation.turn": str(turn),
             }
             if simulation_guidelines:

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -2175,6 +2175,24 @@ def test_wrapper_isinstance_checks_for_dataset_interfaces(experiments):
             },
             {"inputs": {"goal": "Single goal"}, "expectations": {"output": "expected"}},
         ],
+        [
+            {"inputs": {"goal": "Learn ML", "simulation_guidelines": "Be concise"}},
+            {
+                "inputs": {
+                    "persona": "Engineer",
+                    "goal": "Debug",
+                    "simulation_guidelines": "Focus on logs",
+                }
+            },
+            {
+                "inputs": {
+                    "persona": "Student",
+                    "goal": "Study",
+                    "context": {"course": "CS101"},
+                    "simulation_guidelines": "Ask clarifying questions",
+                }
+            },
+        ],
     ],
 )
 def test_multiturn_valid_formats(experiments, records):
@@ -2184,7 +2202,9 @@ def test_multiturn_valid_formats(experiments, records):
 
     assert len(df) == 3
     for _, row in df.iterrows():
-        assert any(key in row["inputs"] for key in ["persona", "goal", "context"])
+        assert any(
+            key in row["inputs"] for key in ["persona", "goal", "context", "simulation_guidelines"]
+        )
 
 
 @pytest.mark.parametrize(
@@ -2263,6 +2283,7 @@ def test_multiturn_with_expectations_and_tags(experiments):
                 "persona": "Graduate Student",
                 "goal": "Find peer-reviewed articles on machine learning",
                 "context": {"user_id": "U0001", "department": "CS"},
+                "simulation_guidelines": "Be thorough and cite sources",
             },
             "expectations": {"expected_output": "relevant articles", "quality": "high"},
             "tags": {"difficulty": "medium"},
@@ -2286,3 +2307,4 @@ def test_multiturn_with_expectations_and_tags(experiments):
     assert grad_record["expectations"]["quality"] == "high"
     assert grad_record["tags"]["difficulty"] == "medium"
     assert grad_record["inputs"]["context"] == {"user_id": "U0001", "department": "CS"}
+    assert grad_record["inputs"]["simulation_guidelines"] == "Be thorough and cite sources"

--- a/tests/genai/simulators/conftest.py
+++ b/tests/genai/simulators/conftest.py
@@ -105,3 +105,11 @@ def test_case_with_context():
         "goal": "Debug an error",
         "context": {"user_id": "U001", "session_id": "S001"},
     }
+
+
+@pytest.fixture
+def test_case_with_simulation_guidelines():
+    return {
+        "goal": "Learn about ML pipelines",
+        "simulation_guidelines": "Ask clarifying questions before proceeding",
+    }

--- a/tests/genai/simulators/test_distillation.py
+++ b/tests/genai/simulators/test_distillation.py
@@ -23,16 +23,29 @@ def test_goal_and_persona_model_goal_required():
 
 
 @pytest.mark.parametrize(
-    ("input_data", "expected_goal", "expected_persona"),
+    ("input_data", "expected_goal", "expected_persona", "expected_guidelines"),
     [
-        ({"goal": "Test goal"}, "Test goal", None),
-        ({"goal": "Test goal", "persona": "Friendly user"}, "Test goal", "Friendly user"),
+        ({"goal": "Test goal"}, "Test goal", None, None),
+        ({"goal": "Test goal", "persona": "Friendly user"}, "Test goal", "Friendly user", None),
+        (
+            {
+                "goal": "Test goal",
+                "persona": "Friendly user",
+                "simulation_guidelines": "Be concise",
+            },
+            "Test goal",
+            "Friendly user",
+            "Be concise",
+        ),
     ],
 )
-def test_goal_and_persona_model_validation(input_data, expected_goal, expected_persona):
+def test_goal_and_persona_model_validation(
+    input_data, expected_goal, expected_persona, expected_guidelines
+):
     result = _GoalAndPersona.model_validate(input_data)
     assert result.goal == expected_goal
     assert result.persona == expected_persona
+    assert result.simulation_guidelines == expected_guidelines
 
 
 def test_distill_returns_none_for_empty_conversation(mock_session):
@@ -52,6 +65,15 @@ def test_distill_returns_none_for_empty_conversation(mock_session):
             {"goal": "Get help", "persona": "Data scientist"},
         ),
         ('{"goal": "Get help"}', {"goal": "Get help"}),
+        (
+            '{"goal": "Get help", "persona": "Engineer", '
+            '"simulation_guidelines": "Start with a vague request"}',
+            {
+                "goal": "Get help",
+                "persona": "Engineer",
+                "simulation_guidelines": "Start with a vague request",
+            },
+        ),
     ],
 )
 def test_distill_extracts_goal_and_persona(mock_session, llm_response, expected):

--- a/tests/genai/simulators/test_distillation.py
+++ b/tests/genai/simulators/test_distillation.py
@@ -31,11 +31,11 @@ def test_goal_and_persona_model_goal_required():
             {
                 "goal": "Test goal",
                 "persona": "Friendly user",
-                "simulation_guidelines": "Be concise",
+                "simulation_guidelines": ["Be concise", "Ask follow-ups"],
             },
             "Test goal",
             "Friendly user",
-            "Be concise",
+            ["Be concise", "Ask follow-ups"],
         ),
     ],
 )
@@ -67,11 +67,11 @@ def test_distill_returns_none_for_empty_conversation(mock_session):
         ('{"goal": "Get help"}', {"goal": "Get help"}),
         (
             '{"goal": "Get help", "persona": "Engineer", '
-            '"simulation_guidelines": "Start with a vague request"}',
+            '"simulation_guidelines": ["Start with a vague request", "Be concise"]}',
             {
                 "goal": "Get help",
                 "persona": "Engineer",
-                "simulation_guidelines": "Start with a vague request",
+                "simulation_guidelines": ["Start with a vague request", "Be concise"],
             },
         ),
     ],

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -340,6 +340,15 @@ def test_conversation_simulator_validation(test_cases, expected_error):
         [{"goal": "Learn about MLflow"}],
         [{"goal": "Debug issue", "persona": "Engineer"}],
         [{"goal": "Ask questions", "persona": "Student", "context": {"id": "1"}}],
+        [{"goal": "Learn ML", "simulation_guidelines": "Be concise"}],
+        [
+            {
+                "goal": "Debug deployment",
+                "persona": "Engineer",
+                "context": {"env": "prod"},
+                "simulation_guidelines": "Focus on logs",
+            }
+        ],
     ],
 )
 def test_conversation_simulator_evaluation_dataset_valid(inputs):
@@ -467,6 +476,17 @@ def test_simulator_context_is_frozen():
     )
     with pytest.raises(AttributeError, match="cannot assign to field"):
         context.goal = "New goal"
+
+
+def test_simulator_context_with_simulation_guidelines():
+    context = SimulatorContext(
+        goal="Test goal",
+        persona="Test persona",
+        conversation_history=[],
+        turn=0,
+        simulation_guidelines="Be concise and ask clarifying questions",
+    )
+    assert context.simulation_guidelines == "Be concise and ask clarifying questions"
 
 
 def test_custom_user_agent_class(simple_test_case, mock_predict_fn, simulation_mocks):
@@ -820,3 +840,102 @@ def test_conversation_simulator_rejects_both_input_and_messages(simple_test_case
 
     with pytest.raises(Exception, match="cannot have both 'messages' and 'input' parameters"):
         simulator.simulate(invalid_predict_fn)
+
+
+def test_simulated_user_agent_with_simulation_guidelines():
+    with patch(
+        "mlflow.genai.simulators.simulator.invoke_model_without_tracing"
+    ) as mock_invoke:
+        mock_invoke.return_value = "I have a question about ML pipelines."
+
+        agent = SimulatedUserAgent()
+        context = SimulatorContext(
+            goal="Learn about ML pipelines",
+            persona=DEFAULT_PERSONA,
+            conversation_history=[],
+            turn=0,
+            simulation_guidelines="Ask clarifying questions before proceeding",
+        )
+
+        message = agent.generate_message(context)
+
+        assert message == "I have a question about ML pipelines."
+        mock_invoke.assert_called_once()
+
+        call_args = mock_invoke.call_args
+        messages = call_args.kwargs["messages"]
+        prompt = messages[0].content
+
+        assert "Learn about ML pipelines" in prompt
+        assert "Ask clarifying questions before proceeding" in prompt
+        assert "simulation_guidelines" in prompt
+
+
+def test_simulated_user_agent_followup_with_simulation_guidelines():
+    with patch(
+        "mlflow.genai.simulators.simulator.invoke_model_without_tracing"
+    ) as mock_invoke:
+        mock_invoke.return_value = "Let me clarify something first."
+
+        agent = SimulatedUserAgent()
+        context = SimulatorContext(
+            goal="Learn about ML",
+            persona=DEFAULT_PERSONA,
+            conversation_history=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ],
+            turn=1,
+            simulation_guidelines="Be thorough and ask follow-up questions",
+        )
+
+        message = agent.generate_message(context)
+
+        assert message == "Let me clarify something first."
+        mock_invoke.assert_called_once()
+
+        call_args = mock_invoke.call_args
+        messages = call_args.kwargs["messages"]
+        prompt = messages[0].content
+
+        assert "Be thorough and ask follow-up questions" in prompt
+        assert "simulation_guidelines" in prompt
+
+
+def test_conversation_simulator_with_simulation_guidelines(mock_predict_fn):
+    test_case = {
+        "goal": "Learn about ML pipelines",
+        "simulation_guidelines": "Ask clarifying questions before proceeding",
+    }
+
+    with patch(
+        "mlflow.genai.simulators.simulator.invoke_model_without_tracing"
+    ) as mock_invoke:
+        mock_invoke.side_effect = [
+            "Test message with simulation_guidelines",
+            '{"rationale": "Goal achieved!", "result": "yes"}',
+        ]
+
+        simulator = ConversationSimulator(
+            test_cases=[test_case],
+            max_turns=2,
+        )
+
+        all_traces = simulator.simulate(mock_predict_fn)
+
+        assert len(all_traces) == 1
+        assert len(all_traces[0]) == 1
+
+        # Verify simulation_guidelines are in the generate_message prompt
+        generate_call = mock_invoke.call_args_list[0]
+        prompt = generate_call.kwargs["messages"][0].content
+        assert "Ask clarifying questions before proceeding" in prompt
+
+        # Verify simulation_guidelines are in trace metadata
+        trace = all_traces[0][0]
+        metadata = trace.info.request_metadata
+        assert "mlflow.simulation.simulation_guidelines" in metadata
+        assert (
+            metadata["mlflow.simulation.simulation_guidelines"]
+            == "Ask clarifying questions before proceeding"
+        )

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -843,9 +843,7 @@ def test_conversation_simulator_rejects_both_input_and_messages(simple_test_case
 
 
 def test_simulated_user_agent_with_simulation_guidelines():
-    with patch(
-        "mlflow.genai.simulators.simulator.invoke_model_without_tracing"
-    ) as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.return_value = "I have a question about ML pipelines."
 
         agent = SimulatedUserAgent()
@@ -872,9 +870,7 @@ def test_simulated_user_agent_with_simulation_guidelines():
 
 
 def test_simulated_user_agent_followup_with_simulation_guidelines():
-    with patch(
-        "mlflow.genai.simulators.simulator.invoke_model_without_tracing"
-    ) as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.return_value = "Let me clarify something first."
 
         agent = SimulatedUserAgent()
@@ -908,9 +904,7 @@ def test_conversation_simulator_with_simulation_guidelines(mock_predict_fn):
         "simulation_guidelines": "Ask clarifying questions before proceeding",
     }
 
-    with patch(
-        "mlflow.genai.simulators.simulator.invoke_model_without_tracing"
-    ) as mock_invoke:
+    with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.side_effect = [
             "Test message with simulation_guidelines",
             '{"rationale": "Goal achieved!", "result": "yes"}',

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -341,6 +341,7 @@ def test_conversation_simulator_validation(test_cases, expected_error):
         [{"goal": "Debug issue", "persona": "Engineer"}],
         [{"goal": "Ask questions", "persona": "Student", "context": {"id": "1"}}],
         [{"goal": "Learn ML", "simulation_guidelines": "Be concise"}],
+        [{"goal": "Learn ML", "simulation_guidelines": ["Be concise", "Ask follow-ups"]}],
         [
             {
                 "goal": "Debug deployment",


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
