### PR TITLE
Fix docs: trace spans are stored in database, not artifact storage

### DIFF
--- a/docs/docs/genai/concepts/trace.mdx
+++ b/docs/docs/genai/concepts/trace.mdx
@@ -94,6 +94,10 @@ To learn more about the span object and its schema, continue to the [Span Concep
 
 ## Storage Layout
 
-`TraceInfo` is a lightweight metadata object, hence can be stored directly in a relational database. For example, if you are running MLflow Tracking Server on SQL database such as PostgreSQL, `TraceInfo` is stored as a single row in the trace table and support efficient query with indexes. For example, the data that is contained in the `TraceInfo` object is used to populate the trace view page within the MLflow tracking UI.
+`TraceInfo` is a lightweight metadata object stored in the `trace_info` table in a relational database. For example, if you are running MLflow Tracking Server on a SQL database such as PostgreSQL, `TraceInfo` is stored as a single row in the table and supports efficient querying with indexes. The data contained in the `TraceInfo` object is used to populate the trace view page within the MLflow tracking UI.
 
-`TraceData` (Spans) are relatively large objects compared to `TraceInfo`, because it contains rich information about each execution step, such as the full message history input to an LLM call. Therefore, MLflow stores them in artifact storage rather than in the database. This allows you to handle large number of traces with cheaper costs and minimum impact to the performance of typical filtering and grouping operations for traces.
+`TraceData` (Spans) are relatively large objects compared to `TraceInfo`, because they contain rich information about each execution step, such as the full message history input to an LLM call. MLflow stores each span as a separate row in the `spans` table, with the full span content serialized as JSON. This approach enables efficient retrieval and querying of span data within the same transactional store.
+
+:::note
+Prior to MLflow 3.3.0, spans were stored in artifact storage (e.g., S3, local filesystem) rather than in the database. Starting from MLflow 3.3.0, spans are stored directly in the database for improved query performance and transactional consistency.
+:::

--- a/docs/docs/genai/tracing/faq.mdx
+++ b/docs/docs/genai/tracing/faq.mdx
@@ -459,11 +459,9 @@ Traces are stored in your MLflow tracking backend:
 
 **Local filesystem**: When using `mlflow server` locally, traces are stored in the `mlruns` directory
 
-**Remote tracking server**: When using a remote MLflow server, traces are stored in the configured backend (database + artifact store)
+**Remote tracking server**: When using a remote MLflow server, traces are stored in the configured backend database
 
-**Database**: Trace metadata is stored in the MLflow tracking database
-
-**Artifact store**: Large trace data may be stored in the artifact store (filesystem, S3, etc.)
+**Database**: Both trace metadata (`TraceInfo`) and span data (`TraceData`) are stored in the MLflow tracking database. Trace metadata is stored in the `trace_info` table, while individual spans are stored in the `spans` table with their content serialized as JSON
 
 ## Integration and Compatibility
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updates the trace storage documentation to reflect the current implementation. The docs previously stated that `TraceData` (spans) are stored in artifact storage, but spans are now stored directly in the SQL database in the `spans` table.

### Changes:
- **`docs/docs/genai/concepts/trace.mdx`** (Storage Layout section): Updated to explain that spans are stored as rows in the `spans` table with content serialized as JSON, rather than in artifact storage
- **`docs/docs/genai/tracing/faq.mdx`** (FAQ: "Where are my traces stored?"): Removed the separate "Artifact store" entry and clarified that both `TraceInfo` and `TraceData` are stored in the tracking database

## How is this PR tested?

Documentation-only change. No code modifications.

## Does this PR require documentation update?

This PR *is* the documentation update.

## Release Notes

### Is this a user-facing change?

- [x] No. This is a documentation fix only.

Fixes #20552

🤖 Generated with [Claude Code](https://claude.ai/code)