### PR TITLE
Enable parquet content_type in the scoring server input for pyfunc

### DIFF
--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -575,17 +575,6 @@ def _predict(model_uri, input_path, output_path, content_type):
                 else parse_csv_input(sys.stdin)
             )
             params = None
-        elif content_type == "parquet":
-            # For a direct stdin stream we need to read through the entire text buffer first
-            # before converting it from a TextIO stream into a BytesIO stream for Pandas.
-            # A seek that pyarrow engine will try to do with Parquet for sys.stdin input
-            # will get forbidden otherwise.
-            df = (
-                parse_parquet_input(input_path)
-                if input_path is not None
-                else parse_parquet_input(BytesIO(sys.stdin.buffer.read()))
-            )
-            params = None
         else:
             raise Exception(f"Unknown content type '{content_type}'")
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -62,7 +62,7 @@ SERVING_MODEL_CONFIG = "SERVING_MODEL_CONFIG"
 
 CONTENT_TYPE_CSV = "text/csv"
 CONTENT_TYPE_JSON = "application/json"
-CONTENT_TYPE_PARQUET = "application/x-parquet"
+CONTENT_TYPE_PARQUET = "application/vnd.apache.parquet"
 
 CONTENT_TYPES = [
     CONTENT_TYPE_CSV,

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -3,7 +3,7 @@ import math
 import os
 import random
 import signal
-from io import StringIO
+from io import BytesIO, StringIO
 from typing import Any, NamedTuple
 
 import keras
@@ -341,6 +341,25 @@ def test_scoring_server_responds_to_invalid_csv_input_with_stacktrace_and_error_
     assert "stack_trace" in response_json
 
 
+def test_scoring_server_responds_to_invalid_parquet_input_with_stacktrace_and_error_code(
+    sklearn_model, model_path
+):
+    mlflow.sklearn.save_model(sk_model=sklearn_model.model, path=model_path)
+
+    # Any empty string is not valid pandas parquet input
+    incorrect_parquet_content = ""
+    response = score_model_in_process(
+        model_uri=os.path.abspath(model_path),
+        data=incorrect_parquet_content,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_PARQUET,
+    )
+    response_json = json.loads(response.content)
+    assert "error_code" in response_json
+    assert response_json["error_code"] == ErrorCode.Name(BAD_REQUEST)
+    assert "message" in response_json
+    assert "stack_trace" in response_json
+
+
 def test_scoring_server_successfully_evaluates_correct_dataframes_with_pandas_records_orientation(
     sklearn_model, model_path
 ):
@@ -547,6 +566,14 @@ def test_parse_with_schema_csv(pandas_df_with_csv_types):
     df = _shuffle_pdf(pandas_df_with_csv_types)
     csv_str = df.to_csv(index=False)
     df = pyfunc_scoring_server.parse_csv_input(StringIO(csv_str), schema=schema)
+    assert schema == infer_signature(df[schema.input_names()]).inputs
+
+
+def test_parse_parquet_schema(pandas_df_with_all_types):
+    schema = Schema([ColSpec(c, c) for c in pandas_df_with_all_types.columns])
+    df = _shuffle_pdf(pandas_df_with_all_types)
+    parquet_stream = df.to_parquet()
+    df = pyfunc_scoring_server.parse_parquet_input(BytesIO(parquet_stream))
     assert schema == infer_signature(df[schema.input_names()]).inputs
 
 

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -741,6 +741,29 @@ def test_numpy_encoder_for_pydantic():
     )
 
 
+def test_parse_parquet_input():
+    class TestModel(PythonModel):
+        def predict(self, context, model_input, params=None):
+            return 1
+
+    with mlflow.start_run() as run:
+        mlflow.pyfunc.log_model(name="model", python_model=TestModel())
+
+    pandas_df = pd.DataFrame(
+        {
+            "foo": [3.0, 4.0],
+            "bar": [1.0, 2.0],
+        }
+    )
+
+    response_records_content_type = score_model_in_process(
+        model_uri=f"runs:/{run.info.run_id}/model",
+        data=pandas_df,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_PARQUET,
+    )
+    expect_status_code(response_records_content_type, 200)
+
+
 def test_parse_json_input_including_path():
     class TestModel(PythonModel):
         def predict(self, context, model_input, params=None):

--- a/tests/pyfunc/utils.py
+++ b/tests/pyfunc/utils.py
@@ -25,6 +25,8 @@ def score_model_in_process(model_uri: str, data: str, content_type: str) -> "htt
         if isinstance(data, pd.DataFrame):
             if content_type == scoring_server.CONTENT_TYPE_CSV:
                 data = data.to_csv(index=False)
+            elif content_type == scoring_server.CONTENT_TYPE_PARQUET:
+                data = data.to_parquet()
             else:
                 assert content_type == scoring_server.CONTENT_TYPE_JSON
                 data = json.dumps({"dataframe_split": data.to_dict(orient="split")})


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #20602

### What changes are proposed in this pull request?

This modifies the invocations call of the scoring server to include the parquet content type (applications/x-parquet) alongside the preexisting CSV and JSON.

The parquet file is directly read into a Pandas dataframe and the parquet input should already contain the proper data schema as expected in the subsequent steps before the actual model prediction call.

The feature is also added to the `_predict` function in the same file even though I don't see a corresponding test for it or a use of this method in general in other places.

This commit adds parquet only as an input type. Output stays as JSON.

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)