### PR TITLE
Enable dynamic import for third-party scorer metrics

### DIFF
--- a/mlflow/genai/scorers/guardrails/registry.py
+++ b/mlflow/genai/scorers/guardrails/registry.py
@@ -13,12 +13,29 @@ _SUPPORTED_VALIDATORS = [
 
 
 def get_validator_class(validator_name: str):
-    if validator_name not in _SUPPORTED_VALIDATORS:
-        available = ", ".join(sorted(_SUPPORTED_VALIDATORS))
-        raise MlflowException.invalid_parameter_value(
-            f"Unknown Guardrails AI validator: '{validator_name}'. Available: {available}"
-        )
+    """
+    Get Guardrails AI validator class by name.
 
+    For validators in the supported list, imports from guardrails.hub. For unknown
+    validators, attempts to dynamically import from guardrails.hub.<ValidatorName>.
+
+    Args:
+        validator_name: Name of the validator (e.g., "ToxicLanguage", "DetectPII")
+
+    Returns:
+        The Guardrails AI validator class
+
+    Raises:
+        MlflowException: If the validator cannot be imported or guardrails is not installed
+    """
     from guardrails import hub
 
-    return getattr(hub, validator_name)
+    try:
+        return getattr(hub, validator_name)
+    except AttributeError:
+        available = ", ".join(sorted(_SUPPORTED_VALIDATORS))
+        raise MlflowException.invalid_parameter_value(
+            f"Unknown Guardrails AI validator: '{validator_name}'. Could not find "
+            f"'{validator_name}' in 'guardrails.hub'. "
+            f"Available pre-configured validators: {available}"
+        )

--- a/mlflow/genai/scorers/phoenix/registry.py
+++ b/mlflow/genai/scorers/phoenix/registry.py
@@ -16,6 +16,9 @@ def get_evaluator_class(metric_name: str):
     """
     Get the Phoenix evaluator class for a given metric name.
 
+    For metrics in the registry, uses the registered class name. For unknown metrics,
+    attempts to dynamically import <MetricName>Evaluator from phoenix.evals.
+
     Args:
         metric_name: Name of the metric (e.g., "Hallucination")
 
@@ -23,17 +26,23 @@ def get_evaluator_class(metric_name: str):
         The Phoenix evaluator class
 
     Raises:
-        MlflowException: If the metric is not supported
+        MlflowException: If the metric cannot be imported or phoenix is not installed
     """
     check_phoenix_installed()
 
-    if metric_name not in _METRIC_REGISTRY:
-        available_metrics = ", ".join(sorted(_METRIC_REGISTRY.keys()))
-        raise MlflowException.invalid_parameter_value(
-            f"Unknown Phoenix metric: '{metric_name}'. Available metrics: {available_metrics}"
-        )
-
     import phoenix.evals as phoenix_evals
 
-    evaluator_class_name = _METRIC_REGISTRY[metric_name]
-    return getattr(phoenix_evals, evaluator_class_name)
+    if metric_name in _METRIC_REGISTRY:
+        evaluator_class_name = _METRIC_REGISTRY[metric_name]
+    else:
+        # Attempt dynamic import for metrics not in registry
+        evaluator_class_name = f"{metric_name}Evaluator"
+
+    try:
+        return getattr(phoenix_evals, evaluator_class_name)
+    except AttributeError:
+        available_metrics = ", ".join(sorted(_METRIC_REGISTRY.keys()))
+        raise MlflowException.invalid_parameter_value(
+            f"Unknown Phoenix metric: '{metric_name}'. Could not find '{evaluator_class_name}' "
+            f"in 'phoenix.evals'. Available pre-configured metrics: {available_metrics}"
+        )

--- a/mlflow/genai/scorers/ragas/registry.py
+++ b/mlflow/genai/scorers/ragas/registry.py
@@ -123,6 +123,11 @@ def get_metric_class(metric_name: str):
         raise MlflowException.invalid_parameter_value(
             "RAGAS metrics require the 'ragas' package. Please install it with: pip install ragas"
         ) from e
+    except AttributeError:
+        raise MlflowException.invalid_parameter_value(
+            f"Unknown RAGAS metric: '{metric_name}'. Could not find class '{class_name}' "
+            f"in module '{module_path}'."
+        )
 
 
 def is_agentic_or_multiturn_metric(metric_name: str) -> bool:
@@ -146,9 +151,7 @@ def requires_args_from_placeholders(metric_name: str) -> bool:
 
 
 def _get_config(metric_name: str) -> MetricConfig:
-    if metric_name not in _METRIC_REGISTRY:
-        available_metrics = ", ".join(sorted(_METRIC_REGISTRY.keys()))
-        raise MlflowException.invalid_parameter_value(
-            f"Unknown metric: '{metric_name}'. Available metrics: {available_metrics}"
-        )
-    return _METRIC_REGISTRY[metric_name]
+    if metric_name in _METRIC_REGISTRY:
+        return _METRIC_REGISTRY[metric_name]
+    # Return default config for unknown metrics - dynamic import will be attempted
+    return MetricConfig(f"ragas.metrics.collections.{metric_name}")

--- a/mlflow/genai/scorers/trulens/registry.py
+++ b/mlflow/genai/scorers/trulens/registry.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
+import re
 from typing import Any
-
-from mlflow.exceptions import MlflowException
 
 # Mapping: metric name -> (feedback method name, argument mapping)
 # Argument mapping: generic key -> TruLens-specific argument name
@@ -35,21 +34,18 @@ _METRIC_REGISTRY: dict[str, tuple[str, dict[str, str]]] = {
 
 
 def get_feedback_method_name(metric_name: str) -> str:
-    if metric_name not in _METRIC_REGISTRY:
-        available_metrics = ", ".join(sorted(_METRIC_REGISTRY.keys()))
-        raise MlflowException.invalid_parameter_value(
-            f"Unknown TruLens metric: '{metric_name}'. Available metrics: {available_metrics}"
-        )
-    return _METRIC_REGISTRY[metric_name][0]
+    if metric_name in _METRIC_REGISTRY:
+        return _METRIC_REGISTRY[metric_name][0]
+    # Convert CamelCase to snake_case and append _with_cot_reasons
+    snake_case = re.sub(r"(?<!^)(?=[A-Z])", "_", metric_name).lower()
+    return f"{snake_case}_with_cot_reasons"
 
 
 def get_argument_mapping(metric_name: str) -> dict[str, str]:
-    if metric_name not in _METRIC_REGISTRY:
-        available_metrics = ", ".join(sorted(_METRIC_REGISTRY.keys()))
-        raise MlflowException.invalid_parameter_value(
-            f"Unknown TruLens metric: '{metric_name}'. Available metrics: {available_metrics}"
-        )
-    return _METRIC_REGISTRY[metric_name][1]
+    if metric_name in _METRIC_REGISTRY:
+        return _METRIC_REGISTRY[metric_name][1]
+    # Return default empty mapping for unknown metrics
+    return {}
 
 
 def build_trulens_args(

--- a/tests/genai/scorers/deepeval/test_registry.py
+++ b/tests/genai/scorers/deepeval/test_registry.py
@@ -1,7 +1,9 @@
+from unittest import mock
+
 import pytest
 
 from mlflow.exceptions import MlflowException
-from mlflow.genai.scorers.deepeval.registry import get_metric_class
+from mlflow.genai.scorers.deepeval.registry import get_metric_class, is_deterministic_metric
 
 
 def test_get_metric_class_returns_valid_class():
@@ -12,3 +14,30 @@ def test_get_metric_class_returns_valid_class():
 def test_get_metric_class_raises_error_for_invalid_name():
     with pytest.raises(MlflowException, match="Unknown metric: 'InvalidMetric'"):
         get_metric_class("InvalidMetric")
+
+
+def test_get_metric_class_dynamic_import_success():
+    mock_metric_class = mock.MagicMock()
+    mock_metric_class.__name__ = "NewMetricMetric"
+
+    mock_module = mock.MagicMock()
+    mock_module.NewMetricMetric = mock_metric_class
+
+    with mock.patch.dict("sys.modules", {"deepeval.metrics": mock_module}):
+        result = get_metric_class("NewMetric")
+        assert result is mock_metric_class
+
+
+def test_is_deterministic_metric_returns_false_for_unknown():
+    # Unknown metrics should default to non-deterministic (requires model)
+    assert not is_deterministic_metric("UnknownMetric")
+
+
+def test_is_deterministic_metric_returns_true_for_deterministic():
+    assert is_deterministic_metric("ExactMatch")
+    assert is_deterministic_metric("PatternMatch")
+
+
+def test_is_deterministic_metric_returns_false_for_non_deterministic():
+    assert not is_deterministic_metric("AnswerRelevancy")
+    assert not is_deterministic_metric("Faithfulness")

--- a/tests/genai/scorers/guardrails/test_registry.py
+++ b/tests/genai/scorers/guardrails/test_registry.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -27,5 +27,16 @@ def test_get_validator_class(validator_name, expected_class):
 
 
 def test_get_validator_class_unknown():
-    with pytest.raises(MlflowException, match="Unknown Guardrails AI validator"):
-        get_validator_class("UnknownValidator")
+    with patch("guardrails.hub", spec=[]):
+        with pytest.raises(MlflowException, match="Unknown Guardrails AI validator"):
+            get_validator_class("UnknownValidator")
+
+
+def test_get_validator_class_dynamic_import():
+    with patch("guardrails.hub") as mock_hub:
+        mock_validator = MagicMock()
+        mock_hub.NewValidator = mock_validator
+
+        result = get_validator_class("NewValidator")
+
+        assert result is mock_validator

--- a/tests/genai/scorers/phoenix/test_registry.py
+++ b/tests/genai/scorers/phoenix/test_registry.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from mlflow.exceptions import MlflowException
@@ -28,3 +30,14 @@ def test_get_evaluator_class_invalid_metric():
 
     with pytest.raises(MlflowException, match="Unknown Phoenix metric"):
         get_evaluator_class("InvalidMetric")
+
+
+def test_get_evaluator_class_dynamic_import():
+    from mlflow.genai.scorers.phoenix.registry import get_evaluator_class
+
+    mock_evaluator = mock.MagicMock()
+    mock_evaluator.__name__ = "NewMetricEvaluator"
+
+    with mock.patch.object(phoenix_evals, "NewMetricEvaluator", mock_evaluator, create=True):
+        result = get_evaluator_class("NewMetric")
+        assert result is mock_evaluator

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -154,7 +154,7 @@ def test_ragas_scorer_returns_error_feedback_on_exception():
 
 
 def test_unknown_metric_raises_error():
-    with pytest.raises(MlflowException, match="Unknown metric: 'NonExistentMetric'"):
+    with pytest.raises(MlflowException, match="Unknown RAGAS metric: 'NonExistentMetric'"):
         get_scorer("NonExistentMetric")
 
 

--- a/tests/genai/scorers/ragas/test_registry.py
+++ b/tests/genai/scorers/ragas/test_registry.py
@@ -1,9 +1,12 @@
+from unittest import mock
+
 import pytest
 
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers.ragas.registry import (
     get_metric_class,
     is_agentic_or_multiturn_metric,
+    requires_args_from_placeholders,
     requires_embeddings,
     requires_llm_at_score_time,
     requires_llm_in_constructor,
@@ -16,8 +19,20 @@ def test_get_metric_class_returns_valid_class():
 
 
 def test_get_metric_class_raises_error_for_invalid_name():
-    with pytest.raises(MlflowException, match="Unknown metric: 'InvalidMetric'"):
+    with pytest.raises(MlflowException, match="Unknown RAGAS metric: 'InvalidMetric'"):
         get_metric_class("InvalidMetric")
+
+
+def test_get_metric_class_dynamic_import():
+    mock_metric_class = mock.MagicMock()
+    mock_metric_class.__name__ = "NewMetric"
+
+    mock_module = mock.MagicMock()
+    mock_module.NewMetric = mock_metric_class
+
+    with mock.patch.dict("sys.modules", {"ragas.metrics.collections": mock_module}):
+        result = get_metric_class("NewMetric")
+        assert result is mock_metric_class
 
 
 @pytest.mark.parametrize(
@@ -75,3 +90,23 @@ def test_requires_llm_in_constructor(metric_name, expected):
 )
 def test_requires_llm_at_score_time(metric_name, expected):
     assert requires_llm_at_score_time(metric_name) is expected
+
+
+def test_is_agentic_or_multiturn_metric_unknown():
+    assert not is_agentic_or_multiturn_metric("UnknownMetric")
+
+
+def test_requires_embeddings_unknown():
+    assert not requires_embeddings("UnknownMetric")
+
+
+def test_requires_llm_in_constructor_unknown():
+    assert requires_llm_in_constructor("UnknownMetric")
+
+
+def test_requires_llm_at_score_time_unknown():
+    assert not requires_llm_at_score_time("UnknownMetric")
+
+
+def test_requires_args_from_placeholders_unknown():
+    assert not requires_args_from_placeholders("UnknownMetric")


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Allow third-party integration scorers (DeepEval, RAGAS, Phoenix, Guardrails AI, TruLens) to dynamically import metrics not explicitly registered in MLflow's registry. This enables users to use new metrics from third-party libraries immediately without waiting for MLflow to add them to the pre-configured registry.

For each integration:
- DeepEval: Attempts deepeval.metrics.<MetricName>Metric
- RAGAS: Attempts ragas.metrics.collections then ragas.metrics
- Phoenix: Attempts phoenix.evals.<MetricName>Evaluator
- Guardrails: Attempts guardrails.hub.<ValidatorName>
- TruLens: Infers method name via snake_case conversion


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
def test_metric_not_present():
    """Test 1: What happens when metric doesn't exist in ragas."""
    print("=" * 60)
    print("TEST 1: Metric does not exist in ragas")
    print("=" * 60)

    registry = _load_registry()
    get_metric_class = registry.get_metric_class

    try:
        get_metric_class("NonExistentMetric")
    except Exception as e:
        print(f"Error type: {type(e).__name__}")
        print(f"Error message: {e}")
    print()


def _load_registry():
    """Load registry module directly to avoid __init__.py top-level ragas imports."""
    import importlib.util
    spec = importlib.util.spec_from_file_location(
        "registry",
        "mlflow/genai/scorers/ragas/registry.py"
    )
    registry = importlib.util.module_from_spec(spec)
    spec.loader.exec_module(registry)
    return registry


def test_remove_metric_from_registry():
    """Test 2: Remove a metric from registry and verify dynamic import works."""
    print("=" * 60)
    print("TEST 2: Remove metric from registry, verify dynamic import works")
    print("=" * 60)

    registry = _load_registry()

    # Show that Faithfulness is in the registry
    print(f"'Faithfulness' in registry: {'Faithfulness' in registry._METRIC_REGISTRY}")

    # Temporarily remove Faithfulness from the registry
    original_config = registry._METRIC_REGISTRY.pop("Faithfulness")
    print(f"'Faithfulness' in registry after removal: {'Faithfulness' in registry._METRIC_REGISTRY}")

    try:
        # This should now use dynamic import from ragas.metrics.collections
        cls = registry.get_metric_class("Faithfulness")
        print(f"Dynamic import successful!")
        print(f"Class name: {cls.__name__}")
        print(f"Class module: {cls.__module__}")
    except Exception as e:
        print(f"Error: {type(e).__name__}: {e}")
    finally:
        # Restore the registry
        registry._METRIC_REGISTRY["Faithfulness"] = original_config
        print(f"'Faithfulness' in registry after restore: {'Faithfulness' in registry._METRIC_REGISTRY}")
    print()


def test_unregistered_metric_that_exists():
    """Test 3: Import a metric that exists in ragas but isn't in our registry."""
    print("=" * 60)
    print("TEST 3: Import unregistered metric that exists in ragas")
    print("=" * 60)

    from mlflow.genai.scorers.ragas.registry import get_metric_class

    # These metrics exist in ragas.metrics.collections but aren't in our registry
    unregistered_metrics = [
        "AnswerCorrectness",
        "ContextPrecisionWithReference",
        "MultiModalFaithfulness",
    ]

    for metric_name in unregistered_metrics:
        try:
            cls = get_metric_class(metric_name)
            print(f"{metric_name}: {cls.__name__} (from {cls.__module__})")
        except Exception as e:
            print(f"{metric_name}: {type(e).__name__}: {e}")
    print()


if __name__ == "__main__":
    test_metric_not_present()
    test_remove_metric_from_registry()
    test_unregistered_metric_that_exists()
```

Output:
```
============================================================
TEST 1: Metric does not exist in ragas
============================================================
Error type: MlflowException
Error message: Unknown RAGAS metric: 'NonExistentMetric'. Could not find class 'NonExistentMetric' in module 'ragas.metrics.collections'.

============================================================
TEST 2: Remove metric from registry, verify dynamic import works
============================================================
'Faithfulness' in registry: True
'Faithfulness' in registry after removal: False
Dynamic import successful!
Class name: Faithfulness
Class module: ragas.metrics.collections.faithfulness.metric
'Faithfulness' in registry after restore: True

============================================================
TEST 3: Import unregistered metric that exists in ragas
============================================================
AnswerCorrectness: AnswerCorrectness (from ragas.metrics.collections.answer_correctness.metric)
ContextPrecisionWithReference: ContextPrecisionWithReference (from ragas.metrics.collections.context_precision.metric)
MultiModalFaithfulness: MultiModalFaithfulness (from ragas.metrics.collections.multi_modal_faithfulness.metric)
```

Another test:
```python
from mlflow.genai.scorers.ragas import get_scorer

# Load a RAGAS metric
scorer = get_scorer("Faithfulness")
print(f"Faithfulness: {scorer}")

# Load a RAGAS metric that's NOT in our registry (dynamic import)
scorer = get_scorer("ContextPrecisionWithReference")
print(f"ContextPrecisionWithReference: {scorer}")
```

Tests:
```
third_party_arbitrary [third_party_arbitrary]$ uv run --with litellm python a.py
Traceback (most recent call last):
  File "/Users/samraj.moorjani/personal_repos/mlflow-worktrees/third_party_arbitrary/a.py", line 3, in <module>
    from mlflow.genai.scorers.ragas import get_scorer
  File "/Users/samraj.moorjani/personal_repos/mlflow-worktrees/third_party_arbitrary/mlflow/genai/scorers/ragas/__init__.py", line 27, in <module>
    from ragas.dataset_schema import MultiTurnSample, SingleTurnSample
ModuleNotFoundError: No module named 'ragas'
third_party_arbitrary [third_party_arbitrary]$ uv run --with litellm --with ragas python a.py
Faithfulness: name='Faithfulness' aggregations=None description=None
ContextPrecisionWithReference: name='ContextPrecisionWithReference' aggregations=None description=None
```


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
