### PR TITLE
Add tooltip link to navigate to traces tab with time range filter

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { renderHook } from '@testing-library/react';
 import { DesignSystemProvider } from '@databricks/design-system';
 import {
@@ -109,7 +109,7 @@ describe('ScrollableTooltip', () => {
       linkConfig: {
         experimentId: 'test-exp-123',
         timeIntervalSeconds: 3600,
-        componentId: 'test.component.link',
+        componentId: 'mlflow.overview.usage.traces.view_traces_link',
       },
     });
 
@@ -125,7 +125,7 @@ describe('ScrollableTooltip', () => {
       linkConfig: {
         experimentId: 'test-exp-123',
         timeIntervalSeconds: 3600,
-        componentId: 'test.component.link',
+        componentId: 'mlflow.overview.usage.traces.view_traces_link',
       },
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.test.tsx
@@ -1,11 +1,137 @@
 import { describe, it, expect } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { renderHook } from '@testing-library/react';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { useScrollableLegendProps } from './OverviewChartComponents';
+import {
+  useScrollableLegendProps,
+  getTracesFilteredByTimeRangeUrl,
+  ScrollableTooltip,
+} from './OverviewChartComponents';
+import { MemoryRouter } from '../../../../common/utils/RoutingUtils';
+import { IntlProvider } from 'react-intl';
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <DesignSystemProvider>{children}</DesignSystemProvider>
 );
+
+const renderTooltipWithProviders = (props: React.ComponentProps<typeof ScrollableTooltip>) => {
+  return render(
+    <MemoryRouter>
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <ScrollableTooltip {...props} />
+        </DesignSystemProvider>
+      </IntlProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe('getTracesFilteredByTimeRangeUrl', () => {
+  it('should generate correct URL with time range parameters', () => {
+    const experimentId = 'test-experiment-123';
+    const timestampMs = new Date('2025-12-22T10:00:00Z').getTime();
+    const timeIntervalSeconds = 3600; // 1 hour
+
+    const url = getTracesFilteredByTimeRangeUrl(experimentId, timestampMs, timeIntervalSeconds);
+
+    expect(url).toContain('/experiments/test-experiment-123/traces');
+    expect(url).toContain('startTimeLabel=CUSTOM');
+    expect(url).toContain('startTime=2025-12-22T10%3A00%3A00.000Z');
+    expect(url).toContain('endTime=2025-12-22T11%3A00%3A00.000Z');
+  });
+
+  it('should calculate end time based on time interval', () => {
+    const experimentId = 'exp-1';
+    const timestampMs = new Date('2025-01-01T00:00:00Z').getTime();
+
+    // Test with 1 day interval
+    const urlDaily = getTracesFilteredByTimeRangeUrl(experimentId, timestampMs, 86400);
+    expect(urlDaily).toContain('endTime=2025-01-02T00%3A00%3A00.000Z');
+
+    // Test with 1 minute interval
+    const urlMinute = getTracesFilteredByTimeRangeUrl(experimentId, timestampMs, 60);
+    expect(urlMinute).toContain('endTime=2025-01-01T00%3A01%3A00.000Z');
+  });
+
+  it('should include all required query parameters', () => {
+    const url = getTracesFilteredByTimeRangeUrl('exp-1', Date.now(), 3600);
+
+    expect(url).toContain('startTimeLabel=CUSTOM');
+    expect(url).toContain('startTime=');
+    expect(url).toContain('endTime=');
+  });
+});
+
+describe('ScrollableTooltip', () => {
+  const mockFormatter = (value: number, name: string): [string, string] => [`${value}`, name];
+
+  it('should not render when not active', () => {
+    renderTooltipWithProviders({
+      active: false,
+      payload: [{ payload: { timestampMs: 1234567890 }, name: 'count', value: 42, color: 'blue' }],
+      label: 'Test Label',
+      formatter: mockFormatter,
+    });
+
+    expect(screen.queryByText('Test Label')).not.toBeInTheDocument();
+  });
+
+  it('should render tooltip content when active', () => {
+    renderTooltipWithProviders({
+      active: true,
+      payload: [{ payload: { timestampMs: 1234567890 }, name: 'count', value: 42, color: 'blue' }],
+      label: 'Test Label',
+      formatter: mockFormatter,
+    });
+
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('count:')).toBeInTheDocument();
+  });
+
+  it('should not show link when linkConfig is not provided', () => {
+    renderTooltipWithProviders({
+      active: true,
+      payload: [{ payload: { timestampMs: 1234567890 }, name: 'count', value: 42, color: 'blue' }],
+      label: 'Test Label',
+      formatter: mockFormatter,
+    });
+
+    expect(screen.queryByText('View traces for this period')).not.toBeInTheDocument();
+  });
+
+  it('should show "View traces for this period" link when linkConfig is provided', () => {
+    renderTooltipWithProviders({
+      active: true,
+      payload: [{ payload: { timestampMs: 1234567890 }, name: 'count', value: 42, color: 'blue' }],
+      label: 'Test Label',
+      formatter: mockFormatter,
+      linkConfig: {
+        experimentId: 'test-exp-123',
+        timeIntervalSeconds: 3600,
+        componentId: 'test.component.link',
+      },
+    });
+
+    expect(screen.getByText('View traces for this period')).toBeInTheDocument();
+  });
+
+  it('should not show link when payload has no timestampMs', () => {
+    renderTooltipWithProviders({
+      active: true,
+      payload: [{ payload: {}, name: 'count', value: 42, color: 'blue' }],
+      label: 'Test Label',
+      formatter: mockFormatter,
+      linkConfig: {
+        experimentId: 'test-exp-123',
+        timeIntervalSeconds: 3600,
+        componentId: 'test.component.link',
+      },
+    });
+
+    expect(screen.queryByText('View traces for this period')).not.toBeInTheDocument();
+  });
+});
 
 describe('useScrollableLegendProps', () => {
   it('should return formatter and wrapperStyle', () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/OverviewChartComponents.tsx
@@ -191,6 +191,11 @@ export function getTracesFilteredByTimeRangeUrl(
   return `${tracesPath}?${queryParams.toString()}`;
 }
 
+/** Allowed component IDs for tooltip "View traces" links */
+type TooltipLinkComponentId =
+  | 'mlflow.overview.usage.traces.view_traces_link'
+  | 'mlflow.overview.usage.latency.view_traces_link';
+
 /** Optional link configuration for ScrollableTooltip */
 interface TooltipLinkConfig {
   /** Experiment ID for navigation */
@@ -198,7 +203,7 @@ interface TooltipLinkConfig {
   /** Time interval in seconds for calculating end time of the bucket */
   timeIntervalSeconds: number;
   /** Component ID for telemetry tracking */
-  componentId: string;
+  componentId: TooltipLinkComponentId;
 }
 
 interface ScrollableTooltipProps {
@@ -227,7 +232,7 @@ interface ScrollableTooltipProps {
  *     linkConfig={{
  *       experimentId,
  *       timeIntervalSeconds,
- *       componentId: "mlflow.charts.my_chart.view_traces_link"
+ *       componentId: 'mlflow.overview.usage.traces.view_traces_link',
  *     }}
  *   />
  * ), [experimentId, timeIntervalSeconds]);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceLatencyChart.tsx
@@ -16,6 +16,7 @@ import {
   DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
 import { formatLatency, useLegendHighlight, getLineDotStyle } from '../utils/chartUtils';
+import { useOverviewChartContext } from '../OverviewChartContext';
 
 export const TraceLatencyChart: React.FC = () => {
   const { theme } = useDesignSystemTheme();
@@ -23,6 +24,7 @@ export const TraceLatencyChart: React.FC = () => {
   const yAxisProps = useChartYAxisProps();
   const scrollableLegendProps = useScrollableLegendProps();
   const { getOpacity, handleLegendMouseEnter, handleLegendMouseLeave } = useLegendHighlight();
+  const { experimentId, timeIntervalSeconds } = useOverviewChartContext();
 
   // Fetch and process latency chart data
   const { chartData, avgLatency, isLoading, error, hasData } = useTraceLatencyChartData();
@@ -63,7 +65,16 @@ export const TraceLatencyChart: React.FC = () => {
               <XAxis dataKey="name" {...xAxisProps} />
               <YAxis {...yAxisProps} />
               <Tooltip
-                content={<ScrollableTooltip formatter={tooltipFormatter} />}
+                content={
+                  <ScrollableTooltip
+                    formatter={tooltipFormatter}
+                    linkConfig={{
+                      experimentId,
+                      timeIntervalSeconds,
+                      componentId: 'mlflow.overview.usage.latency.view_traces_link',
+                    }}
+                  />
+                }
                 cursor={{ stroke: theme.colors.actionTertiaryBackgroundHover }}
               />
               <Line

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceLatencyChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceLatencyChartData.ts
@@ -17,6 +17,7 @@ export interface LatencyChartDataPoint {
   p50: number;
   p90: number;
   p99: number;
+  timestampMs: number;
 }
 
 export interface UseTraceLatencyChartDataResult {
@@ -101,6 +102,7 @@ export function useTraceLatencyChartData(): UseTraceLatencyChartDataResult {
         p50: latency?.p50 || 0,
         p90: latency?.p90 || 0,
         p99: latency?.p99 || 0,
+        timestampMs,
       };
     });
   }, [timeBuckets, latencyByTimestamp, timeIntervalSeconds]);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceRequestsChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceRequestsChartData.ts
@@ -12,6 +12,8 @@ import { useOverviewChartContext } from '../OverviewChartContext';
 export interface RequestsChartDataPoint {
   name: string;
   count: number;
+  /** Raw timestamp in milliseconds for navigation */
+  timestampMs: number;
 }
 
 export interface UseTraceRequestsChartDataResult {
@@ -78,6 +80,7 @@ export function useTraceRequestsChartData(): UseTraceRequestsChartDataResult {
     return timeBuckets.map((timestampMs) => ({
       name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
       count: countByTimestamp.get(timestampMs) || 0,
+      timestampMs,
     }));
   }, [timeBuckets, countByTimestamp, timeIntervalSeconds]);
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5239,6 +5239,10 @@
     "defaultMessage": "Fail",
     "description": "Failing evaluation status in the evaluations table."
   },
+  "c+3yBY": {
+    "defaultMessage": "View traces for this period",
+    "description": "Link text to navigate to traces tab filtered by the selected time period"
+  },
   "c0ljd6": {
     "defaultMessage": "MLflow documentation",
     "description": "Link to MLflow documentation"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20466/files) to review incremental changes.
- [**stack/trace_requests_tooltip_filter**](https://github.com/mlflow/mlflow/pull/20466) [[Files changed](https://github.com/mlflow/mlflow/pull/20466/files)]
  - [stack/usage_tab_charts_tooltips](https://github.com/mlflow/mlflow/pull/20467) [[Files changed](https://github.com/mlflow/mlflow/pull/20467/files/3e2871ab8484ee20df609e06fed2087c48be0583..0e88f7a6592e6ae7679374e455f7321b76caaa48)]
    - [stack/assessments_distribution_tooltip](https://github.com/mlflow/mlflow/pull/20499) [[Files changed](https://github.com/mlflow/mlflow/pull/20499/files/0e88f7a6592e6ae7679374e455f7321b76caaa48..0dab3e88dd682b056b30bf974373fabfa3504a7f)]
      - [stack/assessments_null_backend_support](https://github.com/mlflow/mlflow/pull/20500) [[Files changed](https://github.com/mlflow/mlflow/pull/20500/files/0dab3e88dd682b056b30bf974373fabfa3504a7f..6a2ef12dfdab79525b6b4a84afd29b08fd63679f)]
        - [stack/assessment_filters_update](https://github.com/mlflow/mlflow/pull/20506) [[Files changed](https://github.com/mlflow/mlflow/pull/20506/files/6a2ef12dfdab79525b6b4a84afd29b08fd63679f..e83252717737e78def67d2e81435b5549d1e6209)]
          - [stack/assessments_tooltip](https://github.com/mlflow/mlflow/pull/20503) [[Files changed](https://github.com/mlflow/mlflow/pull/20503/files/e83252717737e78def67d2e81435b5549d1e6209..1bc3a3ba0018fb56eb3d1fbcb414411da0376b0e)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Add 'view traces' link in tooltip so that we can jump to the traces view filtered by the current timestamp. This currently only works for a single bar, if users want an easy way to filter a certain range I think we should support changing time range based on zoom in & out behavior instead later.

The selected time range is preserved between overview tab and traces tab, so when we jump back to overview tab the charts are automatically updated


https://github.com/user-attachments/assets/cce87e22-45e2-4177-a9cc-8c6dfeaa6fe8




<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
