### PR TITLE
Support output aggregation for chat completion

### DIFF
--- a/mlflow/gateway/tracing_utils.py
+++ b/mlflow/gateway/tracing_utils.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import mlflow
 from mlflow.entities.trace_location import MlflowExperimentLocation
+from mlflow.gateway.schemas.chat import StreamResponsePayload
 from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig
 
 
@@ -12,6 +13,7 @@ def maybe_traced_gateway_call(
     func: Callable[..., Any],
     endpoint_config: GatewayEndpointConfig,
     metadata: dict[str, Any] | None = None,
+    output_reducer: Callable[[list[Any]], Any] | None = None,
 ) -> Callable[..., Any]:
     """
     Wrap a gateway function with tracing.
@@ -20,6 +22,7 @@ def maybe_traced_gateway_call(
         func: The function to trace.
         endpoint_config: The gateway endpoint configuration.
         metadata: Additional metadata to include in the trace (e.g., auth user info).
+        output_reducer: A function to aggregate streaming chunks into a single output.
 
     Returns:
         A traced version of the function.
@@ -36,6 +39,7 @@ def maybe_traced_gateway_call(
             "endpoint_id": endpoint_config.endpoint_id,
             "endpoint_name": endpoint_config.endpoint_name,
         },
+        "output_reducer": output_reducer,
         "trace_destination": MlflowExperimentLocation(endpoint_config.experiment_id),
     }
 
@@ -66,3 +70,92 @@ def maybe_traced_gateway_call(
             return func(*args, **kwargs)
 
     return mlflow.trace(wrapper, **trace_kwargs)
+
+
+def aggregate_chat_stream_chunks(chunks: list[StreamResponsePayload]) -> dict[str, Any] | None:
+    """
+    Aggregate streaming chat completion chunks into a single ChatCompletion-like response.
+
+    Returns:
+        A ChatCompletion-like response.
+    """
+    if not chunks:
+        return None
+
+    # Group state per choice index
+    choices_state: dict[int, dict[str, Any]] = {}
+
+    for chunk in chunks:
+        for choice in chunk.choices:
+            state = choices_state.setdefault(
+                choice.index,
+                {
+                    "role": None,
+                    "content_parts": [],
+                    "tool_calls_by_index": {},
+                    "finish_reason": None,
+                },
+            )
+            delta = choice.delta
+            if delta.role and state["role"] is None:
+                state["role"] = delta.role
+            if delta.content:
+                state["content_parts"].append(delta.content)
+            if choice.finish_reason:
+                state["finish_reason"] = choice.finish_reason
+            if delta.tool_calls:
+                for tc_delta in delta.tool_calls:
+                    tc = state["tool_calls_by_index"].setdefault(
+                        tc_delta.index,
+                        {"id": None, "type": "function", "name": "", "arguments": ""},
+                    )
+                    if tc_delta.id:
+                        tc["id"] = tc_delta.id
+                    if tc_delta.type:
+                        tc["type"] = tc_delta.type
+                    if tc_delta.function:
+                        if tc_delta.function.name:
+                            tc["name"] += tc_delta.function.name
+                        if tc_delta.function.arguments:
+                            tc["arguments"] += tc_delta.function.arguments
+
+    aggregated_choices = []
+    for choice_index, state in sorted(choices_state.items()):
+        message: dict[str, Any] = {
+            "role": state["role"] or "assistant",
+            "content": "".join(state["content_parts"]) or None,
+        }
+        if state["tool_calls_by_index"]:
+            message["tool_calls"] = [
+                {
+                    "id": tc["id"],
+                    "type": tc["type"],
+                    "function": {"name": tc["name"], "arguments": tc["arguments"]},
+                }
+                for tc in state["tool_calls_by_index"].values()
+            ]
+        aggregated_choices.append(
+            {
+                "index": choice_index,
+                "message": message,
+                "finish_reason": state["finish_reason"] or "stop",
+            }
+        )
+
+    last_chunk = chunks[-1]
+    result = {
+        "id": last_chunk.id,
+        "object": "chat.completion",
+        "created": last_chunk.created,
+        "model": last_chunk.model,
+        "choices": aggregated_choices,
+    }
+
+    if last_chunk.usage:
+        result["usage"] = {
+            "prompt_tokens": last_chunk.usage.prompt_tokens,
+            "completion_tokens": last_chunk.usage.completion_tokens,
+            "total_tokens": last_chunk.usage.total_tokens,
+        }
+
+    return result

--- a/tests/gateway/test_tracing_utils.py
+++ b/tests/gateway/test_tracing_utils.py
@@ -1,10 +1,12 @@
 import pytest
 
-from mlflow.gateway.tracing_utils import maybe_traced_gateway_call
+from mlflow.gateway.schemas.chat import StreamResponsePayload
+from mlflow.gateway.tracing_utils import aggregate_chat_stream_chunks, maybe_traced_gateway_call
 from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig
 from mlflow.tracing.client import TracingClient
 from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracking.fluent import _get_experiment_id
+from mlflow.types.chat import ChatChoiceDelta, ChatChunkChoice, ChatUsage
 
 
 def get_traces():
@@ -33,6 +35,68 @@ def endpoint_config_no_experiment():
 
 async def mock_async_func(payload):
     return {"result": "success", "payload": payload}
+
+
+def _make_chunk(
+    content=None,
+    finish_reason=None,
+    id="chunk-1",
+    model="test-model",
+    created=1700000000,
+    usage=None,
+):
+    delta = ChatChoiceDelta(role="assistant", content=content)
+    choice = ChatChunkChoice(index=0, finish_reason=finish_reason, delta=delta)
+    return StreamResponsePayload(
+        id=id,
+        created=created,
+        model=model,
+        choices=[choice],
+        usage=usage,
+    )
+
+
+def test_aggregate_chat_stream_chunks_aggregates_content():
+    chunks = [
+        _make_chunk(content="Hello"),
+        _make_chunk(content=" "),
+        _make_chunk(content="world"),
+        _make_chunk(content=None, finish_reason="stop"),
+    ]
+    result = aggregate_chat_stream_chunks(chunks)
+
+    assert result["object"] == "chat.completion"
+    assert result["model"] == "test-model"
+    assert result["choices"][0]["message"]["role"] == "assistant"
+    assert result["choices"][0]["message"]["content"] == "Hello world"
+    assert result["choices"][0]["finish_reason"] == "stop"
+
+
+def test_aggregate_chat_stream_chunks_with_usage():
+    usage = ChatUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    chunks = [
+        _make_chunk(content="Hi"),
+        _make_chunk(content=None, finish_reason="stop", usage=usage),
+    ]
+    result = aggregate_chat_stream_chunks(chunks)
+
+    assert result["choices"][0]["message"]["content"] == "Hi"
+    assert result["usage"] == {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+    }
+
+
+def test_aggregate_chat_stream_chunks_empty():
+    assert aggregate_chat_stream_chunks([]) is None
+
+
+def test_aggregate_chat_stream_chunks_defaults_finish_reason():
+    chunks = [_make_chunk(content="Hi")]
+    result = aggregate_chat_stream_chunks(chunks)
+
+    assert result["choices"][0]["finish_reason"] == "stop"
 
 
 @pytest.mark.asyncio
@@ -106,3 +170,41 @@ async def test_maybe_traced_gateway_call_without_experiment_id(endpoint_config_n
     # No traces should be created
     traces = get_traces()
     assert len(traces) == 0
+
+
+@pytest.mark.asyncio
+async def test_maybe_traced_gateway_call_with_output_reducer(endpoint_config):
+    async def mock_async_stream(payload):
+        yield _make_chunk(content="Hello")
+        yield _make_chunk(content=" world")
+        yield _make_chunk(
+            content=None,
+            finish_reason="stop",
+            usage=ChatUsage(prompt_tokens=5, completion_tokens=2, total_tokens=7),
+        )
+
+    traced_func = maybe_traced_gateway_call(
+        mock_async_stream,
+        endpoint_config,
+        output_reducer=aggregate_chat_stream_chunks,
+    )
+
+    # Consume the stream
+    chunks = [
+        chunk async for chunk in traced_func({"messages": [{"role": "user", "content": "hi"}]})
+    ]
+    assert len(chunks) == 3
+
+    traces = get_traces()
+    assert len(traces) == 1
+    trace = traces[0]
+
+    span_name_to_span = {span.name: span for span in trace.data.spans}
+    gateway_span = span_name_to_span[f"gateway/{endpoint_config.endpoint_name}"]
+
+    # The output should be the reduced aggregated response, not raw chunks
+    output = gateway_span.outputs
+    assert output["object"] == "chat.completion"
+    assert output["choices"][0]["message"]["content"] == "Hello world"
+    assert output["choices"][0]["finish_reason"] == "stop"
+    assert output["usage"]["total_tokens"] == 7


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20682/files) to review incremental changes.
- [**stack/gateway/aggregate/openai**](https://github.com/mlflow/mlflow/pull/20682) [[Files changed](https://github.com/mlflow/mlflow/pull/20682/files)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Title

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
