### PR TITLE
Revert "Fix bug: linking prompt to experiments does not work for defa…

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -60,6 +60,7 @@ from mlflow.entities.webhook import (
 from mlflow.environment_variables import (
     MLFLOW_ALIAS_PROMPT_CACHE_TTL_SECONDS,
     MLFLOW_ENABLE_ASYNC_LOGGING,
+    MLFLOW_EXPERIMENT_ID,
     MLFLOW_VERSION_PROMPT_CACHE_TTL_SECONDS,
 )
 from mlflow.exceptions import MlflowException
@@ -695,10 +696,7 @@ class MlflowClient:
 
         prompt_version = model_version_to_prompt_version(mv, prompt_tags=prompt_tags)
 
-        # Import here to avoid circular import
-        from mlflow.tracking.fluent import _get_experiment_id
-
-        if experiment_id := _get_experiment_id():
+        if experiment_id := MLFLOW_EXPERIMENT_ID.get():
             self._link_prompt_to_experiment(prompt_version, experiment_id)
 
         return prompt_version
@@ -877,10 +875,7 @@ class MlflowClient:
 
             # Link the prompt to the active experiment. This is called only when
             # the prompt is loaded from the registry to avoid performance overhead.
-            # Import here to avoid circular import
-            from mlflow.tracking.fluent import _get_experiment_id
-
-            if prompt and (experiment_id := _get_experiment_id()):
+            if prompt and (experiment_id := MLFLOW_EXPERIMENT_ID.get()):
                 self._link_prompt_to_experiment(prompt, experiment_id)
 
             # Cache the result if cache_ttl_seconds > 0

--- a/tests/genai/prompts/test_prompts.py
+++ b/tests/genai/prompts/test_prompts.py
@@ -63,9 +63,6 @@ def test_crud_prompts(tmp_path):
         tags={"model": "my-model"},
     )
 
-    # Wait for background prompt linking thread to complete
-    join_thread_by_name_prefix("link_prompt_to_experiment_thread")
-
     prompt = mlflow.genai.load_prompt("prompt_1", version=1)
     assert prompt.name == "prompt_1"
     assert prompt.template == "Hi, {title} {name}! How are you today?"
@@ -73,15 +70,12 @@ def test_crud_prompts(tmp_path):
     # Currently, the tags from register_prompt become version tags
     assert prompt.tags == {"model": "my-model"}
 
-    # Wait for background prompt linking thread from load_prompt
-    join_thread_by_name_prefix("link_prompt_to_experiment_thread")
-
     # Check prompt-level tags separately (if needed for test completeness)
     from mlflow import MlflowClient
 
     client = MlflowClient()
     prompt_entity = client.get_prompt("prompt_1")
-    assert prompt_entity.tags == {"model": "my-model", "_mlflow_experiment_ids": ",0,"}
+    assert prompt_entity.tags == {"model": "my-model"}
 
     mlflow.genai.register_prompt(
         name="prompt_1",
@@ -467,20 +461,12 @@ def test_register_prompt_with_nested_variables():
 
 def test_set_and_delete_prompt_tag_genai():
     mlflow.genai.register_prompt(name="tag_prompt", template="Hi")
-
-    # Wait for background prompt linking thread to complete
-    join_thread_by_name_prefix("link_prompt_to_experiment_thread")
-
     mlflow.genai.set_prompt_tag("tag_prompt", "env", "prod")
     mlflow.genai.set_prompt_version_tag("tag_prompt", 1, "env", "prod")
-    assert mlflow.genai.get_prompt_tags("tag_prompt") == {
-        "env": "prod",
-        "_mlflow_experiment_ids": ",0,",
-    }
+    assert mlflow.genai.get_prompt_tags("tag_prompt") == {"env": "prod"}
     assert mlflow.genai.load_prompt("tag_prompt", version=1).tags == {"env": "prod"}
     mlflow.genai.delete_prompt_tag("tag_prompt", "env")
-    # After deleting 'env' tag, only the experiment IDs tag should remain
-    assert mlflow.genai.get_prompt_tags("tag_prompt") == {"_mlflow_experiment_ids": ",0,"}
+    assert "env" not in mlflow.genai.get_prompt_tags("tag_prompt")
     mlflow.genai.delete_prompt_version_tag("tag_prompt", 1, "env")
     assert "env" not in mlflow.genai.load_prompt("tag_prompt", version=1).tags
 
@@ -1673,50 +1659,6 @@ def test_link_prompt_to_experiment_no_duplicate():
     client = MlflowClient()
     prompt_info = client.get_prompt("no_dup_prompt")
     assert experiment.experiment_id in prompt_info.tags.get(PROMPT_EXPERIMENT_IDS_TAG_KEY)
-
-
-def test_prompt_links_to_default_experiment():
-    from mlflow.environment_variables import MLFLOW_EXPERIMENT_ID
-    from mlflow.tracking import fluent
-
-    # Reset experiment state to ensure we're using the Default experiment
-    fluent._active_experiment_id = None
-    MLFLOW_EXPERIMENT_ID.unset()
-
-    # Register a prompt without setting an experiment - should use Default (ID "0")
-    mlflow.genai.register_prompt(name="default_exp_prompt", template="Hello {{name}}!")
-
-    # Wait for the links to be established
-    join_thread_by_name_prefix("link_prompt_to_experiment_thread")
-
-    # Verify the prompt was linked to the Default experiment
-    client = MlflowClient()
-    default_experiment = client.get_experiment("0")
-    prompt_info = client.get_prompt("default_exp_prompt")
-    experiment_ids_tag = prompt_info.tags.get(PROMPT_EXPERIMENT_IDS_TAG_KEY, "")
-
-    assert default_experiment.experiment_id in experiment_ids_tag, (
-        f"Expected Default experiment ID '{default_experiment.experiment_id}' "
-        f"in prompt tags, but got: {experiment_ids_tag!r}"
-    )
-
-    # Also test that load_prompt links to Default experiment
-    fluent._active_experiment_id = None
-    MLFLOW_EXPERIMENT_ID.unset()
-
-    mlflow.genai.register_prompt(name="default_exp_load_prompt", template="Test {{x}}!")
-    # Don't wait after register, wait after load
-    mlflow.genai.load_prompt("default_exp_load_prompt", version=1)
-
-    join_thread_by_name_prefix("link_prompt_to_experiment_thread")
-
-    prompt_info = client.get_prompt("default_exp_load_prompt")
-    experiment_ids_tag = prompt_info.tags.get(PROMPT_EXPERIMENT_IDS_TAG_KEY, "")
-
-    assert default_experiment.experiment_id in experiment_ids_tag, (
-        f"Expected Default experiment ID '{default_experiment.experiment_id}' "
-        f"in prompt tags after load_prompt, but got: {experiment_ids_tag!r}"
-    )
 
 
 def test_search_prompts_by_experiment_id():

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1,7 +1,6 @@
 import json
 import os
 import pickle
-import threading
 import time
 import uuid
 from pathlib import Path
@@ -2119,14 +2118,6 @@ def test_crud_prompts(tracking_uri):
 
 
 def test_create_prompt_with_tags_and_metadata(tracking_uri, disable_prompt_cache):
-    def wait_for_prompt_linking():
-        """Wait for background prompt linking threads to complete."""
-        for t in threading.enumerate():
-            if t.name.startswith("link_prompt_to_experiment_thread"):
-                t.join(timeout=5.0)
-                if t.is_alive():
-                    raise TimeoutError(f"Thread {t.name} did not complete within timeout.")
-
     client = MlflowClient(tracking_uri=tracking_uri)
 
     # Create prompt with version-specific tags
@@ -2135,9 +2126,6 @@ def test_create_prompt_with_tags_and_metadata(tracking_uri, disable_prompt_cache
         template="Hi, {{name}}!",
         tags={"author": "Alice"},  # This will be version-level tags now
     )
-
-    # Wait for the background linking thread to complete
-    wait_for_prompt_linking()
 
     # Set some prompt-level tags separately
     client.set_prompt_tag("prompt_1", "application", "greeting")
@@ -2149,9 +2137,6 @@ def test_create_prompt_with_tags_and_metadata(tracking_uri, disable_prompt_cache
     # Version tags are separate from prompt tags
     assert prompt_v1.tags == {"author": "Alice"}
 
-    # Wait for the background linking thread from load_prompt
-    wait_for_prompt_linking()
-
     # Test prompt-level tags (separate from version)
     prompt_entity = client.get_prompt("prompt_1")
     # Note: Currently includes the version tags too, but we expect this behavior to change
@@ -2159,7 +2144,6 @@ def test_create_prompt_with_tags_and_metadata(tracking_uri, disable_prompt_cache
         "author": "Alice",  # This appears due to current implementation
         "application": "greeting",
         "language": "en",
-        "_mlflow_experiment_ids": ",0,",  # Linked to Default experiment
     }
 
     # Create version 2 with different version-level tags
@@ -2168,9 +2152,6 @@ def test_create_prompt_with_tags_and_metadata(tracking_uri, disable_prompt_cache
         template="こんにちは、{{name}}!",
         tags={"author": "Bob", "date": "2022-01-01"},  # Version-level tags
     )
-
-    # Wait for the background linking thread from register_prompt
-    wait_for_prompt_linking()
 
     # Update some prompt-level tags
     client.set_prompt_tag("prompt_1", "project", "toy")
@@ -2182,9 +2163,6 @@ def test_create_prompt_with_tags_and_metadata(tracking_uri, disable_prompt_cache
     # Version 2 has its own version tags (decoupled from prompt and version 1)
     assert prompt_v2.tags == {"author": "Bob", "date": "2022-01-01"}
 
-    # Wait for the background linking thread from load_prompt
-    wait_for_prompt_linking()
-
     # Verify prompt-level tags are updated and separate
     prompt_entity_updated = client.get_prompt("prompt_1")
     # Note: Currently the prompt tags get overwritten by the newest version's tags
@@ -2194,7 +2172,6 @@ def test_create_prompt_with_tags_and_metadata(tracking_uri, disable_prompt_cache
         "application": "greeting",
         "project": "toy",
         "language": "ja",
-        "_mlflow_experiment_ids": ",0,",  # Linked to Default experiment
     }
 
     # Version 1 tags should be unchanged (decoupled from prompt tags)


### PR DESCRIPTION
…ult experiments (#20562)"

This reverts commit 42a5ee0645f08d9473baf17f9a9dfd25f67d10b7.

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
