### PR TITLE
Add documentation for pickle-free model formats

### DIFF
--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -7,11 +7,11 @@ import { APILink } from "@site/src/components/APILink";
 
 # Pickle-Free Model format
 
-Saving models with Python's `pickle` or `cloudpickle` rely on Python's object serialization mechanism, which can execute arbitrary code during deserialization. MLflow supports safer **pickle-free** saving formats for several model flavors. Prefer these formats when possible.
+Saving models with Python's `pickle` or `cloudpickle` relies on Python's object serialization mechanism, which can execute arbitrary code during deserialization. MLflow supports safer **pickle-free** saving formats for several model flavors. Prefer these formats when possible.
 
 ## Pickle-free format for Scikit-learn model
 
-When saving a scikit-learn model, set param `serialization_format="skops"` to use the **skops** format for safe deserialization of scikit-learn models. The `skops` format does not rely on Python's pickle and avoids arbitrary code execution when loading.
+When saving a scikit-learn model, set the parameter `serialization_format="skops"` to use the **skops** format for safe deserialization of scikit-learn models. The `skops` format does not rely on Python's pickle and avoids arbitrary code execution when loading.
 
 ```python
 import mlflow
@@ -29,7 +29,7 @@ with mlflow.start_run():
     )
 ```
 
-For some scikit-learn model that contains custom or third-party types, you need to set `skops_trusted_types` to a list of fully qualified type names so skops can load them. For example, a pipeline with a custom transformer must list that transformer's type as trusted:
+For some scikit-learn models that contain custom or third-party types, you need to set `skops_trusted_types` to a list of fully qualified type names so skops can load them. For example, a pipeline with a custom transformer must list that transformer's type as trusted:
 
 ```python
 from numpy.random import randint
@@ -99,7 +99,7 @@ See <APILink fn="mlflow.pytorch.log_model" /> and <APILink fn="mlflow.pytorch.sa
 
 ## Pickle-free format for DSPy model
 
-Right now DSPy models don't support pickle-free format, but a new saving option `use_dspy_model_save` is introduced to delegate the model saving implementation to DSPy library.
+Currently, DSPy models do not support a pickle-free format, but a new saving option `use_dspy_model_save` is introduced to delegate the model saving implementation to the DSPy library.
 Set param `use_dspy_model_save=True` to use the DSPy built-in `dspy.Module.save` method. This option requires **dspy > 3.1.0**.
 
 ```python
@@ -120,7 +120,7 @@ See <APILink fn="mlflow.dspy.log_model" /> and <APILink fn="mlflow.dspy.save_mod
 
 ## Pickle-free format for LightGBM model
 
-For LightGBM models that are the scikit-learn model types (e.g., `LGBMClassifier`, `LGBMRegressor`), you can use the **skops** format. This does not apply to `lightgbm.Booster` instances, which use a native format.
+For LightGBM models that are scikit-learn model types (e.g., `LGBMClassifier`, `LGBMRegressor`), you can use the **skops** format. This does not apply to `lightgbm.Booster` instances, which use a native format.
 
 ```python
 import mlflow
@@ -170,6 +170,6 @@ When set to `false`, loading a model that was saved with `pickle` or `cloudpickl
 | Scikit-learn        | `serialization_format="skops"` | Use `skops_trusted_types` when needed.                        |
 | PyTorch             | `serialization_format="pt2"`   | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
 | DSPy                | `use_dspy_model_save=True`     | Requires dspy > 3.1.0.                                        |
-| LightGBM            | `serialization_format="skops"` | Only for lightGBM model of sklearn type.                      |
+| LightGBM            | `serialization_format="skops"` | Only for lightGBM models of sklearn type.                     |
 | LangChain           | Models From Code               | Pickle saving emits warnings.                                 |
 | Custom Python model | Models From Code               | Pickle saving emits warnings.                                 |

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -90,7 +90,7 @@ with mlflow.start_run():
     mlflow.pytorch.log_model(
         sequential_model,
         name="model",
-        serialization_format="skops",
+        serialization_format="pt2",
         input_example=input_example,
     )
 ```

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -5,19 +5,9 @@ sidebar_position: 5
 
 import { APILink } from "@site/src/components/APILink";
 
-# Pickle-Free Model Saving
+# Pickle-Free Model format
 
 Saving models with Python's `pickle` or `cloudpickle` rely on Python's object serialization mechanism, which can execute arbitrary code during deserialization. MLflow supports safer **pickle-free** saving formats for several model flavors. Prefer these formats when possible.
-
-## Environment Variable: `MLFLOW_ALLOW_PICKLE_DESERIALIZATION`
-
-You can disallow MLflow model loading with `pickle` or `cloudpickle` globally by setting the environment variable as follows:
-
-```bash
-export MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false
-```
-
-When set to `false`, loading a model that was saved with `pickle` or `cloudpickle` will raise an error unless you use a pickle-free saving option when logging the model. The default is `true` for backward compatibility.
 
 ## Pickle-free format for Scikit-learn model
 
@@ -135,13 +125,25 @@ LangChain model supports saving as **Models-From-Code** artifacts, which avoids 
 
 Custom Python model supports saving as **Models-From-Code** artifacts, which avoids pickle entirely. For details and examples, see [Models From Code](/ml/model/models-from-code).
 
+
+## Global configuration to force MLflow pickle-free model loading
+
+You can disallow MLflow model loading with `pickle` or `cloudpickle` globally by setting the environment variable as follows:
+
+```bash
+export MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false
+```
+
+When set to `false`, loading a model that was saved with `pickle` or `cloudpickle` will raise an error unless you use a pickle-free saving option when logging the model. The default is `true` for backward compatibility.
+
+
 ## Summary
 
-| Flavor        | Pickle-free option                         | Notes |
-|---------------|--------------------------------------------|-------|
-| Scikit-learn  | `serialization_format="skops"`             | Use `skops_trusted_types` when needed. |
-| PyTorch       | `export_model=True`                        | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
-| DSPy          | `use_dspy_model_save=True`                 | Requires dspy >= 3.1.0. |
-| LightGBM      | `serialization_format="skops"`             | For sklearn API only; use `skops_trusted_types` when needed. |
-| LangChain     | Models From Code (script path + `set_model`) | Pickle saving emits warnings. |
-| mlflow.pyfunc | Models From Code (script path + `set_model`) | Pickle saving emits warnings. |
+| Flavor | Pickle-free option | Notes |
+|--------|--------------------|-------|
+| Scikit-learn | `serialization_format="skops"` | Use `skops_trusted_types` when needed. |
+| PyTorch | `export_model=True` | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
+| DSPy | `use_dspy_model_save=True` | Requires dspy >= 3.1.0. |
+| LightGBM | `serialization_format="skops"` | Only for lightGBM model of sklearn type |
+| LangChain | Models From Code | Pickle saving emits warnings. |
+| Custom Python model | Models From Code | Pickle saving emits warnings. |

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -66,7 +66,7 @@ See <APILink fn="mlflow.sklearn.log_model" /> and <APILink fn="mlflow.sklearn.sa
 
 ## Pickle-free format for PyTorch model
 
-When saving a PyTorch model, saving with `serialization_format="skops"` uses `torch.export.save` and stores the model as a traced graph instead of pickle serialization format.
+When saving a PyTorch model, saving with `serialization_format="pt2"` uses `torch.export.save` and stores the model as a traced graph instead of pickle serialization format.
 
 Requirements:
 

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -15,7 +15,6 @@ When saving a scikit-learn model, set param `serialization_format="skops"` to us
 
 ```python
 import mlflow
-import mlflow.sklearn
 from sklearn.datasets import load_iris
 from sklearn.tree import DecisionTreeClassifier
 
@@ -30,10 +29,39 @@ with mlflow.start_run():
     )
 ```
 
-For some scikit-learn model that contains custom or third-party types, you need to set `skops_trusted_types` mark a list of classes as trusted types.
+For some scikit-learn model that contains custom or third-party types, you need to set `skops_trusted_types` to a list of fully qualified type names so skops can load them. For example, a pipeline with a custom transformer must list that transformer's type as trusted:
 
 ```python
-# Add an example that contains custom type, e.g. a pipeline with a custom transformer.
+from numpy.random import randint
+from sklearn.base import BaseEstimator, TransformerMixin
+import pandas as pd
+from sklearn.pipeline import Pipeline
+
+class CustomTransformer(BaseEstimator, TransformerMixin):
+    def fit(self, X, y=None):
+        return self
+
+    def transform(self, X, y=None):
+        # Perform arbitary transformation
+        X["random_int"] = randint(0, 10, X.shape[0])
+        return X
+
+df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+
+pipeline = Pipeline(
+    steps=[
+        ("use_custom_transformer", CustomTransformer())
+    ]
+)
+
+# Custom classes must be marked as trusted for skops
+with mlflow.start_run():
+    mlflow.sklearn.log_model(
+        pipeline,
+        "model",
+        serialization_format="skops",
+        skops_trusted_types=['__main__.CustomTransformer']
+    )
 ```
 
 See <APILink fn="mlflow.sklearn.log_model" /> and <APILink fn="mlflow.sklearn.save_model" /> for full parameters.
@@ -48,24 +76,24 @@ Requirements:
 - An **input_example** is required (and only `Tensor` type input are supported for the exported model)
 - Not supported for `torch.jit.ScriptModule` models
 
+Note:
+
+This graph-based pytorch model format does not allow the loaded model weights to transfer between different devices. E.g., if the model weights are in GPU device  when saving, then the loaded model must load weights to the same GPU device.
+
 ```python
 import mlflow
-import mlflow.pytorch
 import torch
 from torch import nn
-from mlflow.models import infer_signature
 
-model = nn.Linear(10, 2)
-input_example = torch.randn(1, 10)
-signature = infer_signature(input_example.numpy(), model(input_example).detach().numpy())
+sequential_model = nn.Sequential(nn.Linear(4, 3), nn.ReLU(), nn.Linear(3, 1))
+input_example = torch.rand(5, 4).numpy()
 
 with mlflow.start_run():
-    mlflow.pytorch.log_model(
-        model,
+    mlflow.pytorch.save_model(
+        sequential_model,
         "model",
         export_model=True,
         input_example=input_example,
-        signature=signature,
     )
 ```
 
@@ -73,16 +101,14 @@ See <APILink fn="mlflow.pytorch.log_model" /> and <APILink fn="mlflow.pytorch.sa
 
 ## Pickle-free format for DSPy model
 
-DSPy models can be save with param `use_dspy_model_save=True` to use the DSPy built-in `dspy.Module.save` method instead of pickle format. This option requires **dspy >= 3.1.0**.
+Right now DSPy model hasn't supported pickle-free format, but a new saving option `use_dspy_model_save` is introduced to delegate the model saving implementation to DSPy library.
+Set param `use_dspy_model_save=True` to use the DSPy built-in `dspy.Module.save` method. This option requires **dspy >= 3.1.0**.
 
 ```python
 import mlflow
-import mlflow.dspy
 import dspy
 
-# Build and compile your DSPy model
-model = dspy.Module(...)  # your module
-# ... compile, etc.
+model = dspy.ChainOfThought("question -> answer")
 
 with mlflow.start_run():
     mlflow.dspy.log_model(
@@ -100,7 +126,6 @@ For LightGBM models that are the scikit-learn model types (e.g., `LGBMClassifier
 
 ```python
 import mlflow
-import mlflow.lightgbm
 from lightgbm import LGBMClassifier
 from sklearn.datasets import load_iris
 
@@ -112,6 +137,7 @@ with mlflow.start_run():
         model,
         "model",
         serialization_format="skops",
+        skops_trusted_types=['collections.OrderedDict', 'lightgbm.basic.Booster', 'lightgbm.sklearn.LGBMClassifier']
     )
 ```
 

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -66,7 +66,7 @@ See <APILink fn="mlflow.sklearn.log_model" /> and <APILink fn="mlflow.sklearn.sa
 
 ## Pickle-free format for PyTorch model
 
-When saving a PyTorch model, saving with **export_model=True** uses `torch.export.save` and stores the model as a traced graph instead of pickle serialization format.
+When saving a PyTorch model, saving with `serialization_format="skops"` uses `torch.export.save` and stores the model as a traced graph instead of pickle serialization format.
 
 Requirements:
 
@@ -90,7 +90,7 @@ with mlflow.start_run():
     mlflow.pytorch.log_model(
         sequential_model,
         name="model",
-        export_model=True,
+        serialization_format="skops",
         input_example=input_example,
     )
 ```
@@ -168,7 +168,7 @@ When set to `false`, loading a model that was saved with `pickle` or `cloudpickl
 | Flavor              | Pickle-free option             | Notes                                                         |
 | ------------------- | ------------------------------ | ------------------------------------------------------------- |
 | Scikit-learn        | `serialization_format="skops"` | Use `skops_trusted_types` when needed.                        |
-| PyTorch             | `export_model=True`            | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
+| PyTorch             | `serialization_format="pt2"`   | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
 | DSPy                | `use_dspy_model_save=True`     | Requires dspy > 3.1.0.                                        |
 | LightGBM            | `serialization_format="skops"` | Only for lightGBM model of sklearn type.                      |
 | LangChain           | Models From Code               | Pickle saving emits warnings.                                 |

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -76,7 +76,7 @@ Requirements:
 
 Note:
 
-This graph-based PyTorch model format does not allow the loaded model weights to transfer between different devices. E.g., if the model weights are in GPU device when saving, then the loaded model must load weights to the same GPU device.
+This graph-based PyTorch model format does not allow the loaded model weights to transfer between different devices. For example, if the model is saved with weights on GPU device 0, the loaded model must also load the weights onto GPU device 0. The weights cannot be transferred to a different device (for example, CPU or a different GPU) after loading.
 
 ```python
 import mlflow

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -72,15 +72,14 @@ See <APILink fn="mlflow.sklearn.log_model" /> and <APILink fn="mlflow.sklearn.sa
 
 When saving a PyTorch model, saving with `serialization_format="pt2"` uses `torch.export.save` and stores the model as a traced graph instead of pickle serialization format.
 
-Requirements:
+:::danger Requirements and Limitations
 
 - `torch` >= 2.4
-- An **input_example** is required (and only `Tensor` type input are supported for the exported model)
+- An **input_example** is required (and only `Tensor` type inputs are supported for the exported model)
 - Not supported for `torch.jit.ScriptModule` models
+- Model weights **cannot be transferred between devices** after loading. If the model is saved with weights on GPU device 0, it must also be loaded onto GPU device 0 — not CPU or a different GPU.
 
-Note:
-
-This graph-based PyTorch model format does not allow the loaded model weights to transfer between different devices. For example, if the model is saved with weights on GPU device 0, the loaded model must also load the weights onto GPU device 0. The weights cannot be transferred to a different device (for example, CPU or a different GPU) after loading.
+:::
 
 ```python
 import mlflow

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -66,7 +66,7 @@ See <APILink fn="mlflow.sklearn.log_model" /> and <APILink fn="mlflow.sklearn.sa
 
 ## Pickle-free format for PyTorch model
 
-When saving a pytorch model, saving with **export_model=True** uses `torch.export.save` and stores the model as a traced graph instead of pickle serialization format.
+When saving a PyTorch model, saving with **export_model=True** uses `torch.export.save` and stores the model as a traced graph instead of pickle serialization format.
 
 Requirements:
 
@@ -76,7 +76,7 @@ Requirements:
 
 Note:
 
-This graph-based pytorch model format does not allow the loaded model weights to transfer between different devices. E.g., if the model weights are in GPU device when saving, then the loaded model must load weights to the same GPU device.
+This graph-based PyTorch model format does not allow the loaded model weights to transfer between different devices. E.g., if the model weights are in GPU device when saving, then the loaded model must load weights to the same GPU device.
 
 ```python
 import mlflow
@@ -99,8 +99,8 @@ See <APILink fn="mlflow.pytorch.log_model" /> and <APILink fn="mlflow.pytorch.sa
 
 ## Pickle-free format for DSPy model
 
-Right now DSPy model hasn't supported pickle-free format, but a new saving option `use_dspy_model_save` is introduced to delegate the model saving implementation to DSPy library.
-Set param `use_dspy_model_save=True` to use the DSPy built-in `dspy.Module.save` method. This option requires **dspy >= 3.1.0**.
+Right now DSPy models don't support pickle-free format, but a new saving option `use_dspy_model_save` is introduced to delegate the model saving implementation to DSPy library.
+Set param `use_dspy_model_save=True` to use the DSPy built-in `dspy.Module.save` method. This option requires **dspy > 3.1.0**.
 
 ```python
 import mlflow
@@ -169,7 +169,7 @@ When set to `false`, loading a model that was saved with `pickle` or `cloudpickl
 | ------------------- | ------------------------------ | ------------------------------------------------------------- |
 | Scikit-learn        | `serialization_format="skops"` | Use `skops_trusted_types` when needed.                        |
 | PyTorch             | `export_model=True`            | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
-| DSPy                | `use_dspy_model_save=True`     | Requires dspy >= 3.1.0.                                       |
-| LightGBM            | `serialization_format="skops"` | Only for lightGBM model of sklearn type                       |
+| DSPy                | `use_dspy_model_save=True`     | Requires dspy > 3.1.0.                                       |
+| LightGBM            | `serialization_format="skops"` | Only for lightGBM model of sklearn type.                      |
 | LangChain           | Models From Code               | Pickle saving emits warnings.                                 |
 | Custom Python model | Models From Code               | Pickle saving emits warnings.                                 |

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -129,9 +129,11 @@ See <APILink fn="mlflow.lightgbm.log_model" /> and <APILink fn="mlflow.lightgbm.
 
 ## Pickle-free format for LangChain model
 
+LangChain model supports saving as **Models-From-Code** artifacts, which avoids pickle entirely. For details and examples, see [Models From Code](/ml/model/models-from-code).
+
 ## Pickle-free format for custom Python model
 
-
+Custom Python model supports saving as **Models-From-Code** artifacts, which avoids pickle entirely. For details and examples, see [Models From Code](/ml/model/models-from-code).
 
 ## Summary
 

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -170,11 +170,11 @@ When set to `false`, loading a model that was saved with `pickle` or `cloudpickl
 
 ## Summary
 
-| Flavor              | Pickle-free option             | Notes                                                         | Impact when becoming default                                                  |
-| ------------------- | ------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Scikit-learn        | `serialization_format="skops"` | Use `skops_trusted_types` when needed.                        | No impact — transparent upgrade for most models.                              |
+| Flavor              | Pickle-free option             | Notes                                                         | Impact when becoming default                                                                       |
+| ------------------- | ------------------------------ | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Scikit-learn        | `serialization_format="skops"` | Use `skops_trusted_types` when needed.                        | No impact — transparent upgrade for most models.                                                   |
 | PyTorch             | `serialization_format="pt2"`   | Requires `input_example`, torch >= 2.4; not for ScriptModule. | **Breaking change** — `input_example` will be required; `torch.jit.ScriptModule` is not supported. |
-| DSPy                | `use_dspy_model_save=True`     | Requires dspy > 3.1.0.                                        | Requires upgrading to dspy > 3.1.0.                                           |
-| LightGBM            | `serialization_format="skops"` | Only for lightGBM models of sklearn type.                     | No impact — transparent upgrade for sklearn-type LightGBM models.             |
-| LangChain           | Models From Code               | Pickle saving emits warnings.                                 | No impact.                                                                    |
-| Custom Python model | Models From Code               | Pickle saving emits warnings.                                 | No impact.                                                                    |
+| DSPy                | `use_dspy_model_save=True`     | Requires dspy > 3.1.0.                                        | Requires upgrading to dspy > 3.1.0.                                                                |
+| LightGBM            | `serialization_format="skops"` | Only for lightGBM models of sklearn type.                     | No impact — transparent upgrade for sklearn-type LightGBM models.                                  |
+| LangChain           | Models From Code               | Pickle saving emits warnings.                                 | No impact.                                                                                         |
+| Custom Python model | Models From Code               | Pickle saving emits warnings.                                 | No impact.                                                                                         |

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -9,6 +9,10 @@ import { APILink } from "@site/src/components/APILink";
 
 Saving models with Python's `pickle` or `cloudpickle` relies on Python's object serialization mechanism, which can execute arbitrary code during deserialization. MLflow supports safer **pickle-free** saving formats for several model flavors. Prefer these formats when possible.
 
+:::warning Upcoming Default Behavior Change
+Pickle-free saving formats will become the **default** in an upcoming MLflow release. We strongly recommend adopting these formats now to ensure a smooth transition.
+:::
+
 ## Pickle-free format for Scikit-learn model
 
 When saving a scikit-learn model, set the parameter `serialization_format="skops"` to use the **skops** format for safe deserialization of scikit-learn models. The `skops` format does not rely on Python's pickle and avoids arbitrary code execution when loading.

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -1,0 +1,145 @@
+---
+sidebar_label: Pickle-Free Model format
+sidebar_position: 5
+---
+
+import { APILink } from "@site/src/components/APILink";
+
+# Pickle-Free Model Saving
+
+Saving models with Python's `pickle` or `cloudpickle` rely on Python's object serialization mechanism, which can execute arbitrary code during deserialization. MLflow supports safer **pickle-free** saving formats for several model flavors. Prefer these formats when possible.
+
+## Environment Variable: `MLFLOW_ALLOW_PICKLE_DESERIALIZATION`
+
+You can disallow MLflow model loading with `pickle` or `cloudpickle` globally by setting the environment variable as follows:
+
+```bash
+export MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false
+```
+
+When set to `false`, loading a model that was saved with `pickle` or `cloudpickle` will raise an error unless you use a pickle-free saving option when logging the model. The default is `true` for backward compatibility.
+
+## Pickle-free format for Scikit-learn model
+
+When saving a scikit-learn model, set param `serialization_format="skops"` to use the **skops** format for safe deserialization of scikit-learn models. The `skops` format does not rely on Python's pickle and avoids arbitrary code execution when loading.
+
+```python
+import mlflow
+import mlflow.sklearn
+from sklearn.datasets import load_iris
+from sklearn.tree import DecisionTreeClassifier
+
+X, y = load_iris(return_X_y=True)
+model = DecisionTreeClassifier().fit(X, y)
+
+with mlflow.start_run():
+    mlflow.sklearn.log_model(
+        model,
+        "model",
+        serialization_format="skops",
+    )
+```
+
+For some scikit-learn model that contains custom or third-party types, you need to set `skops_trusted_types` mark a list of classes as trusted types.
+
+```python
+# Add an example that contains custom type, e.g. a pipeline with a custom transformer.
+```
+
+See <APILink fn="mlflow.sklearn.log_model" /> and <APILink fn="mlflow.sklearn.save_model" /> for full parameters.
+
+## Pickle-free format for PyTorch model
+
+When saving a pytorch model, saving with **export_model=True** uses `torch.export.save` and stores the model as a traced graph instead of pickle serialization format.
+
+Requirements:
+
+- `torch` >= 2.4
+- An **input_example** is required (and only `Tensor` type input are supported for the exported model)
+- Not supported for `torch.jit.ScriptModule` models
+
+```python
+import mlflow
+import mlflow.pytorch
+import torch
+from torch import nn
+from mlflow.models import infer_signature
+
+model = nn.Linear(10, 2)
+input_example = torch.randn(1, 10)
+signature = infer_signature(input_example.numpy(), model(input_example).detach().numpy())
+
+with mlflow.start_run():
+    mlflow.pytorch.log_model(
+        model,
+        "model",
+        export_model=True,
+        input_example=input_example,
+        signature=signature,
+    )
+```
+
+See <APILink fn="mlflow.pytorch.log_model" /> and <APILink fn="mlflow.pytorch.save_model" /> for details.
+
+## Pickle-free format for DSPy model
+
+DSPy models can be save with param `use_dspy_model_save=True` to use the DSPy built-in `dspy.Module.save` method instead of pickle format. This option requires **dspy >= 3.1.0**.
+
+```python
+import mlflow
+import mlflow.dspy
+import dspy
+
+# Build and compile your DSPy model
+model = dspy.Module(...)  # your module
+# ... compile, etc.
+
+with mlflow.start_run():
+    mlflow.dspy.log_model(
+        model,
+        "model",
+        use_dspy_model_save=True,
+    )
+```
+
+See <APILink fn="mlflow.dspy.log_model" /> and <APILink fn="mlflow.dspy.save_model" /> for full parameters.
+
+## Pickle-free format for LightGBM model
+
+For LightGBM models that are the scikit-learn model types (e.g., `LGBMClassifier`, `LGBMRegressor`), you can use the **skops** format. This does not apply to `lightgbm.Booster` instances, which use a native format.
+
+```python
+import mlflow
+import mlflow.lightgbm
+from lightgbm import LGBMClassifier
+from sklearn.datasets import load_iris
+
+X, y = load_iris(return_X_y=True)
+model = LGBMClassifier(objective="multiclass", random_state=42).fit(X, y)
+
+with mlflow.start_run():
+    mlflow.lightgbm.log_model(
+        model,
+        "model",
+        serialization_format="skops",
+    )
+```
+
+See <APILink fn="mlflow.lightgbm.log_model" /> and <APILink fn="mlflow.lightgbm.save_model" /> for details.
+
+## Pickle-free format for LangChain model
+
+## Pickle-free format for custom Python model
+
+
+
+## Summary
+
+| Flavor        | Pickle-free option                         | Notes |
+|---------------|--------------------------------------------|-------|
+| Scikit-learn  | `serialization_format="skops"`             | Use `skops_trusted_types` when needed. |
+| PyTorch       | `export_model=True`                        | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
+| DSPy          | `use_dspy_model_save=True`                 | Requires dspy >= 3.1.0. |
+| LightGBM      | `serialization_format="skops"`             | For sklearn API only; use `skops_trusted_types` when needed. |
+| LangChain     | Models From Code (script path + `set_model`) | Pickle saving emits warnings. |
+| mlflow.pyfunc | Models From Code (script path + `set_model`) | Pickle saving emits warnings. |

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -147,11 +147,11 @@ See <APILink fn="mlflow.lightgbm.log_model" /> and <APILink fn="mlflow.lightgbm.
 
 ## Pickle-free format for LangChain model
 
-LangChain model supports saving as **Models-From-Code** artifacts, which avoids pickle entirely. For details and examples, see [Models From Code](/ml/model/models-from-code).
+LangChain model supports saving as **Models From Code** artifacts, which avoids pickle entirely. For details and examples, see [Models From Code](/ml/model/models-from-code).
 
 ## Pickle-free format for custom Python model
 
-Custom Python model supports saving as **Models-From-Code** artifacts, which avoids pickle entirely. For details and examples, see [Models From Code](/ml/model/models-from-code).
+Custom Python model supports saving as **Models From Code** artifacts, which avoids pickle entirely. For details and examples, see [Models From Code](/ml/model/models-from-code).
 
 ## Global configuration to force MLflow pickle-free model loading
 

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -85,10 +85,12 @@ When saving a PyTorch model, saving with `serialization_format="pt2"` uses `torc
 import mlflow
 import torch
 from torch import nn
+from sklearn.datasets import load_diabetes
 
-sequential_model = nn.Sequential(nn.Linear(4, 3), nn.ReLU(), nn.Linear(3, 1))
-input_example = torch.rand(5, 4).numpy()
-
+# Load a real dataset and use a sample as the input example
+X, _ = load_diabetes(return_X_y=True)
+input_example = torch.tensor(X[:5], dtype=torch.float32).numpy()
+sequential_model = nn.Sequential(nn.Linear(10, 3), nn.ReLU(), nn.Linear(3, 1))
 with mlflow.start_run():
     mlflow.pytorch.log_model(
         sequential_model,

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -24,7 +24,7 @@ model = DecisionTreeClassifier().fit(X, y)
 with mlflow.start_run():
     mlflow.sklearn.log_model(
         model,
-        "model",
+        name="model",
         serialization_format="skops",
     )
 ```
@@ -37,30 +37,28 @@ from sklearn.base import BaseEstimator, TransformerMixin
 import pandas as pd
 from sklearn.pipeline import Pipeline
 
+
 class CustomTransformer(BaseEstimator, TransformerMixin):
     def fit(self, X, y=None):
         return self
 
     def transform(self, X, y=None):
-        # Perform arbitary transformation
+        # Perform arbitrary transformation
         X["random_int"] = randint(0, 10, X.shape[0])
         return X
 
+
 df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
 
-pipeline = Pipeline(
-    steps=[
-        ("use_custom_transformer", CustomTransformer())
-    ]
-)
+pipeline = Pipeline(steps=[("use_custom_transformer", CustomTransformer())])
 
 # Custom classes must be marked as trusted for skops
 with mlflow.start_run():
     mlflow.sklearn.log_model(
         pipeline,
-        "model",
+        name="model",
         serialization_format="skops",
-        skops_trusted_types=['__main__.CustomTransformer']
+        skops_trusted_types=["__main__.CustomTransformer"],
     )
 ```
 
@@ -78,7 +76,7 @@ Requirements:
 
 Note:
 
-This graph-based pytorch model format does not allow the loaded model weights to transfer between different devices. E.g., if the model weights are in GPU device  when saving, then the loaded model must load weights to the same GPU device.
+This graph-based pytorch model format does not allow the loaded model weights to transfer between different devices. E.g., if the model weights are in GPU device when saving, then the loaded model must load weights to the same GPU device.
 
 ```python
 import mlflow
@@ -89,9 +87,9 @@ sequential_model = nn.Sequential(nn.Linear(4, 3), nn.ReLU(), nn.Linear(3, 1))
 input_example = torch.rand(5, 4).numpy()
 
 with mlflow.start_run():
-    mlflow.pytorch.save_model(
+    mlflow.pytorch.log_model(
         sequential_model,
-        "model",
+        name="model",
         export_model=True,
         input_example=input_example,
     )
@@ -113,7 +111,7 @@ model = dspy.ChainOfThought("question -> answer")
 with mlflow.start_run():
     mlflow.dspy.log_model(
         model,
-        "model",
+        name="model",
         use_dspy_model_save=True,
     )
 ```
@@ -135,9 +133,13 @@ model = LGBMClassifier(objective="multiclass", random_state=42).fit(X, y)
 with mlflow.start_run():
     mlflow.lightgbm.log_model(
         model,
-        "model",
+        name="model",
         serialization_format="skops",
-        skops_trusted_types=['collections.OrderedDict', 'lightgbm.basic.Booster', 'lightgbm.sklearn.LGBMClassifier']
+        skops_trusted_types=[
+            "collections.OrderedDict",
+            "lightgbm.basic.Booster",
+            "lightgbm.sklearn.LGBMClassifier",
+        ],
     )
 ```
 
@@ -151,7 +153,6 @@ LangChain model supports saving as **Models-From-Code** artifacts, which avoids 
 
 Custom Python model supports saving as **Models-From-Code** artifacts, which avoids pickle entirely. For details and examples, see [Models From Code](/ml/model/models-from-code).
 
-
 ## Global configuration to force MLflow pickle-free model loading
 
 You can disallow MLflow model loading with `pickle` or `cloudpickle` globally by setting the environment variable as follows:
@@ -162,14 +163,13 @@ export MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false
 
 When set to `false`, loading a model that was saved with `pickle` or `cloudpickle` will raise an error unless you use a pickle-free saving option when logging the model. The default is `true` for backward compatibility.
 
-
 ## Summary
 
-| Flavor | Pickle-free option | Notes |
-|--------|--------------------|-------|
-| Scikit-learn | `serialization_format="skops"` | Use `skops_trusted_types` when needed. |
-| PyTorch | `export_model=True` | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
-| DSPy | `use_dspy_model_save=True` | Requires dspy >= 3.1.0. |
-| LightGBM | `serialization_format="skops"` | Only for lightGBM model of sklearn type |
-| LangChain | Models From Code | Pickle saving emits warnings. |
-| Custom Python model | Models From Code | Pickle saving emits warnings. |
+| Flavor              | Pickle-free option             | Notes                                                         |
+| ------------------- | ------------------------------ | ------------------------------------------------------------- |
+| Scikit-learn        | `serialization_format="skops"` | Use `skops_trusted_types` when needed.                        |
+| PyTorch             | `export_model=True`            | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
+| DSPy                | `use_dspy_model_save=True`     | Requires dspy >= 3.1.0.                                       |
+| LightGBM            | `serialization_format="skops"` | Only for lightGBM model of sklearn type                       |
+| LangChain           | Models From Code               | Pickle saving emits warnings.                                 |
+| Custom Python model | Models From Code               | Pickle saving emits warnings.                                 |

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -169,7 +169,7 @@ When set to `false`, loading a model that was saved with `pickle` or `cloudpickl
 | ------------------- | ------------------------------ | ------------------------------------------------------------- |
 | Scikit-learn        | `serialization_format="skops"` | Use `skops_trusted_types` when needed.                        |
 | PyTorch             | `export_model=True`            | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
-| DSPy                | `use_dspy_model_save=True`     | Requires dspy > 3.1.0.                                       |
+| DSPy                | `use_dspy_model_save=True`     | Requires dspy > 3.1.0.                                        |
 | LightGBM            | `serialization_format="skops"` | Only for lightGBM model of sklearn type.                      |
 | LangChain           | Models From Code               | Pickle saving emits warnings.                                 |
 | Custom Python model | Models From Code               | Pickle saving emits warnings.                                 |

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -10,7 +10,7 @@ import { APILink } from "@site/src/components/APILink";
 Saving models with Python's `pickle` or `cloudpickle` relies on Python's object serialization mechanism, which can execute arbitrary code during deserialization. MLflow supports safer **pickle-free** saving formats for several model flavors. Prefer these formats when possible.
 
 :::warning Upcoming Default Behavior Change
-Pickle-free saving formats will become the **default** in an upcoming MLflow release. We strongly recommend adopting these formats now to ensure a smooth transition.
+Pickle-free saving formats will become the **default** in an upcoming MLflow release. **Most users (scikit-learn, LightGBM, LangChain, custom Python) will see no breaking change.** PyTorch users should review the [requirements](#pickle-free-format-for-pytorch-model) — `input_example` will be required and `torch.jit.ScriptModule` is not supported.
 :::
 
 ## Pickle-free format for Scikit-learn model
@@ -169,11 +169,11 @@ When set to `false`, loading a model that was saved with `pickle` or `cloudpickl
 
 ## Summary
 
-| Flavor              | Pickle-free option             | Notes                                                         |
-| ------------------- | ------------------------------ | ------------------------------------------------------------- |
-| Scikit-learn        | `serialization_format="skops"` | Use `skops_trusted_types` when needed.                        |
-| PyTorch             | `serialization_format="pt2"`   | Requires `input_example`, torch >= 2.4; not for ScriptModule. |
-| DSPy                | `use_dspy_model_save=True`     | Requires dspy > 3.1.0.                                        |
-| LightGBM            | `serialization_format="skops"` | Only for lightGBM models of sklearn type.                     |
-| LangChain           | Models From Code               | Pickle saving emits warnings.                                 |
-| Custom Python model | Models From Code               | Pickle saving emits warnings.                                 |
+| Flavor              | Pickle-free option             | Notes                                                         | Impact when becoming default                                                  |
+| ------------------- | ------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Scikit-learn        | `serialization_format="skops"` | Use `skops_trusted_types` when needed.                        | No impact — transparent upgrade for most models.                              |
+| PyTorch             | `serialization_format="pt2"`   | Requires `input_example`, torch >= 2.4; not for ScriptModule. | **Breaking change** — `input_example` will be required; `torch.jit.ScriptModule` is not supported. |
+| DSPy                | `use_dspy_model_save=True`     | Requires dspy > 3.1.0.                                        | Requires upgrading to dspy > 3.1.0.                                           |
+| LightGBM            | `serialization_format="skops"` | Only for lightGBM models of sklearn type.                     | No impact — transparent upgrade for sklearn-type LightGBM models.             |
+| LangChain           | Models From Code               | Pickle saving emits warnings.                                 | No impact.                                                                    |
+| Custom Python model | Models From Code               | Pickle saving emits warnings.                                 | No impact.                                                                    |

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -80,7 +80,7 @@ When saving a PyTorch model, saving with `serialization_format="pt2"` uses `torc
 - Not supported for `torch.jit.ScriptModule` models
 - Model weights **cannot be transferred between devices** after loading. If the model is saved with weights on GPU device 0, it must also be loaded onto GPU device 0 — not CPU or a different GPU.
 - To avoid these limitations, use the pickle-based serialization by setting `serialization_format="pickle"`.
-:::
+  :::
 
 ```python
 import mlflow

--- a/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
+++ b/docs/docs/classic-ml/tracking/pickle-free-models/index.mdx
@@ -11,6 +11,7 @@ Saving models with Python's `pickle` or `cloudpickle` relies on Python's object 
 
 :::warning Upcoming Default Behavior Change
 Pickle-free saving formats will become the **default** in an upcoming MLflow release. **Most users (scikit-learn, LightGBM, LangChain, custom Python) will see no breaking change.** PyTorch users should review the [requirements](#pickle-free-format-for-pytorch-model) — `input_example` will be required and `torch.jit.ScriptModule` is not supported.
+To avoid getting affected by the change, pin the MLflow version or specify `serialization_format="pickle"` in the model logging code.
 :::
 
 ## Pickle-free format for Scikit-learn model
@@ -78,7 +79,7 @@ When saving a PyTorch model, saving with `serialization_format="pt2"` uses `torc
 - An **input_example** is required (and only `Tensor` type inputs are supported for the exported model)
 - Not supported for `torch.jit.ScriptModule` models
 - Model weights **cannot be transferred between devices** after loading. If the model is saved with weights on GPU device 0, it must also be loaded onto GPU device 0 — not CPU or a different GPU.
-
+- To avoid these limitations, use the pickle-based serialization by setting `serialization_format="pickle"`.
 :::
 
 ```python
@@ -101,27 +102,6 @@ with mlflow.start_run():
 ```
 
 See <APILink fn="mlflow.pytorch.log_model" /> and <APILink fn="mlflow.pytorch.save_model" /> for details.
-
-## Pickle-free format for DSPy model
-
-Currently, DSPy models do not support a pickle-free format, but a new saving option `use_dspy_model_save` is introduced to delegate the model saving implementation to the DSPy library.
-Set param `use_dspy_model_save=True` to use the DSPy built-in `dspy.Module.save` method. This option requires **dspy > 3.1.0**.
-
-```python
-import mlflow
-import dspy
-
-model = dspy.ChainOfThought("question -> answer")
-
-with mlflow.start_run():
-    mlflow.dspy.log_model(
-        model,
-        name="model",
-        use_dspy_model_save=True,
-    )
-```
-
-See <APILink fn="mlflow.dspy.log_model" /> and <APILink fn="mlflow.dspy.save_model" /> for full parameters.
 
 ## Pickle-free format for LightGBM model
 

--- a/docs/sidebarsClassicML.ts
+++ b/docs/sidebarsClassicML.ts
@@ -369,7 +369,7 @@ const sidebarsClassicML: SidebarsConfig = {
             {
               type: 'doc',
               id: 'tracking/pickle-free-models/index',
-              label: 'Pickle-Free Model Saving',
+              label: 'Pickle-Free Model format',
             },
             {
               type: 'doc',

--- a/docs/sidebarsClassicML.ts
+++ b/docs/sidebarsClassicML.ts
@@ -368,11 +368,6 @@ const sidebarsClassicML: SidebarsConfig = {
             },
             {
               type: 'doc',
-              id: 'tracking/pickle-free-models/index',
-              label: 'Pickle-Free Model format',
-            },
-            {
-              type: 'doc',
               id: 'tracking/tracking-api/index',
               label: 'Tracking APIs',
             },
@@ -394,6 +389,11 @@ const sidebarsClassicML: SidebarsConfig = {
               type: 'doc',
               id: 'community-model-flavors/index',
               label: 'Community-Managed Model Integrations',
+            },
+            {
+              type: 'doc',
+              id: 'tracking/pickle-free-models/index',
+              label: 'Pickle-Free Model format',
             },
           ],
         },

--- a/docs/sidebarsClassicML.ts
+++ b/docs/sidebarsClassicML.ts
@@ -368,6 +368,11 @@ const sidebarsClassicML: SidebarsConfig = {
             },
             {
               type: 'doc',
+              id: 'tracking/pickle-free-models/index',
+              label: 'Pickle-Free Model Saving',
+            },
+            {
+              type: 'doc',
               id: 'tracking/tracking-api/index',
               label: 'Tracking APIs',
             },


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Pickle free model format doc

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
