### PR TITLE
[UI] Reduce complexity of isEmptyChartCard in RunsCharts rendering

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsCharts.common.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsCharts.common.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, test } from '@jest/globals';
 import type { MetricEntity } from '../../../types';
-import type { RunsChartsParallelCardConfig } from '../runs-charts.types';
+import type {
+  RunsChartsBarCardConfig,
+  RunsChartsContourCardConfig,
+  RunsChartsDifferenceCardConfig,
+  RunsChartsLineCardConfig,
+  RunsChartsParallelCardConfig,
+  RunsChartsScatterCardConfig,
+} from '../runs-charts.types';
 import { RunsChartType } from '../runs-charts.types';
-import { RunsChartsParallelChartCard } from './cards/RunsChartsParallelChartCard';
 import type { RunsChartsRunData } from './RunsCharts.common';
-import { isEmptyChartCard, removeOutliersFromMetricHistory } from './RunsCharts.common';
+import { createEmptyChartCardPredicate, isEmptyChartCard, removeOutliersFromMetricHistory } from './RunsCharts.common';
 
 describe('removeOutliersFromMetricHistory', () => {
   it.each([
@@ -48,5 +54,211 @@ describe('isEmptyChartCard', () => {
     );
 
     expect(isEmpty).toEqual(true);
+  });
+});
+
+describe('createEmptyChartCardPredicate', () => {
+  const mockRunData: RunsChartsRunData[] = [
+    {
+      uuid: 'run-1',
+      displayName: 'Run 1',
+      metrics: { metric_1: { key: 'metric_1', value: 10 }, metric_2: { key: 'metric_2', value: 20 } },
+      params: {},
+      tags: {},
+      images: {},
+      hidden: false,
+    } as unknown as RunsChartsRunData,
+    {
+      uuid: 'run-2',
+      displayName: 'Run 2',
+      metrics: { metric_3: { key: 'metric_3', value: 30 } },
+      params: {},
+      tags: {},
+      images: {},
+      hidden: false,
+    } as unknown as RunsChartsRunData,
+  ];
+
+  test('should create a predicate that filters hidden runs', () => {
+    const runDataWithHidden: RunsChartsRunData[] = [
+      ...mockRunData,
+      {
+        uuid: 'run-3',
+        displayName: 'Run 3',
+        metrics: { metric_4: { key: 'metric_4', value: 40 } },
+        params: {},
+        tags: {},
+        images: {},
+        hidden: true,
+      } as unknown as RunsChartsRunData,
+    ];
+
+    const predicate = createEmptyChartCardPredicate(runDataWithHidden);
+    const barChart: RunsChartsBarCardConfig = {
+      type: RunsChartType.BAR,
+      metricKey: 'metric_4',
+      deleted: false,
+      isGenerated: false,
+    };
+
+    expect(predicate(barChart)).toBe(true);
+  });
+
+  test('should identify empty bar chart', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+    const emptyBarChart: RunsChartsBarCardConfig = {
+      type: RunsChartType.BAR,
+      metricKey: 'nonexistent_metric',
+      deleted: false,
+      isGenerated: false,
+    };
+
+    expect(predicate(emptyBarChart)).toBe(true);
+  });
+
+  test('should identify non-empty bar chart', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+    const nonEmptyBarChart: RunsChartsBarCardConfig = {
+      type: RunsChartType.BAR,
+      metricKey: 'metric_1',
+      deleted: false,
+      isGenerated: false,
+    };
+
+    expect(predicate(nonEmptyBarChart)).toBe(false);
+  });
+
+  test('should identify empty contour chart', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+    const emptyContourChart: RunsChartsContourCardConfig = {
+      type: RunsChartType.CONTOUR,
+      xaxis: { key: 'metric_x', type: 'METRIC' },
+      yaxis: { key: 'metric_y', type: 'METRIC' },
+      zaxis: { key: 'metric_z', type: 'METRIC' },
+      deleted: false,
+      isGenerated: false,
+    };
+
+    expect(predicate(emptyContourChart)).toBe(true);
+  });
+
+  test('should identify non-empty contour chart', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+    const nonEmptyContourChart: RunsChartsContourCardConfig = {
+      type: RunsChartType.CONTOUR,
+      xaxis: { key: 'metric_1', type: 'METRIC' },
+      yaxis: { key: 'metric_2', type: 'METRIC' },
+      zaxis: { key: 'metric_3', type: 'METRIC' },
+      deleted: false,
+      isGenerated: false,
+    };
+
+    expect(predicate(nonEmptyContourChart)).toBe(false);
+  });
+
+  test('should identify empty scatter chart', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+    const emptyScatterChart: RunsChartsScatterCardConfig = {
+      type: RunsChartType.SCATTER,
+      xaxis: { key: 'metric_x', type: 'METRIC' },
+      yaxis: { key: 'metric_y', type: 'METRIC' },
+      deleted: false,
+      isGenerated: false,
+    } as unknown as RunsChartsScatterCardConfig;
+
+    expect(predicate(emptyScatterChart)).toBe(true);
+  });
+
+  test('should identify non-empty scatter chart', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+    const nonEmptyScatterChart: RunsChartsScatterCardConfig = {
+      type: RunsChartType.SCATTER,
+      xaxis: { key: 'metric_1', type: 'METRIC' },
+      yaxis: { key: 'metric_2', type: 'METRIC' },
+      deleted: false,
+      isGenerated: false,
+    } as unknown as RunsChartsScatterCardConfig;
+
+    expect(predicate(nonEmptyScatterChart)).toBe(false);
+  });
+
+  test('should identify empty line chart', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+    const emptyLineChart: RunsChartsLineCardConfig = {
+      type: RunsChartType.LINE,
+      metricKey: 'nonexistent_metric',
+      selectedMetricKeys: ['nonexistent_metric'],
+      deleted: false,
+      isGenerated: false,
+    } as unknown as RunsChartsLineCardConfig;
+
+    expect(predicate(emptyLineChart)).toBe(true);
+  });
+
+  test('should identify non-empty line chart', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+    const nonEmptyLineChart: RunsChartsLineCardConfig = {
+      type: RunsChartType.LINE,
+      metricKey: 'metric_1',
+      selectedMetricKeys: ['metric_1', 'metric_2'],
+      deleted: false,
+      isGenerated: false,
+      runsCountToCompare: 0,
+    } as unknown as RunsChartsLineCardConfig;
+
+    expect(predicate(nonEmptyLineChart)).toBe(false);
+  });
+
+  test('should identify empty difference chart', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+    const emptyDifferenceChart: RunsChartsDifferenceCardConfig = {
+      type: RunsChartType.DIFFERENCE,
+      compareGroups: [],
+      deleted: false,
+      isGenerated: false,
+    } as unknown as RunsChartsDifferenceCardConfig;
+
+    expect(predicate(emptyDifferenceChart)).toBe(true);
+  });
+
+  test('should identify non-empty difference chart', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+    const nonEmptyDifferenceChart: RunsChartsDifferenceCardConfig = {
+      type: RunsChartType.DIFFERENCE,
+      compareGroups: [{ groupId: 'group1' }],
+      deleted: false,
+      isGenerated: false,
+    } as unknown as RunsChartsDifferenceCardConfig;
+
+    expect(predicate(nonEmptyDifferenceChart)).toBe(false);
+  });
+
+  test('should reuse predicate for multiple chart configs efficiently', () => {
+    const predicate = createEmptyChartCardPredicate(mockRunData);
+
+    const chart1: RunsChartsBarCardConfig = {
+      type: RunsChartType.BAR,
+      metricKey: 'metric_1',
+      deleted: false,
+      isGenerated: false,
+    };
+
+    const chart2: RunsChartsBarCardConfig = {
+      type: RunsChartType.BAR,
+      metricKey: 'metric_2',
+      deleted: false,
+      isGenerated: false,
+    };
+
+    const chart3: RunsChartsBarCardConfig = {
+      type: RunsChartType.BAR,
+      metricKey: 'nonexistent',
+      deleted: false,
+      isGenerated: false,
+    };
+
+    expect(predicate(chart1)).toBe(false);
+    expect(predicate(chart2)).toBe(false);
+    expect(predicate(chart3)).toBe(true);
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
@@ -3,7 +3,7 @@ import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { useUpdateRunsChartsUIConfiguration } from '../hooks/useRunsChartsUIConfiguration';
 import type { RunsChartsCardConfig } from '../runs-charts.types';
 import type { RunsChartsRunData } from './RunsCharts.common';
-import { isEmptyChartCard } from './RunsCharts.common';
+import { createEmptyChartCardPredicate } from './RunsCharts.common';
 import { useMediaQuery } from '@databricks/web-shared/hooks';
 import { Global } from '@emotion/react';
 import { FormattedMessage } from 'react-intl';
@@ -159,11 +159,12 @@ export const RunsChartsDraggableCardsGridSection = memo(
     );
 
     const cardsToRender = useMemo(() => {
+      const isEmptyChartCard = createEmptyChartCardPredicate(chartRunData);
       return cardsConfig.filter((cardConfig) => {
         if (!hideEmptyCharts) {
           return true;
         }
-        return !isEmptyChartCard(chartRunData, cardConfig);
+        return !isEmptyChartCard(cardConfig);
       });
     }, [cardsConfig, chartRunData, hideEmptyCharts]);
 

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
@@ -8,7 +8,7 @@ import { RunsChartsCardConfig } from '../runs-charts/runs-charts.types';
 import type { RunsChartType } from '../runs-charts/runs-charts.types';
 import { type SerializedRunsChartsCardConfigCard } from '../runs-charts/runs-charts.types';
 import { RunsChartsConfigureModal } from '../runs-charts/components/RunsChartsConfigureModal';
-import { isEmptyChartCard, type RunsChartsRunData } from '../runs-charts/components/RunsCharts.common';
+import { createEmptyChartCardPredicate, type RunsChartsRunData } from '../runs-charts/components/RunsCharts.common';
 import {
   AUTOML_EVALUATION_METRIC_TAG,
   LOG_IMAGE_TAG_INDICATOR,
@@ -362,7 +362,8 @@ const RunsCompareImpl = ({
   // If using draggable grid layout, already filter out charts that are empty or deleted
   const visibleChartCards = useMemo(() => {
     if (hideEmptyCharts) {
-      return compareRunCharts?.filter((chartCard) => !chartCard.deleted && !isEmptyChartCard(chartData, chartCard));
+      const isEmptyChartCard = createEmptyChartCardPredicate(chartData);
+      return compareRunCharts?.filter((chartCard) => !chartCard.deleted && !isEmptyChartCard(chartCard));
     }
     return compareRunCharts?.filter((chartCard) => !chartCard.deleted);
   }, [chartData, compareRunCharts, hideEmptyCharts]);


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

### What changes are proposed in this pull request?

This commit optimizes the performance of empty chart detection in RunsCharts when dealing with high metric counts. It introduces a predicate factory pattern that pre-computes which metrics are available across runs once, then reuses that information when evaluating multiple charts. The implementation replaces expensive array operations with efficient Set-based lookups, significantly reducing redundant computation when filtering large numbers of chart cards.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Before:

https://github.com/user-attachments/assets/b176cfce-1042-4b7b-b1c0-a5b82b5988d2

After:

https://github.com/user-attachments/assets/89df448b-8353-44bf-8293-4c10d77729dd

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
