### PR TITLE
Fix charts tab and click handling in evaluation runs page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -365,8 +365,8 @@ const ExperimentEvaluationRunsPageImpl = () => {
     </div>
   );
 
-  // Full-page list view (default, non-comparison mode)
-  if (!isComparisonMode) {
+  // Full-page list view (default, non-comparison mode, but not when viewing charts)
+  if (!isComparisonMode && viewMode !== ExperimentEvaluationRunsPageMode.CHARTS) {
     return (
       <ExperimentEvaluationRunsRowVisibilityProvider>
         <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: '0px' }}>
@@ -450,7 +450,19 @@ const ExperimentEvaluationRunsPageImpl = () => {
             overflowY: 'scroll',
           }}
         >
-          {selectedRunUuid ? (
+          {viewMode === ExperimentEvaluationRunsPageMode.CHARTS ? (
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'column',
+                flex: 1,
+                minHeight: '0px',
+                paddingLeft: theme.spacing.sm,
+              }}
+            >
+              <ExperimentEvaluationRunsPageCharts runs={runs} experimentId={experimentId} />
+            </div>
+          ) : selectedRunUuid ? (
             <div
               css={{
                 display: 'flex',

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -107,7 +107,8 @@ export const DatasetCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({
     return <div>-</div>;
   }
 
-  const openDatasetDrawer = () => {
+  const openDatasetDrawer = (e: React.MouseEvent) => {
+    e.stopPropagation();
     (meta as any).setSelectedDatasetWithRun({
       datasetWithTags: { dataset: displayedDataset },
       runData: {
@@ -266,5 +267,13 @@ export const VisiblityCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({ row, ta
   const runStatus = row.original.info.status;
   const Icon = isRowHidden(runUuid, rowIndex, runStatus) ? VisibleOffIcon : VisibleIcon;
 
-  return <Icon onClick={() => toggleRowVisibility(runUuid)} css={{ cursor: 'pointer' }} />;
+  return (
+    <Icon
+      onClick={(e: React.MouseEvent) => {
+        e.stopPropagation();
+        toggleRowVisibility(runUuid);
+      }}
+      css={{ cursor: 'pointer' }}
+    />
+  );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
@@ -265,30 +265,32 @@ export const ExperimentEvaluationRunsTableControls = ({
           runs={runs}
         />
 
-        <Tooltip
-          componentId="mlflow.eval-runs.compare-button.tooltip"
-          content={
-            isCompareEnabled ? (
-              <FormattedMessage
-                defaultMessage="Compare selected runs"
-                description="Tooltip for the compare button when enabled"
-              />
-            ) : (
-              <FormattedMessage
-                defaultMessage="Select up to 2 runs to compare"
-                description="Tooltip for the compare button when disabled"
-              />
-            )
-          }
-        >
-          <Button
-            componentId="mlflow.eval-runs.compare-button"
-            onClick={handleCompareClick}
-            disabled={!isCompareEnabled}
+        {viewMode !== ExperimentEvaluationRunsPageMode.CHARTS && (
+          <Tooltip
+            componentId="mlflow.eval-runs.compare-button.tooltip"
+            content={
+              isCompareEnabled ? (
+                <FormattedMessage
+                  defaultMessage="Compare selected runs"
+                  description="Tooltip for the compare button when enabled"
+                />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="Select up to 2 runs to compare"
+                  description="Tooltip for the compare button when disabled"
+                />
+              )
+            }
           >
-            <FormattedMessage defaultMessage="Compare" description="Compare runs button label" />
-          </Button>
-        </Tooltip>
+            <Button
+              componentId="mlflow.eval-runs.compare-button"
+              onClick={handleCompareClick}
+              disabled={!isCompareEnabled}
+            >
+              <FormattedMessage defaultMessage="Compare" description="Compare runs button label" />
+            </Button>
+          </Tooltip>
+        )}
 
         <ExperimentEvaluationRunsTableActions
           rowSelection={rowSelection}


### PR DESCRIPTION
- Always show charts panel on right side when in charts view mode
- Hide Compare button when viewing charts (not applicable)
- Fix eye icon (visibility toggle) click being captured by row click
- Fix dataset tag click being captured by row click

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix behavior where charts tab doesn't automatically show up (have to click compare). Additionally, removes the compare button (implicitly handled by selection) and fixes click events on the eye.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
![Clipboard-20260202-234345-838](https://github.com/user-attachments/assets/e131a4c6-9883-4c70-b028-5a9d71366ae9)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
