### PR TITLE
Use async long-running API for search traces on Databricks

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -996,6 +996,16 @@ MLFLOW_TRACING_SQL_WAREHOUSE_ID = _EnvironmentVariable("MLFLOW_TRACING_SQL_WAREH
 #: (default: ``None`` (an active MLflow experiment will be used))
 MLFLOW_TRACING_DESTINATION = _EnvironmentVariable("MLFLOW_TRACING_DESTINATION", str, None)
 
+#: Specifies the poll interval in seconds for long-running trace search operations.
+#: (default: ``2.0``)
+MLFLOW_SEARCH_TRACES_POLL_INTERVAL = _EnvironmentVariable(
+    "MLFLOW_SEARCH_TRACES_POLL_INTERVAL", float, 2.0
+)
+
+#: Specifies the timeout in seconds for long-running trace search operations.
+#: (default: ``600`` - 10 minutes)
+MLFLOW_SEARCH_TRACES_TIMEOUT = _EnvironmentVariable("MLFLOW_SEARCH_TRACES_TIMEOUT", float, 600.0)
+
 
 #######################################################################################
 # Model Logging


### PR DESCRIPTION
### Related Issues/PRs

#xxx

### What changes are proposed in this pull request?

Switch `DatabricksTracingRestStore.search_traces` from the synchronous `SearchTracesV4` endpoint to the async `search-long-running` API with polling. This enables searching traces backed by UC schema storage where queries may take longer to execute via SQL warehouses.

Key changes:
- Add `_search_traces_long_running()` method that POSTs to `/api/4.0/mlflow/traces/search-long-running`, then polls `/api/4.0/mlflow/traces/search/operations/{name}` until the operation completes
- Add `_get_search_operation()` for polling operation status
- Add `MLFLOW_SEARCH_TRACES_POLL_INTERVAL` (default 2s) and `MLFLOW_SEARCH_TRACES_TIMEOUT` (default 600s) environment variables for configurable polling behavior
- Use `SearchTraces.Response` proto for deserializing the inner response payload (Operation wrapper stays as raw JSON since no proto exists for it)
- Preserve existing fallback to V3 API when the long-running endpoint is unavailable

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**New unit tests:**
- `test_search_traces_long_running_polls_until_done` — verifies the polling loop (initial request + 3 polls)
- `test_search_traces_long_running_handles_operation_error` — verifies operation errors are raised

**Manual testing — long-running API (UC schema):**

```python
import os
os.environ["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] = "02c6ce260d0e8ffe"

import mlflow

mlflow.search_traces(
    experiment_ids=["337647222314534"],
    return_type="list",
)
# Results: 417 traces returned in 45.34s
# trace_id=trace:/somto.default/91d61b149f0d6e5c916e1b9a3d7e6e44  state=OK
```

**Manual testing — V3 fallback (experiment ID, no regression):**

```python
import os
os.environ["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] = "02c6ce260d0e8ffe"

import mlflow

mlflow.search_traces(
    experiment_ids=["486607857624029"],
    return_type="list",
)
# DEBUG: Experiment locations are not supported yet. Falling back to V3 API.
# Results: 91 traces returned in 21.87s
# trace_id=tr-fa7171bb413fc637471599426dba1e48  state=OK
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)