### PR TITLE
Add `/polish` GitHub Action to improve PR titles using AI

### DIFF
--- a/.github/workflows/polish.yml
+++ b/.github/workflows/polish.yml
@@ -1,0 +1,75 @@
+# Polish PR using AI
+
+name: Polish PR
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    paths:
+      - ".github/workflows/polish.yml"
+      - ".github/workflows/polish.sh"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  polish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Trigger conditions:
+    # - pull_request: skip fork PRs (no access to secrets)
+    # - issue_comment: only maintainers can trigger via `/polish`
+    if: >
+      (
+        github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+      )
+      || (
+        github.event.issue.pull_request
+        && github.event.comment.body == '/polish'
+        && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      )
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+      REPO: ${{ github.repository }}
+      COMMENT_ID: ${{ github.event.comment.id }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/workflows/polish.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Add reaction to comment
+        if: github.event_name != 'pull_request'
+        run: |
+          gh api \
+            --method POST \
+            "/repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content='eyes'
+
+      - name: Generate new title
+        id: generate
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          new_title=$(bash .github/workflows/polish.sh)
+          echo "new_title=$new_title" >> "$GITHUB_OUTPUT"
+
+      - name: Update PR title
+        if: github.event_name != 'pull_request'
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --title "${{ steps.generate.outputs.new_title }}"
+
+      - name: Post failure comment
+        if: failure() && github.event_name != 'pull_request'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+            "> [!WARNING]
+            > Failed to polish the PR. See [workflow run]($RUN_URL) for details."


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a GitHub Action that improves PR titles using AI when a maintainer comments `/polish`.

- Uses Anthropic API with structured outputs
- Fetches PR title, body, diff, and referenced issues for context
- Includes dry-run mode for testing when workflow files change

**Required setup:** Add `ANTHROPIC_API_KEY` to repository secrets

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
