### PR TITLE
Revert PR #20418 feature flag changes

### DIFF
--- a/mlflow/server/js/src/common/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/common/utils/FeatureUtils.ts
@@ -160,11 +160,3 @@ export const shouldEnableExperimentOverviewTab = () => {
 export const shouldEnableWorkflowBasedNavigation = () => {
   return false;
 };
-
-/**
- * Determines if improved evaluation run comparison feature is enabled.
- * This controls the ability to select and compare evaluation runs in split view.
- */
-export const shouldEnableImprovedEvalRunsComparison = () => {
-  return false;
-};

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.intg.test.tsx
@@ -14,7 +14,6 @@ jest.mock('../../../common/utils/FeatureUtils', () => ({
   shouldUseRenamedUnifiedTracesTab: () => false,
   shouldDisableReproduceRunButton: () => false,
   shouldEnableWorkflowBasedNavigation: () => false,
-  shouldEnableImprovedEvalRunsComparison: () => false,
 }));
 
 describe('RunViewHeader - integration test', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
@@ -16,7 +16,6 @@ import { RunIcon } from './assets/RunIcon';
 import { ExperimentPageTabName } from '@mlflow/mlflow/src/experiment-tracking/constants';
 import { useExperimentKind, isGenAIExperimentKind } from '../../utils/ExperimentKindUtils';
 import { useCallback, useMemo } from 'react';
-import { shouldEnableImprovedEvalRunsComparison } from '../../../common/utils/FeatureUtils';
 const RunViewHeaderIcon = () => {
   const { theme } = useDesignSystemTheme();
   return (
@@ -131,7 +130,7 @@ export const RunViewHeader = ({
   }, [navigate, experiment.experimentId, runUuid]);
 
   const renderCompareButton = () => {
-    if (!shouldRouteToEvaluations || !shouldEnableImprovedEvalRunsComparison()) {
+    if (!shouldRouteToEvaluations) {
       return null;
     }
     return (

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -40,7 +40,6 @@ import { ExperimentEvaluationRunsPageCharts } from './charts/ExperimentEvaluatio
 import { ExperimentEvaluationRunsRowVisibilityProvider } from './hooks/useExperimentEvaluationRunsRowVisibility';
 import { useGetExperimentRunColor } from '../../components/experiment-page/hooks/useExperimentRunColor';
 import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
-import { shouldEnableImprovedEvalRunsComparison } from '../../../common/utils/FeatureUtils';
 
 const DEFAULT_VISIBLE_METRIC_COLUMNS = 5;
 
@@ -104,13 +103,8 @@ const ExperimentEvaluationRunsPageImpl = () => {
 
   // On mount, if URL has selectedRunUuid (and optionally compareToRunUuid), initialize rowSelection and enter comparison mode
   // Initialize with BOTH URL params to prevent compareToRunUuid from being stripped
-  // Only enabled when comparison feature flag is on
   const hasInitializedFromUrl = useRef(false);
-  const isComparisonEnabled = shouldEnableImprovedEvalRunsComparison();
   useEffect(() => {
-    if (!isComparisonEnabled) {
-      return;
-    }
     if (!hasInitializedFromUrl.current && selectedRunUuid && runs?.length) {
       if (runUuids.includes(selectedRunUuid)) {
         hasInitializedFromUrl.current = true;
@@ -123,14 +117,10 @@ const ExperimentEvaluationRunsPageImpl = () => {
         setIsComparisonMode(true);
       }
     }
-  }, [isComparisonEnabled, selectedRunUuid, compareToRunUuid, runs, runUuids, setIsComparisonMode]);
+  }, [selectedRunUuid, compareToRunUuid, runs, runUuids, setIsComparisonMode]);
 
   // Sync URL params from checkbox selection when in comparison mode (as useEffect to avoid render-time state updates)
-  // Only enabled when comparison feature flag is on
   useEffect(() => {
-    if (!isComparisonEnabled) {
-      return;
-    }
     // Skip syncing if we haven't finished initializing yet
     if (!isComparisonMode) {
       return;
@@ -162,7 +152,6 @@ const ExperimentEvaluationRunsPageImpl = () => {
       }
     }
   }, [
-    isComparisonEnabled,
     isComparisonMode,
     selectedRunUuidsFromCheckbox,
     selectedRunUuid,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
@@ -110,22 +110,17 @@ export const EVAL_RUNS_COLUMN_TYPE_LABELS: Record<EvalRunsTableKeyedColumnPrefix
 
 export const getExperimentEvalRunsDefaultColumns = (
   viewMode: ExperimentEvaluationRunsPageMode,
-  options?: { showCheckbox?: boolean },
 ): EvalRunsTableColumnDef[] => {
-  const { showCheckbox = true } = options ?? {};
-
-  const unselectableColumns: EvalRunsTableColumnDef[] = [];
-
-  if (showCheckbox) {
-    unselectableColumns.push({
+  const unselectableColumns: EvalRunsTableColumnDef[] = [
+    {
       id: EvalRunsTableColumnId.checkbox,
       cell: CheckboxCell,
       enableResizing: false,
       enableSorting: false,
       size: 32,
       meta: { styles: { minWidth: 32, maxWidth: 32 } },
-    });
-  }
+    },
+  ];
 
   if (viewMode === ExperimentEvaluationRunsPageMode.CHARTS) {
     unselectableColumns.push({

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.tsx
@@ -13,7 +13,6 @@ import { getEvalRunCellValueBasedOnColumn } from './ExperimentEvaluationRunsTabl
 import type { RunEntityOrGroupData } from './ExperimentEvaluationRunsPage.utils';
 import type { ExperimentEvaluationRunsPageMode } from './hooks/useExperimentEvaluationRunsPageMode';
 import { useExperimentEvaluationRunsRowVisibility } from './hooks/useExperimentEvaluationRunsRowVisibility';
-import { shouldEnableImprovedEvalRunsComparison } from '../../../common/utils/FeatureUtils';
 
 export interface ExperimentEvaluationRunsTableProps {
   data: RunEntityOrGroupData[];
@@ -58,9 +57,7 @@ export const ExperimentEvaluationRunsTable = forwardRef<HTMLDivElement, Experime
     const { isRowHidden } = useExperimentEvaluationRunsRowVisibility();
 
     const columns = useMemo(() => {
-      const allColumns = getExperimentEvalRunsDefaultColumns(viewMode, {
-        showCheckbox: shouldEnableImprovedEvalRunsComparison(),
-      });
+      const allColumns = getExperimentEvalRunsDefaultColumns(viewMode);
 
       // add a column for each available metric
       uniqueColumns.forEach((column) => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
@@ -37,7 +37,6 @@ import { ExperimentEvaluationRunsTableGroupBySelector } from './ExperimentEvalua
 import type { RunsGroupByConfig } from '../../components/experiment-page/utils/experimentPage.group-row-utils';
 import { ExperimentEvaluationRunsPageMode } from './hooks/useExperimentEvaluationRunsPageMode';
 import { ExperimentEvaluationRunsTableActions } from './ExperimentEvaluationRunsTableActions';
-import { shouldEnableImprovedEvalRunsComparison } from '../../../common/utils/FeatureUtils';
 
 // function to mimic the data structure of the legacy runs response
 // so we can reuse the RunsSearchAutoComplete component
@@ -266,32 +265,30 @@ export const ExperimentEvaluationRunsTableControls = ({
           runs={runs}
         />
 
-        {shouldEnableImprovedEvalRunsComparison() && (
-          <Tooltip
-            componentId="mlflow.eval-runs.compare-button.tooltip"
-            content={
-              isCompareEnabled ? (
-                <FormattedMessage
-                  defaultMessage="Compare selected runs"
-                  description="Tooltip for the compare button when enabled"
-                />
-              ) : (
-                <FormattedMessage
-                  defaultMessage="Select 2 runs to compare"
-                  description="Tooltip for the compare button when disabled"
-                />
-              )
-            }
+        <Tooltip
+          componentId="mlflow.eval-runs.compare-button.tooltip"
+          content={
+            isCompareEnabled ? (
+              <FormattedMessage
+                defaultMessage="Compare selected runs"
+                description="Tooltip for the compare button when enabled"
+              />
+            ) : (
+              <FormattedMessage
+                defaultMessage="Select up to 2 runs to compare"
+                description="Tooltip for the compare button when disabled"
+              />
+            )
+          }
+        >
+          <Button
+            componentId="mlflow.eval-runs.compare-button"
+            onClick={handleCompareClick}
+            disabled={!isCompareEnabled}
           >
-            <Button
-              componentId="mlflow.eval-runs.compare-button"
-              onClick={handleCompareClick}
-              disabled={!isCompareEnabled}
-            >
-              <FormattedMessage defaultMessage="Compare" description="Compare runs button label" />
-            </Button>
-          </Tooltip>
-        )}
+            <FormattedMessage defaultMessage="Compare" description="Compare runs button label" />
+          </Button>
+        </Tooltip>
 
         <ExperimentEvaluationRunsTableActions
           rowSelection={rowSelection}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1166,10 +1166,6 @@
     "defaultMessage": "Off",
     "description": "Runs charts > line chart > ignore outliers > off setting label"
   },
-  "756RTp": {
-    "defaultMessage": "Select 2 runs to compare",
-    "description": "Tooltip for the compare button when disabled"
-  },
   "757GVc": {
     "defaultMessage": "Cancel",
     "description": "experiment page > description modal > cancel button"
@@ -2553,6 +2549,10 @@
   "HZdpLU": {
     "defaultMessage": "Only alphanumeric characters, underscores, hyphens, and dots are allowed",
     "description": "A validation state for the prompt name format in the prompt creation modal"
+  },
+  "Hay/ss": {
+    "defaultMessage": "Select up to 2 runs to compare",
+    "description": "Tooltip for the compare button when disabled"
   },
   "HbC1a1": {
     "defaultMessage": "Tags",


### PR DESCRIPTION
Remove shouldEnableImprovedEvalRunsComparison() feature flag and all associated gating logic that was causing bugs with checkboxes not showing and full run screen being visible incorrectly.

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled - reverts the feature flag gating improved evaluation run changes. Broke ability to select runs.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Before (no checkbox):

<img width="528" height="448" alt="image" src="https://github.com/user-attachments/assets/98f7f5cb-0a1f-4d25-8fbc-0b4fdb24778a" />

After:
<img width="794" height="522" alt="image" src="https://github.com/user-attachments/assets/18323d18-6eef-4116-86b7-f71bfd2c7c7e" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
