### PR TITLE
Fix span filter combination to apply conditions on the same span

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -6071,6 +6071,11 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
 
     # Combine all span filter conditions into a single subquery
     # This ensures all conditions are applied to the SAME span
+    # Example trace:
+    # span 1. name: foo          status: OK
+    # span 2. name: search_web   status: ERROR
+    # This trace shouldn't be returned for filter_string
+    # 'span.name = "search_web" AND span.status = "OK"'
     if span_filter_conditions:
         combined_span_subquery = (
             session.query(SqlSpan.trace_id.label("request_id"))


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20540/files) to review incremental changes.
- [**stack/span_filters_backend_fix**](https://github.com/mlflow/mlflow/pull/20540) [[Files changed](https://github.com/mlflow/mlflow/pull/20540/files)]
  - [stack/span_status_filter_ui](https://github.com/mlflow/mlflow/pull/20541) [[Files changed](https://github.com/mlflow/mlflow/pull/20541/files/de6d856bdbdbcdc91aa97ce8cab0afb75f8abfbe..1a659fc974c3d0c22e5cd708c9154da566b8c5d8)]
    - [stack/tool_call_error_tooltip](https://github.com/mlflow/mlflow/pull/20542) [[Files changed](https://github.com/mlflow/mlflow/pull/20542/files/1a659fc974c3d0c22e5cd708c9154da566b8c5d8..11cecfc7095f109e2816b24e83e425eb0b8cef5d)]
      - [stack/error_chart_tooltip](https://github.com/mlflow/mlflow/pull/20567) [[Files changed](https://github.com/mlflow/mlflow/pull/20567/files/11cecfc7095f109e2816b24e83e425eb0b8cef5d..eb9d6bfd050338d2faed1b5b72add73ee4c31507)]
        - stack/assessment_tooltip_update

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Existing span filter contains an issue that the filters are not applied on the same span.
For example: I want to search for traces that contain an ERROR span named 'ABC', the two conditions 'span.name = "ABC"' and 'span.status = "ERROR"' may not apply on the same span, causing confused results.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
