### PR TITLE
Make session linking more obvious when grouping by session

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -23,6 +23,7 @@ import {
   REQUEST_TIME_COLUMN_ID,
   STATE_COLUMN_ID,
   RESPONSE_COLUMN_ID,
+  SESSION_COLUMN_ID,
   TracesTableColumnType,
   useSearchMlflowTraces,
   useSelectedColumns,
@@ -205,6 +206,17 @@ const TracesV3LogsImpl = React.memo(
       undefined, // runUuid
       columnStorageKeyPrefix,
     );
+
+    // Auto-select session column when session grouping is enabled
+    useEffect(() => {
+      if (isGroupedBySession || forceGroupBySession) {
+        const sessionColumn = allColumns.find((col) => col.id === SESSION_COLUMN_ID);
+        const isSessionColumnSelected = selectedColumns.some((col) => col.id === SESSION_COLUMN_ID);
+        if (sessionColumn && !isSessionColumnSelected) {
+          setSelectedColumns([...selectedColumns, sessionColumn]);
+        }
+      }
+    }, [isGroupedBySession, forceGroupBySession, allColumns, selectedColumns, setSelectedColumns]);
 
     const [tableSort, setTableSort] = useTableSort(selectedColumns, {
       key: REQUEST_TIME_COLUMN_ID,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -207,9 +207,14 @@ const TracesV3LogsImpl = React.memo(
       columnStorageKeyPrefix,
     );
 
-    // Auto-select session column when session grouping is enabled
+    // Auto-select session column when session grouping is first enabled
+    const prevIsGroupedBySession = React.useRef(isGroupedBySession);
     useEffect(() => {
-      if (isGroupedBySession || forceGroupBySession) {
+      // Only auto-select when transitioning from ungrouped to grouped
+      const justEnabledGrouping = (isGroupedBySession || forceGroupBySession) && !prevIsGroupedBySession.current;
+      prevIsGroupedBySession.current = isGroupedBySession || forceGroupBySession;
+
+      if (justEnabledGrouping) {
         const sessionColumn = allColumns.find((col) => col.id === SESSION_COLUMN_ID);
         const isSessionColumnSelected = selectedColumns.some((col) => col.id === SESSION_COLUMN_ID);
         if (sessionColumn && !isSessionColumnSelected) {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -237,17 +237,24 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
       );
     } else {
       cellContent = inputTitle ? (
-        <div
-          css={{
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            minWidth: 0,
-          }}
-          title={inputTitle}
-        >
-          {inputTitle}
-        </div>
+        <SessionIdLinkWrapper sessionId={sessionId} experimentId={experimentId}>
+          <span
+            css={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+              color: theme.colors.actionPrimaryBackgroundDefault,
+              cursor: 'pointer',
+              '&:hover': {
+                textDecoration: 'underline',
+              },
+            }}
+            title={inputTitle}
+          >
+            {inputTitle}
+          </span>
+        </SessionIdLinkWrapper>
       ) : (
         <NullCell />
       );


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Two changes:
1. Automatically display session column when grouping by session
2. Add a link to the request which takes you directly to the session

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
![Clipboard-20260130-194534-517](https://github.com/user-attachments/assets/42572ed8-1965-4d65-b52d-078437f8868d)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
