### PR TITLE
[Workspace] Restore artifact root configuration validation for workspaces

### DIFF
--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -356,6 +356,7 @@ def _exec_job(
                     tmpdir,
                     job_store,
                     job_id,
+                    job_name,
                     workspace,
                 )
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2201,7 +2201,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         current_time = get_current_time_millis()
         with self.ManagedSessionMaker() as session:
             models = (
-                session.query(SqlLoggedModel)
+                self._get_query(session, SqlLoggedModel)
                 .filter(
                     SqlLoggedModel.lifecycle_stage == LifecycleStage.DELETED,
                     SqlLoggedModel.last_updated_timestamp_ms <= (current_time - older_than),

--- a/tests/db/check_migration.py
+++ b/tests/db/check_migration.py
@@ -135,7 +135,7 @@ def log_everything():
             sa.insert(jobs_table).values(
                 id=uuid.uuid4().hex,
                 creation_time=0,
-                function_fullname="tests.db.check_migration.log_everything",
+                job_name="tests.db.check_migration.log_everything",
                 params="{}",
                 timeout=None,
                 status=0,

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -68,12 +68,12 @@ CREATE TABLE jobs (
 	creation_time BIGINT NOT NULL,
 	job_name VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	params VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
 	timeout FLOAT,
 	status INTEGER NOT NULL,
 	result VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	retry_count INTEGER NOT NULL,
 	last_update_time BIGINT NOT NULL,
+	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 
@@ -158,7 +158,7 @@ CREATE TABLE endpoints (
 	usage_tracking BIT DEFAULT ('0') NOT NULL,
 	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
 	CONSTRAINT endpoints_pk PRIMARY KEY (endpoint_id),
-	CONSTRAINT fk_endpoints_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE SET NULL
+	CONSTRAINT fk_endpoints_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE SET NULL,
 	CONSTRAINT uq_endpoints_workspace_name UNIQUE (workspace, name)
 )
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -69,12 +69,12 @@ CREATE TABLE jobs (
 	creation_time BIGINT NOT NULL,
 	job_name VARCHAR(500),
 	params TEXT NOT NULL,
-	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	timeout DOUBLE,
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER NOT NULL,
 	last_update_time BIGINT NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	PRIMARY KEY (id)
 )
 
@@ -159,7 +159,7 @@ CREATE TABLE endpoints (
 	usage_tracking TINYINT DEFAULT '0' NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	PRIMARY KEY (endpoint_id),
-	CONSTRAINT fk_endpoints_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE SET NULL
+	CONSTRAINT fk_endpoints_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE SET NULL,
 	CONSTRAINT uq_endpoints_workspace_name UNIQUE (workspace, name)
 )
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -69,12 +69,12 @@ CREATE TABLE jobs (
 	creation_time BIGINT NOT NULL,
 	job_name VARCHAR(500) NOT NULL,
 	params TEXT NOT NULL,
-	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
 	timeout DOUBLE PRECISION,
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER NOT NULL,
 	last_update_time BIGINT NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 
@@ -159,7 +159,7 @@ CREATE TABLE endpoints (
 	usage_tracking BOOLEAN DEFAULT false NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
 	CONSTRAINT endpoints_pk PRIMARY KEY (endpoint_id),
-	CONSTRAINT fk_endpoints_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE SET NULL
+	CONSTRAINT fk_endpoints_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE SET NULL,
 	CONSTRAINT uq_endpoints_workspace_name UNIQUE (workspace, name)
 )
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -69,12 +69,12 @@ CREATE TABLE jobs (
 	creation_time BIGINT NOT NULL,
 	job_name VARCHAR(500) NOT NULL,
 	params TEXT NOT NULL,
-	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	timeout FLOAT,
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER NOT NULL,
 	last_update_time BIGINT NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 
@@ -159,7 +159,7 @@ CREATE TABLE endpoints (
 	usage_tracking BOOLEAN DEFAULT '0' NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	CONSTRAINT endpoints_pk PRIMARY KEY (endpoint_id),
-	CONSTRAINT fk_endpoints_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE SET NULL
+	CONSTRAINT fk_endpoints_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE SET NULL,
 	CONSTRAINT uq_endpoints_workspace_name UNIQUE (workspace, name)
 )
 

--- a/tests/server/auth/test_client_workspace.py
+++ b/tests/server/auth/test_client_workspace.py
@@ -164,7 +164,10 @@ def _graphql_search_runs(
     resp.raise_for_status()
     payload = resp.json()
     assert payload.get("errors") in (None, [])
-    return payload["data"]["mlflowSearchRuns"]["runs"]
+    search_runs = payload["data"]["mlflowSearchRuns"]
+    if search_runs is None:
+        return []
+    return search_runs["runs"]
 
 
 def _graphql_search_model_versions(

--- a/tests/store/tracking/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/test_sqlalchemy_workspace_store.py
@@ -801,6 +801,41 @@ def test_log_spans_update_is_workspace_scoped(workspace_tracking_store):
         assert len(updated_trace.data.spans) == 2
 
 
+def test_validate_artifact_root_allows_missing_global_root(workspace_tracking_store):
+    workspace_tracking_store.artifact_root_uri = None
+    workspace_tracking_store._validate_artifact_root_configuration()
+
+
+def test_workspace_startup_rejects_root_ending_with_workspaces(tmp_path, monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    backend_uri = f"sqlite:///{tmp_path / 'suffix.db'}"
+    bad_root = tmp_path / "base" / "workspaces"
+    bad_root.mkdir(parents=True)
+
+    with pytest.raises(
+        MlflowException,
+        match="ends with the reserved 'workspaces' segment",
+    ) as excinfo:
+        tracking_utils._get_sqlalchemy_store(backend_uri, bad_root.as_uri())
+    assert excinfo.value.error_code == "INVALID_STATE"
+    SqlAlchemyStore._engine_map.pop(backend_uri, None)
+
+
+def test_workspace_startup_rejects_root_already_scoped(tmp_path, monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    backend_uri = f"sqlite:///{tmp_path / 'scoped.db'}"
+    bad_root = tmp_path / "base" / "workspaces" / "team"
+    bad_root.mkdir(parents=True)
+
+    with pytest.raises(
+        MlflowException,
+        match="is already scoped under the reserved 'workspaces/<name>' prefix",
+    ) as excinfo:
+        tracking_utils._get_sqlalchemy_store(backend_uri, bad_root.as_uri())
+    assert excinfo.value.error_code == "INVALID_STATE"
+    SqlAlchemyStore._engine_map.pop(backend_uri, None)
+
+
 def test_workspace_startup_ignores_default_experiment_reserved_location(tmp_path, monkeypatch):
     backend_uri = f"sqlite:///{tmp_path / 'default_conflict.db'}"
     base_root = tmp_path / "base"


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Re-add preflight checks that validate the default artifact root is not configured with reserved path segments:

1. Reject roots ending with 'workspaces' (e.g., /artifacts/workspaces)
2. Reject roots already scoped under 'workspaces/<name>' prefix

These validations catch admin misconfiguration without blocking the disable/re-enable workspace workflow. The previous removal in #20477 was too aggressive - only the database query for existing experiments needed to be removed (that check blocked re-enabling workspaces after experiments had been moved to the default workspace).

This also addresses issues after the rebase.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
