### PR TITLE
ResponsesAgent: allow list content in function call output

### DIFF
--- a/mlflow/types/responses.py
+++ b/mlflow/types/responses.py
@@ -340,8 +340,8 @@ def responses_to_cc(message: dict[str, Any]) -> list[dict[str, Any]]:
         return [{"role": "assistant", "content": json.dumps(message["summary"])}]
     elif msg_type == "function_call_output":
         output = message["output"]
-        # Convert list output to JSON string for ChatCompletion compatibility
-        if isinstance(output, list):
+        # Convert non-string output to string for ChatCompletion compatibility
+        if not isinstance(output, str):
             try:
                 output = json.dumps(output)
             except (TypeError, ValueError):

--- a/mlflow/types/responses.py
+++ b/mlflow/types/responses.py
@@ -339,10 +339,17 @@ def responses_to_cc(message: dict[str, Any]) -> list[dict[str, Any]]:
     elif msg_type == "reasoning":
         return [{"role": "assistant", "content": json.dumps(message["summary"])}]
     elif msg_type == "function_call_output":
+        output = message["output"]
+        # Convert list output to JSON string for ChatCompletion compatibility
+        if isinstance(output, list):
+            try:
+                output = json.dumps(output)
+            except (TypeError, ValueError):
+                output = str(output)
         return [
             {
                 "role": "tool",
-                "content": message["output"],
+                "content": output,
                 "tool_call_id": message["call_id"],
             }
         ]

--- a/mlflow/types/responses_helpers.py
+++ b/mlflow/types/responses_helpers.py
@@ -370,7 +370,7 @@ class Message(Status):
 
 class FunctionCallOutput(Status):
     call_id: str
-    output: str
+    output: str | list[dict[str, Any]]
     type: str = "function_call_output"
 
 

--- a/tests/pyfunc/test_responses_agent_validation.py
+++ b/tests/pyfunc/test_responses_agent_validation.py
@@ -5,8 +5,9 @@ from mlflow.types.responses import (
     ResponsesAgentRequest,
     ResponsesAgentResponse,
     ResponsesAgentStreamEvent,
+    responses_to_cc,
 )
-from mlflow.types.responses_helpers import Message
+from mlflow.types.responses_helpers import FunctionCallOutput, Message
 
 
 def test_responses_request_validation():
@@ -174,3 +175,87 @@ def test_responses_stream_event_validation():
                 },
             },
         )
+
+
+def test_function_call_output_accepts_string_and_list():
+    output_with_string = FunctionCallOutput(
+        call_id="call_123",
+        output="Hello, world!",
+    )
+    assert output_with_string.output == "Hello, world!"
+
+    output_with_list = FunctionCallOutput(
+        call_id="call_456",
+        output=[
+            {"type": "input_text", "text": "Result from tool"},
+            {"type": "input_image", "image_url": "https://example.com/image.png"},
+        ],
+    )
+    assert isinstance(output_with_list.output, list)
+    assert len(output_with_list.output) == 2
+    assert output_with_list.output[0]["type"] == "input_text"
+
+
+def test_function_call_output_stream_event_with_list_output():
+    event = ResponsesAgentStreamEvent(
+        **{
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "type": "function_call_output",
+                "call_id": "call_789",
+                "output": [
+                    {"type": "input_text", "text": "Tool execution result"},
+                ],
+            },
+        }
+    )
+    assert event.type == "response.output_item.done"
+
+
+def test_responses_to_cc_converts_list_output_to_json_string():
+    message_with_string_output = {
+        "type": "function_call_output",
+        "call_id": "call_123",
+        "output": "Hello, world!",
+    }
+    result = responses_to_cc(message_with_string_output)
+    assert len(result) == 1
+    assert result[0]["role"] == "tool"
+    assert result[0]["content"] == "Hello, world!"
+    assert result[0]["tool_call_id"] == "call_123"
+
+    message_with_list_output = {
+        "type": "function_call_output",
+        "call_id": "call_456",
+        "output": [
+            {"type": "input_text", "text": "Result from tool"},
+            {"type": "input_image", "image_url": "https://example.com/image.png"},
+        ],
+    }
+    result = responses_to_cc(message_with_list_output)
+    assert len(result) == 1
+    assert result[0]["role"] == "tool"
+    assert result[0]["tool_call_id"] == "call_456"
+    # List output should be converted to JSON string
+    assert isinstance(result[0]["content"], str)
+    assert "input_text" in result[0]["content"]
+    assert "Result from tool" in result[0]["content"]
+
+
+def test_responses_to_cc_handles_non_serializable_list_output():
+    class NonSerializable:
+        def __str__(self):
+            return "non-serializable-object"
+
+    message_with_non_serializable = {
+        "type": "function_call_output",
+        "call_id": "call_789",
+        "output": [NonSerializable(), "some text"],
+    }
+    result = responses_to_cc(message_with_non_serializable)
+    assert len(result) == 1
+    assert result[0]["role"] == "tool"
+    assert result[0]["tool_call_id"] == "call_789"
+    # Should fall back to str() when json.dumps fails
+    assert isinstance(result[0]["content"], str)

--- a/tests/pyfunc/test_responses_agent_validation.py
+++ b/tests/pyfunc/test_responses_agent_validation.py
@@ -215,5 +215,7 @@ def test_responses_to_cc_fallback_to_str_on_non_serializable():
     class NonSerializable:
         pass
 
-    result = responses_to_cc({"type": "function_call_output", "call_id": "c", "output": [NonSerializable()]})
+    result = responses_to_cc(
+        {"type": "function_call_output", "call_id": "c", "output": [NonSerializable()]}
+    )
     assert isinstance(result[0]["content"], str)

--- a/tests/pyfunc/test_responses_agent_validation.py
+++ b/tests/pyfunc/test_responses_agent_validation.py
@@ -177,85 +177,43 @@ def test_responses_stream_event_validation():
         )
 
 
-def test_function_call_output_accepts_string_and_list():
-    output_with_string = FunctionCallOutput(
-        call_id="call_123",
-        output="Hello, world!",
-    )
-    assert output_with_string.output == "Hello, world!"
-
-    output_with_list = FunctionCallOutput(
-        call_id="call_456",
-        output=[
-            {"type": "input_text", "text": "Result from tool"},
-            {"type": "input_image", "image_url": "https://example.com/image.png"},
-        ],
-    )
-    assert isinstance(output_with_list.output, list)
-    assert len(output_with_list.output) == 2
-    assert output_with_list.output[0]["type"] == "input_text"
+@pytest.mark.parametrize(
+    "output",
+    [
+        "Hello, world!",
+        [{"type": "input_text", "text": "Result"}],
+    ],
+)
+def test_function_call_output_accepts_string_and_list(output):
+    item = FunctionCallOutput(call_id="call_123", output=output)
+    assert item.output == output
 
 
 def test_function_call_output_stream_event_with_list_output():
     event = ResponsesAgentStreamEvent(
-        **{
-            "type": "response.output_item.done",
-            "output_index": 0,
-            "item": {
-                "type": "function_call_output",
-                "call_id": "call_789",
-                "output": [
-                    {"type": "input_text", "text": "Tool execution result"},
-                ],
-            },
-        }
+        type="response.output_item.done",
+        item={"type": "function_call_output", "call_id": "c", "output": [{"type": "input_text"}]},
     )
     assert event.type == "response.output_item.done"
 
 
-def test_responses_to_cc_converts_list_output_to_json_string():
-    message_with_string_output = {
-        "type": "function_call_output",
-        "call_id": "call_123",
-        "output": "Hello, world!",
-    }
-    result = responses_to_cc(message_with_string_output)
-    assert len(result) == 1
-    assert result[0]["role"] == "tool"
-    assert result[0]["content"] == "Hello, world!"
-    assert result[0]["tool_call_id"] == "call_123"
-
-    message_with_list_output = {
-        "type": "function_call_output",
-        "call_id": "call_456",
-        "output": [
-            {"type": "input_text", "text": "Result from tool"},
-            {"type": "input_image", "image_url": "https://example.com/image.png"},
-        ],
-    }
-    result = responses_to_cc(message_with_list_output)
-    assert len(result) == 1
-    assert result[0]["role"] == "tool"
-    assert result[0]["tool_call_id"] == "call_456"
-    # List output should be converted to JSON string
-    assert isinstance(result[0]["content"], str)
-    assert "input_text" in result[0]["content"]
-    assert "Result from tool" in result[0]["content"]
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("hello", "hello"),
+        ([{"key": "value"}], '[{"key": "value"}]'),
+        ({"a": 1}, '{"a": 1}'),
+        (12345, "12345"),
+    ],
+)
+def test_responses_to_cc_stringifies_function_call_output(output, expected):
+    result = responses_to_cc({"type": "function_call_output", "call_id": "c", "output": output})
+    assert result[0]["content"] == expected
 
 
-def test_responses_to_cc_handles_non_serializable_list_output():
+def test_responses_to_cc_fallback_to_str_on_non_serializable():
     class NonSerializable:
-        def __str__(self):
-            return "non-serializable-object"
+        pass
 
-    message_with_non_serializable = {
-        "type": "function_call_output",
-        "call_id": "call_789",
-        "output": [NonSerializable(), "some text"],
-    }
-    result = responses_to_cc(message_with_non_serializable)
-    assert len(result) == 1
-    assert result[0]["role"] == "tool"
-    assert result[0]["tool_call_id"] == "call_789"
-    # Should fall back to str() when json.dumps fails
+    result = responses_to_cc({"type": "function_call_output", "call_id": "c", "output": [NonSerializable()]})
     assert isinstance(result[0]["content"], str)


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

report: https://databricks.slack.com/archives/C064WHH7830/p1770896544446249

cc session: list-function-call

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

before:

<img width="1702" height="1636" alt="image" src="https://github.com/user-attachments/assets/50146091-f672-401d-8b10-b5b46602f6df" />


after: 
<img width="1712" height="1486" alt="image" src="https://github.com/user-attachments/assets/3b44c36b-951f-4d78-b5da-9eef1e2b2cd2" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
