### PR TITLE
#20769: Fixing dev/generate-protos.sh script when running on MacOS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,8 +11,12 @@ mlflow.Rcheck
 outputs
 examples
 
-dev
-# required for Docker build
+# Exclude dev contents but keep files required for proto build (COPY dev ./dev/)
+dev/*
+!dev/generate_protos.py
+!dev/Dockerfile.protos
+!dev/proto-plugin.sh
+!dev/proto_plugin.py
 !requirements/test-requirements.txt
 !requirements/lint-requirements.txt
 !requirements/extra-ml-requirements.txt
@@ -20,6 +24,7 @@ dev
 tests
 # required for Docker build
 !tests/resources/mlflow-test-plugin/
+!tests/protos/
 
 node_modules
 coverage

--- a/dev/Dockerfile.protos
+++ b/dev/Dockerfile.protos
@@ -8,3 +8,6 @@ RUN pip install protobuf packaging
 COPY mlflow/protos ./mlflow/protos/
 COPY dev ./dev/
 COPY tests/protos ./tests/protos/
+
+# Ensure proto-plugin.sh is executable (slim image may not preserve execute bit from COPY)
+RUN chmod +x dev/proto-plugin.sh

--- a/dev/Dockerfile.protos
+++ b/dev/Dockerfile.protos
@@ -7,7 +7,6 @@ RUN pip install protobuf packaging
 # Copy only necessary files to compile protos
 COPY mlflow/protos ./mlflow/protos/
 COPY dev ./dev/
-COPY tests/protos ./tests/protos/
-
 # Ensure proto-plugin.sh is executable (slim image may not preserve execute bit from COPY)
 RUN chmod +x dev/proto-plugin.sh
+COPY tests/protos ./tests/protos/

--- a/dev/proto-plugin.sh
+++ b/dev/proto-plugin.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 export PYTHONPATH="$PWD:$PYTHONPATH"
-python dev/proto_plugin.py
+exec python dev/proto_plugin.py


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #20769

### What changes are proposed in this pull request?

This PR fixes the `dev/generate-protos.sh` script so it runs successfully on macOS (and other environments using Podman/Docker) when building the proto compilation image.

**Root cause:** The `.dockerignore` excluded the entire `dev` directory. When the Dockerfile ran `COPY dev ./dev/`, the build context contained no `dev` path (the directory was filtered out), so the copy step failed with "no items matching glob .../dev copied".

**Changes:**

1. **`.dockerignore`**
   - Replaced the blanket `dev` exclusion with `dev/*` and explicit re-includes for the files required by the proto build: `dev/generate_protos.py`, `dev/Dockerfile.protos`, `dev/proto-plugin.sh`, `dev/proto_plugin.py`. The build context now includes a `dev` directory with only these files, so `COPY dev ./dev/` succeeds.
   - Added `!tests/protos/` so `tests/protos` is included in the context for the proto build.

2. **`dev/proto-plugin.sh`**
   - Shebang changed from `#!/usr/bin/env bash` to `#!/bin/sh` so the script runs in the `python:3.10-slim` image, which typically does not include bash.
   - Invocation changed from `python dev/proto_plugin.py` to `exec python dev/proto_plugin.py` so the Python process replaces the shell and exit codes/signals are correct when protoc invokes the plugin.

3. **`dev/Dockerfile.protos`**
   - Added `RUN chmod +x dev/proto-plugin.sh` so the plugin script is executable in the image (the slim image may not preserve the execute bit from `COPY`).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual testing: Run `dev/generate-protos.sh` on macOS with Docker or Podman. The image build completes, proto compilation runs in the container, and generated files are copied back; `uv run ./dev/gen_rest_api.py` then runs successfully on the host.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
