### PR TITLE
fix: allow overriding notebook trace iframe base URL

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -738,6 +738,15 @@ MLFLOW_MAX_TRACES_TO_DISPLAY_IN_NOTEBOOK = _EnvironmentVariable(
     "MLFLOW_MAX_TRACES_TO_DISPLAY_IN_NOTEBOOK", int, 10
 )
 
+#: Override the base URL used for the notebook trace iframe renderer.
+#: This is useful when the tracking URI is only reachable inside a container
+#: network (e.g. http://mlflow:5000) but the browser must load assets from a
+#: host-reachable URL (e.g. http://localhost:5000).
+#: (default: ``None``)
+MLFLOW_NOTEBOOK_TRACE_RENDERER_BASE_URL = _EnvironmentVariable(
+    "MLFLOW_NOTEBOOK_TRACE_RENDERER_BASE_URL", str, None
+)
+
 #: Specifies the sampling ratio for traces. Value should be between 0.0 and 1.0.
 #: A value of 1.0 means all traces are sampled (default behavior).
 #: A value of 0.5 means 50% of traces are sampled.

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlencode, urljoin
 
 import mlflow
-from mlflow.environment_variables import MLFLOW_MAX_TRACES_TO_DISPLAY_IN_NOTEBOOK
+from mlflow.environment_variables import (
+    MLFLOW_MAX_TRACES_TO_DISPLAY_IN_NOTEBOOK,
+    MLFLOW_NOTEBOOK_TRACE_RENDERER_BASE_URL,
+)
 from mlflow.tracing.constant import TRACE_RENDERER_ASSET_PATH
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.uri import is_http_uri
@@ -55,7 +58,8 @@ IFRAME_HTML = """
 
 def get_notebook_iframe_html(traces: list["Trace"]):
     # fetch assets from tracking server
-    uri = urljoin(mlflow.get_tracking_uri(), f"{TRACE_RENDERER_ASSET_PATH}/index.html")
+    base_url = MLFLOW_NOTEBOOK_TRACE_RENDERER_BASE_URL.get() or mlflow.get_tracking_uri()
+    uri = urljoin(base_url, f"{TRACE_RENDERER_ASSET_PATH}/index.html")
     query_string = _get_query_string_for_traces(traces)
 
     # include mlflow version to invalidate browser cache when mlflow updates

--- a/tests/tracing/display/test_ipython.py
+++ b/tests/tracing/display/test_ipython.py
@@ -250,6 +250,16 @@ def test_mimebundle_in_oss():
     }
 
 
+def test_notebook_trace_renderer_base_url_override(monkeypatch):
+    trace = create_trace("a")
+    mlflow.set_tracking_uri("http://mlflow:5000")
+    monkeypatch.setenv("MLFLOW_NOTEBOOK_TRACE_RENDERER_BASE_URL", "http://localhost:5000")
+
+    html = get_notebook_iframe_html([trace])
+    assert "http://localhost:5000/static-files/lib/notebook-trace-renderer/index.html" in html
+    assert "http://mlflow:5000/static-files/lib/notebook-trace-renderer/index.html" not in html
+
+
 def test_display_in_oss(monkeypatch):
     mock_ipython = MockIPython()
     monkeypatch.setattr("IPython.get_ipython", lambda: mock_ipython)


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #16724 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
- Add `MLFLOW_NOTEBOOK_TRACE_RENDERER_BASE_URL` to override the notebook trace iframe base URL.
- Use the override when building the iframe src.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

- Started MLflow server (`localhost:5001`) + Jupyter (`localhost:8888`) in separate Docker containers.
    - In the Jupyter container, set:
        - `MLFLOW_TRACKING_URI=http://mlflow:5000`
        - `MLFLOW_NOTEBOOK_TRACE_RENDERER_BASE_URL=http://localhost:5001`
- Executed cells to create a trace and render the notebook iframe.

**Before fix**
<img width="1496" height="833" alt="スクリーンショット 2026-01-31 22 40 50" src="https://github.com/user-attachments/assets/856641d6-971a-4484-b1ad-da20345d9fad" />


**After fix**
<img width="1889" height="837" alt="スクリーンショット 2026-01-31 22 48 34" src="https://github.com/user-attachments/assets/a10678be-2c36-499a-910d-ede9fb46e24f" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Allow overriding the notebook trace iframe base URL via `MLFLOW_NOTEBOOK_TRACE_RENDERER_BASE_URL`, enabling trace rendering when the tracking URI is only reachable inside a container network.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)