### PR TITLE
Preserve query params when navigating between traces-related tabs in new sidebar

### DIFF
--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.test.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.test.tsx
@@ -1,68 +1,36 @@
 import { describe, jest, test, expect, beforeEach } from '@jest/globals';
-import { render, screen } from '@testing-library/react';
-import { IntlProvider } from 'react-intl';
-import { DesignSystemProvider } from '@databricks/design-system';
+import { screen } from '@testing-library/react';
 import { MlflowSidebarExperimentItems } from './MlflowSidebarExperimentItems';
 import { MemoryRouter } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import { QueryClient, QueryClientProvider } from '../../common/utils/reactQueryHooks';
-import { MockedReduxStoreProvider } from '../../common/utils/TestUtils';
 import { WorkflowType } from '../contexts/WorkflowTypeContext';
-import { ExperimentPageTabName } from '../../experiment-tracking/constants';
+import { renderWithDesignSystem } from '../utils/TestUtils.react18';
+
+jest.mock('../../experiment-tracking/hooks/useExperimentQuery', () => ({
+  useGetExperimentQuery: jest.fn(() => ({})),
+}));
 
 jest.mock('../../experiment-tracking/components/experiment-page/hooks/useExperimentEvaluationRunsData', () => ({
   useExperimentEvaluationRunsData: jest.fn(() => ({ trainingRuns: [] })),
 }));
 
-jest.mock('../../experiment-tracking/hooks/useExperimentQuery', () => ({
-  useGetExperimentQuery: jest.fn(() => ({ data: { name: 'Test Experiment' }, loading: false })),
-}));
-
-jest.mock('@mlflow/mlflow/src/telemetry/hooks/useLogTelemetryEvent', () => ({
-  useLogTelemetryEvent: jest.fn(() => jest.fn()),
-}));
-
-jest.mock('@mlflow/mlflow/src/common/utils/FeatureUtils', () => ({
-  ...jest.requireActual<typeof import('@mlflow/mlflow/src/common/utils/FeatureUtils')>(
-    '@mlflow/mlflow/src/common/utils/FeatureUtils',
-  ),
-  shouldEnableExperimentOverviewTab: jest.fn(() => true),
-}));
-
-const mockUseGetExperimentPageActiveTabByRoute = jest.fn();
-jest.mock('../../experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute', () => ({
-  useGetExperimentPageActiveTabByRoute: () => mockUseGetExperimentPageActiveTabByRoute(),
-}));
-
 describe('MlflowSidebarExperimentItems', () => {
   const renderTestComponent = (initialEntries: string[] = ['/experiments/test-123/traces']) => {
     const queryClient = new QueryClient();
-    return render(
-      <MockedReduxStoreProvider state={{ entities: { experimentTagsByExperimentId: {}, experimentsById: {} } }}>
-        <IntlProvider locale="en">
-          <QueryClientProvider client={queryClient}>
-            <DesignSystemProvider>
-              <MemoryRouter initialEntries={initialEntries}>
-                <MlflowSidebarExperimentItems
-                  collapsed={false}
-                  experimentId="test-123"
-                  workflowType={WorkflowType.GENAI}
-                />
-              </MemoryRouter>
-            </DesignSystemProvider>
-          </QueryClientProvider>
-        </IntlProvider>
-      </MockedReduxStoreProvider>,
+    return renderWithDesignSystem(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <MlflowSidebarExperimentItems collapsed={false} experimentId="test-123" workflowType={WorkflowType.GENAI} />
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseGetExperimentPageActiveTabByRoute.mockReturnValue({ tabName: ExperimentPageTabName.Traces });
   });
 
-  test('preserves query params when navigating between traces-related tabs', () => {
-    mockUseGetExperimentPageActiveTabByRoute.mockReturnValue({ tabName: ExperimentPageTabName.Traces });
-
+  test('preserves query params when navigating between traces-related tabs', async () => {
     renderTestComponent(['/experiments/test-123/traces?startTimeLabel=LAST_24_HOURS&startTime=2024-01-01']);
 
     // Find the Sessions link (traces-related tab)
@@ -76,8 +44,6 @@ describe('MlflowSidebarExperimentItems', () => {
   });
 
   test('does not preserve query params when navigating to non-traces-related tabs', () => {
-    mockUseGetExperimentPageActiveTabByRoute.mockReturnValue({ tabName: ExperimentPageTabName.Traces });
-
     renderTestComponent(['/experiments/test-123/traces?startTimeLabel=LAST_24_HOURS']);
 
     // Find the Datasets link (non-traces-related tab)
@@ -86,8 +52,6 @@ describe('MlflowSidebarExperimentItems', () => {
   });
 
   test('does not preserve query params when navigating from non-traces-related tab', () => {
-    mockUseGetExperimentPageActiveTabByRoute.mockReturnValue({ tabName: ExperimentPageTabName.Datasets });
-
     renderTestComponent(['/experiments/test-123/datasets?startTimeLabel=LAST_24_HOURS']);
 
     // Even though we have query params, they should not be preserved when coming from Datasets

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.test.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.test.tsx
@@ -67,18 +67,12 @@ describe('MlflowSidebarExperimentItems', () => {
 
     // Find the Sessions link (traces-related tab)
     const sessionsLink = screen.getByText('Sessions').closest('a');
-    expect(sessionsLink).toHaveAttribute(
-      'href',
-      expect.stringContaining('startTimeLabel=LAST_24_HOURS'),
-    );
+    expect(sessionsLink).toHaveAttribute('href', expect.stringContaining('startTimeLabel=LAST_24_HOURS'));
     expect(sessionsLink).toHaveAttribute('href', expect.stringContaining('startTime=2024-01-01'));
 
     // Find the Overview link (traces-related tab)
     const overviewLink = screen.getByText('Overview').closest('a');
-    expect(overviewLink).toHaveAttribute(
-      'href',
-      expect.stringContaining('startTimeLabel=LAST_24_HOURS'),
-    );
+    expect(overviewLink).toHaveAttribute('href', expect.stringContaining('startTimeLabel=LAST_24_HOURS'));
   });
 
   test('does not preserve query params when navigating to non-traces-related tabs', () => {

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.test.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.test.tsx
@@ -1,0 +1,103 @@
+import { describe, jest, test, expect, beforeEach } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { MlflowSidebarExperimentItems } from './MlflowSidebarExperimentItems';
+import { MemoryRouter } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import { QueryClient, QueryClientProvider } from '../../common/utils/reactQueryHooks';
+import { MockedReduxStoreProvider } from '../../common/utils/TestUtils';
+import { WorkflowType } from '../contexts/WorkflowTypeContext';
+import { ExperimentPageTabName } from '../../experiment-tracking/constants';
+
+jest.mock('../../experiment-tracking/components/experiment-page/hooks/useExperimentEvaluationRunsData', () => ({
+  useExperimentEvaluationRunsData: jest.fn(() => ({ trainingRuns: [] })),
+}));
+
+jest.mock('../../experiment-tracking/hooks/useExperimentQuery', () => ({
+  useGetExperimentQuery: jest.fn(() => ({ data: { name: 'Test Experiment' }, loading: false })),
+}));
+
+jest.mock('@mlflow/mlflow/src/telemetry/hooks/useLogTelemetryEvent', () => ({
+  useLogTelemetryEvent: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('@mlflow/mlflow/src/common/utils/FeatureUtils', () => ({
+  ...jest.requireActual<typeof import('@mlflow/mlflow/src/common/utils/FeatureUtils')>(
+    '@mlflow/mlflow/src/common/utils/FeatureUtils',
+  ),
+  shouldEnableExperimentOverviewTab: jest.fn(() => true),
+}));
+
+const mockUseGetExperimentPageActiveTabByRoute = jest.fn();
+jest.mock('../../experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute', () => ({
+  useGetExperimentPageActiveTabByRoute: () => mockUseGetExperimentPageActiveTabByRoute(),
+}));
+
+describe('MlflowSidebarExperimentItems', () => {
+  const renderTestComponent = (initialEntries: string[] = ['/experiments/test-123/traces']) => {
+    const queryClient = new QueryClient();
+    return render(
+      <MockedReduxStoreProvider state={{ entities: { experimentTagsByExperimentId: {}, experimentsById: {} } }}>
+        <IntlProvider locale="en">
+          <QueryClientProvider client={queryClient}>
+            <DesignSystemProvider>
+              <MemoryRouter initialEntries={initialEntries}>
+                <MlflowSidebarExperimentItems
+                  collapsed={false}
+                  experimentId="test-123"
+                  workflowType={WorkflowType.GENAI}
+                />
+              </MemoryRouter>
+            </DesignSystemProvider>
+          </QueryClientProvider>
+        </IntlProvider>
+      </MockedReduxStoreProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseGetExperimentPageActiveTabByRoute.mockReturnValue({ tabName: ExperimentPageTabName.Traces });
+  });
+
+  test('preserves query params when navigating between traces-related tabs', () => {
+    mockUseGetExperimentPageActiveTabByRoute.mockReturnValue({ tabName: ExperimentPageTabName.Traces });
+
+    renderTestComponent(['/experiments/test-123/traces?startTimeLabel=LAST_24_HOURS&startTime=2024-01-01']);
+
+    // Find the Sessions link (traces-related tab)
+    const sessionsLink = screen.getByText('Sessions').closest('a');
+    expect(sessionsLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('startTimeLabel=LAST_24_HOURS'),
+    );
+    expect(sessionsLink).toHaveAttribute('href', expect.stringContaining('startTime=2024-01-01'));
+
+    // Find the Overview link (traces-related tab)
+    const overviewLink = screen.getByText('Overview').closest('a');
+    expect(overviewLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('startTimeLabel=LAST_24_HOURS'),
+    );
+  });
+
+  test('does not preserve query params when navigating to non-traces-related tabs', () => {
+    mockUseGetExperimentPageActiveTabByRoute.mockReturnValue({ tabName: ExperimentPageTabName.Traces });
+
+    renderTestComponent(['/experiments/test-123/traces?startTimeLabel=LAST_24_HOURS']);
+
+    // Find the Datasets link (non-traces-related tab)
+    const datasetsLink = screen.getByText('Datasets').closest('a');
+    expect(datasetsLink).not.toHaveAttribute('href', expect.stringContaining('startTimeLabel'));
+  });
+
+  test('does not preserve query params when navigating from non-traces-related tab', () => {
+    mockUseGetExperimentPageActiveTabByRoute.mockReturnValue({ tabName: ExperimentPageTabName.Datasets });
+
+    renderTestComponent(['/experiments/test-123/datasets?startTimeLabel=LAST_24_HOURS']);
+
+    // Even though we have query params, they should not be preserved when coming from Datasets
+    const tracesLink = screen.getByText('Traces').closest('a');
+    expect(tracesLink).not.toHaveAttribute('href', expect.stringContaining('startTimeLabel'));
+  });
+});

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeftIcon, BeakerIcon, Spinner, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { useGetExperimentQuery } from '../../experiment-tracking/hooks/useExperimentQuery';
+import { useLocation } from '../utils/RoutingUtils';
 import ExperimentTrackingRoutes from '../../experiment-tracking/routes';
 import { MlflowSidebarLink } from './MlflowSidebarLink';
 import { getExperimentKindForWorkflowType } from '../../experiment-tracking/utils/ExperimentKindUtils';
@@ -13,6 +14,7 @@ import { WorkflowType } from '../contexts/WorkflowTypeContext';
 import { useGetExperimentPageActiveTabByRoute } from '../../experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute';
 import { ExperimentPageTabName } from '../../experiment-tracking/constants';
 import { FormattedMessage } from 'react-intl';
+import { isTracesRelatedTab } from '../../experiment-tracking/pages/experiment-page-tabs/side-nav/utils';
 
 // pass a dummy function to avoid highlighting the experiment back link
 const isExperimentsActive = () => false;
@@ -40,6 +42,8 @@ export const MlflowSidebarExperimentItems = ({
     hasTrainingRuns: (trainingRuns?.length ?? 0) > 0,
   });
   const { tabName: activeTabByRoute } = useGetExperimentPageActiveTabByRoute();
+  const location = useLocation();
+  const { search } = location;
 
   return (
     <>
@@ -86,11 +90,16 @@ export const MlflowSidebarExperimentItems = ({
               }
               return activeTabByRoute === item.tabName;
             };
+            const preserveQueryParams =
+              activeTabByRoute && isTracesRelatedTab(activeTabByRoute) && isTracesRelatedTab(item.tabName);
             return (
               <MlflowSidebarLink
                 css={{ paddingLeft: collapsed ? undefined : theme.spacing.lg }}
                 key={item.componentId}
-                to={ExperimentTrackingRoutes.getExperimentPageTabRoute(experimentId ?? '', item.tabName)}
+                to={{
+                  pathname: ExperimentTrackingRoutes.getExperimentPageTabRoute(experimentId ?? '', item.tabName),
+                  search: preserveQueryParams ? search : undefined,
+                }}
                 componentId={item.componentId}
                 isActive={isActive}
                 collapsed={collapsed}

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
@@ -15,6 +15,7 @@ import { useGetExperimentPageActiveTabByRoute } from '../../experiment-tracking/
 import { ExperimentPageTabName } from '../../experiment-tracking/constants';
 import { FormattedMessage } from 'react-intl';
 import { isTracesRelatedTab } from '../../experiment-tracking/pages/experiment-page-tabs/side-nav/utils';
+import { Fragment } from 'react';
 
 // pass a dummy function to avoid highlighting the experiment back link
 const isExperimentsActive = () => false;
@@ -62,7 +63,7 @@ export const MlflowSidebarExperimentItems = ({
         {loading ? <Spinner /> : <Typography.Text ellipsis>{experiment?.name}</Typography.Text>}
       </MlflowSidebarLink>
       {Object.entries(config).map(([sectionKey, items]) => (
-        <>
+        <Fragment key={`${sectionKey}-section`}>
           {sectionKey !== 'top-level' && collapsed ? (
             <div
               css={{
@@ -108,7 +109,7 @@ export const MlflowSidebarExperimentItems = ({
               </MlflowSidebarLink>
             );
           })}
-        </>
+        </Fragment>
       ))}
       <div
         css={{

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
@@ -42,8 +42,7 @@ export const MlflowSidebarExperimentItems = ({
     hasTrainingRuns: (trainingRuns?.length ?? 0) > 0,
   });
   const { tabName: activeTabByRoute } = useGetExperimentPageActiveTabByRoute();
-  const location = useLocation();
-  const { search } = location;
+  const { search } = useLocation();
 
   return (
     <>

--- a/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import type { Location } from '../utils/RoutingUtils';
+import type { Location, To } from '../utils/RoutingUtils';
 import { Link, useLocation } from '../utils/RoutingUtils';
 import {
   DesignSystemEventProviderAnalyticsEventTypes,
@@ -24,7 +24,7 @@ export const MlflowSidebarLink = ({
   tooltipContent,
 }: {
   className?: string;
-  to: string;
+  to: To;
   componentId: string;
   icon?: React.ReactNode;
   children: React.ReactNode;


### PR DESCRIPTION
## What changes are proposed in this pull request?

The new `MlflowSidebar` component was not preserving query params (`startTimeLabel`, `startTime`, `endTime`) when navigating between Overview, Traces, and Chat Sessions tabs. This caused the time selector to reset when switching between these tabs.

This fix adds the same query param preservation logic that exists in `ExperimentPageSideNavSection` to the new sidebar.

### Changes:
- Add optional `search` prop to `MlflowSidebarLink` component
- Use `isTracesRelatedTab` utility to determine when to preserve params
- Pass search params to `MlflowSidebarLink` for traces-related navigation

## How is this PR tested?

- Manual testing: Verified that time range filters persist when navigating between Overview, Traces, and Chat Sessions tabs
- Verified compatibility with workspace prefix logic in `RoutingUtils`


https://github.com/user-attachments/assets/e5b08a40-5ca6-4a4e-a330-375df4cd7647



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)