### PR TITLE
Add workflow to request visual media on UI-related issues

### DIFF
--- a/.github/workflows/needs_visual_media.py
+++ b/.github/workflows/needs_visual_media.py
@@ -1,0 +1,161 @@
+"""Classify whether a GitHub issue needs visual media (screenshots/recordings)."""
+# ruff: noqa: T201
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+
+VISUAL_MEDIA_PATTERNS = [
+    r"!\[",  # Markdown image
+    r"<img\s",  # HTML image tag
+    r"<video\s",  # HTML video tag
+    r"\.png",
+    r"\.jpg",
+    r"\.jpeg",
+    r"\.gif",
+    r"\.mp4",
+    r"\.webm",
+    r"\.webp",
+    r"user-attachments",
+    r"user-images\.githubusercontent\.com",
+]
+
+VISUAL_MEDIA_RE = re.compile("|".join(VISUAL_MEDIA_PATTERNS), re.IGNORECASE)
+
+
+def run_gh(*args: str) -> str:
+    return subprocess.check_output(["gh", *args], text=True)
+
+
+def get_issue(repo: str, issue_number: str) -> dict[str, str]:
+    output = run_gh("issue", "view", issue_number, "--repo", repo, "--json", "title,body,labels")
+    return json.loads(output)
+
+
+def has_visual_media(body: str | None) -> bool:
+    if not body:
+        return False
+    return bool(VISUAL_MEDIA_RE.search(body))
+
+
+PROMPT_TEMPLATE = """\
+Classify whether the following GitHub issue describes a problem that is \
+visual/UI-related and would benefit from a screenshot or screen recording \
+to understand and reproduce.
+
+## Issue Title
+{title}
+
+## Issue Body
+{body}
+
+## Instructions
+- Return {{"needs_visual_media": true}} if the issue describes a visual or \
+UI problem (e.g., layout issues, rendering bugs, styling problems, \
+UI elements not appearing correctly, visual regressions).
+- Return {{"needs_visual_media": false}} if the issue is about backend logic, \
+APIs, CLI behavior, documentation, performance metrics, or other non-visual topics.
+- When in doubt, return false — only flag issues that clearly describe \
+something visual."""
+
+
+def build_prompt(title: str, body: str) -> str:
+    return PROMPT_TEMPLATE.format(title=title, body=body)
+
+
+def call_anthropic_api(prompt: str) -> dict[str, object]:
+    print("Calling Claude API...", file=sys.stderr)
+
+    api_key = os.environ["ANTHROPIC_API_KEY"]
+    request_body = {
+        "model": "claude-haiku-4-5-20251001",
+        "max_tokens": 128,
+        "messages": [{"role": "user", "content": prompt}],
+        "output_config": {
+            "format": {
+                "type": "json_schema",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "needs_visual_media": {
+                            "type": "boolean",
+                            "description": (
+                                "Whether the issue would benefit from a screenshot or recording."
+                            ),
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": ("Brief explanation for the classification."),
+                        },
+                    },
+                    "required": ["needs_visual_media", "reason"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+    }
+
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=json.dumps(request_body).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            response = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode()
+        print(f"API Error {e.code}: {error_body}", file=sys.stderr)
+        raise
+
+    print("API Response:", file=sys.stderr)
+    print(json.dumps(response, indent=2), file=sys.stderr)
+
+    return json.loads(response["content"][0]["text"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Classify if an issue needs visual media")
+    parser.add_argument("--repo", required=True, help="Repository (owner/name)")
+    parser.add_argument("--issue-number", required=True, help="Issue number")
+    args = parser.parse_args()
+
+    issue = get_issue(args.repo, args.issue_number)
+    title = issue["title"]
+    body = issue.get("body") or ""
+    labels = [label["name"] for label in issue.get("labels", [])]
+    print(f"Issue: {title}", file=sys.stderr)
+    print(f"Labels: {labels}", file=sys.stderr)
+
+    # Short-circuit: already has visual media
+    if has_visual_media(body):
+        print("Issue already contains visual media, skipping.", file=sys.stderr)
+        result = {
+            "needs_visual_media": False,
+            "has_visual_media": True,
+            "reason": "already has visual media",
+        }
+        print(json.dumps(result))
+        return
+
+    # Call LLM to classify
+    classification = call_anthropic_api(build_prompt(title, body))
+    result = {
+        "needs_visual_media": classification["needs_visual_media"],
+        "has_visual_media": False,
+        "reason": classification["reason"],
+    }
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/needs_visual_media.yml
+++ b/.github/workflows/needs_visual_media.yml
@@ -1,0 +1,120 @@
+name: Needs Visual Media
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    paths:
+      - .github/workflows/needs_visual_media.yml
+      - .github/workflows/needs_visual_media.py
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Test job: runs on PR changes against a fixed set of issues
+  test:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      issues: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: mlflow/mlflow
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/workflows/needs_visual_media.py
+          sparse-checkout-cone-mode: false
+
+      - name: Test classification on sample issues
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Format: issue_number expected_needs expected_has description
+          issues=(
+            "20645 true  false  UI-bug-no-media"
+            "20479 false true   has-screenshots"
+            "19643 false false  backend-crash"
+            "18854 true  false  UI-perf-no-media"
+            "20357 false true   has-screenshots"
+            "20547 false false  backend-error"
+            "20527 false false  backend-logging"
+            "20486 true  false  UI-bug-no-media"
+            "20366 false true   has-screenshots"
+            "20265 false false  feature-request"
+          )
+
+          pass=0
+          fail=0
+          for entry in "${issues[@]}"; do
+            read -r number expected_needs expected_has desc <<< "$entry"
+            echo "=== Issue #$number ($desc) ==="
+            result=$(python .github/workflows/needs_visual_media.py --repo "$REPO" --issue-number "$number")
+            echo "$result" | jq .
+
+            actual_needs=$(echo "$result" | jq -r '.needs_visual_media')
+            actual_has=$(echo "$result" | jq -r '.has_visual_media')
+
+            ok=true
+            if [ "$actual_needs" != "$expected_needs" ]; then
+              echo "  MISMATCH: needs_visual_media=$actual_needs (expected $expected_needs)"
+              ok=false
+            fi
+            if [ "$actual_has" != "$expected_has" ]; then
+              echo "  MISMATCH: has_visual_media=$actual_has (expected $expected_has)"
+              ok=false
+            fi
+
+            if [ "$ok" = true ]; then
+              echo "  PASS"
+              ((pass++))
+            else
+              echo "  FAIL"
+              ((fail++))
+            fi
+            echo ""
+          done
+
+          echo "=== Results: $pass passed, $fail failed ==="
+          if [ "$fail" -gt 0 ]; then
+            exit 1
+          fi
+
+  # Production job: runs on new issues
+  classify:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/workflows/needs_visual_media.py
+          sparse-checkout-cone-mode: false
+
+      - name: Classify issue
+        id: classify
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          result=$(python .github/workflows/needs_visual_media.py --repo "$REPO" --issue-number "$ISSUE_NUMBER")
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+
+      - name: Comment and label if visual media needed
+        if: fromJSON(steps.classify.outputs.result).needs_visual_media && !fromJSON(steps.classify.outputs.result).has_visual_media
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body \
+            "Thank you for opening this issue! Based on the description, it sounds like a screenshot or screen recording would help us understand and reproduce the problem faster.
+
+          Could you attach a visual showing what you're experiencing? A screenshot, GIF, or short video would be very helpful.
+
+          *If this issue is not UI-related, you can safely ignore this message.*"
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs_visual_media"


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

Add a GitHub Actions workflow that automatically detects UI-related issues filed without screenshots/recordings and posts a friendly comment asking for visual media. Uses Claude Haiku to classify whether an issue is visual/UI-related, with a regex short-circuit to skip issues that already contain images or videos.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

The workflow includes a `test` job that runs on PR changes, classifying 10 sample issues against expected results.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)