### PR TITLE
Add rate-limited pipelined execution for mlflow.genai.evaluate

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -694,8 +694,8 @@ MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT = _EnvironmentVariable(
 
 #: Maximum scorer calls per second during mlflow.genai.evaluate. A token-bucket
 #: rate limiter throttles individual scorer invocations across all worker threads.
-#: When not set, auto-derived from predict rate × num_scorers. Accepts ``auto``,
-#: a positive number, or ``0`` to disable. (default: auto-derived)
+#: Accepted values: ``auto`` (auto-derived from predict rate x num_scorers),
+#: a positive number (fixed rate), or ``0`` to disable. (default: ``auto``)
 MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT = _EnvironmentVariable(
     "MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", str, None
 )
@@ -703,9 +703,7 @@ MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT = _EnvironmentVariable(
 #: Maximum number of retries for rate-limit (429) errors during evaluate.
 #: Applies to both predict_fn and scorer calls. Set to 0 to disable retries.
 #: (default: ``3``)
-MLFLOW_GENAI_EVAL_MAX_RETRIES = _EnvironmentVariable(
-    "MLFLOW_GENAI_EVAL_MAX_RETRIES", int, 3
-)
+MLFLOW_GENAI_EVAL_MAX_RETRIES = _EnvironmentVariable("MLFLOW_GENAI_EVAL_MAX_RETRIES", int, 3)
 
 #: Multiplier for the adaptive rate limiter ceiling. When rate limiting is set to
 #: ``auto``, the rate can climb up to ``initial_rps * multiplier`` on sustained
@@ -713,12 +711,6 @@ MLFLOW_GENAI_EVAL_MAX_RETRIES = _EnvironmentVariable(
 #: (default: ``5``)
 MLFLOW_GENAI_EVAL_RATE_LIMIT_UPPER_MULTIPLIER = _EnvironmentVariable(
     "MLFLOW_GENAI_EVAL_RATE_LIMIT_UPPER_MULTIPLIER", float, 5.0
-)
-
-#: When True, dump stack traces for evaluation threads in each heartbeat.
-#: Useful for diagnosing hangs. (default: ``false``)
-MLFLOW_GENAI_EVAL_DUMP_THREAD_STACKS = _BooleanEnvironmentVariable(
-    "MLFLOW_GENAI_EVAL_DUMP_THREAD_STACKS", False
 )
 
 #: Maximum number of workers to use for running conversation simulations in parallel.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -693,7 +693,7 @@ MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT = _EnvironmentVariable(
 
 #: Maximum scorer calls per second during mlflow.genai.evaluate. A token-bucket
 #: rate limiter throttles individual scorer invocations across all worker threads.
-#: When not set, auto-derived as ``predict_rate × num_scorers`` to match pipeline
+#: When not set, auto-derived as ``predict_rate * num_scorers`` to match pipeline
 #: throughput. Set to 0 to disable rate limiting. (default: auto)
 MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT = _EnvironmentVariable(
     "MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", float, None

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -750,6 +750,13 @@ MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING = _BooleanEnvironmentVariable(
     "MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING", False
 )
 
+#: Enable periodic heartbeat logging during mlflow.genai.evaluate. When True, pipeline
+#: progress (predicted/scored counts, pending futures, current rate limits) is logged at
+#: DEBUG level every 15 seconds. Useful for diagnosing throughput issues. (default: ``False``)
+MLFLOW_GENAI_EVAL_ENABLE_HEARTBEAT = _BooleanEnvironmentVariable(
+    "MLFLOW_GENAI_EVAL_ENABLE_HEARTBEAT", False
+)
+
 #: Timeout in seconds for async predict functions in mlflow.genai.evaluate. When an async
 #: function is passed as predict_fn, it will be wrapped with asyncio.run() with this timeout.
 #: (default: ``300``)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -684,6 +684,20 @@ MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS = _EnvironmentVariable(
     "MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS", int, 10
 )
 
+#: Maximum predict_fn calls per second during mlflow.genai.evaluate. A token-bucket
+#: rate limiter throttles predict_fn invocations across all worker threads.
+#: Set to 0 to disable rate limiting. (default: ``20``)
+MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT = _EnvironmentVariable(
+    "MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT", float, 20
+)
+
+#: Maximum scorer calls per second during mlflow.genai.evaluate. A token-bucket
+#: rate limiter throttles individual scorer invocations across all worker threads.
+#: Set to 0 to disable rate limiting. (default: ``100``)
+MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT = _EnvironmentVariable(
+    "MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", float, 100
+)
+
 #: Maximum number of workers to use for running conversation simulations in parallel.
 #: Controls concurrency when simulating multiple test cases and fetching traces.
 #: (default: ``10``)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -686,17 +686,39 @@ MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS = _EnvironmentVariable(
 
 #: Maximum predict_fn calls per second during mlflow.genai.evaluate. A token-bucket
 #: rate limiter throttles predict_fn invocations across all worker threads.
-#: Set to 0 to disable rate limiting. (default: ``20``)
+#: Accepted values: ``auto`` (adaptive rate starting at 10 rps), a positive number
+#: (fixed rate), or ``0`` to disable rate limiting. (default: ``auto``)
 MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT = _EnvironmentVariable(
-    "MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT", float, 20
+    "MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT", str, "auto"
 )
 
 #: Maximum scorer calls per second during mlflow.genai.evaluate. A token-bucket
 #: rate limiter throttles individual scorer invocations across all worker threads.
-#: When not set, auto-derived as ``predict_rate * num_scorers`` to match pipeline
-#: throughput. Set to 0 to disable rate limiting. (default: auto)
+#: When not set, auto-derived from predict rate × num_scorers. Accepts ``auto``,
+#: a positive number, or ``0`` to disable. (default: auto-derived)
 MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT = _EnvironmentVariable(
-    "MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", float, None
+    "MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", str, None
+)
+
+#: Maximum number of retries for rate-limit (429) errors during evaluate.
+#: Applies to both predict_fn and scorer calls. Set to 0 to disable retries.
+#: (default: ``3``)
+MLFLOW_GENAI_EVAL_MAX_RETRIES = _EnvironmentVariable(
+    "MLFLOW_GENAI_EVAL_MAX_RETRIES", int, 3
+)
+
+#: Multiplier for the adaptive rate limiter ceiling. When rate limiting is set to
+#: ``auto``, the rate can climb up to ``initial_rps * multiplier`` on sustained
+#: success. Set to 1 to disable rate climbing beyond the initial rate.
+#: (default: ``5``)
+MLFLOW_GENAI_EVAL_RATE_LIMIT_UPPER_MULTIPLIER = _EnvironmentVariable(
+    "MLFLOW_GENAI_EVAL_RATE_LIMIT_UPPER_MULTIPLIER", float, 5.0
+)
+
+#: When True, dump stack traces for evaluation threads in each heartbeat.
+#: Useful for diagnosing hangs. (default: ``false``)
+MLFLOW_GENAI_EVAL_DUMP_THREAD_STACKS = _BooleanEnvironmentVariable(
+    "MLFLOW_GENAI_EVAL_DUMP_THREAD_STACKS", False
 )
 
 #: Maximum number of workers to use for running conversation simulations in parallel.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -693,9 +693,10 @@ MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT = _EnvironmentVariable(
 
 #: Maximum scorer calls per second during mlflow.genai.evaluate. A token-bucket
 #: rate limiter throttles individual scorer invocations across all worker threads.
-#: Set to 0 to disable rate limiting. (default: ``100``)
+#: When not set, auto-derived as ``predict_rate × num_scorers`` to match pipeline
+#: throughput. Set to 0 to disable rate limiting. (default: auto)
 MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT = _EnvironmentVariable(
-    "MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", float, 100
+    "MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", float, None
 )
 
 #: Maximum number of workers to use for running conversation simulations in parallel.

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -139,9 +139,14 @@ def run(
 
     total_tasks = len(eval_items) + len(session_groups)
 
-    # Create rate limiters from environment variables
+    # Create rate limiters from environment variables.
+    # Scorer rate auto-derives from predict rate × num_scorers when not set explicitly.
     predict_rate = MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT.get()
-    scorer_rate = MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT.get()
+    if MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT.is_set():
+        scorer_rate = MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT.get()
+    else:
+        num_scorers = len(single_turn_scorers) + len(multi_turn_scorers)
+        scorer_rate = (predict_rate * num_scorers) if predict_rate and num_scorers else predict_rate
     predict_limiter = _make_rate_limiter(predict_rate)
     scorer_limiter = _make_rate_limiter(scorer_rate)
 

--- a/mlflow/genai/evaluation/rate_limiter.py
+++ b/mlflow/genai/evaluation/rate_limiter.py
@@ -3,32 +3,98 @@
 from __future__ import annotations
 
 import abc
+import contextlib
+import logging
 import threading
 import time
+from contextvars import ContextVar
 from typing import Callable
+
+_logger = logging.getLogger(__name__)
+
+# ContextVar that signals the evaluate pipeline owns retry logic for rate-limit errors.
+# When True, downstream adapters (e.g. litellm) should disable their own 429 retries
+# so that errors bubble up to call_with_retry().
+_EVAL_RETRY_ACTIVE = ContextVar("_EVAL_RETRY_ACTIVE", default=False)
+
+
+@contextlib.contextmanager
+def eval_retry_context():
+    from mlflow.utils.rest_utils import disable_429_retry
+
+    token = _EVAL_RETRY_ACTIVE.set(True)
+    try:
+        with disable_429_retry():
+            yield
+    finally:
+        _EVAL_RETRY_ACTIVE.reset(token)
+
+
+def is_eval_retry_active() -> bool:
+    return _EVAL_RETRY_ACTIVE.get()
+
+
+def is_rate_limit_error(exc: BaseException) -> bool:
+    # 1. Known exception types from popular LLM libraries
+    type_name = type(exc).__name__
+    if type_name == "RateLimitError":
+        return True
+
+    # 2. Check .response.status_code or .status_code (httpx / requests style)
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        resp = getattr(exc, "response", None)
+        if resp is not None:
+            status = getattr(resp, "status_code", None)
+    if status == 429:
+        return True
+
+    # 3. Fallback: string matching
+    exc_str = str(exc).lower()
+    if "429" in exc_str or "rate limit" in exc_str:
+        return True
+
+    return False
 
 
 class RateLimiter(abc.ABC):
     @abc.abstractmethod
     def acquire(self) -> None: ...
 
+    def report_throttle(self) -> None:
+        """Called when a 429 / rate-limit error is observed. No-op by default."""
+
+    def report_success(self) -> None:
+        """Called on a successful request. No-op by default."""
+
+    @property
+    def current_rps(self) -> float | None:
+        """Current requests-per-second, or None if not rate-limited."""
+        return None
+
 
 class RPSRateLimiter(RateLimiter):
-    """Thread-safe token-bucket rate limiter.
+    """Thread-safe token-bucket rate limiter with optional AIMD adaptation.
 
     Each acquire() consumes one token and blocks until a token is available.
     Tokens refill at the configured rate, with a burst capacity of one second.
+
+    When ``adaptive=True``, report_throttle() multiplicatively decreases the
+    rate and report_success() additively increases it (AIMD).
     """
 
     def __init__(
         self,
         requests_per_second: float,
+        adaptive: bool = False,
+        max_rps_multiplier: float = 5.0,
         clock: Callable[[], float] = time.monotonic,
         sleep: Callable[[float], None] = time.sleep,
     ):
         if requests_per_second <= 0:
             raise ValueError("requests_per_second must be positive")
         self._rps = requests_per_second
+        self._initial_rps = requests_per_second
         self._max_tokens = requests_per_second
         self._tokens = requests_per_second
         self._clock = clock
@@ -36,7 +102,20 @@ class RPSRateLimiter(RateLimiter):
         self._last_refill = clock()
         self._lock = threading.Lock()
 
+        # AIMD parameters
+        self._adaptive = adaptive
+        self._beta = 0.5  # multiplicative decrease factor
+        self._alpha = 1.0  # additive increase per success
+        self._min_rps = 1.0  # floor for rate reduction
+        self._max_rps = max_rps_multiplier * requests_per_second  # ceiling for additive increase
+        self._throttle_cooldown = 5.0  # seconds between consecutive decreases
+        self._last_throttle_time = -float("inf")
+
     def acquire(self) -> None:
+        thread = threading.current_thread().name
+        _logger.debug(
+            f"[{thread}] acquire() called — rps={self._rps:.1f} tokens={self._tokens:.2f}"
+        )
         while True:
             with self._lock:
                 now = self._clock()
@@ -51,9 +130,69 @@ class RPSRateLimiter(RateLimiter):
 
                 wait_time = (1.0 - self._tokens) / self._rps
 
+            _logger.debug(f"[{thread}] acquire() sleeping {wait_time:.3f}s")
             self._sleep(wait_time)
+
+    def report_throttle(self) -> None:
+        if not self._adaptive:
+            return
+        with self._lock:
+            now = self._clock()
+            if now - self._last_throttle_time < self._throttle_cooldown:
+                return
+            self._last_throttle_time = now
+            old_rps = self._rps
+            self._rps = max(self._min_rps, self._rps * self._beta)
+            self._max_tokens = self._rps
+            # Clamp current tokens to new burst size
+            self._tokens = min(self._tokens, self._max_tokens)
+            _logger.info(
+                f"Rate limit hit — reducing rate from {old_rps:.1f} to {self._rps:.1f} rps"
+            )
+
+    def report_success(self) -> None:
+        if not self._adaptive:
+            return
+        with self._lock:
+            old_rps = self._rps
+            self._rps = min(self._max_rps, self._rps + self._alpha / self._rps)
+            self._max_tokens = self._rps
+            if self._rps > old_rps + 0.5:
+                _logger.debug(f"Rate increased to {self._rps:.1f} rps")
+
+    @property
+    def current_rps(self) -> float | None:
+        return self._rps
 
 
 class NoOpRateLimiter(RateLimiter):
     def acquire(self) -> None:
         pass
+
+
+def call_with_retry(
+    fn: Callable,
+    rate_limiter: RateLimiter,
+    max_retries: int,
+    sleep: Callable[[float], None] = time.sleep,
+) -> object:
+    last_exc = None
+    for attempt in range(max_retries + 1):
+        rate_limiter.acquire()
+        try:
+            result = fn()
+        except Exception as e:
+            if not is_rate_limit_error(e):
+                raise
+            last_exc = e
+            rate_limiter.report_throttle()
+            if attempt < max_retries:
+                delay = min(2**attempt, 60)
+                _logger.info(
+                    f"Rate-limited (attempt {attempt + 1}/{max_retries + 1}), retrying in {delay}s"
+                )
+                sleep(delay)
+        else:
+            rate_limiter.report_success()
+            return result
+    raise last_exc

--- a/mlflow/genai/evaluation/rate_limiter.py
+++ b/mlflow/genai/evaluation/rate_limiter.py
@@ -169,7 +169,7 @@ class NoOpRateLimiter(RateLimiter):
 
 
 def call_with_retry(
-    fn: Callable,
+    fn: Callable[[], object],
     rate_limiter: RateLimiter,
     max_retries: int,
     sleep: Callable[[float], None] = time.sleep,

--- a/mlflow/genai/evaluation/rate_limiter.py
+++ b/mlflow/genai/evaluation/rate_limiter.py
@@ -1,0 +1,59 @@
+"""Thread-safe rate limiters for evaluation harness."""
+
+from __future__ import annotations
+
+import abc
+import threading
+import time
+from typing import Callable
+
+
+class RateLimiter(abc.ABC):
+    @abc.abstractmethod
+    def acquire(self) -> None: ...
+
+
+class RPSRateLimiter(RateLimiter):
+    """Thread-safe token-bucket rate limiter.
+
+    Each acquire() consumes one token and blocks until a token is available.
+    Tokens refill at the configured rate, with a burst capacity of one second.
+    """
+
+    def __init__(
+        self,
+        requests_per_second: float,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ):
+        if requests_per_second <= 0:
+            raise ValueError("requests_per_second must be positive")
+        self._rps = requests_per_second
+        self._max_tokens = requests_per_second
+        self._tokens = requests_per_second
+        self._clock = clock
+        self._sleep = sleep
+        self._last_refill = clock()
+        self._lock = threading.Lock()
+
+    def acquire(self) -> None:
+        while True:
+            with self._lock:
+                now = self._clock()
+                elapsed = now - self._last_refill
+                self._tokens = min(self._max_tokens, self._tokens + elapsed * self._rps)
+                self._last_refill = now
+
+                # Epsilon avoids floating-point drift (e.g. 0.1*10 = 0.9999...98)
+                if self._tokens >= 1.0 - 1e-9:
+                    self._tokens -= 1.0
+                    return
+
+                wait_time = (1.0 - self._tokens) / self._rps
+
+            self._sleep(wait_time)
+
+
+class NoOpRateLimiter(RateLimiter):
+    def acquire(self) -> None:
+        pass

--- a/mlflow/genai/evaluation/session_utils.py
+++ b/mlflow/genai/evaluation/session_utils.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING, Any
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_error import AssessmentError
 from mlflow.exceptions import MlflowException
-from mlflow.genai.evaluation.rate_limiter import NoOpRateLimiter, RateLimiter
+from mlflow.genai.evaluation.rate_limiter import (
+    NoOpRateLimiter,
+    RateLimiter,
+    call_with_retry,
+    eval_retry_context,
+)
 from mlflow.genai.evaluation.utils import (
     make_code_type_assessment_source,
     standardize_scorer_value,
@@ -95,6 +100,7 @@ def evaluate_session_level_scorers(
     session_items: list["EvalItem"],
     multi_turn_scorers: list[Scorer],
     scorer_rate_limiter: RateLimiter = NoOpRateLimiter(),
+    max_retries: int = 0,
 ) -> dict[str, list[Feedback]]:
     """
     Evaluate all multi-turn scorers for a single session.
@@ -114,8 +120,12 @@ def evaluate_session_level_scorers(
 
     def run_scorer(scorer: Scorer) -> list[Feedback]:
         try:
-            scorer_rate_limiter.acquire()
-            value = scorer.run(session=session_traces)
+            with eval_retry_context():
+                value = call_with_retry(
+                    lambda: scorer.run(session=session_traces),
+                    scorer_rate_limiter,
+                    max_retries,
+                )
             feedbacks = standardize_scorer_value(scorer.name, value)
 
             # Add session_id to metadata for each feedback

--- a/mlflow/genai/evaluation/session_utils.py
+++ b/mlflow/genai/evaluation/session_utils.py
@@ -110,6 +110,7 @@ def evaluate_session_level_scorers(
         session_items: List of EvalItem objects from the same session
         multi_turn_scorers: List of multi-turn scorer instances
         scorer_rate_limiter: Rate limiter to throttle scorer invocations.
+        max_retries: Max 429-retry attempts per scorer call.
 
     Returns:
         dict: {first_trace_id: [feedback1, feedback2, ...]}

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -56,7 +56,7 @@ _logger = logging.getLogger(__name__)
 
 USER_DEFINED_ASSESSMENT_NAME_KEY = "_user_defined_assessment_name"
 PGBAR_FORMAT = (
-    "{l_bar}{bar}| {n_fmt}/{total_fmt} [Elapsed: {elapsed}, Remaining: {remaining}] {postfix}"
+    "{l_bar}{bar}| {n_fmt}/{total_fmt} [Elapsed: {elapsed}, Remaining: {remaining}]{postfix}"
 )
 
 

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -5,6 +5,7 @@ import logging
 import re
 import threading
 from contextlib import ContextDecorator
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -42,6 +43,21 @@ from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
 from mlflow.tracing.constant import AssessmentMetadataKey
 
 _logger = logging.getLogger(__name__)
+
+# ContextVar that upstream modules (e.g. the evaluate harness) can set to disable
+# litellm's own rate-limit retries, so 429 errors propagate to the caller's retry logic.
+_DISABLE_RATE_LIMIT_RETRIES = ContextVar("_DISABLE_RATE_LIMIT_RETRIES", default=False)
+
+
+def disable_litellm_rate_limit_retries() -> ContextVar:
+    """Return the ContextVar that controls litellm rate-limit retry suppression.
+
+    Callers should use ``token = _DISABLE_RATE_LIMIT_RETRIES.set(True)`` and
+    ``_DISABLE_RATE_LIMIT_RETRIES.reset(token)`` (or a context manager) to
+    temporarily disable litellm's RateLimitErrorRetries.
+    """
+    return _DISABLE_RATE_LIMIT_RETRIES
+
 
 # Global cache to track model capabilities across function calls
 # Key: model URI (e.g., "openai/gpt-4"), Value: boolean indicating response_format support
@@ -488,11 +504,10 @@ def _get_litellm_retry_policy(num_retries: int) -> "litellm.RetryPolicy":
     """
     from litellm import RetryPolicy
 
-    from mlflow.genai.evaluation.rate_limiter import is_eval_retry_active
-
-    # When the evaluate pipeline owns retry logic, disable litellm's rate-limit retries
-    # so 429 errors bubble up to call_with_retry() for AIMD adaptation.
-    rate_limit_retries = 0 if is_eval_retry_active() else num_retries
+    # When an upstream module (e.g. the evaluate harness) has set the flag,
+    # disable litellm's rate-limit retries so 429 errors propagate to the
+    # caller's own retry logic for adaptive rate control.
+    rate_limit_retries = 0 if _DISABLE_RATE_LIMIT_RETRIES.get() else num_retries
 
     return RetryPolicy(
         TimeoutErrorRetries=num_retries,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -471,6 +471,7 @@ example-rules = [
 
 # typos
 [tool.typos.default.extend-words]
+aimd = "aimd"                      # additive increase multiplicative decrease
 als = "als"                        # alternating least squares
 mape = "mape"                      # mean absolute percentage error
 fpr = "fpr"                        # false positive rate

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -1,7 +1,14 @@
 import pytest
 
-from mlflow.genai.evaluation.harness import _make_rate_limiter
-from mlflow.genai.evaluation.rate_limiter import NoOpRateLimiter, RPSRateLimiter
+from mlflow.genai.evaluation.harness import _make_rate_limiter, _parse_rate_limit
+from mlflow.genai.evaluation.rate_limiter import (
+    NoOpRateLimiter,
+    RPSRateLimiter,
+    call_with_retry,
+    eval_retry_context,
+    is_eval_retry_active,
+    is_rate_limit_error,
+)
 
 
 class FakeClock:
@@ -21,6 +28,9 @@ class FakeClock:
     def sleep(self, seconds: float) -> None:
         self.sleep_calls.append(seconds)
         self._now += seconds
+
+
+# ── Token bucket tests ──
 
 
 def test_invalid_rate_raises():
@@ -104,6 +114,9 @@ def test_noop_acquire_does_nothing():
         limiter.acquire()
 
 
+# ── _make_rate_limiter / _parse_rate_limit tests ──
+
+
 def test_make_rate_limiter_positive_rate():
     assert isinstance(_make_rate_limiter(10.0), RPSRateLimiter)
 
@@ -114,3 +127,247 @@ def test_make_rate_limiter_zero_returns_noop():
 
 def test_make_rate_limiter_none_returns_noop():
     assert isinstance(_make_rate_limiter(None), NoOpRateLimiter)
+
+
+def test_make_rate_limiter_adaptive():
+    limiter = _make_rate_limiter(10.0, adaptive=True)
+    assert isinstance(limiter, RPSRateLimiter)
+    assert limiter._adaptive is True
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_rps", "expected_adaptive"),
+    [
+        ("auto", 10.0, True),
+        ("AUTO", 10.0, True),
+        (" Auto ", 10.0, True),
+        ("25", 25.0, False),
+        ("0", None, False),
+        (None, None, False),
+    ],
+)
+def test_parse_rate_limit(raw, expected_rps, expected_adaptive):
+    rps, adaptive = _parse_rate_limit(raw)
+    assert rps == expected_rps
+    assert adaptive == expected_adaptive
+
+
+# ── is_rate_limit_error tests ──
+
+
+class _FakeRateLimitError(Exception):
+    pass
+
+
+_FakeRateLimitError.__name__ = "RateLimitError"
+
+
+class _FakeStatusCodeError(Exception):
+    def __init__(self, status_code):
+        self.status_code = status_code
+        super().__init__(f"HTTP {status_code}")
+
+
+class _FakeResponseError(Exception):
+    def __init__(self, status_code):
+        self.response = type("R", (), {"status_code": status_code})()
+        super().__init__(f"HTTP {status_code}")
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (_FakeRateLimitError("rate limit"), True),
+        (_FakeStatusCodeError(429), True),
+        (_FakeResponseError(429), True),
+        (Exception("Error 429: too many requests"), True),
+        (Exception("rate limit exceeded"), True),
+        (_FakeStatusCodeError(500), False),
+        (_FakeResponseError(500), False),
+        (Exception("something else entirely"), False),
+        (ValueError("bad value"), False),
+    ],
+)
+def test_is_rate_limit_error(exc, expected):
+    assert is_rate_limit_error(exc) == expected
+
+
+# ── AIMD tests ──
+
+
+def test_throttle_halves_rate():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(10.0, adaptive=True, clock=clock.monotonic, sleep=clock.sleep)
+
+    limiter.report_throttle()
+    assert limiter._rps == pytest.approx(5.0)
+
+
+def test_throttle_respects_floor():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(2.0, adaptive=True, clock=clock.monotonic, sleep=clock.sleep)
+
+    # First throttle: 2.0 * 0.5 = 1.0
+    limiter.report_throttle()
+    assert limiter._rps == pytest.approx(1.0)
+
+    # Second throttle (after cooldown): should stay at floor 1.0
+    clock._now += 10.0
+    limiter.report_throttle()
+    assert limiter._rps == pytest.approx(1.0)
+
+
+def test_throttle_cooldown_coalesces_rapid_signals():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(10.0, adaptive=True, clock=clock.monotonic, sleep=clock.sleep)
+
+    limiter.report_throttle()
+    assert limiter._rps == pytest.approx(5.0)
+
+    # Within cooldown window — should be ignored
+    clock._now += 1.0
+    limiter.report_throttle()
+    assert limiter._rps == pytest.approx(5.0)
+
+    # After cooldown — should take effect
+    clock._now += 10.0
+    limiter.report_throttle()
+    assert limiter._rps == pytest.approx(2.5)
+
+
+def test_success_restores_rate():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(10.0, adaptive=True, clock=clock.monotonic, sleep=clock.sleep)
+
+    limiter.report_throttle()
+    assert limiter._rps == pytest.approx(5.0)
+
+    # Repeatedly report success — rate should climb back past initial
+    for _ in range(100):
+        limiter.report_success()
+
+    assert limiter._rps > 10.0
+
+
+@pytest.mark.parametrize(
+    ("multiplier", "expected_ceiling"),
+    [(5.0, 50.0), (3.0, 30.0)],
+)
+def test_success_climbs_to_multiplier_ceiling(multiplier, expected_ceiling):
+    clock = FakeClock()
+    limiter = RPSRateLimiter(
+        10.0,
+        adaptive=True,
+        max_rps_multiplier=multiplier,
+        clock=clock.monotonic,
+        sleep=clock.sleep,
+    )
+    for _ in range(10000):
+        limiter.report_success()
+    assert limiter._rps == pytest.approx(expected_ceiling)
+
+
+def test_adaptive_false_ignores_throttle_and_success():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(10.0, adaptive=False, clock=clock.monotonic, sleep=clock.sleep)
+
+    limiter.report_throttle()
+    assert limiter._rps == pytest.approx(10.0)
+
+    limiter.report_success()
+    assert limiter._rps == pytest.approx(10.0)
+
+
+# ── call_with_retry tests ──
+
+
+def test_call_with_retry_success():
+    sleep_calls = []
+    limiter = NoOpRateLimiter()
+    result = call_with_retry(lambda: 42, limiter, max_retries=3, sleep=sleep_calls.append)
+    assert result == 42
+    assert sleep_calls == []
+
+
+def test_call_with_retry_retries_on_429_then_succeeds():
+    sleep_calls = []
+    limiter = NoOpRateLimiter()
+    attempts = []
+
+    def flaky_fn():
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise _FakeRateLimitError("rate limited")
+        return "ok"
+
+    result = call_with_retry(flaky_fn, limiter, max_retries=3, sleep=sleep_calls.append)
+    assert result == "ok"
+    assert len(attempts) == 3
+    # Two retries with exponential backoff: 2^0=1, 2^1=2
+    assert sleep_calls == [1, 2]
+
+
+def test_call_with_retry_non_429_propagates_immediately():
+    sleep_calls = []
+    limiter = NoOpRateLimiter()
+
+    def always_raises():
+        raise ValueError("bad input")
+
+    with pytest.raises(ValueError, match="bad input"):
+        call_with_retry(always_raises, limiter, max_retries=3, sleep=sleep_calls.append)
+    assert sleep_calls == []
+
+
+def test_call_with_retry_exhausted_retries():
+    sleep_calls = []
+    limiter = NoOpRateLimiter()
+
+    def always_rate_limited():
+        raise _FakeRateLimitError("rate limited")
+
+    with pytest.raises(_FakeRateLimitError, match="rate limited"):
+        call_with_retry(always_rate_limited, limiter, max_retries=2, sleep=sleep_calls.append)
+    # 3 attempts total (initial + 2 retries), 2 sleeps
+    assert len(sleep_calls) == 2
+
+
+def test_call_with_retry_reports_throttle_and_success():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(10.0, adaptive=True, clock=clock.monotonic, sleep=clock.sleep)
+    attempts = []
+
+    def flaky_fn():
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise _FakeRateLimitError("rate limited")
+        return "ok"
+
+    result = call_with_retry(flaky_fn, limiter, max_retries=3, sleep=clock.sleep)
+    assert result == "ok"
+    # After throttle: 10.0 * 0.5 = 5.0, then success bumps it back up slightly
+    assert limiter._rps < 10.0
+
+
+# ── eval_retry_context tests ──
+
+
+def test_eval_retry_context_sets_and_resets():
+    assert not is_eval_retry_active()
+
+    with eval_retry_context():
+        assert is_eval_retry_active()
+
+    assert not is_eval_retry_active()
+
+
+def test_eval_retry_context_nests():
+    assert not is_eval_retry_active()
+
+    with eval_retry_context():
+        assert is_eval_retry_active()
+        with eval_retry_context():
+            assert is_eval_retry_active()
+        assert is_eval_retry_active()
+
+    assert not is_eval_retry_active()

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -1,0 +1,116 @@
+import pytest
+
+from mlflow.genai.evaluation.harness import _make_rate_limiter
+from mlflow.genai.evaluation.rate_limiter import NoOpRateLimiter, RPSRateLimiter
+
+
+class FakeClock:
+    """Deterministic clock for testing. sleep() advances the clock by the requested amount.
+
+    Thread safety is not needed here because RPSRateLimiter's internal lock serializes
+    all calls to clock() and sleep() — they are never called concurrently for a given limiter.
+    """
+
+    def __init__(self):
+        self._now = 0.0
+        self.sleep_calls: list[float] = []
+
+    def monotonic(self) -> float:
+        return self._now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleep_calls.append(seconds)
+        self._now += seconds
+
+
+def test_invalid_rate_raises():
+    with pytest.raises(ValueError, match="must be positive"):
+        RPSRateLimiter(0)
+    with pytest.raises(ValueError, match="must be positive"):
+        RPSRateLimiter(-1)
+
+
+def test_burst_tokens_consumed_without_sleeping():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(5, clock=clock.monotonic, sleep=clock.sleep)
+
+    for _ in range(5):
+        limiter.acquire()
+
+    assert clock.sleep_calls == []
+
+
+def test_sleep_called_when_tokens_exhausted():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(5, clock=clock.monotonic, sleep=clock.sleep)
+
+    for _ in range(5):
+        limiter.acquire()
+
+    limiter.acquire()
+    assert len(clock.sleep_calls) == 1
+    assert clock.sleep_calls[0] == pytest.approx(0.2, abs=0.01)
+
+
+def test_total_sleep_for_sustained_rate():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(10, clock=clock.monotonic, sleep=clock.sleep)
+
+    for _ in range(20):
+        limiter.acquire()
+
+    total_sleep = sum(clock.sleep_calls)
+    assert total_sleep == pytest.approx(1.0, abs=0.01)
+
+
+def test_tokens_refill_after_idle():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(10, clock=clock.monotonic, sleep=clock.sleep)
+
+    for _ in range(10):
+        limiter.acquire()
+
+    clock._now += 1.0
+
+    sleep_before = len(clock.sleep_calls)
+    for _ in range(10):
+        limiter.acquire()
+
+    assert clock.sleep_calls[sleep_before:] == []
+
+
+def test_partial_refill():
+    clock = FakeClock()
+    limiter = RPSRateLimiter(10, clock=clock.monotonic, sleep=clock.sleep)
+
+    for _ in range(10):
+        limiter.acquire()
+
+    clock._now += 0.5
+
+    sleep_before = len(clock.sleep_calls)
+    for _ in range(5):
+        limiter.acquire()
+
+    assert clock.sleep_calls[sleep_before:] == []
+
+    limiter.acquire()
+    assert len(clock.sleep_calls) == sleep_before + 1
+
+
+def test_noop_acquire_does_nothing():
+    limiter = NoOpRateLimiter()
+    for _ in range(1000):
+        limiter.acquire()
+
+
+def test_make_rate_limiter_positive_rate():
+    assert isinstance(_make_rate_limiter(10.0), RPSRateLimiter)
+
+
+def test_make_rate_limiter_zero_returns_noop():
+    assert isinstance(_make_rate_limiter(0.0), NoOpRateLimiter)
+
+
+def test_make_rate_limiter_none_returns_noop():
+    assert isinstance(_make_rate_limiter(None), NoOpRateLimiter)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Replace the sequential predict-then-score execution in `mlflow.genai.evaluate` with a **pipelined architecture** using two independent thread pools. As each prediction completes, its scoring task is immediately submitted to the score pool, improving throughput by overlapping predict and score work.

**Rate limiting** (on by default) prevents overwhelming LLM endpoints:
- `MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT` — max predict_fn calls/sec (default: `auto` — adaptive AIMD starting at 10 rps)
- `MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT` — max scorer calls/sec (default: `auto` -- adaptive AIMD; can be overridden explicitly)

Both accept three value forms: `auto` (adaptive rate with AIMD), a positive number (fixed rate), or `0` (disabled). Both use a thread-safe token-bucket algorithm.

**Adaptive rate limiting (AIMD)**: When set to `auto`, the rate limiter automatically adjusts throughput based on 429 responses:
- **Multiplicative decrease**: On 429 → rate halved (floor at 1 rps), with 5s cooldown between decreases
- **Additive increase**: On each success → rate gradually climbs, up to `initial_rps × multiplier` ceiling
- **Retry with backoff**: 429 errors are retried with exponential backoff (configurable via `MLFLOW_GENAI_EVAL_MAX_RETRIES`, default 3)
- **Full-stack 429 visibility**: During evaluate, both litellm's internal rate-limit retries and the Databricks SDK HTTP-layer 429 retries are disabled so errors bubble up to the adaptive retry layer

**Independent pool sizing**: Predict and score thread pools are sized independently based on their respective rate limits (`min(500, max(10, rate * 2))`). `MLFLOW_GENAI_EVAL_MAX_WORKERS` still overrides both when set explicitly.

**Backpressure**: A semaphore caps the number of predicted-but-not-yet-scored items (via `backpressure_buffer(score_workers)`), bounding memory when predict_fn is faster than scorers. A dedicated submit thread handles backpressure-aware task submission, with error propagation to the main pipeline loop.

**Diagnostics**: A 15-second heartbeat logs progress and current rates for predict and score limiters. Optional thread stack dumps can be enabled via `MLFLOW_GENAI_EVAL_DUMP_THREAD_STACKS=true` for diagnosing hangs.

The progress bar shows a predict/score time split at completion:
```
Evaluating: 100%|██████████| 500/500 [Elapsed: 02:47, Remaining: 00:00] [predict_fn: 39%, scorers: 61%]
```

**Key files:**
- `mlflow/genai/evaluation/rate_limiter.py` — `RateLimiter` ABC, `RPSRateLimiter` with AIMD, `NoOpRateLimiter`, `call_with_retry()`, `eval_retry_context()`
- `mlflow/genai/evaluation/harness.py` — pipelined execution with two independent thread pools, adaptive rate parsing, backpressure, heartbeat, import warmup
- `mlflow/environment_variables.py` — env vars for rate limits, retries, AIMD ceiling multiplier, thread stack dumps
- `mlflow/genai/evaluation/session_utils.py` — scorer rate limiter + retry plumbing for multi-turn evaluation
- `mlflow/genai/judges/adapters/litellm_adapter.py` — disable litellm 429 retries during evaluate
- `mlflow/utils/rest_utils.py` — generic `disable_429_retry()` ContextVar for HTTP-layer retry control

**New environment variables:**
| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| `MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT` | str | `auto` | Predict rate limit (`auto`/number/`0`) |
| `MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT` | str | auto-derived | Scorer rate limit (`auto`/number/`0`) |
| `MLFLOW_GENAI_EVAL_MAX_RETRIES` | int | `3` | Max retries on 429 errors |
| `MLFLOW_GENAI_EVAL_RATE_LIMIT_UPPER_MULTIPLIER` | float | `5.0` | AIMD ceiling = initial_rps × multiplier |
| `MLFLOW_GENAI_EVAL_DUMP_THREAD_STACKS` | bool | `false` | Dump thread stacks in heartbeat |

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests added:
- `tests/genai/evaluate/test_rate_limiter.py` — 40 tests covering token-bucket semantics, burst, refill, sustained rate, noop, factory function, `_parse_rate_limit`, `is_rate_limit_error` (parametrized), AIMD (throttle, floor, cooldown, success restore, ceiling, adaptive=False), `call_with_retry` (success, retry-on-429, non-429 propagation, exhausted retries, throttle+success reporting), `eval_retry_context` (set/reset, nesting)
- `tests/genai/evaluate/test_evaluation.py` — 9 new tests: predict rate limiter wiring, scorer rate limiter wiring, pipelining structural test, backpressure cap, backward compatibility, predict retries on 429, scorer retries on 429, adaptive rate reduces on 429

Manual benchmarking against a Databricks serving endpoint confirmed correct behavior at 500 items with adaptive rate limiting.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.genai.evaluate` now uses pipelined execution with adaptive rate limiting by default. Predictions and scoring run concurrently in separate thread pools with token-bucket rate limiters. The default rate limit mode is `auto`, which uses AIMD (Additive Increase Multiplicative Decrease) to automatically adapt throughput based on 429 responses — reducing the rate on rate-limit errors and gradually recovering on success. Rate-limited calls are retried with exponential backoff (default 3 retries). Configure via `MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT` and `MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT` environment variables (accepted values: `auto`, a positive number, or `0` to disable).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)