### PR TITLE
Fix session ID display and run coloring when grouping by session and comparing

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -36,8 +36,7 @@ import {
   createTraceLocationForUCSchema,
   useFetchTraceV4LazyQuery,
   doesTraceSupportV4API,
-  SIMULATION_GOAL_COLUMN_ID,
-  SIMULATION_PERSONA_COLUMN_ID,
+  getSimulationColumnsToAdd,
 } from '@databricks/web-shared/genai-traces-table';
 import { GenAiTraceTableRowSelectionProvider } from '@databricks/web-shared/genai-traces-table/hooks/useGenAiTraceTableRowSelection';
 import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
@@ -199,32 +198,11 @@ const RunViewEvaluationsTabInner = ({
   // Helper to add goal/persona columns if traces have the metadata
   const maybeAddGoalPersonaColumns = useCallback(
     (traces: ModelTraceInfoV3[]) => {
-      if (hasAutoSelectedGoalPersona.current || traces.length === 0) {
+      if (hasAutoSelectedGoalPersona.current) {
         return;
       }
 
-      const hasGoalMetadata = traces.some((trace) => Boolean(trace.trace_metadata?.['mlflow.simulation.goal']));
-      const hasPersonaMetadata = traces.some((trace) => Boolean(trace.trace_metadata?.['mlflow.simulation.persona']));
-
-      if (!hasGoalMetadata && !hasPersonaMetadata) {
-        return;
-      }
-
-      const columnsToAdd: TracesTableColumn[] = [];
-      const goalColumn = allColumns.find((col) => col.id === SIMULATION_GOAL_COLUMN_ID);
-      const personaColumn = allColumns.find((col) => col.id === SIMULATION_PERSONA_COLUMN_ID);
-
-      if (hasGoalMetadata && goalColumn && !selectedColumns.some((col) => col.id === SIMULATION_GOAL_COLUMN_ID)) {
-        columnsToAdd.push(goalColumn);
-      }
-      if (
-        hasPersonaMetadata &&
-        personaColumn &&
-        !selectedColumns.some((col) => col.id === SIMULATION_PERSONA_COLUMN_ID)
-      ) {
-        columnsToAdd.push(personaColumn);
-      }
-
+      const columnsToAdd = getSimulationColumnsToAdd(traces, allColumns, selectedColumns);
       if (columnsToAdd.length > 0) {
         toggleColumns(columnsToAdd);
         hasAutoSelectedGoalPersona.current = true;

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -342,6 +342,7 @@ const RunViewEvaluationsTabInner = ({
                     experimentId={experimentId}
                     currentRunDisplayName={runDisplayName}
                     compareToRunDisplayName={compareToRunDisplayName}
+                    runUuid={runUuid}
                     compareToRunUuid={compareToRunUuid}
                     getTrace={getTrace}
                     getRunColor={getRunColor}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { getSimulationColumnsToAdd } from './GenAiTracesTable.utils';
+import { SIMULATION_GOAL_COLUMN_ID, SIMULATION_PERSONA_COLUMN_ID } from './hooks/useTableColumns';
+import type { TracesTableColumn } from './types';
+import { TracesTableColumnType, TracesTableColumnGroup } from './types';
+import type { ModelTraceInfoV3 } from '../model-trace-explorer';
+
+const createTrace = (metadata: Record<string, string> = {}): ModelTraceInfoV3 =>
+  ({
+    trace_id: 'test-id',
+    trace_location: { type: 'MLFLOW_EXPERIMENT', mlflow_experiment: { experiment_id: 'exp' } },
+    trace_metadata: metadata,
+  }) as ModelTraceInfoV3;
+
+const goalColumn: TracesTableColumn = {
+  id: SIMULATION_GOAL_COLUMN_ID,
+  label: 'Goal',
+  type: TracesTableColumnType.TRACE_INFO,
+  group: TracesTableColumnGroup.INFO,
+};
+const personaColumn: TracesTableColumn = {
+  id: SIMULATION_PERSONA_COLUMN_ID,
+  label: 'Persona',
+  type: TracesTableColumnType.TRACE_INFO,
+  group: TracesTableColumnGroup.INFO,
+};
+
+const goalMetadata = { 'mlflow.simulation.goal': 'test-goal' };
+const personaMetadata = { 'mlflow.simulation.persona': 'test-persona' };
+const bothMetadata = { ...goalMetadata, ...personaMetadata };
+
+describe('getSimulationColumnsToAdd', () => {
+  it('returns empty array when traces is empty or has no metadata', () => {
+    expect(getSimulationColumnsToAdd([], [goalColumn, personaColumn], [])).toEqual([]);
+    expect(getSimulationColumnsToAdd([createTrace()], [goalColumn, personaColumn], [])).toEqual([]);
+  });
+
+  it.each([
+    ['goal only', [createTrace(goalMetadata)], [goalColumn]],
+    ['persona only', [createTrace(personaMetadata)], [personaColumn]],
+    ['both', [createTrace(bothMetadata)], [goalColumn, personaColumn]],
+    ['partial traces', [createTrace(), createTrace(goalMetadata)], [goalColumn]],
+  ])('returns columns based on metadata: %s', (_, traces, expected) => {
+    expect(getSimulationColumnsToAdd(traces, [goalColumn, personaColumn], [])).toEqual(expected);
+  });
+
+  it.each([
+    ['goal', [createTrace(goalMetadata)], [goalColumn], []],
+    ['persona', [createTrace(personaMetadata)], [personaColumn], []],
+    ['goal when both present', [createTrace(bothMetadata)], [goalColumn], [personaColumn]],
+  ])('skips already selected: %s', (_, traces, selected, expected) => {
+    expect(getSimulationColumnsToAdd(traces, [goalColumn, personaColumn], selected)).toEqual(expected);
+  });
+
+  it('returns only columns available in allColumns', () => {
+    expect(getSimulationColumnsToAdd([createTrace(bothMetadata)], [goalColumn], [])).toEqual([goalColumn]);
+    expect(getSimulationColumnsToAdd([createTrace(bothMetadata)], [], [])).toEqual([]);
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from '@jest/globals';
 
 import { getSimulationColumnsToAdd } from './GenAiTracesTable.utils';
 import { SIMULATION_GOAL_COLUMN_ID, SIMULATION_PERSONA_COLUMN_ID } from './hooks/useTableColumns';
+import { SIMULATION_GOAL_KEY, SIMULATION_PERSONA_KEY } from './utils/SessionGroupingUtils';
 import type { TracesTableColumn } from './types';
 import { TracesTableColumnType, TracesTableColumnGroup } from './types';
 import type { ModelTraceInfoV3 } from '../model-trace-explorer';
@@ -26,8 +27,8 @@ const personaColumn: TracesTableColumn = {
   group: TracesTableColumnGroup.INFO,
 };
 
-const goalMetadata = { 'mlflow.simulation.goal': 'test-goal' };
-const personaMetadata = { 'mlflow.simulation.persona': 'test-persona' };
+const goalMetadata = { [SIMULATION_GOAL_KEY]: 'test-goal' };
+const personaMetadata = { [SIMULATION_PERSONA_KEY]: 'test-persona' };
 const bothMetadata = { ...goalMetadata, ...personaMetadata };
 
 describe('getSimulationColumnsToAdd', () => {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
@@ -235,3 +235,37 @@ export function computeEvaluationsComparison(
     };
   });
 }
+
+/**
+ * Returns simulation columns (goal/persona) that should be auto-selected based on trace metadata.
+ * Only returns columns that exist in allColumns and are not already in selectedColumns.
+ */
+export function getSimulationColumnsToAdd(
+  traces: ModelTraceInfoV3[],
+  allColumns: TracesTableColumn[],
+  selectedColumns: TracesTableColumn[],
+): TracesTableColumn[] {
+  if (traces.length === 0) {
+    return [];
+  }
+
+  const hasGoalMetadata = traces.some((trace) => Boolean(trace.trace_metadata?.['mlflow.simulation.goal']));
+  const hasPersonaMetadata = traces.some((trace) => Boolean(trace.trace_metadata?.['mlflow.simulation.persona']));
+
+  if (!hasGoalMetadata && !hasPersonaMetadata) {
+    return [];
+  }
+
+  const columnsToAdd: TracesTableColumn[] = [];
+  const goalColumn = allColumns.find((col) => col.id === SIMULATION_GOAL_COLUMN_ID);
+  const personaColumn = allColumns.find((col) => col.id === SIMULATION_PERSONA_COLUMN_ID);
+
+  if (hasGoalMetadata && goalColumn && !selectedColumns.some((col) => col.id === SIMULATION_GOAL_COLUMN_ID)) {
+    columnsToAdd.push(goalColumn);
+  }
+  if (hasPersonaMetadata && personaColumn && !selectedColumns.some((col) => col.id === SIMULATION_PERSONA_COLUMN_ID)) {
+    columnsToAdd.push(personaColumn);
+  }
+
+  return columnsToAdd;
+}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
@@ -70,6 +70,17 @@ export function sortGroupedColumns(
       if (colB.id === SESSION_COLUMN_ID) return 1;
     }
 
+    // If grouped by session AND comparing, put goal and persona columns near the front (after session)
+    if (isGroupedBySession && isComparing) {
+      const isGoalOrPersonaA = colA.id === SIMULATION_GOAL_COLUMN_ID || colA.id === SIMULATION_PERSONA_COLUMN_ID;
+      const isGoalOrPersonaB = colB.id === SIMULATION_GOAL_COLUMN_ID || colB.id === SIMULATION_PERSONA_COLUMN_ID;
+      if (isGoalOrPersonaA && !isGoalOrPersonaB) return -1;
+      if (!isGoalOrPersonaA && isGoalOrPersonaB) return 1;
+      // Between goal and persona, put goal first
+      if (colA.id === SIMULATION_GOAL_COLUMN_ID && colB.id === SIMULATION_PERSONA_COLUMN_ID) return -1;
+      if (colA.id === SIMULATION_PERSONA_COLUMN_ID && colB.id === SIMULATION_GOAL_COLUMN_ID) return 1;
+    }
+
     // If comparing, always put request time column first
     if (isComparing) {
       if (colA.id === INPUTS_COLUMN_ID) return -1;

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
@@ -24,6 +24,7 @@ import {
 import type { TracesTableColumn, EvalTraceComparisonEntry, RunEvaluationTracesDataEntry } from './types';
 import { TracesTableColumnGroup, TracesTableColumnType } from './types';
 import { getTraceInfoInputs, shouldUseTraceInfoV3 } from './utils/TraceUtils';
+import { SIMULATION_GOAL_KEY, SIMULATION_PERSONA_KEY } from './utils/SessionGroupingUtils';
 import type { ModelTraceInfoV3 } from '../model-trace-explorer';
 
 const GROUP_PRIORITY = [
@@ -249,8 +250,20 @@ export function getSimulationColumnsToAdd(
     return [];
   }
 
-  const hasGoalMetadata = traces.some((trace) => Boolean(trace.trace_metadata?.['mlflow.simulation.goal']));
-  const hasPersonaMetadata = traces.some((trace) => Boolean(trace.trace_metadata?.['mlflow.simulation.persona']));
+  let hasGoalMetadata = false;
+  let hasPersonaMetadata = false;
+
+  for (const trace of traces) {
+    if (!hasGoalMetadata && trace.trace_metadata?.[SIMULATION_GOAL_KEY]) {
+      hasGoalMetadata = true;
+    }
+    if (!hasPersonaMetadata && trace.trace_metadata?.[SIMULATION_PERSONA_KEY]) {
+      hasPersonaMetadata = true;
+    }
+    if (hasGoalMetadata && hasPersonaMetadata) {
+      break;
+    }
+  }
 
   if (!hasGoalMetadata && !hasPersonaMetadata) {
     return [];

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -495,6 +495,8 @@ export const GenAiTracesTableBody = React.memo(
                 toggleSessionExpanded={toggleSessionExpanded}
                 experimentId={experimentId}
                 getRunColor={getRunColor}
+                runUuid={runUuid}
+                compareToRunUuid={compareToRunUuid}
                 rowSelectionChangeHandler={rowSelectionChangeHandler}
               />
             ) : (

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
@@ -24,6 +24,8 @@ interface GenAiTracesTableSessionGroupedRowsProps {
   toggleSessionExpanded: (sessionId: string) => void;
   experimentId: string;
   getRunColor?: (runUuid: string) => string;
+  runUuid?: string;
+  compareToRunUuid?: string;
   rowSelectionChangeHandler?: (row: Row<EvalTraceComparisonEntry>, event: unknown) => void;
 }
 
@@ -41,6 +43,8 @@ interface SessionHeaderRowProps {
   isComparing: boolean;
   toggleSessionExpanded: (sessionId: string) => void;
   getRunColor?: (runUuid: string) => string;
+  runUuid?: string;
+  compareToRunUuid?: string;
 }
 
 export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTracesTableSessionGroupedRows({
@@ -56,6 +60,8 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
   expandedSessions,
   toggleSessionExpanded,
   getRunColor,
+  runUuid,
+  compareToRunUuid,
   rowSelectionChangeHandler,
 }: GenAiTracesTableSessionGroupedRowsProps) {
   // Create a map from eval data (contained in `groupedRows`) to the
@@ -113,6 +119,8 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
                 isComparing={isComparing}
                 toggleSessionExpanded={toggleSessionExpanded}
                 getRunColor={getRunColor}
+                runUuid={runUuid}
+                compareToRunUuid={compareToRunUuid}
               />
             </div>
           );
@@ -169,6 +177,8 @@ const SessionHeaderRow = React.memo(function SessionHeaderRow({
   isComparing,
   toggleSessionExpanded,
   getRunColor,
+  runUuid,
+  compareToRunUuid,
 }: SessionHeaderRowProps) {
   // Handle toggle all rows in this session
   const handleToggleExpanded = useCallback(() => {
@@ -202,6 +212,8 @@ const SessionHeaderRow = React.memo(function SessionHeaderRow({
           experimentId={experimentId}
           isComparing={isComparing}
           getRunColor={getRunColor}
+          runUuid={runUuid}
+          compareToRunUuid={compareToRunUuid}
         />
       ))}
     </TableRow>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -75,6 +75,8 @@ interface SessionHeaderCellProps {
   experimentId: string;
   isComparing?: boolean;
   getRunColor?: (runUuid: string) => string;
+  runUuid?: string;
+  compareToRunUuid?: string;
 }
 
 /**
@@ -92,17 +94,21 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
   experimentId,
   isComparing,
   getRunColor,
+  runUuid,
+  compareToRunUuid,
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const firstTrace = traces[0];
   const firstOtherTrace = otherTraces?.[0];
 
-  // Get run colors
-  const currentRunUuid = firstTrace?.trace_metadata?.[MLFLOW_SOURCE_RUN_KEY];
-  const otherRunUuid = firstOtherTrace?.trace_metadata?.[MLFLOW_SOURCE_RUN_KEY];
-  const currentRunColor = getRunColor && currentRunUuid ? getRunColor(currentRunUuid) : CURRENT_RUN_COLOR;
-  const otherRunColor = getRunColor && otherRunUuid ? getRunColor(otherRunUuid) : COMPARE_TO_RUN_COLOR;
+  // Get run colors - use the passed runUuid/compareToRunUuid props directly for consistency with the comparison header.
+  // Fall back to extracting from trace metadata if not available.
+  const currentRunUuidResolved = runUuid || firstTrace?.trace_metadata?.[MLFLOW_SOURCE_RUN_KEY];
+  const otherRunUuidResolved = compareToRunUuid || firstOtherTrace?.trace_metadata?.[MLFLOW_SOURCE_RUN_KEY];
+  const currentRunColor =
+    getRunColor && currentRunUuidResolved ? getRunColor(currentRunUuidResolved) : CURRENT_RUN_COLOR;
+  const otherRunColor = getRunColor && otherRunUuidResolved ? getRunColor(otherRunUuidResolved) : COMPARE_TO_RUN_COLOR;
 
   // Default: render empty cell for columns without session-level data
   let cellContent: React.ReactNode = null;
@@ -110,11 +116,12 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
   // Render specific columns with data from the first trace
   if (column.id === SESSION_COLUMN_ID) {
     // Session ID column - render as a tag with link to session view
-    // In comparison mode, show both session IDs stacked (unless they're the same)
+    // In comparison mode, show both session IDs stacked only if they're different
     const effectiveOtherSessionId = otherSessionId || (otherTraces?.[0] ? getSessionIdFromTrace(otherTraces[0]) : null);
     const showBothSessionIds = isComparing && effectiveOtherSessionId && effectiveOtherSessionId !== sessionId;
 
-    if (isComparing) {
+    if (isComparing && showBothSessionIds) {
+      // Different session IDs - show stacked
       cellContent = (
         <StackedComponents
           first={
@@ -134,25 +141,37 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
             )
           }
           second={
-            showBothSessionIds ? (
-              <SessionIdLinkWrapper sessionId={effectiveOtherSessionId} experimentId={experimentId}>
-                <Tag
-                  componentId="mlflow.genai-traces-table.session-header-session-id-other"
-                  title={effectiveOtherSessionId}
-                  css={{ maxWidth: '100%' }}
-                >
-                  <SpeechBubbleIcon css={{ fontSize: theme.typography.fontSizeBase, marginRight: theme.spacing.xs }} />
-                  <Typography.Text ellipsis>{effectiveOtherSessionId}</Typography.Text>
-                </Tag>
-              </SessionIdLinkWrapper>
-            ) : effectiveOtherSessionId ? (
-              // Same session ID - show a placeholder to maintain row height consistency
-              <div css={{ height: 24 }} />
-            ) : (
-              <NullCell isComparing />
-            )
+            <SessionIdLinkWrapper sessionId={effectiveOtherSessionId} experimentId={experimentId}>
+              <Tag
+                componentId="mlflow.genai-traces-table.session-header-session-id-other"
+                title={effectiveOtherSessionId}
+                css={{ maxWidth: '100%' }}
+              >
+                <SpeechBubbleIcon css={{ fontSize: theme.typography.fontSizeBase, marginRight: theme.spacing.xs }} />
+                <Typography.Text ellipsis>{effectiveOtherSessionId}</Typography.Text>
+              </Tag>
+            </SessionIdLinkWrapper>
           }
         />
+      );
+    } else if (isComparing) {
+      // Same session ID or only one exists - show single session ID (not stacked)
+      const displaySessionId = sessionId || effectiveOtherSessionId;
+      cellContent = displaySessionId ? (
+        <div css={{ overflow: 'hidden', minWidth: 0, maxWidth: '100%' }}>
+          <SessionIdLinkWrapper sessionId={displaySessionId} experimentId={experimentId}>
+            <Tag
+              componentId="mlflow.genai-traces-table.session-header-session-id"
+              title={displaySessionId}
+              css={{ maxWidth: '100%' }}
+            >
+              <SpeechBubbleIcon css={{ fontSize: theme.typography.fontSizeBase, marginRight: theme.spacing.xs }} />
+              <Typography.Text ellipsis>{displaySessionId}</Typography.Text>
+            </Tag>
+          </SessionIdLinkWrapper>
+        </div>
+      ) : (
+        <NullCell />
       );
     } else {
       cellContent = (

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
@@ -89,6 +89,8 @@ export {
   CUSTOM_METADATA_COLUMN_ID,
   SESSION_COLUMN_ID,
   INPUTS_COLUMN_ID,
+  SIMULATION_GOAL_COLUMN_ID,
+  SIMULATION_PERSONA_COLUMN_ID,
 } from './hooks/useTableColumns';
 
 // Test utilities

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
@@ -93,6 +93,8 @@ export {
   SIMULATION_PERSONA_COLUMN_ID,
 } from './hooks/useTableColumns';
 
+export { getSimulationColumnsToAdd } from './GenAiTracesTable.utils';
+
 // Test utilities
 export {
   createTestTraceInfoV3,

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.ts
@@ -17,8 +17,8 @@ export interface SessionHeaderRowData {
 
 export type GroupedTraceTableRowData = { type: 'trace'; data: EvalTraceComparisonEntry } | SessionHeaderRowData;
 
-const SIMULATION_GOAL_KEY = 'mlflow.simulation.goal';
-const SIMULATION_PERSONA_KEY = 'mlflow.simulation.persona';
+export const SIMULATION_GOAL_KEY = 'mlflow.simulation.goal';
+export const SIMULATION_PERSONA_KEY = 'mlflow.simulation.persona';
 
 /**
  * Extract session ID from a ModelTraceInfoV3.


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled - there were three issues here from the bug bash:

- The run color did not match the runs when comparing sessions
- The session IDs rendered weirdly (sometimes didn't show both sessions)
- Want to automatically show goal and persona

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
![fix_session_comparison_view](https://github.com/user-attachments/assets/87b50519-58d8-4bcc-8eb1-48d5ccbebdbe)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
