### PR TITLE
Add Bedrock Converse API support for basic chat

### DIFF
--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -147,7 +147,7 @@ class AI21Adapter(ProviderAdapter):
 
 class ConverseAdapter(ProviderAdapter):
     # TODO Add tool calling support (toolUse/toolResult blocks, tool_choice mapping)
-    # TODO handle images, documents, videos
+    # TODO handle images
 
     @classmethod
     def _transform_message_content(cls, content):
@@ -165,18 +165,6 @@ class ConverseAdapter(ProviderAdapter):
                     raise AIGatewayException(
                         status_code=422,
                         detail="Image content is not yet supported in "
-                        "Bedrock Converse API integration",
-                    )
-                elif part_type == "document":
-                    raise AIGatewayException(
-                        status_code=422,
-                        detail="Document content is not yet supported in "
-                        "Bedrock Converse API integration",
-                    )
-                elif part_type == "video":
-                    raise AIGatewayException(
-                        status_code=422,
-                        detail="Video content is not yet supported in "
                         "Bedrock Converse API integration",
                     )
                 else:

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import json
 import time
 from enum import Enum
+from typing import AsyncIterable
 
 from mlflow.gateway.config import AmazonBedrockConfig, AWSIdAndKey, AWSRole, EndpointConfig
 from mlflow.gateway.constants import (
@@ -11,7 +14,7 @@ from mlflow.gateway.providers.anthropic import AnthropicAdapter
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.cohere import CohereAdapter
 from mlflow.gateway.providers.utils import rename_payload_keys
-from mlflow.gateway.schemas import completions
+from mlflow.gateway.schemas import chat, completions
 
 AWS_BEDROCK_ANTHROPIC_MAXIMUM_MAX_TOKENS = 8191
 
@@ -131,6 +134,279 @@ class AI21Adapter(ProviderAdapter):
                 completion_tokens=None,
                 total_tokens=None,
             ),
+        )
+
+    @classmethod
+    def embeddings_to_model(cls, payload, config):
+        raise NotImplementedError
+
+    @classmethod
+    def model_to_embeddings(cls, resp, config):
+        raise NotImplementedError
+
+
+class ConverseAdapter(ProviderAdapter):
+    # TODO Add tool calling support (toolUse/toolResult blocks, tool_choice mapping)
+    # TODO handle images, documents, videos
+
+    @classmethod
+    def _transform_message_content(cls, content):
+        if isinstance(content, str):
+            return [{"text": content}]
+
+        if isinstance(content, list):
+            converse_content = []
+            for part in content:
+                part_type = part.get("type")
+
+                if part_type == "text":
+                    converse_content.append({"text": part["text"]})
+                elif part_type == "image_url":
+                    raise AIGatewayException(
+                        status_code=422,
+                        detail="Image content is not yet supported in "
+                        "Bedrock Converse API integration",
+                    )
+                elif part_type == "document":
+                    raise AIGatewayException(
+                        status_code=422,
+                        detail="Document content is not yet supported in "
+                        "Bedrock Converse API integration",
+                    )
+                elif part_type == "video":
+                    raise AIGatewayException(
+                        status_code=422,
+                        detail="Video content is not yet supported in "
+                        "Bedrock Converse API integration",
+                    )
+                else:
+                    raise AIGatewayException(
+                        status_code=422,
+                        detail=f"Unsupported content part type: '{part_type}'. "
+                        "Converse API currently only supports 'text' content parts.",
+                    )
+            return converse_content
+
+        return [{"text": str(content)}]
+
+    @classmethod
+    def chat_to_model(cls, payload, config):
+        n = payload.pop("n", 1)
+        if n != 1:
+            raise AIGatewayException(
+                status_code=422,
+                detail=f"'n' must be '1' for Bedrock Converse API. Received value: '{n}'.",
+            )
+
+        # TODO: Add tool calling support in a future update
+        if payload.get("tools"):
+            raise AIGatewayException(
+                status_code=422,
+                detail="Tool calling is not yet supported in Bedrock Converse API integration. "
+                "This feature will be added in a future update.",
+            )
+        if payload.get("tool_choice"):
+            raise AIGatewayException(
+                status_code=422,
+                detail="tool_choice is not yet supported in Bedrock Converse API integration. "
+                "This feature will be added in a future update.",
+            )
+
+        messages = payload.get("messages", [])
+
+        # Separate system messages from regular messages
+        # Converse API expects system messages in a separate "system" parameter
+        system_messages = []
+        converse_messages = []
+
+        for msg in messages:
+            role = msg["role"]
+
+            # TODO: Add tool message support in a future update
+            if role == "tool":
+                raise AIGatewayException(
+                    status_code=422,
+                    detail="Tool result messages (role='tool') are not yet supported in "
+                    "Bedrock Converse API integration. "
+                    "This feature will be added in a future update.",
+                )
+            if msg.get("tool_calls"):
+                raise AIGatewayException(
+                    status_code=422,
+                    detail="Assistant messages with tool_calls are not yet supported in "
+                    "Bedrock Converse API integration. "
+                    "This feature will be added in a future update.",
+                )
+
+            if role == "system":
+                # System messages go in a separate list
+                # Converse API only supports text in system blocks
+                content = msg.get("content", "")
+                if not isinstance(content, str):
+                    raise AIGatewayException(
+                        status_code=422,
+                        detail="System message content must be a string. "
+                        "Bedrock Converse API does not support content parts (e.g., images) "
+                        "in system messages.",
+                    )
+                system_messages.append({"text": content})
+            else:
+                converse_msg = {
+                    "role": role,
+                    "content": cls._transform_message_content(msg.get("content", "")),
+                }
+                converse_messages.append(converse_msg)
+
+        request = {"messages": converse_messages}
+        if system_messages:
+            request["system"] = system_messages
+
+        inference_config = {}
+        if "temperature" in payload:
+            inference_config["temperature"] = payload["temperature"]
+        if "max_tokens" in payload:
+            inference_config["maxTokens"] = payload["max_tokens"]
+        elif "max_completion_tokens" in payload:
+            inference_config["maxTokens"] = payload["max_completion_tokens"]
+        if "top_p" in payload:
+            inference_config["topP"] = payload["top_p"]
+        if "stop" in payload:
+            inference_config["stopSequences"] = payload["stop"]
+
+        if inference_config:
+            request["inferenceConfig"] = inference_config
+
+        return request
+
+    @classmethod
+    def model_to_chat(cls, resp, config):
+        output_message = resp.get("output", {}).get("message", {})
+        content_blocks = output_message.get("content", [])
+
+        text_parts = [block["text"] for block in content_blocks if "text" in block]
+        content = "".join(text_parts) if text_parts else None
+
+        stop_reason = resp.get("stopReason", "end_turn")
+        finish_reason_map = {
+            "end_turn": "stop",
+            "max_tokens": "length",
+            "stop_sequence": "stop",
+            "content_filtered": "content_filter",
+        }
+        finish_reason = finish_reason_map.get(stop_reason, "stop")
+
+        message = chat.ResponseMessage(
+            role=output_message.get("role", "assistant"),
+            content=content,
+            refusal=None,
+        )
+
+        usage_data = resp.get("usage", {})
+        usage = chat.ChatUsage(
+            prompt_tokens=usage_data.get("inputTokens"),
+            completion_tokens=usage_data.get("outputTokens"),
+            total_tokens=usage_data.get("totalTokens"),
+        )
+
+        return chat.ResponsePayload(
+            id=None,  # Converse API doesn't provide request ID
+            created=int(time.time()),
+            object="chat.completion",
+            model=config.model.name,
+            choices=[
+                chat.Choice(
+                    index=0,
+                    message=message,
+                    finish_reason=finish_reason,
+                )
+            ],
+            usage=usage,
+        )
+
+    @classmethod
+    def chat_streaming_to_model(cls, payload, config):
+        return cls.chat_to_model(payload, config)
+
+    @classmethod
+    def model_to_chat_streaming(cls, chunk, config):
+        """
+        The converse_stream API returns events like:
+        - messageStart: Start of message
+        - contentBlockStart: Start of content block
+        - contentBlockDelta: Incremental content (text)
+        - contentBlockStop: End of content block
+        - messageStop: End of message with stop reason
+        - metadata: Usage statistics
+        """
+        event_type = chunk.get("type")
+
+        # Handle different event types
+        if event_type == "contentBlockDelta":
+            # Text delta events
+            delta_data = chunk.get("delta", {})
+            if "text" in delta_data:
+                return chat.StreamResponsePayload(
+                    id=None,
+                    created=int(time.time()),
+                    object="chat.completion.chunk",
+                    model=config.model.name,
+                    choices=[
+                        chat.StreamChoice(
+                            # Always use index=0 for choice index (assuming n=1)
+                            # This is NOT the contentBlockIndex, which is used only internally
+                            index=0,
+                            finish_reason=None,
+                            delta=chat.StreamDelta(
+                                role="assistant",
+                                content=delta_data["text"],
+                            ),
+                        )
+                    ],
+                )
+
+        elif event_type == "messageStop":
+            stop_reason = chunk.get("stopReason", "end_turn")
+            finish_reason_map = {
+                "end_turn": "stop",
+                "max_tokens": "length",
+                "stop_sequence": "stop",
+                "content_filtered": "content_filter",
+            }
+            finish_reason = finish_reason_map.get(stop_reason, "stop")
+
+            return chat.StreamResponsePayload(
+                id=None,
+                created=int(time.time()),
+                object="chat.completion.chunk",
+                model=config.model.name,
+                choices=[
+                    chat.StreamChoice(
+                        index=0,
+                        finish_reason=finish_reason,
+                        delta=chat.StreamDelta(),
+                    )
+                ],
+            )
+
+        elif event_type == "metadata":
+            # Usage metadata event - currently not converted to usage info in stream responses.
+            # In the Converse API, metadata (including usage) arrives after messageStop,
+            # which makes it difficult to include in the final content chunk.
+            return None
+
+        # For other events (messageStart, contentBlockStart, contentBlockStop), return None
+        return None
+
+    @classmethod
+    def completions_to_model(cls, payload, config):
+        raise NotImplementedError(
+            "Converse API does not support completions. Use chat endpoint instead."
+        )
+
+    @classmethod
+    def model_to_completions(cls, resp, config):
+        raise NotImplementedError(
+            "Converse API does not support completions. Use chat endpoint instead."
         )
 
     @classmethod
@@ -288,6 +564,17 @@ class AmazonBedrockProvider(BaseProvider):
         except botocore.exceptions.ReadTimeoutError as e:
             raise AIGatewayException(status_code=408) from e
 
+    def _converse_request(self, **kwargs):
+        """
+        Make a request using the Bedrock Converse API.
+        """
+        import botocore.exceptions
+
+        try:
+            return self.get_bedrock_client().converse(modelId=self.config.model.name, **kwargs)
+        except botocore.exceptions.ReadTimeoutError as e:
+            raise AIGatewayException(status_code=408) from e
+
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
         from fastapi.encoders import jsonable_encoder
 
@@ -296,3 +583,107 @@ class AmazonBedrockProvider(BaseProvider):
         payload = self.adapter_class.completions_to_model(payload, self.config)
         response = self._request(payload)
         return self.adapter_class.model_to_completions(response, self.config)
+
+    async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        """
+        Chat completion using Bedrock Converse API.
+        """
+        from fastapi.encoders import jsonable_encoder
+
+        self.check_for_model_field(payload)
+        payload = jsonable_encoder(payload, exclude_none=True, exclude_defaults=True)
+
+        # Transform to Converse API format
+        converse_payload = ConverseAdapter.chat_to_model(payload, self.config)
+
+        # Make the request
+        response = self._converse_request(**converse_payload)
+
+        # Transform response back to MLflow format
+        return ConverseAdapter.model_to_chat(response, self.config)
+
+    async def chat_stream(
+        self, payload: chat.RequestPayload
+    ) -> AsyncIterable[chat.StreamResponsePayload]:
+        """
+        Streaming chat completion using Bedrock Converse Stream API.
+
+        The converse_stream API returns an event stream with the following event types:
+        - messageStart: Beginning of the response
+        - contentBlockStart: Start of a content block (text)
+        - contentBlockDelta: Incremental content chunks
+        - contentBlockStop: End of a content block
+        - messageStop: End of message with stop reason
+        - metadata: Usage statistics
+        """
+        from fastapi.encoders import jsonable_encoder
+
+        self.check_for_model_field(payload)
+        payload = jsonable_encoder(payload, exclude_none=True, exclude_defaults=True)
+
+        if payload.get("stream_options", {}).get("include_usage"):
+            raise AIGatewayException(
+                status_code=422,
+                detail="stream_options.include_usage is not supported for Bedrock streaming",
+            )
+
+        # Transform to Converse API format (same as non-streaming)
+        converse_payload = ConverseAdapter.chat_streaming_to_model(payload, self.config)
+
+        # Make streaming request
+        try:
+            response = self.get_bedrock_client().converse_stream(
+                modelId=self.config.model.name, **converse_payload
+            )
+        except Exception as e:
+            raise AIGatewayException(
+                status_code=500,
+                detail=f"Bedrock converse_stream request failed: {e}",
+            ) from e
+
+        # Parse event stream
+        event_stream = response.get("stream")
+        if not event_stream:
+            raise AIGatewayException(
+                status_code=500,
+                detail="No event stream returned from converse_stream",
+            )
+
+        for event in event_stream:
+            # Extract event type and data
+            if "messageStart" in event:
+                # Message start event - no data to yield
+                continue
+
+            elif "contentBlockStart" in event:
+                # Content block start - no data to yield for text blocks
+                continue
+
+            elif "contentBlockDelta" in event:
+                # Content delta event - yield chunk
+                delta_data = event["contentBlockDelta"]
+
+                chunk = {
+                    "type": "contentBlockDelta",
+                    "delta": delta_data.get("delta", {}),
+                }
+                if stream_chunk := ConverseAdapter.model_to_chat_streaming(chunk, self.config):
+                    yield stream_chunk
+
+            elif "contentBlockStop" in event:
+                # Content block end - no data to yield
+                continue
+
+            elif "messageStop" in event:
+                # Message stop event with stop reason
+                stop_data = event["messageStop"]
+                chunk = {
+                    "type": "messageStop",
+                    "stopReason": stop_data.get("stopReason", "end_turn"),
+                }
+                if stream_chunk := ConverseAdapter.model_to_chat_streaming(chunk, self.config):
+                    yield stream_chunk
+
+            elif "metadata" in event:
+                # Metadata event with usage statistics
+                continue

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -609,9 +609,7 @@ def test_chat_to_model_transformation(fixture):
     assert result["messages"] == fixture["expected_converse_request"]["messages"]
 
     if "inferenceConfig" in fixture["expected_converse_request"]:
-        assert (
-            result["inferenceConfig"] == fixture["expected_converse_request"]["inferenceConfig"]
-        )
+        assert result["inferenceConfig"] == fixture["expected_converse_request"]["inferenceConfig"]
 
 
 def test_chat_to_model_uses_max_completion_tokens(bedrock_chat_config):
@@ -696,13 +694,9 @@ async def test_chat_stream_basic(bedrock_chat_config):
 
         provider = AmazonBedrockProvider(bedrock_chat_config)
 
-        payload = chat.RequestPayload(
-            messages=[chat.RequestMessage(role="user", content="Hello")]
-        )
+        payload = chat.RequestPayload(messages=[chat.RequestMessage(role="user", content="Hello")])
 
-        chunks = [
-            jsonable_encoder(chunk) async for chunk in provider.chat_stream(payload) if chunk
-        ]
+        chunks = [jsonable_encoder(chunk) async for chunk in provider.chat_stream(payload) if chunk]
 
         assert len(chunks) > 0, "Should receive streaming chunks"
 
@@ -774,9 +768,7 @@ def test_unsupported_content_part_types_raise_error(bedrock_chat_config, part):
         ConverseAdapter.chat_to_model(payload, bedrock_chat_config)
 
     assert exc_info.value.status_code == 422
-    assert "Converse API currently only supports 'text' content parts" in str(
-        exc_info.value.detail
-    )
+    assert "Converse API currently only supports 'text' content parts" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
@@ -822,9 +814,7 @@ async def test_streaming_omits_usage_when_stream_options_not_enabled(bedrock_cha
             messages=[chat.RequestMessage(role="user", content="Hello")],
         )
 
-        chunks = [
-            jsonable_encoder(chunk) async for chunk in provider.chat_stream(payload) if chunk
-        ]
+        chunks = [jsonable_encoder(chunk) async for chunk in provider.chat_stream(payload) if chunk]
 
         chunks_with_usage = [c for c in chunks if c.get("usage")]
         assert len(chunks_with_usage) == 0, "Usage should not be emitted without include_usage"
@@ -887,9 +877,7 @@ def test_tool_calling_not_yet_supported(bedrock_chat_config):
             }
         ],
     }
-    with pytest.raises(
-        AIGatewayException, match="Tool calling is not yet supported"
-    ) as exc_info:
+    with pytest.raises(AIGatewayException, match="Tool calling is not yet supported") as exc_info:
         ConverseAdapter.chat_to_model(payload_with_tools, bedrock_chat_config)
     assert exc_info.value.status_code == 422
 
@@ -897,9 +885,7 @@ def test_tool_calling_not_yet_supported(bedrock_chat_config):
         "messages": [{"role": "user", "content": "Hello"}],
         "tool_choice": "auto",
     }
-    with pytest.raises(
-        AIGatewayException, match="tool_choice is not yet supported"
-    ) as exc_info:
+    with pytest.raises(AIGatewayException, match="tool_choice is not yet supported") as exc_info:
         ConverseAdapter.chat_to_model(payload_with_tool_choice, bedrock_chat_config)
     assert exc_info.value.status_code == 422
 
@@ -943,8 +929,6 @@ def test_tool_messages_not_yet_supported(bedrock_chat_config):
             },
         ],
     }
-    with pytest.raises(
-        AIGatewayException, match="tool_calls are not yet supported"
-    ) as exc_info:
+    with pytest.raises(AIGatewayException, match="tool_calls are not yet supported") as exc_info:
         ConverseAdapter.chat_to_model(payload_with_tool_calls, bedrock_chat_config)
     assert exc_info.value.status_code == 422

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -420,3 +420,531 @@ async def test_bedrock_request_response(
 def test_amazon_bedrock_model_provider(model_name, expected):
     provider = AmazonBedrockModelProvider.of_str(model_name)
     assert provider == expected
+
+
+# Converse API Test Fixtures and Tests
+
+
+_DEFAULT_BEDROCK_CHAT_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+
+def bedrock_chat_config_dict(model_name=_DEFAULT_BEDROCK_CHAT_MODEL):
+    return {
+        "name": "chat",
+        "endpoint_type": "llm/v1/chat",
+        "model": {
+            "provider": "bedrock",
+            "name": model_name,
+            "config": {"aws_config": {"aws_region": "us-east-1"}},
+        },
+    }
+
+
+def make_bedrock_chat_config(model_name=_DEFAULT_BEDROCK_CHAT_MODEL):
+    return EndpointConfig(**bedrock_chat_config_dict(model_name=model_name))
+
+
+@pytest.fixture
+def bedrock_chat_config():
+    return make_bedrock_chat_config()
+
+
+def make_converse_stream(text_chunks, stop_reason="end_turn", usage=None, metrics=None):
+    events = [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "contentBlockStart": {
+                "contentBlockIndex": 0,
+                "start": {"text": ""},
+            }
+        },
+    ]
+    events.extend(
+        {
+            "contentBlockDelta": {
+                "contentBlockIndex": 0,
+                "delta": {"text": text},
+            }
+        }
+        for text in text_chunks
+    )
+    events.append({"contentBlockStop": {"contentBlockIndex": 0}})
+    events.append({"messageStop": {"stopReason": stop_reason}})
+    metadata = {}
+    if usage is not None:
+        metadata["usage"] = usage
+    if metrics is not None:
+        metadata["metrics"] = metrics
+    if metadata:
+        events.append({"metadata": metadata})
+    return events
+
+
+def converse_chat_response():
+    return {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Hello! How can I assist you today?"}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {
+            "inputTokens": 10,
+            "outputTokens": 12,
+            "totalTokens": 22,
+        },
+        "metrics": {"latencyMs": 551},
+    }
+
+
+def parsed_converse_chat_response():
+    return {
+        "id": None,
+        "object": "chat.completion",
+        "created": 1677858242,
+        "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello! How can I assist you today?",
+                    "refusal": None,
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 12, "total_tokens": 22},
+    }
+
+
+converse_api_test_fixtures = [
+    {
+        "name": "basic_chat",
+        "config": bedrock_chat_config_dict(),
+        "request": {
+            "messages": [{"role": "user", "content": "Hello"}],
+        },
+        "expected_converse_request": {
+            "messages": [{"role": "user", "content": [{"text": "Hello"}]}],
+        },
+        "response": converse_chat_response(),
+        "expected": parsed_converse_chat_response(),
+    },
+    {
+        "name": "chat_with_params",
+        "config": bedrock_chat_config_dict(),
+        "request": {
+            "messages": [{"role": "user", "content": "Tell me a joke"}],
+            "temperature": 0.8,
+            "max_tokens": 500,
+            "top_p": 0.9,
+            "stop": ["END"],
+        },
+        "expected_converse_request": {
+            "messages": [{"role": "user", "content": [{"text": "Tell me a joke"}]}],
+            "inferenceConfig": {
+                "temperature": 0.8,
+                "maxTokens": 500,
+                "topP": 0.9,
+                "stopSequences": ["END"],
+            },
+        },
+        "response": converse_chat_response(),
+        "expected": parsed_converse_chat_response(),
+    },
+    {
+        "name": "chat_with_system_message",
+        "config": bedrock_chat_config_dict(),
+        "request": {
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello"},
+            ],
+        },
+        "expected_converse_request": {
+            "system": [{"text": "You are a helpful assistant."}],
+            "messages": [{"role": "user", "content": [{"text": "Hello"}]}],
+        },
+        "response": converse_chat_response(),
+        "expected": parsed_converse_chat_response(),
+    },
+    {
+        "name": "multi_turn_conversation",
+        "config": bedrock_chat_config_dict(),
+        "request": {
+            "messages": [
+                {"role": "user", "content": "What is 2+2?"},
+                {"role": "assistant", "content": "2+2 equals 4."},
+                {"role": "user", "content": "And what is 3+3?"},
+            ],
+        },
+        "expected_converse_request": {
+            "messages": [
+                {"role": "user", "content": [{"text": "What is 2+2?"}]},
+                {"role": "assistant", "content": [{"text": "2+2 equals 4."}]},
+                {"role": "user", "content": [{"text": "And what is 3+3?"}]},
+            ],
+        },
+        "response": converse_chat_response(),
+        "expected": parsed_converse_chat_response(),
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    converse_api_test_fixtures,
+    ids=[f["name"] for f in converse_api_test_fixtures],
+)
+def test_chat_to_model_transformation(fixture):
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    config = EndpointConfig(**fixture["config"])
+    payload = fixture["request"]
+
+    result = ConverseAdapter.chat_to_model(payload, config)
+
+    assert result["messages"] == fixture["expected_converse_request"]["messages"]
+
+    if "inferenceConfig" in fixture["expected_converse_request"]:
+        assert (
+            result["inferenceConfig"] == fixture["expected_converse_request"]["inferenceConfig"]
+        )
+
+
+def test_chat_to_model_uses_max_completion_tokens(bedrock_chat_config):
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    payload = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_completion_tokens": 123,
+    }
+
+    result = ConverseAdapter.chat_to_model(payload, bedrock_chat_config)
+
+    assert "inferenceConfig" in result
+    assert result["inferenceConfig"]["maxTokens"] == 123
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    converse_api_test_fixtures,
+    ids=[f["name"] for f in converse_api_test_fixtures],
+)
+def test_model_to_chat_transformation(fixture):
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    config = EndpointConfig(**fixture["config"])
+
+    with mock.patch("time.time", return_value=1677858242):
+        result = ConverseAdapter.model_to_chat(fixture["response"], config)
+
+    result_dict = jsonable_encoder(result)
+
+    assert result_dict["object"] == "chat.completion"
+    assert result_dict["model"] == config.model.name
+    assert len(result_dict["choices"]) == 1
+
+    choice = result_dict["choices"][0]
+    expected_choice = fixture["expected"]["choices"][0]
+    assert choice["message"]["role"] == expected_choice["message"]["role"]
+    assert choice["message"]["content"] == expected_choice["message"]["content"]
+
+    assert choice["finish_reason"] == expected_choice["finish_reason"]
+
+    assert result_dict["usage"] == fixture["expected"]["usage"]
+
+
+def test_model_to_chat_multiple_text_blocks(bedrock_chat_config):
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"text": "First part"},
+                    {"text": "Second part"},
+                ],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+    }
+
+    with mock.patch("time.time", return_value=1677858242):
+        result = ConverseAdapter.model_to_chat(response, bedrock_chat_config)
+
+    result_dict = jsonable_encoder(result)
+    assert result_dict["choices"][0]["message"]["content"] == "First partSecond part"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_basic(bedrock_chat_config):
+    from mlflow.gateway.providers.bedrock import AmazonBedrockProvider
+    from mlflow.gateway.schemas import chat
+
+    with mock.patch.object(AmazonBedrockProvider, "get_bedrock_client") as mock_client:
+        mock_stream = make_converse_stream(
+            ["Hello! ", "How can I help you?"],
+            usage={"inputTokens": 10, "outputTokens": 8, "totalTokens": 18},
+        )
+
+        mock_client.return_value.converse_stream.return_value = {"stream": iter(mock_stream)}
+
+        provider = AmazonBedrockProvider(bedrock_chat_config)
+
+        payload = chat.RequestPayload(
+            messages=[chat.RequestMessage(role="user", content="Hello")]
+        )
+
+        chunks = [
+            jsonable_encoder(chunk) async for chunk in provider.chat_stream(payload) if chunk
+        ]
+
+        assert len(chunks) > 0, "Should receive streaming chunks"
+
+        text_chunks = [c for c in chunks if c["choices"][0].get("delta", {}).get("content")]
+
+        assert len(text_chunks) == 2, "Should receive two text delta chunks"
+        assert text_chunks[0]["choices"][0]["delta"]["content"] == "Hello! "
+        assert text_chunks[1]["choices"][0]["delta"]["content"] == "How can I help you?"
+
+        final_chunk = chunks[-1]
+        assert final_chunk["choices"][0]["finish_reason"] == "stop"
+
+
+def test_system_message_with_content_parts_raises_error(bedrock_chat_config):
+    from mlflow.gateway.exceptions import AIGatewayException
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    payload = {
+        "messages": [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "You are a helpful assistant."},
+                ],
+            },
+            {"role": "user", "content": "Hello"},
+        ],
+    }
+
+    with pytest.raises(
+        AIGatewayException, match="System message content must be a string"
+    ) as exc_info:
+        ConverseAdapter.chat_to_model(payload, bedrock_chat_config)
+
+    assert exc_info.value.status_code == 422
+    assert "Bedrock Converse API does not support content parts" in str(exc_info.value.detail)
+
+
+@pytest.mark.parametrize(
+    "part",
+    [
+        {
+            "type": "input_audio",
+            "input_audio": {"data": "base64data", "format": "wav"},
+        }
+    ],
+    ids=["input_audio"],
+)
+def test_unsupported_content_part_types_raise_error(bedrock_chat_config, part):
+    from mlflow.gateway.exceptions import AIGatewayException
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello"},
+                    part,
+                ],
+            }
+        ],
+    }
+
+    part_type = part["type"]
+    with pytest.raises(
+        AIGatewayException, match=f"Unsupported content part type: '{part_type}'"
+    ) as exc_info:
+        ConverseAdapter.chat_to_model(payload, bedrock_chat_config)
+
+    assert exc_info.value.status_code == 422
+    assert "Converse API currently only supports 'text' content parts" in str(
+        exc_info.value.detail
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_include_usage_not_supported(bedrock_chat_config):
+    from mlflow.gateway.exceptions import AIGatewayException
+    from mlflow.gateway.providers.bedrock import AmazonBedrockProvider
+    from mlflow.gateway.schemas import chat
+
+    with mock.patch.object(AmazonBedrockProvider, "get_bedrock_client"):
+        provider = AmazonBedrockProvider(bedrock_chat_config)
+
+        payload = chat.RequestPayload(
+            messages=[chat.RequestMessage(role="user", content="Hello")],
+            stream_options={"include_usage": True},
+        )
+
+        with pytest.raises(
+            AIGatewayException, match="stream_options.include_usage is not supported"
+        ) as exc_info:
+            async for _ in provider.chat_stream(payload):
+                pass
+
+        assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_streaming_omits_usage_when_stream_options_not_enabled(bedrock_chat_config):
+    from mlflow.gateway.providers.bedrock import AmazonBedrockProvider
+    from mlflow.gateway.schemas import chat
+
+    with mock.patch.object(AmazonBedrockProvider, "get_bedrock_client") as mock_client:
+        mock_stream = make_converse_stream(
+            ["Hello! How can I help you today?"],
+            usage={"inputTokens": 10, "outputTokens": 12, "totalTokens": 22},
+            metrics={"latencyMs": 551},
+        )
+
+        mock_client.return_value.converse_stream.return_value = {"stream": iter(mock_stream)}
+
+        provider = AmazonBedrockProvider(bedrock_chat_config)
+
+        payload = chat.RequestPayload(
+            messages=[chat.RequestMessage(role="user", content="Hello")],
+        )
+
+        chunks = [
+            jsonable_encoder(chunk) async for chunk in provider.chat_stream(payload) if chunk
+        ]
+
+        chunks_with_usage = [c for c in chunks if c.get("usage")]
+        assert len(chunks_with_usage) == 0, "Usage should not be emitted without include_usage"
+
+
+def test_n_parameter_accepts_one():
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    config = make_bedrock_chat_config(model_name="anthropic.claude-3-sonnet-20240229-v1:0")
+    payload_n1 = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "n": 1,
+    }
+    result = ConverseAdapter.chat_to_model(payload_n1, config)
+    assert "messages" in result
+
+
+@pytest.mark.parametrize("n", [2, 3])
+def test_n_parameter_rejects_non_one(n):
+    from mlflow.gateway.exceptions import AIGatewayException
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    config = make_bedrock_chat_config(model_name="anthropic.claude-3-sonnet-20240229-v1:0")
+    payload = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "n": n,
+    }
+    with pytest.raises(AIGatewayException, match="'n' must be '1'") as exc_info:
+        ConverseAdapter.chat_to_model(payload, config)
+
+    assert exc_info.value.status_code == 422
+    assert "Bedrock Converse API" in str(exc_info.value.detail)
+
+
+def test_n_parameter_defaults_to_one():
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    config = make_bedrock_chat_config(model_name="anthropic.claude-3-sonnet-20240229-v1:0")
+    payload = {
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+    result = ConverseAdapter.chat_to_model(payload, config)
+    assert "messages" in result
+
+
+def test_tool_calling_not_yet_supported(bedrock_chat_config):
+    from mlflow.gateway.exceptions import AIGatewayException
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    payload_with_tools = {
+        "messages": [{"role": "user", "content": "What's the weather?"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather information",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    }
+    with pytest.raises(
+        AIGatewayException, match="Tool calling is not yet supported"
+    ) as exc_info:
+        ConverseAdapter.chat_to_model(payload_with_tools, bedrock_chat_config)
+    assert exc_info.value.status_code == 422
+
+    payload_with_tool_choice = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "tool_choice": "auto",
+    }
+    with pytest.raises(
+        AIGatewayException, match="tool_choice is not yet supported"
+    ) as exc_info:
+        ConverseAdapter.chat_to_model(payload_with_tool_choice, bedrock_chat_config)
+    assert exc_info.value.status_code == 422
+
+
+def test_tool_messages_not_yet_supported(bedrock_chat_config):
+    from mlflow.gateway.exceptions import AIGatewayException
+    from mlflow.gateway.providers.bedrock import ConverseAdapter
+
+    payload_with_tool_role = {
+        "messages": [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_123",
+                "content": '{"temperature": 72}',
+            },
+        ],
+    }
+    with pytest.raises(
+        AIGatewayException, match=r"Tool result messages \(role='tool'\).*not yet supported"
+    ) as exc_info:
+        ConverseAdapter.chat_to_model(payload_with_tool_role, bedrock_chat_config)
+    assert exc_info.value.status_code == 422
+
+    payload_with_tool_calls = {
+        "messages": [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "Tokyo"}',
+                        },
+                    }
+                ],
+            },
+        ],
+    }
+    with pytest.raises(
+        AIGatewayException, match="tool_calls are not yet supported"
+    ) as exc_info:
+        ConverseAdapter.chat_to_model(payload_with_tool_calls, bedrock_chat_config)
+    assert exc_info.value.status_code == 422


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #17702 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Introduces the ConverseAdapter class to support Amazon Bedrock's Converse API, which provides a universal interface for Bedrock models that support messaging (Claude, Nova, Meta Llama, Mistral, etc.).

Not handled in this PR:

- Types other than text (images, video, etc.)
- tools
- usage in stream response

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

<details>
<summary>E2E test with real Bedrock API</summary>

Test script
```
#!/usr/bin/env python3
"""
MLflow Gateway Integration Test - Amazon Bedrock Converse API

This test verifies the Bedrock Converse API integration using the same flow as production:

User → MLflow Gateway REST API → Provider Layer → Bedrock API

Prerequisites:
1. AWS credentials configured (via environment variables or ~/.aws/credentials)
2. Access to Amazon Bedrock with appropriate model permissions
3. MLflow development environment

Usage:
    # Set AWS credentials
    export AWS_REGION=us-east-1
    export AWS_ACCESS_KEY_ID=your_key_id
    export AWS_SECRET_ACCESS_KEY=your_secret_key

    # Run basic test (Nova Lite only)
    python tmp-converse-api/bedrock_gateway_integration_test.py

    # Run all test types
    python tmp-converse-api/bedrock_gateway_integration_test.py --all

    # Test specific model
    python tmp-converse-api/bedrock_gateway_integration_test.py --model mistral-small --all

    # Use custom port (if 5000 is already in use)
    python tmp-converse-api/bedrock_gateway_integration_test.py --port 5555
"""

import argparse
import json
import os
import subprocess
import sys
import time
from pathlib import Path
from typing import Any

import requests

# Test model configurations
MODELS = {
    "nova-lite": {
        "name": "Amazon Nova Lite",
        "model_id": "amazon.nova-lite-v1:0",
        "description": "Amazon Nova Lite",
    },
    "mistral-small": {
        "name": "mistral-small-2509",
        "model_id": "mistral.magistral-small-2509",
        "description": "Mistral Small 2509",
    },
    "gpt-oss-20b": {
        "name": "GPT-OSS 20B",
        "model_id": "openai.gpt-oss-20b-1:0",
        "description": "GPT-OSS 20B",
    },
}


class GatewayServer:
    """MLflow Gateway server manager for testing"""

    def __init__(self, port: int = 5000):
        self.port = port
        self.process = None
        self.config_file = None

    def create_config(self, model_id: str) -> Path:
        """Create Gateway configuration file"""
        config_dir = Path(__file__).parent
        config_file = config_dir / f".gateway_config_{self.port}.yaml"

        config_content = f"""
endpoints:
  - name: bedrock-converse-test
    endpoint_type: llm/v1/chat
    model:
      provider: bedrock
      name: {model_id}
      config:
        aws_config:
          aws_region: {os.environ.get('AWS_REGION', 'us-east-1')}
"""
        config_file.write_text(config_content)
        self.config_file = config_file
        return config_file

    def start(self, model_id: str) -> bool:
        """Start Gateway server"""
        config_file = self.create_config(model_id)

        # Check if port is already in use
        try:
            response = requests.get(f"http://localhost:{self.port}/health", timeout=1)
            if response.status_code == 200:
                print(f"✅ Gateway server already running on port {self.port}")
                return True
        except requests.exceptions.RequestException:
            pass

        print(f"🚀 Starting MLflow Gateway server on port {self.port}...")

        # Start Gateway server
        mlflow_root = Path(__file__).parent.parent
        cmd = [
            sys.executable,
            "-m",
            "mlflow",
            "gateway",
            "start",
            "--config-path",
            str(config_file),
            "--port",
            str(self.port),
            "--host",
            "127.0.0.1",
        ]

        self.process = subprocess.Popen(
            cmd,
            cwd=str(mlflow_root),
            stdout=subprocess.PIPE,
            stderr=subprocess.PIPE,
            env={**os.environ, "PYTHONPATH": str(mlflow_root)},
        )

        # Wait for server to be ready
        max_retries = 30
        for i in range(max_retries):
            try:
                response = requests.get(f"http://localhost:{self.port}/health", timeout=1)
                if response.status_code == 200:
                    print(f"✅ Gateway server started successfully")
                    return True
            except requests.exceptions.RequestException:
                if i < max_retries - 1:
                    time.sleep(1)
                    print(f"⏳ Waiting for server to start... ({i + 1}/{max_retries})")

        print("❌ Failed to start Gateway server")

        # Print error output for debugging
        if self.process:
            # Check if process has terminated
            poll_result = self.process.poll()
            if poll_result is not None:
                # Process has terminated, read its output
                stdout, stderr = self.process.communicate()
                print(f"\nServer process exited with code: {poll_result}")
                if stdout:
                    print("\nServer stdout:")
                    print(stdout.decode())
                if stderr:
                    print("\nServer stderr:")
                    print(stderr.decode())
            else:
                # Process is still running but not responding
                print("\nServer process is still running but not responding to health checks")
                print("Check if another service is using port 5000 or if there's a configuration issue")

        self.stop()
        return False

    def stop(self):
        """Stop Gateway server"""
        if self.process:
            print(f"🛑 Stopping Gateway server...")
            self.process.terminate()
            try:
                self.process.wait(timeout=5)
            except subprocess.TimeoutExpired:
                self.process.kill()
                self.process.wait()
            self.process = None

        if self.config_file and self.config_file.exists():
            self.config_file.unlink()
            self.config_file = None

    def __enter__(self):
        return self

    def __exit__(self, exc_type, exc_val, exc_tb):
        self.stop()


def call_gateway_chat(endpoint: str, payload: dict[str, Any], port: int = 5000) -> dict[str, Any]:
    """Call Gateway chat endpoint"""
    url = f"http://localhost:{port}/gateway/{endpoint}/invocations"
    response = requests.post(url, json=payload, timeout=30)
    if not response.ok:
        print(f"\n🔴 HTTP Error {response.status_code}")
        print(f"Response body: {response.text}")
    response.raise_for_status()
    return response.json()


def call_gateway_stream(endpoint: str, payload: dict[str, Any], port: int = 5000):
    """Call Gateway streaming endpoint"""
    url = f"http://localhost:{port}/gateway/{endpoint}/invocations"
    payload_with_stream = {**payload, "stream": True}

    response = requests.post(url, json=payload_with_stream, stream=True, timeout=30)
    response.raise_for_status()

    for line in response.iter_lines():
        if line:
            line_str = line.decode("utf-8")
            if line_str.startswith("data: "):
                data_str = line_str[6:]
                if data_str.strip() == "[DONE]":
                    break
                yield json.loads(data_str)


def test_basic_chat(model_name: str, port: int = 5000):
    """Test basic chat functionality"""
    print("\n" + "=" * 80)
    print(f"📝 Test 1: Basic Chat ({model_name})")
    print("=" * 80)

    payload = {
        "messages": [{"role": "user", "content": "Hello! Who are you?"}],
        "temperature": 0.7,
        "max_tokens": 100,
    }

    print(f"\n🔵 Request:")
    print(json.dumps(payload, indent=2, ensure_ascii=False))

    result = call_gateway_chat("bedrock-converse-test", payload, port)

    print(f"\n🟢 Response:")
    print(f"  Model: {result.get('model')}")
    print(f"  Response: {result['choices'][0]['message']['content']}")
    print(f"  Token usage: {result['usage']}")
    print(f"  Finish reason: {result['choices'][0]['finish_reason']}")

    # Verify response structure
    assert "choices" in result
    assert len(result["choices"]) > 0
    assert "message" in result["choices"][0]
    assert "content" in result["choices"][0]["message"]
    assert "usage" in result
    assert "prompt_tokens" in result["usage"]

    print("\n✅ Test passed: Basic chat")
    return True


def test_streaming_chat(model_name: str, port: int = 5000):
    """Test streaming chat functionality"""
    print("\n" + "=" * 80)
    print(f"🌊 Test 2: Streaming ({model_name})")
    print("=" * 80)

    payload = {
        "messages": [{"role": "user", "content": "Count from 1 to 5."}],
        "temperature": 0.5,
        "max_tokens": 50,
    }

    print(f"\n🔵 Request:")
    print(json.dumps(payload, indent=2, ensure_ascii=False))

    print(f"\n🟢 Streaming response:")
    chunks = []
    for chunk in call_gateway_stream("bedrock-converse-test", payload, port):
        if "choices" in chunk and len(chunk["choices"]) > 0:
            delta = chunk["choices"][0].get("delta", {})
            if "content" in delta:
                content = delta["content"]
                print(content, end="", flush=True)
                chunks.append(chunk)

    print()  # New line after streaming

    assert len(chunks) > 0, "No streaming chunks received"

    print(f"\n📊 Chunks received: {len(chunks)}")
    print("✅ Test passed: Streaming")
    return True


def test_system_message(model_name: str, port: int = 5000):
    """Test system message functionality"""
    print("\n" + "=" * 80)
    print(f"⚙️  Test 4: System Message ({model_name})")
    print("=" * 80)

    payload = {
        "messages": [
            {
                "role": "system",
                "content": "You are a helpful and polite assistant.",
            },
            {"role": "user", "content": "Hello"},
        ],
        "temperature": 0.7,
        "max_tokens": 100,
    }

    print(f"\n🔵 Request:")
    print(json.dumps(payload, indent=2, ensure_ascii=False))

    result = call_gateway_chat("bedrock-converse-test", payload, port)

    print(f"\n🟢 Response:")
    print(f"  Response: {result['choices'][0]['message']['content']}")
    print(f"  Token usage: {result['usage']}")

    assert "choices" in result
    assert "message" in result["choices"][0]
    assert "content" in result["choices"][0]["message"]

    print("\n✅ Test passed: System message")
    return True


def run_tests(model_key: str, test_types: list[str], port: int = 5000):
    """Run specified tests for a model"""
    model_info = MODELS[model_key]
    model_id = model_info["model_id"]
    model_name = model_info["name"]

    print("\n" + "=" * 80)
    print(f"🚀 Starting tests: {model_name}")
    print(f"   Model ID: {model_id}")
    print(f"   Description: {model_info['description']}")
    print(f"   Port: {port}")
    print("=" * 80)

    # Start Gateway server
    with GatewayServer(port=port) as server:
        if not server.start(model_id):
            print(f"❌ Failed to start Gateway server")
            return False

        # Run tests
        results = {}
        test_functions = {
            "basic": test_basic_chat,
            "streaming": test_streaming_chat,
            "system": test_system_message,
        }

        for test_type in test_types:
            if test_type in test_functions:
                try:
                    results[test_type] = test_functions[test_type](model_name, port)
                except Exception as e:
                    print(f"\n❌ Test failed: {test_type}")
                    print(f"   Error: {e}")
                    import traceback

                    traceback.print_exc()
                    results[test_type] = False

        # Print summary
        print("\n" + "=" * 80)
        print(f"📊 Test Results Summary - {model_name}")
        print("=" * 80)
        for test_type, success in results.items():
            status = "✅ Passed" if success else "❌ Failed"
            print(f"  {test_type:15s}: {status}")

        all_passed = all(results.values())
        if all_passed:
            print(f"\n🎉 All tests passed!")
        else:
            print(f"\n⚠️  Some tests failed")

        return all_passed


def main():
    parser = argparse.ArgumentParser(description="MLflow Gateway Integration Test - Bedrock Converse API")
    parser.add_argument(
        "--model",
        choices=list(MODELS.keys()),
        default="nova-lite",
        help="Model to test (default: nova-lite)",
    )
    parser.add_argument(
        "--all",
        action="store_true",
        help="Run all test types (default: basic only)",
    )
    parser.add_argument(
        "--tests",
        nargs="+",
        choices=[
            "basic",
            "streaming",
            "streaming_usage",
            "system",
        ],
        help="Specify test types to run",
    )
    parser.add_argument(
        "--port",
        type=int,
        default=5000,
        help="Gateway server port (default: 5000)",
    )

    args = parser.parse_args()

    # Determine test types to run
    if args.tests:
        test_types = args.tests
    elif args.all:
        test_types = [
            "basic",
            "streaming",
            "streaming_usage",
            "system",
        ]
    else:
        test_types = ["basic"]

    # Check AWS credentials
    if not os.environ.get("AWS_REGION"):
        print("⚠️  AWS_REGION is not set")
        print("   export AWS_REGION=us-east-1")
        return 1

    if not os.environ.get("AWS_ACCESS_KEY_ID") and not os.environ.get("AWS_PROFILE"):
        print("⚠️  AWS credentials are not configured")
        print("   export AWS_ACCESS_KEY_ID=your_key")
        print("   export AWS_SECRET_ACCESS_KEY=your_secret")
        return 1

    # Run tests
    success = run_tests(args.model, test_types, args.port)
    return 0 if success else 1


if __name__ == "__main__":
    sys.exit(main())

```

Test results
```
❯ uv run python tmp-converse-api/bedrock_gateway_integration_test.py --port 5555 --all

================================================================================
🚀 Starting tests: Amazon Nova Lite
   Model ID: amazon.nova-lite-v1:0
   Description: Amazon Nova Lite
   Port: 5555
================================================================================
🚀 Starting MLflow Gateway server on port 5555...
⏳ Waiting for server to start... (1/30)
✅ Gateway server started successfully

================================================================================
📝 Test 1: Basic Chat (Amazon Nova Lite)
================================================================================

🔵 Request:
{
  "messages": [
    {
      "role": "user",
      "content": "Hello! Who are you?"
    }
  ],
  "temperature": 0.7,
  "max_tokens": 100
}

🟢 Response:
  Model: amazon.nova-lite-v1:0
  Response: Hello! I'm an AI created to assist with a wide range of tasks. I can help answer questions, provide information, assist with writing, and much more. If you have any specific needs or questions, feel free to ask, and I'll do my best to help you!
  Token usage: {'prompt_tokens': 6, 'completion_tokens': 60, 'total_tokens': 66}
  Finish reason: stop

✅ Test passed: Basic chat

================================================================================
🌊 Test 2: Streaming (Amazon Nova Lite)
================================================================================

🔵 Request:
{
  "messages": [
    {
      "role": "user",
      "content": "Count from 1 to 5."
    }
  ],
  "temperature": 0.5,
  "max_tokens": 50
}

🟢 Streaming response:
Sure, here we go:

1. One
2. Two
3. Three
4. Four
5. FiveNone

📊 Chunks received: 9
✅ Test passed: Streaming

================================================================================
⚙️  Test 4: System Message (Amazon Nova Lite)
================================================================================

🔵 Request:
{
  "messages": [
    {
      "role": "system",
      "content": "You are a helpful and polite assistant."
    },
    {
      "role": "user",
      "content": "Hello"
    }
  ],
  "temperature": 0.7,
  "max_tokens": 100
}

🟢 Response:
  Response: Hello! How can I assist you today? If you have any questions or need help with something, feel free to let me know. Whether it's information, advice, or just a friendly chat, I'm here to help!
  Token usage: {'prompt_tokens': 9, 'completion_tokens': 49, 'total_tokens': 58}

✅ Test passed: System message

================================================================================
📊 Test Results Summary - Amazon Nova Lite
================================================================================
  basic          : ✅ Passed
  streaming      : ✅ Passed
  system         : ✅ Passed

🎉 All tests passed!
🛑 Stopping Gateway server...
```

</details>

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Add support for Amazon Bedrock Converse API in MLflow AI Gateway, enabling a unified interface for chat completions across all Bedrock models.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
