### PR TITLE
DSPy: skip saving `model_config.json` file when model_config param of `log_model` is None

### DIFF
--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -79,7 +79,9 @@ def _load_model(model_uri, dst_path=None):
             os.path.join(local_model_path, _MODEL_DATA_PATH, _DSPY_SETTINGS_FILE_NAME)
         )
 
-        model_config_file = os.path.join(local_model_path, _MODEL_DATA_PATH, _MODEL_CONFIG_FILE_NAME)
+        model_config_file = os.path.join(
+            local_model_path, _MODEL_DATA_PATH, _MODEL_CONFIG_FILE_NAME
+        )
         if os.path.exists(model_config_file):
             with open(model_config_file) as f:
                 model_config = json.load(f)

--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -85,6 +85,8 @@ def _load_model(model_uri, dst_path=None):
         if os.path.exists(model_config_file):
             with open(model_config_file) as f:
                 model_config = json.load(f)
+        else:
+            model_config = None
 
         if task == "llm/v1/chat":
             loaded_wrapper = DspyChatModelWrapper(model, dspy_settings, model_config)

--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -79,8 +79,10 @@ def _load_model(model_uri, dst_path=None):
             os.path.join(local_model_path, _MODEL_DATA_PATH, _DSPY_SETTINGS_FILE_NAME)
         )
 
-        with open(os.path.join(local_model_path, _MODEL_DATA_PATH, _MODEL_CONFIG_FILE_NAME)) as f:
-            model_config = json.load(f)
+        model_config_file = os.path.join(local_model_path, _MODEL_DATA_PATH, _MODEL_CONFIG_FILE_NAME)
+        if os.path.exists(model_config_file):
+            with open(model_config_file) as f:
+                model_config = json.load(f)
 
         if task == "llm/v1/chat":
             loaded_wrapper = DspyChatModelWrapper(model, dspy_settings, model_config)

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -232,8 +232,9 @@ def save_model(
     if use_dspy_model_save:
         wrapped_dspy_model.model.save(model_path, save_program=True)
 
-        with open(os.path.join(data_path, _MODEL_CONFIG_FILE_NAME), "w") as f:
-            json.dump(model_config, f)
+        if model_config:
+            with open(os.path.join(data_path, _MODEL_CONFIG_FILE_NAME), "w") as f:
+                json.dump(model_config, f)
 
         dspy.settings.save(
             os.path.join(data_path, _DSPY_SETTINGS_FILE_NAME), exclude_keys=["trace"]


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
DSPy: skip saving `model_config.json` file when model_config param of `log_model` is None

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
