### PR TITLE
[Left nav refactor][4/6] Only display experiment tabs when in an experiment context

### DIFF
--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -55,15 +55,6 @@ const MlflowRootRoute = () => {
 
   const [showSidebar, setShowSidebar] = useState(true);
   const { theme } = useDesignSystemTheme();
-  const { experimentId } = useParams();
-  const enableWorkflowBasedNavigation = shouldEnableWorkflowBasedNavigation();
-
-  // Hide sidebar if we are in a single experiment page (only when feature flag is disabled)
-  // When feature flag is enabled, sidebar should always be visible
-  const isSingleExperimentPage = Boolean(experimentId);
-  useEffect(() => {
-    setShowSidebar(enableWorkflowBasedNavigation || !isSingleExperimentPage);
-  }, [isSingleExperimentPage, enableWorkflowBasedNavigation]);
 
   return (
     <AssistantProvider>

--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -55,6 +55,15 @@ const MlflowRootRoute = () => {
 
   const [showSidebar, setShowSidebar] = useState(true);
   const { theme } = useDesignSystemTheme();
+  const { experimentId } = useParams();
+  const enableWorkflowBasedNavigation = shouldEnableWorkflowBasedNavigation();
+
+  // Hide sidebar if we are in a single experiment page (only when feature flag is disabled)
+  // When feature flag is enabled, sidebar should always be visible
+  const isSingleExperimentPage = Boolean(experimentId);
+  useEffect(() => {
+    setShowSidebar(enableWorkflowBasedNavigation || !isSingleExperimentPage);
+  }, [isSingleExperimentPage, enableWorkflowBasedNavigation]);
 
   return (
     <AssistantProvider>

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useMemo, useState } from 'react';
+import React, { Fragment, useCallback, useMemo, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import {
   BeakerIcon,
@@ -16,6 +16,7 @@ import {
   Tooltip,
   Typography,
   useDesignSystemTheme,
+  Typography,
   DesignSystemEventProviderComponentTypes,
   DesignSystemEventProviderAnalyticsEventTypes,
   SidebarCollapseIcon,
@@ -48,7 +49,11 @@ import { MlflowSidebarLink } from './MlflowSidebarLink';
 import { MlflowLogo } from './MlflowLogo';
 import { HomePageDocsUrl, Version } from '../constants';
 import { WorkspaceSelector } from '../../workspaces/components/WorkspaceSelector';
+import { MlflowSidebarExperimentItems } from './MlflowSidebarExperimentItems';
+import { MlflowSidebarGatewayItems } from './MlflowSidebarGatewayItems';
 
+const isInsideExperiment = (location: Location) =>
+  Boolean(matchPath('/experiments/:experimentId/*', location.pathname));
 const isHomeActive = (location: Location) => Boolean(matchPath({ path: '/', end: true }, location.pathname));
 const isExperimentsActive = (location: Location) =>
   Boolean(
@@ -93,25 +98,7 @@ type MenuItemWithNested = {
     onClick: () => void;
     children: React.ReactNode;
   };
-  nestedItems?: NestedMenuItem[];
-  nestedItemsGroups?: NestedItemsGroup[];
-};
-
-const buildNestedItemsFromConfig = (
-  items: Array<{ tabName: ExperimentPageTabName; icon: React.ReactNode; label: React.ReactNode; componentId: string }>,
-  experimentId?: string,
-): NestedMenuItem[] => {
-  return items.map((item) => ({
-    key: `experiments-${item.tabName}`,
-    icon: item.icon,
-    label: item.label,
-    to: experimentId
-      ? Routes.getExperimentPageTabRoute(experimentId, item.tabName)
-      : ExperimentTrackingRoutes.experimentsObservatoryRoute,
-    componentId: item.componentId,
-    isActive: (loc) =>
-      Boolean(experimentId && matchPath(`/experiments/${experimentId}/${item.tabName}/*`, loc.pathname)),
-  }));
+  nestedItems?: React.ReactNode;
 };
 
 const NESTED_ITEMS_UL_CSS = {
@@ -143,6 +130,24 @@ export function MlflowSidebar({
     setShowSidebar(!showSidebar);
   }, [setShowSidebar, showSidebar]);
 
+  // Persist the last selected experiment ID so the nested experiment view
+  // stays visible when navigating away from experiment pages
+  const lastSelectedExperimentIdRef = useRef<string | null>(null);
+
+  // Update the ref when we're inside an experiment
+  if (experimentId && isInsideExperiment(location)) {
+    lastSelectedExperimentIdRef.current = experimentId;
+  }
+
+  // Callback to clear the persisted experiment ID (used by back button)
+  const clearLastSelectedExperiment = useCallback(() => {
+    lastSelectedExperimentIdRef.current = null;
+  }, []);
+
+  // Use the current experimentId if inside an experiment, otherwise use the persisted one
+  const activeExperimentId = isInsideExperiment(location) ? experimentId : lastSelectedExperimentIdRef.current;
+  const showNestedExperimentItems = Boolean(activeExperimentId) && shouldEnableWorkflowBasedNavigation();
+
   const { trainingRuns } = useExperimentEvaluationRunsData({
     experimentId: experimentId || '',
     enabled: Boolean(experimentId) && workflowType === WorkflowType.GENAI,
@@ -172,89 +177,6 @@ export function MlflowSidebar({
     });
   }, [isPanelOpen, closePanel, openPanel, logTelemetryEvent, viewId]);
 
-  const renderNestedItemLink = useCallback(
-    (nestedItem: NestedMenuItem, isDisabled: boolean) => {
-      const isNestedActive = nestedItem.isActive(location);
-      const linkElement = (
-        <Link
-          to={nestedItem.to}
-          aria-current={isNestedActive ? 'page' : undefined}
-          css={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: theme.spacing.sm,
-            color: isDisabled ? theme.colors.textSecondary : theme.colors.textPrimary,
-            paddingInline: theme.spacing.md,
-            paddingLeft: 40,
-            paddingBlock: theme.spacing.xs,
-            borderRadius: theme.borders.borderRadiusSm,
-            cursor: isDisabled ? 'not-allowed' : 'pointer',
-            opacity: isDisabled ? 0.5 : 1,
-            '&:hover': isDisabled
-              ? {}
-              : {
-                  color: theme.colors.actionLinkHover,
-                  backgroundColor: theme.colors.actionDefaultBackgroundHover,
-                },
-            '&[aria-current="page"]': {
-              backgroundColor: theme.colors.actionDefaultBackgroundPress,
-              color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
-              fontWeight: theme.typography.typographyBoldFontWeight,
-            },
-          }}
-          onClick={(e) => {
-            if (isDisabled) {
-              e.preventDefault();
-              return;
-            }
-            logTelemetryEvent({
-              componentId: nestedItem.componentId,
-              componentViewId: viewId,
-              componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
-              componentSubType: null,
-              eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
-            });
-          }}
-        >
-          {nestedItem.icon}
-          {nestedItem.label}
-        </Link>
-      );
-
-      if (isDisabled) {
-        return (
-          <Tooltip
-            componentId={`mlflow.sidebar.nested-item.disabled-tooltip.${nestedItem.key}`}
-            content={
-              <FormattedMessage
-                defaultMessage="Select an experiment to view this tab"
-                description="Tooltip shown when nested experiment items are disabled because no experiment is selected"
-              />
-            }
-            side="right"
-          >
-            {linkElement}
-          </Tooltip>
-        );
-      }
-      return linkElement;
-    },
-    [location, theme, logTelemetryEvent, viewId],
-  );
-
-  const experimentNestedItemsGroups = useMemo((): NestedItemsGroup[] => {
-    if (!enableWorkflowBasedNavigation) {
-      return [];
-    }
-
-    const groups: NestedItemsGroup[] = Object.entries(config).map(([sectionKey, items]) => ({
-      sectionKey: sectionKey as ExperimentPageSideNavSectionKey,
-      items: buildNestedItemsFromConfig(items, experimentId),
-    }));
-
-    return groups;
-  }, [enableWorkflowBasedNavigation, config, experimentId]);
-
   const menuItems: MenuItemWithNested[] = useMemo(
     () => [
       {
@@ -276,7 +198,13 @@ export function MlflowSidebar({
           children: <FormattedMessage defaultMessage="Experiments" description="Sidebar link for experiments tab" />,
         },
         componentId: 'mlflow.sidebar.experiments_tab_link',
-        nestedItemsGroups: experimentNestedItemsGroups.length > 0 ? experimentNestedItemsGroups : undefined,
+        nestedItems: showNestedExperimentItems ? (
+          <MlflowSidebarExperimentItems
+            experimentId={activeExperimentId ?? undefined}
+            workflowType={workflowType}
+            onBackClick={clearLastSelectedExperiment}
+          />
+        ) : undefined,
       },
       ...(workflowType === WorkflowType.MACHINE_LEARNING || !enableWorkflowBasedNavigation
         ? [
@@ -286,13 +214,15 @@ export function MlflowSidebar({
               linkProps: {
                 to: ModelRegistryRoutes.modelListPageRoute,
                 isActive: isModelsActive,
-                children: <FormattedMessage defaultMessage="Models" description="Sidebar link for models tab" />,
+                children: (
+                  <FormattedMessage defaultMessage="Model registry" description="Sidebar link for model registry tab" />
+                ),
               },
               componentId: 'mlflow.sidebar.models_tab_link',
             },
           ]
         : []),
-      ...(shouldShowGenAIFeatures(enableWorkflowBasedNavigation, workflowType)
+      ...(shouldShowGenAIFeatures(enableWorkflowBasedNavigation, workflowType) && !showNestedExperimentItems
         ? [
             {
               key: 'prompts',
@@ -320,36 +250,21 @@ export function MlflowSidebar({
               },
               componentId: 'mlflow.sidebar.gateway_tab_link',
               nestedItems:
-                enableWorkflowBasedNavigation && workflowType === WorkflowType.GENAI
-                  ? [
-                      {
-                        key: 'gateway-endpoints',
-                        icon: <ChainIcon />,
-                        label: (
-                          <FormattedMessage defaultMessage="Endpoints" description="Gateway side nav > Endpoints tab" />
-                        ),
-                        to: GatewayRoutes.gatewayPageRoute,
-                        componentId: 'mlflow.sidebar.gateway.endpoints',
-                        isActive: (loc: Location) =>
-                          Boolean(matchPath('/gateway', loc.pathname) && !matchPath('/gateway/api-keys', loc.pathname)),
-                      },
-                      {
-                        key: 'gateway-api-keys',
-                        icon: <KeyIcon />,
-                        label: (
-                          <FormattedMessage defaultMessage="API Keys" description="Gateway side nav > API Keys tab" />
-                        ),
-                        to: GatewayRoutes.apiKeysPageRoute,
-                        componentId: 'mlflow.sidebar.gateway.api-keys',
-                        isActive: (loc: Location) => Boolean(matchPath('/gateway/api-keys', loc.pathname)),
-                      },
-                    ]
-                  : undefined,
+                shouldEnableWorkflowBasedNavigation() && isGatewayActive(location) ? (
+                  <MlflowSidebarGatewayItems />
+                ) : undefined,
             },
           ]
         : []),
     ],
-    [enableWorkflowBasedNavigation, workflowType, experimentNestedItemsGroups],
+    [
+      showNestedExperimentItems,
+      activeExperimentId,
+      workflowType,
+      clearLastSelectedExperiment,
+      enableWorkflowBasedNavigation,
+      location,
+    ],
   );
 
   // Workspace support
@@ -444,53 +359,16 @@ export function MlflowSidebar({
           }}
         >
           {showWorkspaceMenuItems &&
-            menuItems.map(({ key, icon, linkProps, componentId, nestedItemsGroups, nestedItems }) => (
-              <>
-                <MlflowSidebarLink
-                  to={linkProps.to}
-                  componentId={componentId}
-                  isActive={linkProps.isActive}
-                  icon={icon}
-                  collapsed={!showSidebar}
-                >
-                  {linkProps.children}
-                </MlflowSidebarLink>
-                {nestedItemsGroups && nestedItemsGroups.length > 0 && (
-                  <ul css={NESTED_ITEMS_UL_CSS}>
-                    {nestedItemsGroups.map((group) => (
-                      <Fragment key={group.sectionKey}>
-                        {group.sectionKey !== 'top-level' && (
-                          <li
-                            css={{
-                              display: 'flex',
-                              marginTop: theme.spacing.xs,
-                              marginBottom: theme.spacing.xs,
-                              position: 'relative',
-                              height: theme.typography.lineHeightBase,
-                              paddingLeft: 40,
-                            }}
-                          >
-                            <Typography.Text size="sm" color="secondary">
-                              {getExperimentPageSideNavSectionLabel(group.sectionKey, [])}
-                            </Typography.Text>
-                          </li>
-                        )}
-                        {group.items.map((nestedItem) => {
-                          const isDisabled = !experimentId && key === 'experiments';
-                          return <li key={nestedItem.key}>{renderNestedItemLink(nestedItem, isDisabled)}</li>;
-                        })}
-                      </Fragment>
-                    ))}
-                  </ul>
-                )}
-                {nestedItems && nestedItems.length > 0 && (
-                  <ul css={NESTED_ITEMS_UL_CSS}>
-                    {nestedItems.map((nestedItem) => (
-                      <li key={nestedItem.key}>{renderNestedItemLink(nestedItem, false)}</li>
-                    ))}
-                  </ul>
-                )}
-              </>
+            menuItems.map(({ key, icon, linkProps, componentId }) => (
+              <MlflowSidebarLink
+                to={linkProps.to}
+                componentId={componentId}
+                isActive={linkProps.isActive}
+                icon={icon}
+                collapsed={!showSidebar}
+              >
+                {linkProps.children}
+              </MlflowSidebarLink>
             ))}
         </ul>
         <div>

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import {
   BeakerIcon,
@@ -16,7 +16,6 @@ import {
   Tooltip,
   Typography,
   useDesignSystemTheme,
-  Typography,
   DesignSystemEventProviderComponentTypes,
   DesignSystemEventProviderAnalyticsEventTypes,
   SidebarCollapseIcon,
@@ -70,20 +69,6 @@ type MlFlowSidebarMenuDropdownComponentId =
   | 'mlflow_sidebar.create_model_button'
   | 'mlflow_sidebar.create_prompt_button';
 
-type NestedMenuItem = {
-  key: string;
-  icon: React.ReactNode;
-  label: React.ReactNode;
-  to: string;
-  componentId: string;
-  isActive: (location: Location) => boolean;
-};
-
-type NestedItemsGroup = {
-  sectionKey: ExperimentPageSideNavSectionKey;
-  items: NestedMenuItem[];
-};
-
 type MenuItemWithNested = {
   key: string;
   icon: React.ReactNode;
@@ -99,12 +84,6 @@ type MenuItemWithNested = {
     children: React.ReactNode;
   };
   nestedItems?: React.ReactNode;
-};
-
-const NESTED_ITEMS_UL_CSS = {
-  listStyleType: 'none' as const,
-  padding: 0,
-  margin: 0,
 };
 
 const shouldShowGenAIFeatures = (enableWorkflowBasedNavigation: boolean, workflowType: WorkflowType) =>
@@ -200,6 +179,7 @@ export function MlflowSidebar({
         componentId: 'mlflow.sidebar.experiments_tab_link',
         nestedItems: showNestedExperimentItems ? (
           <MlflowSidebarExperimentItems
+            collapsed={!showSidebar}
             experimentId={activeExperimentId ?? undefined}
             workflowType={workflowType}
             onBackClick={clearLastSelectedExperiment}
@@ -251,7 +231,7 @@ export function MlflowSidebar({
               componentId: 'mlflow.sidebar.gateway_tab_link',
               nestedItems:
                 shouldEnableWorkflowBasedNavigation() && isGatewayActive(location) ? (
-                  <MlflowSidebarGatewayItems />
+                  <MlflowSidebarGatewayItems collapsed={!showSidebar} />
                 ) : undefined,
             },
           ]
@@ -264,6 +244,7 @@ export function MlflowSidebar({
       clearLastSelectedExperiment,
       enableWorkflowBasedNavigation,
       location,
+      showSidebar,
     ],
   );
 

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -3,17 +3,14 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   BeakerIcon,
   Button,
-  ChainIcon,
   CloudModelIcon,
   GearIcon,
   HomeIcon,
-  KeyIcon,
   ModelsIcon,
   SegmentedControlGroup,
   SegmentedControlButton,
   Tag,
   TextBoxIcon,
-  Tooltip,
   Typography,
   useDesignSystemTheme,
   DesignSystemEventProviderComponentTypes,
@@ -24,25 +21,16 @@ import {
   CodeIcon,
 } from '@databricks/design-system';
 import type { Location } from '../utils/RoutingUtils';
-import { Link, matchPath, useLocation, useNavigate, useParams, useSearchParams } from '../utils/RoutingUtils';
+import { Link, matchPath, useLocation, useParams, useSearchParams } from '../utils/RoutingUtils';
 import ExperimentTrackingRoutes from '../../experiment-tracking/routes';
 import { ModelRegistryRoutes } from '../../model-registry/routes';
 import GatewayRoutes from '../../gateway/routes';
-import Routes from '../../experiment-tracking/routes';
 import { FormattedMessage } from 'react-intl';
 import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
 import { useWorkflowType, WorkflowType } from '../contexts/WorkflowTypeContext';
-import {
-  getExperimentPageSideNavSectionLabel,
-  type ExperimentPageSideNavSectionKey,
-  useExperimentPageSideNavConfig,
-} from '../../experiment-tracking/pages/experiment-page-tabs/side-nav/constants';
-import { ExperimentPageTabName } from '../../experiment-tracking/constants';
 import { shouldEnableWorkflowBasedNavigation, shouldEnableWorkspaces } from '../utils/FeatureUtils';
 import { AssistantSparkleIcon } from '../../assistant/AssistantIconButton';
 import { useAssistant } from '../../assistant/AssistantContext';
-import { useExperimentEvaluationRunsData } from '../../experiment-tracking/components/experiment-page/hooks/useExperimentEvaluationRunsData';
-import { getExperimentKindForWorkflowType } from '../../experiment-tracking/utils/ExperimentKindUtils';
 import { extractWorkspaceFromSearchParams } from '../../workspaces/utils/WorkspaceUtils';
 import { MlflowSidebarLink } from './MlflowSidebarLink';
 import { MlflowLogo } from './MlflowLogo';
@@ -126,17 +114,6 @@ export function MlflowSidebar({
   // Use the current experimentId if inside an experiment, otherwise use the persisted one
   const activeExperimentId = isInsideExperiment(location) ? experimentId : lastSelectedExperimentIdRef.current;
   const showNestedExperimentItems = Boolean(activeExperimentId) && shouldEnableWorkflowBasedNavigation();
-
-  const { trainingRuns } = useExperimentEvaluationRunsData({
-    experimentId: experimentId || '',
-    enabled: Boolean(experimentId) && workflowType === WorkflowType.GENAI,
-    filter: '', // not important in this case, we show the runs tab if there are any training runs
-  });
-
-  const config = useExperimentPageSideNavConfig({
-    experimentKind: getExperimentKindForWorkflowType(workflowType),
-    hasTrainingRuns: (trainingRuns?.length ?? 0) > 0,
-  });
 
   const { openPanel, closePanel, isPanelOpen, isLocalServer } = useAssistant();
   const [isAssistantHovered, setIsAssistantHovered] = useState(false);
@@ -340,17 +317,20 @@ export function MlflowSidebar({
           }}
         >
           {showWorkspaceMenuItems &&
-            menuItems.map(({ key, icon, linkProps, componentId }) => (
-              <MlflowSidebarLink
-                to={linkProps.to}
-                componentId={componentId}
-                isActive={linkProps.isActive}
-                icon={icon}
-                collapsed={!showSidebar}
-              >
-                {linkProps.children}
-              </MlflowSidebarLink>
-            ))}
+            menuItems.map(
+              ({ key, icon, linkProps, componentId, nestedItems }) =>
+                nestedItems ?? (
+                  <MlflowSidebarLink
+                    to={linkProps.to}
+                    componentId={componentId}
+                    isActive={linkProps.isActive}
+                    icon={icon}
+                    collapsed={!showSidebar}
+                  >
+                    {linkProps.children}
+                  </MlflowSidebarLink>
+                ),
+            )}
         </ul>
         <div>
           {isLocalServer && (

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
@@ -22,10 +22,12 @@ const isExperimentsActive = (location: Location) =>
   );
 
 export const MlflowSidebarExperimentItems = ({
+  collapsed,
   experimentId,
   workflowType,
   onBackClick,
 }: {
+  collapsed: boolean;
   experimentId: string | undefined;
   workflowType: WorkflowType;
   onBackClick?: () => void;
@@ -59,14 +61,24 @@ export const MlflowSidebarExperimentItems = ({
         componentId="mlflow.experiment-sidebar.back-button"
         isActive={isExperimentsActive}
         onClick={onBackClick}
+        icon={<ArrowLeftIcon />}
+        collapsed={collapsed}
       >
-        <ArrowLeftIcon />
         <BeakerIcon />
         {loading ? <Spinner /> : <Typography.Text ellipsis>{experiment?.name}</Typography.Text>}
       </MlflowSidebarLink>
       {Object.entries(config).map(([sectionKey, items]) => (
         <>
-          {sectionKey !== 'top-level' && (
+          {sectionKey !== 'top-level' && collapsed ? (
+            <div
+              css={{
+                paddingLeft: theme.spacing.lg,
+                marginTop: theme.spacing.sm,
+                marginBottom: theme.spacing.sm,
+                borderBottom: `1px solid ${theme.colors.actionDefaultBorderDefault}`,
+              }}
+            />
+          ) : (
             <li css={{ paddingLeft: theme.spacing.lg, marginTop: theme.spacing.sm, marginBottom: theme.spacing.sm }}>
               <Typography.Text size="sm" color="secondary">
                 {getExperimentPageSideNavSectionLabel(sectionKey as ExperimentPageSideNavSectionKey, items)}
@@ -85,13 +97,14 @@ export const MlflowSidebarExperimentItems = ({
             };
             return (
               <MlflowSidebarLink
-                css={{ paddingLeft: theme.spacing.lg }}
+                css={{ paddingLeft: collapsed ? undefined : theme.spacing.lg }}
                 key={item.componentId}
                 to={ExperimentTrackingRoutes.getExperimentPageTabRoute(experimentId ?? '', item.tabName)}
                 componentId={item.componentId}
                 isActive={isActive}
+                collapsed={collapsed}
+                icon={item.icon}
               >
-                {item.icon}
                 {item.label}
               </MlflowSidebarLink>
             );

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
@@ -1,0 +1,111 @@
+import { ArrowLeftIcon, BeakerIcon, Spinner, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useGetExperimentQuery } from '../../experiment-tracking/hooks/useExperimentQuery';
+import type { Location } from '../utils/RoutingUtils';
+import { matchPath } from '../utils/RoutingUtils';
+import ExperimentTrackingRoutes from '../../experiment-tracking/routes';
+import { MlflowSidebarLink } from './MlflowSidebarLink';
+import { getExperimentKindForWorkflowType } from '../../experiment-tracking/utils/ExperimentKindUtils';
+import {
+  ExperimentPageSideNavSectionKey,
+  getExperimentPageSideNavSectionLabel,
+  useExperimentPageSideNavConfig,
+} from '../../experiment-tracking/pages/experiment-page-tabs/side-nav/constants';
+import { useExperimentEvaluationRunsData } from '../../experiment-tracking/components/experiment-page/hooks/useExperimentEvaluationRunsData';
+import { WorkflowType } from '../contexts/WorkflowTypeContext';
+import { useGetExperimentPageActiveTabByRoute } from '../../experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute';
+import { ExperimentPageTabName } from '../../experiment-tracking/constants';
+
+const isExperimentsActive = (location: Location) =>
+  Boolean(
+    matchPath({ path: '/experiments', end: true }, location.pathname) ||
+    matchPath('/compare-experiments/*', location.pathname),
+  );
+
+export const MlflowSidebarExperimentItems = ({
+  experimentId,
+  workflowType,
+  onBackClick,
+}: {
+  experimentId: string | undefined;
+  workflowType: WorkflowType;
+  onBackClick?: () => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const { data: experiment, loading } = useGetExperimentQuery({ experimentId });
+  const { trainingRuns } = useExperimentEvaluationRunsData({
+    experimentId: experimentId || '',
+    enabled: Boolean(experimentId) && workflowType === WorkflowType.GENAI,
+    filter: '', // not important in this case, we show the runs tab if there are any training runs
+  });
+  const config = useExperimentPageSideNavConfig({
+    experimentKind: getExperimentKindForWorkflowType(workflowType),
+    hasTrainingRuns: (trainingRuns?.length ?? 0) > 0,
+  });
+  const { tabName: activeTabByRoute } = useGetExperimentPageActiveTabByRoute();
+
+  return (
+    <>
+      <div
+        css={{
+          borderTop: `1px solid ${theme.colors.actionDefaultBorderDefault}`,
+          width: '100%',
+          paddingBottom: theme.spacing.sm,
+          marginTop: theme.spacing.xs,
+        }}
+      />
+      <MlflowSidebarLink
+        css={{ border: `1px solid ${theme.colors.actionDefaultBorderDefault}`, marginBottom: theme.spacing.sm }}
+        to={ExperimentTrackingRoutes.experimentsObservatoryRoute}
+        componentId="mlflow.experiment-sidebar.back-button"
+        isActive={isExperimentsActive}
+        onClick={onBackClick}
+      >
+        <ArrowLeftIcon />
+        <BeakerIcon />
+        {loading ? <Spinner /> : <Typography.Text ellipsis>{experiment?.name}</Typography.Text>}
+      </MlflowSidebarLink>
+      {Object.entries(config).map(([sectionKey, items]) => (
+        <>
+          {sectionKey !== 'top-level' && (
+            <li css={{ paddingLeft: theme.spacing.lg, marginTop: theme.spacing.sm, marginBottom: theme.spacing.sm }}>
+              <Typography.Text size="sm" color="secondary">
+                {getExperimentPageSideNavSectionLabel(sectionKey as ExperimentPageSideNavSectionKey, items)}
+              </Typography.Text>
+            </li>
+          )}
+          {items.map((item) => {
+            const isActive = () => {
+              if (item.tabName === ExperimentPageTabName.ChatSessions) {
+                return (
+                  activeTabByRoute === ExperimentPageTabName.ChatSessions ||
+                  activeTabByRoute === ExperimentPageTabName.SingleChatSession
+                );
+              }
+              return activeTabByRoute === item.tabName;
+            };
+            return (
+              <MlflowSidebarLink
+                css={{ paddingLeft: theme.spacing.lg }}
+                key={item.componentId}
+                to={ExperimentTrackingRoutes.getExperimentPageTabRoute(experimentId ?? '', item.tabName)}
+                componentId={item.componentId}
+                isActive={isActive}
+              >
+                {item.icon}
+                {item.label}
+              </MlflowSidebarLink>
+            );
+          })}
+        </>
+      ))}
+      <div
+        css={{
+          borderBottom: `1px solid ${theme.colors.actionDefaultBorderDefault}`,
+          width: '100%',
+          paddingTop: theme.spacing.sm,
+          marginBottom: theme.spacing.xs,
+        }}
+      />
+    </>
+  );
+};

--- a/mlflow/server/js/src/common/components/MlflowSidebarGatewayItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarGatewayItems.tsx
@@ -8,7 +8,7 @@ import { MlflowSidebarLink } from './MlflowSidebarLink';
 const isEndpointsActive = (location: Location) => Boolean(matchPath('/gateway', location.pathname));
 const isApiKeysActive = (location: Location) => Boolean(matchPath('/gateway/api-keys', location.pathname));
 
-export const MlflowSidebarGatewayItems = () => {
+export const MlflowSidebarGatewayItems = ({ collapsed }: { collapsed: boolean }) => {
   const { theme } = useDesignSystemTheme();
 
   return (
@@ -18,30 +18,36 @@ export const MlflowSidebarGatewayItems = () => {
           display: 'flex',
           alignItems: 'center',
           gap: theme.spacing.sm,
-          paddingLeft: theme.spacing.md,
-          paddingTop: theme.spacing.xs,
-          paddingBottom: theme.spacing.xs,
+          justifyContent: collapsed ? 'center' : 'flex-start',
+          paddingLeft: collapsed ? 0 : theme.spacing.sm,
+          paddingBlock: theme.spacing.xs,
+          border: collapsed ? `1px solid ${theme.colors.actionDefaultBorderDefault}` : 'none',
+          borderRadius: theme.borders.borderRadiusSm,
+          marginTop: collapsed ? theme.spacing.sm : 0,
+          marginBottom: collapsed ? theme.spacing.sm : 0,
         }}
       >
         <CloudModelIcon />
-        <FormattedMessage defaultMessage="AI Gateway" description="Sidebar link for gateway" />
+        {!collapsed && <FormattedMessage defaultMessage="AI Gateway" description="Sidebar link for gateway" />}
       </div>
       <MlflowSidebarLink
-        css={{ paddingLeft: theme.spacing.lg }}
+        css={{ paddingLeft: collapsed ? undefined : theme.spacing.lg }}
         to={GatewayRoutes.gatewayPageRoute}
         componentId="mlflow.sidebar.gateway_endpoints_tab_link"
         isActive={isEndpointsActive}
+        icon={<ChainIcon />}
+        collapsed={collapsed}
       >
-        <ChainIcon />
         <FormattedMessage defaultMessage="Endpoints" description="Sidebar link for gateway endpoints" />
       </MlflowSidebarLink>
       <MlflowSidebarLink
-        css={{ paddingLeft: theme.spacing.lg }}
+        css={{ paddingLeft: collapsed ? undefined : theme.spacing.lg }}
         to={GatewayRoutes.apiKeysPageRoute}
         componentId="mlflow.sidebar.gateway_api_keys_tab_link"
         isActive={isApiKeysActive}
+        icon={<KeyIcon />}
+        collapsed={collapsed}
       >
-        <KeyIcon />
         <FormattedMessage defaultMessage="API Keys" description="Sidebar link for gateway API keys" />
       </MlflowSidebarLink>
     </div>

--- a/mlflow/server/js/src/common/components/MlflowSidebarGatewayItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarGatewayItems.tsx
@@ -1,0 +1,49 @@
+import { ChainIcon, CloudModelIcon, KeyIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+import GatewayRoutes from '../../gateway/routes';
+import { matchPath } from '../utils/RoutingUtils';
+import type { Location } from '../utils/RoutingUtils';
+import { MlflowSidebarLink } from './MlflowSidebarLink';
+
+const isEndpointsActive = (location: Location) => Boolean(matchPath('/gateway', location.pathname));
+const isApiKeysActive = (location: Location) => Boolean(matchPath('/gateway/api-keys', location.pathname));
+
+export const MlflowSidebarGatewayItems = () => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column' }}>
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.sm,
+          paddingLeft: theme.spacing.md,
+          paddingTop: theme.spacing.xs,
+          paddingBottom: theme.spacing.xs,
+        }}
+      >
+        <CloudModelIcon />
+        <FormattedMessage defaultMessage="AI Gateway" description="Sidebar link for gateway" />
+      </div>
+      <MlflowSidebarLink
+        css={{ paddingLeft: theme.spacing.lg }}
+        to={GatewayRoutes.gatewayPageRoute}
+        componentId="mlflow.sidebar.gateway_endpoints_tab_link"
+        isActive={isEndpointsActive}
+      >
+        <ChainIcon />
+        <FormattedMessage defaultMessage="Endpoints" description="Sidebar link for gateway endpoints" />
+      </MlflowSidebarLink>
+      <MlflowSidebarLink
+        css={{ paddingLeft: theme.spacing.lg }}
+        to={GatewayRoutes.apiKeysPageRoute}
+        componentId="mlflow.sidebar.gateway_api_keys_tab_link"
+        isActive={isApiKeysActive}
+      >
+        <KeyIcon />
+        <FormattedMessage defaultMessage="API Keys" description="Sidebar link for gateway API keys" />
+      </MlflowSidebarLink>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1626,6 +1626,10 @@
     "defaultMessage": "MLflow runs:",
     "description": "A label for the associated MLflow runs in the prompt details page"
   },
+  "9ZzOhu": {
+    "defaultMessage": "API Keys",
+    "description": "Sidebar link for gateway API keys"
+  },
   "9cTaBs": {
     "defaultMessage": "Fail",
     "description": "Failing assessment label"
@@ -2357,10 +2361,6 @@
   "EkUD0b": {
     "defaultMessage": "No results",
     "description": "Experiment page > sort selector > no results after filtering by search query"
-  },
-  "Emh131": {
-    "defaultMessage": "Select an experiment to view this tab",
-    "description": "Tooltip shown when nested experiment items are disabled because no experiment is selected"
   },
   "EpFST9": {
     "defaultMessage": "No trace data recorded",
@@ -4464,6 +4464,10 @@
     "defaultMessage": "Add chart",
     "description": "Confirm button label within a modal when adding a new runs comparison chart"
   },
+  "Uzii0L": {
+    "defaultMessage": "AI Gateway",
+    "description": "Sidebar link for gateway"
+  },
   "V0/LoE": {
     "defaultMessage": "This trace is not exportable because it either contains an error or the response is not a ChatCompletionResponse.",
     "description": "Tooltip message for the export button when the trace is not exportable"
@@ -4607,6 +4611,10 @@
   "VwxvII": {
     "defaultMessage": "forecasting",
     "description": "A short label for experiments focused on time series forecasting"
+  },
+  "W0PKNU": {
+    "defaultMessage": "Model registry",
+    "description": "Sidebar link for model registry tab"
   },
   "W1ZIP4": {
     "defaultMessage": "Safety",
@@ -4870,10 +4878,6 @@
   "Xt8M9f": {
     "defaultMessage": "Loading workspaces...",
     "description": "Loading workspaces message"
-  },
-  "Xuz/xh": {
-    "defaultMessage": "Models",
-    "description": "Sidebar link for models tab"
   },
   "XuzIWs": {
     "defaultMessage": "Some traces are hidden by your time range filter: \"{filterLabel}\"",
@@ -7634,6 +7638,10 @@
   "qcYoo4": {
     "defaultMessage": "Please select sessions to run the judge",
     "description": "Tooltip message when no sessions are selected"
+  },
+  "qhOwHa": {
+    "defaultMessage": "Endpoints",
+    "description": "Sidebar link for gateway endpoints"
   },
   "qkRBUr": {
     "defaultMessage": "Line smoothing",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20697/files) to review incremental changes.
- [**stack/nest-tabs**](https://github.com/mlflow/mlflow/pull/20697) [[Files changed](https://github.com/mlflow/mlflow/pull/20697/files)]
  - [stack/update-selector](https://github.com/mlflow/mlflow/pull/20698) [[Files changed](https://github.com/mlflow/mlflow/pull/20698/files/b6bd7e95c30cf5279528de090729d4982e742595..2e85d86050f100e78c66cbdd564238b80eeb41ea)]
    - [stack/tooltips](https://github.com/mlflow/mlflow/pull/20699) [[Files changed](https://github.com/mlflow/mlflow/pull/20699/files/2e85d86050f100e78c66cbdd564238b80eeb41ea..9115a35cf62dc0a16719174e01652a43b0ee27a0)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

When the flag is enabled for the GenAI / ML top-level split, this PR changes the way experiment specific tabs are shown

Previously they were all shown at the top level but disabled. This caused some confusion, so in accordance with design feedback, we only display the experiment tabs after the user selects an experiment.

The last experiment selection is kept in state, so the user can easily navigate between experiment tabs and gateway/home.

Note that the flag is not enabled this PR, so this should not result in any user facing change yet.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

With flag enabled:

https://github.com/user-attachments/assets/e75285c6-5087-4e0e-98a1-0efdad92bebc



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
