### PR TITLE
Fix: Do not emit pickle warning when user calls `mlflow.pyfunc.log_model` with `loader_module` param

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -412,7 +412,6 @@ import sys
 import tempfile
 import threading
 import uuid
-import warnings
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Iterator, Tuple, Union
@@ -3052,9 +3051,7 @@ def save_model(
             "it requires exercising caution as Python object serialization mechanisms may "
             "execute arbitrary code during deserialization."
             "Consider using a file path (str or Path) instead. See "
-            "https://mlflow.org/docs/latest/ml/model/models-from-code/ for details.",
-            FutureWarning,
-            stacklevel=2,
+            "https://mlflow.org/docs/latest/ml/model/models-from-code/ for details."
         )
 
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3046,7 +3046,7 @@ def save_model(
         not isinstance(python_model, (Path, str)) and
         not is_in_databricks_runtime()
     ):
-        warnings.warn(
+        _logger.warning(
             "Passing a Python object as `python_model` causes it to be serialized "
             "using CloudPickle, "
             "it requires exercising caution as Python object serialization mechanisms may "

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3042,9 +3042,9 @@ def save_model(
         kwargs: Extra keyword arguments.
     """
     if (
-        python_model is not None and
-        not isinstance(python_model, (Path, str)) and
-        not is_in_databricks_runtime()
+        python_model is not None
+        and not isinstance(python_model, (Path, str))
+        and not is_in_databricks_runtime()
     ):
         _logger.warning(
             "Passing a Python object as `python_model` causes it to be serialized "

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -3041,7 +3041,11 @@ def save_model(
         auth_policy: {{ auth_policy }}
         kwargs: Extra keyword arguments.
     """
-    if not isinstance(python_model, (Path, str)) and not is_in_databricks_runtime():
+    if (
+        python_model is not None and
+        not isinstance(python_model, (Path, str)) and
+        not is_in_databricks_runtime()
+    ):
         warnings.warn(
             "Passing a Python object as `python_model` causes it to be serialized "
             "using CloudPickle, "

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -227,7 +227,7 @@ def test_model_log_load(sklearn_knn_model, main_scoped_model_class, iris_data):
     pyfunc_artifact_path = "pyfunc_model"
     with (
         mlflow.start_run(),
-        mock.patch("warnings.warn") as mock_warning,
+        mock.patch("mlflow.pyfunc._logger.warning") as mock_warning,
     ):
         pyfunc_model_info = mlflow.pyfunc.log_model(
             name=pyfunc_artifact_path,
@@ -1425,7 +1425,6 @@ def test_python_model_with_type_hint_errors_with_different_signature():
                 python_model=AnnotatedPythonModel(),
                 signature=signature,
             )
-        warn_mock.assert_called_once()
         assert (
             "Provided signature does not match the signature inferred from"
             in warn_mock.call_args[0][0]

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -347,7 +347,7 @@ def test_streamable_model_save_load(tmp_path, model_path):
     assert list(stream_result) == ["test1", "test2"]
 
 
-def test_log_model_does_not_emit_pickle_warning(sklearn_knn_model, tmp_path):
+def test_log_loader_module_model_does_not_emit_pickle_warning(sklearn_knn_model, tmp_path):
     sk_model_path = os.path.join(tmp_path, "knn.pkl")
     with open(sk_model_path, "wb") as f:
         pickle.dump(sklearn_knn_model, f)

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -352,18 +352,17 @@ def test_log_loader_module_model_does_not_emit_pickle_warning(sklearn_knn_model,
     with open(sk_model_path, "wb") as f:
         pickle.dump(sklearn_knn_model, f)
 
-    pyfunc_artifact_path = "pyfunc_model"
     with mlflow.start_run(), mock.patch("mlflow.pyfunc._logger.warning") as mock_log_warning:
         mlflow.pyfunc.log_model(
-            name=pyfunc_artifact_path,
+            name="pyfunc_model",
             data_path=sk_model_path,
             loader_module=__name__,
             code_paths=[__file__],
         )
 
-    warning_messages = [str(args[0]) for args, _ in mock_log_warning.call_args_list if args]
+    warning_messages = [args[0] for args, _ in mock_log_warning.call_args_list if args]
     assert not any(
         "Passing a Python object as `python_model` causes it to be serialized using CloudPickle"
-        in msg.lower()
+        in msg
         for msg in warning_messages
     )

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -348,7 +348,7 @@ def test_streamable_model_save_load(tmp_path, model_path):
 
 
 def test_log_loader_module_model_does_not_emit_pickle_warning(sklearn_knn_model, tmp_path):
-    sk_model_path = os.path.join(tmp_path, "knn.pkl")
+    sk_model_path = tmp_path / "knn.pkl"
     with open(sk_model_path, "wb") as f:
         pickle.dump(sklearn_knn_model, f)
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix: Do not emit pickle warning when user calls `mlflow.pyfunc.log_model` with `loader_module` param

The pickle warning "Passing a Python object as `python_model` causes it to be serialized using CloudPickle..." is only for the case that `mlflow.pyfunc.log_model(python_model=python_model_object)`
 
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
