### PR TITLE
Fix multiple align() calls on MemoryAugmentedJudge

### DIFF
--- a/mlflow/genai/judges/optimizers/memalign/optimizer.py
+++ b/mlflow/genai/judges/optimizers/memalign/optimizer.py
@@ -151,11 +151,17 @@ class MemoryAugmentedJudge(Judge):
         )
         self._retriever = None
 
-        # Inherit memory from base_judge if it's a MemoryAugmentedJudge
+        # Inherit memory from base_judge if it's a MemoryAugmentedJudge.
+        # Episodic memory index is not built here — _add_examples_to_memory() handles it.
         if isinstance(base_judge, MemoryAugmentedJudge):
             self._semantic_memory = copy.deepcopy(base_judge._semantic_memory)
-            self._episodic_memory = copy.deepcopy(base_judge._episodic_memory)
-            self._build_episodic_memory()
+            self._episodic_trace_ids = base_judge._episodic_trace_ids.copy()
+            if base_judge._episodic_memory:
+                self._episodic_memory = copy.deepcopy(base_judge._episodic_memory)
+            elif self._episodic_trace_ids:
+                self._episodic_memory = self._reconstruct_episodic_memory()
+            else:
+                self._episodic_memory: list["dspy.Example"] = []
         else:
             self._episodic_memory: list["dspy.Example"] = []
             self._semantic_memory: list[Guideline] = []
@@ -321,6 +327,29 @@ class MemoryAugmentedJudge(Judge):
 
         return judge_copy
 
+    def _reconstruct_episodic_memory(self) -> list["dspy.Example"]:
+        examples = []
+        missing_ids = []
+        for trace_id in self._episodic_trace_ids:
+            trace = mlflow.get_trace(trace_id, silent=True)
+            if trace is not None:
+                if example := trace_to_dspy_example(trace, self._base_judge):
+                    example._trace_id = trace.info.trace_id
+                    examples.append(example)
+            else:
+                missing_ids.append(trace_id)
+
+        if missing_ids:
+            _logger.warning(
+                f"Could not find {len(missing_ids)} traces for episodic memory reconstruction. "
+                f"Missing trace IDs: {missing_ids[:5]}"
+                f"{'...' if len(missing_ids) > 5 else ''}. "
+                f"Judge will operate with partial memory "
+                f"({len(examples)}/{len(self._episodic_trace_ids)} traces)."
+            )
+
+        return examples
+
     def _lazy_init(self) -> None:
         """
         Lazily initialize DSPy components and episodic memory from stored trace IDs.
@@ -349,29 +378,7 @@ class MemoryAugmentedJudge(Judge):
         self._predict_module = dspy.Predict(extended_signature)
         self._predict_module.set_lm(construct_dspy_lm(self._base_judge.model))
 
-        # Fetch traces by ID using mlflow.get_trace which handles location context
-        traces = []
-        missing_ids = []
-        for trace_id in self._episodic_trace_ids:
-            trace = mlflow.get_trace(trace_id, silent=True)
-            if trace is not None:
-                traces.append(trace)
-            else:
-                missing_ids.append(trace_id)
-
-        if missing_ids:
-            _logger.warning(
-                f"Could not find {len(missing_ids)} traces for episodic memory reconstruction. "
-                f"Missing trace IDs: {missing_ids[:5]}"
-                f"{'...' if len(missing_ids) > 5 else ''}. "
-                f"Judge will operate with partial memory "
-                f"({len(traces)}/{len(self._episodic_trace_ids)} traces)."
-            )
-
-        for trace in traces:
-            if example := trace_to_dspy_example(trace, self._base_judge):
-                example._trace_id = trace.info.trace_id
-                self._episodic_memory.append(example)
+        self._episodic_memory = self._reconstruct_episodic_memory()
 
         if self._episodic_memory:
             self._build_episodic_memory()

--- a/tests/genai/judges/optimizers/memalign/test_optimizer.py
+++ b/tests/genai/judges/optimizers/memalign/test_optimizer.py
@@ -262,22 +262,67 @@ def test_incremental_alignment_preserves_examples(sample_judge, sample_traces):
     with mock_apis(guidelines=["Guideline 1"]):
         optimizer = MemAlignOptimizer()
 
-        # First alignment with 2 traces
         judge_v2 = optimizer.align(sample_judge, sample_traces[:2])
         assert len(judge_v2._episodic_memory) == 2
         assert judge_v2._base_judge is sample_judge
 
-        # Second alignment with 2 more traces - should preserve previous examples
         judge_v3 = optimizer.align(judge_v2, sample_traces[2:4])
         assert len(judge_v3._episodic_memory) == 4
-        assert judge_v3._base_judge is sample_judge  # Should unwrap to original
+        assert judge_v3._base_judge is sample_judge
 
-        # Verify all trace IDs are present
         trace_ids_in_v3 = {
             ex._trace_id for ex in judge_v3._episodic_memory if hasattr(ex, "_trace_id")
         }
         expected_trace_ids = {sample_traces[i].info.trace_id for i in range(4)}
         assert trace_ids_in_v3 == expected_trace_ids
+
+
+def test_incremental_alignment_preserves_trace_ids(sample_judge, sample_traces):
+    with mock_apis(guidelines=["Guideline 1"]):
+        optimizer = MemAlignOptimizer()
+
+        judge_v2 = optimizer.align(sample_judge, sample_traces[:2])
+        batch1_ids = {t.info.trace_id for t in sample_traces[:2]}
+        assert set(judge_v2._episodic_trace_ids) == batch1_ids
+
+        judge_v3 = optimizer.align(judge_v2, sample_traces[2:4])
+        all_ids = batch1_ids | {t.info.trace_id for t in sample_traces[2:4]}
+        assert set(judge_v3._episodic_trace_ids) == all_ids
+
+
+def test_incremental_alignment_with_single_example(sample_judge, sample_traces):
+    with mock_apis(guidelines=[]):
+        optimizer = MemAlignOptimizer()
+
+        judge_v2 = optimizer.align(sample_judge, sample_traces[:1])
+        assert len(judge_v2._episodic_memory) == 1
+
+        judge_v3 = optimizer.align(judge_v2, sample_traces[1:3])
+        assert len(judge_v3._episodic_memory) == 3
+
+
+def test_incremental_alignment_after_deserialization(sample_judge, sample_traces):
+    with mock_apis(guidelines=["Guideline 1"]):
+        optimizer = MemAlignOptimizer()
+
+        aligned_v1 = optimizer.align(sample_judge, sample_traces[:3])
+        assert len(aligned_v1._episodic_memory) == 3
+
+        dumped = aligned_v1.model_dump()
+        serialized = SerializedScorer(**dumped)
+        deserialized = MemoryAugmentedJudge._from_serialized(serialized)
+
+        assert deserialized._episodic_memory == []
+        assert len(deserialized._episodic_trace_ids) == 3
+
+        trace_map = {t.info.trace_id: t for t in sample_traces[:3]}
+        with patch(
+            "mlflow.genai.judges.optimizers.memalign.optimizer.mlflow.get_trace",
+            side_effect=lambda tid, **kwargs: trace_map.get(tid),
+        ):
+            aligned_v2 = optimizer.align(deserialized, sample_traces[3:5])
+
+        assert len(aligned_v2._episodic_memory) == 5
 
 
 def test_incremental_alignment_redistills_guidelines(sample_judge, sample_traces):


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Calling align() a second time on an already-aligned judge had three bugs:

1. _initialize_dspy_components called _build_episodic_memory() prematurely (before new examples were added), which could crash with AxisError when the inherited memory had a single-item corpus.

2. When the base judge was deserialized (via register/get_scorer), its _episodic_memory was empty (deferred init), so the copy inherited nothing and old episodic examples were silently lost.

3. _episodic_trace_ids were never copied from the base judge, so serializing an incrementally-aligned judge lost references to earlier traces.

The fix:
- Extract _reconstruct_episodic_memory() from _lazy_init() for reuse
- In _initialize_dspy_components, copy trace IDs, reconstruct from them if the base judge was deserialized, and defer _build_episodic_memory() to _add_examples_to_memory()

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
from typing import Literal

import mlflow
from mlflow.genai.judges import make_judge
from mlflow.genai.judges.optimizers import MemAlignOptimizer
from mlflow.genai.scorers import get_scorer

JUDGE_NAME = "grammar"

print("Fetching traces...")
traces = mlflow.search_traces(locations=[SOURCE_EXPERIMENT_ID], return_type="list")
filtered = [
    t
    for t in traces
    if any(assessment.name == JUDGE_NAME for assessment in t.info.assessments)
]
print(f"Found {len(filtered)} traces with '{JUDGE_NAME}' assessments")

batch1 = filtered[: len(filtered) // 2]
batch2 = filtered[len(filtered) // 2 :]
print(f"Batch 1: {len(batch1)} traces, Batch 2: {len(batch2)} traces")

judge = make_judge(
    name=JUDGE_NAME,
    instructions=(
        "Please review the conversation and evaluate whether it satisfies the "
        "judge's instruction as follows:\n"
        "The response must not have grammatical or punctuation issues:\n"
        "Response: {{ outputs }}\n"
        'Return "pass" if there are no issues and "fail" if there are issues.'
    ),
    feedback_value_type=Literal["pass", "fail"],
    model="databricks:/databricks-claude-haiku-4-5",
)

optimizer = MemAlignOptimizer(
    reflection_lm="databricks:/databricks-claude-sonnet-4-5",
    embedding_model="databricks:/databricks-gte-large-en",
    retrieval_k=3,
)

# --- First alignment ---
print("\n=== First alignment ===")
aligned_v1 = judge.align(traces=batch1, optimizer=optimizer)
print(f"episodic_memory={len(aligned_v1._episodic_memory)}, "
      f"semantic_memory={len(aligned_v1._semantic_memory)}, "
      f"trace_ids={len(aligned_v1._episodic_trace_ids)}")

# --- Second alignment directly (no registration) ---
print("\n=== Second alignment (in-memory, no registration) ===")
try:
    aligned_v2 = aligned_v1.align(traces=batch2, optimizer=optimizer)
    print(f"episodic_memory={len(aligned_v2._episodic_memory)}, "
          f"semantic_memory={len(aligned_v2._semantic_memory)}, "
          f"trace_ids={len(aligned_v2._episodic_trace_ids)}")
except Exception as e:
    print(f"FAILED: {type(e).__name__}: {e}")

# --- Register, retrieve, then align again ---
print("\n=== Register aligned judge ===")
repro_experiment = mlflow.set_experiment("/Users/samraj.moorjani@databricks.com/memalign-repro-test")
repro_experiment_id = repro_experiment.experiment_id
aligned_v1.register(name="grammar_repro", experiment_id=repro_experiment_id)
print("Registered as 'grammar_repro'")

print("\n=== Retrieve registered judge ===")
retrieved = get_scorer(name="grammar_repro", experiment_id=repro_experiment_id)
print(f"episodic_memory={len(retrieved._episodic_memory)}, "
      f"trace_ids={len(retrieved._episodic_trace_ids)}")

print("\n=== Run retrieved judge on a trace ===")
result = retrieved(trace=filtered[0])
print(f"value={result.value}, rationale={result.rationale}")

print("\n=== Second alignment (after register → get_scorer) ===")
try:
    aligned_v3 = retrieved.align(traces=batch2, optimizer=optimizer)
    print(f"episodic_memory={len(aligned_v3._episodic_memory)}, "
          f"semantic_memory={len(aligned_v3._semantic_memory)}, "
          f"trace_ids={len(aligned_v3._episodic_trace_ids)}")
except Exception as e:
    print(f"FAILED: {type(e).__name__}: {e}")

# --- Cleanup ---
print("\n=== Cleanup ===")
from mlflow.genai.scorers import delete_scorer

delete_scorer(name="grammar_repro", experiment_id=repro_experiment_id)
print("Deleted 'grammar_repro'")
```

Result:

```
Fetching traces...
Found 12 traces with 'grammar' assessments
Batch 1: 6 traces, Batch 2: 6 traces

=== First alignment ===
Distilling guidelines: 100%|██████████████████████████████████| 1/1 [00:00<00:00, 5777.28it/s]
episodic_memory=6, semantic_memory=2, trace_ids=6

=== Second alignment (in-memory, no registration) ===
Distilling guidelines: 100%|███████████████████████████████████| 1/1 [00:00<00:00, 898.52it/s]
episodic_memory=12, semantic_memory=2, trace_ids=12

=== Register aligned judge ===
Registered as 'grammar_repro'

=== Retrieve registered judge ===
episodic_memory=0, trace_ids=6

=== Run retrieved judge on a trace ===
value=fail, rationale=The response contains multiple grammatical and structural issues. First, the sentence lacks proper ending punctuation - it does not end with a period despite being a complete statement. Second, the sentence structure is fragmented and unclear, with mismatched information about locations (mentioning both Liaoning province and Ningde prefecture-level city without clear logical connection). The use of empty parentheses () and the awkward phrasing 'is a county-level city in northeastern Ningde prefecture level city' indicates incomplete or malformed content. These issues violate the requirement that complete sentences must end with a period and that sentences should be properly structured without fragmentation.

=== Second alignment (after register → get_scorer) ===
Distilling guidelines: 100%|█████████████████████████████████| 1/1 [00:00<00:00, 29330.80it/s]
episodic_memory=12, semantic_memory=2, trace_ids=12

=== Cleanup ===
Deleted 'grammar_repro'
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fix issue with multiple align() calls on MemAlign judges.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
