### PR TITLE
Add CI check to flag newly introduced lazy imports

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,7 +87,6 @@ jobs:
 
       - name: Check lazy imports
         if: matrix.os == 'ubuntu-latest'
-        continue-on-error: true
         run: |
           uv run --no-project dev/check_lazy_imports.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,6 +85,11 @@ jobs:
         run: |
           uv run --no-project dev/check_function_signatures.py
 
+      - name: Check lazy imports
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          uv run --no-project dev/check_lazy_imports.py
+
       - name: Check whitespace-only changes
         if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,6 +87,7 @@ jobs:
 
       - name: Check lazy imports
         if: matrix.os == 'ubuntu-latest'
+        continue-on-error: true
         run: |
           uv run --no-project dev/check_lazy_imports.py
 

--- a/dev/check_lazy_imports.py
+++ b/dev/check_lazy_imports.py
@@ -144,7 +144,10 @@ def compare_lazy_imports(
 
     warnings: list[Warning] = []
     new_keys = set(current_imports) - set(base_imports)
-    for key in sorted(new_keys, key=lambda k: current_imports[k].line):
+    for key in sorted(
+        new_keys,
+        key=lambda k: (current_imports[k].line, current_imports[k].module),
+    ):
         lazy = current_imports[key]
         warnings.append(
             Warning(

--- a/dev/check_lazy_imports.py
+++ b/dev/check_lazy_imports.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def is_github_actions() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+@dataclass
+class Warning:
+    file_path: Path
+    line: int
+    column: int
+    message: str
+
+    def format(self, github: bool = False) -> str:
+        if github:
+            return (
+                f"::warning file={self.file_path},"
+                f"line={self.line},col={self.column}::{self.message}"
+            )
+        return f"{self.file_path}:{self.line}:{self.column}: {self.message}"
+
+
+@dataclass
+class LazyImport:
+    func_name: str
+    module: str
+    line: int
+    column: int
+
+
+def _is_type_checking_guard(test: ast.expr) -> bool:
+    # Match `if TYPE_CHECKING:` and `if typing.TYPE_CHECKING:`
+    if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+        return True
+    if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
+        return True
+    return False
+
+
+def _get_module_names(node: ast.Import | ast.ImportFrom) -> list[str]:
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    module = "." * node.level + (node.module or "")
+    return [module]
+
+
+class LazyImportExtractor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.lazy_imports: dict[tuple[str, str], LazyImport] = {}
+        self._scope_stack: list[str] = []
+        self._func_depth: int = 0
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._scope_stack.append(node.name)
+        self._func_depth += 1
+        self.generic_visit(node)
+        self._func_depth -= 1
+        self._scope_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._scope_stack.append(node.name)
+        self.generic_visit(node)
+        self._scope_stack.pop()
+
+    def visit_If(self, node: ast.If) -> None:
+        if self._func_depth > 0 and _is_type_checking_guard(node.test):
+            # Skip the TYPE_CHECKING body (those imports are fine),
+            # but still visit the else branch
+            for child in node.orelse:
+                self.visit(child)
+        else:
+            self.generic_visit(node)
+
+    def _record_import(self, node: ast.Import | ast.ImportFrom) -> None:
+        if self._func_depth == 0:
+            return
+        func_name = ".".join(self._scope_stack)
+        for module in _get_module_names(node):
+            key = (func_name, module)
+            if key not in self.lazy_imports:
+                self.lazy_imports[key] = LazyImport(
+                    func_name=func_name,
+                    module=module,
+                    line=node.lineno,
+                    column=node.col_offset,
+                )
+
+    def visit_Import(self, node: ast.Import) -> None:
+        self._record_import(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        self._record_import(node)
+
+
+def extract_lazy_imports(content: str) -> dict[tuple[str, str], LazyImport]:
+    tree = ast.parse(content)
+    extractor = LazyImportExtractor()
+    extractor.visit(tree)
+    return extractor.lazy_imports
+
+
+def get_changed_python_files(base_branch: str) -> list[Path]:
+    if is_github_actions():
+        subprocess.check_call(
+            ["git", "fetch", "origin", f"{base_branch}:{base_branch}"],
+        )
+
+    result = subprocess.check_output(
+        ["git", "diff", "--name-only", f"{base_branch}...HEAD"], text=True
+    )
+    files = [s.strip() for s in result.splitlines()]
+    return [Path(f) for f in files if f]
+
+
+def get_file_content_at_revision(file_path: Path, revision: str) -> str | None:
+    try:
+        return subprocess.check_output(["git", "show", f"{revision}:{file_path}"], text=True)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def compare_lazy_imports(
+    file_path: Path,
+    base_content: str | None,
+    current_content: str,
+) -> list[Warning]:
+    current_imports = extract_lazy_imports(current_content)
+    base_imports = extract_lazy_imports(base_content) if base_content else {}
+
+    warnings: list[Warning] = []
+    new_keys = set(current_imports) - set(base_imports)
+    for key in sorted(new_keys, key=lambda k: current_imports[k].line):
+        lazy = current_imports[key]
+        warnings.append(
+            Warning(
+                file_path=file_path,
+                line=lazy.line,
+                column=lazy.column + 1,
+                message=(
+                    f"[Non-blocking] Lazy import '{lazy.module}'. "
+                    f"Consider moving to top-level."
+                ),
+            )
+        )
+    return warnings
+
+
+def check_lazy_imports(base_branch: str = "master") -> list[Warning]:
+    warnings: list[Warning] = []
+    for file_path in get_changed_python_files(base_branch):
+        if file_path.suffix != ".py":
+            continue
+
+        if file_path.parts[0] != "mlflow":
+            continue
+
+        if not file_path.exists():
+            continue
+
+        current_content = file_path.read_text()
+        base_content = get_file_content_at_revision(file_path, base_branch)
+        warnings.extend(compare_lazy_imports(file_path, base_content, current_content))
+
+    return warnings
+
+
+@dataclass
+class Args:
+    base_branch: str
+
+
+def parse_args() -> Args:
+    parser = argparse.ArgumentParser(description="Check for newly introduced lazy imports")
+    parser.add_argument("--base-branch", default=os.environ.get("GITHUB_BASE_REF", "master"))
+    args = parser.parse_args()
+    return Args(base_branch=args.base_branch)
+
+
+def main() -> None:
+    args = parse_args()
+    warnings = check_lazy_imports(args.base_branch)
+    for warning in warnings:
+        print(warning.format(github=is_github_actions()))
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/check_lazy_imports.py
+++ b/dev/check_lazy_imports.py
@@ -63,14 +63,15 @@ class LazyImportExtractor(ast.NodeVisitor):
         self._scope_stack: list[str] = []
         self._func_depth: int = 0
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         self._scope_stack.append(node.name)
         self._func_depth += 1
         self.generic_visit(node)
         self._func_depth -= 1
         self._scope_stack.pop()
 
-    visit_AsyncFunctionDef = visit_FunctionDef
+    visit_FunctionDef = _visit_function
+    visit_AsyncFunctionDef = _visit_function
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self._scope_stack.append(node.name)

--- a/dev/check_lazy_imports.py
+++ b/dev/check_lazy_imports.py
@@ -155,8 +155,7 @@ def compare_lazy_imports(
                 line=lazy.line,
                 column=lazy.column + 1,
                 message=(
-                    f"[Non-blocking] Lazy import '{lazy.module}'. "
-                    f"Consider moving to top-level."
+                    f"[Non-blocking] Lazy import '{lazy.module}'. Consider moving to top-level."
                 ),
             )
         )

--- a/dev/check_lazy_imports.py
+++ b/dev/check_lazy_imports.py
@@ -108,10 +108,7 @@ class LazyImportExtractor(ast.NodeVisitor):
 
 
 def extract_lazy_imports(content: str) -> dict[tuple[str, str], LazyImport]:
-    try:
-        tree = ast.parse(content)
-    except SyntaxError:
-        return {}
+    tree = ast.parse(content)
     extractor = LazyImportExtractor()
     extractor.visit(tree)
     return extractor.lazy_imports

--- a/dev/check_lazy_imports.py
+++ b/dev/check_lazy_imports.py
@@ -20,12 +20,10 @@ class Warning:
     message: str
 
     def format(self, github: bool = False) -> str:
+        path = self.file_path.as_posix()
         if github:
-            return (
-                f"::warning file={self.file_path},"
-                f"line={self.line},col={self.column}::{self.message}"
-            )
-        return f"{self.file_path}:{self.line}:{self.column}: {self.message}"
+            return f"::warning file={path},line={self.line},col={self.column}::{self.message}"
+        return f"{path}:{self.line}:{self.column}: {self.message}"
 
 
 @dataclass

--- a/tests/dev/test_check_lazy_imports.py
+++ b/tests/dev/test_check_lazy_imports.py
@@ -78,6 +78,18 @@ def func():
     assert len(result) == 0
 
 
+def test_non_typing_type_checking_not_excluded():
+    code = """\
+def func():
+    if foo.TYPE_CHECKING:
+        import bar
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("func", "bar") in result
+
+
 def test_type_checking_else_branch_not_excluded():
     code = """\
 from typing import TYPE_CHECKING

--- a/tests/dev/test_check_lazy_imports.py
+++ b/tests/dev/test_check_lazy_imports.py
@@ -1,0 +1,410 @@
+from pathlib import Path
+
+from dev.check_lazy_imports import compare_lazy_imports, extract_lazy_imports
+
+
+def test_no_lazy_imports():
+    code = """\
+import os
+from pathlib import Path
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 0
+
+
+def test_import_inside_function():
+    code = """\
+def foo():
+    import json
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("foo", "json") in result
+    assert result[("foo", "json")].line == 2
+
+
+def test_from_import_inside_function():
+    code = """\
+def foo():
+    from pathlib import Path
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("foo", "pathlib") in result
+
+
+def test_multiple_lazy_imports():
+    code = """\
+def foo():
+    import json
+    from pathlib import Path
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 2
+    assert ("foo", "json") in result
+    assert ("foo", "pathlib") in result
+
+
+def test_type_checking_excluded():
+    code = """\
+from typing import TYPE_CHECKING
+
+def foo():
+    if TYPE_CHECKING:
+        import json
+    from pathlib import Path
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("foo", "pathlib") in result
+    assert ("foo", "json") not in result
+
+
+def test_typing_dot_type_checking_excluded():
+    code = """\
+import typing
+
+def foo():
+    if typing.TYPE_CHECKING:
+        import json
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 0
+
+
+def test_type_checking_else_branch_not_excluded():
+    code = """\
+from typing import TYPE_CHECKING
+
+def foo():
+    if TYPE_CHECKING:
+        import json
+    else:
+        import orjson
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("foo", "orjson") in result
+
+
+def test_nested_function():
+    code = """\
+def outer():
+    def inner():
+        import os
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("outer.inner", "os") in result
+
+
+def test_class_method():
+    code = """\
+class MyClass:
+    def method(self):
+        import os
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("MyClass.method", "os") in result
+
+
+def test_nested_class_method():
+    code = """\
+def outer():
+    class Inner:
+        def method(self):
+            import os
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("outer.Inner.method", "os") in result
+
+
+def test_async_function():
+    code = """\
+async def fetch():
+    import aiohttp
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("fetch", "aiohttp") in result
+
+
+def test_import_alias():
+    code = """\
+def foo():
+    import numpy as np
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("foo", "numpy") in result
+
+
+def test_multiple_imports_one_statement():
+    code = """\
+def foo():
+    import os, sys
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 2
+    assert ("foo", "os") in result
+    assert ("foo", "sys") in result
+
+
+def test_relative_import():
+    code = """\
+def foo():
+    from . import utils
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("foo", ".") in result
+
+
+def test_relative_dotted_import():
+    code = """\
+def foo():
+    from ..bar import baz
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("foo", "..bar") in result
+
+
+def test_dotted_module_import():
+    code = """\
+def foo():
+    import os.path
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("foo", "os.path") in result
+
+
+def test_class_body_import_not_lazy():
+    code = """\
+class MyClass:
+    import os
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 0
+
+
+def test_same_module_in_different_functions():
+    code = """\
+def foo():
+    import os
+
+def bar():
+    import os
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 2
+    assert ("foo", "os") in result
+    assert ("bar", "os") in result
+
+
+def test_duplicate_import_in_same_function():
+    code = """\
+def foo():
+    import os
+    import os
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert result[("foo", "os")].line == 2
+
+
+def test_deeply_nested_import():
+    code = """\
+def foo():
+    if True:
+        for x in []:
+            import os
+"""
+    result = extract_lazy_imports(code)
+
+    assert len(result) == 1
+    assert ("foo", "os") in result
+
+
+# --- compare_lazy_imports (base vs head diff) ---
+
+FILE_PATH = Path("mlflow/example.py")
+
+
+def test_compare_new_lazy_import_flagged():
+    base = """\
+def foo():
+    pass
+"""
+    head = """\
+def foo():
+    import json
+"""
+    warnings = compare_lazy_imports(FILE_PATH, base, head)
+
+    assert len(warnings) == 1
+    assert "'json'" in warnings[0].message
+
+
+def test_compare_existing_lazy_import_not_flagged():
+    base = """\
+def foo():
+    import json
+"""
+    head = """\
+def foo():
+    import json
+"""
+    warnings = compare_lazy_imports(FILE_PATH, base, head)
+
+    assert len(warnings) == 0
+
+
+def test_compare_removed_lazy_import_not_flagged():
+    base = """\
+def foo():
+    import json
+    import os
+"""
+    head = """\
+def foo():
+    import json
+"""
+    warnings = compare_lazy_imports(FILE_PATH, base, head)
+
+    assert len(warnings) == 0
+
+
+def test_compare_new_file_all_lazy_imports_flagged():
+    head = """\
+def foo():
+    import json
+    import os
+"""
+    warnings = compare_lazy_imports(FILE_PATH, None, head)
+
+    assert len(warnings) == 2
+    modules = {w.message.split("'")[1] for w in warnings}
+    assert modules == {"json", "os"}
+
+
+def test_compare_mixed_new_and_existing():
+    base = """\
+def foo():
+    import json
+"""
+    head = """\
+def foo():
+    import json
+    import os
+"""
+    warnings = compare_lazy_imports(FILE_PATH, base, head)
+
+    assert len(warnings) == 1
+    assert "'os'" in warnings[0].message
+
+
+def test_compare_new_function_with_lazy_import():
+    base = """\
+def foo():
+    import json
+"""
+    head = """\
+def foo():
+    import json
+
+def bar():
+    import os
+"""
+    warnings = compare_lazy_imports(FILE_PATH, base, head)
+
+    assert len(warnings) == 1
+    assert "'os'" in warnings[0].message
+
+
+def test_compare_lazy_import_moved_to_top_level_not_flagged():
+    base = """\
+def foo():
+    import json
+"""
+    head = """\
+import json
+
+def foo():
+    pass
+"""
+    warnings = compare_lazy_imports(FILE_PATH, base, head)
+
+    assert len(warnings) == 0
+
+
+def test_compare_warning_has_correct_location():
+    base = """\
+def foo():
+    pass
+"""
+    head = """\
+def foo():
+    x = 1
+    import json
+"""
+    warnings = compare_lazy_imports(FILE_PATH, base, head)
+
+    assert len(warnings) == 1
+    assert warnings[0].file_path == FILE_PATH
+    assert warnings[0].line == 3
+    assert warnings[0].column == 5
+
+
+def test_compare_warning_format_local():
+    base = """\
+def foo():
+    pass
+"""
+    head = """\
+def foo():
+    import json
+"""
+    warnings = compare_lazy_imports(FILE_PATH, base, head)
+
+    formatted = warnings[0].format(github=False)
+    assert formatted.startswith("mlflow/example.py:2:5:")
+    assert "[Non-blocking]" in formatted
+
+
+def test_compare_warning_format_github():
+    base = """\
+def foo():
+    pass
+"""
+    head = """\
+def foo():
+    import json
+"""
+    warnings = compare_lazy_imports(FILE_PATH, base, head)
+
+    formatted = warnings[0].format(github=True)
+    assert formatted.startswith("::warning file=mlflow/example.py,")
+    assert "[Non-blocking]" in formatted


### PR DESCRIPTION
### Related Issues/PRs

#20610 (comment)

### What changes are proposed in this pull request?

PR reviewers frequently ask contributors to move imports to the top level. This PR adds a non-blocking CI check that automatically flags newly introduced lazy imports (imports inside function bodies), saving reviewer effort.

The check:
- Uses `ast` to parse both old and new versions of changed files
- Only flags imports that are **new** in the PR (not existing ones)
- Excludes `if TYPE_CHECKING:` blocks
- Outputs `::warning` annotations in GitHub Actions (non-blocking)

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)