### PR TITLE
Add visual indicator for demo experiment in experiment list

### DIFF
--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -102,6 +102,11 @@ class TracesDemoGenerator(BaseDemoGenerator):
         mlflow.MlflowClient().set_experiment_tag(
             experiment.experiment_id, "mlflow.experimentKind", "genai_development"
         )
+        mlflow.set_experiment_tag(
+            "mlflow.note.content",
+            "Sample experiment with pre-populated demo data including traces, evaluations, "
+            "and prompts. Explore MLflow's GenAI features with this experiment.",
+        )
 
         v1_trace_ids = self._generate_trace_set("v1")
         v2_trace_ids = self._generate_trace_set("v2")

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
@@ -12,6 +12,9 @@ import {
   TableHeader,
   TableCell,
   TableSkeletonRows,
+  Tag,
+  Tooltip,
+  QuestionMarkIcon,
 } from '@databricks/design-system';
 import 'react-virtualized/styles.css';
 import type { ExperimentEntity } from '../types';
@@ -23,6 +26,7 @@ import Utils from '../../common/utils/Utils';
 import { Link } from '../../common/utils/RoutingUtils';
 import Routes from '../routes';
 import { ExperimentListTableTagsCell } from './ExperimentListTableTagsCell';
+import { isDemoExperiment } from '../utils/isDemoExperiment';
 
 export type ExperimentTableColumnDef = ColumnDef<ExperimentEntity>;
 
@@ -217,6 +221,39 @@ export const ExperimentListTable = ({
 };
 
 const ExperimentListTableCell: ExperimentTableColumnDef['cell'] = ({ row: { original } }) => {
+  const { theme } = useDesignSystemTheme();
+  if (isDemoExperiment(original)) {
+    return (
+      <div css={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <Link
+          to={Routes.getExperimentPageRoute(original.experimentId)}
+          title={original.name}
+          data-testid="experiment-list-item-link"
+          css={{ textDecoration: 'none' }}
+        >
+          <Tag componentId="mlflow.experiment_list.demo_badge" color="turquoise">
+            <FormattedMessage
+              defaultMessage="MLflow Demo Experiment"
+              description="Badge label for the demo experiment in the experiments list"
+            />
+          </Tag>
+        </Link>
+        <Tooltip
+          componentId="mlflow.experiment_list.demo_tooltip"
+          content={
+            <FormattedMessage
+              defaultMessage="A demo experiment to quickly explore MLflow's core features with sample pre-generated data. You can clean up demo resources from Settings."
+              description="Tooltip explaining the demo experiment in the experiments list"
+            />
+          }
+        >
+          <span css={{ display: 'inline-flex', color: theme.colors.textSecondary }}>
+            <QuestionMarkIcon css={{ fontSize: 13 }} />
+          </span>
+        </Tooltip>
+      </div>
+    );
+  }
   return (
     <Link
       className="experiment-link"

--- a/mlflow/server/js/src/experiment-tracking/utils/isDemoExperiment.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/isDemoExperiment.ts
@@ -1,0 +1,6 @@
+import type { ExperimentEntity } from '../types';
+
+const DEMO_VERSION_TAG_PREFIX = 'mlflow.demo.version.';
+
+export const isDemoExperiment = (experiment: ExperimentEntity): boolean =>
+  experiment.tags?.some(({ key }) => key.startsWith(DEMO_VERSION_TAG_PREFIX)) ?? false;

--- a/mlflow/server/js/src/home/components/ExperimentsHomeView.tsx
+++ b/mlflow/server/js/src/home/components/ExperimentsHomeView.tsx
@@ -6,6 +6,7 @@ import { ExperimentListTable } from '../../experiment-tracking/components/Experi
 import Routes from '../../experiment-tracking/routes';
 import { Link } from '../../common/utils/RoutingUtils';
 import type { ExperimentEntity } from '../../experiment-tracking/types';
+import { isDemoExperiment } from '../../experiment-tracking/utils/isDemoExperiment';
 
 type ExperimentsHomeViewProps = {
   experiments?: ExperimentEntity[];
@@ -58,7 +59,12 @@ export const ExperimentsHomeView = ({
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [sorting, setSorting] = useState<SortingState>([]);
 
-  const topExperiments = useMemo(() => experiments?.slice(0, 5) ?? [], [experiments]);
+  const topExperiments = useMemo(() => {
+    const sliced = experiments?.slice(0, 5) ?? [];
+    const demo = sliced.filter(isDemoExperiment);
+    const nonDemo = sliced.filter((e) => !isDemoExperiment(e));
+    return [...demo, ...nonDemo];
+  }, [experiments]);
   const shouldShowEmptyState = !isLoading && !error && topExperiments.length === 0;
 
   return (

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5471,6 +5471,10 @@
     "defaultMessage": "Ungrouped",
     "description": "Label for the group of logged models that are not grouped by any source run"
   },
+  "ba7/ni": {
+    "defaultMessage": "A demo experiment to quickly explore MLflow's core features with sample pre-generated data. You can clean up demo resources from Settings.",
+    "description": "Tooltip explaining the demo experiment in the experiments list"
+  },
   "bcw06n": {
     "defaultMessage": "Is the output semantically equivalent to the expected output?",
     "description": "Hint for Equivalence template"
@@ -7430,6 +7434,10 @@
   "orKoPo": {
     "defaultMessage": "Delete",
     "description": "A label for the confirm button in the delete prompt version modal"
+  },
+  "ot8KVZ": {
+    "defaultMessage": "MLflow Demo Experiment",
+    "description": "Badge label for the demo experiment in the experiments list"
   },
   "ov1whU": {
     "defaultMessage": "AI Judge",


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Makes the "MLflow Demo" experiment visually distinct from regular experiments in the experiment list:

1. **Description**: Sets `mlflow.note.content` tag on the demo experiment during generation, populating the Description column with a helpful summary.
2. **Demo badge**: Replaces the plain experiment name with a clickable turquoise "MLflow Demo Experiment" badge (`Tag` component) in the Name column. Includes a `?` icon with a tooltip explaining the demo and how to clean it up from Settings.
3. **Pinned to top**: Demo experiment is always sorted to the top of both the full experiment list page and the home page "Recent Experiments" section via client-side reordering.

Demo detection uses `mlflow.demo.version.*` tags (already set by the demo generator framework), avoiding fragile name-based matching.

### How is this PR tested?

- [x] Manual tests

Manually verified:
- Demo experiment shows at top of experiment list with turquoise badge and `?` tooltip
- Demo experiment shows at top of home page recent experiments
- Description column shows the demo description
- Clicking the badge navigates to the experiment page
- Non-demo experiments render normally

<img width="1630" height="490" alt="Screenshot 2026-02-13 at 15 50 56" src="https://github.com/user-attachments/assets/3c621835-1b18-4018-8795-48b681aca2a4" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The demo experiment now displays a distinct turquoise "MLflow Demo Experiment" badge in the experiment list, is pinned to the top, and includes a tooltip with cleanup instructions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)