### PR TITLE
Improve demo experiment UX: set GenAI kind, switch workflow type, and fix default tab

### DIFF
--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -99,6 +99,9 @@ class TracesDemoGenerator(BaseDemoGenerator):
     def generate(self) -> DemoResult:
         self._restore_experiment_if_deleted()
         experiment = mlflow.set_experiment(DEMO_EXPERIMENT_NAME)
+        mlflow.MlflowClient().set_experiment_tag(
+            experiment.experiment_id, "mlflow.experimentKind", "genai_development"
+        )
 
         v1_trace_ids = self._generate_trace_set("v1")
         v2_trace_ids = self._generate_trace_set("v2")
@@ -108,7 +111,7 @@ class TracesDemoGenerator(BaseDemoGenerator):
         return DemoResult(
             feature=self.name,
             entity_ids=all_trace_ids,
-            navigation_url=f"#/experiments/{experiment.experiment_id}/traces",
+            navigation_url=f"#/experiments/{experiment.experiment_id}",
         )
 
     def _generate_trace_set(self, version: Literal["v1", "v2"]) -> list[str]:

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5325,7 +5325,7 @@ def _generate_demo():
                 "status": "exists",
                 "experiment_id": experiment.experiment_id,
                 "features_generated": [],
-                "navigation_url": f"/experiments/{experiment.experiment_id}/traces",
+                "navigation_url": f"/experiments/{experiment.experiment_id}",
             }
         )
 
@@ -5333,7 +5333,7 @@ def _generate_demo():
 
     experiment = store.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
     experiment_id = experiment.experiment_id if experiment else None
-    navigation_url = f"/experiments/{experiment_id}/traces" if experiment_id else "/experiments"
+    navigation_url = f"/experiments/{experiment_id}" if experiment_id else "/experiments"
 
     return jsonify(
         {

--- a/mlflow/server/js/src/home/components/DemoBanner.tsx
+++ b/mlflow/server/js/src/home/components/DemoBanner.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { useNavigate } from '../../common/utils/RoutingUtils';
 import Utils from '../../common/utils/Utils';
 import { fetchAPI, getAjaxUrl } from '../../common/utils/FetchUtils';
+import { WorkflowType, useWorkflowType } from '../../common/contexts/WorkflowTypeContext';
 
 const DEMO_BANNER_DISMISSED_KEY = 'mlflow.demo.banner.dismissed';
 
@@ -12,6 +13,7 @@ export const DemoBanner = () => {
   const { theme } = useDesignSystemTheme();
   const [isDismissed, setIsDismissed] = useState(() => localStorage.getItem(DEMO_BANNER_DISMISSED_KEY) === 'true');
   const [isLoading, setIsLoading] = useState(false);
+  const { setWorkflowType } = useWorkflowType();
 
   const handleLaunchDemo = useCallback(async () => {
     setIsLoading(true);
@@ -19,13 +21,14 @@ export const DemoBanner = () => {
       const data = await fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/demo/generate'), {
         method: 'POST',
       });
+      setWorkflowType(WorkflowType.GENAI);
       navigate(data.navigation_url || '/experiments');
     } catch (error) {
       Utils.logErrorAndNotifyUser(error);
     } finally {
       setIsLoading(false);
     }
-  }, [navigate]);
+  }, [navigate, setWorkflowType]);
 
   const handleDismiss = useCallback(() => {
     localStorage.setItem(DEMO_BANNER_DISMISSED_KEY, 'true');

--- a/mlflow/server/js/src/home/components/features/LaunchDemoCard.tsx
+++ b/mlflow/server/js/src/home/components/features/LaunchDemoCard.tsx
@@ -3,6 +3,7 @@ import { ArrowRightIcon, Button, Spinner, useDesignSystemTheme } from '@databric
 import { FormattedMessage } from 'react-intl';
 import { useNavigate } from '../../../common/utils/RoutingUtils';
 import { fetchAPI, getAjaxUrl } from '../../../common/utils/FetchUtils';
+import { WorkflowType, useWorkflowType } from '../../../common/contexts/WorkflowTypeContext';
 import demoScreenshot from '../../../common/static/demo-tracing-screenshot.png';
 
 export const DEMO_BANNER_DISMISSED_KEY = 'mlflow.demo.banner.dismissed';
@@ -11,6 +12,7 @@ export const LaunchDemoCard = () => {
   const navigate = useNavigate();
   const { theme } = useDesignSystemTheme();
   const [isLoading, setIsLoading] = useState(false);
+  const { setWorkflowType } = useWorkflowType();
 
   const handleLaunchDemo = useCallback(async () => {
     setIsLoading(true);
@@ -19,6 +21,7 @@ export const LaunchDemoCard = () => {
         method: 'POST',
       });
       const url = (data.navigation_url || '/experiments').replace(/^#\//, '/');
+      setWorkflowType(WorkflowType.GENAI);
       navigate(url);
     } catch (error) {
       console.error('Failed to generate demo:', error);
@@ -26,7 +29,7 @@ export const LaunchDemoCard = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [navigate]);
+  }, [navigate, setWorkflowType]);
 
   return (
     <div

--- a/tests/demo/test_traces_generator.py
+++ b/tests/demo/test_traces_generator.py
@@ -41,7 +41,7 @@ def test_generate_creates_traces():
     assert isinstance(result, DemoResult)
     assert result.feature == DemoFeature.TRACES
     assert len(result.entity_ids) > 0
-    assert "traces" in result.navigation_url
+    assert "experiments" in result.navigation_url
 
 
 def test_generate_creates_experiment():


### PR DESCRIPTION
### What changes are proposed in this pull request?

When launching the demo experiment via "Start Demo" / "Launch Demo", three UX issues existed:

1. **Experiment type confirmation popup appeared** — The demo experiment had no `mlflow.experimentKind` tag, so users were prompted to choose the experiment type on every visit.
2. **Workflow type toggle wasn't switched to GenAI** — If the user had previously selected "Machine Learning" in the sidebar toggle, the demo (which showcases GenAI features) would open in the wrong view.
3. **Hardcoded `/traces` tab** — The navigation URL always opened the Traces tab, bypassing the frontend's tab routing logic which would navigate to Overview for GenAI experiments.

**Changes:**
- **Backend** (`traces.py`): Set `mlflow.experimentKind` tag to `genai_development` when generating the demo experiment, suppressing the confirmation popup.
- **Frontend** (`LaunchDemoCard.tsx`, `DemoBanner.tsx`): Call `setWorkflowType(WorkflowType.GENAI)` before navigating after demo generation, so the sidebar switches to GenAI view.
- **Backend** (`handlers.py`, `traces.py`): Remove hardcoded `/traces` suffix from `navigation_url`, letting the frontend's `useNavigateToExperimentPageTab` hook route to the correct default tab (Overview for GenAI experiments).

### How is this PR tested?

- [x] Manual tests

Verified that:
- Launching demo no longer shows the experiment type confirmation popup
- The sidebar workflow toggle switches to GenAI when demo is launched
- The demo experiment opens on the Overview tab instead of Traces

https://github.com/user-attachments/assets/729d5561-2956-4e84-9fb0-ec7e81533e02

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)