### PR TITLE
Implement postgres optimized get_metric_history_bulk_interval

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -99,7 +99,7 @@ from mlflow.protos.databricks_pb2 import (
     RESOURCE_DOES_NOT_EXIST,
 )
 from mlflow.store.analytics import trace_correlation
-from mlflow.store.db.db_types import MSSQL, MYSQL
+from mlflow.store.db.db_types import MSSQL, MYSQL, POSTGRES
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import (
     MAX_RESULTS_QUERY_TRACE_METRICS,
@@ -1213,6 +1213,55 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 )
                 for metric in metrics
             ]
+
+    def get_metric_history_bulk_interval(
+        self, run_ids: list[str], metric_key: str, max_results: int, start_step: int, end_step: int
+    ) -> list[MetricWithRunId]:
+        """
+        This is an override function to improve performance by pushing down the sampling logic to DB
+        UNIFORM SAMPLING (Top-X Spaced Samples Per Run):
+         - Divide each run's chronological steps into max_results buckets using `ntile`.
+         - Select the first item per bucket per run
+         - This results in max_results uniformly spaced metrics per run.
+        """
+
+        dialect = self._get_dialect()
+        if dialect != POSTGRES:
+            return super().get_metric_history_bulk_interval(
+                run_ids, metric_key, max_results, start_step, end_step
+            )
+
+        with self.ManagedSessionMaker() as session:
+            filters = [SqlMetric.key == metric_key, SqlMetric.run_uuid.in_(run_ids)]
+            if start_step is not None:
+                filters.append(SqlMetric.step >= start_step)
+            if end_step is not None:
+                filters.append(SqlMetric.step <= end_step)
+
+            metrics_with_ntile = (
+                session.query(
+                    SqlMetric,
+                    func.ntile(max_results)
+                    .over(partition_by=SqlMetric.run_uuid, order_by=SqlMetric.step)
+                    .label("nt"),
+                )
+                .filter(*filters)
+                .order_by(SqlMetric.run_uuid, SqlMetric.step)
+                .cte("metrics_with_ntile")
+            )
+            metrics_with_ntile = sqlalchemy.orm.aliased(SqlMetric, metrics_with_ntile)
+            metrics = (
+                session.query(metrics_with_ntile).distinct(metrics_with_ntile.run_uuid, "nt").all()
+            )
+
+            return [
+                MetricWithRunId(
+                    run_id=metric.run_uuid,
+                    metric=metric.to_mlflow_entity(),
+                )
+                for metric in metrics
+            ]
+
 
     def get_max_step_for_metric(self, run_id, metric_key):
         with self.ManagedSessionMaker() as session:


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

### What changes are proposed in this pull request?

This PR implements a PostgreSQL-optimized version of `get_metric_history_bulk_interval` that pushes uniform sampling logic down to the database layer using window functions. The optimization uses `ntile` to divide each run's metrics into buckets and selects the first item per bucket, resulting in evenly spaced samples without loading all data into memory. For non-PostgreSQL databases, the implementation falls back to the parent class method, maintaining backward compatibility.
### How is this PR tested?

- [x] New unit/integration tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
