### PR TITLE
Add functionality to handle stacked pull requests in reviewer selection

### DIFF
--- a/.github/scripts/select-reviewers.js
+++ b/.github/scripts/select-reviewers.js
@@ -181,7 +181,9 @@ module.exports = async ({ github, context }) => {
           reviewers: reviewersToAdd,
         });
         console.log(`Stacked PR detected (base: ${baseBranch})`);
-        console.log(`Copied reviewers from parent PR #${parentPR.number}: ${reviewersToAdd.join(", ")}`);
+        console.log(
+          `Copied reviewers from parent PR #${parentPR.number}: ${reviewersToAdd.join(", ")}`
+        );
       } catch (error) {
         console.error("Failed to assign reviewers from parent PR:", error);
       }

--- a/.github/scripts/select-reviewers.js
+++ b/.github/scripts/select-reviewers.js
@@ -110,10 +110,86 @@ async function getCopilotInitiator(github, owner, repo, pull_number) {
   return timeline.data.find((e) => e.event === "copilot_work_started")?.actor?.login;
 }
 
+async function getParentStackPR(github, owner, repo, baseBranch) {
+  // Check if the base branch is a stack branch (starts with "stack/")
+  if (!baseBranch.startsWith("stack/")) {
+    return null;
+  }
+
+  // Find the open PR with head branch matching the base branch
+  // Use GraphQL since REST API's head filter requires owner prefix, which doesn't work for forks
+  const query = `
+    query($owner: String!, $repo: String!, $baseBranch: String!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequests(states: OPEN, headRefName: $baseBranch, first: 1) {
+          nodes {
+            number
+            headRefName
+            reviewRequests(first: 10) {
+              nodes {
+                requestedReviewer {
+                  ... on User {
+                    login
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await github.graphql(query, { owner, repo, baseBranch });
+  const prs = result.repository.pullRequests.nodes;
+
+  if (prs.length === 0) {
+    return null;
+  }
+
+  const pr = prs[0];
+  return {
+    number: pr.number,
+    requested_reviewers: pr.reviewRequests.nodes
+      .map((r) => r.requestedReviewer)
+      .filter((r) => r && r.login)
+      .map((r) => ({ login: r.login })),
+  };
+}
+
 module.exports = async ({ github, context }) => {
   const { owner, repo } = context.repo;
   const pull_number = context.payload.pull_request.number;
   const author = context.payload.pull_request.user.login;
+  const baseBranch = context.payload.pull_request.base.ref;
+
+  // Check if this is a stacked PR (base branch is another stack branch)
+  const parentPR = await getParentStackPR(github, owner, repo, baseBranch);
+  if (parentPR) {
+    const parentReviewers = parentPR.requested_reviewers.map((r) => r.login);
+    const currentRequested = context.payload.pull_request.requested_reviewers.map((r) => r.login);
+
+    // Filter out reviewers already requested on this PR
+    const reviewersToAdd = parentReviewers.filter((r) => !currentRequested.includes(r));
+
+    if (reviewersToAdd.length > 0) {
+      try {
+        await github.rest.pulls.requestReviewers({
+          owner,
+          repo,
+          pull_number,
+          reviewers: reviewersToAdd,
+        });
+        console.log(`Stacked PR detected (base: ${baseBranch})`);
+        console.log(`Copied reviewers from parent PR #${parentPR.number}: ${reviewersToAdd.join(", ")}`);
+      } catch (error) {
+        console.error("Failed to assign reviewers from parent PR:", error);
+      }
+    } else {
+      console.log(`Stacked PR detected but all parent reviewers already requested`);
+    }
+    return;
+  }
 
   const copilotInitiator = await getCopilotInitiator(github, owner, repo, pull_number);
 

--- a/.github/workflows/team-review.yml
+++ b/.github/workflows/team-review.yml
@@ -1,7 +1,7 @@
 name: Team review
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
 


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Adjust the logic for team-review flow for stack prs.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
