### PR TITLE
Add missing workspace awareness in tracking store queries

### DIFF
--- a/tests/store/test_workspace_model_coverage.py
+++ b/tests/store/test_workspace_model_coverage.py
@@ -1,0 +1,90 @@
+"""Verify that every SQLAlchemy model with a ``workspace`` column is handled
+by at least one workspace store's ``_get_query`` method.
+
+If a new model is added with a ``workspace`` column but the developer forgets
+to add it to ``_get_query``, that model's queries will bypass workspace
+isolation.  This test catches that gap.
+"""
+
+import ast
+from pathlib import Path
+
+# Explicitly import all dbmodel modules so that every ORM model is registered
+# with Base.registry before we inspect mappers.
+import mlflow.store.model_registry.dbmodels.models  # noqa: F401
+import mlflow.store.tracking.dbmodels.models  # noqa: F401
+import mlflow.store.workspace.dbmodels.models  # noqa: F401
+from mlflow.store.db.base_sql_model import Base
+
+# Locate the repository root relative to this test file so that workspace
+# store paths resolve correctly regardless of the pytest working directory.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Every workspace store that provides a ``_get_query`` override.
+WORKSPACE_STORE_PATHS = [
+    "mlflow/store/tracking/sqlalchemy_workspace_store.py",
+    "mlflow/store/model_registry/sqlalchemy_workspace_store.py",
+    "mlflow/store/jobs/sqlalchemy_workspace_store.py",
+]
+
+
+def _models_handled_by_get_query(ws_path: str) -> set[str]:
+    """Parse a workspace store file and return the ``Sql*`` model names
+    referenced in comparisons inside its ``_get_query`` method.
+    """
+    tree = ast.parse((_REPO_ROOT / ws_path).read_text())
+
+    # Collect module-level variables holding Sql* names (e.g. tuples of models)
+    var_models: dict[str, set[str]] = {}
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names = {
+                        n.id
+                        for n in ast.walk(node.value)
+                        if isinstance(n, ast.Name) and n.id.startswith("Sql")
+                    }
+                    if names:
+                        var_models[target.id] = names
+
+    # Extract model names from _get_query comparisons
+    models: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name != "_get_query":
+            continue
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Compare):
+                continue
+            for comp in inner.comparators:
+                models |= {
+                    n.id
+                    for n in ast.walk(comp)
+                    if isinstance(n, ast.Name) and n.id.startswith("Sql")
+                }
+                if isinstance(comp, ast.Name) and comp.id in var_models:
+                    models |= var_models[comp.id]
+    return models
+
+
+def test_all_workspace_models_handled_in_get_query():
+    """Every model with a workspace column must appear in at least one
+    workspace store's ``_get_query``.
+    """
+    handled: set[str] = set()
+    for ws_path in WORKSPACE_STORE_PATHS:
+        handled |= _models_handled_by_get_query(ws_path)
+
+    models_with_column: set[str] = set()
+    for mapper in Base.registry.mappers:
+        if "workspace" in {col.key for col in mapper.columns}:
+            models_with_column.add(mapper.class_.__name__)
+
+    missing = models_with_column - handled
+    assert not missing, (
+        f"These models have a `workspace` column but are not handled by any "
+        f"workspace store's _get_query: {sorted(missing)}. "
+        f"Add handling in the appropriate workspace store's _get_query method."
+    )


### PR DESCRIPTION
### Related Issues/PRs

This commit is also included in #20706, which includes a linter to catch these.

#1464
#5844
Design document: https://docs.google.com/document/d/1IbFfceCmWV3knJfc0ninn58EXLVbHUh1meV_pknOM40/edit

### What changes are proposed in this pull request?

Fix workspace isolation gaps found after rebase.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
