### PR TITLE
Function Call items take Tool Call IDs if it exists

### DIFF
--- a/mlflow/types/responses.py
+++ b/mlflow/types/responses.py
@@ -435,7 +435,7 @@ if _HAS_LANGCHAIN_BASE_MESSAGE:
                 if tool_calls := message.get("tool_calls"):
                     for tool_call in tool_calls:
                         function_call_item = create_function_call_item(
-                            id=message.get("id") or str(uuid4()),
+                            id=tool_call.get("id") or message.get("id") or str(uuid4()),
                             call_id=tool_call["id"],
                             name=tool_call["name"],
                             arguments=json.dumps(tool_call["args"]),

--- a/tests/langchain/test_responses_agent_langchain.py
+++ b/tests/langchain/test_responses_agent_langchain.py
@@ -1,3 +1,5 @@
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
 from mlflow.types.responses import ResponsesAgentStreamEvent, output_to_responses_items_stream
 
 
@@ -10,8 +12,6 @@ def test_output_to_responses_items_stream_langchain():
     - Filtering out HumanMessage from the stream
     - Message
     """
-    from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-
     messages = [
         AIMessage(
             content="test text0",
@@ -271,8 +271,6 @@ def test_output_to_responses_items_stream_langchain_multiple_tool_calls_unique_i
     gets a unique ID from the tool_call's own ID, not the shared message ID.
     This prevents ID duplication when a single message contains multiple tool calls.
     """
-    from langchain_core.messages import AIMessage, ToolMessage
-
     messages = [
         AIMessage(
             content="I'll look up both the current and historical stock prices for Apple.",

--- a/tests/langchain/test_responses_agent_langchain.py
+++ b/tests/langchain/test_responses_agent_langchain.py
@@ -266,11 +266,6 @@ def test_output_to_responses_items_stream_langchain():
 
 
 def test_output_to_responses_items_stream_langchain_multiple_tool_calls_unique_ids():
-    """
-    Tests that when an AI message has multiple tool calls, each function_call_item
-    gets a unique ID from the tool_call's own ID, not the shared message ID.
-    This prevents ID duplication when a single message contains multiple tool calls.
-    """
     messages = [
         AIMessage(
             content="I'll look up both the current and historical stock prices for Apple.",

--- a/tests/langchain/test_responses_agent_langchain.py
+++ b/tests/langchain/test_responses_agent_langchain.py
@@ -317,7 +317,8 @@ def test_output_to_responses_items_stream_langchain_multiple_tool_calls_unique_i
                 "id": "lc_run--019c2b6f-4d8d-70e3-b620-b80545b4cb30",
                 "content": [
                     {
-                        "text": "I'll look up both the current and historical stock prices for Apple.",
+                        "text": "I'll look up both the current and historical "
+                        "stock prices for Apple.",
                         "type": "output_text",
                     }
                 ],
@@ -344,7 +345,8 @@ def test_output_to_responses_items_stream_langchain_multiple_tool_calls_unique_i
                 "id": "toolu_bdrk_01Dte8KnRx9Tk7pMz9h83okn",
                 "call_id": "toolu_bdrk_01Dte8KnRx9Tk7pMz9h83okn",
                 "name": "get_historical_stock_prices",
-                "arguments": '{"ticker": "AAPL", "start_date": "2023-01-01", "end_date": "2024-01-01"}',
+                "arguments": '{"ticker": "AAPL", "start_date": "2023-01-01", '
+                '"end_date": "2024-01-01"}',
             },
         ),
         ResponsesAgentStreamEvent(


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

Bug fix: 

For parallel tool calls with identical `message_id` and varying `tool_call_id`s we assign `function_call`=>`message_id`and the `tool_call`=>`tool_call_id`. This results in some orphaned tool calls.

Fixed by setting the `function_call`=>`tool_call_id` if it exists, otherwise `message_id`, otherwise some random UUID.

### Related Issues/PRs

No related issues.

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
