### PR TITLE
Use `logger.warning` instead of `warnings.warn` for sklearn pickle warning message

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -17,7 +17,6 @@ import logging
 import os
 import pickle
 import shutil
-import warnings
 import weakref
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
@@ -266,14 +265,12 @@ def save_model(
         )
 
     if serialization_format != SERIALIZATION_FORMAT_SKOPS and not is_in_databricks_runtime():
-        warnings.warn(
+        _logger.warning(
             "Saving scikit-learn models in the pickle or cloudpickle format requires exercising "
             "caution because these formats rely on Python's object serialization mechanism, "
             "which can execute arbitrary code during deserialization. "
             "The recommended safe alternative is the 'skops' format. "
             "For more information, see: https://scikit-learn.org/stable/model_persistence.html",
-            FutureWarning,
-            stacklevel=2,
         )
 
     _validate_and_prepare_target_save_path(path)

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1032,10 +1032,7 @@ def test_autolog_does_not_throw_when_failing_to_sample_X():
     model_conf = Model.load(_get_model_uri())
 
     warning_messages = [args[0] for args, _ in mock_warning.call_args_list if args]
-    assert any(
-        msg.endswith("DO NOT SLICE ME")
-        for msg in warning_messages
-    )
+    assert any(msg.endswith("DO NOT SLICE ME") for msg in warning_messages)
 
     assert "signature" not in model_conf.to_dict()
     assert "saved_input_example_info" not in model_conf.to_dict()

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1030,8 +1030,13 @@ def test_autolog_does_not_throw_when_failing_to_sample_X():
         model.fit(throwing_X, y)
 
     model_conf = Model.load(_get_model_uri())
-    assert mock_warning.call_count == 2
-    mock_warning.call_args[0][0].endswith("DO NOT SLICE ME")
+
+    warning_messages = [args[0] for args, _ in mock_warning.call_args_list if args]
+    assert any(
+        msg.endswith("DO NOT SLICE ME")
+        for msg in warning_messages
+    )
+
     assert "signature" not in model_conf.to_dict()
     assert "saved_input_example_info" not in model_conf.to_dict()
 
@@ -1068,7 +1073,8 @@ def test_autolog_does_not_throw_when_predict_fails():
         model = sklearn.linear_model.LinearRegression()
         model.fit(X, y)
 
-    mock_warning.assert_called_with("Failed to infer model signature: Failed")
+    warning_messages = [args[0] for args, _ in mock_warning.call_args_list if args]
+    assert "Failed to infer model signature: Failed" in warning_messages
     model_conf = Model.load(_get_model_uri())
     assert "signature" not in model_conf.to_dict()
 
@@ -1085,7 +1091,8 @@ def test_autolog_does_not_throw_when_infer_signature_fails():
         model = sklearn.linear_model.LinearRegression()
         model.fit(X, y)
 
-    mock_warning.assert_called_once_with("Failed to infer model signature: Failed")
+    warning_messages = [args[0] for args, _ in mock_warning.call_args_list if args]
+    assert "Failed to infer model signature: Failed" in warning_messages
     model_conf = Model.load(_get_model_uri())
     assert "signature" not in model_conf.to_dict()
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Use `logger.warning` instead of `warnings.warn` for sklearn pickle warning message

warnings.warn will emit the same error only once, it is usually used in deprecated API case.

but we should log the warning for each log_model invocation (if it triggers the pickle dumping) .
### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
