### PR TITLE
Add skills repository checkbox to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@
   - [ ] API references
   - [ ] Instructions
 
-### Does this PR require updating the [Skills](https://github.com/mlflow/skills) repository?
+### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?
 
 <!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,13 @@
   - [ ] API references
   - [ ] Instructions
 
+### Does this PR require updating the [Skills](https://github.com/mlflow/skills) repository?
+
+- [ ] No. You can skip the rest of this section.
+- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.
+
+<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->
+
 ### Release Notes
 
 #### Is this a user-facing change?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,8 @@
 
 ### Does this PR require updating the [Skills](https://github.com/mlflow/skills) repository?
 
+<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->
+
 - [ ] No. You can skip the rest of this section.
 - [ ] Yes. Please link the corresponding PR or explain how you plan to update it.
 


### PR DESCRIPTION
### Related Issues/PRs

Resolve #20450

### What changes are proposed in this pull request?

This PR adds a new checkbox section to the PR template reminding contributors to update the [Skills repository](https://github.com/mlflow/skills) when adding new major features to MLflow.

The new section is placed after the documentation update section and includes:
- A "No" checkbox for PRs that don't require skills updates
- A "Yes" checkbox with guidance to link a corresponding PR or explain the changes needed

### How is this PR tested?

- [x] Manual tests

Verified the template renders correctly.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)