### PR TITLE
Fix the demo generation and deletion when workspaces are enabled

### DIFF
--- a/mlflow/demo/__init__.py
+++ b/mlflow/demo/__init__.py
@@ -3,6 +3,7 @@ import logging
 import mlflow.demo.generators  # noqa: F401
 from mlflow.demo.base import DEMO_EXPERIMENT_NAME, DEMO_PROMPT_PREFIX, BaseDemoGenerator, DemoResult
 from mlflow.demo.registry import demo_registry
+from mlflow.utils.workspace_context import WorkspaceContext, get_request_workspace
 
 _logger = logging.getLogger(__name__)
 
@@ -24,17 +25,24 @@ def generate_all_demos(
     generator_names = demo_registry.list_generators()
     if features is not None:
         generator_names = [n for n in generator_names if n in features]
-    for name in generator_names:
-        generator_cls = demo_registry.get(name)
-        generator = generator_cls()
-        if refresh:
-            _logger.debug(f"Refresh requested, deleting existing demo data for '{name}'")
-            generator.delete_demo()
-        elif generator.is_generated():
-            _logger.debug(f"Demo '{name}' already exists, skipping")
-            continue
-        _logger.info(f"Generating demo data for '{name}'")
-        result = generator.generate()
-        generator.store_version()
-        results.append(result)
+
+    # Propagate the workspace to the environment so that child threads spawned during
+    # demo generation (e.g. by the evaluation harness's ThreadPoolExecutor) can resolve
+    # the active workspace via the MLFLOW_WORKSPACE env-var fallback.  The ContextVar
+    # set by the server middleware is thread-local and is invisible to new threads.
+    with WorkspaceContext(get_request_workspace()):
+        for name in generator_names:
+            generator_cls = demo_registry.get(name)
+            generator = generator_cls()
+            if refresh:
+                _logger.debug(f"Refresh requested, deleting existing demo data for '{name}'")
+                generator.delete_demo()
+            elif generator.is_generated():
+                _logger.debug(f"Demo '{name}' already exists, skipping")
+                continue
+            _logger.info(f"Generating demo data for '{name}'")
+            result = generator.generate()
+            generator.store_version()
+            results.append(result)
+
     return results

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -397,7 +397,6 @@ export function MlflowSidebar({
             </span>
           </MlflowSidebarLink>
           <MlflowSidebarLink
-            disableWorkspacePrefix
             css={{ paddingBlock: theme.spacing.sm }}
             to={ExperimentTrackingRoutes.settingsPageRoute}
             componentId="mlflow.sidebar.settings_tab_link"

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -229,7 +229,6 @@ export const getRouteDefs = () => [
     element: createLazyRouteElement(() => import('../settings/SettingsPage')),
     pageId: PageId.settingsPage,
     handle: { getPageTitle: () => 'Settings' } satisfies RouteHandle,
-    globalRoute: true, // Settings is a global route, not workspace-specific
   },
   ...getExperimentPageRouteDefs(),
   {

--- a/mlflow/server/js/src/settings/SettingsPage.test.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.test.tsx
@@ -1,0 +1,47 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithIntl } from '../common/utils/TestUtils.react18';
+import SettingsPage from './SettingsPage';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { DarkThemeProvider } from '../common/contexts/DarkThemeContext';
+
+jest.mock('../common/utils/FetchUtils', () => ({
+  fetchEndpointRaw: jest.fn(() => Promise.resolve()),
+  HTTPMethods: { POST: 'POST', GET: 'GET' },
+}));
+
+import { fetchEndpointRaw } from '../common/utils/FetchUtils';
+const mockFetchEndpointRaw = fetchEndpointRaw as jest.MockedFunction<typeof fetchEndpointRaw>;
+
+describe('SettingsPage', () => {
+  const renderComponent = () =>
+    renderWithIntl(
+      <DesignSystemProvider>
+        <DarkThemeProvider setIsDarkTheme={() => {}}>
+          <SettingsPage />
+        </DarkThemeProvider>
+      </DesignSystemProvider>,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls fetchEndpointRaw with the demo delete endpoint when clearing demo data', async () => {
+    renderComponent();
+
+    // Open the confirmation modal
+    await userEvent.click(screen.getByText('Clear all demo data'));
+
+    // Confirm deletion
+    await userEvent.click(screen.getByText('Clear'));
+
+    await waitFor(() => {
+      expect(mockFetchEndpointRaw).toHaveBeenCalledWith({
+        relativeUrl: 'ajax-api/3.0/mlflow/demo/delete',
+        method: 'POST',
+      });
+    });
+  });
+});

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -4,7 +4,7 @@ import { useLocalStorage } from '../shared/web-shared/hooks';
 import { TELEMETRY_ENABLED_STORAGE_KEY, TELEMETRY_ENABLED_STORAGE_VERSION } from '../telemetry/utils';
 import { telemetryClient } from '../telemetry';
 import { useCallback, useState } from 'react';
-import { getAjaxUrl } from '../common/utils/FetchUtils';
+import { fetchEndpointRaw, HTTPMethods } from '../common/utils/FetchUtils';
 import { useDarkThemeContext } from '../common/contexts/DarkThemeContext';
 
 const SettingsPage = () => {
@@ -43,8 +43,9 @@ const SettingsPage = () => {
   const handleClearAllDemoData = useCallback(async () => {
     setIsCleaningDemo(true);
     try {
-      await fetch(getAjaxUrl('ajax-api/3.0/mlflow/demo/delete'), {
-        method: 'POST',
+      await fetchEndpointRaw({
+        relativeUrl: 'ajax-api/3.0/mlflow/demo/delete',
+        method: HTTPMethods.POST,
       });
     } catch (error) {
       console.error('Failed to clear demo data:', error);

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/RoutingUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/RoutingUtils.tsx
@@ -63,8 +63,11 @@ const getActiveWorkspace = (): string | null => {
 
 const isAbsoluteUrl = (value: string) => /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value);
 
-/** Routes that never have workspace context (e.g., /settings). Root '/' is contextual. */
-const ALWAYS_GLOBAL_ROUTES = ['/settings'];
+/**
+ * Routes that never have workspace context. Root '/' is contextual.
+ * Kept as an extension point for any future workspace-agnostic routes.
+ */
+const ALWAYS_GLOBAL_ROUTES: string[] = [];
 
 /** Check if pathname is always global (workspace-agnostic). */
 const isGlobalRoute = (pathname: string): boolean => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/RoutingUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/RoutingUtils.tsx
@@ -45,8 +45,11 @@ const getActiveWorkspace = (): string | null => {
 
 const isAbsoluteUrl = (value: string) => /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value);
 
-/** Routes that never have workspace context (e.g., /settings). Root '/' is contextual. */
-const ALWAYS_GLOBAL_ROUTES = ['/settings'];
+/**
+ * Routes that never have workspace context. Root '/' is contextual.
+ * Kept as an extension point for any future workspace-agnostic routes.
+ */
+const ALWAYS_GLOBAL_ROUTES: string[] = [];
 
 /** Check if pathname is always global (workspace-agnostic). */
 const isGlobalRoute = (pathname: string): boolean => {

--- a/mlflow/server/js/src/workspaces/utils/WorkspaceUtils.test.ts
+++ b/mlflow/server/js/src/workspaces/utils/WorkspaceUtils.test.ts
@@ -223,9 +223,9 @@ describe('WorkspaceUtils', () => {
       expect(isGlobalRoute('/')).toBe(false);
     });
 
-    it('returns true for settings path (always global)', () => {
-      expect(isGlobalRoute('/settings')).toBe(true);
-      expect(isGlobalRoute('/settings/general')).toBe(true);
+    it('returns false for settings path (workspace-scoped)', () => {
+      expect(isGlobalRoute('/settings')).toBe(false);
+      expect(isGlobalRoute('/settings/general')).toBe(false);
     });
 
     it('returns false for workspace-scoped paths', () => {
@@ -236,7 +236,6 @@ describe('WorkspaceUtils', () => {
 
     it('ignores query params and hash', () => {
       expect(isGlobalRoute('/?workspace=default')).toBe(false);
-      expect(isGlobalRoute('/settings?tab=general#section')).toBe(true);
     });
   });
 
@@ -358,9 +357,9 @@ describe('WorkspaceUtils', () => {
       expect(prefixRouteWithWorkspace('/?workspace=old')).toBe('/?workspace=old');
     });
 
-    it('removes workspace param for global routes (settings)', () => {
-      expect(prefixRouteWithWorkspace('/settings')).toBe('/settings');
-      expect(prefixRouteWithWorkspace('/settings?workspace=old')).toBe('/settings');
+    it('adds workspace param for settings route', () => {
+      expect(prefixRouteWithWorkspace('/settings')).toBe('/settings?workspace=default');
+      expect(prefixRouteWithWorkspace('/settings?workspace=old')).toBe('/settings?workspace=old');
     });
 
     it('uses different workspace when set', () => {
@@ -407,8 +406,8 @@ describe('WorkspaceUtils', () => {
       expect(appendWorkspaceSearchParams('/')).toBe('/');
     });
 
-    it('returns always-global routes unchanged (settings)', () => {
-      expect(appendWorkspaceSearchParams('/settings')).toBe('/settings');
+    it('adds workspace param to settings route', () => {
+      expect(appendWorkspaceSearchParams('/settings')).toBe('/settings?workspace=default');
     });
 
     it('returns pathname without workspace when feature disabled', () => {

--- a/mlflow/server/js/src/workspaces/utils/WorkspaceUtils.ts
+++ b/mlflow/server/js/src/workspaces/utils/WorkspaceUtils.ts
@@ -94,8 +94,11 @@ export const extractWorkspaceFromSearchParams = (search: string | URLSearchParam
 
 const isAbsoluteUrl = (value: string) => /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value);
 
-/** Routes that never have workspace context (e.g., /settings). Root '/' is contextual. */
-const ALWAYS_GLOBAL_ROUTES = ['/settings'];
+/**
+ * Routes that never have workspace context. Root '/' is contextual.
+ * Kept as an extension point for any future workspace-agnostic routes.
+ */
+const ALWAYS_GLOBAL_ROUTES: string[] = [];
 
 /** Check if pathname is always global (workspace-agnostic). */
 export const isGlobalRoute = (pathname: string): boolean => {

--- a/tests/demo/test_generate.py
+++ b/tests/demo/test_generate.py
@@ -1,7 +1,14 @@
+import threading
 from unittest import mock
 
 from mlflow.demo import generate_all_demos
-from mlflow.demo.base import DemoResult
+from mlflow.demo.base import BaseDemoGenerator, DemoFeature, DemoResult
+from mlflow.environment_variables import MLFLOW_WORKSPACE
+from mlflow.utils.workspace_context import (
+    clear_server_request_workspace,
+    get_request_workspace,
+    set_server_request_workspace,
+)
 
 
 def test_generate_all_demos_calls_generators(stub_generator, another_stub_generator):
@@ -69,3 +76,46 @@ def test_generate_all_demos_regenerates_on_version_mismatch(stub_generator):
         assert stub_generator.generate_called
         assert stub_generator.delete_demo_called
         assert stub_generator.stored_version_value == 2
+
+
+def test_generate_all_demos_propagates_workspace_to_child_threads():
+    workspace_seen_in_thread = [None]
+
+    class ThreadSpawningGenerator(BaseDemoGenerator):
+        name = DemoFeature.TRACES
+
+        def generate(self) -> DemoResult:
+            def _worker():
+                workspace_seen_in_thread[0] = get_request_workspace()
+
+            t = threading.Thread(target=_worker)
+            t.start()
+            t.join()
+            return DemoResult(
+                feature=self.name,
+                entity_ids=["t1"],
+                navigation_url="/test",
+            )
+
+        def _data_exists(self) -> bool:
+            return False
+
+        def store_version(self) -> None:
+            pass
+
+    generator = ThreadSpawningGenerator()
+
+    # Simulate server middleware: set workspace via ContextVar only (no env var)
+    set_server_request_workspace("test-workspace")
+    try:
+        assert MLFLOW_WORKSPACE.get_raw() is None
+
+        with mock.patch("mlflow.demo.demo_registry") as mock_registry:
+            mock_registry.list_generators.return_value = ["traces"]
+            mock_registry.get.return_value = lambda: generator
+
+            generate_all_demos()
+
+        assert workspace_seen_in_thread[0] == "test-workspace"
+    finally:
+        clear_server_request_workspace()


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Add workspace awareness to the generate demo endpoint. The issue is that some threads were created which didn't keep the workspace context var. By using the WorkspaceContext context manager, it sets the workspace env var temporarily and then unsets it.
- Add workspace awareness to the Settings page since now that this page has a button to clear the demo data, it needs to know the workspace it's in.
- 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
