### PR TITLE
Fix SelectTracesModal closing all modals when opened from trace drawer

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useActiveEvaluation.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useActiveEvaluation.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { createContext, useCallback, useContext } from 'react';
 
 import { createTraceV4LongIdentifier, type ModelTraceInfoV3 } from '../../model-trace-explorer';
 import { useSearchParams } from '../utils/RoutingUtils';
@@ -6,17 +6,33 @@ import { doesTraceSupportV4API } from '../utils/TraceLocationUtils';
 
 const QUERY_PARAM_KEY = 'selectedEvaluationId';
 
+type SetSelectedEvaluationIdFn = (selectedEvaluationId: string | undefined, traceInfo?: ModelTraceInfoV3) => void;
+
+/**
+ * Context to override the active evaluation state.
+ * When provided, useActiveEvaluation will use the context value instead of URL params.
+ * This is useful for components like SelectTracesModal that need to render a traces table
+ * without inheriting the parent's selected evaluation state.
+ */
+export const ActiveEvaluationContext = createContext<{
+  selectedEvaluationId: string | undefined;
+  setSelectedEvaluationId: SetSelectedEvaluationIdFn;
+} | null>(null);
+
 /**
  * Query param-powered hook that returns the currently selected evaluation ID
  * and a function to set the selected evaluation ID.
+ *
+ * If ActiveEvaluationContext is provided, uses context value instead of URL params.
  */
 export const useActiveEvaluation = () => {
+  const context = useContext(ActiveEvaluationContext);
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const selectedEvaluationId = searchParams.get(QUERY_PARAM_KEY) ?? undefined;
+  const selectedEvaluationIdFromUrl = searchParams.get(QUERY_PARAM_KEY) ?? undefined;
 
-  const setSelectedEvaluationId = useCallback(
-    (selectedEvaluationId: string | undefined, traceInfo?: ModelTraceInfoV3) => {
+  const setSelectedEvaluationIdFromUrl: SetSelectedEvaluationIdFn = useCallback(
+    (selectedEvaluationId, traceInfo) => {
       setSearchParams((params) => {
         if (selectedEvaluationId === undefined) {
           params.delete(QUERY_PARAM_KEY);
@@ -37,5 +53,10 @@ export const useActiveEvaluation = () => {
     [setSearchParams],
   );
 
-  return [selectedEvaluationId, setSelectedEvaluationId] as const;
+  // If context is provided, use context values instead of URL params
+  if (context) {
+    return [context.selectedEvaluationId, context.setSelectedEvaluationId] as const;
+  }
+
+  return [selectedEvaluationIdFromUrl, setSelectedEvaluationIdFromUrl] as const;
 };

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
@@ -110,3 +110,4 @@ export { doesTraceSupportV4API } from './utils/TraceLocationUtils';
 export { GenAIChatSessionsTable } from './sessions-table/GenAIChatSessionsTable';
 export { useGetTraces } from './hooks/useGetTraces';
 export { useGetTrace } from './hooks/useGetTrace';
+export { ActiveEvaluationContext } from './hooks/useActiveEvaluation';


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

When opening SelectTracesModal from the "Create Judge" flow (trace drawer → Add feedback → LLM judge → Create judge → Select traces -> View all traces), the trace drawer would unexpectedly appear on top of the select traces modal. This happened because the nested TracesV3Logs component read the same `selectedEvaluationId` URL param as the parent, causing a conflicting trace drawer to attempt rendering inside the modal.

**Key changes:**
- Add `ActiveEvaluationContext` to `useActiveEvaluation` hook for state isolation
- `SelectTracesModal` provides context with `undefined` selectedEvaluationId to prevent drawer from rendering inside modal
- Clicking a trace in SelectTracesModal now opens it in a new tab instead (preserving the current time filter including CUSTOM ranges)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Before fix:

https://github.com/user-attachments/assets/b48c5a1b-3773-4832-b417-094e247858f9

After fix:

https://github.com/user-attachments/assets/b17461a7-f8e6-4405-abbf-02e9f4c82a4b



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where opening the "Select traces" modal from the Create Judge flow would cause all modals to close unexpectedly.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)