### PR TITLE
Fix N+1 query issue in search_registered_models

### DIFF
--- a/mlflow/store/model_registry/dbmodels/models.py
+++ b/mlflow/store/model_registry/dbmodels/models.py
@@ -53,7 +53,7 @@ class SqlRegisteredModel(Base):
             f"{self.creation_time}, {self.last_updated_time})>"
         )
 
-    def to_mlflow_entity(self, preloaded_latest_versions: list | None = None):
+    def to_mlflow_entity(self, preloaded_latest_versions: list["SqlModelVersion"] | None = None):
         """
         Convert to MLflow RegisteredModel entity.
 

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -178,7 +178,9 @@ class SqlAlchemyStore(AbstractStore):
         ]
 
     @classmethod
-    def _get_latest_versions_for_models(cls, session, model_names: list[str]) -> dict[str, list]:
+    def _get_latest_versions_for_models(
+        cls, session, model_names: list[str]
+    ) -> dict[str, list[SqlModelVersion]]:
         """
         Batch-fetch the latest model version per stage for multiple registered models.
 
@@ -221,7 +223,7 @@ class SqlAlchemyStore(AbstractStore):
 
         latest_versions = session.execute(query).scalars().all()
 
-        result: dict[str, list] = {name: [] for name in model_names}
+        result: dict[str, list[SqlModelVersion]] = {name: [] for name in model_names}
         for mv in latest_versions:
             result[mv.name].append(mv)
 
@@ -446,8 +448,8 @@ class SqlAlchemyStore(AbstractStore):
 
             rm_entities = [
                 rm.to_mlflow_entity(preloaded_latest_versions=latest_versions_map.get(rm.name))
-                for rm in sql_registered_models
-            ][:max_results]
+                for rm in sql_registered_models[:max_results]
+            ]
             return PagedList(rm_entities, next_page_token)
 
     @classmethod

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -165,13 +165,67 @@ class SqlAlchemyStore(AbstractStore):
         """
         A list of SQLAlchemy query options that can be used to eagerly
         load the following registered model attributes
-        when fetching a registered model: ``registered_model_tags``.
+        when fetching a registered model: ``registered_model_tags`` and
+        ``registered_model_aliases``.
         """
         # Use a subquery load rather than a joined load in order to minimize the memory overhead
         # of the eager loading procedure. For more information about relationship loading
         # techniques, see https://docs.sqlalchemy.org/en/13/orm/
         # loading_relationships.html#relationship-loading-techniques
-        return [sqlalchemy.orm.subqueryload(SqlRegisteredModel.registered_model_tags)]
+        return [
+            sqlalchemy.orm.subqueryload(SqlRegisteredModel.registered_model_tags),
+            sqlalchemy.orm.subqueryload(SqlRegisteredModel.registered_model_aliases),
+        ]
+
+    @classmethod
+    def _get_latest_versions_for_models(cls, session, model_names: list[str]) -> dict[str, list]:
+        """
+        Batch-fetch the latest model version per stage for multiple registered models.
+
+        Uses a SQL window function to compute the latest version per (name, stage) directly
+        in the database, avoiding N+1 queries and Python-side iteration through all versions.
+        """
+        if not model_names:
+            return {}
+
+        row_num = (
+            sqlalchemy.func.row_number()
+            .over(
+                partition_by=[SqlModelVersion.name, SqlModelVersion.current_stage],
+                order_by=SqlModelVersion.version.desc(),
+            )
+            .label("rn")
+        )
+
+        subquery = (
+            select(SqlModelVersion, row_num)
+            .where(
+                SqlModelVersion.name.in_(model_names),
+                SqlModelVersion.current_stage != STAGE_DELETED_INTERNAL,
+            )
+            .subquery()
+        )
+
+        query = (
+            select(SqlModelVersion)
+            .join(
+                subquery,
+                sqlalchemy.and_(
+                    SqlModelVersion.name == subquery.c.name,
+                    SqlModelVersion.version == subquery.c.version,
+                ),
+            )
+            .where(subquery.c.rn == 1)
+            .options(*cls._get_eager_model_version_query_options())
+        )
+
+        latest_versions = session.execute(query).scalars().all()
+
+        result: dict[str, list] = {name: [] for name in model_names}
+        for mv in latest_versions:
+            result[mv.name].append(mv)
+
+        return result
 
     @staticmethod
     def _get_eager_model_version_query_options():
@@ -385,7 +439,15 @@ class SqlAlchemyStore(AbstractStore):
             next_page_token = self._compute_next_token(
                 max_results_for_query, len(sql_registered_models), offset, max_results
             )
-            rm_entities = [rm.to_mlflow_entity() for rm in sql_registered_models][:max_results]
+
+            # Batch-fetch latest versions for all models to avoid N+1 queries
+            model_names = [rm.name for rm in sql_registered_models[:max_results]]
+            latest_versions_map = self._get_latest_versions_for_models(session, model_names)
+
+            rm_entities = [
+                rm.to_mlflow_entity(preloaded_latest_versions=latest_versions_map.get(rm.name))
+                for rm in sql_registered_models
+            ][:max_results]
             return PagedList(rm_entities, next_page_token)
 
     @classmethod


### PR DESCRIPTION

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #16587

### What changes are proposed in this pull request?

The search_registered_models API was slow when models had many versions due to N+1 queries - for each model returned, separate queries were triggered to lazy-load model_versions and registered_model_aliases.

Changes:
- Add SQL window function (ROW_NUMBER) to batch-fetch latest version per stage for all models in a single query
- Eagerly load registered_model_aliases to fix that N+1 as well
- Update to_mlflow_entity() to accept pre-computed latest versions

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Improve the performance of the search_registered_models endpoint by speeding it up by x3 times with 60k model versions.
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
