### PR TITLE
Gate improved evaluation runs comparison UI behind feature flag

### DIFF
--- a/mlflow/server/js/src/common/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/common/utils/FeatureUtils.ts
@@ -162,15 +162,8 @@ export const shouldEnableWorkflowBasedNavigation = () => {
 };
 
 /**
- * Determines if improved evaluation runs comparison UI is enabled.
- * When enabled, this enables:
- * - Grouping by dataset digest
- * - List view with metrics by default
- * - Row click navigation to run detail page
- * - Compare button in list view and run detail page
- * - Selection limit of 2 runs with auto-compare
- * - Indent for grouped rows
- * - Charts tab and click handling fixes
+ * Enables improved evaluation runs comparison UI with full-page list view,
+ * dataset grouping, and streamlined run comparison workflow.
  */
 export const shouldEnableImprovedEvalRunsComparison = () => {
   return false;

--- a/mlflow/server/js/src/common/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/common/utils/FeatureUtils.ts
@@ -160,3 +160,18 @@ export const shouldEnableExperimentOverviewTab = () => {
 export const shouldEnableWorkflowBasedNavigation = () => {
   return false;
 };
+
+/**
+ * Determines if improved evaluation runs comparison UI is enabled.
+ * When enabled, this enables:
+ * - Grouping by dataset digest
+ * - List view with metrics by default
+ * - Row click navigation to run detail page
+ * - Compare button in list view and run detail page
+ * - Selection limit of 2 runs with auto-compare
+ * - Indent for grouped rows
+ * - Charts tab and click handling fixes
+ */
+export const shouldEnableImprovedEvalRunsComparison = () => {
+  return false;
+};

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.intg.test.tsx
@@ -14,6 +14,7 @@ jest.mock('../../../common/utils/FeatureUtils', () => ({
   shouldUseRenamedUnifiedTracesTab: () => false,
   shouldDisableReproduceRunButton: () => false,
   shouldEnableWorkflowBasedNavigation: () => false,
+  shouldEnableImprovedEvalRunsComparison: () => false,
 }));
 
 describe('RunViewHeader - integration test', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
@@ -130,7 +130,7 @@ export const RunViewHeader = ({
     navigate(`${evaluationRunsRoute}?${searchParams.toString()}`);
   }, [navigate, experiment.experimentId, runUuid]);
 
-  // PR #20284: Compare button - only enabled when feature flag is on
+  // Compare button - only enabled when feature flag is on
   const renderCompareButton = () => {
     if (!shouldEnableImprovedEvalRunsComparison() || !shouldRouteToEvaluations) {
       return null;

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
@@ -16,6 +16,7 @@ import { RunIcon } from './assets/RunIcon';
 import { ExperimentPageTabName } from '@mlflow/mlflow/src/experiment-tracking/constants';
 import { useExperimentKind, isGenAIExperimentKind } from '../../utils/ExperimentKindUtils';
 import { useCallback, useMemo } from 'react';
+import { shouldEnableImprovedEvalRunsComparison } from '../../../common/utils/FeatureUtils';
 const RunViewHeaderIcon = () => {
   const { theme } = useDesignSystemTheme();
   return (
@@ -129,8 +130,9 @@ export const RunViewHeader = ({
     navigate(`${evaluationRunsRoute}?${searchParams.toString()}`);
   }, [navigate, experiment.experimentId, runUuid]);
 
+  // PR #20284: Compare button - only enabled when feature flag is on
   const renderCompareButton = () => {
-    if (!shouldRouteToEvaluations) {
+    if (!shouldEnableImprovedEvalRunsComparison() || !shouldRouteToEvaluations) {
       return null;
     }
     return (

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -40,6 +40,7 @@ import { ExperimentEvaluationRunsPageCharts } from './charts/ExperimentEvaluatio
 import { ExperimentEvaluationRunsRowVisibilityProvider } from './hooks/useExperimentEvaluationRunsRowVisibility';
 import { useGetExperimentRunColor } from '../../components/experiment-page/hooks/useExperimentRunColor';
 import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
+import { shouldEnableImprovedEvalRunsComparison } from '../../../common/utils/FeatureUtils';
 
 const DEFAULT_VISIBLE_METRIC_COLUMNS = 5;
 
@@ -60,10 +61,17 @@ const ExperimentEvaluationRunsPageImpl = () => {
     EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
   );
 
-  const [groupBy, setGroupBy] = useState<RunsGroupByConfig | null>({
-    aggregateFunction: RunGroupingAggregateFunction.Average,
-    groupByKeys: [{ mode: RunGroupingMode.Dataset, groupByData: 'dataset' }],
-  });
+  const enableImprovedComparison = shouldEnableImprovedEvalRunsComparison();
+
+  // PR #20280: When flag is enabled, default to grouping by dataset
+  const [groupBy, setGroupBy] = useState<RunsGroupByConfig | null>(
+    enableImprovedComparison
+      ? {
+          aggregateFunction: RunGroupingAggregateFunction.Average,
+          groupByKeys: [{ mode: RunGroupingMode.Dataset, groupByData: 'dataset' }],
+        }
+      : null,
+  );
   const [isComparisonMode, setIsComparisonMode] = useState(false);
   const { viewMode, setViewMode } = useExperimentEvaluationRunsPageMode();
 
@@ -92,6 +100,12 @@ const ExperimentEvaluationRunsPageImpl = () => {
 
   const runUuids = useMemo(() => runs?.map((run) => run.info.runUuid) ?? [], [runs]);
 
+  // ORIGINAL BEHAVIOR (flag OFF): Auto-select first run when no run is selected or selected run is out of scope
+  // This ensures the split view always has a run to display
+  if (!enableImprovedComparison && runs?.length && (!selectedRunUuid || !runUuids.includes(selectedRunUuid))) {
+    setSelectedRunUuid(runs[0].info.runUuid);
+  }
+
   // Get selected run UUIDs from checkbox selection
   const selectedRunUuidsFromCheckbox = useMemo(
     () =>
@@ -101,10 +115,14 @@ const ExperimentEvaluationRunsPageImpl = () => {
     [rowSelection],
   );
 
-  // On mount, if URL has selectedRunUuid (and optionally compareToRunUuid), initialize rowSelection and enter comparison mode
+  // PR #20281/#20285: On mount, if URL has selectedRunUuid (and optionally compareToRunUuid), initialize rowSelection and enter comparison mode
   // Initialize with BOTH URL params to prevent compareToRunUuid from being stripped
+  // Only enabled when feature flag is on
   const hasInitializedFromUrl = useRef(false);
   useEffect(() => {
+    if (!enableImprovedComparison) {
+      return;
+    }
     if (!hasInitializedFromUrl.current && selectedRunUuid && runs?.length) {
       if (runUuids.includes(selectedRunUuid)) {
         hasInitializedFromUrl.current = true;
@@ -117,10 +135,14 @@ const ExperimentEvaluationRunsPageImpl = () => {
         setIsComparisonMode(true);
       }
     }
-  }, [selectedRunUuid, compareToRunUuid, runs, runUuids, setIsComparisonMode]);
+  }, [enableImprovedComparison, selectedRunUuid, compareToRunUuid, runs, runUuids, setIsComparisonMode]);
 
-  // Sync URL params from checkbox selection when in comparison mode (as useEffect to avoid render-time state updates)
+  // PR #20285: Sync URL params from checkbox selection when in comparison mode (as useEffect to avoid render-time state updates)
+  // Only enabled when feature flag is on
   useEffect(() => {
+    if (!enableImprovedComparison) {
+      return;
+    }
     // Skip syncing if we haven't finished initializing yet
     if (!isComparisonMode) {
       return;
@@ -152,6 +174,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
       }
     }
   }, [
+    enableImprovedComparison,
     isComparisonMode,
     selectedRunUuidsFromCheckbox,
     selectedRunUuid,
@@ -292,6 +315,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
       compareToRunUuid={compareToRunUuid}
       isComparisonMode={isComparisonMode}
       setIsComparisonMode={setIsComparisonMode}
+      enableImprovedComparison={enableImprovedComparison}
     />
   );
 
@@ -301,7 +325,9 @@ const ExperimentEvaluationRunsPageImpl = () => {
       uniqueColumns={uniqueColumns}
       selectedColumns={selectedColumns}
       selectedRunUuid={
-        isComparisonMode && viewMode === ExperimentEvaluationRunsPageMode.TRACES ? selectedRunUuid : undefined
+        enableImprovedComparison && isComparisonMode && viewMode === ExperimentEvaluationRunsPageMode.TRACES
+          ? selectedRunUuid
+          : undefined
       }
       setSelectedRunUuid={(runUuid: string) => {
         setSelectedRunUuid(runUuid);
@@ -317,6 +343,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
       onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget)}
       ref={tableContainerRef}
       isGrouped={Boolean(groupBy?.groupByKeys?.length)}
+      enableImprovedComparison={enableImprovedComparison}
     />
   );
 
@@ -365,8 +392,12 @@ const ExperimentEvaluationRunsPageImpl = () => {
     </div>
   );
 
-  // Full-page list view (default, non-comparison mode, but not when viewing charts)
-  if (!isComparisonMode && viewMode !== ExperimentEvaluationRunsPageMode.CHARTS) {
+  // PR #20281/#20525: Full-page list view (non-comparison mode, but not when viewing charts)
+  // When flag is OFF, NEVER show full-page list view - always show split view (original behavior)
+  // When flag is ON, show full-page list view when not in comparison mode and not in charts mode
+  const shouldShowFullPageView =
+    enableImprovedComparison && !isComparisonMode && viewMode !== ExperimentEvaluationRunsPageMode.CHARTS;
+  if (shouldShowFullPageView) {
     return (
       <ExperimentEvaluationRunsRowVisibilityProvider>
         <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: '0px' }}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -115,8 +115,9 @@ const ExperimentEvaluationRunsPageImpl = () => {
     [rowSelection],
   );
 
-  // PR #20281/#20285: On mount, if URL has selectedRunUuid (and optionally compareToRunUuid), initialize rowSelection and enter comparison mode
-  // Initialize with BOTH URL params to prevent compareToRunUuid from being stripped
+  // PR #20281/#20285: On mount, if URL has selectedRunUuid (and optionally compareToRunUuid), initialize rowSelection
+  // Only enter comparison mode if BOTH params are present (indicating an active comparison)
+  // If only selectedRunUuid is present, just pre-select the checkbox but stay in full-page list view
   // Only enabled when feature flag is on
   const hasInitializedFromUrl = useRef(false);
   useEffect(() => {
@@ -130,9 +131,10 @@ const ExperimentEvaluationRunsPageImpl = () => {
         // Also include compareToRunUuid if present in URL
         if (compareToRunUuid && runUuids.includes(compareToRunUuid)) {
           initialSelection[compareToRunUuid] = true;
+          // Only enter comparison mode if BOTH runs are in URL (active comparison)
+          setIsComparisonMode(true);
         }
         setRowSelection(initialSelection);
-        setIsComparisonMode(true);
       }
     }
   }, [enableImprovedComparison, selectedRunUuid, compareToRunUuid, runs, runUuids, setIsComparisonMode]);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -63,7 +63,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
 
   const enableImprovedComparison = shouldEnableImprovedEvalRunsComparison();
 
-  // PR #20280: When flag is enabled, default to grouping by dataset
+  // When flag is enabled, default to grouping by dataset
   const [groupBy, setGroupBy] = useState<RunsGroupByConfig | null>(
     enableImprovedComparison
       ? {
@@ -115,7 +115,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
     [rowSelection],
   );
 
-  // PR #20281/#20285: On mount, if URL has selectedRunUuid (and optionally compareToRunUuid), initialize rowSelection
+  // On mount, if URL has selectedRunUuid (and optionally compareToRunUuid), initialize rowSelection
   // Only enter comparison mode if BOTH params are present (indicating an active comparison)
   // If only selectedRunUuid is present, just pre-select the checkbox but stay in full-page list view
   // Only enabled when feature flag is on
@@ -139,7 +139,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
     }
   }, [enableImprovedComparison, selectedRunUuid, compareToRunUuid, runs, runUuids, setIsComparisonMode]);
 
-  // PR #20285: Sync URL params from checkbox selection when in comparison mode (as useEffect to avoid render-time state updates)
+  // Sync URL params from checkbox selection when in comparison mode (as useEffect to avoid render-time state updates)
   // Only enabled when feature flag is on
   useEffect(() => {
     if (!enableImprovedComparison) {
@@ -394,7 +394,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
     </div>
   );
 
-  // PR #20281/#20525: Full-page list view (non-comparison mode, but not when viewing charts)
+  // Full-page list view (non-comparison mode, but not when viewing charts)
   // When flag is OFF, NEVER show full-page list view - always show split view (original behavior)
   // When flag is ON, show full-page list view when not in comparison mode and not in charts mode
   const shouldShowFullPageView =

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.tsx
@@ -29,6 +29,7 @@ export interface ExperimentEvaluationRunsTableProps {
   viewMode: ExperimentEvaluationRunsPageMode;
   onScroll?: React.UIEventHandler<HTMLDivElement>;
   isGrouped?: boolean;
+  enableImprovedComparison?: boolean;
 }
 
 export const ExperimentEvaluationRunsTable = forwardRef<HTMLDivElement, ExperimentEvaluationRunsTableProps>(
@@ -49,6 +50,7 @@ export const ExperimentEvaluationRunsTable = forwardRef<HTMLDivElement, Experime
       viewMode,
       onScroll,
       isGrouped,
+      enableImprovedComparison,
     },
     ref,
   ) => {
@@ -166,6 +168,7 @@ export const ExperimentEvaluationRunsTable = forwardRef<HTMLDivElement, Experime
                 isHidden={isRowHidden(row.id, row.index, runStatus)}
                 columns={columns}
                 isGrouped={isGrouped}
+                enableImprovedComparison={enableImprovedComparison}
               />
             );
           })}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
@@ -88,6 +88,7 @@ export const ExperimentEvaluationRunsTableControls = ({
   compareToRunUuid,
   isComparisonMode,
   setIsComparisonMode,
+  enableImprovedComparison,
 }: {
   rowSelection: RowSelectionState;
   setRowSelection: (selection: RowSelectionState) => void;
@@ -108,6 +109,7 @@ export const ExperimentEvaluationRunsTableControls = ({
   compareToRunUuid?: string;
   isComparisonMode: boolean;
   setIsComparisonMode: (isComparisonMode: boolean) => void;
+  enableImprovedComparison?: boolean;
 }) => {
   const intl = useIntl();
   const { theme } = useDesignSystemTheme();
@@ -265,7 +267,8 @@ export const ExperimentEvaluationRunsTableControls = ({
           runs={runs}
         />
 
-        {viewMode !== ExperimentEvaluationRunsPageMode.CHARTS && (
+        {/* PR #20283/#20525: Compare button - only enabled when feature flag is on, hidden in charts mode */}
+        {enableImprovedComparison && viewMode !== ExperimentEvaluationRunsPageMode.CHARTS && (
           <Tooltip
             componentId="mlflow.eval-runs.compare-button.tooltip"
             content={
@@ -296,6 +299,10 @@ export const ExperimentEvaluationRunsTableControls = ({
           rowSelection={rowSelection}
           setRowSelection={setRowSelection}
           refetchRuns={refetchRuns}
+          onCompare={onCompare}
+          selectedRunUuid={selectedRunUuid}
+          compareToRunUuid={compareToRunUuid}
+          enableImprovedComparison={enableImprovedComparison}
         />
       </div>
     </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
@@ -267,7 +267,7 @@ export const ExperimentEvaluationRunsTableControls = ({
           runs={runs}
         />
 
-        {/* PR #20283/#20525: Compare button - only enabled when feature flag is on, hidden in charts mode */}
+        {/* Compare button - only enabled when feature flag is on, hidden in charts mode */}
         {enableImprovedComparison && viewMode !== ExperimentEvaluationRunsPageMode.CHARTS && (
           <Tooltip
             componentId="mlflow.eval-runs.compare-button.tooltip"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableRow.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableRow.tsx
@@ -74,7 +74,7 @@ export const ExperimentEvaluationRunsTableRow = React.memo(
     const { theme } = useDesignSystemTheme();
     const navigate = useNavigate();
 
-    // PR #20282: Row click navigation - only enabled when feature flag is on
+    // Row click navigation - only enabled when feature flag is on
     const handleRowClick = useCallback(() => {
       if (!enableImprovedComparison) {
         return;
@@ -112,8 +112,7 @@ export const ExperimentEvaluationRunsTableRow = React.memo(
       );
     }
 
-    // PR #20282: Row click navigation - only enabled when feature flag is on
-    // PR #20457: Indent for grouped rows - only enabled when feature flag is on
+    // Row click navigation and indent for grouped rows - only enabled when feature flag is on
     return (
       <TableRow
         key={row.id}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableRow.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableRow.tsx
@@ -30,6 +30,7 @@ type TracesViewTableRowProps = {
   columns: EvalRunsTableColumnDef[];
   isHidden: boolean;
   isGrouped?: boolean;
+  enableImprovedComparison?: boolean;
 };
 
 const GroupTag = ({ groupKey, groupValue }: { groupKey: string; groupValue: string }): React.ReactElement => {
@@ -69,16 +70,20 @@ const GroupLabel = ({ groupValues }: { groupValues: RunGroupByGroupingValue }): 
 
 export const ExperimentEvaluationRunsTableRow = React.memo(
   // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
-  ({ row, isActive, isGrouped }: TracesViewTableRowProps) => {
+  ({ row, isActive, isGrouped, enableImprovedComparison }: TracesViewTableRowProps) => {
     const { theme } = useDesignSystemTheme();
     const navigate = useNavigate();
 
+    // PR #20282: Row click navigation - only enabled when feature flag is on
     const handleRowClick = useCallback(() => {
+      if (!enableImprovedComparison) {
+        return;
+      }
       if ('info' in row.original) {
         const { experimentId, runUuid } = row.original.info;
         navigate(Routes.getRunPageTabRoute(experimentId, runUuid, RunPageTabName.EVALUATIONS));
       }
-    }, [navigate, row.original]);
+    }, [enableImprovedComparison, navigate, row.original]);
 
     if ('groupValues' in row.original) {
       return (
@@ -107,12 +112,17 @@ export const ExperimentEvaluationRunsTableRow = React.memo(
       );
     }
 
+    // PR #20282: Row click navigation - only enabled when feature flag is on
+    // PR #20457: Indent for grouped rows - only enabled when feature flag is on
     return (
       <TableRow
         key={row.id}
         className="eval-runs-table-row"
-        onClick={handleRowClick}
-        css={{ cursor: 'pointer', marginLeft: isGrouped && row.depth > 0 ? theme.spacing.lg : undefined }}
+        onClick={enableImprovedComparison ? handleRowClick : undefined}
+        css={{
+          cursor: enableImprovedComparison ? 'pointer' : undefined,
+          marginLeft: enableImprovedComparison && isGrouped && row.depth > 0 ? theme.spacing.lg : undefined,
+        }}
       >
         {row.getVisibleCells().map((cell) => (
           <TableCell
@@ -138,7 +148,8 @@ export const ExperimentEvaluationRunsTableRow = React.memo(
       prev.columns === next.columns &&
       prev.isExpanded === next.isExpanded &&
       prev.isHidden === next.isHidden &&
-      prev.isGrouped === next.isGrouped
+      prev.isGrouped === next.isGrouped &&
+      prev.enableImprovedComparison === next.enableImprovedComparison
     );
   },
 );

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -643,6 +643,10 @@
     "defaultMessage": "Text",
     "description": "Label for the text render mode of the prompt"
   },
+  "2igs1f": {
+    "defaultMessage": "Compare",
+    "description": "Compare evaluation runs action"
+  },
   "2mRfvl": {
     "defaultMessage": "Request error",
     "description": "A title shown on the experiment page if the runs request fails"
@@ -4247,6 +4251,10 @@
   "UYSMKb": {
     "defaultMessage": "Schema is too large to display all rows. Please search for a column name to filter the results. Currently showing {currentResults} results from {allResults} total rows.",
     "description": "Text for model inputs/outputs schema table when schema is too large to display all rows"
+  },
+  "Ub+VQh": {
+    "defaultMessage": "Please select 2 runs to compare",
+    "description": "Tooltip for disabled compare action in evaluation runs table actions"
   },
   "UbXw8O": {
     "defaultMessage": "Expectations",


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Add `shouldEnableImprovedEvalRunsComparison()` feature flag (default: false) to gate the following changes from the PR stack:

- PR #20280: Default grouping by dataset
- PR #20281: Full-page list view (vs split view)
- PR #20282: Row click navigation to run detail
- PR #20283: Standalone Compare button in controls
- PR #20284: Compare button in run detail header
- PR #20285: URL syncing for comparison mode
- PR #20456: Selection limit fixes
- PR #20457: Row indent for grouped rows
- PR #20525: Charts tab and click handling fixes

When flag is OFF (default): Original split view behavior with Compare option in Actions dropdown menu, no grouping, auto-select first run.

When flag is ON: New list view with comparison mode, grouping by dataset, standalone Compare button, row click navigation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Flag Off:

https://github.com/user-attachments/assets/4b1aa572-ea90-4f72-b270-676dcda1e9d0

Flag on:


https://github.com/user-attachments/assets/586ad681-2ee4-42f2-8f88-0274a8475b0a



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
