### PR TITLE
Bump TypeScript tracing SDK versions to 0.1.3

### DIFF
--- a/libs/typescript/core/package.json
+++ b/libs/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlflow-tracing",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript implementation of MLflow Tracing SDK for LLM observability",
   "repository": {
     "type": "git",

--- a/libs/typescript/integrations/anthropic/package.json
+++ b/libs/typescript/integrations/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlflow-anthropic",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Anthropic integration package for MLflow Tracing",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "format:check": "prettier --check ."
   },
   "peerDependencies": {
-    "mlflow-tracing": "^0.1.2",
+    "mlflow-tracing": "^0.1.3",
     "@anthropic-ai/sdk": "^0.71.0"
   },
   "devDependencies": {

--- a/libs/typescript/integrations/gemini/package.json
+++ b/libs/typescript/integrations/gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlflow-gemini",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Gemini integration package for MLflow Tracing",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "format:check": "prettier --check ."
   },
   "peerDependencies": {
-    "mlflow-tracing": "^0.1.2",
+    "mlflow-tracing": "^0.1.3",
     "@google/genai": "^1.22.0"
   },
   "devDependencies": {

--- a/libs/typescript/integrations/openai/package.json
+++ b/libs/typescript/integrations/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlflow-openai",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OpenAI integration package for MLflow Tracing",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "format:check": "prettier --check ."
   },
   "peerDependencies": {
-    "mlflow-tracing": "^0.1.2",
+    "mlflow-tracing": "^0.1.3",
     "openai": ">=4.0.0"
   },
   "devDependencies": {

--- a/libs/typescript/package-lock.json
+++ b/libs/typescript/package-lock.json
@@ -15,7 +15,7 @@
     },
     "core": {
       "name": "mlflow-tracing",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@databricks/sdk-experimental": "0.15.0",
@@ -46,7 +46,7 @@
     },
     "integrations/anthropic": {
       "name": "mlflow-anthropic",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^29.6.2",
@@ -57,12 +57,12 @@
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "^0.71.0",
-        "mlflow-tracing": "^0.1.2"
+        "mlflow-tracing": "^0.1.3"
       }
     },
     "integrations/gemini": {
       "name": "mlflow-gemini",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^29.6.2",
@@ -74,12 +74,12 @@
       },
       "peerDependencies": {
         "@google/genai": "^1.22.0",
-        "mlflow-tracing": "^0.1.2"
+        "mlflow-tracing": "^0.1.3"
       }
     },
     "integrations/openai": {
       "name": "mlflow-openai",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^29.6.2",
@@ -89,7 +89,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "mlflow-tracing": "^0.1.2",
+        "mlflow-tracing": "^0.1.3",
         "openai": ">=4.0.0"
       }
     },


### PR DESCRIPTION
### Related Issues/PRs

Resolve #20681

### What changes are proposed in this pull request?

Bump the version of all TypeScript tracing SDK packages from `0.1.2` to `0.1.3`:

- `mlflow-tracing` (core): `0.1.2` → `0.1.3`
- `mlflow-openai`: `0.1.2` → `0.1.3`
- `mlflow-anthropic`: `0.1.2` → `0.1.3`
- `mlflow-gemini`: `0.1.2` → `0.1.3`

Also updates `mlflow-tracing` peer dependency references in integration packages and `package-lock.json` accordingly.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)