### PR TITLE
Add AI-powered triage workflow for UI/UX issues

### DIFF
--- a/.github/workflows/triage.md
+++ b/.github/workflows/triage.md
@@ -1,0 +1,188 @@
+# Synthetic triage dataset
+
+Each issue is separated by `---`. Expected result is noted in the header.
+
+---
+
+## Issue 1 — UI bug, no screenshot (expect comment)
+
+**Title:** Sidebar overlaps main content on narrow screens
+
+**Body:**
+When I resize the browser window to less than 1000px, the left sidebar overlaps
+with the experiment table. The columns become unreadable and I can't click on
+any runs.
+
+---
+
+## Issue 2 — UI bug with screenshot (expect no comment)
+
+**Title:** Run name truncated in experiment list
+
+**Body:**
+The run name gets cut off when it's longer than 30 characters. See below:
+
+![truncated run name](https://user-images.githubusercontent.com/12345/screenshot.png)
+
+MLflow 2.17.0, Python 3.11, macOS 14.
+
+Steps:
+
+1. Create a run with a long name
+2. Open the experiment page
+3. Observe the truncated name
+
+---
+
+## Issue 3 — Bug, no repro steps, no env info (expect comment)
+
+**Title:** `mlflow.log_metric` silently drops NaN values
+
+**Body:**
+I noticed that when I log NaN as a metric value, it just disappears. No error,
+no warning, nothing in the UI. This is really confusing because I thought my
+training was going fine but the metrics were just not being recorded.
+
+---
+
+## Issue 4 — Bug with repro steps and env info (expect no comment)
+
+**Title:** `mlflow server` crashes on startup with SQLite backend
+
+**Body:**
+**Environment:**
+
+- OS: Ubuntu 22.04
+- Python: 3.10.12
+- MLflow: 2.18.0
+
+**Steps to reproduce:**
+
+1. Install mlflow 2.18.0
+2. Run `mlflow server --backend-store-uri sqlite:///mlflow.db`
+3. Server crashes with `OperationalError: database is locked`
+
+**Traceback:**
+
+```
+Traceback (most recent call last):
+  File "/home/user/.local/lib/python3.10/site-packages/mlflow/server/__init__.py", line 42, in _run_server
+    store = _get_store(backend_store_uri)
+  File "/home/user/.local/lib/python3.10/site-packages/mlflow/store/tracking/__init__.py", line 75, in _get_store
+    return _tracking_store_registry.get_store(store_uri)
+  File "/home/user/.local/lib/python3.10/site-packages/mlflow/store/tracking/sqlalchemy_store.py", line 112, in __init__
+    self._setup_db()
+sqlite3.OperationalError: database is locked
+```
+
+---
+
+## Issue 5 — Feature request (expect no comment)
+
+**Title:** Add support for grouping runs by tag in the UI
+
+**Body:**
+It would be great to be able to group runs in the experiment view by a specific
+tag value. For example, I tag my runs with `model_type=cnn` or
+`model_type=transformer` and I'd love to see them grouped in the table.
+
+This is similar to how you can group by "dataset" in Weights & Biases.
+
+---
+
+## Issue 6 — Bug with repro steps but no env info (expect comment)
+
+**Title:** Autologging fails with PyTorch Lightning 2.5
+
+**Body:**
+When I enable autologging with PyTorch Lightning 2.5, I get an AttributeError.
+
+```python
+import mlflow
+
+mlflow.pytorch.autolog()
+
+trainer = pl.Trainer(max_epochs=5)
+trainer.fit(model, dataloader)
+```
+
+```
+AttributeError: module 'pytorch_lightning' has no attribute 'callbacks'
+```
+
+---
+
+## Issue 7 — Bug with env info but no repro steps (expect comment)
+
+**Title:** Model serving returns 500 on valid input
+
+**Body:**
+I deployed a model using `mlflow models serve` and it returns 500 errors
+on inputs that used to work fine. This started happening after I upgraded
+MLflow.
+
+Environment: Python 3.11, MLflow 2.18.0, macOS Sonoma.
+
+---
+
+## Issue 8 — UI bug, has env and repro but no screenshot (expect comment)
+
+**Title:** Chart tooltip shows wrong metric value
+
+**Body:**
+The tooltip on the metric chart shows a different value than what's actually
+plotted. The line is at ~0.95 but the tooltip says 0.42.
+
+**Environment:** MLflow 2.17.0, Python 3.10, Chrome 130, Ubuntu 22.04
+
+**Steps:**
+
+1. Log 100 metric values for "accuracy"
+2. Open the run page
+3. Hover over the chart line near the end
+4. Tooltip shows an incorrect value
+
+---
+
+## Issue 9 — Documentation issue (expect no comment)
+
+**Title:** Typo in quickstart guide
+
+**Body:**
+In the quickstart guide, the command `mlflow server --port 500` should be
+`mlflow server --port 5000`. The wrong port causes a "permission denied" error
+on Linux.
+
+---
+
+## Issue 10 — Bug, detailed report with everything (expect no comment)
+
+**Title:** `mlflow.evaluate()` fails with custom metrics on Spark DataFrame
+
+**Body:**
+**Environment:**
+
+- OS: CentOS 7
+- Python: 3.10.8
+- MLflow: 2.17.2
+- PySpark: 3.5.0
+
+**Description:**
+When passing a Spark DataFrame to `mlflow.evaluate()` with a custom metric
+function, the evaluation fails with a serialization error.
+
+**Steps to reproduce:**
+
+1. Create a Spark DataFrame with columns `prediction` and `target`
+2. Define a custom metric: `def rmse(eval_df, _): return np.sqrt(np.mean(...))`
+3. Call `mlflow.evaluate(model, data=spark_df, extra_metrics=[rmse])`
+
+**Error:**
+
+```
+pickle.PicklingError: Could not serialize object
+```
+
+**Expected behavior:**
+The evaluation should work with Spark DataFrames just like it does with
+Pandas DataFrames.

--- a/.github/workflows/triage.py
+++ b/.github/workflows/triage.py
@@ -1,0 +1,227 @@
+"""Triage GitHub issues: generate a comment requesting missing info."""
+# ruff: noqa: T201
+
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+PROMPT_TEMPLATE = """\
+Triage the following GitHub issue and decide whether to request more information \
+from the author.
+
+## Issue Title
+{title}
+
+## Issue Body
+{body}
+
+## Instructions
+Evaluate the issue and return a JSON object with two fields:
+
+- `comment`: A polite comment to post on the issue requesting missing information, \
+or null if no comment is needed. The comment should be concise and specific about \
+what information would help. It may ask for any combination of:
+  - Steps to reproduce the problem (for bug reports without clear repro steps)
+  - Environment info such as OS, Python version, or MLflow version (for bug reports)
+  - Full traceback (for bug reports that mention an error but don't include one)
+  - A screenshot or screen recording (only for issues that would benefit from visual evidence \
+to understand and reproduce, e.g., layout issues, rendering bugs, styling problems — \
+do not request for backend, API, CLI, docs, or performance issues)
+- `reason`: A brief explanation of why you decided to return or not return a comment. \
+This is for internal verification only and will not be shown to the user.
+
+Guidelines:
+- Only request information that is clearly missing and would help investigate the issue.
+- Do not request repro steps if the issue already contains numbered steps, a code snippet, \
+or a clear description of how to trigger the bug.
+- Do not request environment info if OS, Python version, or MLflow version is already provided.
+- Do not request anything for feature requests.
+- When in doubt, return null — only return a comment when information is clearly missing."""
+
+MAX_BODY_LENGTH = 10_000
+
+
+def strip_html_comments(text: str) -> str:
+    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
+
+def build_prompt(title: str, body: str) -> str:
+    body = strip_html_comments(body)
+    return PROMPT_TEMPLATE.format(
+        title=title,
+        body=body[:MAX_BODY_LENGTH],
+    )
+
+
+def call_anthropic_api(prompt: str) -> tuple[dict[str, Any], dict[str, int]]:
+    api_key = os.environ["ANTHROPIC_API_KEY"]
+    request_body = {
+        "model": "claude-haiku-4-5-20251001",
+        "max_tokens": 1024,
+        "temperature": 0,
+        "messages": [{"role": "user", "content": prompt}],
+        "output_config": {
+            "format": {
+                "type": "json_schema",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "comment": {
+                            "type": ["string", "null"],
+                            "description": (
+                                "A comment to post requesting missing information, "
+                                "or null if no comment is needed."
+                            ),
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Brief explanation for the decision.",
+                        },
+                    },
+                    "required": ["comment", "reason"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+    }
+
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=json.dumps(request_body).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            response = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode()
+        print(f"API Error {e.code}: {error_body}", file=sys.stderr)
+        raise
+
+    usage = response.get("usage", {})
+    classification = json.loads(response["content"][0]["text"])
+    return classification, usage
+
+
+# https://docs.anthropic.com/en/docs/about-claude/models#model-comparison-table
+HAIKU_INPUT_COST_PER_MTOK = 1.00
+HAIKU_OUTPUT_COST_PER_MTOK = 5.00
+
+
+def compute_cost(usage: dict[str, int]) -> float:
+    input_tokens = usage.get("input_tokens", 0)
+    output_tokens = usage.get("output_tokens", 0)
+    return (
+        input_tokens * HAIKU_INPUT_COST_PER_MTOK + output_tokens * HAIKU_OUTPUT_COST_PER_MTOK
+    ) / 1_000_000
+
+
+def triage_issue(title: str, body: str) -> dict[str, Any]:
+    prompt = build_prompt(title, body)
+    classification, _ = call_anthropic_api(prompt)
+    return {
+        "comment": classification["comment"],
+        "reason": classification["reason"],
+    }
+
+
+GREEN = "\033[32m"
+RED = "\033[31m"
+RESET = "\033[0m"
+
+
+def parse_dataset(path: Path) -> list[dict[str, str]]:
+    text = path.read_text()
+    issues = []
+    for section in re.split(r"\n---\n", text):
+        header_match = re.search(r"^## (.+)$", section, re.MULTILINE)
+        title_match = re.search(r"\*\*Title:\*\*\s*(.+)$", section, re.MULTILINE)
+        body_match = re.search(r"\*\*Body:\*\*\s*\n(.*)", section, re.DOTALL)
+        if header_match and title_match and body_match:
+            issues.append(
+                {
+                    "header": header_match.group(1).strip(),
+                    "title": title_match.group(1).strip(),
+                    "body": body_match.group(1).strip(),
+                }
+            )
+    return issues
+
+
+def triage_synthetic(title: str, body: str) -> tuple[dict[str, Any], dict[str, int]]:
+    prompt = build_prompt(title, body)
+    classification, usage = call_anthropic_api(prompt)
+    return {
+        "title": title,
+        "comment": classification["comment"],
+        "reason": classification["reason"],
+    }, usage
+
+
+def run_tests() -> None:
+    dataset_path = Path(__file__).parent / "triage.md"
+    issues = parse_dataset(dataset_path)
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = {
+            executor.submit(triage_synthetic, issue["title"], issue["body"]): issue
+            for issue in issues
+        }
+
+    total_usage = {"input_tokens": 0, "output_tokens": 0}
+
+    for future in futures:
+        issue = futures[future]
+        result, usage = future.result()
+        for k in total_usage:
+            total_usage[k] += usage.get(k, 0)
+
+        has_comment = result["comment"] is not None
+        color = RED if has_comment else GREEN
+        print(f"{color}{issue['header']}{RESET}")
+        print(f"  reason: {result['reason']}")
+        if result["comment"]:
+            print(f"  comment: {result['comment'][:200]}")
+
+    cost = compute_cost(total_usage)
+    print(
+        f"\nTokens: {total_usage['input_tokens']} input, {total_usage['output_tokens']} output"
+        f" (${cost:.4f})"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Triage GitHub issues")
+    subparsers = parser.add_subparsers(dest="command")
+
+    triage_parser = subparsers.add_parser("triage")
+    triage_parser.add_argument("--title", required=True)
+    triage_parser.add_argument("--body", default="")
+
+    subparsers.add_parser("test")
+
+    args = parser.parse_args()
+    match args.command:
+        case "triage":
+            result = triage_issue(args.title, args.body)
+            print(json.dumps(result))
+        case "test":
+            run_tests()
+        case _:
+            parser.print_help()
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,75 @@
+name: triage
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    paths:
+      - .github/workflows/triage.yml
+      - .github/workflows/triage.py
+      - .github/workflows/triage.md
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Test job: runs on PR changes against a fixed set of issues
+  test:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions: {}
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: |
+            .github/workflows/triage.py
+            .github/workflows/triage.md
+          sparse-checkout-cone-mode: false
+
+      - run: python .github/workflows/triage.py test
+
+  # Production job: runs on new issues
+  # Scoped to area/uiux for now; expand to other labels once we validate the results.
+  classify:
+    if: >-
+      github.event_name == 'issues'
+      && contains(github.event.issue.labels.*.name, 'area/uiux')
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/workflows/triage.py
+          sparse-checkout-cone-mode: false
+
+      - name: Triage issue
+        id: triage
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          result=$(python .github/workflows/triage.py triage --title "$ISSUE_TITLE" --body "$ISSUE_BODY")
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+
+      - name: Comment and label if info needed
+        if: fromJSON(steps.triage.outputs.result).comment
+        env:
+          COMMENT: ${{ fromJSON(steps.triage.outputs.result).comment }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$COMMENT
+
+          ---
+          [Workflow run]($RUN_URL)"
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs author feedback"


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

Add a GitHub Actions workflow that uses Claude Haiku to triage new issues labeled `area/uiux`. It checks for missing information (repro steps, environment info, tracebacks, screenshots) and posts a comment requesting what's needed.

Scoped to `area/uiux` for now; the prompt and workflow are designed to be easily extended to other label types in the future (e.g., by adding label-specific conditions or prompt adjustments).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

The workflow includes a `test` job that classifies 10 synthetic issues (in `triage.md`) and prints the results. The test runs on PRs touching the workflow files.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)