### PR TITLE
Fix `gen_rest_api.py` to use per-method API versions from proto definitions

### DIFF
--- a/.github/workflows/protos.yml
+++ b/.github/workflows/protos.yml
@@ -9,6 +9,7 @@ on:
       - ready_for_review
     paths:
       - .github/workflows/protos.yml
+      - dev/gen_rest_api.py
       - dev/generate_protos.py
       - dev/generate-protos.sh
       - dev/test-generate-protos.sh

--- a/docs/api_reference/source/rest-api.rst
+++ b/docs/api_reference/source/rest-api.rst
@@ -1289,7 +1289,7 @@ Register Scorer
 +---------------------------------+-------------+
 |            Endpoint             | HTTP Method |
 +=================================+=============+
-| ``2.0/mlflow/scorers/register`` | ``POST``    |
+| ``3.0/mlflow/scorers/register`` | ``POST``    |
 +---------------------------------+-------------+
 
 Register a scorer for an experiment.
@@ -1356,7 +1356,7 @@ List Scorers
 +-----------------------------+-------------+
 |          Endpoint           | HTTP Method |
 +=============================+=============+
-| ``2.0/mlflow/scorers/list`` | ``GET``     |
+| ``3.0/mlflow/scorers/list`` | ``GET``     |
 +-----------------------------+-------------+
 
 List all scorers for an experiment.
@@ -1409,7 +1409,7 @@ List Scorer Versions
 +---------------------------------+-------------+
 |            Endpoint             | HTTP Method |
 +=================================+=============+
-| ``2.0/mlflow/scorers/versions`` | ``GET``     |
+| ``3.0/mlflow/scorers/versions`` | ``GET``     |
 +---------------------------------+-------------+
 
 List all versions of a specific scorer for an experiment.
@@ -1464,7 +1464,7 @@ Get Scorer
 +----------------------------+-------------+
 |          Endpoint          | HTTP Method |
 +============================+=============+
-| ``2.0/mlflow/scorers/get`` | ``GET``     |
+| ``3.0/mlflow/scorers/get`` | ``GET``     |
 +----------------------------+-------------+
 
 Get a specific scorer for an experiment.
@@ -1521,7 +1521,7 @@ Delete Scorer
 +-------------------------------+-------------+
 |           Endpoint            | HTTP Method |
 +===============================+=============+
-| ``2.0/mlflow/scorers/delete`` | ``DELETE``  |
+| ``3.0/mlflow/scorers/delete`` | ``DELETE``  |
 +-------------------------------+-------------+
 
 Delete a scorer for an experiment.
@@ -1562,7 +1562,7 @@ Create Gateway Secret
 +---------------------------------------+-------------+
 |               Endpoint                | HTTP Method |
 +=======================================+=============+
-| ``2.0/mlflow/gateway/secrets/create`` | ``POST``    |
+| ``3.0/mlflow/gateway/secrets/create`` | ``POST``    |
 +---------------------------------------+-------------+
 
 Create a new encrypted secret for LLM provider authentication
@@ -1625,7 +1625,7 @@ Get Gateway Secret Info
 +------------------------------------+-------------+
 |              Endpoint              | HTTP Method |
 +====================================+=============+
-| ``2.0/mlflow/gateway/secrets/get`` | ``GET``     |
+| ``3.0/mlflow/gateway/secrets/get`` | ``GET``     |
 +------------------------------------+-------------+
 
 Get metadata about a secret (does not include the encrypted value)
@@ -1680,7 +1680,7 @@ Update Gateway Secret
 +---------------------------------------+-------------+
 |               Endpoint                | HTTP Method |
 +=======================================+=============+
-| ``2.0/mlflow/gateway/secrets/update`` | ``POST``    |
+| ``3.0/mlflow/gateway/secrets/update`` | ``POST``    |
 +---------------------------------------+-------------+
 
 Update an existing secret's value or auth configuration
@@ -1741,7 +1741,7 @@ Delete Gateway Secret
 +---------------------------------------+-------------+
 |               Endpoint                | HTTP Method |
 +=======================================+=============+
-| ``2.0/mlflow/gateway/secrets/delete`` | ``DELETE``  |
+| ``3.0/mlflow/gateway/secrets/delete`` | ``DELETE``  |
 +---------------------------------------+-------------+
 
 Delete a secret
@@ -1778,7 +1778,7 @@ List Gateway Secrets
 +-------------------------------------+-------------+
 |              Endpoint               | HTTP Method |
 +=====================================+=============+
-| ``2.0/mlflow/gateway/secrets/list`` | ``GET``     |
+| ``3.0/mlflow/gateway/secrets/list`` | ``GET``     |
 +-------------------------------------+-------------+
 
 List all secrets with optional filtering by provider
@@ -1831,7 +1831,7 @@ Create Gateway Model Definition
 +-------------------------------------------------+-------------+
 |                    Endpoint                     | HTTP Method |
 +=================================================+=============+
-| ``2.0/mlflow/gateway/model-definitions/create`` | ``POST``    |
+| ``3.0/mlflow/gateway/model-definitions/create`` | ``POST``    |
 +-------------------------------------------------+-------------+
 
 Create a reusable model definition
@@ -1892,7 +1892,7 @@ Get Gateway Model Definition
 +----------------------------------------------+-------------+
 |                   Endpoint                   | HTTP Method |
 +==============================================+=============+
-| ``2.0/mlflow/gateway/model-definitions/get`` | ``GET``     |
+| ``3.0/mlflow/gateway/model-definitions/get`` | ``GET``     |
 +----------------------------------------------+-------------+
 
 Get a model definition by ID
@@ -1945,7 +1945,7 @@ List Gateway Model Definitions
 +-----------------------------------------------+-------------+
 |                   Endpoint                    | HTTP Method |
 +===============================================+=============+
-| ``2.0/mlflow/gateway/model-definitions/list`` | ``GET``     |
+| ``3.0/mlflow/gateway/model-definitions/list`` | ``GET``     |
 +-----------------------------------------------+-------------+
 
 List all model definitions with optional filters
@@ -2000,7 +2000,7 @@ Update Gateway Model Definition
 +-------------------------------------------------+-------------+
 |                    Endpoint                     | HTTP Method |
 +=================================================+=============+
-| ``2.0/mlflow/gateway/model-definitions/update`` | ``POST``    |
+| ``3.0/mlflow/gateway/model-definitions/update`` | ``POST``    |
 +-------------------------------------------------+-------------+
 
 Update a model definition
@@ -2063,7 +2063,7 @@ Delete Gateway Model Definition
 +-------------------------------------------------+-------------+
 |                    Endpoint                     | HTTP Method |
 +=================================================+=============+
-| ``2.0/mlflow/gateway/model-definitions/delete`` | ``DELETE``  |
+| ``3.0/mlflow/gateway/model-definitions/delete`` | ``DELETE``  |
 +-------------------------------------------------+-------------+
 
 Delete a model definition (fails if in use by any endpoint)
@@ -2100,7 +2100,7 @@ Create Gateway Endpoint
 +-----------------------------------------+-------------+
 |                Endpoint                 | HTTP Method |
 +=========================================+=============+
-| ``2.0/mlflow/gateway/endpoints/create`` | ``POST``    |
+| ``3.0/mlflow/gateway/endpoints/create`` | ``POST``    |
 +-----------------------------------------+-------------+
 
 Create a new endpoint with model configurations
@@ -2167,7 +2167,7 @@ Get Gateway Endpoint
 +--------------------------------------+-------------+
 |               Endpoint               | HTTP Method |
 +======================================+=============+
-| ``2.0/mlflow/gateway/endpoints/get`` | ``GET``     |
+| ``3.0/mlflow/gateway/endpoints/get`` | ``GET``     |
 +--------------------------------------+-------------+
 
 Get endpoint details including all model configurations
@@ -2222,7 +2222,7 @@ Update Gateway Endpoint
 +-----------------------------------------+-------------+
 |                Endpoint                 | HTTP Method |
 +=========================================+=============+
-| ``2.0/mlflow/gateway/endpoints/update`` | ``POST``    |
+| ``3.0/mlflow/gateway/endpoints/update`` | ``POST``    |
 +-----------------------------------------+-------------+
 
 Update an endpoint's name
@@ -2290,7 +2290,7 @@ Delete Gateway Endpoint
 +-----------------------------------------+-------------+
 |                Endpoint                 | HTTP Method |
 +=========================================+=============+
-| ``2.0/mlflow/gateway/endpoints/delete`` | ``DELETE``  |
+| ``3.0/mlflow/gateway/endpoints/delete`` | ``DELETE``  |
 +-----------------------------------------+-------------+
 
 Delete an endpoint and all its model configurations
@@ -2327,7 +2327,7 @@ List Gateway Endpoints
 +---------------------------------------+-------------+
 |               Endpoint                | HTTP Method |
 +=======================================+=============+
-| ``2.0/mlflow/gateway/endpoints/list`` | ``GET``     |
+| ``3.0/mlflow/gateway/endpoints/list`` | ``GET``     |
 +---------------------------------------+-------------+
 
 List endpoints with optional filtering by provider or secret
@@ -2382,7 +2382,7 @@ Attach Model to Endpoint
 +------------------------------------------------+-------------+
 |                    Endpoint                    | HTTP Method |
 +================================================+=============+
-| ``2.0/mlflow/gateway/endpoints/models/attach`` | ``POST``    |
+| ``3.0/mlflow/gateway/endpoints/models/attach`` | ``POST``    |
 +------------------------------------------------+-------------+
 
 Attach an existing model definition to an endpoint
@@ -2439,7 +2439,7 @@ Detach Model from Endpoint
 +------------------------------------------------+-------------+
 |                    Endpoint                    | HTTP Method |
 +================================================+=============+
-| ``2.0/mlflow/gateway/endpoints/models/detach`` | ``POST``    |
+| ``3.0/mlflow/gateway/endpoints/models/detach`` | ``POST``    |
 +------------------------------------------------+-------------+
 
 Detach a model definition from an endpoint (does not delete the model definition)
@@ -2478,7 +2478,7 @@ Create Endpoint Binding
 +--------------------------------------------------+-------------+
 |                     Endpoint                     | HTTP Method |
 +==================================================+=============+
-| ``2.0/mlflow/gateway/endpoints/bindings/create`` | ``POST``    |
+| ``3.0/mlflow/gateway/endpoints/bindings/create`` | ``POST``    |
 +--------------------------------------------------+-------------+
 
 Create a binding between an endpoint and an MLflow resource
@@ -2537,7 +2537,7 @@ Delete Endpoint Binding
 +--------------------------------------------------+-------------+
 |                     Endpoint                     | HTTP Method |
 +==================================================+=============+
-| ``2.0/mlflow/gateway/endpoints/bindings/delete`` | ``DELETE``  |
+| ``3.0/mlflow/gateway/endpoints/bindings/delete`` | ``DELETE``  |
 +--------------------------------------------------+-------------+
 
 Delete a binding between an endpoint and a resource
@@ -2578,7 +2578,7 @@ List Endpoint Bindings
 +------------------------------------------------+-------------+
 |                    Endpoint                    | HTTP Method |
 +================================================+=============+
-| ``2.0/mlflow/gateway/endpoints/bindings/list`` | ``GET``     |
+| ``3.0/mlflow/gateway/endpoints/bindings/list`` | ``GET``     |
 +------------------------------------------------+-------------+
 
 List all bindings for an endpoint
@@ -2635,7 +2635,7 @@ Gateway Set Endpoint Tag
 +------------------------------------------+-------------+
 |                 Endpoint                 | HTTP Method |
 +==========================================+=============+
-| ``2.0/mlflow/gateway/endpoints/set-tag`` | ``POST``    |
+| ``3.0/mlflow/gateway/endpoints/set-tag`` | ``POST``    |
 +------------------------------------------+-------------+
 
 Set a tag on an endpoint
@@ -2676,7 +2676,7 @@ Gateway Delete Endpoint Tag
 +---------------------------------------------+-------------+
 |                  Endpoint                   | HTTP Method |
 +=============================================+=============+
-| ``2.0/mlflow/gateway/endpoints/delete-tag`` | ``DELETE``  |
+| ``3.0/mlflow/gateway/endpoints/delete-tag`` | ``DELETE``  |
 +---------------------------------------------+-------------+
 
 Delete a tag from an endpoint
@@ -2715,7 +2715,7 @@ Create Prompt Optimization Job
 +-----------------------------------------+-------------+
 |                Endpoint                 | HTTP Method |
 +=========================================+=============+
-| ``2.0/mlflow/prompt-optimization/jobs`` | ``POST``    |
+| ``3.0/mlflow/prompt-optimization/jobs`` | ``POST``    |
 +-----------------------------------------+-------------+
 
 Create a new prompt optimization job.
@@ -2776,7 +2776,7 @@ Get Prompt Optimization Job
 +--------------------------------------------------+-------------+
 |                     Endpoint                     | HTTP Method |
 +==================================================+=============+
-| ``2.0/mlflow/prompt-optimization/jobs/{job_id}`` | ``GET``     |
+| ``3.0/mlflow/prompt-optimization/jobs/{job_id}`` | ``GET``     |
 +--------------------------------------------------+-------------+
 
 Get the details and status of a prompt optimization job.
@@ -2831,7 +2831,7 @@ Search Prompt Optimization Jobs
 +------------------------------------------------+-------------+
 |                    Endpoint                    | HTTP Method |
 +================================================+=============+
-| ``2.0/mlflow/prompt-optimization/jobs/search`` | ``POST``    |
+| ``3.0/mlflow/prompt-optimization/jobs/search`` | ``POST``    |
 +------------------------------------------------+-------------+
 
 Search for prompt optimization jobs.
@@ -2885,7 +2885,7 @@ Cancel Prompt Optimization Job
 +---------------------------------------------------------+-------------+
 |                        Endpoint                         | HTTP Method |
 +=========================================================+=============+
-| ``2.0/mlflow/prompt-optimization/jobs/{job_id}/cancel`` | ``POST``    |
+| ``3.0/mlflow/prompt-optimization/jobs/{job_id}/cancel`` | ``POST``    |
 +---------------------------------------------------------+-------------+
 
 Cancel an in-progress prompt optimization job.
@@ -2939,7 +2939,7 @@ Delete Prompt Optimization Job
 +--------------------------------------------------+-------------+
 |                     Endpoint                     | HTTP Method |
 +==================================================+=============+
-| ``2.0/mlflow/prompt-optimization/jobs/{job_id}`` | ``DELETE``  |
+| ``3.0/mlflow/prompt-optimization/jobs/{job_id}`` | ``DELETE``  |
 +--------------------------------------------------+-------------+
 
 Delete a prompt optimization job and its associated data.


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #20772

### What changes are proposed in this pull request?

This PR fixes `dev/gen_rest_api.py` so that the generated REST API documentation (`docs/api_reference/source/rest-api.rst`) reflects the **actual API version** of each endpoint as defined in the proto files, instead of applying the default `2.0` to every method.

**Problem:** The script previously set `method.api_version = self.api_version` (the global default `"2.0"`) for all methods. Endpoints that are declared with `since: { major: 3, minor: 0 }` in the protos (e.g. scorers, gateway, prompt-optimization) were therefore documented as `2.0`, which is incorrect.

**Solution:** Use the per-method version from `protos.json` when present (the proto plugin already populates `since_major` and `since_minor` from the `(rpc)` option in the `.proto` files), and only fall back to the default `"2.0"` when a method has no `since` in the proto.

**Changes in `dev/gen_rest_api.py`:**
- `Method`: add optional `api_version` argument and set `self.api_version` from it.
- `Method.parse_all_from`: read `since_major` and `since_minor` from each method’s `rpc_options` in `protos.json` and pass `method_api_version` when constructing `Method` instances.
- `API.connect_methods_messages`: stop overwriting every method’s version with the default; only set `method.api_version = self.api_version` when `method.api_version is None` (i.e. when the proto did not specify a `since`).

After this change, running the proto doc pipeline and then `gen_rest_api.py` produces `rest-api.rst` with correct versions (e.g. `3.0` for scorers/gateway/prompt-optimization, `2.0` for the rest).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual testing: Run the proto doc generation (e.g. `dev/generate-protos.sh` or ensure `protos.json` is up to date), then run `uv run ./dev/gen_rest_api.py`. Inspect `docs/api_reference/source/rest-api.rst` and confirm that endpoints with `since: { major: 3 }` in the protos appear as `3.0` and others as `2.0`.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
