### PR TITLE
Fix the deadlock between run linking and trace linking

### DIFF
--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -67,23 +67,29 @@ class AbstractStore:
                 to support subsequently uploading them to the model registry storage
                 location.
         """
-        # Create a thread lock to ensure thread safety when linking prompts to other entities,
-        # since the default linking implementation reads and appends entity tags, which
-        # is prone to concurrent modification issues
-        self._prompt_link_lock = threading.RLock()
+        # Create separate thread locks for each linking operation to ensure thread safety
+        # without unnecessary contention. Each lock protects a different entity type's
+        # read-modify-write operations on tags.
+        self._link_to_trace_lock = threading.RLock()
+        self._link_to_model_lock = threading.RLock()
+        self._link_to_run_lock = threading.RLock()
 
     def __getstate__(self):
-        """Support for pickle serialization by excluding the non-picklable RLock."""
+        """Support for pickle serialization by excluding the non-picklable RLocks."""
         state = self.__dict__.copy()
-        # Remove the RLock as it cannot be pickled
-        del state["_prompt_link_lock"]
+        # Remove the RLocks as they cannot be pickled
+        del state["_link_to_trace_lock"]
+        del state["_link_to_model_lock"]
+        del state["_link_to_run_lock"]
         return state
 
     def __setstate__(self, state):
-        """Support for pickle deserialization by recreating the RLock."""
+        """Support for pickle deserialization by recreating the RLocks."""
         self.__dict__.update(state)
-        # Recreate the RLock
-        self._prompt_link_lock = threading.RLock()
+        # Recreate the RLocks
+        self._link_to_trace_lock = threading.RLock()
+        self._link_to_model_lock = threading.RLock()
+        self._link_to_run_lock = threading.RLock()
 
     # CRUD API for RegisteredModel objects
 
@@ -981,7 +987,7 @@ class AbstractStore:
         from mlflow.tracking import _get_store as _get_tracking_store
 
         client = TracingClient()
-        with self._prompt_link_lock:
+        with self._link_to_trace_lock:
             trace_info = client.get_trace_info(trace_id)
             if not trace_info:
                 raise MlflowException(
@@ -989,11 +995,13 @@ class AbstractStore:
                     error_code=ErrorCode.Name(RESOURCE_DOES_NOT_EXIST),
                 )
 
-            # Try to use the tracking store's EntityAssociation-based linking
+            # Try to use the tracking store's link_prompts_to_trace method
             tracking_store = _get_tracking_store()
             try:
                 tracking_store.link_prompts_to_trace(trace_id, prompt_versions)
             except NotImplementedError:
+                # The failure happens when the tracking store or the tracking server store does
+                # not support `link_prompts_to_trace` method
                 _logger.debug(
                     f"Linking prompts to trace {trace_id} failed. "
                     "Tracking store does not support `link_prompts_to_trace` method."
@@ -1071,7 +1079,7 @@ class AbstractStore:
         prompt_version = self.get_prompt_version(name, version)
         tracking_store = _get_tracking_store()
 
-        with self._prompt_link_lock:
+        with self._link_to_model_lock:
             logged_model = tracking_store.get_logged_model(model_id)
             if not logged_model:
                 raise MlflowException(
@@ -1109,7 +1117,7 @@ class AbstractStore:
         prompt_version = self.get_prompt_version(name, version)
         tracking_store = _get_tracking_store()
 
-        with self._prompt_link_lock:
+        with self._link_to_run_lock:
             run = tracking_store.get_run(run_id)
             if not run:
                 raise MlflowException(

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -999,7 +999,7 @@ class AbstractStore:
             tracking_store = _get_tracking_store()
             try:
                 tracking_store.link_prompts_to_trace(trace_id, prompt_versions)
-            except NotImplementedError:
+            except Exception:
                 # The failure happens when the tracking store or the tracking server store does
                 # not support `link_prompts_to_trace` method
                 _logger.debug(

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -1384,13 +1384,13 @@ class AbstractStore(GatewayStoreMixin):
             f"Unlinking traces from runs is not implemented for {self.__class__.__name__}."
         )
 
-    def link_prompts_to_trace(self, _trace_id: str, _prompt_versions: list[PromptVersion]) -> None:
+    def link_prompts_to_trace(self, trace_id: str, prompt_versions: list[PromptVersion]) -> None:
         """
         Link multiple prompt versions to a trace by creating entity associations.
 
         Args:
-            _trace_id: ID of the trace to link prompt versions to.
-            _prompt_versions: List of PromptVersion objects to link.
+            trace_id: ID of the trace to link prompt versions to.
+            prompt_versions: List of PromptVersion objects to link.
 
         Raises:
             NotImplementedError: If the operation is not supported by this store.

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -46,6 +46,7 @@ from mlflow.entities.trace_info_v2 import TraceInfoV2
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_TRACKING_DIR
 from mlflow.exceptions import MissingConfigException, MlflowException
+from mlflow.genai.prompts import PromptVersion
 from mlflow.protos import databricks_pb2
 from mlflow.protos.databricks_pb2 import (
     INTERNAL_ERROR,
@@ -2880,6 +2881,20 @@ class FileStore(AbstractStore):
         """
         raise MlflowException(
             "Linking traces to runs is not supported in FileStore. "
+            "Please use a database-backed store (e.g., SQLAlchemy store) for this feature.",
+            error_code=databricks_pb2.INVALID_PARAMETER_VALUE,
+        )
+
+    def link_prompts_to_trace(self, trace_id: str, prompt_versions: list[PromptVersion]) -> None:
+        """
+        Link multiple prompt versions to a trace by creating entity associations.
+
+        Args:
+            trace_id: ID of the trace to link prompt versions to.
+            prompt_versions: List of PromptVersion objects to link.
+        """
+        raise MlflowException(
+            "Linking prompts to traces is not supported in FileStore. "
             "Please use a database-backed store (e.g., SQLAlchemy store) for this feature.",
             error_code=databricks_pb2.INVALID_PARAMETER_VALUE,
         )


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

There is an issue that load_prompt hangs inside both active run and trace with file store, due to the deadlock caused by the unnecessary shared lock and error handling for the trace linking for file store. This PR:

1. Use different lock for different types of linking operations
2. Fixed the error handling to catch any exception instead of not implemented exception only
3. Fix the incorrect signature of the abstract store `link_prompts_to_trace`

```python
from openai import OpenAI
import mlflow
mlflow.set_tracking_uri("http://localhost:5000") <- file store backend
mlflow.set_experiment("Link Prompt")
mlflow.genai.register_prompt("question", "What is {{name}}")
@mlflow.trace
def question(name):
    prompt = mlflow.genai.load_prompt("prompts:/question@latest")
    client = OpenAI()
    messages = [{"role": "user", "content": prompt.format(name=name)}]
    response = client.chat.completions.create(
       model="gpt-5-mini",
       messages=messages,
    )
    return response.choices[0].message.content

for i in range(5):
    with mlflow.start_run():
        question("1+1")
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
