### PR TITLE
Remove experiment selector from the gateway edit UI

### DIFF
--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -252,19 +252,11 @@ export const EditEndpointFormRenderer = ({
                     <Controller
                       control={form.control}
                       name="usageTracking"
-                      render={({ field: usageTrackingField }) => (
-                        <Controller
-                          control={form.control}
-                          name="experimentId"
-                          render={({ field: experimentIdField }) => (
-                            <UsageTrackingConfigurator
-                              value={usageTrackingField.value}
-                              onChange={usageTrackingField.onChange}
-                              experimentId={experimentIdField.value}
-                              onExperimentIdChange={experimentIdField.onChange}
-                              componentIdPrefix="mlflow.gateway.edit-endpoint.usage-tracking"
-                            />
-                          )}
+                      render={({ field }) => (
+                        <UsageTrackingConfigurator
+                          value={field.value}
+                          onChange={field.onChange}
+                          componentIdPrefix="mlflow.gateway.edit-endpoint.usage-tracking"
                         />
                       )}
                     />

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/UsageTrackingConfigurator.test.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/UsageTrackingConfigurator.test.tsx
@@ -1,81 +1,31 @@
-import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { describe, test, expect, jest } from '@jest/globals';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { UsageTrackingConfigurator } from './UsageTrackingConfigurator';
 
-const mockExperiments = [
-  { experimentId: 'exp-1', name: 'Experiment 1' },
-  { experimentId: 'exp-2', name: 'Experiment 2' },
-];
-
-const mockUseExperimentsForSelect = jest.fn();
-
-jest.mock('../../hooks/useExperimentsForSelect', () => ({
-  useExperimentsForSelect: () => mockUseExperimentsForSelect(),
-}));
-
 describe('UsageTrackingConfigurator', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseExperimentsForSelect.mockReturnValue({
-      experiments: mockExperiments,
-      isLoading: false,
-      error: null,
-    });
-  });
-
   test('renders toggle in off state by default', () => {
     const onChange = jest.fn();
-    const onExperimentIdChange = jest.fn();
 
-    renderWithDesignSystem(
-      <UsageTrackingConfigurator
-        value={false}
-        onChange={onChange}
-        experimentId=""
-        onExperimentIdChange={onExperimentIdChange}
-      />,
-    );
+    renderWithDesignSystem(<UsageTrackingConfigurator value={false} onChange={onChange} />);
 
     expect(screen.getByText('Enable usage tracking')).toBeInTheDocument();
     expect(screen.getByRole('switch')).not.toBeChecked();
-    expect(screen.queryByText('Experiment')).not.toBeInTheDocument();
   });
 
-  test('shows experiment selector when toggle is on', () => {
+  test('renders toggle in on state when value is true', () => {
     const onChange = jest.fn();
-    const onExperimentIdChange = jest.fn();
 
-    renderWithDesignSystem(
-      <UsageTrackingConfigurator
-        value
-        onChange={onChange}
-        experimentId=""
-        onExperimentIdChange={onExperimentIdChange}
-      />,
-    );
+    renderWithDesignSystem(<UsageTrackingConfigurator value onChange={onChange} />);
 
     expect(screen.getByRole('switch')).toBeChecked();
-    expect(screen.getByText('Experiment')).toBeInTheDocument();
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
-    expect(
-      screen.getByText(/Select an existing experiment or leave blank to auto-create one named/),
-    ).toBeInTheDocument();
   });
 
   test('calls onChange when toggle is clicked', async () => {
     const onChange = jest.fn();
-    const onExperimentIdChange = jest.fn();
 
-    renderWithDesignSystem(
-      <UsageTrackingConfigurator
-        value={false}
-        onChange={onChange}
-        experimentId=""
-        onExperimentIdChange={onExperimentIdChange}
-      />,
-    );
+    renderWithDesignSystem(<UsageTrackingConfigurator value={false} onChange={onChange} />);
 
     await userEvent.click(screen.getByRole('switch'));
     expect(onChange).toHaveBeenCalledWith(true);
@@ -83,16 +33,8 @@ describe('UsageTrackingConfigurator', () => {
 
   test('displays description text', () => {
     const onChange = jest.fn();
-    const onExperimentIdChange = jest.fn();
 
-    renderWithDesignSystem(
-      <UsageTrackingConfigurator
-        value={false}
-        onChange={onChange}
-        experimentId=""
-        onExperimentIdChange={onExperimentIdChange}
-      />,
-    );
+    renderWithDesignSystem(<UsageTrackingConfigurator value={false} onChange={onChange} />);
 
     expect(screen.getByText(/all requests to this endpoint will be logged as traces/)).toBeInTheDocument();
   });

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/UsageTrackingConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/UsageTrackingConfigurator.tsx
@@ -32,7 +32,7 @@ export const UsageTrackingConfigurator = ({
 
       <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
         <FormattedMessage
-          defaultMessage="When enabled, all requests to this endpoint will be logged as traces in an MLflow experiment. This allows you to monitor usage, debug issues, and analyze performance."
+          defaultMessage="When enabled, all requests to this endpoint will be logged as traces. This allows you to monitor usage, debug issues, and analyze performance."
           description="Usage tracking description"
         />
       </Typography.Text>

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/UsageTrackingConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/UsageTrackingConfigurator.tsx
@@ -1,22 +1,17 @@
 import { Switch, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
-import { ExperimentSelect } from '../shared/ExperimentSelect';
 
 type ComponentIds = 'mlflow.gateway.edit-endpoint.usage-tracking' | 'mlflow.gateway.create-endpoint.usage-tracking';
 
 export interface UsageTrackingConfiguratorProps {
   value: boolean;
   onChange: (value: boolean) => void;
-  experimentId: string;
-  onExperimentIdChange: (experimentId: string) => void;
   componentIdPrefix?: ComponentIds;
 }
 
 export const UsageTrackingConfigurator = ({
   value,
   onChange,
-  experimentId,
-  onExperimentIdChange,
   componentIdPrefix = 'mlflow.gateway.edit-endpoint.usage-tracking',
 }: UsageTrackingConfiguratorProps) => {
   const { theme } = useDesignSystemTheme();
@@ -41,25 +36,6 @@ export const UsageTrackingConfigurator = ({
           description="Usage tracking description"
         />
       </Typography.Text>
-
-      {value && (
-        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-          <Typography.Text bold css={{ fontSize: theme.typography.fontSizeSm }}>
-            <FormattedMessage defaultMessage="Experiment" description="Label for experiment selector" />
-          </Typography.Text>
-          <ExperimentSelect
-            value={experimentId}
-            onChange={onExperimentIdChange}
-            componentIdPrefix={`${componentIdPrefix}.experiment`}
-          />
-          <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
-            <FormattedMessage
-              defaultMessage="Select an existing experiment or leave blank to auto-create one named 'gateway/[endpoint_name]'."
-              description="Experiment selector help text"
-            />
-          </Typography.Text>
-        </div>
-      )}
     </div>
   );
 };

--- a/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
@@ -212,19 +212,11 @@ export const EndpointFormRenderer = ({
               <Controller
                 control={form.control}
                 name="usageTracking"
-                render={({ field: usageTrackingField }) => (
-                  <Controller
-                    control={form.control}
-                    name="experimentId"
-                    render={({ field: experimentIdField }) => (
-                      <UsageTrackingConfigurator
-                        value={usageTrackingField.value}
-                        onChange={usageTrackingField.onChange}
-                        experimentId={experimentIdField.value ?? ''}
-                        onExperimentIdChange={experimentIdField.onChange}
-                        componentIdPrefix="mlflow.gateway.create-endpoint.usage-tracking"
-                      />
-                    )}
+                render={({ field }) => (
+                  <UsageTrackingConfigurator
+                    value={field.value}
+                    onChange={field.onChange}
+                    componentIdPrefix="mlflow.gateway.create-endpoint.usage-tracking"
                   />
                 )}
               />

--- a/mlflow/server/js/src/gateway/hooks/useEditEndpointForm.ts
+++ b/mlflow/server/js/src/gateway/hooks/useEditEndpointForm.ts
@@ -353,7 +353,6 @@ export function useEditEndpointForm(endpointId: string): UseEditEndpointFormResu
 
   const name = form.watch('name');
   const usageTracking = form.watch('usageTracking');
-  const experimentId = form.watch('experimentId');
 
   const hasChanges = useMemo(() => {
     if (!endpoint) return false;
@@ -363,9 +362,6 @@ export function useEditEndpointForm(endpointId: string): UseEditEndpointFormResu
 
     const originalUsageTracking = endpoint.usage_tracking ?? false;
     if (usageTracking !== originalUsageTracking) return true;
-
-    const originalExperimentId = endpoint.experiment_id ?? '';
-    if (experimentId !== originalExperimentId) return true;
 
     const originalPrimaryMappings = endpoint.model_mappings?.filter((m) => m.linkage_type === 'PRIMARY') ?? [];
     const originalFallbackMappings = endpoint.model_mappings?.filter((m) => m.linkage_type === 'FALLBACK') ?? [];
@@ -432,7 +428,7 @@ export function useEditEndpointForm(endpointId: string): UseEditEndpointFormResu
     });
 
     return trafficSplitChanged || fallbackChanged;
-  }, [endpoint, name, usageTracking, experimentId, trafficSplitModels, fallbackModels]);
+  }, [endpoint, name, usageTracking, trafficSplitModels, fallbackModels]);
 
   const { data: existingEndpoints } = useEndpointsQuery();
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -734,10 +734,6 @@
     "defaultMessage": "Download data",
     "description": "String for the download csv button to download metrics from this run offline in a CSV format"
   },
-  "3UM+1S": {
-    "defaultMessage": "Select an existing experiment or leave blank to auto-create one named 'gateway/[endpoint_name]'.",
-    "description": "Experiment selector help text"
-  },
   "3VURvw": {
     "defaultMessage": "No metrics or parameters available",
     "description": "Message displayed when no metrics or params are available in the compare runs chart configure modal"
@@ -1241,10 +1237,6 @@
   "757GVc": {
     "defaultMessage": "Cancel",
     "description": "experiment page > description modal > cancel button"
-  },
-  "76S52o": {
-    "defaultMessage": "Experiment",
-    "description": "Label for experiment selector"
   },
   "79dD5F": {
     "defaultMessage": "There was an error submitting your note.",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -355,10 +355,6 @@
     "defaultMessage": "Irrelevant",
     "description": "Evaluation results > relevancy assessment > negative value label. Displayed if evaluation result is considered as irrelevant to the query."
   },
-  "0NbqZr": {
-    "defaultMessage": "When enabled, all requests to this endpoint will be logged as traces in an MLflow experiment. This allows you to monitor usage, debug issues, and analyze performance.",
-    "description": "Usage tracking description"
-  },
   "0Qu0bD": {
     "defaultMessage": "Endpoints",
     "description": "Endpoints using this key column header"
@@ -6822,6 +6818,10 @@
   "kmtWGf": {
     "defaultMessage": "{count, plural, one { # trace } other { # traces }} will be deleted.",
     "description": "Experiment page > traces view controls > Delete traces modal > Confirmation message title"
+  },
+  "knEhQp": {
+    "defaultMessage": "When enabled, all requests to this endpoint will be logged as traces. This allows you to monitor usage, debug issues, and analyze performance.",
+    "description": "Usage tracking description"
   },
   "knJfuf": {
     "defaultMessage": "Learn more about the AI Gateway in the {gatewayDocs}.",


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Stop asking users to select the linked experiment. Instead, we'll always create a new experiment linked to the endpoint.

<img width="1190" height="326" alt="image" src="https://github.com/user-attachments/assets/4e8f1b5c-1523-43db-bba8-ef5f05cdeca0" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
