### PR TITLE
Add a clint rule to catch missing workspace aware database queries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,14 @@ Claude's training data may lag behind current releases. When reviewing docs or c
 - Use top-level imports (only use lazy imports when necessary)
 - Only add docstrings in tests when they provide additional context
 - Only add comments that explain non-obvious logic or provide additional context
-- When touching the SQLAlchemy tracking store, keep all workspace-aware paths and validations intact; never drop workspace plumbing even if the change focuses on single-tenant behavior
+- When touching the SQLAlchemy tracking store, keep all workspace-aware paths and validations intact; never drop workspace plumbing even if the change focuses on non-workspace behavior
 - New functionality in the tracking layer should be mirrored by workspace-aware tests (e.g., add workspace variants in `tests/store/tracking/test_sqlalchemy_store_workspace.py` when applicable)
+- The SQLAlchemy stores use a base/workspace subclass architecture for workspace-level isolation. Base stores (`sqlalchemy_store.py`) define hooks that workspace-aware subclasses (`sqlalchemy_workspace_store.py`) override to add workspace filtering. When adding new store methods:
+  - Use `self._get_query(session, Model)` instead of `session.query(Model)` for workspace-isolated models (subclasses of `WorkspaceIsolatedModel`)
+  - When operating on a specific entity by ID, call the appropriate validation helper to confirm it belongs to the current workspace
+  - If new behavior needs workspace-specific filtering, add a hook in the base store and override it in the workspace subclass
+  - New database models that require workspace isolation must subclass `WorkspaceIsolatedModel` and implement `workspace_query_filter`
+  - Run `uv run clint mlflow/store/` to check for workspace isolation violations
 
 ## Repository Overview
 

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -394,6 +394,7 @@ class Linter(ast.NodeVisitor):
         self.ignored_rules = get_ignored_rules_for_file(path, config.per_file_ignores)
         self.prev_stmt: ast.stmt | None = None
         self.used_disables: set[tuple[str, int]] = set()
+        self.node_stack: list[ast.AST] = []
 
     def _check(self, range: Range, rule: rules.Rule) -> None:
         # Skip rules that are not selected in the config
@@ -501,7 +502,9 @@ class Linter(ast.NodeVisitor):
             self._check(Range.from_node(docstring_node), rules.RedundantTestDocstring())
 
     def visit(self, node: ast.AST) -> None:
+        self.node_stack.append(node)
         super().visit(node)
+        self.node_stack.pop()
         if isinstance(node, ast.stmt):
             self.prev_stmt = node
 
@@ -518,6 +521,12 @@ class Linter(ast.NodeVisitor):
             return False
 
         return self.stack[-1].name.startswith("test_")
+
+    def _current_function_name(self) -> str | None:
+        for node in reversed(self.stack):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                return node.name
+        return None
 
     @classmethod
     def visit_example(
@@ -771,6 +780,15 @@ class Linter(ast.NodeVisitor):
         )
 
     def visit_Call(self, node: ast.Call) -> None:
+        if rules.WorkspaceQueryIsolation.name in self.config.select:
+            if rules.WorkspaceQueryIsolation.check(
+                node,
+                path=self.path,
+                function_name=self._current_function_name(),
+                ancestors=self.node_stack,
+            ):
+                self._check(Range.from_node(node), rules.WorkspaceQueryIsolation())
+
         if (
             self.is_mlflow_init_py
             and isinstance(node.func, ast.Name)

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -55,6 +55,7 @@ from clint.rules.use_gh_token import UseGhToken
 from clint.rules.use_sys_executable import UseSysExecutable
 from clint.rules.use_walrus_operator import UseWalrusOperator, WalrusOperatorVisitor
 from clint.rules.version_major_check import MajorVersionCheck
+from clint.rules.workspace_query_isolation import WorkspaceQueryIsolation
 
 ALL_RULES = {rule.name for rule in Rule.__subclasses__()}
 
@@ -117,4 +118,5 @@ __all__ = [
     "UseWalrusOperator",
     "WalrusOperatorVisitor",
     "MajorVersionCheck",
+    "WorkspaceQueryIsolation",
 ]

--- a/dev/clint/src/clint/rules/workspace_query_isolation.py
+++ b/dev/clint/src/clint/rules/workspace_query_isolation.py
@@ -1,0 +1,309 @@
+import ast
+from collections.abc import Iterator
+from functools import lru_cache
+from pathlib import Path
+
+from clint.rules.base import Rule
+
+# Map each base store path to its workspace-aware counterpart.
+_TRACKING = "mlflow/store/tracking"
+_REGISTRY = "mlflow/store/model_registry"
+_JOBS = "mlflow/store/jobs"
+WORKSPACE_STORE_PATHS = {
+    f"{_TRACKING}/sqlalchemy_store.py": f"{_TRACKING}/sqlalchemy_workspace_store.py",
+    f"{_REGISTRY}/sqlalchemy_store.py": f"{_REGISTRY}/sqlalchemy_workspace_store.py",
+    f"{_JOBS}/sqlalchemy_store.py": f"{_JOBS}/sqlalchemy_workspace_store.py",
+}
+BASE_STORE_PATHS = set(WORKSPACE_STORE_PATHS)
+# Methods that intentionally don't need workspace isolation (e.g., DB setup).
+ALLOWLISTED_METHODS = {"_initialize_store_state"}
+
+# Per-model coverage for workspace helpers.  When a method calls one of these
+# helpers via ``self``, only queries on the listed models are trusted.
+# New workspace helpers must be added here to be recognized by the linter.
+#
+# Child models (e.g. SqlMetric, SqlTag) that derive workspace scope from a
+# validated parent are listed under the helper that validates the parent.
+HELPER_MODEL_COVERAGE: dict[str, frozenset[str]] = {
+    # --- Experiment-level validation ---
+    "get_experiment": frozenset(
+        {"SqlExperiment", "SqlExperimentTag", "SqlScorer", "SqlScorerVersion"}
+    ),
+    "get_experiment_by_name": frozenset({"SqlExperiment"}),
+    "_get_experiment": frozenset({"SqlExperiment", "SqlExperimentTag"}),
+    "_experiment_where_clauses": frozenset({"SqlExperiment"}),
+    "_filter_experiment_ids": frozenset({"SqlExperiment", "SqlDataset", "SqlInputTag"}),
+    # --- Run-level validation ---
+    "_validate_run_accessible": frozenset(
+        {"SqlRun", "SqlMetric", "SqlTag", "SqlEntityAssociation"}
+    ),
+    "_get_run": frozenset(
+        {
+            "SqlRun",
+            "SqlMetric",
+            "SqlLatestMetric",
+            "SqlTag",
+            "SqlInput",
+            "SqlInputTag",
+            "SqlDataset",
+            "SqlLoggedModelMetric",
+        }
+    ),
+    # --- Trace-level validation ---
+    "_validate_trace_accessible": frozenset(
+        {
+            "SqlTraceInfo",
+            "SqlAssessments",
+            "SqlTraceTag",
+            "SqlTraceMetadata",
+            "SqlEntityAssociation",
+        }
+    ),
+    "_trace_query": frozenset({"SqlTraceInfo", "SqlTraceMetadata"}),
+    "_get_sql_assessment": frozenset({"SqlAssessments"}),
+    # --- Dataset-level validation ---
+    "_validate_dataset_accessible": frozenset(
+        {"SqlEvaluationDataset", "SqlEvaluationDatasetRecord", "SqlEvaluationDatasetTag"}
+    ),
+    "_dataset_query": frozenset(
+        {
+            "SqlEvaluationDataset",
+            "SqlEvaluationDatasetRecord",
+            "SqlEvaluationDatasetTag",
+            "SqlEntityAssociation",
+        }
+    ),
+    # --- Logged model validation ---
+    "_get_logged_model_record": frozenset(
+        {"SqlLoggedModel", "SqlLoggedModelTag", "SqlLoggedModelParam"}
+    ),
+    # --- Entity ID / association filtering (workspace overrides) ---
+    "_filter_entity_ids": frozenset({"SqlMetric", "SqlEntityAssociation"}),
+    "_filter_association_query": frozenset({"SqlEntityAssociation"}),
+    # --- Endpoint-level validation ---
+    "_filter_endpoint_binding_query": frozenset({"SqlGatewayEndpointBinding"}),
+    # --- Webhook validation ---
+    "_get_webhook_by_id": frozenset({"SqlWebhook", "SqlWebhookEvent"}),
+}
+
+# Model definition files to discover WorkspaceIsolatedModel subclasses.
+MODEL_FILE_PATHS = [
+    "mlflow/store/tracking/dbmodels/models.py",
+    "mlflow/store/model_registry/dbmodels/models.py",
+]
+
+
+@lru_cache(maxsize=None)
+def _get_workspace_overrides(base_store_posix: str) -> frozenset[str]:
+    """Discover methods overridden by the corresponding workspace store.
+
+    For a base store at ``mlflow/store/tracking/sqlalchemy_store.py``, this
+    reads ``mlflow/store/tracking/sqlalchemy_workspace_store.py`` and returns
+    the set of method names defined in the workspace-aware class.  These
+    methods are "workspace extension points" — the workspace store replaces
+    them at runtime to add filtering.
+    """
+    tree = _parse_file(Path(WORKSPACE_STORE_PATHS[base_store_posix]))
+    methods: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    methods.add(item.name)
+    return frozenset(methods)
+
+
+@lru_cache(maxsize=None)
+def _get_workspace_isolated_models() -> frozenset[str]:
+    """Discover models that require workspace-aware queries.
+
+    Includes both ``WorkspaceIsolatedModel`` subclasses (which go through
+    ``_get_query``) and models listed in ``HELPER_MODEL_COVERAGE`` (child
+    models that inherit workspace scope through parent validation).
+    """
+    models: set[str] = set()
+    for path_str in MODEL_FILE_PATHS:
+        tree = _parse_file(Path(path_str))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and _has_workspace_isolated_base(node):
+                models.add(node.name)
+    if not models:
+        raise RuntimeError(
+            "No WorkspaceIsolatedModel subclasses found. "
+            "Has the mixin or model file structure been refactored?"
+        )
+    for covered_models in HELPER_MODEL_COVERAGE.values():
+        models.update(covered_models)
+    return frozenset(models)
+
+
+def _has_workspace_isolated_base(node: ast.ClassDef) -> bool:
+    """Return True if *node* lists ``WorkspaceIsolatedModel`` in its bases."""
+    for base in node.bases:
+        if isinstance(base, ast.Name) and base.id == "WorkspaceIsolatedModel":
+            return True
+        if isinstance(base, ast.Attribute) and base.attr == "WorkspaceIsolatedModel":
+            return True
+    return False
+
+
+@lru_cache(maxsize=None)
+def _parse_file(path: Path) -> ast.Module:
+    return ast.parse(path.read_text())
+
+
+class WorkspaceQueryIsolation(Rule):
+    def _message(self) -> str:
+        return (
+            "Direct session.query() on a workspace-isolated model must go through "
+            "self._get_query(...) or a workspace-aware helper for workspace filtering."
+        )
+
+    @staticmethod
+    def check(
+        node: ast.Call,
+        *,
+        path: Path,
+        function_name: str | None,
+        ancestors: list[ast.AST],
+    ) -> bool:
+        if path.as_posix() not in BASE_STORE_PATHS:
+            return False
+        if not function_name:
+            return False
+        # For a chain like session.query(X).filter(...).all(), only check the
+        # outermost call (.all()) to avoid reporting the same chain multiple times.
+        if not _is_outermost_call(node, ancestors):
+            return False
+        # Chains rooted in self._get_query() or self._trace_query() are already
+        # workspace-aware — only flag direct session.query() chains.
+        if not _is_direct_session_query(node):
+            return False
+
+        workspace_models = _get_workspace_isolated_models()
+        queried_models = _get_queried_models(node)
+        isolated = queried_models & workspace_models
+        if not isolated:
+            return False
+
+        method_name, method_node = _get_enclosing_class_method(ancestors)
+        if not method_name:
+            return False
+        if method_name in ALLOWLISTED_METHODS:
+            return False
+
+        workspace_overrides = _get_workspace_overrides(path.as_posix())
+        # The workspace store overrides this method, so its base implementation
+        # is replaced at runtime with a workspace-filtered version.
+        if method_name in workspace_overrides:
+            return False
+        # Per-model trust: check which models the method's workspace helpers
+        # actually protect, and only trust queries on those specific models.
+        safe_methods = workspace_overrides | frozenset(HELPER_MODEL_COVERAGE)
+        if method_node is not None:
+            protected = _get_protected_models(id(method_node), method_node, safe_methods)
+            if isolated <= protected:
+                return False
+
+        return True
+
+
+def _is_outermost_call(node: ast.Call, ancestors: list[ast.AST]) -> bool:
+    """Return False if this call is an inner part of a larger method chain."""
+    if len(ancestors) < 3:
+        return True
+    parent = ancestors[-2]
+    grandparent = ancestors[-3]
+    return not (
+        isinstance(parent, ast.Attribute)
+        and parent.value is node
+        and isinstance(grandparent, ast.Call)
+        and grandparent.func is parent
+    )
+
+
+def _iter_call_chain(node: ast.Call) -> Iterator[ast.Call]:
+    """Yield calls in a method chain like ``session.query(...).filter(...).all()``."""
+    current: ast.Call | None = node
+    while isinstance(current, ast.Call) and isinstance(current.func, ast.Attribute):
+        yield current
+        current = current.func.value if isinstance(current.func.value, ast.Call) else None
+
+
+def _is_direct_session_query(node: ast.Call) -> bool:
+    """Return True if this chain originates from a direct ``.query()`` call.
+
+    Returns False for chains starting with ``self._get_query(...)`` or other
+    ``self.<method>(...)`` calls since those are workspace-aware helpers.
+    """
+    for call in _iter_call_chain(node):
+        if not isinstance(call.func, ast.Attribute):
+            continue
+        if call.func.attr == "query":
+            # .query() on self (e.g. self.query()) is not a session query
+            if isinstance(call.func.value, ast.Name) and call.func.value.id == "self":
+                return False
+            return True
+    return False
+
+
+def _get_queried_models(node: ast.Call) -> frozenset[str]:
+    """Extract all ``Sql*`` model names from the ``session.query()`` in the chain."""
+    models: set[str] = set()
+    for call in _iter_call_chain(node):
+        if not isinstance(call.func, ast.Attribute) or call.func.attr != "query":
+            continue
+        for arg in call.args:
+            for inner in ast.walk(arg):
+                if isinstance(inner, ast.Name) and inner.id.startswith("Sql"):
+                    models.add(inner.id)
+    return frozenset(models)
+
+
+def _get_enclosing_class_method(
+    ancestors: list[ast.AST],
+) -> tuple[str | None, ast.FunctionDef | ast.AsyncFunctionDef | None]:
+    """Find the enclosing method defined directly in a class."""
+    for i in range(len(ancestors) - 1, 0, -1):
+        node = ancestors[i]
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and isinstance(
+            ancestors[i - 1], ast.ClassDef
+        ):
+            return node.name, node
+    return None, None
+
+
+@lru_cache(maxsize=None)
+def _get_protected_models(
+    _method_id: int,
+    method_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    safe_methods: frozenset[str],
+) -> frozenset[str]:
+    """Return models protected by workspace helpers called via ``self``.
+
+    Returns an empty frozenset if no recognized workspace helpers are called.
+    Results are cached per method node to avoid repeated AST walks.
+    ``_method_id`` (``id(method_node)``) is safe as a cache key because AST
+    nodes live for the entire file traversal, so ids are not recycled.
+    """
+    protected: set[str] = set()
+    for node in ast.walk(method_node):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "self"
+            and node.func.attr in safe_methods
+        ):
+            continue
+        helper_name = node.func.attr
+        if helper_name in HELPER_MODEL_COVERAGE:
+            protected.update(HELPER_MODEL_COVERAGE[helper_name])
+        elif helper_name == "_get_query" and len(node.args) >= 2:
+            model_arg = node.args[1]
+            if isinstance(model_arg, ast.Name) and model_arg.id.startswith("Sql"):
+                protected.add(model_arg.id)
+        # Helpers not in HELPER_MODEL_COVERAGE and not _get_query are ignored —
+        # they don't contribute any model coverage.  This is intentionally
+        # strict: new helpers must be added to the mapping to be recognized.
+    return frozenset(protected)

--- a/dev/clint/tests/rules/test_workspace_query_isolation.py
+++ b/dev/clint/tests/rules/test_workspace_query_isolation.py
@@ -1,0 +1,369 @@
+from collections.abc import Generator
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import patch
+
+import pytest
+from clint.config import Config
+from clint.linter import Violation, lint_file
+from clint.rules.workspace_query_isolation import (
+    WorkspaceQueryIsolation,
+    _get_protected_models,
+    _get_workspace_isolated_models,
+    _get_workspace_overrides,
+    _parse_file,
+)
+
+BASE_STORE_PATH = Path("mlflow/store/tracking/sqlalchemy_store.py")
+
+# Simulated workspace overrides (methods the workspace store overrides).
+MOCK_WORKSPACE_OVERRIDES = frozenset(
+    {
+        "__init__",
+        "_get_query",
+        "_trace_query",
+        "_validate_run_accessible",
+        "_validate_trace_accessible",
+        "_validate_dataset_accessible",
+        "_create_default_experiment",
+        "_initialize_store_state",
+    }
+)
+
+# Simulated workspace-isolated models (WorkspaceIsolatedModel subclasses).
+MOCK_WORKSPACE_MODELS = frozenset(
+    {
+        "SqlExperiment",
+        "SqlRun",
+        "SqlTraceInfo",
+        "SqlLoggedModel",
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_workspace_discovery() -> Generator[None, None, None]:
+    _get_workspace_overrides.cache_clear()
+    _get_workspace_isolated_models.cache_clear()
+    _get_protected_models.cache_clear()
+    _parse_file.cache_clear()
+    with (
+        patch(
+            "clint.rules.workspace_query_isolation._get_workspace_overrides",
+            return_value=MOCK_WORKSPACE_OVERRIDES,
+        ),
+        patch(
+            "clint.rules.workspace_query_isolation._get_workspace_isolated_models",
+            return_value=MOCK_WORKSPACE_MODELS,
+        ),
+    ):
+        yield
+    _get_workspace_overrides.cache_clear()
+    _get_workspace_isolated_models.cache_clear()
+    _get_protected_models.cache_clear()
+    _parse_file.cache_clear()
+
+
+def _lint(code: str, index_path: Path, path: Path = BASE_STORE_PATH) -> list[Violation]:
+    config = Config(select={WorkspaceQueryIsolation.name})
+    return lint_file(path, dedent(code).strip() + "\n", config, index_path)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(
+            """
+class Store:
+    def search_runs(self, session):
+        session.query(SqlRun).filter(SqlRun.lifecycle_stage == "deleted").all()
+""",
+            id="public_method_session_query",
+        ),
+        pytest.param(
+            """
+class Store:
+    def _helper(self, session):
+        session.query(SqlRun).filter(SqlRun.run_uuid == "abc").one_or_none()
+""",
+            id="private_method_session_query",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_run(self, session, run_id):
+        session.query(SqlRun).get(run_id)
+""",
+            id="get_call",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_run(self, session, run_id):
+        session.query(SqlRun).filter(SqlRun.run_uuid == run_id).one_or_none()
+""",
+            id="id_filter_no_workspace",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_run(self, session, run_id):
+        session.query(SqlRun).filter_by(run_uuid=run_id).one_or_none()
+""",
+            id="filter_by_id_no_workspace",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_runs(self, session, run_ids):
+        session.query(SqlRun).filter(SqlRun.run_uuid.in_(run_ids)).all()
+""",
+            id="in_filter_no_workspace",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_experiment(self, session, experiment_id):
+        session.query(SqlExperiment).filter(
+            SqlExperiment.experiment_id == experiment_id
+        ).one()
+""",
+            id="workspace_model_direct_query",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_data(self, session, run_id):
+        session.query(SqlTag, SqlRun).filter(SqlRun.run_uuid == run_id).all()
+""",
+            id="multi_model_query_with_isolated_model",
+        ),
+    ],
+)
+def test_flags_session_query(code: str, index_path: Path) -> None:
+    violations = _lint(code, index_path)
+    assert len(violations) == 1
+    assert isinstance(violations[0].rule, WorkspaceQueryIsolation)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(
+            """
+class Store:
+    def _get_query(self, session, model):
+        return session.query(model)
+""",
+            id="workspace_override_method",
+        ),
+        pytest.param(
+            """
+class Store:
+    def _trace_query(self, session):
+        return session.query(SqlTraceInfo).all()
+""",
+            id="another_workspace_override",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_run(self, session, run_id):
+        return self._get_query(session, SqlRun).filter(SqlRun.run_uuid == run_id).one()
+""",
+            id="uses_get_query_helper",
+        ),
+        pytest.param(
+            """
+class Store:
+    def delete_tag(self, session, run_id, key):
+        self._validate_run_accessible(session, run_id)
+        session.query(SqlRun).filter(SqlRun.run_uuid == run_id).delete()
+""",
+            id="calls_workspace_helper_then_session_query",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_trace(self, session, trace_id):
+        trace = self._trace_query(session).filter(SqlTraceInfo.request_id == trace_id).one()
+        session.query(SqlTraceInfo).filter(SqlTraceInfo.request_id == trace_id).all()
+""",
+            id="calls_workspace_override_then_session_query",
+        ),
+        pytest.param(
+            """
+class Store:
+    def _initialize_store_state(self, session):
+        session.query(SqlExperiment).filter(SqlExperiment.workspace != "default").first()
+""",
+            id="allowlisted_method",
+        ),
+        pytest.param(
+            """
+class Store:
+    def check(self, session):
+        session.query(SqlRun).count()  # clint: disable=workspace-query-isolation
+""",
+            id="clint_disable_comment",
+        ),
+        pytest.param(
+            """
+class Store:
+    def helper(self, session):
+        session.execute(text("SELECT 1"))
+""",
+            id="non_query_call",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_experiment(self, session, experiment_id):
+        return self._get_query(session, SqlExperiment).filter(
+            SqlExperiment.experiment_id == experiment_id
+        ).one()
+""",
+            id="get_query_chain",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_metric(self, session, run_id, key):
+        self._validate_run_accessible(session, run_id)
+        return session.query(SqlRun).filter(
+            SqlRun.run_uuid == run_id
+        ).first()
+""",
+            id="workspace_helper_protects_workspace_model",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_tag(self, session, run_id, key):
+        return session.query(SqlTag).filter(
+            SqlTag.run_uuid == run_id, SqlTag.key == key
+        ).first()
+""",
+            id="child_model_implicitly_safe",
+        ),
+        pytest.param(
+            """
+class Store:
+    def get_metrics(self, session, run_id):
+        return session.query(SqlMetric).filter(
+            SqlMetric.run_uuid == run_id
+        ).all()
+""",
+            id="non_workspace_model_not_flagged",
+        ),
+    ],
+)
+def test_no_violation(code: str, index_path: Path) -> None:
+    violations = _lint(code, index_path)
+    assert len(violations) == 0
+
+
+def test_ignores_non_base_store_path(index_path: Path) -> None:
+    code = """
+class Store:
+    def search_runs(self, session):
+        session.query(SqlRun).filter(SqlRun.lifecycle_stage == "deleted").all()
+"""
+    violations = _lint(
+        code,
+        index_path,
+        path=Path("mlflow/store/tracking/sqlalchemy_workspace_store.py"),
+    )
+    assert len(violations) == 0
+
+
+def test_inner_function_inherits_method_safety(index_path: Path) -> None:
+    code = """
+class Store:
+    def delete_tag(self, session, run_id, key):
+        self._validate_run_accessible(session, run_id)
+        def _do_delete():
+            session.query(SqlRun).filter(SqlRun.run_uuid == run_id).delete()
+        _do_delete()
+"""
+    violations = _lint(code, index_path)
+    assert len(violations) == 0
+
+
+def test_per_model_trust_flags_unrelated_model(index_path: Path) -> None:
+    code = """
+class Store:
+    def bad_method(self, session, run_id):
+        self._validate_run_accessible(session, run_id)
+        session.query(SqlExperiment).filter(SqlExperiment.experiment_id == "1").first()
+"""
+    violations = _lint(code, index_path)
+    assert len(violations) == 1
+
+
+def test_per_model_trust_unknown_helper_not_trusted(index_path: Path) -> None:
+    code = """
+class Store:
+    def method(self, session):
+        self._create_default_experiment(session)
+        session.query(SqlExperiment).filter(SqlExperiment.experiment_id == "1").first()
+"""
+    violations = _lint(code, index_path)
+    assert len(violations) == 1
+
+
+def test_per_model_trust_get_query_extracts_model(index_path: Path) -> None:
+    code = """
+class Store:
+    def method(self, session, run_id):
+        ws_query = self._get_query(session, SqlRun)
+        session.query(SqlRun).filter(SqlRun.run_uuid == run_id).first()
+"""
+    violations = _lint(code, index_path)
+    assert len(violations) == 0
+
+
+def test_experiment_helper_does_not_protect_run(index_path: Path) -> None:
+    """Without MODEL_CHILDREN, validating an experiment does not trust
+    queries on child models like SqlRun.
+    """
+    code = """
+class Store:
+    def method(self, session, experiment_id):
+        experiment = self.get_experiment(experiment_id)
+        session.query(SqlRun).filter(SqlRun.experiment_id == experiment.experiment_id).all()
+"""
+    violations = _lint(code, index_path)
+    assert len(violations) == 1
+
+
+def test_model_registry_store_path(index_path: Path) -> None:
+    code = """
+class Store:
+    def get_model(self, session, name):
+        session.query(SqlRegisteredModel).filter(SqlRegisteredModel.name == name).one()
+"""
+    registry_models = frozenset({"SqlRegisteredModel", "SqlModelVersion"})
+    with patch(
+        "clint.rules.workspace_query_isolation._get_workspace_isolated_models",
+        return_value=registry_models,
+    ):
+        violations = _lint(
+            code,
+            index_path,
+            path=Path("mlflow/store/model_registry/sqlalchemy_store.py"),
+        )
+    assert len(violations) == 1
+
+
+def test_inner_function_without_helper_flagged(index_path: Path) -> None:
+    code = """
+class Store:
+    def get_runs(self, session):
+        def _fetch():
+            return session.query(SqlRun).all()
+        return _fetch()
+"""
+    violations = _lint(code, index_path)
+    assert len(violations) == 1
+    assert isinstance(violations[0].rule, WorkspaceQueryIsolation)

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -311,30 +311,28 @@ def _get_request_param(param: str) -> str:
 
 def _get_permission_from_store_or_default(
     store_permission_func: Callable[[], str],
-    workspace_level_permission_func: Callable[[], Permission | None] | None = None,
+    workspace_level_permission_func: Callable[[], Permission | None],
 ) -> Permission:
     """
-    Resolve a permission from the auth store, with an optional workspace-aware fallback.
+    Resolve a permission from the auth store, with a workspace-aware fallback.
 
     Behavior:
     - If a direct (resource-level) permission exists, it is returned.
     - If no direct permission exists and workspaces are enabled, callers provide
       ``workspace_level_permission_func`` to check workspace-level permissions for the resource's
       workspace. This fallback should default to ``NO_PERMISSIONS`` to preserve workspace isolation.
-    - If workspace permissions are not applicable (e.g. workspaces are disabled and the func
-      returns ``None``), fall back to ``auth_config.default_permission``.
+    - If workspaces are disabled, fall back to ``auth_config.default_permission``.
     - Unexpected errors are propagated rather than granting access.
     """
     try:
         perm = store_permission_func()
     except MlflowException as e:
         if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
-            if workspace_level_permission_func is not None:
+            if MLFLOW_ENABLE_WORKSPACES.get():
                 workspace_permission = workspace_level_permission_func()
-                # workspace_permission is only None when workspaces are not enabled.
-                # workspace_permission defaults to NO_PERMISSIONS. In effect, this means that
-                # auth_config.default_permission is not supported when workspaces are enabled
-                # to keep workspace isolation.
+                # workspace_permission defaults to NO_PERMISSIONS when workspaces are
+                # enabled, so auth_config.default_permission is intentionally bypassed
+                # to preserve workspace isolation.
                 if workspace_permission is not None:
                     return workspace_permission
             perm = auth_config.default_permission

--- a/mlflow/store/db/workspace_isolated_model.py
+++ b/mlflow/store/db/workspace_isolated_model.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+
+
+class WorkspaceIsolatedModel:
+    """Mixin for DB models that require workspace-scoped queries.
+
+    Models that participate in workspace isolation must subclass this mixin and
+    implement :meth:`workspace_query_filter` to define how queries on the model
+    are restricted to a given workspace.
+
+    Note: this class intentionally does not inherit from ``ABC`` because
+    SQLAlchemy's ``DeclarativeMeta`` is incompatible with ``ABCMeta``.
+    The ``@abstractmethod`` decorator serves as documentation; actual
+    enforcement is provided by ``test_all_workspace_isolated_models_implement_filter``.
+    """
+
+    @classmethod
+    @abstractmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        """Apply workspace filtering to *query* and return the filtered query.
+
+        Implementations should use one of three strategies depending on the
+        model's schema:
+
+        - **Direct column filter** — the model has its own ``workspace`` column:
+          ``return query.filter(cls.workspace == workspace)``
+
+        - **Join filter** — the model inherits workspace through a FK parent:
+          ``return query.join(Parent, ...).filter(Parent.workspace == workspace)``
+
+        - **Subquery filter** — join is not possible or not efficient:
+          ``return query.filter(cls.parent_id.in_(subquery))``
+        """

--- a/mlflow/store/jobs/sqlalchemy_workspace_store.py
+++ b/mlflow/store/jobs/sqlalchemy_workspace_store.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import logging
 
+from mlflow.store.db.workspace_isolated_model import WorkspaceIsolatedModel
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
-from mlflow.store.tracking.dbmodels.models import SqlJob
 from mlflow.store.workspace_aware_mixin import WorkspaceAwareMixin
 
 _logger = logging.getLogger(__name__)
@@ -25,13 +25,8 @@ class WorkspaceAwareSqlAlchemyJobStore(WorkspaceAwareMixin, SqlAlchemyJobStore):
         super().__init__(db_uri)
 
     def _get_query(self, session, model):
-        """
-        Return a query for ``model`` filtered by the active workspace.
-        """
+        """Return a query for ``model`` filtered by the active workspace."""
         query = super()._get_query(session, model)
-        workspace = self._get_active_workspace()
-
-        if model is SqlJob:
-            return query.filter(SqlJob.workspace == workspace)
-
+        if issubclass(model, WorkspaceIsolatedModel):
+            return model.workspace_query_filter(query, session, self._get_active_workspace())
         return query

--- a/mlflow/store/model_registry/dbmodels/models.py
+++ b/mlflow/store/model_registry/dbmodels/models.py
@@ -32,12 +32,17 @@ from mlflow.entities.webhook import (
 )
 from mlflow.environment_variables import MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY
 from mlflow.store.db.base_sql_model import Base
+from mlflow.store.db.workspace_isolated_model import WorkspaceIsolatedModel
 from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 
-class SqlRegisteredModel(Base):
+class SqlRegisteredModel(WorkspaceIsolatedModel, Base):
     __tablename__ = "registered_models"
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     workspace = Column(
         String(63),
@@ -94,8 +99,12 @@ class SqlRegisteredModel(Base):
         )
 
 
-class SqlModelVersion(Base):
+class SqlModelVersion(WorkspaceIsolatedModel, Base):
     __tablename__ = "model_versions"
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     workspace = Column(
         String(63),
@@ -165,8 +174,12 @@ class SqlModelVersion(Base):
         )
 
 
-class SqlRegisteredModelTag(Base):
+class SqlRegisteredModelTag(WorkspaceIsolatedModel, Base):
     __tablename__ = "registered_model_tags"
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     workspace = Column(
         String(63),
@@ -203,8 +216,12 @@ class SqlRegisteredModelTag(Base):
         return RegisteredModelTag(self.key, self.value)
 
 
-class SqlModelVersionTag(Base):
+class SqlModelVersionTag(WorkspaceIsolatedModel, Base):
     __tablename__ = "model_version_tags"
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     workspace = Column(
         String(63),
@@ -246,8 +263,12 @@ class SqlModelVersionTag(Base):
         return ModelVersionTag(self.key, self.value)
 
 
-class SqlRegisteredModelAlias(Base):
+class SqlRegisteredModelAlias(WorkspaceIsolatedModel, Base):
     __tablename__ = "registered_model_aliases"
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     workspace = Column(
         String(63),
@@ -311,8 +332,12 @@ class EncryptedString(TypeDecorator):
         return value
 
 
-class SqlWebhook(Base):
+class SqlWebhook(WorkspaceIsolatedModel, Base):
     __tablename__ = "webhooks"
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     workspace = Column(
         String(63),

--- a/mlflow/store/model_registry/sqlalchemy_workspace_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_workspace_store.py
@@ -6,27 +6,11 @@ from __future__ import annotations
 
 import logging
 
-from mlflow.store.model_registry.dbmodels.models import (
-    SqlModelVersion,
-    SqlModelVersionTag,
-    SqlRegisteredModel,
-    SqlRegisteredModelAlias,
-    SqlRegisteredModelTag,
-    SqlWebhook,
-)
+from mlflow.store.db.workspace_isolated_model import WorkspaceIsolatedModel
 from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.workspace_aware_mixin import WorkspaceAwareMixin
 
 _logger = logging.getLogger(__name__)
-
-_WORKSPACE_ISOLATED_MODELS = (
-    SqlRegisteredModel,
-    SqlModelVersion,
-    SqlWebhook,
-    SqlRegisteredModelTag,
-    SqlModelVersionTag,
-    SqlRegisteredModelAlias,
-)
 
 
 class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
@@ -41,15 +25,10 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
         super().__init__(db_uri)
 
     def _get_query(self, session, model):
-        """
-        Return a query for ``model`` filtered by the active workspace.
-        """
+        """Return a query for ``model`` filtered by the active workspace."""
         query = super()._get_query(session, model)
-        workspace = self._get_active_workspace()
-
-        if model in _WORKSPACE_ISOLATED_MODELS:
-            return query.filter(model.workspace == workspace)
-
+        if issubclass(model, WorkspaceIsolatedModel):
+            return model.workspace_query_filter(query, session, self._get_active_workspace())
         return query
 
     def _initialize_store_state(self):
@@ -59,16 +38,8 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
         In workspace mode, we skip the non-default workspace validation since
         having entries in different workspaces is expected and correct behavior.
         """
-        # No validation needed in workspace-aware mode - entries in different
-        # workspaces are expected and correct behavior
 
     def _get_workspace_clauses(self, model):
-        """
-        Return workspace filter clauses for the model.
-        """
-        workspace = self._get_active_workspace()
-
-        if model in _WORKSPACE_ISOLATED_MODELS:
-            return [model.workspace == workspace]
-
+        if issubclass(model, WorkspaceIsolatedModel):
+            return [model.workspace == self._get_active_workspace()]
         return []

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -79,6 +79,7 @@ from mlflow.entities.trace_state import TraceState
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers.online.entities import OnlineScoringConfig
 from mlflow.store.db.base_sql_model import Base
+from mlflow.store.db.workspace_isolated_model import WorkspaceIsolatedModel
 from mlflow.tracing.utils import generate_assessment_id
 from mlflow.utils.mlflow_tags import MLFLOW_USER, _get_run_name_from_tags
 from mlflow.utils.time import get_current_time_millis
@@ -105,10 +106,14 @@ RunStatusTypes = [
 MutableJSON = MutableDict.as_mutable(JSON)
 
 
-class SqlExperiment(Base):
+class SqlExperiment(WorkspaceIsolatedModel, Base):
     """
     DB model for :py:class:`mlflow.entities.Experiment`. These are recorded in ``experiment`` table.
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     __tablename__ = "experiments"
 
@@ -181,10 +186,16 @@ class SqlExperiment(Base):
         )
 
 
-class SqlRun(Base):
+class SqlRun(WorkspaceIsolatedModel, Base):
     """
     DB model for :py:class:`mlflow.entities.Run`. These are recorded in ``runs`` table.
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.join(SqlExperiment, SqlExperiment.experiment_id == cls.experiment_id).filter(
+            SqlExperiment.workspace == workspace
+        )
 
     __tablename__ = "runs"
 
@@ -705,8 +716,14 @@ class SqlInputTag(Base):
 #######################################################################################
 
 
-class SqlTraceInfo(Base):
+class SqlTraceInfo(WorkspaceIsolatedModel, Base):
     __tablename__ = "trace_info"
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.join(SqlExperiment, cls.experiment_id == SqlExperiment.experiment_id).filter(
+            SqlExperiment.workspace == workspace
+        )
 
     request_id = Column(String(50), nullable=False)
     """
@@ -1191,8 +1208,17 @@ class SqlIssue(Base):
         return f"<SqlIssue({self.issue_id}, {self.name}, {self.status})>"
 
 
-class SqlLoggedModel(Base):
+class SqlLoggedModel(WorkspaceIsolatedModel, Base):
     __tablename__ = "logged_models"
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        workspace_exp_ids = (
+            session.query(SqlExperiment.experiment_id)
+            .filter(SqlExperiment.workspace == workspace)
+            .subquery()
+        )
+        return query.filter(cls.experiment_id.in_(workspace_exp_ids.element))
 
     model_id = Column(String(36), nullable=False)
     """
@@ -1486,10 +1512,14 @@ class SqlLoggedModelTag(Base):
         return LoggedModelTag(key=self.tag_key, value=self.tag_value)
 
 
-class SqlEvaluationDataset(Base):
+class SqlEvaluationDataset(WorkspaceIsolatedModel, Base):
     """
     DB model for evaluation datasets.
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     __tablename__ = "evaluation_datasets"
 
@@ -2158,11 +2188,17 @@ class SqlScorerVersion(Base):
         )
 
 
-class SqlOnlineScoringConfig(Base):
+class SqlOnlineScoringConfig(WorkspaceIsolatedModel, Base):
     """
     DB model for storing online scoring configuration. These are recorded in
     ``online_scoring_configs`` table.
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.join(SqlExperiment, cls.experiment_id == SqlExperiment.experiment_id).filter(
+            SqlExperiment.workspace == workspace
+        )
 
     __tablename__ = "online_scoring_configs"
 
@@ -2223,10 +2259,14 @@ class SqlOnlineScoringConfig(Base):
         )
 
 
-class SqlJob(Base):
+class SqlJob(WorkspaceIsolatedModel, Base):
     """
     DB model for Job entities. These are recorded in the ``jobs`` table.
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     __tablename__ = "jobs"
 
@@ -2323,11 +2363,15 @@ class SqlJob(Base):
         )
 
 
-class SqlGatewaySecret(Base):
+class SqlGatewaySecret(WorkspaceIsolatedModel, Base):
     """
     DB model for secrets. These are recorded in the ``secrets`` table.
     Stores encrypted credentials used by MLflow resources (e.g., LLM provider API keys).
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     __tablename__ = "secrets"
 
@@ -2444,11 +2488,15 @@ class SqlGatewaySecret(Base):
         )
 
 
-class SqlGatewayEndpoint(Base):
+class SqlGatewayEndpoint(WorkspaceIsolatedModel, Base):
     """
     DB model for endpoints. These are recorded in ``endpoints`` table.
     Represents LLM gateway endpoints that route requests to configured models.
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     __tablename__ = "endpoints"
 
@@ -2553,11 +2601,15 @@ class SqlGatewayEndpoint(Base):
         )
 
 
-class SqlGatewayModelDefinition(Base):
+class SqlGatewayModelDefinition(WorkspaceIsolatedModel, Base):
     """
     DB model for model definitions. These are recorded in ``model_definitions`` table.
     Represents reusable LLM model configurations that can be shared across multiple endpoints.
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     __tablename__ = "model_definitions"
 
@@ -2648,11 +2700,15 @@ class SqlGatewayModelDefinition(Base):
         )
 
 
-class SqlGatewayEndpointModelMapping(Base):
+class SqlGatewayEndpointModelMapping(WorkspaceIsolatedModel, Base):
     """
     DB model for endpoint-model mappings. These are recorded in ``endpoint_model_mappings`` table.
     Junction table linking endpoints to model definitions (supports multi-model routing).
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.join(SqlGatewayEndpoint).filter(SqlGatewayEndpoint.workspace == workspace)
 
     __tablename__ = "endpoint_model_mappings"
 
@@ -2750,11 +2806,20 @@ class SqlGatewayEndpointModelMapping(Base):
         )
 
 
-class SqlGatewayEndpointBinding(Base):
+class SqlGatewayEndpointBinding(WorkspaceIsolatedModel, Base):
     """
     DB model for endpoint bindings. These are recorded in ``endpoint_bindings`` table.
     Tracks which resources are bound to which endpoints (e.g., model configurations, experiments).
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        workspace_endpoint_ids = (
+            session.query(SqlGatewayEndpoint.endpoint_id)
+            .filter(SqlGatewayEndpoint.workspace == workspace)
+            .subquery()
+        )
+        return query.filter(cls.endpoint_id.in_(workspace_endpoint_ids.element))
 
     __tablename__ = "endpoint_bindings"
 
@@ -2869,11 +2934,15 @@ class SqlGatewayEndpointTag(Base):
         return GatewayEndpointTag(key=self.key, value=self.value)
 
 
-class SqlGatewayBudgetPolicy(Base):
+class SqlGatewayBudgetPolicy(WorkspaceIsolatedModel, Base):
     """
     DB model for budget policies. These are recorded in ``budget_policies`` table.
     Represents cost-based budget limits for the AI Gateway with fixed time windows.
     """
+
+    @classmethod
+    def workspace_query_filter(cls, query, session, workspace):
+        return query.filter(cls.workspace == workspace)
 
     __tablename__ = "budget_policies"
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -711,7 +711,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         # in the assessment_metadata JSON field under the reserved
         # "mlflow.assessment.sourceRunId" key, not in the run_id column.
         source_run_id_pattern = f'"{AssessmentMetadataKey.SOURCE_RUN_ID}": "{run.run_uuid}"'
-        session.query(SqlAssessments).filter(
+        session.query(SqlAssessments).filter(  # clint: disable=workspace-query-isolation
             SqlAssessments.assessment_metadata.contains(source_run_id_pattern)
         ).delete(synchronize_session=False)
 
@@ -835,7 +835,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         return self._get_query(session, SqlEvaluationDataset)
 
     def _get_run_inputs(self, session, run_uuids):
-        datasets_with_tags = (
+        datasets_with_tags = (  # clint: disable=workspace-query-isolation
             session.query(
                 SqlInput.input_uuid,
                 SqlInput.destination_id.label("run_uuid"),
@@ -922,7 +922,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
     def _try_get_run_tag(self, session, run_id, tagKey, eager=False):
         query_options = self._get_eager_run_query_options() if eager else []
         return (
-            session.query(SqlTag)
+            session.query(SqlTag)  # clint: disable=workspace-query-isolation
             .options(*query_options)
             .filter(SqlTag.run_uuid == run_id, SqlTag.key == tagKey)
             .one_or_none()
@@ -1161,7 +1161,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                             SqlLoggedModelMetric.run_id == run_id,
                             SqlLoggedModelMetric.metric_name.in_(batch),
                         )
-                        .all()
+                        .all()  # clint: disable=workspace-query-isolation
                     )
                     existing_metrics = {m.to_mlflow_entity() for m in existing_metrics}
                     non_existing_metrics = [
@@ -1211,7 +1211,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         for metric_key_batch in metric_key_batches:
             # First, determine which metric keys are present in the database
             latest_metrics_key_records_from_db = (
-                session.query(SqlLatestMetric.key)
+                session.query(SqlLatestMetric.key)  # clint: disable=workspace-query-isolation
                 .filter(
                     SqlLatestMetric.run_uuid == logged_metrics[0].run_uuid,
                     SqlLatestMetric.key.in_(metric_key_batch),
@@ -1228,7 +1228,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     record[0] for record in latest_metrics_key_records_from_db
                 ]
                 latest_metrics_batch = (
-                    session.query(SqlLatestMetric)
+                    session.query(SqlLatestMetric)  # clint: disable=workspace-query-isolation
                     .filter(
                         SqlLatestMetric.run_uuid == logged_metrics[0].run_uuid,
                         SqlLatestMetric.key.in_(latest_metric_keys_from_db),
@@ -1916,7 +1916,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             # find all datasets with the same name and digest
             # if the dataset already exists, use the existing dataset uuid
             existing_datasets = (
-                session.query(SqlDataset)
+                session.query(SqlDataset)  # clint: disable=workspace-query-isolation
                 .filter(SqlDataset.experiment_id == experiment_id)
                 .filter(SqlDataset.name.in_(dataset_names_to_check))
                 .filter(SqlDataset.digest.in_(dataset_digests_to_check))
@@ -1957,7 +1957,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             # find all inputs with the same source_id and destination_id
             # if the input already exists, use the existing input uuid
             existing_inputs = (
-                session.query(SqlInput)
+                session.query(SqlInput)  # clint: disable=workspace-query-isolation
                 .filter(SqlInput.source_type == "DATASET")
                 .filter(SqlInput.source_id.in_(dataset_uuids.values()))
                 .filter(SqlInput.destination_type == "RUN")
@@ -2037,7 +2037,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         return [
             LoggedModelInput(model_id=input.destination_id)
             for input in (
-                session.query(SqlInput)
+                session.query(SqlInput)  # clint: disable=workspace-query-isolation
                 .filter(
                     SqlInput.source_type == "RUN_INPUT",
                     SqlInput.source_id == run_id,
@@ -2054,7 +2054,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
     ) -> list[LoggedModelOutput]:
         return [
             LoggedModelOutput(model_id=output.destination_id, step=output.step)
-            for output in session.query(SqlInput)
+            for output in session.query(SqlInput)  # clint: disable=workspace-query-isolation
             .filter(
                 SqlInput.source_type == "RUN_OUTPUT",
                 SqlInput.source_id == run_id,
@@ -2073,7 +2073,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         Returns a dict mapping run_id to list of LoggedModelOutput.
         """
         outputs = (
-            session.query(SqlInput)
+            session.query(SqlInput)  # clint: disable=workspace-query-isolation
             .filter(
                 SqlInput.source_type == "RUN_OUTPUT",
                 SqlInput.source_id.in_(run_ids),
@@ -2363,7 +2363,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     session.query(SqlGatewayEndpointBinding).filter(
                         SqlGatewayEndpointBinding.resource_type == GatewayResourceType.SCORER.value,
                         SqlGatewayEndpointBinding.resource_id == scorer.scorer_id,
-                    ).delete()
+                    ).delete()  # clint: disable=workspace-query-isolation
 
                     binding = SqlGatewayEndpointBinding(
                         endpoint_id=endpoint_id,
@@ -2582,7 +2582,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 session.query(SqlGatewayEndpointBinding).filter(
                     SqlGatewayEndpointBinding.resource_type == GatewayResourceType.SCORER.value,
                     SqlGatewayEndpointBinding.resource_id == scorer.scorer_id,
-                ).delete()
+                ).delete()  # clint: disable=workspace-query-isolation
 
                 session.delete(scorer)
 
@@ -2778,7 +2778,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             # Delete existing online configs for this scorer
             session.query(SqlOnlineScoringConfig).filter(
                 SqlOnlineScoringConfig.scorer_id == scorer.scorer_id
-            ).delete()
+            ).delete()  # clint: disable=workspace-query-isolation
 
             # Create new online config
             config = SqlOnlineScoringConfig(
@@ -2807,7 +2807,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         with self.ManagedSessionMaker() as session:
             # Subquery to get the max version for each scorer
             max_version_subquery = (
-                session.query(
+                session.query(  # clint: disable=workspace-query-isolation
                     SqlScorerVersion.scorer_id,
                     func.max(SqlScorerVersion.scorer_version).label("max_version"),
                 )
@@ -2926,7 +2926,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 dataset_filter.append(SqlLoggedModelMetric.dataset_digest == dataset_digest)
 
             subquery = (
-                session.query(
+                session.query(  # clint: disable=workspace-query-isolation
                     SqlLoggedModelMetric.model_id,
                     SqlLoggedModelMetric.metric_value,
                     func.rank()
@@ -3004,11 +3004,13 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 if dataset_filters:
                     metric_filters.append(sqlalchemy.or_(*dataset_filters))
                 non_attr_filters.append(
-                    session.query(SqlLoggedModelMetric).filter(*metric_filters).subquery()
+                    session.query(SqlLoggedModelMetric)  # clint: disable=workspace-query-isolation
+                    .filter(*metric_filters)
+                    .subquery()
                 )
             elif comp.entity.type == EntityType.PARAM:
                 non_attr_filters.append(
-                    session.query(SqlLoggedModelParam)
+                    session.query(SqlLoggedModelParam)  # clint: disable=workspace-query-isolation
                     .filter(
                         SqlLoggedModelParam.param_key == comp.entity.key,
                         comp_func(SqlLoggedModelParam.param_value, comp.value),
@@ -3017,7 +3019,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 )
             elif comp.entity.type == EntityType.TAG:
                 non_attr_filters.append(
-                    session.query(SqlLoggedModelTag)
+                    session.query(SqlLoggedModelTag)  # clint: disable=workspace-query-isolation
                     .filter(
                         SqlLoggedModelTag.tag_key == comp.entity.key,
                         comp_func(SqlLoggedModelTag.tag_value, comp.value),
@@ -3035,7 +3037,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 session.query(SqlLoggedModelMetric.model_id)
                 .filter(sqlalchemy.or_(*dataset_filters))
                 .distinct()
-                .subquery()
+                .subquery()  # clint: disable=workspace-query-isolation
             )
             models = models.join(subquery)
 
@@ -5201,7 +5203,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             Profile dictionary with current statistics
         """
         total_records = (
-            session.query(SqlEvaluationDatasetRecord)
+            session.query(SqlEvaluationDatasetRecord)  # clint: disable=workspace-query-isolation
             .filter(SqlEvaluationDatasetRecord.dataset_id == dataset_id)
             .count()
         )

--- a/mlflow/store/tracking/sqlalchemy_workspace_store.py
+++ b/mlflow/store/tracking/sqlalchemy_workspace_store.py
@@ -18,18 +18,13 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_STATE,
     RESOURCE_DOES_NOT_EXIST,
 )
+from mlflow.store.db.workspace_isolated_model import WorkspaceIsolatedModel
 from mlflow.store.tracking.dbmodels.models import (
     SqlAssessments,
     SqlEvaluationDataset,
     SqlExperiment,
-    SqlGatewayBudgetPolicy,
     SqlGatewayEndpoint,
     SqlGatewayEndpointBinding,
-    SqlGatewayEndpointModelMapping,
-    SqlGatewayModelDefinition,
-    SqlGatewaySecret,
-    SqlLoggedModel,
-    SqlOnlineScoringConfig,
     SqlRun,
     SqlTraceInfo,
 )
@@ -60,54 +55,10 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
         super().__init__(db_uri, default_artifact_root)
 
     def _get_query(self, session, model):
+        """Return a query for ``model`` filtered by the active workspace."""
         query = super()._get_query(session, model)
-        workspace = self._get_active_workspace()
-
-        if model is SqlExperiment:
-            return query.filter(SqlExperiment.workspace == workspace)
-
-        if model is SqlRun:
-            return query.join(
-                SqlExperiment, SqlExperiment.experiment_id == SqlRun.experiment_id
-            ).filter(SqlExperiment.workspace == workspace)
-
-        if model is SqlTraceInfo:
-            return query.join(
-                SqlExperiment, SqlTraceInfo.experiment_id == SqlExperiment.experiment_id
-            ).filter(SqlExperiment.workspace == workspace)
-
-        if model is SqlLoggedModel:
-            workspace_experiment_ids = (
-                session.query(SqlExperiment.experiment_id)
-                .filter(SqlExperiment.workspace == workspace)
-                .subquery()
-            )
-            return query.filter(
-                SqlLoggedModel.experiment_id.in_(select(workspace_experiment_ids.c.experiment_id))
-            )
-
-        if model is SqlOnlineScoringConfig:
-            return query.join(
-                SqlExperiment, SqlOnlineScoringConfig.experiment_id == SqlExperiment.experiment_id
-            ).filter(SqlExperiment.workspace == workspace)
-
-        if model is SqlEvaluationDataset:
-            return query.filter(SqlEvaluationDataset.workspace == workspace)
-
-        if model in (
-            SqlGatewaySecret,
-            SqlGatewayEndpoint,
-            SqlGatewayModelDefinition,
-            SqlGatewayBudgetPolicy,
-        ):
-            return query.filter(model.workspace == workspace)
-
-        if model is SqlGatewayEndpointBinding:
-            return self._filter_endpoint_binding_query(session, query)
-
-        if model is SqlGatewayEndpointModelMapping:
-            return query.join(SqlGatewayEndpoint).filter(SqlGatewayEndpoint.workspace == workspace)
-
+        if issubclass(model, WorkspaceIsolatedModel):
+            return model.workspace_query_filter(query, session, self._get_active_workspace())
         return query
 
     def _initialize_store_state(self):

--- a/tests/store/test_workspace_model_coverage.py
+++ b/tests/store/test_workspace_model_coverage.py
@@ -1,13 +1,12 @@
-"""Verify that every SQLAlchemy model with a ``workspace`` column is handled
-by at least one workspace store's ``_get_query`` method.
-
-If a new model is added with a ``workspace`` column but the developer forgets
-to add it to ``_get_query``, that model's queries will bypass workspace
-isolation.  This test catches that gap.
+"""Verify that every SQLAlchemy model with a ``workspace`` column subclasses
+``WorkspaceIsolatedModel`` and that every ``WorkspaceIsolatedModel`` subclass
+implements ``workspace_query_filter``.
 """
 
 import ast
 from pathlib import Path
+
+import pytest
 
 # Explicitly import all dbmodel modules so that every ORM model is registered
 # with Base.registry before we inspect mappers.
@@ -15,10 +14,13 @@ import mlflow.store.model_registry.dbmodels.models  # noqa: F401
 import mlflow.store.tracking.dbmodels.models  # noqa: F401
 import mlflow.store.workspace.dbmodels.models  # noqa: F401
 from mlflow.store.db.base_sql_model import Base
+from mlflow.store.db.workspace_isolated_model import WorkspaceIsolatedModel
 
-# Locate the repository root relative to this test file so that workspace
-# store paths resolve correctly regardless of the pytest working directory.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# The linter source lives under dev/clint/ and may not be present in all
+# environments (e.g., packaged distributions or minimal CI checkouts).
+_LINTER_RULE_PATH = _REPO_ROOT / "dev/clint/src/clint/rules/workspace_query_isolation.py"
 
 # Every workspace store that provides a ``_get_query`` override.
 WORKSPACE_STORE_PATHS = [
@@ -28,63 +30,104 @@ WORKSPACE_STORE_PATHS = [
 ]
 
 
-def _models_handled_by_get_query(ws_path: str) -> set[str]:
-    """Parse a workspace store file and return the ``Sql*`` model names
-    referenced in comparisons inside its ``_get_query`` method.
+def test_workspace_column_requires_mixin():
+    """Every model with a ``workspace`` column must subclass
+    ``WorkspaceIsolatedModel``.
     """
-    tree = ast.parse((_REPO_ROOT / ws_path).read_text())
-
-    # Collect module-level variables holding Sql* names (e.g. tuples of models)
-    var_models: dict[str, set[str]] = {}
-    for node in ast.iter_child_nodes(tree):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name):
-                    names = {
-                        n.id
-                        for n in ast.walk(node.value)
-                        if isinstance(n, ast.Name) and n.id.startswith("Sql")
-                    }
-                    if names:
-                        var_models[target.id] = names
-
-    # Extract model names from _get_query comparisons
-    models: set[str] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if node.name != "_get_query":
-            continue
-        for inner in ast.walk(node):
-            if not isinstance(inner, ast.Compare):
-                continue
-            for comp in inner.comparators:
-                models |= {
-                    n.id
-                    for n in ast.walk(comp)
-                    if isinstance(n, ast.Name) and n.id.startswith("Sql")
-                }
-                if isinstance(comp, ast.Name) and comp.id in var_models:
-                    models |= var_models[comp.id]
-    return models
-
-
-def test_all_workspace_models_handled_in_get_query():
-    """Every model with a workspace column must appear in at least one
-    workspace store's ``_get_query``.
-    """
-    handled: set[str] = set()
-    for ws_path in WORKSPACE_STORE_PATHS:
-        handled |= _models_handled_by_get_query(ws_path)
-
-    models_with_column: set[str] = set()
+    missing = []
     for mapper in Base.registry.mappers:
+        cls = mapper.class_
         if "workspace" in {col.key for col in mapper.columns}:
-            models_with_column.add(mapper.class_.__name__)
-
-    missing = models_with_column - handled
+            if not issubclass(cls, WorkspaceIsolatedModel):
+                missing.append(cls.__name__)
     assert not missing, (
-        f"These models have a `workspace` column but are not handled by any "
-        f"workspace store's _get_query: {sorted(missing)}. "
-        f"Add handling in the appropriate workspace store's _get_query method."
+        f"These models have a `workspace` column but do not subclass "
+        f"WorkspaceIsolatedModel: {sorted(missing)}. "
+        f"Add WorkspaceIsolatedModel to their bases and implement "
+        f"workspace_query_filter."
+    )
+
+
+def test_all_workspace_isolated_models_implement_filter():
+    """Every ``WorkspaceIsolatedModel`` subclass must define
+    ``workspace_query_filter`` in its own class (not just inherit it).
+    """
+    missing = []
+    for mapper in Base.registry.mappers:
+        cls = mapper.class_
+        if issubclass(cls, WorkspaceIsolatedModel) and cls is not WorkspaceIsolatedModel:
+            if "workspace_query_filter" not in cls.__dict__:
+                missing.append(cls.__name__)
+    assert not missing, (
+        f"These WorkspaceIsolatedModel subclasses do not define "
+        f"workspace_query_filter: {sorted(missing)}. "
+        f"Each model must implement its own workspace_query_filter classmethod."
+    )
+
+
+def _parse_helper_model_coverage_keys_from_source() -> set[str]:
+    """Parse HELPER_MODEL_COVERAGE keys from the linter source without importing clint."""
+    src = _LINTER_RULE_PATH.read_text()
+    tree = ast.parse(src)
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.AnnAssign):
+            continue
+        if not (isinstance(node.target, ast.Name) and node.target.id == "HELPER_MODEL_COVERAGE"):
+            continue
+        if isinstance(node.value, ast.Dict):
+            keys = {
+                k.value
+                for k in node.value.keys
+                if isinstance(k, ast.Constant) and isinstance(k.value, str)
+            }
+            if not keys:
+                raise AssertionError(
+                    f"Failed to parse any HELPER_MODEL_COVERAGE keys from {_LINTER_RULE_PATH}"
+                )
+            return keys
+    raise AssertionError(
+        f"HELPER_MODEL_COVERAGE annotated assignment not found in {_LINTER_RULE_PATH}"
+    )
+
+
+def _all_workspace_store_methods() -> set[str]:
+    """Collect all method names defined in any workspace store class."""
+    methods: set[str] = set()
+    for ws_path in WORKSPACE_STORE_PATHS:
+        tree = ast.parse((_REPO_ROOT / ws_path).read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                for item in node.body:
+                    if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        methods.add(item.name)
+    return methods
+
+
+@pytest.mark.skipif(
+    not _LINTER_RULE_PATH.exists(),
+    reason="clint linter source not available in this environment",
+)
+def test_helper_model_coverage_entries_are_real_methods():
+    """Verify every key in HELPER_MODEL_COVERAGE is defined as a method in at
+    least one workspace store class or base store class.
+    """
+    coverage_keys = _parse_helper_model_coverage_keys_from_source()
+    ws_methods = _all_workspace_store_methods()
+    base_store_paths = [
+        "mlflow/store/tracking/sqlalchemy_store.py",
+        "mlflow/store/model_registry/sqlalchemy_store.py",
+        "mlflow/store/jobs/sqlalchemy_store.py",
+    ]
+    for base_path in base_store_paths:
+        tree = ast.parse((_REPO_ROOT / base_path).read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                for item in node.body:
+                    if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        ws_methods.add(item.name)
+
+    unknown = coverage_keys - ws_methods
+    assert not unknown, (
+        f"HELPER_MODEL_COVERAGE references methods not found in any store: "
+        f"{sorted(unknown)}. Remove stale entries or fix typos."
     )


### PR DESCRIPTION
### Related Issues/PRs

The first commit comes from #20705. If #20705 gets merged separately, I'll rebase this PR.

#1464
#5844
Design document: https://docs.google.com/document/d/1IbFfceCmWV3knJfc0ninn58EXLVbHUh1meV_pknOM40/edit

### What changes are proposed in this pull request?

The first commit comes from #20705. If #20705 gets merged separately, I'll rebase this PR.

The second commit adds a clint rule to ensure there is at least one workspace aware call (e.g. `_get_query` or `_filter_experiment_ids`, etc.) before a direct `session.query` call is made. Additionally, it includes a test to ensure all database models are covered in at least one `_get_query` method.

The last commit makes `workspace_level_permission_func` a required argument on `_get_permission_from_store_or_default` to ensure all new permission calls account for the workspace-level global permission.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
