### PR TITLE
Remove HTTP simulation from MLflow Demo integration tests to improve performance

### DIFF
--- a/tests/demo/test_demo_integration.py
+++ b/tests/demo/test_demo_integration.py
@@ -26,16 +26,10 @@ from mlflow.demo.generators.traces import (
 from mlflow.demo.registry import demo_registry
 from mlflow.genai.datasets import search_datasets
 from mlflow.genai.prompts import load_prompt, search_prompts
-from mlflow.server import handlers
-from mlflow.server.handlers import initialize_backend_stores
 
 
 @pytest.fixture
-def tracking_server(db_uri: str, tmp_path: Path):
-    handlers._tracking_store = None
-    handlers._model_registry_store = None
-    initialize_backend_stores(db_uri, default_artifact_root=tmp_path.as_uri())
-
+def client(db_uri: str, tmp_path: Path):
     # Point the tracking URI directly at the SQLite database to avoid HTTP
     # overhead during data generation (3,000+ requests per test run).
     set_tracking_uri(db_uri)
@@ -67,7 +61,7 @@ def prompts_generator():
     PromptsDemoGenerator.version = original_version
 
 
-def test_generate_all_demos_generates_all_registered(tracking_server):
+def test_generate_all_demos_generates_all_registered(client):
     results = generate_all_demos()
 
     registered_names = set(demo_registry.list_generators())
@@ -75,7 +69,7 @@ def test_generate_all_demos_generates_all_registered(tracking_server):
     assert generated_names == registered_names
 
 
-def test_generate_all_demos_is_idempotent(tracking_server):
+def test_generate_all_demos_is_idempotent(client):
     results_first = generate_all_demos()
     assert len(results_first) > 0
 
@@ -83,15 +77,15 @@ def test_generate_all_demos_is_idempotent(tracking_server):
     assert len(results_second) == 0
 
 
-def test_generate_all_demos_creates_experiment(tracking_server):
+def test_generate_all_demos_creates_experiment(client):
     generate_all_demos()
 
-    experiment = tracking_server.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
     assert experiment is not None
     assert experiment.lifecycle_stage == "active"
 
 
-def test_version_mismatch_triggers_cleanup_and_regeneration(tracking_server, traces_generator):
+def test_version_mismatch_triggers_cleanup_and_regeneration(client, traces_generator):
     result = traces_generator.generate()
     traces_generator.store_version()
     original_entity_count = len(result.entity_ids)
@@ -107,23 +101,23 @@ def test_version_mismatch_triggers_cleanup_and_regeneration(tracking_server, tra
     assert traces_generator.is_generated() is True
 
 
-def test_traces_creates_on_server(tracking_server, traces_generator):
+def test_traces_creates_on_server(client, traces_generator):
     result = traces_generator.generate()
     traces_generator.store_version()
 
-    experiment = tracking_server.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    traces = tracking_server.search_traces(locations=[experiment.experiment_id], max_results=200)
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=200)
 
     assert len(traces) == len(result.entity_ids)
     assert len(traces) == 34
 
 
-def test_traces_have_expected_span_types(tracking_server, traces_generator):
+def test_traces_have_expected_span_types(client, traces_generator):
     traces_generator.generate()
     traces_generator.store_version()
 
-    experiment = tracking_server.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    traces = tracking_server.search_traces(locations=[experiment.experiment_id], max_results=200)
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=200)
 
     all_span_names = {span.name for trace in traces for span in trace.data.spans}
 
@@ -137,12 +131,12 @@ def test_traces_have_expected_span_types(tracking_server, traces_generator):
     assert "render_prompt" in all_span_names
 
 
-def test_traces_session_metadata(tracking_server, traces_generator):
+def test_traces_session_metadata(client, traces_generator):
     traces_generator.generate()
     traces_generator.store_version()
 
-    experiment = tracking_server.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    traces = tracking_server.search_traces(locations=[experiment.experiment_id], max_results=200)
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=200)
 
     session_traces = [t for t in traces if t.info.trace_metadata.get("mlflow.trace.session")]
     assert len(session_traces) == 14
@@ -151,12 +145,12 @@ def test_traces_session_metadata(tracking_server, traces_generator):
     assert len(session_ids) == 6
 
 
-def test_traces_version_metadata(tracking_server, traces_generator):
+def test_traces_version_metadata(client, traces_generator):
     traces_generator.generate()
     traces_generator.store_version()
 
-    experiment = tracking_server.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    traces = tracking_server.search_traces(locations=[experiment.experiment_id], max_results=200)
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=200)
 
     v1_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_VERSION_TAG) == "v1"]
     v2_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_VERSION_TAG) == "v2"]
@@ -165,12 +159,12 @@ def test_traces_version_metadata(tracking_server, traces_generator):
     assert len(v2_traces) == 17
 
 
-def test_traces_type_metadata(tracking_server, traces_generator):
+def test_traces_type_metadata(client, traces_generator):
     traces_generator.generate()
     traces_generator.store_version()
 
-    experiment = tracking_server.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    traces = tracking_server.search_traces(locations=[experiment.experiment_id], max_results=200)
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    traces = client.search_traces(locations=[experiment.experiment_id], max_results=200)
 
     rag_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "rag"]
     agent_traces = [t for t in traces if t.info.trace_metadata.get(DEMO_TRACE_TYPE_TAG) == "agent"]
@@ -187,31 +181,27 @@ def test_traces_type_metadata(tracking_server, traces_generator):
     assert len(session_traces) == 14
 
 
-def test_traces_delete_removes_all(tracking_server, traces_generator):
+def test_traces_delete_removes_all(client, traces_generator):
     traces_generator.generate()
     traces_generator.store_version()
 
-    experiment = tracking_server.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
-    traces_before = tracking_server.search_traces(
-        locations=[experiment.experiment_id], max_results=200
-    )
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    traces_before = client.search_traces(locations=[experiment.experiment_id], max_results=200)
     assert len(traces_before) == 34
 
     traces_generator.delete_demo()
 
-    traces_after = tracking_server.search_traces(
-        locations=[experiment.experiment_id], max_results=200
-    )
+    traces_after = client.search_traces(locations=[experiment.experiment_id], max_results=200)
     assert len(traces_after) == 0
 
 
-def test_evaluation_creates_two_datasets(tracking_server, evaluation_generator):
+def test_evaluation_creates_two_datasets(client, evaluation_generator):
     result = evaluation_generator.generate()
     evaluation_generator.store_version()
 
     assert len(result.entity_ids) == 2  # Two evaluation run IDs
 
-    experiment = tracking_server.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
     v1_datasets = search_datasets(
         experiment_ids=[experiment.experiment_id],
         filter_string=f"name = '{DEMO_DATASET_V1_NAME}'",
@@ -229,11 +219,11 @@ def test_evaluation_creates_two_datasets(tracking_server, evaluation_generator):
     assert v2_datasets[0].name == DEMO_DATASET_V2_NAME
 
 
-def test_evaluation_datasets_have_records(tracking_server, evaluation_generator):
+def test_evaluation_datasets_have_records(client, evaluation_generator):
     evaluation_generator.generate()
     evaluation_generator.store_version()
 
-    experiment = tracking_server.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
 
     v1_datasets = search_datasets(
         experiment_ids=[experiment.experiment_id],
@@ -257,11 +247,11 @@ def test_evaluation_datasets_have_records(tracking_server, evaluation_generator)
     assert len(v2_df) == 17
 
 
-def test_evaluation_delete_removes_datasets(tracking_server, evaluation_generator):
+def test_evaluation_delete_removes_datasets(client, evaluation_generator):
     evaluation_generator.generate()
     evaluation_generator.store_version()
 
-    experiment = tracking_server.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
 
     datasets_before = search_datasets(
         experiment_ids=[experiment.experiment_id],
@@ -280,7 +270,7 @@ def test_evaluation_delete_removes_datasets(tracking_server, evaluation_generato
     assert len(datasets_after) == 0
 
 
-def test_prompts_creates_on_server(tracking_server, prompts_generator):
+def test_prompts_creates_on_server(client, prompts_generator):
     result = prompts_generator.generate()
     prompts_generator.store_version()
 
@@ -294,7 +284,7 @@ def test_prompts_creates_on_server(tracking_server, prompts_generator):
     assert any("versions:" in e for e in result.entity_ids)
 
 
-def test_prompts_have_multiple_versions(tracking_server, prompts_generator):
+def test_prompts_have_multiple_versions(client, prompts_generator):
     prompts_generator.generate()
     prompts_generator.store_version()
 
@@ -305,7 +295,7 @@ def test_prompts_have_multiple_versions(tracking_server, prompts_generator):
         assert prompt.version == expected_versions
 
 
-def test_prompts_have_production_alias(tracking_server, prompts_generator):
+def test_prompts_have_production_alias(client, prompts_generator):
     prompts_generator.generate()
     prompts_generator.store_version()
 
@@ -316,7 +306,7 @@ def test_prompts_have_production_alias(tracking_server, prompts_generator):
                 assert prompt.version == version_num
 
 
-def test_prompts_delete_removes_all(tracking_server, prompts_generator):
+def test_prompts_delete_removes_all(client, prompts_generator):
     prompts_generator.generate()
     prompts_generator.store_version()
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Addresses significant performance issues discovered by testing in #20511 . 
For the actual generation in general use, these operations are server-side. However, through the integration test, an http path was setup for simulating the environment (which is not realistic and introduces thousands of http requests). 
For the CLI, however, http IS required (there is no way to know / fetch what a remote tracking DB's uri is), but it is infrequent and not the most likely path of usage. Using demo generation through the UI follows the pure server-side path that already exists. 

This PR simply removes the poor simulation from the integration test. Confirmed a 3.1x speedup in mac and the windows speedup should be far more substantial. 

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
