### PR TITLE
Add automatic run creation for standalone simulation

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -317,7 +317,10 @@ def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult
 
     scorers = validate_scorers(scorers)
 
-    # Handle ConversationSimulator: run simulation first, then evaluate the generated traces
+    # Handle ConversationSimulator: prepare for simulation, but run it inside the run context
+    # so that traces are logged to the correct run.
+    simulator = None
+    sim_predict_fn = None
     precomputed_digest = None
     precomputed_dataset_name = None
     if isinstance(data, ConversationSimulator):
@@ -337,76 +340,7 @@ def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult
         if inspect.iscoroutinefunction(predict_fn):
             sim_predict_fn = _wrap_async_predict_fn(predict_fn)
 
-        all_traces = data.simulate(sim_predict_fn)
-        logger.debug(
-            f"Simulation produced {len(all_traces)} conversation(s) with "
-            f"{[len(traces) for traces in all_traces]} trace(s) each"
-        )
-        data = [trace for traces in all_traces for trace in traces]
-
-        if not data:
-            raise MlflowException.invalid_parameter_value(
-                "Simulation produced no traces. This may indicate that all conversations "
-                "failed during simulation. Check the logs above for error details."
-            )
-        # Set predict_fn to None since the simulation already invoked it for each conversation
-        # turn. The resulting traces contain all the prediction outputs, so the evaluation
-        # harness will use those traces directly rather than calling predict_fn again.
-        predict_fn = None
-
-    is_managed_dataset = isinstance(data, (EvaluationDataset, EntityEvaluationDataset))
-
-    # Validate session-level input if session-level scorers are present
-    validate_session_level_evaluation_inputs(scorers, predict_fn)
-
-    df = _convert_to_eval_set(data)
-
-    builtin_scorers = [scorer for scorer in scorers if isinstance(scorer, BuiltInScorer)]
-    valid_data_for_builtin_scorers(df, builtin_scorers, predict_fn)
-
-    sample_input = df.iloc[0][InputDatasetColumn.INPUTS]
-
-    # Only check 'inputs' column when it is not derived from the trace object
-    if "trace" not in df.columns and not isinstance(sample_input, dict):
-        raise MlflowException.invalid_parameter_value(
-            "The 'inputs' column must be a dictionary of field names and values. "
-            "For example: {'query': 'What is MLflow?'}"
-        )
-
-    # If the input dataset is a managed dataset, we pass the original dataset
-    # to the evaluate function to preserve metadata like dataset name.
-    data = data if is_managed_dataset else df
-
-    if predict_fn:
-        predict_fn = convert_predict_fn(predict_fn=predict_fn, sample_input=sample_input)
-
-    # NB: The "RAG_EVAL_MAX_WORKERS" env var is used in the DBX agent harness, but is
-    # deprecated in favor of the new "MLFLOW_GENAI_EVAL_MAX_WORKERS" env var. The old
-    # one is not publicly documented, but we keep it for backward compatibility.
-    if "RAG_EVAL_MAX_WORKERS" in os.environ:
-        logger.warning(
-            "The `RAG_EVAL_MAX_WORKERS` environment variable is deprecated. "
-            f"Please use `{MLFLOW_GENAI_EVAL_MAX_WORKERS.name}` instead."
-        )
-        os.environ[MLFLOW_GENAI_EVAL_MAX_WORKERS.name] = os.environ["RAG_EVAL_MAX_WORKERS"]
-
-    if isinstance(data, (EvaluationDataset, EntityEvaluationDataset)):
-        mlflow_dataset = data
-        df = data.to_df()
-    else:
-        # Use precomputed name from ConversationSimulator, or default "dataset" for other sources.
-        # Pass precomputed_digest if available (e.g., from ConversationSimulator test cases).
-        dataset_name = precomputed_dataset_name or "dataset"
-        mlflow_dataset = mlflow.data.from_pandas(
-            df=data, name=dataset_name, digest=precomputed_digest
-        )
-        df = data
-
-    try:
-        telemetry_data = _get_eval_data_size_and_fields(df)
-    except Exception:
-        _log_error("Failed to get evaluation data size and fields for GenAIEvaluateEvent")
-        telemetry_data = {}
+        simulator = data
 
     with (
         _start_run_or_reuse_active_run() as run_id,
@@ -414,6 +348,79 @@ def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult
         # NB: Auto-logging should be enabled outside the thread pool to avoid race conditions.
         configure_autologging_for_evaluation(enable_tracing=True),
     ):
+        # Run simulation inside the run context so traces are logged to this run
+        if simulator is not None:
+            all_traces = simulator.simulate(sim_predict_fn)
+            logger.debug(
+                f"Simulation produced {len(all_traces)} conversation(s) with "
+                f"{[len(traces) for traces in all_traces]} trace(s) each"
+            )
+            data = [trace for traces in all_traces for trace in traces]
+
+            if not data:
+                raise MlflowException.invalid_parameter_value(
+                    "Simulation produced no traces. This may indicate that all conversations "
+                    "failed during simulation. Check the logs above for error details."
+                )
+            # Set predict_fn to None since the simulation already invoked it for each conversation
+            # turn. The resulting traces contain all the prediction outputs, so the evaluation
+            # harness will use those traces directly rather than calling predict_fn again.
+            predict_fn = None
+
+        is_managed_dataset = isinstance(data, (EvaluationDataset, EntityEvaluationDataset))
+
+        # Validate session-level input if session-level scorers are present
+        validate_session_level_evaluation_inputs(scorers, predict_fn)
+
+        df = _convert_to_eval_set(data)
+
+        builtin_scorers = [scorer for scorer in scorers if isinstance(scorer, BuiltInScorer)]
+        valid_data_for_builtin_scorers(df, builtin_scorers, predict_fn)
+
+        sample_input = df.iloc[0][InputDatasetColumn.INPUTS]
+
+        # Only check 'inputs' column when it is not derived from the trace object
+        if "trace" not in df.columns and not isinstance(sample_input, dict):
+            raise MlflowException.invalid_parameter_value(
+                "The 'inputs' column must be a dictionary of field names and values. "
+                "For example: {'query': 'What is MLflow?'}"
+            )
+
+        # If the input dataset is a managed dataset, we pass the original dataset
+        # to the evaluate function to preserve metadata like dataset name.
+        data = data if is_managed_dataset else df
+
+        if predict_fn:
+            predict_fn = convert_predict_fn(predict_fn=predict_fn, sample_input=sample_input)
+
+        # NB: The "RAG_EVAL_MAX_WORKERS" env var is used in the DBX agent harness, but is
+        # deprecated in favor of the new "MLFLOW_GENAI_EVAL_MAX_WORKERS" env var. The old
+        # one is not publicly documented, but we keep it for backward compatibility.
+        if "RAG_EVAL_MAX_WORKERS" in os.environ:
+            logger.warning(
+                "The `RAG_EVAL_MAX_WORKERS` environment variable is deprecated. "
+                f"Please use `{MLFLOW_GENAI_EVAL_MAX_WORKERS.name}` instead."
+            )
+            os.environ[MLFLOW_GENAI_EVAL_MAX_WORKERS.name] = os.environ["RAG_EVAL_MAX_WORKERS"]
+
+        if isinstance(data, (EvaluationDataset, EntityEvaluationDataset)):
+            mlflow_dataset = data
+            df = data.to_df()
+        else:
+            # Use precomputed name from ConversationSimulator, or default "dataset" for
+            # other sources. Pass precomputed_digest if available (from ConversationSimulator).
+            dataset_name = precomputed_dataset_name or "dataset"
+            mlflow_dataset = mlflow.data.from_pandas(
+                df=data, name=dataset_name, digest=precomputed_digest
+            )
+            df = data
+
+        try:
+            telemetry_data = _get_eval_data_size_and_fields(df)
+        except Exception:
+            _log_error("Failed to get evaluation data size and fields for GenAIEvaluateEvent")
+            telemetry_data = {}
+
         _log_dataset_input(mlflow_dataset, run_id, model_id)
 
         # NB: Set this tag before run finishes to suppress the generic run URL printing.

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1402,3 +1402,66 @@ def test_evaluate_handles_empty_expectations(expectations_values, expected_count
     assert result.result_df is not None
     assert len(result.result_df) == expected_count
     assert result.metrics["always_pass/mean"] == 1.0
+
+
+from mlflow.genai.simulators.simulator import BaseSimulatedUserAgent
+
+
+class MockUserAgent(BaseSimulatedUserAgent):
+    def __init__(self, **kwargs):
+        pass
+
+    def generate_message(self, context):
+        if context.turn == 0:
+            return f"Hello, I want to {context.goal}"
+        return "[GOAL ACHIEVED]"
+
+
+def test_evaluate_with_simulator_creates_single_run(tmp_path):
+    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
+    mlflow.set_experiment("test-experiment")
+
+    simulator = ConversationSimulator(
+        test_cases=[{"goal": "get help"}],
+        max_turns=2,
+        user_agent_class=MockUserAgent,
+    )
+
+    def mock_predict_fn(input: list[dict[str, Any]], **kwargs):
+        return {"content": "Response"}
+
+    with mock.patch(
+        "mlflow.genai.simulators.simulator.invoke_model_without_tracing",
+        return_value='{"rationale": "Goal achieved!", "result": "yes"}',
+    ):
+        mlflow.genai.evaluate(data=simulator, predict_fn=mock_predict_fn, scorers=[])
+
+    runs = mlflow.search_runs()
+    assert len(runs) == 1
+
+
+def test_evaluate_with_simulator_within_parent_run(tmp_path):
+    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
+    mlflow.set_experiment("test-experiment")
+
+    simulator = ConversationSimulator(
+        test_cases=[{"goal": "get help"}],
+        max_turns=2,
+        user_agent_class=MockUserAgent,
+    )
+
+    def mock_predict_fn(input: list[dict[str, Any]], **kwargs):
+        return {"content": "Response"}
+
+    with mock.patch(
+        "mlflow.genai.simulators.simulator.invoke_model_without_tracing",
+        return_value='{"rationale": "Goal achieved!", "result": "yes"}',
+    ):
+        with mlflow.start_run(run_name="parent-run") as parent_run:
+            parent_run_id = parent_run.info.run_id
+            mlflow.genai.evaluate(data=simulator, predict_fn=mock_predict_fn, scorers=[])
+            assert mlflow.active_run().info.run_id == parent_run_id
+
+    runs = mlflow.search_runs()
+    assert len(runs) == 1
+    assert runs.iloc[0]["tags.mlflow.runName"] == "parent-run"


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Wraps calls to simulation in a MLflow run to easily see which conversations were generated from the same call.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
"""
Test script for simulation run behavior.
Tests three scenarios:
1. Standalone simulation (should create its own run)
2. Simulation within start_run context (should use parent run)
3. Simulation within evaluation (should use evaluation's run)
"""

import mlflow
from mlflow.genai.simulators import ConversationSimulator
from mlflow.genai.simulators.simulator import BaseSimulatedUserAgent, SimulatorContext


class MockUserAgent(BaseSimulatedUserAgent):
    """Mock user agent that doesn't require an LLM."""

    def __init__(self, **kwargs):
        pass

    def generate_message(self, context: SimulatorContext) -> str:
        if context.turn == 0:
            return f"Hello, I want to {context.goal}"
        return "[GOAL ACHIEVED]"


def mock_predict_fn(input: list[dict], **kwargs) -> dict:
    """Simple mock predict function that echoes back the last user message."""
    last_message = input[-1]["content"] if input else "Hello"
    return {"content": f"Response to: {last_message}"}


test_cases = [
    {"goal": "get help with a simple question", "persona": "A curious user"},
]


def scenario_1_standalone():
    """Scenario 1: Standalone simulation - should create its own run."""
    print("\n=== Scenario 1: Standalone Simulation ===")
    print("Expected: Creates run named 'simulation-<8-digit-hex>'")

    simulator = ConversationSimulator(
        test_cases=test_cases,
        max_turns=2,
        user_agent_class=MockUserAgent,
    )
    traces = simulator.simulate(mock_predict_fn)

    print(f"Simulation completed with {len(traces)} conversation(s)")

    # Check if a run was created
    runs = mlflow.search_runs(filter_string="tags.mlflow.runName LIKE 'simulation-%'")
    if not runs.empty:
        print(f"✓ Created run: {runs.iloc[0]['tags.mlflow.runName']}")
    else:
        print("✗ No simulation run found")


def scenario_2_within_start_run():
    """Scenario 2: Simulation within start_run - should use parent run."""
    print("\n=== Scenario 2: Simulation within start_run ===")
    print("Expected: Uses existing 'my-parent-run', no new run created")

    with mlflow.start_run(run_name="my-parent-run") as parent_run:
        run_id_before = parent_run.info.run_id
        print(f"Parent run ID: {run_id_before}")

        simulator = ConversationSimulator(
            test_cases=test_cases,
            max_turns=2,
            user_agent_class=MockUserAgent,
        )
        traces = simulator.simulate(mock_predict_fn)

        run_id_after = mlflow.active_run().info.run_id
        print(f"Simulation completed with {len(traces)} conversation(s)")

        if run_id_before == run_id_after:
            print("✓ Used parent run (no new run created)")
        else:
            print("✗ Unexpectedly created a new run")


def scenario_3_within_evaluation():
    """Scenario 3: Simulation within evaluation - uses evaluation's run."""
    print("\n=== Scenario 3: Simulation within evaluation ===")
    print("Expected: Uses evaluation's run, simulation doesn't create its own")

    simulator = ConversationSimulator(
        test_cases=test_cases,
        max_turns=2,
        user_agent_class=MockUserAgent,
    )

    result = mlflow.genai.evaluate(
        data=simulator,
        predict_fn=mock_predict_fn,
        scorers=[],
    )

    print("Evaluation completed successfully")
    print("✓ Simulation ran within evaluation context")


if __name__ == "__main__":
    mlflow.set_tracking_uri("sqlite:///mlflow.db")

    scenario_1_standalone()
    scenario_2_within_start_run()
    scenario_3_within_evaluation()

    print("\n=== All scenarios completed ===")
```
Results in 3 runs:
<img width="626" height="499" alt="image" src="https://github.com/user-attachments/assets/0b4b4416-6cae-405d-a8bf-b85ebe22791e" />

Each with respective run name:
<img width="1359" height="527" alt="image" src="https://github.com/user-attachments/assets/d1697238-f646-4b0d-85f9-8494c3a7cf07" />



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
