### PR TITLE
[Left nav refactor][6/6] Add tooltips for the sidebar icons when collapsed

### DIFF
--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -271,7 +271,7 @@ export function MlflowSidebar({
         />
       </div>
       {workspacesEnabled && showSidebar && <WorkspaceSelector />}
-      {enableWorkflowBasedNavigation && showWorkspaceMenuItems &&showSidebar && (
+      {enableWorkflowBasedNavigation && showWorkspaceMenuItems && showSidebar && (
         <MlflowSidebarWorkflowSwitch workflowType={workflowType} setWorkflowType={setWorkflowType} />
       )}
 

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -38,6 +38,7 @@ import { HomePageDocsUrl, Version } from '../constants';
 import { WorkspaceSelector } from '../../workspaces/components/WorkspaceSelector';
 import { MlflowSidebarExperimentItems } from './MlflowSidebarExperimentItems';
 import { MlflowSidebarGatewayItems } from './MlflowSidebarGatewayItems';
+import { MlflowSidebarWorkflowSwitch } from './MlflowSidebarWorkflowSwitch';
 
 const isInsideExperiment = (location: Location) =>
   Boolean(matchPath('/experiments/:experimentId/*', location.pathname));
@@ -234,7 +235,7 @@ export function MlflowSidebar({
   return (
     <aside
       css={{
-        width: showSidebar ? (enableWorkflowBasedNavigation ? 230 : 200) : 36,
+        width: showSidebar ? 190 : 36,
         flexShrink: 0,
         padding: theme.spacing.sm,
         paddingRight: 0,
@@ -270,42 +271,8 @@ export function MlflowSidebar({
         />
       </div>
       {workspacesEnabled && showSidebar && <WorkspaceSelector />}
-      {enableWorkflowBasedNavigation && showWorkspaceMenuItems && showSidebar && (
-        <div
-          css={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: theme.spacing.xs,
-          }}
-        >
-          <Typography.Title level={4} withoutMargins color="info" css={{ textTransform: 'uppercase' }}>
-            <FormattedMessage
-              defaultMessage="Workflow type"
-              description="Label for the workflow type selector in the sidebar"
-            />
-          </Typography.Title>
-          <SegmentedControlGroup
-            value={workflowType}
-            onChange={(e) => {
-              if (e.target.value) {
-                setWorkflowType(e.target.value as WorkflowType);
-              }
-            }}
-            name="workflow-type-selector"
-            componentId="mlflow.sidebar.workflow_type_selector"
-            css={{ width: '100%', display: 'flex' }}
-          >
-            <SegmentedControlButton value={WorkflowType.GENAI}>
-              <FormattedMessage defaultMessage="GenAI" description="Label for GenAI workflow type option" />
-            </SegmentedControlButton>
-            <SegmentedControlButton value={WorkflowType.MACHINE_LEARNING} css={{ whiteSpace: 'nowrap' }}>
-              <FormattedMessage
-                defaultMessage="Machine Learning"
-                description="Label for Machine Learning workflow type option"
-              />
-            </SegmentedControlButton>
-          </SegmentedControlGroup>
-        </div>
+      {enableWorkflowBasedNavigation && showWorkspaceMenuItems &&showSidebar && (
+        <MlflowSidebarWorkflowSwitch workflowType={workflowType} setWorkflowType={setWorkflowType} />
       )}
 
       <nav css={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between', height: '100%' }}>

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -19,6 +19,7 @@ import {
   SidebarExpandIcon,
   InfoBookIcon,
   CodeIcon,
+  Tooltip,
 } from '@databricks/design-system';
 import type { Location } from '../utils/RoutingUtils';
 import { Link, matchPath, useLocation, useParams, useSearchParams } from '../utils/RoutingUtils';
@@ -310,43 +311,55 @@ export function MlflowSidebar({
                   'linear-gradient(90deg, rgba(232, 72, 85, 0.7), rgba(155, 93, 229, 0.7), rgba(67, 97, 238, 0.7))',
               }}
             >
-              <div
-                role="button"
-                tabIndex={0}
-                aria-pressed={isPanelOpen}
-                css={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: theme.spacing.sm,
-                  paddingInline: showSidebar ? theme.spacing.md : 0,
-                  paddingBlock: theme.spacing.xs,
-                  borderRadius: theme.borders.borderRadiusMd - 2,
-                  justifyContent: showSidebar ? 'flex-start' : 'center',
-                  cursor: 'pointer',
-                  background: theme.colors.backgroundSecondary,
-                  color: isPanelOpen ? theme.colors.actionDefaultIconHover : theme.colors.actionDefaultIconDefault,
-                }}
-                onClick={handleAssistantToggle}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    handleAssistantToggle();
-                  }
-                }}
-                onMouseEnter={() => setIsAssistantHovered(true)}
-                onMouseLeave={() => setIsAssistantHovered(false)}
+              <Tooltip
+                componentId="mlflow.sidebar.assistant_tooltip"
+                content={<FormattedMessage defaultMessage="Assistant" description="Tooltip for assistant button" />}
+                open={isAssistantHovered && !showSidebar}
+                side="right"
+                delayDuration={0}
               >
-                <AssistantSparkleIcon isHovered={isAssistantHovered} />
-                {showSidebar && (
-                  <>
-                    <Typography.Text color="primary">
-                      <FormattedMessage defaultMessage="Assistant" description="Sidebar button for AI assistant" />
-                    </Typography.Text>
-                    <Tag componentId="mlflow.sidebar.assistant_beta_tag" color="turquoise" css={{ marginLeft: 'auto' }}>
-                      Beta
-                    </Tag>
-                  </>
-                )}
-              </div>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  aria-pressed={isPanelOpen}
+                  css={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: theme.spacing.sm,
+                    paddingInline: showSidebar ? theme.spacing.md : 0,
+                    paddingBlock: theme.spacing.xs,
+                    borderRadius: theme.borders.borderRadiusMd - 2,
+                    justifyContent: showSidebar ? 'flex-start' : 'center',
+                    cursor: 'pointer',
+                    background: theme.colors.backgroundSecondary,
+                    color: isPanelOpen ? theme.colors.actionDefaultIconHover : theme.colors.actionDefaultIconDefault,
+                  }}
+                  onClick={handleAssistantToggle}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      handleAssistantToggle();
+                    }
+                  }}
+                  onMouseEnter={() => setIsAssistantHovered(true)}
+                  onMouseLeave={() => setIsAssistantHovered(false)}
+                >
+                  <AssistantSparkleIcon isHovered={isAssistantHovered} />
+                  {showSidebar && (
+                    <>
+                      <Typography.Text color="primary">
+                        <FormattedMessage defaultMessage="Assistant" description="Sidebar button for AI assistant" />
+                      </Typography.Text>
+                      <Tag
+                        componentId="mlflow.sidebar.assistant_beta_tag"
+                        color="turquoise"
+                        css={{ marginLeft: 'auto' }}
+                      >
+                        Beta
+                      </Tag>
+                    </>
+                  )}
+                </div>
+              </Tooltip>
             </div>
           )}
           <MlflowSidebarLink

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -20,6 +20,7 @@ import {
   InfoBookIcon,
   CodeIcon,
   Tooltip,
+  NewWindowIcon,
 } from '@databricks/design-system';
 import type { Location } from '../utils/RoutingUtils';
 import { Link, matchPath, useLocation, useParams, useSearchParams } from '../utils/RoutingUtils';
@@ -372,7 +373,10 @@ export function MlflowSidebar({
             collapsed={!showSidebar}
             openInNewTab
           >
-            <FormattedMessage defaultMessage="Docs" description="Sidebar link for docs page" />
+            <span css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+              <FormattedMessage defaultMessage="Docs" description="Sidebar link for docs page" />
+              <NewWindowIcon css={{ fontSize: theme.typography.fontSizeBase }} />
+            </span>
           </MlflowSidebarLink>
           <MlflowSidebarLink
             disableWorkspacePrefix
@@ -384,7 +388,10 @@ export function MlflowSidebar({
             collapsed={!showSidebar}
             openInNewTab
           >
-            <FormattedMessage defaultMessage="GitHub" description="Sidebar link for GitHub page" />
+            <span css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+              <FormattedMessage defaultMessage="GitHub" description="Sidebar link for GitHub page" />
+              <NewWindowIcon css={{ fontSize: theme.typography.fontSizeBase }} />
+            </span>
           </MlflowSidebarLink>
           <MlflowSidebarLink
             disableWorkspacePrefix

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
@@ -14,6 +14,7 @@ import { useExperimentEvaluationRunsData } from '../../experiment-tracking/compo
 import { WorkflowType } from '../contexts/WorkflowTypeContext';
 import { useGetExperimentPageActiveTabByRoute } from '../../experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute';
 import { ExperimentPageTabName } from '../../experiment-tracking/constants';
+import { FormattedMessage } from 'react-intl';
 
 const isExperimentsActive = (location: Location) =>
   Boolean(
@@ -63,6 +64,9 @@ export const MlflowSidebarExperimentItems = ({
         onClick={onBackClick}
         icon={<ArrowLeftIcon />}
         collapsed={collapsed}
+        tooltipContent={
+          <FormattedMessage defaultMessage="Back to experiment list" description="Tooltip for experiments button" />
+        }
       >
         <BeakerIcon />
         {loading ? <Spinner /> : <Typography.Text ellipsis>{experiment?.name}</Typography.Text>}

--- a/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation } from '../utils/RoutingUtils';
 import {
   DesignSystemEventProviderAnalyticsEventTypes,
   DesignSystemEventProviderComponentTypes,
+  Tooltip,
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
@@ -20,6 +21,7 @@ export const MlflowSidebarLink = ({
   openInNewTab = false,
   collapsed = false,
   disableWorkspacePrefix = false,
+  tooltipContent,
 }: {
   className?: string;
   to: string;
@@ -31,6 +33,7 @@ export const MlflowSidebarLink = ({
   openInNewTab?: boolean;
   collapsed?: boolean;
   disableWorkspacePrefix?: boolean;
+  tooltipContent?: React.ReactNode;
 }) => {
   const { theme } = useDesignSystemTheme();
   const logTelemetryEvent = useLogTelemetryEvent();
@@ -39,47 +42,55 @@ export const MlflowSidebarLink = ({
 
   return (
     <li key={componentId}>
-      <Link
-        disableWorkspacePrefix={disableWorkspacePrefix}
-        to={to}
-        aria-current={isActive(location) ? 'page' : undefined}
-        className={className}
-        css={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: theme.spacing.sm,
-          color: theme.colors.textPrimary,
-          paddingInline: collapsed ? 0 : theme.spacing.sm,
-          justifyContent: collapsed ? 'center' : 'flex-start',
-          // 5 seems to be the magic number to match the text line height
-          paddingBlock: collapsed ? 5 : theme.spacing.xs,
-          borderRadius: theme.borders.borderRadiusSm,
-          '&:hover': {
-            color: theme.colors.actionLinkHover,
-            backgroundColor: theme.colors.actionDefaultBackgroundHover,
-          },
-          '&[aria-current="page"]': {
-            backgroundColor: theme.colors.actionDefaultBackgroundPress,
-            color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
-            fontWeight: theme.typography.typographyBoldFontWeight,
-          },
-        }}
-        onClick={() => {
-          logTelemetryEvent({
-            componentId,
-            componentViewId: viewId,
-            componentType: DesignSystemEventProviderComponentTypes.Button,
-            componentSubType: null,
-            eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
-          });
-          onClick?.();
-        }}
-        target={openInNewTab ? '_blank' : undefined}
-        rel={openInNewTab ? 'noopener noreferrer' : undefined}
+      <Tooltip
+        componentId={`${componentId}.tooltip`}
+        open={!collapsed ? false : undefined}
+        content={tooltipContent ?? children}
+        side="right"
+        delayDuration={0}
       >
-        {icon}
-        {!collapsed && children}
-      </Link>
+        <Link
+          disableWorkspacePrefix={disableWorkspacePrefix}
+          to={to}
+          aria-current={isActive(location) ? 'page' : undefined}
+          className={className}
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: theme.spacing.sm,
+            color: theme.colors.textPrimary,
+            paddingInline: collapsed ? 0 : theme.spacing.sm,
+            justifyContent: collapsed ? 'center' : 'flex-start',
+            // 5 seems to be the magic number to match the text line height
+            paddingBlock: collapsed ? 5 : theme.spacing.xs,
+            borderRadius: theme.borders.borderRadiusSm,
+            '&:hover': {
+              color: theme.colors.actionLinkHover,
+              backgroundColor: theme.colors.actionDefaultBackgroundHover,
+            },
+            '&[aria-current="page"]': {
+              backgroundColor: theme.colors.actionDefaultBackgroundPress,
+              color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
+              fontWeight: theme.typography.typographyBoldFontWeight,
+            },
+          }}
+          onClick={() => {
+            logTelemetryEvent({
+              componentId,
+              componentViewId: viewId,
+              componentType: DesignSystemEventProviderComponentTypes.Button,
+              componentSubType: null,
+              eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+            });
+            onClick?.();
+          }}
+          target={openInNewTab ? '_blank' : undefined}
+          rel={openInNewTab ? 'noopener noreferrer' : undefined}
+        >
+          {icon}
+          {!collapsed && children}
+        </Link>
+      </Tooltip>
     </li>
   );
 };

--- a/mlflow/server/js/src/common/components/MlflowSidebarWorkflowSwitch.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarWorkflowSwitch.tsx
@@ -1,0 +1,104 @@
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { WorkflowType } from '../contexts/WorkflowTypeContext';
+import { FormattedMessage } from '@databricks/i18n';
+
+const Pill = ({
+  isActive,
+  workflowType,
+  setWorkflowType,
+}: {
+  isActive: boolean;
+  workflowType: WorkflowType;
+  setWorkflowType: (workflowType: WorkflowType) => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const borderColor =
+    workflowType === WorkflowType.GENAI ? theme.gradients.aiBorderGradient : theme.colors.actionDefaultBorderDefault;
+  const label =
+    workflowType === WorkflowType.GENAI ? (
+      <FormattedMessage defaultMessage="GenAI" description="Label for GenAI workflow type option" />
+    ) : (
+      <FormattedMessage defaultMessage="Model training" description="Label for model training workflow type option" />
+    );
+
+  if (isActive) {
+    return (
+      <div
+        css={{
+          position: 'relative',
+          background: borderColor,
+          margin: -1,
+          borderRadius: theme.borders.borderRadiusFull,
+          padding: 1,
+          cursor: 'pointer',
+        }}
+        onClick={() => setWorkflowType(workflowType)}
+      >
+        <div
+          css={{
+            background: theme.colors.backgroundPrimary,
+            borderRadius: theme.borders.borderRadiusFull,
+            padding: theme.spacing.xs,
+            paddingRight: theme.spacing.md,
+            paddingLeft: theme.spacing.md,
+          }}
+        >
+          <Typography.Text>{label}</Typography.Text>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'pointer',
+        // magic number to prevent the text from jumping around
+        // when switching between workflow types
+        paddingRight: workflowType === WorkflowType.GENAI ? 0 : 7,
+        paddingLeft: workflowType === WorkflowType.GENAI ? 7 : 0,
+      }}
+      onClick={() => setWorkflowType(workflowType)}
+    >
+      <Typography.Text>{label}</Typography.Text>
+    </div>
+  );
+};
+
+export const MlflowSidebarWorkflowSwitch = ({
+  workflowType,
+  setWorkflowType,
+}: {
+  workflowType: WorkflowType;
+  setWorkflowType: (workflowType: WorkflowType) => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        position: 'relative',
+        alignItems: 'center',
+        background: theme.colors.backgroundSecondary,
+        borderRadius: theme.borders.borderRadiusFull,
+        border: `1px solid ${theme.colors.actionDefaultBorderDefault}`,
+      }}
+    >
+      <Pill
+        isActive={workflowType === WorkflowType.GENAI}
+        workflowType={WorkflowType.GENAI}
+        setWorkflowType={setWorkflowType}
+      />
+      <Pill
+        isActive={workflowType === WorkflowType.MACHINE_LEARNING}
+        workflowType={WorkflowType.MACHINE_LEARNING}
+        setWorkflowType={setWorkflowType}
+      />
+    </div>
+  );
+};

--- a/mlflow/server/js/src/common/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/common/utils/FeatureUtils.ts
@@ -167,7 +167,7 @@ export const shouldEnableExperimentOverviewTab = () => {
  * This enables the workflow type selector and nested navigation items in the main sidebar.
  */
 export const shouldEnableWorkflowBasedNavigation = () => {
-  return false;
+  return true;
 };
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useInferExperimentKind.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useInferExperimentKind.test.tsx
@@ -8,6 +8,11 @@ import { rest } from 'msw';
 import { ExperimentKind, ExperimentPageTabName } from '../../../constants';
 import { MemoryRouter } from '../../../../common/utils/RoutingUtils';
 
+// this test is only relevant when the feature flag is disabled
+jest.mock('../../../../common/utils/FeatureUtils', () => ({
+  shouldEnableWorkflowBasedNavigation: () => false,
+}));
+
 describe('useInferExperimentKind', () => {
   const server = setupServer();
   beforeEach(() => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.test.tsx
@@ -19,6 +19,7 @@ jest.setTimeout(60000); // Larger timeout for integration testing
 
 jest.mock('../../../common/utils/FeatureUtils', () => ({
   ...jest.requireActual<typeof import('../../../common/utils/FeatureUtils')>('../../../common/utils/FeatureUtils'),
+  shouldEnableWorkflowBasedNavigation: jest.fn().mockReturnValue(false),
 }));
 jest.mock('../experiment-logged-models/ExperimentLoggedModelListPage', () => ({
   // mock default export

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3306,6 +3306,10 @@
     "defaultMessage": "{count, plural, one {Input} other {Inputs}}",
     "description": "Evaluation review > input section > title"
   },
+  "MS5PhU": {
+    "defaultMessage": "Model training",
+    "description": "Label for model training workflow type option"
+  },
   "MUUYWZ": {
     "defaultMessage": "Created at",
     "description": "Label for the creation timestamp of a logged model on the logged model details page"
@@ -5339,10 +5343,6 @@
     "defaultMessage": "Irrelevant",
     "description": "Evaluation results > retrieval relevancy assessment > negative value label. Displayed if evaluation result is considered as irrelevant to the query."
   },
-  "amFk5F": {
-    "defaultMessage": "Workflow type",
-    "description": "Label for the workflow type selector in the sidebar"
-  },
   "aqMseN": {
     "defaultMessage": "Manage prompt updates and collaborate across teams.",
     "description": "Home page quick action description for registering prompts"
@@ -5614,10 +5614,6 @@
   "cQQnzX": {
     "defaultMessage": "Hide assessments",
     "description": "Tooltip for a button that closes the assessments pane"
-  },
-  "cSEpGa": {
-    "defaultMessage": "Machine Learning",
-    "description": "Label for Machine Learning workflow type option"
   },
   "cSQJ9N": {
     "defaultMessage": "Select sessions",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -8311,6 +8311,10 @@
     "defaultMessage": "Add description",
     "description": "Run page > Overview > Description section > Add description button"
   },
+  "vqWexj": {
+    "defaultMessage": "Back to experiment list",
+    "description": "Tooltip for experiments button"
+  },
   "vwD2zW": {
     "defaultMessage": "Unified APIs",
     "description": "Unified APIs tab title"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20699/files/3b1a6a88c05b3113a8aba67be13cba9ce57e9796..3cdf599f2326f46239c304005653471df60a49b8) to review incremental changes.
- [stack/update-selector](https://github.com/mlflow/mlflow/pull/20698) [[Files changed](https://github.com/mlflow/mlflow/pull/20698/files)]
  - [**stack/tooltips**](https://github.com/mlflow/mlflow/pull/20699) [[Files changed](https://github.com/mlflow/mlflow/pull/20699/files/3b1a6a88c05b3113a8aba67be13cba9ce57e9796..3cdf599f2326f46239c304005653471df60a49b8)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

As title, i missed this previously but when the sidebar is collapsed it's hard to know what the icons mean. This PR adds tooltips.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

https://github.com/user-attachments/assets/6a158aad-244a-49ac-9962-dea36470170a

With workspace mode enabled (currently genai / ML preference is not scoped to workspace, but this can be followed up between RC and stable):


https://github.com/user-attachments/assets/b71d9637-c7c6-4c92-8123-9e521a2b829c


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
