### PR TITLE
[Left nav fixes][1/4] Various padding and style updates for the left nav

### DIFF
--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -59,9 +59,12 @@ const MlflowRootRoute = () => {
   const enableWorkflowBasedNavigation = shouldEnableWorkflowBasedNavigation();
 
   // Hide sidebar if we are in a single experiment page (only when feature flag is disabled)
-  // When feature flag is enabled, sidebar should always be visible
   const isSingleExperimentPage = Boolean(experimentId);
   useEffect(() => {
+    // When feature flag is enabled, sidebar should always retain its current state
+    if (enableWorkflowBasedNavigation) {
+      return;
+    }
     setShowSidebar(enableWorkflowBasedNavigation || !isSingleExperimentPage);
   }, [isSingleExperimentPage, enableWorkflowBasedNavigation]);
 

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -7,8 +7,6 @@ import {
   GearIcon,
   HomeIcon,
   ModelsIcon,
-  SegmentedControlGroup,
-  SegmentedControlButton,
   Tag,
   TextBoxIcon,
   Typography,
@@ -18,7 +16,6 @@ import {
   SidebarCollapseIcon,
   SidebarExpandIcon,
   InfoBookIcon,
-  CodeIcon,
   Tooltip,
   NewWindowIcon,
 } from '@databricks/design-system';
@@ -138,16 +135,20 @@ export function MlflowSidebar({
 
   const menuItems: MenuItemWithNested[] = useMemo(
     () => [
-      {
-        key: 'home',
-        icon: <HomeIcon />,
-        linkProps: {
-          to: ExperimentTrackingRoutes.rootRoute,
-          isActive: isHomeActive,
-          children: <FormattedMessage defaultMessage="Home" description="Sidebar link for home page" />,
-        },
-        componentId: 'mlflow.sidebar.home_tab_link',
-      },
+      ...(!showNestedExperimentItems
+        ? [
+            {
+              key: 'home',
+              icon: <HomeIcon />,
+              linkProps: {
+                to: ExperimentTrackingRoutes.rootRoute,
+                isActive: isHomeActive,
+                children: <FormattedMessage defaultMessage="Home" description="Sidebar link for home page" />,
+              },
+              componentId: 'mlflow.sidebar.home_tab_link',
+            },
+          ]
+        : []),
       {
         key: 'experiments',
         icon: <BeakerIcon />,
@@ -244,7 +245,7 @@ export function MlflowSidebar({
   return (
     <aside
       css={{
-        width: showSidebar ? 190 : 36,
+        width: showSidebar ? 190 : theme.spacing.lg + theme.spacing.md,
         flexShrink: 0,
         padding: theme.spacing.sm,
         paddingRight: 0,
@@ -253,24 +254,24 @@ export function MlflowSidebar({
         gap: theme.spacing.md,
       }}
     >
-      <div css={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <div css={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
         {showSidebar && (
-          <Link to={ExperimentTrackingRoutes.rootRoute}>
-            <MlflowLogo
-              css={{
-                display: 'block',
-                height: theme.spacing.lg,
-                color: theme.colors.textPrimary,
-                marginLeft: -(theme.spacing.sm + theme.spacing.xs),
-                marginRight: -theme.spacing.lg,
-              }}
-            />
-          </Link>
-        )}
-        {showSidebar && (
-          <Typography.Text size="sm" color="secondary">
-            {Version}
-          </Typography.Text>
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+            <Link to={ExperimentTrackingRoutes.rootRoute}>
+              <MlflowLogo
+                css={{
+                  display: 'block',
+                  height: theme.spacing.lg,
+                  color: theme.colors.textPrimary,
+                  marginLeft: -(theme.spacing.sm + theme.spacing.xs),
+                  marginRight: -theme.spacing.lg,
+                }}
+              />
+            </Link>
+            <Typography.Text size="sm" css={{ paddingLeft: theme.spacing.sm }} color="secondary">
+              {Version}
+            </Typography.Text>
+          </div>
         )}
         <Button
           componentId="mlflow_header.toggle_sidebar_button"
@@ -284,7 +285,15 @@ export function MlflowSidebar({
         <MlflowSidebarWorkflowSwitch workflowType={workflowType} setWorkflowType={setWorkflowType} />
       )}
 
-      <nav css={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between', height: '100%' }}>
+      <nav
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          height: '100%',
+          overflow: 'auto',
+        }}
+      >
         <ul
           css={{
             listStyleType: 'none',
@@ -297,6 +306,7 @@ export function MlflowSidebar({
               ({ key, icon, linkProps, componentId, nestedItems }) =>
                 nestedItems ?? (
                   <MlflowSidebarLink
+                    key={componentId}
                     to={linkProps.to}
                     componentId={componentId}
                     isActive={linkProps.isActive}
@@ -310,65 +320,55 @@ export function MlflowSidebar({
         </ul>
         <div>
           {isLocalServer && (
-            <div
-              css={{
-                padding: 2,
-                marginBottom: theme.spacing.xs,
-                borderRadius: theme.borders.borderRadiusMd,
-                background:
-                  'linear-gradient(90deg, rgba(232, 72, 85, 0.7), rgba(155, 93, 229, 0.7), rgba(67, 97, 238, 0.7))',
-              }}
+            <Tooltip
+              componentId="mlflow.sidebar.assistant_tooltip"
+              content={<FormattedMessage defaultMessage="Assistant" description="Tooltip for assistant button" />}
+              open={isAssistantHovered && !showSidebar}
+              side="right"
+              delayDuration={0}
             >
-              <Tooltip
-                componentId="mlflow.sidebar.assistant_tooltip"
-                content={<FormattedMessage defaultMessage="Assistant" description="Tooltip for assistant button" />}
-                open={isAssistantHovered && !showSidebar}
-                side="right"
-                delayDuration={0}
+              <div
+                role="button"
+                tabIndex={0}
+                aria-pressed={isPanelOpen}
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: theme.spacing.sm,
+                  paddingInline: showSidebar ? theme.spacing.sm : theme.spacing.xs,
+                  paddingBlock: theme.spacing.sm,
+                  borderRadius: theme.borders.borderRadiusMd - 2,
+                  justifyContent: showSidebar ? 'flex-start' : 'center',
+                  cursor: 'pointer',
+                  background: theme.colors.backgroundSecondary,
+                  color: isPanelOpen ? theme.colors.actionDefaultIconHover : theme.colors.actionDefaultIconDefault,
+                  '&:hover': {
+                    color: theme.colors.actionLinkHover,
+                    backgroundColor: theme.colors.actionDefaultBackgroundHover,
+                  },
+                }}
+                onClick={handleAssistantToggle}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    handleAssistantToggle();
+                  }
+                }}
+                onMouseEnter={() => setIsAssistantHovered(true)}
+                onMouseLeave={() => setIsAssistantHovered(false)}
               >
-                <div
-                  role="button"
-                  tabIndex={0}
-                  aria-pressed={isPanelOpen}
-                  css={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: theme.spacing.sm,
-                    paddingInline: showSidebar ? theme.spacing.md : 0,
-                    paddingBlock: theme.spacing.xs,
-                    borderRadius: theme.borders.borderRadiusMd - 2,
-                    justifyContent: showSidebar ? 'flex-start' : 'center',
-                    cursor: 'pointer',
-                    background: theme.colors.backgroundSecondary,
-                    color: isPanelOpen ? theme.colors.actionDefaultIconHover : theme.colors.actionDefaultIconDefault,
-                  }}
-                  onClick={handleAssistantToggle}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      handleAssistantToggle();
-                    }
-                  }}
-                  onMouseEnter={() => setIsAssistantHovered(true)}
-                  onMouseLeave={() => setIsAssistantHovered(false)}
-                >
-                  <AssistantSparkleIcon isHovered={isAssistantHovered} />
-                  {showSidebar && (
-                    <>
-                      <Typography.Text color="primary">
-                        <FormattedMessage defaultMessage="Assistant" description="Sidebar button for AI assistant" />
-                      </Typography.Text>
-                      <Tag
-                        componentId="mlflow.sidebar.assistant_beta_tag"
-                        color="turquoise"
-                        css={{ marginLeft: 'auto' }}
-                      >
-                        Beta
-                      </Tag>
-                    </>
-                  )}
-                </div>
-              </Tooltip>
-            </div>
+                <AssistantSparkleIcon isHovered={isAssistantHovered} />
+                {showSidebar && (
+                  <>
+                    <Typography.Text color="primary">
+                      <FormattedMessage defaultMessage="Assistant" description="Sidebar button for AI assistant" />
+                    </Typography.Text>
+                    <Tag componentId="mlflow.sidebar.assistant_beta_tag" color="turquoise" css={{ marginLeft: 'auto' }}>
+                      Beta
+                    </Tag>
+                  </>
+                )}
+              </div>
+            </Tooltip>
           )}
           <MlflowSidebarLink
             disableWorkspacePrefix
@@ -382,21 +382,6 @@ export function MlflowSidebar({
           >
             <span css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
               <FormattedMessage defaultMessage="Docs" description="Sidebar link for docs page" />
-              <NewWindowIcon css={{ fontSize: theme.typography.fontSizeBase }} />
-            </span>
-          </MlflowSidebarLink>
-          <MlflowSidebarLink
-            disableWorkspacePrefix
-            css={{ paddingBlock: theme.spacing.sm }}
-            to="https://github.com/mlflow/mlflow"
-            componentId="mlflow.sidebar.github_link"
-            isActive={() => false}
-            icon={<CodeIcon />}
-            collapsed={!showSidebar}
-            openInNewTab
-          >
-            <span css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
-              <FormattedMessage defaultMessage="GitHub" description="Sidebar link for GitHub page" />
               <NewWindowIcon css={{ fontSize: theme.typography.fontSizeBase }} />
             </span>
           </MlflowSidebarLink>

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
@@ -48,14 +48,6 @@ export const MlflowSidebarExperimentItems = ({
 
   return (
     <>
-      <div
-        css={{
-          borderTop: `1px solid ${theme.colors.actionDefaultBorderDefault}`,
-          width: '100%',
-          paddingBottom: theme.spacing.sm,
-          marginTop: theme.spacing.xs,
-        }}
-      />
       <MlflowSidebarLink
         css={{ border: `1px solid ${theme.colors.actionDefaultBorderDefault}`, marginBottom: theme.spacing.sm }}
         to={ExperimentTrackingRoutes.experimentsObservatoryRoute}
@@ -120,7 +112,7 @@ export const MlflowSidebarExperimentItems = ({
           borderBottom: `1px solid ${theme.colors.actionDefaultBorderDefault}`,
           width: '100%',
           paddingTop: theme.spacing.sm,
-          marginBottom: theme.spacing.xs,
+          marginBottom: theme.spacing.sm,
         }}
       />
     </>

--- a/mlflow/server/js/src/common/components/MlflowSidebarGatewayItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarGatewayItems.tsx
@@ -21,11 +21,11 @@ export const MlflowSidebarGatewayItems = ({ collapsed }: { collapsed: boolean })
           gap: theme.spacing.sm,
           justifyContent: collapsed ? 'center' : 'flex-start',
           paddingLeft: collapsed ? 0 : theme.spacing.sm,
-          paddingBlock: theme.spacing.xs,
+          paddingBlock: collapsed ? 7 : theme.spacing.sm,
           border: collapsed ? `1px solid ${theme.colors.actionDefaultBorderDefault}` : 'none',
           borderRadius: theme.borders.borderRadiusSm,
-          marginTop: collapsed ? theme.spacing.sm : 0,
           marginBottom: collapsed ? theme.spacing.sm : 0,
+          boxSizing: 'border-box',
         }}
       >
         <CloudModelIcon />

--- a/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
@@ -61,7 +61,6 @@ export const MlflowSidebarLink = ({
             color: theme.colors.textPrimary,
             paddingInline: theme.spacing.sm,
             justifyContent: collapsed ? 'center' : 'flex-start',
-            // 5 seems to be the magic number to match the text line height
             paddingBlock: theme.spacing.sm,
             borderRadius: theme.borders.borderRadiusSm,
             '&:hover': {

--- a/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
@@ -59,10 +59,10 @@ export const MlflowSidebarLink = ({
             alignItems: 'center',
             gap: theme.spacing.sm,
             color: theme.colors.textPrimary,
-            paddingInline: collapsed ? 0 : theme.spacing.sm,
+            paddingInline: theme.spacing.sm,
             justifyContent: collapsed ? 'center' : 'flex-start',
             // 5 seems to be the magic number to match the text line height
-            paddingBlock: collapsed ? 5 : theme.spacing.xs,
+            paddingBlock: theme.spacing.sm,
             borderRadius: theme.borders.borderRadiusSm,
             '&:hover': {
               color: theme.colors.actionLinkHover,

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -7107,10 +7107,6 @@
     "defaultMessage": "Delete {numRuns, plural, =1 {1 run} other {# runs}}",
     "description": "Delete evaluation runs modal title"
   },
-  "mowpxw": {
-    "defaultMessage": "GitHub",
-    "description": "Sidebar link for GitHub page"
-  },
   "mpHsCg": {
     "defaultMessage": "Size:",
     "description": "Label to display the size of the artifact of the experiment"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20756/files) to review incremental changes.
- [**stack/left-nav-fixes-1**](https://github.com/mlflow/mlflow/pull/20756) [[Files changed](https://github.com/mlflow/mlflow/pull/20756/files)]
  - [stack/left-nav-fixes-2](https://github.com/mlflow/mlflow/pull/20757) [[Files changed](https://github.com/mlflow/mlflow/pull/20757/files/3c2089a18c071eb045974445a6e9caa9bf8927b8..ab2df577cff8f79ae44bab5d55219f5f45c5f26d)]
    - [stack/left-nav-fixes-3](https://github.com/mlflow/mlflow/pull/20758) [[Files changed](https://github.com/mlflow/mlflow/pull/20758/files/ab2df577cff8f79ae44bab5d55219f5f45c5f26d..1cc07b6955865a1d790d244a74f2dbe3fc225c80)]
      - [stack/left-nav-fixes-4](https://github.com/mlflow/mlflow/pull/20759) [[Files changed](https://github.com/mlflow/mlflow/pull/20759/files/1cc07b6955865a1d790d244a74f2dbe3fc225c80..79b2761379f918d7cde6f47c94025e7b7069cbe4)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR applies a variety of changes from design feedback:

1. Move version text below the MLflow logo
2. Remove gradient outline on assistant button
3. Remove github link from sidebar
4. Increase padding of elements in the sidebar so it doesn't feel so compact
5. Remove home button in navbar when inside experiment

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before

<img width="1920" height="934" alt="Screenshot 2026-02-12 at 3 13 22 PM" src="https://github.com/user-attachments/assets/dea2fd27-5f88-40f3-9997-31d7a4696878" />


After

<img width="1920" height="933" alt="Screenshot 2026-02-12 at 3 13 11 PM" src="https://github.com/user-attachments/assets/8b6c94e9-38cd-40ee-8544-351e559d2923" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
