### PR TITLE
Fix type hints lost with @mlflow.trace decorator

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -10,7 +10,7 @@ import os
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Callable, Generator, Literal
+from typing import TYPE_CHECKING, Any, Callable, Generator, Literal, ParamSpec, TypeVar, overload
 
 from cachetools import TTLCache
 from opentelemetry import trace as trace_api
@@ -80,6 +80,33 @@ def _set_sampling_ratio_override(sampling_ratio_override: float | None):
 # This is necessary for evaluation harness to access generated traces during
 # evaluation using the dataset row ID (evaluation request ID).
 _EVAL_REQUEST_ID_TO_TRACE_ID = TTLCache(maxsize=10000, ttl=3600)
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+@overload
+def trace(
+    func: Callable[_P, _R],
+    name: str | None = None,
+    span_type: str = SpanType.UNKNOWN,
+    attributes: dict[str, Any] | None = None,
+    output_reducer: Callable[[list[Any]], Any] | None = None,
+    trace_destination: TraceLocationBase | None = None,
+    sampling_ratio_override: float | None = None,
+) -> Callable[_P, _R]: ...
+
+
+@overload
+def trace(
+    func: None = None,
+    name: str | None = None,
+    span_type: str = SpanType.UNKNOWN,
+    attributes: dict[str, Any] | None = None,
+    output_reducer: Callable[[list[Any]], Any] | None = None,
+    trace_destination: TraceLocationBase | None = None,
+    sampling_ratio_override: float | None = None,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...
 
 
 def trace(


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #20549

### What changes are proposed in this pull request?

The `@mlflow.trace` decorator was losing type information, causing return types to become `Any` in static type checkers like mypy and pyright. This made it impossible to get accurate autocomplete and type checking for traced functions.

Added proper type annotations using `ParamSpec`, `TypeVar`, and `@overload` decorators to preserve the original function's parameter and return types:

1. **Import typing utilities**: Added `ParamSpec`, `TypeVar`, and `overload` to imports
2. **Type variables**: Created `_P = ParamSpec("_P")` and `_R = TypeVar("_R")` for generic type preservation
3. **Overload signatures**: Added two `@overload` declarations to handle both decorator forms:
   - `@mlflow.trace` (bare decorator)
   - `@mlflow.trace(name="x")` (decorator with arguments)

The `@overload` decorators tell static type checkers what types to expect for different usage patterns, while the actual implementation remains unchanged. This is a type-level fix with **no runtime changes**.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

**Manual Testing:**
- ✅ Verified Python syntax with `py_compile`
- ✅ Type preservation works for both decorator forms
- ✅ Backward compatible (no runtime behavior changes)

**Type Checker Validation:**
The workaround provided in the issue (using generics) is now unnecessary:

```python
import mlflow

@mlflow.trace
def test() -> str:
    return "some string"

a = test()
a.non_existent_method()  # Now properly caught by type checkers!
```

Builds upon the approach from PR #19119 by completing the type annotations needed for full type safety.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed type hints preservation in the `@mlflow.trace` decorator. Return types and parameters are now correctly recognized by static type checkers (mypy, pyright), enabling proper autocomplete and type checking for traced functions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
