### PR TITLE
Add gateway:/ support to simulator

### DIFF
--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -32,6 +32,7 @@ from mlflow.genai.simulators.prompts import (
     FOLLOWUP_USER_PROMPT,
     INITIAL_USER_PROMPT,
 )
+from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
 from mlflow.genai.utils.message_utils import serialize_messages_to_databricks_prompts
 from mlflow.genai.utils.trace_utils import parse_outputs_to_str
 from mlflow.telemetry.events import SimulateConversationEvent
@@ -97,6 +98,8 @@ _MODEL_API_DOC = {
 * `"databricks"` - Uses the Databricks managed LLM endpoint
 * `"databricks:/<endpoint-name>"` - Uses a Databricks model serving endpoint \
 (e.g., `"databricks:/databricks-claude-sonnet-4-5"`)
+* `"gateway:/<endpoint-name>"` - Uses an MLflow AI Gateway endpoint \
+(e.g., `"gateway:/my-chat-endpoint"`)
 * `"<provider>:/<model-name>"` - Uses LiteLLM (e.g., `"openai:/gpt-4.1-mini"`, \
 `"anthropic:/claude-3.5-sonnet-20240620"`)
 
@@ -201,12 +204,20 @@ def _invoke_model_without_tracing(
         litellm_messages = [litellm.Message(role=msg.role, content=msg.content) for msg in messages]
 
         kwargs = {
-            "model": f"{provider}/{model_name}",
             "messages": litellm_messages,
             "max_retries": num_retries,
             # Drop unsupported params (e.g., temperature=0 for certain models)
             "drop_params": True,
         }
+
+        if provider == "gateway":
+            config = get_gateway_litellm_config(model_name)
+            kwargs["api_base"] = config.api_base
+            kwargs["api_key"] = config.api_key
+            kwargs["model"] = config.model
+        else:
+            kwargs["model"] = f"{provider}/{model_name}"
+
         if inference_params:
             kwargs.update(inference_params)
 

--- a/mlflow/genai/utils/gateway_utils.py
+++ b/mlflow/genai/utils/gateway_utils.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mlflow.environment_variables import MLFLOW_GATEWAY_URI
+from mlflow.exceptions import MlflowException
+from mlflow.tracking import get_tracking_uri
+from mlflow.utils.uri import append_to_uri_path, is_http_uri
+
+
+@dataclass
+class GatewayLiteLLMConfig:
+    api_base: str
+    api_key: str
+    model: str
+
+
+def get_gateway_litellm_config(endpoint_name: str) -> GatewayLiteLLMConfig:
+    """
+    Get the LiteLLM configuration for invoking an MLflow Gateway endpoint.
+
+    Args:
+        endpoint_name: The name of the gateway endpoint (e.g., "chat" from "gateway:/chat").
+
+    Returns:
+        A GatewayLiteLLMConfig with api_base, api_key, and model configured for LiteLLM.
+
+    Raises:
+        MlflowException: If the gateway URI is not a valid HTTP(S) URL.
+    """
+    # MLFLOW_GATEWAY_URI takes precedence over tracking URI for gateway routing.
+    # This is needed for async job workers: the job infrastructure passes the HTTP
+    # tracking URI (e.g., http://127.0.0.1:5000) to workers, but _get_tracking_store()
+    # overwrites MLFLOW_TRACKING_URI with the backend store URI (e.g., sqlite://).
+    # Job workers set MLFLOW_GATEWAY_URI to preserve the HTTP URI for gateway calls.
+    gateway_uri = MLFLOW_GATEWAY_URI.get() or get_tracking_uri()
+
+    if not is_http_uri(gateway_uri):
+        raise MlflowException(
+            f"Gateway provider requires an HTTP(S) tracking URI, but got: '{gateway_uri}'. "
+            "The gateway provider routes requests through the MLflow tracking server. "
+            "Please set MLFLOW_TRACKING_URI to a valid HTTP(S) URL "
+            "(e.g., 'http://localhost:5000' or 'https://your-mlflow-server.com')."
+        )
+
+    return GatewayLiteLLMConfig(
+        api_base=append_to_uri_path(gateway_uri, "gateway/mlflow/v1/"),
+        # LiteLLM requires api_key when using custom api_base. Gateway handles
+        # auth in the server layer, so we pass a dummy value to satisfy LiteLLM.
+        api_key="mlflow-gateway-auth",
+        # Use openai/ prefix for LiteLLM to use OpenAI-compatible format.
+        # LiteLLM strips the prefix, so gateway receives endpoint_name as the model.
+        model=f"openai/{endpoint_name}",
+    )

--- a/tests/genai/judges/adapters/test_litellm_adapter.py
+++ b/tests/genai/judges/adapters/test_litellm_adapter.py
@@ -227,7 +227,7 @@ def test_invoke_litellm_and_handle_tools_with_context_window_exceeded_gateway_pr
             "mlflow.genai.judges.adapters.litellm_adapter._remove_oldest_tool_call_pair"
         ) as mock_truncate,
         mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter.get_tracking_uri",
+            "mlflow.genai.utils.gateway_utils.get_tracking_uri",
             return_value="http://localhost:5000",
         ),
     ):
@@ -262,7 +262,7 @@ def test_invoke_litellm_and_handle_tools_gateway_context_window_no_tool_calls_to
             return_value=None,  # No tool calls to truncate
         ),
         mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter.get_tracking_uri",
+            "mlflow.genai.utils.gateway_utils.get_tracking_uri",
             return_value="http://localhost:5000",
         ),
     ):
@@ -341,7 +341,7 @@ def test_gateway_provider_integration():
 
     with (
         mock.patch("litellm.completion", return_value=mock_response) as mock_litellm,
-        mock.patch("mlflow.genai.judges.adapters.litellm_adapter.get_tracking_uri") as mock_get_uri,
+        mock.patch("mlflow.genai.utils.gateway_utils.get_tracking_uri") as mock_get_uri,
     ):
         mock_get_uri.return_value = "http://localhost:5000"
 
@@ -369,9 +369,7 @@ def test_gateway_provider_requires_http_tracking_uri():
     from mlflow.exceptions import MlflowException
     from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm_and_handle_tools
 
-    with mock.patch(
-        "mlflow.genai.judges.adapters.litellm_adapter.get_tracking_uri", return_value="databricks"
-    ):
+    with mock.patch("mlflow.genai.utils.gateway_utils.get_tracking_uri", return_value="databricks"):
         with pytest.raises(MlflowException, match="Gateway provider requires an HTTP"):
             _invoke_litellm_and_handle_tools(
                 provider="gateway",

--- a/tests/genai/utils/test_gateway_utils.py
+++ b/tests/genai/utils/test_gateway_utils.py
@@ -1,0 +1,68 @@
+from unittest import mock
+
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.utils.gateway_utils import GatewayLiteLLMConfig, get_gateway_litellm_config
+
+
+@pytest.mark.parametrize(
+    ("gateway_uri", "tracking_uri", "endpoint_name", "expected_api_base"),
+    [
+        # MLFLOW_GATEWAY_URI set
+        (
+            "http://localhost:5000",
+            "http://other:8000",
+            "chat",
+            "http://localhost:5000/gateway/mlflow/v1/",
+        ),
+        # MLFLOW_GATEWAY_URI not set, falls back to tracking URI
+        (
+            None,
+            "http://localhost:5000",
+            "my-endpoint",
+            "http://localhost:5000/gateway/mlflow/v1/",
+        ),
+        # HTTPS URI
+        (
+            "https://mlflow.example.com",
+            None,
+            "chat",
+            "https://mlflow.example.com/gateway/mlflow/v1/",
+        ),
+    ],
+)
+def test_get_gateway_litellm_config(
+    gateway_uri, tracking_uri, endpoint_name, expected_api_base, monkeypatch
+):
+    if gateway_uri:
+        monkeypatch.setenv("MLFLOW_GATEWAY_URI", gateway_uri)
+    else:
+        monkeypatch.delenv("MLFLOW_GATEWAY_URI", raising=False)
+
+    with mock.patch(
+        "mlflow.genai.utils.gateway_utils.get_tracking_uri",
+        return_value=tracking_uri or "http://default:5000",
+    ):
+        config = get_gateway_litellm_config(endpoint_name)
+
+    assert isinstance(config, GatewayLiteLLMConfig)
+    assert config.api_base == expected_api_base
+    assert config.api_key == "mlflow-gateway-auth"
+    assert config.model == f"openai/{endpoint_name}"
+
+
+@pytest.mark.parametrize(
+    "tracking_uri",
+    [
+        "sqlite:///mlflow.db",
+        "/path/to/mlflow",
+        "databricks",
+    ],
+)
+def test_get_gateway_litellm_config_invalid_uri(tracking_uri, monkeypatch):
+    monkeypatch.delenv("MLFLOW_GATEWAY_URI", raising=False)
+
+    with mock.patch("mlflow.genai.utils.gateway_utils.get_tracking_uri", return_value=tracking_uri):
+        with pytest.raises(MlflowException, match="Gateway provider requires an HTTP"):
+            get_gateway_litellm_config("chat")


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled - adds support, modularizes implementation in litellm adapter.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Set up a `gpt-5` gateway with databricks, tested with both judge and simulation
<img width="740" height="470" alt="image" src="https://github.com/user-attachments/assets/0762e52b-4fec-4c68-924d-c9fdf0a1e6cf" />

Code:
```python
import os

# For standalone gateway (mlflow gateway start), set MLFLOW_GATEWAY_URI
os.environ["MLFLOW_GATEWAY_URI"] = "http://localhost:5000"

import mlflow

mlflow.set_tracking_uri("http://localhost:5000")

MODEL = "gateway:/e2df-gpt-5-mini"


# Test 1: Simulator
print("=" * 50)
print("Testing ConversationSimulator with gateway:/chat")
print("=" * 50)

from mlflow.genai.simulators import ConversationSimulator


def simple_predict(input, **kwargs):
    return {"role": "assistant", "content": "I can help you with that!"}


simulator = ConversationSimulator(
    test_cases=[{"goal": "Ask about the weather"}],
    max_turns=2,
    user_model=MODEL,
)

traces = simulator._simulate(simple_predict)
print(f"Simulator traces: {traces}")
print("Simulator test PASSED\n")


# Test 2: Judge
print("=" * 50)
print("Testing judge with gateway:/chat")
print("=" * 50)

from mlflow.genai.judges import is_context_relevant

result = is_context_relevant(
    request="What is MLflow?",
    context="MLflow is an open-source platform for managing the ML lifecycle.",
    model=MODEL,
)
print(f"Judge result: {result}")
print("Judge test PASSED\n")

print("=" * 50)
print("All tests passed!")
print("=" * 50)
```


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
