### PR TITLE
Unify input schema of gateway traces

### DIFF
--- a/mlflow/gateway/tracing_utils.py
+++ b/mlflow/gateway/tracing_utils.py
@@ -9,6 +9,14 @@ from mlflow.gateway.schemas.chat import StreamResponsePayload
 from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig
 
 
+def _maybe_unwrap_single_arg_input(args, kwargs):
+    """Unwrap single-argument inputs so trace shows the request body directly"""
+    if len(args) == 1 and not kwargs:
+        span = mlflow.get_current_active_span()
+        if span:
+            span.set_inputs(args[0])
+
+
 def maybe_traced_gateway_call(
     func: Callable[..., Any],
     endpoint_config: GatewayEndpointConfig,
@@ -43,15 +51,13 @@ def maybe_traced_gateway_call(
         "trace_destination": MlflowExperimentLocation(endpoint_config.experiment_id),
     }
 
-    if not metadata:
-        return mlflow.trace(func, **trace_kwargs)
-
-    # Wrap function to set metadata inside the trace context
     if inspect.isasyncgenfunction(func):
 
         @functools.wraps(func)
         async def wrapper(*args, **kwargs):
-            mlflow.update_current_trace(metadata=metadata)
+            _maybe_unwrap_single_arg_input(args, kwargs)
+            if metadata:
+                mlflow.update_current_trace(metadata=metadata)
             async for item in func(*args, **kwargs):
                 yield item
 
@@ -59,14 +65,18 @@ def maybe_traced_gateway_call(
 
         @functools.wraps(func)
         async def wrapper(*args, **kwargs):
-            mlflow.update_current_trace(metadata=metadata)
+            _maybe_unwrap_single_arg_input(args, kwargs)
+            if metadata:
+                mlflow.update_current_trace(metadata=metadata)
             return await func(*args, **kwargs)
 
     else:
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            mlflow.update_current_trace(metadata=metadata)
+            _maybe_unwrap_single_arg_input(args, kwargs)
+            if metadata:
+                mlflow.update_current_trace(metadata=metadata)
             return func(*args, **kwargs)
 
     return mlflow.trace(wrapper, **trace_kwargs)

--- a/mlflow/gateway/tracing_utils.py
+++ b/mlflow/gateway/tracing_utils.py
@@ -9,11 +9,10 @@ from mlflow.gateway.schemas.chat import StreamResponsePayload
 from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig
 
 
-def _maybe_unwrap_single_arg_input(args, kwargs):
+def _maybe_unwrap_single_arg_input(args: tuple[Any], kwargs: dict[str, Any]):
     """Unwrap single-argument inputs so trace shows the request body directly"""
-    if len(args) == 1 and not kwargs:
-        if span := mlflow.get_current_active_span():
-            span.set_inputs(args[0])
+    if len(args) == 1 and not kwargs and (span := mlflow.get_current_active_span()):
+        span.set_inputs(args[0])
 
 
 def maybe_traced_gateway_call(

--- a/mlflow/gateway/tracing_utils.py
+++ b/mlflow/gateway/tracing_utils.py
@@ -12,8 +12,7 @@ from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig
 def _maybe_unwrap_single_arg_input(args, kwargs):
     """Unwrap single-argument inputs so trace shows the request body directly"""
     if len(args) == 1 and not kwargs:
-        span = mlflow.get_current_active_span()
-        if span:
+        if span := mlflow.get_current_active_span():
             span.set_inputs(args[0])
 
 

--- a/tests/gateway/test_tracing_utils.py
+++ b/tests/gateway/test_tracing_utils.py
@@ -218,6 +218,8 @@ async def test_maybe_traced_gateway_call_with_user_metadata(endpoint_config):
 
     assert gateway_span.attributes.get("endpoint_id") == "test-endpoint-id"
     assert gateway_span.attributes.get("endpoint_name") == "test-endpoint"
+    # Input should be unwrapped (not nested under "payload" key)
+    assert gateway_span.inputs == {"input": "test"}
     # User metadata should be in trace info, not span attributes
     assert trace.info.request_metadata.get(TraceMetadataKey.AUTH_USERNAME) == "alice"
     assert trace.info.request_metadata.get(TraceMetadataKey.AUTH_USER_ID) == "123"
@@ -274,6 +276,9 @@ async def test_maybe_traced_gateway_call_with_output_reducer(endpoint_config):
 
     span_name_to_span = {span.name: span for span in trace.data.spans}
     gateway_span = span_name_to_span[f"gateway/{endpoint_config.endpoint_name}"]
+
+    # Input should be unwrapped (not nested under "payload" key)
+    assert gateway_span.inputs == {"messages": [{"role": "user", "content": "hi"}]}
 
     # The output should be the reduced aggregated response, not raw chunks
     output = gateway_span.outputs

--- a/tests/gateway/test_tracing_utils.py
+++ b/tests/gateway/test_tracing_utils.py
@@ -188,6 +188,8 @@ async def test_maybe_traced_gateway_call_basic(endpoint_config):
     gateway_span = span_name_to_span[f"gateway/{endpoint_config.endpoint_name}"]
     assert gateway_span.attributes.get("endpoint_id") == "test-endpoint-id"
     assert gateway_span.attributes.get("endpoint_name") == "test-endpoint"
+    # Input should be unwrapped (not nested under "payload" key)
+    assert gateway_span.inputs == {"input": "test"}
     # No user metadata should be present in trace
     assert trace.info.request_metadata.get(TraceMetadataKey.AUTH_USERNAME) is None
     assert trace.info.request_metadata.get(TraceMetadataKey.AUTH_USER_ID) is None


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Unwrap the payload so that the input payload is consistent with the existing tracing standard.

<img width="1558" height="738" alt="image" src="https://github.com/user-attachments/assets/f6c4ef92-82d9-4f59-95c0-2e5d7fd218d9" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
