### PR TITLE
Use JSONAdapter for best-effort structured outputs in MemAlign predictions

### DIFF
--- a/mlflow/genai/judges/optimizers/memalign/optimizer.py
+++ b/mlflow/genai/judges/optimizers/memalign/optimizer.py
@@ -196,14 +196,18 @@ class MemoryAugmentedJudge(Judge):
         relevant_examples = [example for example, _ in retrieved_results]
         retrieved_trace_ids = [trace_id for _, trace_id in retrieved_results]
 
-        prediction = self._predict_module(
-            guidelines=guidelines,
-            example_judgements=relevant_examples,
-            inputs=inputs,
-            outputs=outputs,
-            expectations=expectations,
-            trace=value_to_embedding_text(trace) if trace is not None else None,
-        )
+        import dspy
+        from dspy.adapters.json_adapter import JSONAdapter
+
+        with dspy.settings.context(adapter=JSONAdapter()):
+            prediction = self._predict_module(
+                guidelines=guidelines,
+                example_judgements=relevant_examples,
+                inputs=inputs,
+                outputs=outputs,
+                expectations=expectations,
+                trace=value_to_embedding_text(trace) if trace is not None else None,
+            )
 
         return Feedback(
             name=self._base_judge.name,

--- a/mlflow/genai/judges/optimizers/memalign/optimizer.py
+++ b/mlflow/genai/judges/optimizers/memalign/optimizer.py
@@ -199,7 +199,7 @@ class MemoryAugmentedJudge(Judge):
         import dspy
         from dspy.adapters.json_adapter import JSONAdapter
 
-        with dspy.settings.context(adapter=JSONAdapter()):
+        with dspy.context(adapter=JSONAdapter()):
             prediction = self._predict_module(
                 guidelines=guidelines,
                 example_judgements=relevant_examples,


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Use DSPy's JSONAdapter instead of the default ChatAdapter when invoking the predict module in MemoryAugmentedJudge. JSONAdapter tries structured outputs first (response_format with Pydantic schema), falling back to JSON mode, then text parsing. This improves parsing reliability with models like Claude Opus and ensures consistent output types for bool feedback values.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
```python
from typing import Literal

import mlflow
from mlflow.genai.judges import make_judge
from mlflow.genai.judges.optimizers import MemAlignOptimizer

mlflow.set_tracking_uri("databricks")
mlflow.set_experiment(experiment_id=EXPERIMENT_ID)

JUDGE_NAME = "grammar"
MODEL = "databricks:/databricks-claude-opus-4-5"

traces = mlflow.search_traces(locations=[EXPERIMENT_ID], return_type="list")
filtered = [
    t for t in traces if any(a.name == JUDGE_NAME for a in t.info.assessments)
]

# Issue 1: MemAlign with Literal + opus
print("=== Issue 1: MemAlign Literal with opus ===")
judge = make_judge(
    name=JUDGE_NAME,
    instructions=(
        "The response must not have grammatical or punctuation issues:\n"
        "Response: {{ outputs }}\n"
        'Return "pass" if no issues, "fail" if there are issues.'
    ),
    feedback_value_type=Literal["pass", "fail"],
    model=MODEL,
)
optimizer = MemAlignOptimizer(
    reflection_lm="databricks:/databricks-claude-sonnet-4-5",
    embedding_model="databricks:/databricks-gte-large-en",
    retrieval_k=3,
)
aligned = judge.align(traces=filtered, optimizer=optimizer)
for i, t in enumerate(filtered):
    try:
        result = aligned(trace=t)
        print(f"  [{i+1}] value={result.value!r}, type={type(result.value).__name__}")
    except Exception as e:
        print(f"  [{i+1}] FAILED: {e}")

# Issue 2: MemAlign with bool + opus
print("\n=== Issue 2: MemAlign bool with opus ===")
judge_bool = make_judge(
    name=JUDGE_NAME,
    instructions=(
        "The response must not have grammatical or punctuation issues:\n"
        "Response: {{ outputs }}\n"
        "Return true if no issues, false if there are issues."
    ),
    feedback_value_type=bool,
    model=MODEL,
)
aligned_bool = judge_bool.align(traces=filtered, optimizer=optimizer)
for i, t in enumerate(filtered):
    try:
        result = aligned_bool(trace=t)
        print(f"  [{i+1}] value={result.value!r}, type={type(result.value).__name__}")
    except Exception as e:
        print(f"  [{i+1}] FAILED: {e}")
```

Verified the failures before this change and the fix after:
```
=== Issue 1: MemAlign Literal with opus ===
Distilling guidelines: 100%|████████████████████████████████| 1/1 [00:00<00:00, 8004.40it/s]
  [1] value='fail', type=str
  [2] value='fail', type=str
  [3] value='fail', type=str
  [4] value='fail', type=str
  [5] value='pass', type=str
  [6] value='fail', type=str
  [7] value='fail', type=str
  [8] value='fail', type=str
  [9] value='fail', type=str
  [10] value='pass', type=str
  [11] value='pass', type=str
  [12] value='pass', type=str

=== Issue 2: MemAlign bool with opus ===
Distilling guidelines: 100%|█████████████████████████████████| 1/1 [00:00<00:00, 876.55it/s]
  [1] value=False, type=bool
  [2] value=False, type=bool
  [3] value=False, type=bool
  [4] value=False, type=bool
  [5] value=True, type=bool
  [6] value=False, type=bool
  [7] value=False, type=bool
  [8] value=False, type=bool
  [9] value=False, type=bool
  [10] value=True, type=bool
  [11] value=True, type=bool
  [12] value=True, type=bool
```


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
