### PR TITLE
Add Backblaze B2 artifact repository (`b2://`)

### DIFF
--- a/docs/docs/self-hosting/architecture/artifact-store.mdx
+++ b/docs/docs/self-hosting/architecture/artifact-store.mdx
@@ -174,6 +174,7 @@ You can find your bucket's endpoint on the **Buckets** page of your [Backblaze d
 MLflow uses the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables for authentication.
 Generate a new application key from the [**App Keys**](https://secure.backblaze.com/app_keys.htm?utm_source=mlflow&utm_medium=referral&utm_campaign=ai_artifacts&utm_content=mlflow) page
 in your Backblaze dashboard (the master application key is not compatible with the S3-Compatible API).
+
 ```bash
 export AWS_ACCESS_KEY_ID="your_b2_application_key_id"
 export AWS_SECRET_ACCESS_KEY="your_b2_application_key"

--- a/docs/docs/self-hosting/architecture/artifact-store.mdx
+++ b/docs/docs/self-hosting/architecture/artifact-store.mdx
@@ -9,7 +9,7 @@ Note that metadata like parameters, metrics, and tags are stored in a [backend s
 ## Configuring an Artifact Store
 
 MLflow by default stores artifacts in a local (file system) `./mlruns` directory, but also supports various locations suitable for large data:
-Amazon S3, Azure Blob Storage, Google Cloud Storage, SFTP server, and NFS. You can connect those remote storages via the MLflow Tracking server.
+Amazon S3, Azure Blob Storage, Google Cloud Storage, Backblaze B2, SFTP server, and NFS. You can connect those remote storages via the MLflow Tracking server.
 See [tracking server setup](/self-hosting/architecture/tracking-server#tracking-server-artifact-store) and the specific section for your storage in [supported storages](/self-hosting/architecture/artifact-store#artifacts-store-supported-storages) for guidance on
 how to connect to the remote storage of your choice.
 
@@ -164,6 +164,21 @@ You may set some MLflow environment variables to troubleshoot GCS read-timeouts 
 - `MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT` - (Experimental, may be changed or removed) Sets the standard timeout for transfer operations in seconds (Default: 60 for GCS). Use -1 for indefinite timeout.
 - `MLFLOW_GCS_UPLOAD_CHUNK_SIZE` - Sets the standard upload chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB.
 - `MLFLOW_GCS_DOWNLOAD_CHUNK_SIZE` - Sets the standard download chunk size for bigger files in bytes (Default: 104857600 ≙ 100MiB), must be multiple of 256 KB
+
+### Backblaze B2
+
+To store artifacts in [Backblaze B2 Cloud Storage](https://www.backblaze.com/cloud-storage?utm_source=mlflow&utm_medium=referral&utm_campaign=ai_artifacts&utm_content=mlflow), specify a URI of the form
+`b2://<bucket>@<endpoint-host>/<path>`. The endpoint host is typically `s3.<region>.backblazeb2.com`.
+You can find your bucket's endpoint on the **Buckets** page of your [Backblaze dashboard](https://secure.backblaze.com/b2_buckets.htm?utm_source=mlflow&utm_medium=referral&utm_campaign=ai_artifacts&utm_content=mlflow).
+
+MLflow uses the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables for authentication.
+Generate a new application key from the [**App Keys**](https://secure.backblaze.com/app_keys.htm?utm_source=mlflow&utm_medium=referral&utm_campaign=ai_artifacts&utm_content=mlflow) page
+in your Backblaze dashboard (the master application key is not compatible with the S3-Compatible API).
+```bash
+export AWS_ACCESS_KEY_ID="your_b2_application_key_id"
+export AWS_SECRET_ACCESS_KEY="your_b2_application_key"
+export AWS_DEFAULT_REGION="us-east-005"
+```
 
 ### FTP server
 

--- a/mlflow/store/artifact/artifact_repository_registry.py
+++ b/mlflow/store/artifact/artifact_repository_registry.py
@@ -4,6 +4,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
 from mlflow.store.artifact.azure_data_lake_artifact_repo import AzureDataLakeArtifactRepository
+from mlflow.store.artifact.b2_artifact_repo import B2ArtifactRepository
 from mlflow.store.artifact.dbfs_artifact_repo import dbfs_artifact_repo_factory
 from mlflow.store.artifact.ftp_artifact_repo import FTPArtifactRepository
 from mlflow.store.artifact.gcs_artifact_repo import GCSArtifactRepository
@@ -117,6 +118,7 @@ _artifact_repository_registry.register("", LocalArtifactRepository)
 _artifact_repository_registry.register("file", LocalArtifactRepository)
 _artifact_repository_registry.register("s3", S3ArtifactRepository)
 _artifact_repository_registry.register("r2", R2ArtifactRepository)
+_artifact_repository_registry.register("b2", B2ArtifactRepository)
 _artifact_repository_registry.register("gs", GCSArtifactRepository)
 _artifact_repository_registry.register("wasbs", AzureBlobArtifactRepository)
 _artifact_repository_registry.register("ftp", FTPArtifactRepository)

--- a/mlflow/store/artifact/b2_artifact_repo.py
+++ b/mlflow/store/artifact/b2_artifact_repo.py
@@ -1,0 +1,90 @@
+from urllib.parse import urlparse
+
+from mlflow.store.artifact.optimized_s3_artifact_repo import OptimizedS3ArtifactRepository
+from mlflow.store.artifact.s3_artifact_repo import _get_s3_client
+
+_B2_USER_AGENT = "b2ai-mlflow"
+
+
+def _add_b2_user_agent(request, **kwargs):
+    ua = request.headers.get("User-Agent", "")
+    if _B2_USER_AGENT not in ua:
+        request.headers["User-Agent"] = f"{ua} {_B2_USER_AGENT}"
+
+
+class B2ArtifactRepository(OptimizedS3ArtifactRepository):
+    """Stores artifacts on Backblaze B2."""
+
+    def __init__(
+        self,
+        artifact_uri,
+        access_key_id=None,
+        secret_access_key=None,
+        session_token=None,
+        credential_refresh_def=None,
+        s3_upload_extra_args=None,
+        tracking_uri=None,
+        registry_uri: str | None = None,
+    ):
+        s3_endpoint_url = self.convert_b2_uri_to_s3_endpoint_url(artifact_uri)
+        self._access_key_id = access_key_id
+        self._secret_access_key = secret_access_key
+        self._session_token = session_token
+        self._s3_endpoint_url = s3_endpoint_url
+        self.bucket, self.bucket_path = self.parse_s3_compliant_uri(artifact_uri)
+        super().__init__(
+            artifact_uri,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            session_token=session_token,
+            credential_refresh_def=credential_refresh_def,
+            addressing_style="path",
+            s3_endpoint_url=s3_endpoint_url,
+            s3_upload_extra_args=s3_upload_extra_args,
+            tracking_uri=tracking_uri,
+            registry_uri=registry_uri,
+        )
+
+    @staticmethod
+    def _register_b2_user_agent(client):
+        client.meta.events.register("before-sign.s3", _add_b2_user_agent, unique_id="b2-user-agent")
+        return client
+
+    def _get_region_name(self):
+        # Parse region from the endpoint URL (e.g. https://s3.us-west-004.backblazeb2.com)
+        host = urlparse(self._s3_endpoint_url).hostname
+        match host.split("."):
+            case ["s3", region, "backblazeb2", "com"]:
+                return region
+            case _:
+                raise Exception(f"Unable to parse region from B2 endpoint: {self._s3_endpoint_url}")
+
+    def _get_s3_client(self):
+        client = _get_s3_client(
+            addressing_style="path",
+            access_key_id=self._access_key_id,
+            secret_access_key=self._secret_access_key,
+            session_token=self._session_token,
+            region_name=self._region_name,
+            s3_endpoint_url=self._s3_endpoint_url,
+        )
+        return self._register_b2_user_agent(client)
+
+    def parse_s3_compliant_uri(self, uri):
+        # b2 uri format: b2://<bucket-name>@<endpoint-host>/path
+        parsed = urlparse(uri)
+        if parsed.scheme != "b2":
+            raise Exception(f"Not a B2 URI: {uri}")
+
+        host = parsed.netloc
+        path = parsed.path
+
+        bucket = host.split("@")[0]
+        path = path.removeprefix("/")
+        return bucket, path
+
+    @staticmethod
+    def convert_b2_uri_to_s3_endpoint_url(b2_uri):
+        host = urlparse(b2_uri).netloc
+        host_without_bucket = host.split("@")[-1]
+        return f"https://{host_without_bucket}"

--- a/tests/store/artifact/test_b2_artifact_repo.py
+++ b/tests/store/artifact/test_b2_artifact_repo.py
@@ -1,0 +1,92 @@
+import posixpath
+from unittest import mock
+from unittest.mock import ANY
+
+import pytest
+
+from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+from mlflow.store.artifact.b2_artifact_repo import _B2_USER_AGENT, _add_b2_user_agent
+from mlflow.store.artifact.s3_artifact_repo import _cached_get_s3_client
+
+from tests.helper_functions import set_boto_credentials  # noqa: F401
+
+
+@pytest.fixture
+def b2_artifact_root():
+    return "b2://mock-b2-bucket@s3.us-west-004.backblazeb2.com"
+
+
+@pytest.fixture(autouse=True)
+def reset_cached_get_s3_client():
+    _cached_get_s3_client.cache_clear()
+
+
+def test_parse_b2_uri(b2_artifact_root):
+    with mock.patch("boto3.client"):
+        artifact_uri = posixpath.join(b2_artifact_root, "some/path")
+        repo = get_artifact_repository(artifact_uri)
+        parsed_bucket, parsed_path = repo.parse_s3_compliant_uri(artifact_uri)
+        assert parsed_bucket == "mock-b2-bucket"
+        assert parsed_path == "some/path"
+
+
+def test_s3_client_config_set_correctly(b2_artifact_root):
+    artifact_uri = posixpath.join(b2_artifact_root, "some/path")
+    repo = get_artifact_repository(artifact_uri)
+
+    s3_client = repo._get_s3_client()
+    assert s3_client.meta.config.s3.get("addressing_style") == "path"
+
+
+def test_b2_user_agent_event_registered(b2_artifact_root):
+    artifact_uri = posixpath.join(b2_artifact_root, "some/path")
+    repo = get_artifact_repository(artifact_uri)
+
+    s3_client = repo._get_s3_client()
+    assert "b2-user-agent" in s3_client.meta.events._emitter._unique_id_handlers
+
+
+def test_b2_user_agent_appended_to_request():
+    request = mock.Mock()
+    request.headers = {"User-Agent": "Boto3/1.0"}
+    _add_b2_user_agent(request)
+    assert _B2_USER_AGENT in request.headers["User-Agent"]
+
+
+def test_convert_b2_uri_to_s3_endpoint_url(b2_artifact_root):
+    with mock.patch("boto3.client"):
+        artifact_uri = posixpath.join(b2_artifact_root, "some/path")
+        repo = get_artifact_repository(artifact_uri)
+
+        s3_endpoint_url = repo.convert_b2_uri_to_s3_endpoint_url(b2_artifact_root)
+        assert s3_endpoint_url == "https://s3.us-west-004.backblazeb2.com"
+
+
+def test_s3_endpoint_url_is_used_to_get_s3_client(b2_artifact_root):
+    with mock.patch("boto3.client") as mock_get_s3_client:
+        artifact_uri = posixpath.join(b2_artifact_root, "some/path")
+        repo = get_artifact_repository(artifact_uri)
+        repo._get_s3_client()
+        mock_get_s3_client.assert_called_with(
+            "s3",
+            config=ANY,
+            endpoint_url="https://s3.us-west-004.backblazeb2.com",
+            verify=None,
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            region_name="us-west-004",
+        )
+
+
+def test_region_parsed_from_endpoint_url(b2_artifact_root):
+    with mock.patch("boto3.client"):
+        artifact_uri = posixpath.join(b2_artifact_root, "some/path")
+        repo = get_artifact_repository(artifact_uri)
+        assert repo._region_name == "us-west-004"
+
+
+def test_region_parse_fails_for_invalid_endpoint():
+    invalid_uri = "b2://bucket@invalid-host.example.com/path"
+    with pytest.raises(Exception, match="Unable to parse region from B2 endpoint"):
+        get_artifact_repository(invalid_uri)


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #20371

### What changes are proposed in this pull request?

- Add native `b2://` URI support for Backblaze B2 Cloud Storage artifacts via a new `B2ArtifactRepository`, following the existing S3-compatible provider pattern (similar to `R2ArtifactRepository`).
- Register the `b2` scheme in `artifact_repository_registry.py` so MLflow can resolve `b2://...` artifact locations.
- Add unit tests covering `b2://` URI parsing and S3 client configuration behavior.
- Add documentation describing how to configure MLflow artifact storage using Backblaze B2 and the new `b2://` URI format.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Manual test screenshots:

![MLflow B2 Test 1](https://f005.backblazeb2.com/file/images-testing1/mlflow/mlflow-test1.png)
![MLflow B2 Test 2](https://f005.backblazeb2.com/file/images-testing1/mlflow/mlflow-test2.png)

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow now supports storing and retrieving artifacts in Backblaze B2 using a native `b2://` artifact URI.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)