### PR TITLE
Add tooltip and click-to-expand for session pass/fail aggregated cells

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -770,6 +770,10 @@
     "defaultMessage": "Value (optional)",
     "description": "Key-value tag editor modal > Value input label"
   },
+  "4Bl01p": {
+    "defaultMessage": "Click to expand session and see individual trace details",
+    "description": "Tooltip for pass/fail aggregated cell in session header"
+  },
   "4CNVbz": {
     "defaultMessage": "API key name",
     "description": "Label for API key name input"

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
@@ -214,6 +214,7 @@ const SessionHeaderRow = React.memo(function SessionHeaderRow({
           getRunColor={getRunColor}
           runUuid={runUuid}
           compareToRunUuid={compareToRunUuid}
+          onExpandSession={!isComparing ? handleToggleExpanded : undefined}
         />
       ))}
     </TableRow>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -77,6 +77,7 @@ interface SessionHeaderCellProps {
   getRunColor?: (runUuid: string) => string;
   runUuid?: string;
   compareToRunUuid?: string;
+  onExpandSession?: () => void;
 }
 
 /**
@@ -96,6 +97,7 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
   getRunColor,
   runUuid,
   compareToRunUuid,
+  onExpandSession,
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -683,7 +685,13 @@ export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
 
     const renderAggregatedCell = (tracesList: ModelTraceInfoV3[]) => {
       if (dtype === 'pass-fail' || dtype === 'boolean') {
-        return <SessionHeaderPassFailAggregatedCell assessmentInfo={assessmentInfo} traces={tracesList} />;
+        return (
+          <SessionHeaderPassFailAggregatedCell
+            assessmentInfo={assessmentInfo}
+            traces={tracesList}
+            onExpandSession={onExpandSession}
+          />
+        );
       } else if (dtype === 'numeric') {
         return <SessionHeaderNumericAggregatedCell assessmentInfo={assessmentInfo} traces={tracesList} />;
       } else if (dtype === 'string' || dtype === 'unknown') {


### PR DESCRIPTION
Make the pass/fail aggregated cells in session headers more discoverable by:
- Adding a tooltip explaining users can click to expand and see details
- Making the cell clickable to expand the session
- Adding hover styling and keyboard accessibility

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled - makes it more obvious that the aggregated assessment can be expanded.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
![Clipboard-20260202-214437-457](https://github.com/user-attachments/assets/e306c81f-ce43-4fa3-91c2-bedecd834b30)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
