### PR TITLE
Mark prompt registry APIs as stable.

### DIFF
--- a/docs/docs/genai/prompt-registry/optimize-prompts.mdx
+++ b/docs/docs/genai/prompt-registry/optimize-prompts.mdx
@@ -7,7 +7,7 @@ import { APILink } from "@site/src/components/APILink";
 import { CardGroup, Card, SmallLogoCard } from "@site/src/components/Card";
 import Link from "@docusaurus/Link";
 
-# Optimize Prompts (Experimental)
+# Optimize Prompts
 
 **The simple way to continuously improve your AI agents and prompts.**
 

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -16,7 +16,6 @@ from mlflow.prompt.registry_utils import PromptCache as PromptCache
 from mlflow.prompt.registry_utils import require_prompt_registry
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.tracking.client import MlflowClient
-from mlflow.utils.annotations import experimental
 
 
 @contextmanager
@@ -264,7 +263,6 @@ def delete_prompt_alias(name: str, alias: str) -> None:
         return registry_api.delete_prompt_alias(name=name, alias=alias)
 
 
-@experimental(version="3.5.0")
 @require_prompt_registry
 def get_prompt_tags(name: str) -> Prompt:
     """Get a prompt's metadata from the MLflow Prompt Registry.
@@ -276,7 +274,6 @@ def get_prompt_tags(name: str) -> Prompt:
         return MlflowClient().get_prompt(name=name).tags
 
 
-@experimental(version="3.5.0")
 @require_prompt_registry
 def set_prompt_tag(name: str, key: str, value: str) -> None:
     """Set a tag on a prompt in the MLflow Prompt Registry.
@@ -290,7 +287,6 @@ def set_prompt_tag(name: str, key: str, value: str) -> None:
         MlflowClient().set_prompt_tag(name=name, key=key, value=value)
 
 
-@experimental(version="3.5.0")
 @require_prompt_registry
 def delete_prompt_tag(name: str, key: str) -> None:
     """Delete a tag from a prompt in the MLflow Prompt Registry.
@@ -303,7 +299,6 @@ def delete_prompt_tag(name: str, key: str) -> None:
         MlflowClient().delete_prompt_tag(name=name, key=key)
 
 
-@experimental(version="3.5.0")
 @require_prompt_registry
 def set_prompt_version_tag(name: str, version: str | int, key: str, value: str) -> None:
     """Set a tag on a prompt version in the MLflow Prompt Registry.
@@ -318,7 +313,6 @@ def set_prompt_version_tag(name: str, version: str | int, key: str, value: str) 
         MlflowClient().set_prompt_version_tag(name=name, version=version, key=key, value=value)
 
 
-@experimental(version="3.5.0")
 @require_prompt_registry
 def delete_prompt_version_tag(name: str, version: str | int, key: str) -> None:
     """Delete a tag from a prompt version in the MLflow Prompt Registry.
@@ -332,7 +326,6 @@ def delete_prompt_version_tag(name: str, version: str | int, key: str) -> None:
         MlflowClient().delete_prompt_version_tag(name=name, version=version, key=key)
 
 
-@experimental(version="3.8.0")
 @require_prompt_registry
 def set_prompt_model_config(
     name: str,
@@ -394,7 +387,6 @@ def set_prompt_model_config(
         )
 
 
-@experimental(version="3.8.0")
 @require_prompt_registry
 def delete_prompt_model_config(name: str, version: str | int) -> None:
     """Delete the model configuration from a specific prompt version.


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
As titled
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
