### PR TITLE
Fix cloud_storage_http_request hanging indefinitely due to no timeout

### DIFF
--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -259,7 +259,8 @@ def cloud_storage_http_request(
         backoff_jitter: A random jitter to add to the backoff interval.
         retry_codes: a list of HTTP response error codes that qualifies for retry.
         timeout: wait for timeout seconds for response from remote server for connect and
-            read request. Default to None owing to long duration operation in read / write.
+            read request. Defaults to 120 seconds. Can be configured via the
+            MLFLOW_HTTP_REQUEST_TIMEOUT environment variable.
         kwargs: Additional keyword arguments to pass to `requests.Session.request()`.
 
     Returns:
@@ -267,6 +268,11 @@ def cloud_storage_http_request(
     """
     if method.lower() not in ("put", "get", "patch", "delete"):
         raise ValueError("Illegal http method: " + method)
+    if timeout is None:
+        try:
+            timeout = int(os.getenv("MLFLOW_HTTP_REQUEST_TIMEOUT", "120"))
+        except ValueError:
+            timeout = 120
     return _get_http_response_with_retries(
         method,
         url,


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve -->

### What changes are proposed in this pull request?

PR #4764 disabled the timeout for cloud_storage_http_request (set to None) to prevent retry issues with non-idempotent operations. However, this introduced a regression where cloud storage requests can hang indefinitely when the storage backend is slow or unresponsive.

This is particularly impactful in highly parallel evaluation sessions where multiple concurrent requests to cloud storage can cause the entire eval session to hang and never complete. This is especially prevalent on our side because we use S3 storage that is in a different region than our office. It happens very often. We use Databricks in multiple regions. We mostly do our evals in our office, which is in a different region.

This change restores a default timeout of 120 seconds (matching MLFLOW_HTTP_REQUEST_TIMEOUT), while still allowing users to configure it via the environment variable or an explicit timeout parameter.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (Our evals are not stuck anymore)

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fixed a bug where cloud storage HTTP requests (used for artifact uploads/downloads via presigned URLs) could hang indefinitely due to no default timeout. Requests now default to a 120-second timeout, configurable via the MLFLOW_HTTP_REQUEST_TIMEOUT environment variable.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
