### PR TITLE
[Left nav refactor][1/6] Add dark/light theme toggle to settings page

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5515,6 +5515,10 @@
     "defaultMessage": "Click into an individual run to see all models associated with it",
     "description": "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
+  "c1it6D": {
+    "defaultMessage": "Select your theme preference between light and dark.",
+    "description": "Description for the theme setting in the settings page"
+  },
   "c1jD8u": {
     "defaultMessage": "Create an evaluation dataset",
     "description": "Evaluation datasets empty state title"
@@ -6543,6 +6547,10 @@
     "defaultMessage": "ID",
     "description": "Label for the ID section"
   },
+  "ioD6Ho": {
+    "defaultMessage": "Dark",
+    "description": "Dark theme label"
+  },
   "iqlzHb": {
     "defaultMessage": "Loading API keys...",
     "description": "Loading message for API keys list"
@@ -6890,6 +6898,10 @@
   "lNO3kK": {
     "defaultMessage": "No parameters to display.",
     "description": "Text shown when there are no parameters to display"
+  },
+  "lNv2QR": {
+    "defaultMessage": "Light",
+    "description": "Light theme label"
   },
   "lPNTq7": {
     "defaultMessage": "Metrics ({length})",
@@ -7278,6 +7290,10 @@
   "o0NwZU": {
     "defaultMessage": "Quality metrics computed by scorers.",
     "description": "Description for the scorer insights section"
+  },
+  "o1dN9r": {
+    "defaultMessage": "Theme preference",
+    "description": "Theme settings title"
   },
   "o21MFS": {
     "defaultMessage": "Invalid log value",

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -33,6 +33,13 @@ const SettingsPage = () => {
     [setIsTelemetryEnabled],
   );
 
+  const handleThemeToggle = useCallback(
+    (checked: boolean) => {
+      setIsDarkTheme(checked);
+    },
+    [setIsDarkTheme],
+  );
+
   const handleClearAllDemoData = useCallback(async () => {
     setIsCleaningDemo(true);
     try {
@@ -67,14 +74,14 @@ const SettingsPage = () => {
         <Switch
           componentId="mlflow.settings.theme.toggle-switch"
           checked={isDarkTheme}
-          onChange={() => setIsDarkTheme(!isDarkTheme)}
+          onChange={handleThemeToggle}
           label={
             isDarkTheme
               ? intl.formatMessage({ defaultMessage: 'Dark', description: 'Dark theme label' })
               : intl.formatMessage({ defaultMessage: 'Light', description: 'Light theme label' })
           }
-          activeLabel={intl.formatMessage({ defaultMessage: 'On', description: 'Telemetry enabled label' })}
-          inactiveLabel={intl.formatMessage({ defaultMessage: 'Off', description: 'Telemetry disabled label' })}
+          activeLabel={intl.formatMessage({ defaultMessage: 'Dark', description: 'Dark theme label' })}
+          inactiveLabel={intl.formatMessage({ defaultMessage: 'Light', description: 'Light theme label' })}
         />
       </div>
 

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -5,12 +5,15 @@ import { TELEMETRY_ENABLED_STORAGE_KEY, TELEMETRY_ENABLED_STORAGE_VERSION } from
 import { telemetryClient } from '../telemetry';
 import { useCallback, useState } from 'react';
 import { getAjaxUrl } from '../common/utils/FetchUtils';
+import { useDarkThemeContext } from '../common/contexts/DarkThemeContext';
 
 const SettingsPage = () => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const [isCleaningDemo, setIsCleaningDemo] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const { setIsDarkTheme } = useDarkThemeContext();
+  const isDarkTheme = theme.isDarkMode;
 
   const [isTelemetryEnabled, setIsTelemetryEnabled] = useLocalStorage({
     key: TELEMETRY_ENABLED_STORAGE_KEY,
@@ -44,10 +47,36 @@ const SettingsPage = () => {
   }, []);
 
   return (
-    <div css={{ padding: theme.spacing.md }}>
-      <Typography.Title level={2}>
+    <div css={{ padding: theme.spacing.md, display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
+      <Typography.Title level={2} withoutMargins>
         <FormattedMessage defaultMessage="Settings" description="Settings page title" />
       </Typography.Title>
+
+      <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', maxWidth: 600 }}>
+        <div css={{ display: 'flex', flexDirection: 'column', marginRight: theme.spacing.lg }}>
+          <Typography.Title level={4}>
+            <FormattedMessage defaultMessage="Theme preference" description="Theme settings title" />
+          </Typography.Title>
+          <Typography.Text>
+            <FormattedMessage
+              defaultMessage="Select your theme preference between light and dark."
+              description="Description for the theme setting in the settings page"
+            />
+          </Typography.Text>
+        </div>
+        <Switch
+          componentId="mlflow.settings.theme.toggle-switch"
+          checked={isDarkTheme}
+          onChange={() => setIsDarkTheme(!isDarkTheme)}
+          label={
+            isDarkTheme
+              ? intl.formatMessage({ defaultMessage: 'Dark', description: 'Dark theme label' })
+              : intl.formatMessage({ defaultMessage: 'Light', description: 'Light theme label' })
+          }
+          activeLabel={intl.formatMessage({ defaultMessage: 'On', description: 'Telemetry enabled label' })}
+          inactiveLabel={intl.formatMessage({ defaultMessage: 'Off', description: 'Telemetry disabled label' })}
+        />
+      </div>
 
       <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', maxWidth: 600 }}>
         <div css={{ display: 'flex', flexDirection: 'column', marginRight: theme.spacing.lg }}>
@@ -76,7 +105,11 @@ const SettingsPage = () => {
           componentId="mlflow.settings.telemetry.toggle-switch"
           checked={isTelemetryEnabled}
           onChange={handleTelemetryToggle}
-          label=" "
+          label={
+            isTelemetryEnabled
+              ? intl.formatMessage({ defaultMessage: 'On', description: 'Telemetry enabled label' })
+              : intl.formatMessage({ defaultMessage: 'Off', description: 'Telemetry disabled label' })
+          }
           activeLabel={intl.formatMessage({ defaultMessage: 'On', description: 'Telemetry enabled label' })}
           inactiveLabel={intl.formatMessage({ defaultMessage: 'Off', description: 'Telemetry disabled label' })}
         />
@@ -88,7 +121,6 @@ const SettingsPage = () => {
           justifyContent: 'space-between',
           alignItems: 'center',
           maxWidth: 600,
-          marginTop: theme.spacing.lg,
         }}
       >
         <div css={{ display: 'flex', flexDirection: 'column', marginRight: theme.spacing.lg }}>


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20694/files) to review incremental changes.
- [**stack/remove-header**](https://github.com/mlflow/mlflow/pull/20694) [[Files changed](https://github.com/mlflow/mlflow/pull/20694/files)]
  - [stack/abstract-nav-item](https://github.com/mlflow/mlflow/pull/20695) [[Files changed](https://github.com/mlflow/mlflow/pull/20695/files/2de14d38cea923bc880f16052405a69412e179f7..df0178c2cbe9f0a194f60293b06f43f5cc85e5d3)]
    - [stack/remove-header-really](https://github.com/mlflow/mlflow/pull/20696) [[Files changed](https://github.com/mlflow/mlflow/pull/20696/files/df0178c2cbe9f0a194f60293b06f43f5cc85e5d3..faa210800de516ac817f3685f9216c1801feca17)]
      - [stack/nest-tabs](https://github.com/mlflow/mlflow/pull/20697) [[Files changed](https://github.com/mlflow/mlflow/pull/20697/files/faa210800de516ac817f3685f9216c1801feca17..29511ce2ca4361e1eb711fd9d766a79f9c82a29d)]
        - [stack/update-selector](https://github.com/mlflow/mlflow/pull/20698) [[Files changed](https://github.com/mlflow/mlflow/pull/20698/files/29511ce2ca4361e1eb711fd9d766a79f9c82a29d..0e76919807cfd11a85584f8d69898cc8453a3673)]
          - [stack/tooltips](https://github.com/mlflow/mlflow/pull/20699) [[Files changed](https://github.com/mlflow/mlflow/pull/20699/files/0e76919807cfd11a85584f8d69898cc8453a3673..70105b1a880fdd9311bc4bd268bdc0d3f44dfc4f)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Following up from design feedback, in the new version of the left nav we want to remove the top header bar. To prepare for that, this PR moves the dark/light theme toggle to the settings page.

The header is not removed yet, but will be in a future PR

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/a93a65fb-e297-4627-a253-2c2a779bbb87



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
