### PR TITLE
[Left nav fixes][2/4] Various experiment header fixes

### DIFF
--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -33,7 +33,7 @@ import { useAssistant } from '../../assistant/AssistantContext';
 import { extractWorkspaceFromSearchParams } from '../../workspaces/utils/WorkspaceUtils';
 import { MlflowSidebarLink } from './MlflowSidebarLink';
 import { MlflowLogo } from './MlflowLogo';
-import { HomePageDocsUrl, GenAIDocsUrl, MLDocsUrl, Version } from '../constants';
+import { DOCS_ROOT, GenAIDocsUrl, MLDocsUrl, Version } from '../constants';
 import { WorkspaceSelector } from '../../workspaces/components/WorkspaceSelector';
 import { MlflowSidebarExperimentItems } from './MlflowSidebarExperimentItems';
 import { MlflowSidebarGatewayItems } from './MlflowSidebarGatewayItems';
@@ -240,7 +240,7 @@ export function MlflowSidebar({
     ? workflowType === WorkflowType.GENAI
       ? GenAIDocsUrl
       : MLDocsUrl
-    : HomePageDocsUrl;
+    : DOCS_ROOT;
 
   return (
     <aside

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
@@ -16,11 +16,8 @@ import { useGetExperimentPageActiveTabByRoute } from '../../experiment-tracking/
 import { ExperimentPageTabName } from '../../experiment-tracking/constants';
 import { FormattedMessage } from 'react-intl';
 
-const isExperimentsActive = (location: Location) =>
-  Boolean(
-    matchPath({ path: '/experiments', end: true }, location.pathname) ||
-    matchPath('/compare-experiments/*', location.pathname),
-  );
+// pass a dummy function to avoid highlighting the experiment back link
+const isExperimentsActive = () => false;
 
 export const MlflowSidebarExperimentItems = ({
   collapsed,

--- a/mlflow/server/js/src/common/constants.tsx
+++ b/mlflow/server/js/src/common/constants.tsx
@@ -13,13 +13,11 @@ export const Version = '3.10.1.dev0';
 
 const DOCS_VERSION = 'latest';
 
-const DOCS_ROOT = `https://www.mlflow.org/docs/${DOCS_VERSION}`;
+export const DOCS_ROOT = `https://www.mlflow.org/docs/${DOCS_VERSION}`;
 
-export const HomePageDocsUrl = `${DOCS_ROOT}/index.html`;
+export const GenAIDocsUrl = `${DOCS_ROOT}/genai/`;
 
-export const GenAIDocsUrl = `${DOCS_ROOT}/genai/index.html`;
-
-export const MLDocsUrl = `${DOCS_ROOT}/ml/index.html`;
+export const MLDocsUrl = `${DOCS_ROOT}/ml/`;
 
 export const ModelRegistryDocUrl = `${DOCS_ROOT}/model-registry.html`;
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.test.tsx
@@ -33,6 +33,15 @@ jest.mock('../../../../../common/utils/RoutingUtils', () => {
   };
 });
 
+jest.mock('../../../../../common/utils/FeatureUtils', () => {
+  return {
+    ...jest.requireActual<typeof import('../../../../../common/utils/FeatureUtils')>(
+      '../../../../../common/utils/FeatureUtils',
+    ),
+    shouldEnableWorkflowBasedNavigation: () => false,
+  };
+});
+
 describe('ExperimentViewHeader', () => {
   const defaultExperiment: ExperimentEntity = {
     experimentId: '123',

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.utils.tsx
@@ -1,5 +1,20 @@
 import { FormattedMessage } from 'react-intl';
-import { EXPERIMENT_PAGE_FEEDBACK_URL } from '@mlflow/mlflow/src/experiment-tracking/constants';
+import { EXPERIMENT_PAGE_FEEDBACK_URL, ExperimentPageTabName } from '@mlflow/mlflow/src/experiment-tracking/constants';
+import { WorkflowType } from '@mlflow/mlflow/src/common/contexts/WorkflowTypeContext';
+import {
+  BeakerIcon,
+  ChartLineIcon,
+  DatabaseIcon,
+  ForkHorizontalIcon,
+  GavelIcon,
+  ListIcon,
+  ModelsIcon,
+  PlusMinusSquareIcon,
+  SpeechBubbleIcon,
+  TextBoxIcon,
+  UserGroupIcon,
+} from '@databricks/design-system';
+import { shouldEnableWorkflowBasedNavigation } from '@mlflow/mlflow/src/common/utils/FeatureUtils';
 
 export const getShareFeedbackOverflowMenuItem = () => {
   return {
@@ -12,4 +27,151 @@ export const getShareFeedbackOverflowMenuItem = () => {
     ),
     href: EXPERIMENT_PAGE_FEEDBACK_URL,
   };
+};
+
+export const getTabDisplayIcon = (tabName: ExperimentPageTabName | undefined) => {
+  if (!tabName || !shouldEnableWorkflowBasedNavigation()) {
+    return <BeakerIcon />;
+  }
+
+  switch (tabName) {
+    case ExperimentPageTabName.Overview:
+      return <ChartLineIcon />;
+    case ExperimentPageTabName.Runs:
+      return <ListIcon />;
+    case ExperimentPageTabName.Traces:
+      return <ForkHorizontalIcon />;
+    case ExperimentPageTabName.Models:
+      return <ModelsIcon />;
+    case ExperimentPageTabName.ChatSessions:
+    case ExperimentPageTabName.SingleChatSession:
+      return <SpeechBubbleIcon />;
+    case ExperimentPageTabName.Datasets:
+      return <DatabaseIcon />;
+    case ExperimentPageTabName.EvaluationRuns:
+      return <PlusMinusSquareIcon />;
+    case ExperimentPageTabName.Judges:
+      return <GavelIcon />;
+    case ExperimentPageTabName.Prompts:
+      return <TextBoxIcon />;
+    case ExperimentPageTabName.LabelingSessions:
+      return <UserGroupIcon />;
+    case ExperimentPageTabName.LabelingSchemas:
+      return <TextBoxIcon />;
+    default:
+      return <BeakerIcon />;
+  }
+};
+
+export const getTabDisplayName = (tabName: ExperimentPageTabName, workflowType: WorkflowType) => {
+  if (workflowType === WorkflowType.GENAI) {
+    return getGenAITabDisplayName(tabName);
+  }
+  return getMLTabDisplayName(tabName);
+};
+
+export const getGenAITabDisplayName = (tabName: ExperimentPageTabName) => {
+  switch (tabName) {
+    case ExperimentPageTabName.Models:
+      return (
+        <FormattedMessage
+          defaultMessage="Agent versions"
+          description="Label for the agent versions tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.Runs:
+      return (
+        <FormattedMessage
+          defaultMessage="Training runs"
+          description="Label for the training runs tab in the MLflow experiment navbar"
+        />
+      );
+    default:
+      return getMLTabDisplayName(tabName);
+  }
+};
+
+export const getMLTabDisplayName = (tabName: ExperimentPageTabName) => {
+  switch (tabName) {
+    case ExperimentPageTabName.Overview:
+      return (
+        <FormattedMessage
+          defaultMessage="Overview"
+          description="Label for the overview tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.Runs:
+      return (
+        <FormattedMessage
+          defaultMessage="Runs"
+          description="Label for the training runs tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.Traces:
+      return (
+        <FormattedMessage
+          defaultMessage="Traces"
+          description="Label for the traces tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.SingleChatSession:
+    case ExperimentPageTabName.ChatSessions:
+      return (
+        <FormattedMessage
+          defaultMessage="Chat sessions"
+          description="Label for the chat sessions tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.Datasets:
+      return (
+        <FormattedMessage
+          defaultMessage="Datasets"
+          description="Label for the datasets tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.EvaluationRuns:
+      return (
+        <FormattedMessage
+          defaultMessage="Evaluation runs"
+          description="Label for the evaluation runs tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.Judges:
+      return (
+        <FormattedMessage
+          defaultMessage="Judges"
+          description="Label for the judges tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.LabelingSessions:
+      return (
+        <FormattedMessage
+          defaultMessage="Labeling sessions"
+          description="Label for the labeling sessions tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.LabelingSchemas:
+      return (
+        <FormattedMessage
+          defaultMessage="Labeling schemas"
+          description="Label for the labeling schemas tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.Prompts:
+      return (
+        <FormattedMessage
+          defaultMessage="Prompts"
+          description="Label for the prompts tab in the MLflow experiment navbar"
+        />
+      );
+    case ExperimentPageTabName.Models:
+      return (
+        <FormattedMessage
+          defaultMessage="Models"
+          description="Label for the versions tab in the MLflow experiment navbar"
+        />
+      );
+    default:
+      return tabName;
+  }
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/utils.tsx
@@ -1,5 +1,4 @@
 import { ExperimentPageTabName } from '../../../constants';
-import { FormattedMessage } from '@databricks/i18n';
 
 export const isTracesRelatedTab = (tabName: ExperimentPageTabName) => {
   return (

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/utils.tsx
@@ -1,4 +1,5 @@
 import { ExperimentPageTabName } from '../../../constants';
+import { FormattedMessage } from '@databricks/i18n';
 
 export const isTracesRelatedTab = (tabName: ExperimentPageTabName) => {
   return (

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1582,6 +1582,10 @@
     "defaultMessage": "All endpoints",
     "description": "All endpoints option"
   },
+  "9Gg0Q8": {
+    "defaultMessage": "Chat sessions",
+    "description": "Label for the chat sessions tab in the MLflow experiment navbar"
+  },
   "9HXup+": {
     "defaultMessage": "Toggle visibility of runs",
     "description": "Experiment page > runs table > toggle visibility of runs > accessible label"
@@ -3342,6 +3346,10 @@
     "defaultMessage": "avg per trace",
     "description": "Subtitle for average tokens per trace"
   },
+  "MZCW9F": {
+    "defaultMessage": "Labeling schemas",
+    "description": "Label for the labeling schemas tab in the MLflow experiment navbar"
+  },
   "MZNjYJ": {
     "defaultMessage": "Actions ({count})",
     "description": "Actions dropdown button label with count of selected sessions"
@@ -3772,6 +3780,10 @@
   "PewjIJ": {
     "defaultMessage": "GenAI apps & agents",
     "description": "Label for experiments focused on generative AI model development"
+  },
+  "PmPV+3": {
+    "defaultMessage": "Models",
+    "description": "Label for the versions tab in the MLflow experiment navbar"
   },
   "Pne4Lp": {
     "defaultMessage": "Maximum of {max} sessions can be selected",
@@ -7775,6 +7787,10 @@
     "defaultMessage": "Relevant",
     "description": "Evaluation results > relevancy assessment > positive value label. Displayed if evaluation result is considered as irrelevant to the query."
   },
+  "rPbiUM": {
+    "defaultMessage": "Labeling sessions",
+    "description": "Label for the labeling sessions tab in the MLflow experiment navbar"
+  },
   "rRaThb": {
     "defaultMessage": "Select a provider first",
     "description": "Placeholder when no provider selected"
@@ -8518,6 +8534,10 @@
   "x2+7hZ": {
     "defaultMessage": "Are you sure you want to delete the prompt version?",
     "description": "A content for the delete prompt version confirmation modal"
+  },
+  "x5ukxr": {
+    "defaultMessage": "Runs",
+    "description": "Label for the training runs tab in the MLflow experiment navbar"
   },
   "x6rkyu": {
     "defaultMessage": "Response",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/20757/files) to review incremental changes.
- [**stack/left-nav-fixes-2**](https://github.com/mlflow/mlflow/pull/20757) [[Files changed](https://github.com/mlflow/mlflow/pull/20757/files)]
  - [stack/left-nav-fixes-3](https://github.com/mlflow/mlflow/pull/20758) [[Files changed](https://github.com/mlflow/mlflow/pull/20758/files/5a9cf7aea19e7c8511b5723b4570f854ff9fff06..d22d7b23a1b2ff2096c9c4915697186c6a6ac74d)]
    - [stack/left-nav-fixes-4](https://github.com/mlflow/mlflow/pull/20759) [[Files changed](https://github.com/mlflow/mlflow/pull/20759/files/d22d7b23a1b2ff2096c9c4915697186c6a6ac74d..fbf7542070b301f12b22029808c3d3d4a45aae59)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR makes a few changes mostly related to the experiment header and doc links

1. Remove doc link from experiment header as it exists in the navbar
2. Change doc link to GenAI / ML docs based on workflow type
3. Add breadcrumbs to experiment header for clearer navigation
4. Display tab title instead of experiment title in the experiment header since it already exists in the navbar + info icon

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Header changes

https://github.com/user-attachments/assets/b756e6d6-8689-4a06-817a-0d0e59c5ef2b

Docs link

https://github.com/user-attachments/assets/68c3dae4-e569-44d8-af6b-6cdc27856551



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
