### PR TITLE
[Workspace] Add a utility script to move all resources to the default workspace

### DIFF
--- a/docs/docs/self-hosting/workspaces/configuration.mdx
+++ b/docs/docs/self-hosting/workspaces/configuration.mdx
@@ -24,6 +24,25 @@ mlflow server \
 
 Disable by restarting without `--enable-workspaces` after moving all resources into the `default` workspace.
 
+### Admin Utility: migrate to default workspace
+
+To move all workspace-scoped resources into `default` to disable workspaces, use:
+
+```bash
+mlflow db migrate-to-default-workspace <database_uri>
+```
+
+By default, the command prints the rows to be moved and asks for confirmation. Use `-y` to skip
+the prompt.
+
+Run a dry run first to surface conflicts and see how many rows will be updated:
+
+```bash
+mlflow db migrate-to-default-workspace <database_uri> --dry-run
+```
+
+Use `--verbose` to list all conflicts instead of a truncated sample.
+
 ## Client Workspace Selection (summary)
 
 - Explicit: `mlflow.set_workspace("team-a")`
@@ -37,8 +56,14 @@ Clients send `X-MLFLOW-WORKSPACE` on REST calls; UI AJAX routes remain the same 
 - Tracking and registry stores must report `supports_workspaces() == True`
 - Workspace provider resolved (defaults to SQL-backed provider if none given)
 - Reserved `default` workspace exists (created by migration)
-- Artifact path checks: ensure no conflicts under `<default_artifact_root>/workspaces/...` and that the root is not already workspace-prefixed
 - With `--serve-artifacts`, proxied artifact paths for non-default workspaces must include `workspaces/<workspace>/...`; legacy unprefixed paths remain valid for `default`.
+
+## Admin preflight for artifact roots
+
+Before enabling workspaces, confirm that existing experiment artifact locations do not already
+live under the reserved `<default_artifact_root>/workspaces/<workspace>/...` path unless
+they match the workspace layout you intend to use. If they do, move or rename those artifact
+roots first to avoid collisions.
 
 ## Artifact Behavior
 

--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -25,22 +25,25 @@ from mlflow.environment_variables import (
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_EXPERIMENT_ID,
     MLFLOW_EXPERIMENT_NAME,
+    MLFLOW_WORKSPACE,
     MLFLOW_WORKSPACE_STORE_URI,
 )
 from mlflow.exceptions import InvalidUrlException, MlflowException
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST, ErrorCode
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.tracking import (
     DEFAULT_ARTIFACTS_URI,
     DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
 )
+from mlflow.store.workspace.utils import get_default_workspace_optional
 from mlflow.tracking import _get_store
 from mlflow.tracking._tracking_service.utils import (
     _get_default_tracking_uri,
     is_tracking_uri_set,
     set_tracking_uri,
 )
-from mlflow.utils import cli_args
+from mlflow.tracking._workspace.registry import get_workspace_store
+from mlflow.utils import cli_args, workspace_context
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.os import is_windows
 from mlflow.utils.plugins import get_entry_points
@@ -50,6 +53,7 @@ from mlflow.utils.server_cli_utils import (
     assert_server_workspace_env_unset,
     resolve_default_artifact_root,
 )
+from mlflow.utils.workspace_utils import resolve_workspace_store_uri
 
 _logger = logging.getLogger(__name__)
 
@@ -714,6 +718,7 @@ def _gc_tracking_resources(
     time_delta: int,
     skip_experiments: bool,
     skip_logged_models: bool,
+    ignore_not_found: bool = False,
 ):
     """
     Perform garbage collection of tracking resources (runs, experiments, logged models).
@@ -729,6 +734,8 @@ def _gc_tracking_resources(
         time_delta: Time delta in milliseconds for age filtering.
         skip_experiments: Whether to skip experiment deletion.
         skip_logged_models: Whether to skip logged model deletion.
+        ignore_not_found: If True, skip RESOURCE_DOES_NOT_EXIST errors for explicit IDs
+            that may not exist (e.g., when iterating over multiple workspaces).
     """
     from mlflow.utils.time import get_current_time_millis
 
@@ -754,7 +761,16 @@ def _gc_tracking_resources(
     experiment_ids_to_delete = []
     if not skip_experiments:
         if experiment_ids:
-            experiments = [backend_store.get_experiment(id) for id in experiment_ids]
+            experiments = []
+            for exp_id in experiment_ids:
+                try:
+                    experiments.append(backend_store.get_experiment(exp_id))
+                except MlflowException as exc:
+                    if ignore_not_found and exc.error_code == ErrorCode.Name(
+                        RESOURCE_DOES_NOT_EXIST
+                    ):
+                        continue
+                    raise
 
             # Ensure that the specified experiments are soft-deleted
             active_experiment_ids = [
@@ -776,7 +792,7 @@ def _gc_tracking_resources(
                 ]
                 if non_old_experiment_ids:
                     raise MlflowException(
-                        f"Experiments {non_old_experiment_ids} are not older than the required"
+                        f"Experiments {non_old_experiment_ids} are not older than the required "
                         f"age. Only experiments older than {older_than} can be deleted.",
                         error_code=INVALID_PARAMETER_VALUE,
                     )
@@ -808,7 +824,12 @@ def _gc_tracking_resources(
             run_ids_to_delete.extend([run.info.run_id for run in fetch_runs()])
 
     for run_id in set(run_ids_to_delete):
-        run = backend_store.get_run(run_id)
+        try:
+            run = backend_store.get_run(run_id)
+        except MlflowException as exc:
+            if ignore_not_found and exc.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                continue
+            raise
         if run.info.lifecycle_stage != LifecycleStage.DELETED:
             raise MlflowException(
                 f"Run {run_id} is not in `deleted` lifecycle stage. Only runs in"
@@ -847,6 +868,15 @@ def _gc_tracking_resources(
 
     if not skip_logged_models:
         for model_id in set(logged_model_ids_to_delete):
+            # First, check if the model exists (handles non-existent models correctly)
+            try:
+                logged_model = backend_store.get_logged_model(model_id, allow_deleted=True)
+            except MlflowException as exc:
+                if ignore_not_found and exc.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                    continue
+                raise
+            # Model exists - now check if it's in the deleted lifecycle stage
+            # (never skip active models, even with ignore_not_found)
             if model_id not in deleted_logged_model_ids:
                 raise MlflowException(
                     f"Logged model {model_id} is not in `deleted` lifecycle stage. "
@@ -858,7 +888,6 @@ def _gc_tracking_resources(
                     f"Only logged models older than {older_than} can be deleted.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
-            logged_model = backend_store.get_logged_model(model_id, allow_deleted=True)
             artifact_repo = get_artifact_repository(logged_model.artifact_location)
             try:
                 artifact_repo.delete_artifacts()
@@ -885,6 +914,63 @@ def _gc_tracking_resources(
         for experiment_id in experiment_ids_to_delete:
             backend_store._hard_delete_experiment(experiment_id)
             click.echo(f"Experiment with ID {experiment_id} has been permanently deleted.")
+
+
+def _resolve_gc_workspaces(
+    backend_store,
+    all_workspaces: bool,
+    workspace: str | None,
+    backend_store_uri: str | None,
+) -> list[str | None]:
+    """
+    Determine which workspaces to iterate over for garbage collection.
+
+    Args:
+        backend_store: The tracking store instance.
+        all_workspaces: If True, return all workspaces from the workspace store.
+        workspace: If provided, return a single-element list with this workspace.
+        backend_store_uri: The backend store URI for resolving workspace store.
+
+    Returns:
+        List of workspace names to iterate over, or [None] for non-workspace mode.
+    """
+    supports_workspaces = (
+        getattr(backend_store, "supports_workspaces", False) and MLFLOW_ENABLE_WORKSPACES.get()
+    )
+    if not supports_workspaces:
+        if all_workspaces or workspace:
+            raise MlflowException.invalid_parameter_value(
+                "Workspace selection flags are only supported when the tracking store "
+                "supports workspaces."
+            )
+        return [None]
+
+    if all_workspaces:
+        workspace_store = get_workspace_store(
+            resolve_workspace_store_uri(tracking_uri=backend_store_uri)
+        )
+        workspaces = [ws.name for ws in workspace_store.list_workspaces()]
+        if not workspaces:
+            raise MlflowException(
+                "No workspaces found. Ensure the workspace provider is configured correctly.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        return workspaces
+
+    if workspace:
+        return [workspace]
+
+    workspace_store = get_workspace_store(
+        resolve_workspace_store_uri(tracking_uri=backend_store_uri)
+    )
+    default_workspace, supports_default = get_default_workspace_optional(workspace_store)
+    if supports_default and default_workspace is not None:
+        return [default_workspace.name]
+
+    raise MlflowException.invalid_parameter_value(
+        "Active workspace is required. Configure a default workspace, set MLFLOW_WORKSPACE "
+        "or use --workspace/--all-workspaces when workspaces are enabled."
+    )
 
 
 @cli.command(short_help="Permanently delete runs in the `deleted` lifecycle stage.")
@@ -958,7 +1044,24 @@ def _gc_tracking_resources(
     default=os.environ.get("MLFLOW_TRACKING_URI"),
     help="Tracking URI to use for deleting 'deleted' runs e.g. http://127.0.0.1:8080",
 )
+@click.option(
+    "--workspace",
+    envvar=MLFLOW_WORKSPACE.name,
+    default=None,
+    help=(
+        "Target workspace for deletions when workspaces are enabled. Defaults to the active "
+        "workspace (MLFLOW_WORKSPACE)."
+    ),
+)
+@click.option(
+    "--all-workspaces",
+    is_flag=True,
+    default=False,
+    help="Delete deleted resources across all workspaces (workspace mode only).",
+)
+@click.pass_context
 def gc(
+    ctx,
     older_than,
     backend_store_uri,
     artifacts_destination,
@@ -968,6 +1071,8 @@ def gc(
     jobs,
     job_ids,
     tracking_uri,
+    workspace,
+    all_workspaces,
 ):
     """
     Permanently delete runs in the `deleted` lifecycle stage from the specified backend store.
@@ -1018,6 +1123,9 @@ def gc(
         # Combine criteria: delete runs older than 7 days in specific experiments
         mlflow gc --older-than 7d --experiment-ids 'exp1,exp2'
 
+        # Delete deleted resources across all workspaces
+        mlflow gc --all-workspaces --older-than 30d
+
         # Delete all finalized jobs older than 7 days (requires --jobs flag)
         mlflow gc --jobs --older-than 7d
 
@@ -1025,7 +1133,16 @@ def gc(
         mlflow gc --job-ids 'job1,job2,job3'
 
     """
+    if (workspace or all_workspaces) and not MLFLOW_ENABLE_WORKSPACES.get():
+        os.environ[MLFLOW_ENABLE_WORKSPACES.name] = "true"
     backend_store = _get_store(backend_store_uri, artifacts_destination)
+    # Only error if --workspace was explicitly provided on CLI (not from env var)
+    workspace_from_cli = ctx.get_parameter_source("workspace") == ParameterSource.COMMANDLINE
+    if workspace_from_cli and all_workspaces:
+        raise UsageError("Cannot use --workspace and --all-workspaces together.")
+    # If --all-workspaces is set, ignore workspace from env var
+    if all_workspaces:
+        workspace = None
     skip_experiments = False
     skip_logged_models = False
     if not hasattr(backend_store, "_hard_delete_run"):
@@ -1082,18 +1199,9 @@ def gc(
     experiment_ids_list = experiment_ids.split(",") if experiment_ids else None
     logged_model_ids_list = logged_model_ids.split(",") if logged_model_ids else None
 
-    _gc_tracking_resources(
-        backend_store=backend_store,
-        run_ids=run_ids_list,
-        experiment_ids=experiment_ids_list,
-        logged_model_ids=logged_model_ids_list,
-        older_than=older_than,
-        time_delta=time_delta,
-        skip_experiments=skip_experiments,
-        skip_logged_models=skip_logged_models,
-    )
-
-    # Clean up jobs (only when --jobs flag is set or --job-ids are given and for database backends)
+    # Prepare job cleanup if requested (database backends only)
+    job_store = None
+    job_ids_list = None
     if jobs or job_ids:
         from mlflow.utils.uri import extract_db_type_from_uri
 
@@ -1104,15 +1212,47 @@ def gc(
             # Not a database backend - skip job cleanup silently
             pass
         else:
-            from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
+            if MLFLOW_ENABLE_WORKSPACES.get():
+                from mlflow.store.jobs.sqlalchemy_workspace_store import (
+                    WorkspaceAwareSqlAlchemyJobStore,
+                )
 
-            job_store = SqlAlchemyJobStore(store_uri)
+                job_store = WorkspaceAwareSqlAlchemyJobStore(store_uri)
+            else:
+                from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 
+                job_store = SqlAlchemyJobStore(store_uri)
             job_ids_list = job_ids.split(",") if job_ids else None
 
-            deleted_job_ids = job_store.delete_jobs(older_than=time_delta, job_ids=job_ids_list)
-            for job_id in deleted_job_ids:
-                click.echo(f"Job with ID {job_id} has been permanently deleted.")
+    for workspace_name in _resolve_gc_workspaces(
+        backend_store=backend_store,
+        all_workspaces=all_workspaces,
+        workspace=workspace,
+        backend_store_uri=backend_store_uri,
+    ):
+        workspace_ctx = (
+            workspace_context.WorkspaceContext(workspace_name)
+            if workspace_name
+            else contextlib.nullcontext()
+        )
+        with workspace_ctx:
+            _gc_tracking_resources(
+                backend_store=backend_store,
+                run_ids=run_ids_list,
+                experiment_ids=experiment_ids_list,
+                logged_model_ids=logged_model_ids_list,
+                older_than=older_than,
+                time_delta=time_delta,
+                skip_experiments=skip_experiments,
+                skip_logged_models=skip_logged_models,
+                ignore_not_found=all_workspaces,
+            )
+
+            # Clean up jobs within the same workspace context
+            if job_store is not None:
+                deleted_job_ids = job_store.delete_jobs(older_than=time_delta, job_ids=job_ids_list)
+                for job_id in deleted_job_ids:
+                    click.echo(f"Job with ID {job_id} has been permanently deleted.")
 
 
 @cli.command(short_help="Prints out useful information for debugging issues with MLflow.")

--- a/mlflow/db.py
+++ b/mlflow/db.py
@@ -25,3 +25,69 @@ def upgrade(url):
 
     engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(url)
     mlflow.store.db.utils._upgrade_db(engine)
+
+
+@commands.command("migrate-to-default-workspace")
+@click.argument("url")
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    show_default=True,
+    help="Check for conflicts and report how many rows would be moved.",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="List all conflicts instead of truncating the output.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+def migrate_to_default_workspace(url, dry_run, verbose, yes):
+    """
+    Move workspace-scoped resources into the default workspace.
+
+    **IMPORTANT**: This operation runs in a single transaction, but can still be long-running.
+    Always take a backup of your database before running this command.
+    """
+    import mlflow.store.db.utils
+    from mlflow.store.db.workspace_migration import migrate_to_default_workspace as migrate
+
+    engine = None
+    try:
+        engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(url)
+        counts = migrate(engine, dry_run=True, verbose=verbose)
+
+        total = sum(counts.values())
+        if dry_run:
+            click.echo("Dry run completed. Rows that would be moved to the default workspace:")
+            for table_name, count in counts.items():
+                click.echo(f"  {table_name}: {count}")
+            click.echo(f"Total rows: {total}")
+            return
+
+        if total == 0:
+            click.echo("No rows need to be moved.")
+            return
+
+        click.echo("Rows to be moved to the default workspace:")
+        for table_name, count in counts.items():
+            click.echo(f"  {table_name}: {count}")
+        click.echo(f"Total rows: {total}")
+
+        if not yes:
+            click.confirm("Proceed with migration?", default=False, abort=True)
+
+        migrate(engine, dry_run=False, verbose=verbose)
+        click.echo(f"Moved {total} rows to the default workspace.")
+    except RuntimeError as e:
+        raise click.ClickException(str(e)) from e
+    finally:
+        if engine is not None:
+            engine.dispose()

--- a/mlflow/store/db/__init__.py
+++ b/mlflow/store/db/__init__.py
@@ -1,0 +1,2 @@
+# Note: workspace_migration is not imported here to avoid loading sqlalchemy
+# at import time (breaks skinny client). Import directly from the module when needed.

--- a/mlflow/store/db/workspace_migration.py
+++ b/mlflow/store/db/workspace_migration.py
@@ -1,0 +1,149 @@
+import sqlalchemy as sa
+
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+_WORKSPACE_TABLES = [
+    "experiments",
+    "registered_models",
+    "model_versions",
+    "registered_model_tags",
+    "model_version_tags",
+    "registered_model_aliases",
+    "evaluation_datasets",
+    "webhooks",
+    "secrets",
+    "endpoints",
+    "model_definitions",
+    "jobs",
+]
+
+_CONFLICT_SPECS = [
+    ("experiments", ("name",), "experiments with the same name"),
+    ("registered_models", ("name",), "registered models with the same name"),
+    ("evaluation_datasets", ("name",), "evaluation datasets with the same name"),
+    ("model_versions", ("name", "version"), "model versions with the same model name and version"),
+    (
+        "registered_model_tags",
+        ("name", "key"),
+        "registered model tags with the same model name and key",
+    ),
+    (
+        "model_version_tags",
+        ("name", "version", "key"),
+        "model version tags with the same model name, version, and key",
+    ),
+    (
+        "registered_model_aliases",
+        ("name", "alias"),
+        "registered model aliases with the same model name and alias",
+    ),
+    ("secrets", ("secret_name",), "secrets with the same name"),
+    ("endpoints", ("name",), "endpoints with the same name"),
+    ("model_definitions", ("name",), "model definitions with the same name"),
+]
+
+
+def _format_conflicts(
+    conflicts: list[tuple[object, ...]],
+    columns: tuple[str, ...],
+    *,
+    max_rows: int | None,
+) -> str:
+    rows = conflicts if max_rows is None else conflicts[:max_rows]
+    formatted_conflicts = "\n  ".join(
+        ", ".join(f"{column}={value!r}" for column, value in zip(columns, row)) for row in rows
+    )
+    if formatted_conflicts:
+        formatted_conflicts = f"\n  {formatted_conflicts}"
+    if max_rows is not None and len(conflicts) > max_rows:
+        formatted_conflicts += f"\n  ... ({len(conflicts) - max_rows} more)"
+    return formatted_conflicts
+
+
+def _get_table(conn, table_name: str) -> sa.Table:
+    table = sa.Table(table_name, sa.MetaData(), autoload_with=conn)
+    if "workspace" not in table.c:
+        raise RuntimeError(
+            "Move aborted: the specified tracking server does not have workspaces enabled. "
+            "This command is intended for a workspace-enabled tracking server. Please make sure "
+            "the specified tracking URI is correct."
+        )
+    return table
+
+
+def _assert_no_workspace_conflicts(
+    conn,
+    table_name: str,
+    columns: tuple[str, ...],
+    resource_description: str,
+    *,
+    verbose: bool,
+) -> None:
+    table = _get_table(conn, table_name)
+    group_columns = [table.c[column] for column in columns]
+    conflict_keys = (
+        sa.select(*group_columns).group_by(*group_columns).having(sa.func.count() > 1).subquery()
+    )
+    join_conditions = [table.c[column] == conflict_keys.c[column] for column in columns]
+    extra_columns = []
+    if table_name == "experiments" and "experiment_id" in table.c:
+        extra_columns.append(table.c.experiment_id)
+    conflict_rows_stmt = (
+        sa.select(*group_columns, table.c.workspace, *extra_columns)
+        .select_from(table.join(conflict_keys, sa.and_(*join_conditions)))
+        .order_by(*group_columns, table.c.workspace, *extra_columns)
+    )
+    if conflicts := conn.execute(conflict_rows_stmt).fetchall():
+        formatted_conflicts = _format_conflicts(
+            conflicts,
+            (*columns, "workspace", *(column.name for column in extra_columns)),
+            max_rows=None if verbose else 5,
+        )
+        raise RuntimeError(
+            "Move aborted: merging workspaces would create duplicate "
+            f"{resource_description}. Resolve the following conflicts by renaming the affected "
+            "resources (restore deleted ones first) or permanently deleting them, then retry: "
+            f"{formatted_conflicts}"
+        )
+
+
+def migrate_to_default_workspace(
+    engine: sa.Engine,
+    dry_run: bool = False,
+    *,
+    verbose: bool = False,
+) -> dict[str, int]:
+    """
+    Move all workspace-scoped resources into the default workspace.
+    Returns a mapping of table name -> number of rows moved (or that would be moved in dry-run).
+    When verbose is True, conflict lists are not truncated.
+    """
+    with engine.begin() as conn:
+        for table_name, columns, description in _CONFLICT_SPECS:
+            _assert_no_workspace_conflicts(
+                conn,
+                table_name,
+                columns,
+                description,
+                verbose=verbose,
+            )
+
+        counts = {}
+        for table_name in _WORKSPACE_TABLES:
+            table = _get_table(conn, table_name)
+            stmt = (
+                sa.select(sa.func.count())
+                .select_from(table)
+                .where(table.c.workspace != DEFAULT_WORKSPACE_NAME)
+            )
+            counts[table_name] = conn.execute(stmt).scalar_one()
+
+            if dry_run or counts[table_name] == 0:
+                continue
+            conn.execute(
+                table.update()
+                .where(table.c.workspace != DEFAULT_WORKSPACE_NAME)
+                .values(workspace=DEFAULT_WORKSPACE_NAME)
+            )
+
+        return counts

--- a/tests/store/tracking/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/test_sqlalchemy_store_schema.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sqlite3
 
 import pytest
@@ -14,10 +15,13 @@ import mlflow.db
 # This can be removed once we have a workspace store imported.
 import mlflow.store.workspace.dbmodels as _workspace_models  # noqa: F401
 from mlflow.exceptions import MlflowException
+from mlflow.store.db import workspace_migration
 from mlflow.store.db.base_sql_model import Base
 from mlflow.store.db.utils import _get_alembic_config, _verify_schema
+from mlflow.store.db.workspace_migration import migrate_to_default_workspace
 from mlflow.store.tracking.dbmodels.initial_models import Base as InitialBase
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 from tests.integration.utils import invoke_cli_runner
 from tests.store.dump_schema import dump_db_schema
@@ -213,3 +217,206 @@ def test_secrets_and_endpoints_tables(tmp_path, db_url):
         assert _has_unique_index("secrets", ["workspace", "secret_name"])
         assert _has_unique_index("endpoints", ["workspace", "name"])
         assert _has_unique_index("model_definitions", ["workspace", "name"])
+
+
+def test_workspace_migration_tables_include_all_workspace_tables(tmp_path, db_url):
+    SqlAlchemyStore(db_url, tmp_path.joinpath("ARTIFACTS").as_uri())
+    with sqlite3.connect(db_url[len("sqlite:///") :]) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        workspace_tables = set()
+        for (table_name,) in cursor.fetchall():
+            cursor.execute(f"PRAGMA table_info('{table_name}')")
+            column_names = {row[1] for row in cursor.fetchall()}
+            if "workspace" in column_names:
+                workspace_tables.add(table_name)
+    assert workspace_tables == set(workspace_migration._WORKSPACE_TABLES)
+
+
+def _insert_row(conn, table_name, workspace, overrides=None, seed=1):
+    table = sqlalchemy.Table(table_name, sqlalchemy.MetaData(), autoload_with=conn)
+    base_values = {
+        "experiments": {
+            "name": f"experiment_{seed}",
+            "workspace": workspace,
+            "artifact_location": f"file:///tmp/experiment/{seed}",
+        },
+        "registered_models": {
+            "workspace": workspace,
+            "name": f"model_{seed}",
+        },
+        "model_versions": {
+            "workspace": workspace,
+            "name": f"model_{seed}",
+            "version": seed,
+        },
+        "registered_model_tags": {
+            "workspace": workspace,
+            "name": f"model_{seed}",
+            "key": f"tag_{seed}",
+            "value": f"value_{seed}",
+        },
+        "model_version_tags": {
+            "workspace": workspace,
+            "name": f"model_{seed}",
+            "version": seed,
+            "key": f"mv_tag_{seed}",
+            "value": f"value_{seed}",
+        },
+        "registered_model_aliases": {
+            "workspace": workspace,
+            "name": f"model_{seed}",
+            "alias": f"alias_{seed}",
+            "version": seed,
+        },
+        "evaluation_datasets": {
+            "dataset_id": f"dataset_{seed}",
+            "workspace": workspace,
+            "name": f"dataset_name_{seed}",
+        },
+        "webhooks": {
+            "workspace": workspace,
+            "webhook_id": f"wh_{seed}",
+            "name": f"webhook_{seed}",
+            "url": f"http://localhost/{seed}",
+            "status": "ACTIVE",
+        },
+        "secrets": {
+            "secret_id": f"secret_{seed}",
+            "secret_name": f"secret_name_{seed}",
+            "encrypted_value": b"encrypted",
+            "wrapped_dek": b"wrapped",
+            "kek_version": 1,
+            "masked_value": f"masked_{seed}",
+            "created_at": seed,
+            "last_updated_at": seed,
+            "workspace": workspace,
+        },
+        "endpoints": {
+            "endpoint_id": f"endpoint_{seed}",
+            "name": f"endpoint_{seed}",
+            "created_at": seed,
+            "last_updated_at": seed,
+            "workspace": workspace,
+        },
+        "model_definitions": {
+            "model_definition_id": f"model_def_{seed}",
+            "name": f"model_def_{seed}",
+            "provider": f"provider_{seed}",
+            "model_name": f"model_{seed}",
+            "created_at": seed,
+            "last_updated_at": seed,
+            "workspace": workspace,
+        },
+        "jobs": {
+            "id": f"job_{seed}",
+            "creation_time": seed,
+            "job_name": f"job_{seed}",
+            "params": "{}",
+            "workspace": workspace,
+            "status": 0,
+            "retry_count": 0,
+            "last_update_time": seed,
+        },
+    }
+    if table_name not in base_values:
+        raise AssertionError(f"Unexpected table: {table_name}")
+    values = base_values[table_name]
+    overrides = overrides or {}
+    unknown = set(overrides) - set(table.c.keys())
+    assert not unknown, f"Unknown columns for {table_name}: {unknown}"
+    values.update(overrides)
+    conn.execute(table.insert().values(**values))
+
+
+@pytest.mark.parametrize(
+    ("table_name", "conflict_columns", "description"),
+    [
+        ("experiments", ("name",), "experiments with the same name"),
+        ("registered_models", ("name",), "registered models with the same name"),
+        ("evaluation_datasets", ("name",), "evaluation datasets with the same name"),
+        (
+            "model_versions",
+            ("name", "version"),
+            "model versions with the same model name and version",
+        ),
+        (
+            "registered_model_tags",
+            ("name", "key"),
+            "registered model tags with the same model name and key",
+        ),
+        (
+            "model_version_tags",
+            ("name", "version", "key"),
+            "model version tags with the same model name, version, and key",
+        ),
+        (
+            "registered_model_aliases",
+            ("name", "alias"),
+            "registered model aliases with the same model name and alias",
+        ),
+        ("secrets", ("secret_name",), "secrets with the same name"),
+        ("endpoints", ("name",), "endpoints with the same name"),
+        ("model_definitions", ("name",), "model definitions with the same name"),
+    ],
+)
+def test_migrate_to_default_workspace_conflict(tmp_path, table_name, conflict_columns, description):
+    db_path = tmp_path / f"conflict-{table_name}.db"
+    db_url = f"sqlite:///{db_path}"
+    artifacts = tmp_path / f"artifacts-{table_name}"
+    artifacts.mkdir()
+    SqlAlchemyStore(db_url, artifacts.as_uri())
+    engine = sqlalchemy.create_engine(db_url)
+    conflict_values = {}
+    for column in conflict_columns:
+        if column == "version":
+            conflict_values[column] = 1
+        else:
+            conflict_values[column] = "conflict"
+    with engine.begin() as conn:
+        conn.execute(sqlalchemy.text("PRAGMA foreign_keys = OFF"))
+        _insert_row(
+            conn,
+            table_name,
+            DEFAULT_WORKSPACE_NAME,
+            overrides=conflict_values,
+            seed=1,
+        )
+        _insert_row(
+            conn,
+            table_name,
+            "team-a",
+            overrides=conflict_values,
+            seed=2,
+        )
+    with pytest.raises(RuntimeError, match=re.escape(description)):
+        migrate_to_default_workspace(engine, dry_run=True)
+    engine.dispose()
+
+
+def test_migrate_to_default_workspace_moves_rows(tmp_path):
+    db_path = tmp_path / "migrate-all.db"
+    db_url = f"sqlite:///{db_path}"
+    artifacts = tmp_path / "artifacts-all"
+    artifacts.mkdir()
+    SqlAlchemyStore(db_url, artifacts.as_uri())
+    engine = sqlalchemy.create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(sqlalchemy.text("PRAGMA foreign_keys = OFF"))
+        for seed, table_name in enumerate(workspace_migration._WORKSPACE_TABLES, start=1):
+            _insert_row(conn, table_name, "team-a", seed=seed)
+
+    counts = migrate_to_default_workspace(engine, dry_run=True)
+    assert set(counts.keys()) == set(workspace_migration._WORKSPACE_TABLES)
+    assert all(count == 1 for count in counts.values())
+
+    migrate_to_default_workspace(engine, dry_run=False)
+
+    with engine.begin() as conn:
+        for table_name in workspace_migration._WORKSPACE_TABLES:
+            table = sqlalchemy.Table(table_name, sqlalchemy.MetaData(), autoload_with=conn)
+            stmt = sqlalchemy.select(sqlalchemy.func.count()).where(
+                table.c.workspace != DEFAULT_WORKSPACE_NAME
+            )
+            assert conn.execute(stmt).scalar_one() == 0
+    engine.dispose()


### PR DESCRIPTION
### Related Issues/PRs

#1464
#5844
Design document: https://docs.google.com/document/d/1IbFfceCmWV3knJfc0ninn58EXLVbHUh1meV_pknOM40/edit

### What changes are proposed in this pull request?

This allows an admin to go from a workspace enabled deployment back to it being disabled.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
