### PR TITLE
Fix use_case parameter not being forwarded to chat completions

### DIFF
--- a/mlflow/genai/judges/adapters/databricks_managed_judge_adapter.py
+++ b/mlflow/genai/judges/adapters/databricks_managed_judge_adapter.py
@@ -245,6 +245,7 @@ def _run_databricks_agentic_loop(
     messages: list["litellm.Message"],
     trace: "Trace | None",
     on_final_answer: Callable[[str | None], T],
+    use_case: str | None = None,
 ) -> T:
     """
     Run an agentic loop with Databricks chat completions.
@@ -284,7 +285,11 @@ def _run_databricks_agentic_loop(
             user_prompt, system_prompt = serialize_messages_to_databricks_prompts(messages)
 
             llm_result = call_chat_completions(
-                user_prompt, system_prompt or "", tools=tools, model=_DATABRICKS_AGENTIC_JUDGE_MODEL
+                user_prompt,
+                system_prompt or "",
+                tools=tools,
+                model=_DATABRICKS_AGENTIC_JUDGE_MODEL,
+                use_case=use_case,
             )
 
             # Surface API errors from the response before checking output_json,
@@ -356,7 +361,7 @@ def _invoke_databricks_default_judge(
         def parse_judge_response(content: str | None) -> Feedback:
             return _parse_databricks_judge_response(content, assessment_name, trace)
 
-        return _run_databricks_agentic_loop(messages, trace, parse_judge_response)
+        return _run_databricks_agentic_loop(messages, trace, parse_judge_response, use_case)
 
     except Exception as e:
         _logger.debug(f"Failed to invoke Databricks judge: {e}", exc_info=True)

--- a/tests/genai/judges/adapters/test_databricks_managed_adapter.py
+++ b/tests/genai/judges/adapters/test_databricks_managed_adapter.py
@@ -236,6 +236,30 @@ def test_agentic_loop_final_answer_without_tool_calls():
         assert mock_call.call_count == 1
 
 
+def test_agentic_loop_forwards_use_case():
+    mock_response = AttrDict(
+        {
+            "output_json": json.dumps(
+                {"choices": [{"message": {"role": "assistant", "content": "done"}}]}
+            )
+        }
+    )
+
+    with mock.patch(
+        "mlflow.genai.judges.adapters.databricks_managed_judge_adapter.call_chat_completions",
+        return_value=mock_response,
+    ) as mock_call:
+        _run_databricks_agentic_loop(
+            messages=[litellm.Message(role="user", content="test")],
+            trace=None,
+            on_final_answer=lambda content: content,
+            use_case="builtin_judge",
+        )
+
+        _, kwargs = mock_call.call_args
+        assert kwargs["use_case"] == "builtin_judge"
+
+
 def test_agentic_loop_tool_calling_loop(mock_trace):
     # First response has tool calls, second response is final answer
     mock_responses = [


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
The use_case parameter was accepted by _invoke_databricks_default_judge but never passed through _run_databricks_agentic_loop to call_chat_completions, causing the chat-completions-use-case HTTP header to never be set.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
