### PR TITLE
Add span status filter support to traces UI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/filters/TableFilterItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/filters/TableFilterItem.tsx
@@ -27,6 +27,7 @@ import {
   CUSTOM_METADATA_COLUMN_ID,
   SPAN_NAME_COLUMN_ID,
   SPAN_TYPE_COLUMN_ID,
+  SPAN_STATUS_COLUMN_ID,
   SPAN_CONTENT_COLUMN_ID,
 } from '../../hooks/useTableColumns';
 import type {
@@ -80,6 +81,10 @@ const getAvailableOperators = (column: string, key?: string): FilterOperator[] =
 
   if (column === SPAN_NAME_COLUMN_ID || column === SPAN_TYPE_COLUMN_ID) {
     return [FilterOperator.EQUALS, FilterOperator.NOT_EQUALS, FilterOperator.CONTAINS];
+  }
+
+  if (column === SPAN_STATUS_COLUMN_ID) {
+    return [FilterOperator.EQUALS, FilterOperator.NOT_EQUALS];
   }
 
   if (column === SPAN_CONTENT_COLUMN_ID) {
@@ -163,6 +168,7 @@ export const TableFilterItem = ({
         // these when the search API supports them
         { value: SPAN_CONTENT_COLUMN_ID, renderValue: () => 'Span content' },
         { value: SPAN_NAME_COLUMN_ID, renderValue: () => 'Span name' },
+        { value: SPAN_STATUS_COLUMN_ID, renderValue: () => 'Span status' },
         { value: SPAN_TYPE_COLUMN_ID, renderValue: () => 'Span type' },
       );
     }

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.tsx
@@ -21,6 +21,7 @@ import {
   CUSTOM_METADATA_COLUMN_ID,
   SPAN_NAME_COLUMN_ID,
   SPAN_TYPE_COLUMN_ID,
+  SPAN_STATUS_COLUMN_ID,
   SPAN_CONTENT_COLUMN_ID,
   INPUTS_COLUMN_ID,
   RESPONSE_COLUMN_ID,
@@ -759,6 +760,10 @@ export const createMlflowSearchFilter = (
           } else {
             filter.push(`span.type ${networkFilter.operator} '${networkFilter.value}'`);
           }
+          break;
+        case SPAN_STATUS_COLUMN_ID:
+          // Span status uses exact match (OK, ERROR, UNSET)
+          filter.push(`span.status ${networkFilter.operator} '${networkFilter.value}'`);
           break;
         case SPAN_CONTENT_COLUMN_ID:
           if (networkFilter.operator === 'CONTAINS') {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useTableColumns.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useTableColumns.tsx
@@ -32,6 +32,7 @@ export const TOKENS_COLUMN_ID = 'tokens';
 export const CUSTOM_METADATA_COLUMN_ID = 'custom_metadata';
 export const SPAN_NAME_COLUMN_ID = 'span.name';
 export const SPAN_TYPE_COLUMN_ID = 'span.type';
+export const SPAN_STATUS_COLUMN_ID = 'span.status';
 export const SPAN_CONTENT_COLUMN_ID = 'span.content';
 export const LINKED_PROMPTS_COLUMN_ID = 'prompt';
 export const SIMULATION_GOAL_COLUMN_ID = 'simulation_goal';

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -6071,6 +6071,11 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
 
     # Combine all span filter conditions into a single subquery
     # This ensures all conditions are applied to the SAME span
+    # Example trace:
+    # span 1. name: foo          status: OK
+    # span 2. name: search_web   status: ERROR
+    # This trace shouldn't be returned for filter_string
+    # 'span.name = "search_web" AND span.status = "OK"'
     if span_filter_conditions:
         combined_span_subquery = (
             session.query(SqlSpan.trace_id.label("request_id"))


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20541/files/de6d856bdbdbcdc91aa97ce8cab0afb75f8abfbe..1a659fc974c3d0c22e5cd708c9154da566b8c5d8) to review incremental changes.
- [stack/span_filters_backend_fix](https://github.com/mlflow/mlflow/pull/20540) [[Files changed](https://github.com/mlflow/mlflow/pull/20540/files)]
  - [**stack/span_status_filter_ui**](https://github.com/mlflow/mlflow/pull/20541) [[Files changed](https://github.com/mlflow/mlflow/pull/20541/files/de6d856bdbdbcdc91aa97ce8cab0afb75f8abfbe..1a659fc974c3d0c22e5cd708c9154da566b8c5d8)]
    - [stack/tool_call_error_tooltip](https://github.com/mlflow/mlflow/pull/20542) [[Files changed](https://github.com/mlflow/mlflow/pull/20542/files/1a659fc974c3d0c22e5cd708c9154da566b8c5d8..11cecfc7095f109e2816b24e83e425eb0b8cef5d)]
      - [stack/error_chart_tooltip](https://github.com/mlflow/mlflow/pull/20567) [[Files changed](https://github.com/mlflow/mlflow/pull/20567/files/11cecfc7095f109e2816b24e83e425eb0b8cef5d..eb9d6bfd050338d2faed1b5b72add73ee4c31507)]
        - stack/assessment_tooltip_update

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Support span status filter since backend already supports it

https://github.com/user-attachments/assets/7df73510-3ba1-48ab-bbdd-557682329ab5



<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
