### PR TITLE
Add `serialization_format` parameter to PyTorch save/log model and deprecate `export_model` parameter

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -466,8 +466,7 @@ def save_model(
     if serialization_format == "pt2":
         if Version(torch.__version__) < Version("2.4"):
             raise MlflowException(
-                "If `serialization_format` is set to 'pt2', "
-                "`torch` package version must be >= 2.4."
+                "If `serialization_format` is set to 'pt2', `torch` package version must be >= 2.4."
             )
 
         if isinstance(pytorch_model, torch.jit.ScriptModule):

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -216,8 +216,8 @@ def log_model(
         serialization_format: The serialization format that is used to save the PyTorch model.
             The value can be "pickle" or "pt2". If set it to "pickle", the PyTorch model is saved
             by "pickle" or "cloudpickle", depends on 'pickle_module' param setting.
-            If set it to "pt2", the model is saved by`torch.export.save`, this saving format
-            exports the model  as a traced graph, this is a safer serialization format,
+            If set it to "pt2", the model is saved by `torch.export.save`, this saving format
+            exports the model as a traced graph, this is a safer serialization format,
             it prevents executing arbitrary code during deserialization, if using the "pt2" format,
             the `input_example` is required (because PyTorch traces the model graph by virtually
             executing `model.forward` with the provided example input) and only the `Tensor` type
@@ -370,8 +370,8 @@ def save_model(
         serialization_format: The serialization format that is used to save the PyTorch model.
             The value can be "pickle" or "pt2". If set it to "pickle", the PyTorch model is saved
             by "pickle" or "cloudpickle", depends on 'pickle_module' param setting.
-            If set it to "pt2", the model is saved by`torch.export.save`, this saving format
-            exports the model  as a traced graph, this is a safer serialization format,
+            If set it to "pt2", the model is saved by `torch.export.save`, this saving format
+            exports the model as a traced graph, this is a safer serialization format,
             it prevents executing arbitrary code during deserialization, if using the "pt2" format,
             the `input_example` is required (because PyTorch traces the model graph by virtually
             executing `model.forward` with the provided example input) and only the `Tensor` type
@@ -429,6 +429,11 @@ def save_model(
 
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
+    if serialization_format not in ["pickle", "pt2"]:
+        raise MlflowException.invalid_parameter_value(
+            "The `serialization_format` param value must be one of 'pickle' or 'pt2'."
+        )
+
     pickle_module = pickle_module or mlflow_pytorch_pickle_module
 
     if not isinstance(pytorch_model, torch.nn.Module):
@@ -461,7 +466,8 @@ def save_model(
     if serialization_format == "pt2":
         if Version(torch.__version__) < Version("2.4"):
             raise MlflowException(
-                "If `serialization_format` is set to 'pt2', `torch` package version must be >= 2.4"
+                "If `serialization_format` is set to 'pt2', "
+                "`torch` package version must be >= 2.4."
             )
 
         if isinstance(pytorch_model, torch.jit.ScriptModule):

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -13,9 +13,9 @@ import importlib
 import itertools
 import logging
 import os
+import warnings
 from functools import partial
 from typing import Any
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -443,7 +443,7 @@ def save_model(
         warnings.warn(
             "`export_model` argument is deprecated. "
             "Please set `serialization_format` argument instead.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         serialization_format = "pt2"

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -508,8 +508,8 @@ def save_model(
                 "If `serialization_format` is set to 'pt2', then `input_example` is required and "
                 "must be a numpy array or torch tensor, or a tuple / list of numpy arrays or "
                 "torch tensors, because 'pt2' is a traced-graph format, "
-                "and PyTorch traces the model graph by virtually executing `model.forward` with the "
-                "provided example input."
+                "and PyTorch traces the model graph by virtually executing `model.forward` with "
+                "the provided example input."
             )
 
         if not (

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -219,16 +219,17 @@ def log_model(
         model_id: {{ model_id }}
         export_model: If set to True, save the model as "pt2" format. This argument is deprecated,
             For details, see documentation of `serialization_format` argument.
-        serialization_format: The serialization format that is used to save the PyTorch model.
-            The value can be "pickle" or "pt2". If set to "pickle", the PyTorch model is saved
-            by "pickle" or "cloudpickle", depends on 'pickle_module' param setting.
-            If set it to "pt2", the model is saved by `torch.export.save`. This saving format
-            exports the model as a traced graph and is a safer serialization format,
-            it prevents executing arbitrary code during deserialization. If using the "pt2" format,
-            the `input_example` is required (because PyTorch traces the model graph by virtually
-            executing `model.forward` with the provided example input) and only the `Tensor` type
-            input is supported, for details of 'pt2' format, please refer to
-            https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/pt2_archive.html.
+        serialization_format: The serialization format used to save the PyTorch model.
+           Accepted values are "pickle" and "pt2".
+           When set to "pickle", the model is serialized using either pickle or cloudpickle,
+           depending on the `pickle_module` parameter.
+           When set to "pt2", the model is saved using torch.export.save, which exports the model
+           as a traced graph. This is a safer serialization format that prevents executing
+           arbitrary code during deserialization.
+           Note that "pt2" format requires `input_example` (used to trace the model graph by
+           virtually executing model.forward) and only supports Numpy array / Tensor or a list
+           of Numpy arrays / Tensors as inputs. For details, see the
+           https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/pt2_archive.html.
         kwargs: kwargs to pass to ``torch.save`` method.
 
     Returns:
@@ -377,16 +378,17 @@ def save_model(
         metadata:{{ metadata }}
         export_model: If set to True, save the model as "pt2" format. This argument is deprecated,
             For details, see documentation of `serialization_format` argument.
-        serialization_format: The serialization format that is used to save the PyTorch model.
-            The value can be "pickle" or "pt2". If set to "pickle", the PyTorch model is saved
-            by "pickle" or "cloudpickle", depends on 'pickle_module' param setting.
-            If set it to "pt2", the model is saved by `torch.export.save`. This saving format
-            exports the model as a traced graph and is a safer serialization format,
-            it prevents executing arbitrary code during deserialization. If using the "pt2" format,
-            the `input_example` is required (because PyTorch traces the model graph by virtually
-            executing `model.forward` with the provided example input) and only the `Tensor` type
-            input is supported, for details of 'pt2' format, please refer to
-            https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/pt2_archive.html.
+        serialization_format: The serialization format used to save the PyTorch model.
+           Accepted values are "pickle" and "pt2".
+           When set to "pickle", the model is serialized using either pickle or cloudpickle,
+           depending on the `pickle_module` parameter.
+           When set to "pt2", the model is saved using torch.export.save, which exports the model
+           as a traced graph. This is a safer serialization format that prevents executing
+           arbitrary code during deserialization.
+           Note that "pt2" format requires `input_example` (used to trace the model graph by
+           virtually executing model.forward) and only supports Numpy array / Tensor or a list
+           of Numpy arrays / Tensors as inputs. For details, see the
+           https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/pt2_archive.html.
         kwargs: kwargs to pass to ``torch.save`` method.
 
     .. code-block:: python

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -15,7 +15,7 @@ import logging
 import os
 import warnings
 from functools import partial
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -165,7 +165,7 @@ def log_model(
     step: int = 0,
     model_id: str | None = None,
     export_model: bool = False,
-    serialization_format: str = SERIALIZATION_FORMAT_PICKLE,
+    serialization_format: Literal["pickle", "pt2"] = SERIALIZATION_FORMAT_PICKLE,
     **kwargs,
 ):
     """
@@ -343,7 +343,7 @@ def save_model(
     extra_pip_requirements=None,
     metadata=None,
     export_model: bool = False,
-    serialization_format=SERIALIZATION_FORMAT_PICKLE,
+    serialization_format: Literal["pickle", "pt2"] = SERIALIZATION_FORMAT_PICKLE,
     **kwargs,
 ):
     """
@@ -442,6 +442,11 @@ def save_model(
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     if export_model:
+        if serialization_format != SERIALIZATION_FORMAT_PICKLE:
+            raise MlflowException.invalid_parameter_value(
+                "Cannot set both `export_model=True` and `serialization_format='pickle'`. "
+                "Please use only `serialization_format` argument."
+            )
         warnings.warn(
             "`export_model` argument is deprecated. "
             "Please set `serialization_format` argument instead.",

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -220,16 +220,16 @@ def log_model(
         export_model: If set to True, save the model as "pt2" format. This argument is deprecated.
             For details, see documentation of `serialization_format` argument.
         serialization_format: The serialization format used to save the PyTorch model.
-           Accepted values are "pickle" and "pt2".
-           When set to "pickle", the model is serialized using either pickle or cloudpickle,
-           depending on the `pickle_module` parameter.
-           When set to "pt2", the model is saved using torch.export.save, which exports the model
-           as a traced graph. This is a safer serialization format that prevents executing
-           arbitrary code during deserialization.
-           Note that "pt2" format requires `input_example` (used to trace the model graph by
-           virtually executing model.forward) and only supports Numpy array / Tensor or a list
-           of Numpy arrays / Tensors as inputs. For details, see
-           https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/pt2_archive.html.
+            Accepted values are "pickle" and "pt2".
+            When set to "pickle", the model is serialized using either pickle or cloudpickle,
+            depending on the `pickle_module` parameter.
+            When set to "pt2", the model is saved using torch.export.save, which exports the model
+            as a traced graph. This is a safer serialization format that prevents executing
+            arbitrary code during deserialization.
+            Note that "pt2" format requires `input_example` (used to trace the model graph by
+            virtually executing model.forward) and only supports Numpy array / Tensor or a list
+            of Numpy arrays / Tensors as inputs. For details, see
+            https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/pt2_archive.html.
         kwargs: kwargs to pass to ``torch.save`` method.
 
     Returns:
@@ -379,16 +379,16 @@ def save_model(
         export_model: If set to True, save the model as "pt2" format. This argument is deprecated.
             For details, see documentation of `serialization_format` argument.
         serialization_format: The serialization format used to save the PyTorch model.
-           Accepted values are "pickle" and "pt2".
-           When set to "pickle", the model is serialized using either pickle or cloudpickle,
-           depending on the `pickle_module` parameter.
-           When set to "pt2", the model is saved using torch.export.save, which exports the model
-           as a traced graph. This is a safer serialization format that prevents executing
-           arbitrary code during deserialization.
-           Note that "pt2" format requires `input_example` (used to trace the model graph by
-           virtually executing model.forward) and only supports Numpy array / Tensor or a list
-           of Numpy arrays / Tensors as inputs. For details, see
-           https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/pt2_archive.html.
+            Accepted values are "pickle" and "pt2".
+            When set to "pickle", the model is serialized using either pickle or cloudpickle,
+            depending on the `pickle_module` parameter.
+            When set to "pt2", the model is saved using torch.export.save, which exports the model
+            as a traced graph. This is a safer serialization format that prevents executing
+            arbitrary code during deserialization.
+            Note that "pt2" format requires `input_example` (used to trace the model graph by
+            virtually executing model.forward) and only supports Numpy array / Tensor or a list
+            of Numpy arrays / Tensors as inputs. For details, see
+            https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/pt2_archive.html.
         kwargs: kwargs to pass to ``torch.save`` method.
 
     .. code-block:: python
@@ -442,10 +442,10 @@ def save_model(
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     if export_model:
-        if serialization_format != SERIALIZATION_FORMAT_PICKLE:
+        if serialization_format == SERIALIZATION_FORMAT_PICKLE:
             raise MlflowException.invalid_parameter_value(
                 "Cannot set both `export_model=True` and `serialization_format='pickle'`. "
-                "Please use only `serialization_format` argument."
+                "Please use only the `serialization_format` argument."
             )
         warnings.warn(
             "`export_model` argument is deprecated. "
@@ -512,7 +512,7 @@ def save_model(
             isinstance(value, (np.ndarray, torch.Tensor)) for value in input_example
         ):
             raise MlflowException(
-                "If serialization_format is set to 'pt2', then input_example is required. "
+                "If `serialization_format` is set to 'pt2', then input_example is required. "
                 "It must be a numpy array or torch tensor, or a tuple/list of numpy arrays "
                 "or torch tensors. This is because 'pt2' is a traced-graph format: "
                 "PyTorch traces the model graph by virtually executing model.forward with "
@@ -529,7 +529,7 @@ def save_model(
                 "Unsupported signature type for the selected serialization format. "
                 "If the `serialization_format` argument is set to 'pt2', the input signature "
                 "must be specified using `TensorSpec`. Please update the model signature or "
-                "use `pickle` for serialization format."
+                "set `serialization_format` to 'pickle'."
             )
 
         tensor_spec_list = signature.inputs.inputs
@@ -556,7 +556,7 @@ def save_model(
             _logger.warning(
                 "Saving pytorch model by Pickle or CloudPickle format requires exercising "
                 "caution because these formats rely on Python's object serialization mechanism, "
-                "which can execute arbitrary code during deserialization."
+                "which can execute arbitrary code during deserialization. "
                 "The recommended safe alternative is to set `serialization_format` to 'pt2' to "
                 "save the PyTorch model using the safe graph model format."
             )

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -217,7 +217,7 @@ def log_model(
         model_type: {{ model_type }}
         step: {{ step }}
         model_id: {{ model_id }}
-        export_model: If set to True, save the model as "pt2" format. This argument is deprecated,
+        export_model: If set to True, save the model as "pt2" format. This argument is deprecated.
             For details, see documentation of `serialization_format` argument.
         serialization_format: The serialization format used to save the PyTorch model.
            Accepted values are "pickle" and "pt2".
@@ -376,7 +376,7 @@ def save_model(
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
         metadata:{{ metadata }}
-        export_model: If set to True, save the model as "pt2" format. This argument is deprecated,
+        export_model: If set to True, save the model as "pt2" format. This argument is deprecated.
             For details, see documentation of `serialization_format` argument.
         serialization_format: The serialization format used to save the PyTorch model.
            Accepted values are "pickle" and "pt2".
@@ -507,10 +507,10 @@ def save_model(
             isinstance(value, (np.ndarray, torch.Tensor)) for value in input_example
         ):
             raise MlflowException(
-                "If `serialization_format` is set to 'pt2', then `input_example` is required and "
-                "must be a numpy array or torch tensor, or a tuple / list of numpy arrays or "
-                "torch tensors, because 'pt2' is a traced-graph format, "
-                "and PyTorch traces the model graph by virtually executing `model.forward` with "
+                "If serialization_format is set to 'pt2', then input_example is required. "
+                "It must be a numpy array or torch tensor, or a tuple/list of numpy arrays "
+                "or torch tensors. This is because 'pt2' is a traced-graph format: "
+                "PyTorch traces the model graph by virtually executing model.forward with "
                 "the provided example input."
             )
 
@@ -521,8 +521,10 @@ def save_model(
             and signature.inputs.is_tensor_spec()
         ):
             raise MlflowException(
-                "If `serialization_format` is set to 'pt2', then the model input signature must "
-                "by specified using `TensorSpec`."
+                "Unsupported signature type for the selected serialization format. "
+                "If the `serialization_format` argument is set to 'pt2', the input signature "
+                "must by specified using `TensorSpec`. Please update the model signature or "
+                "use `pickle` for serialization format."
             )
 
         tensor_spec_list = signature.inputs.inputs

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -580,8 +580,8 @@ def save_model(
     # For the case that `input_example` is a tensor or list of numpy arrays / tensors,
     # PyFunc model is not supported yet.
     if not (
-        serialization_format == SERIALIZATION_FORMAT_PT2 and
-        (len(input_example) > 1 or any(isinstance(x, torch.Tensor) for x in input_example))
+        serialization_format == SERIALIZATION_FORMAT_PT2
+        and (len(input_example) > 1 or any(isinstance(x, torch.Tensor) for x in input_example))
     ):
         pyfunc.add_to_model(
             mlflow_model,

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -577,16 +577,22 @@ def save_model(
         code=code_dir_subpath,
         **extra_files_config,
     )
-    pyfunc.add_to_model(
-        mlflow_model,
-        loader_module="mlflow.pytorch",
-        data=model_data_subpath,
-        pickle_module_name=pickle_module.__name__,
-        code=code_dir_subpath,
-        conda_env=_CONDA_ENV_FILE_NAME,
-        python_env=_PYTHON_ENV_FILE_NAME,
-        model_config={"device": None},
-    )
+    # For the case that `input_example` is a tensor or list of numpy arrays / tensors,
+    # PyFunc model is not supported yet.
+    if not (
+        serialization_format == SERIALIZATION_FORMAT_PT2 and
+        (len(input_example) > 1 or any(isinstance(x, torch.Tensor) for x in input_example))
+    ):
+        pyfunc.add_to_model(
+            mlflow_model,
+            loader_module="mlflow.pytorch",
+            data=model_data_subpath,
+            pickle_module_name=pickle_module.__name__,
+            code=code_dir_subpath,
+            conda_env=_CONDA_ENV_FILE_NAME,
+            python_env=_PYTHON_ENV_FILE_NAME,
+            model_config={"device": None},
+        )
     if size := get_total_file_size(path):
         mlflow_model.model_size_bytes = size
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -228,7 +228,7 @@ def log_model(
            arbitrary code during deserialization.
            Note that "pt2" format requires `input_example` (used to trace the model graph by
            virtually executing model.forward) and only supports Numpy array / Tensor or a list
-           of Numpy arrays / Tensors as inputs. For details, see the
+           of Numpy arrays / Tensors as inputs. For details, see
            https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/pt2_archive.html.
         kwargs: kwargs to pass to ``torch.save`` method.
 
@@ -387,7 +387,7 @@ def save_model(
            arbitrary code during deserialization.
            Note that "pt2" format requires `input_example` (used to trace the model graph by
            virtually executing model.forward) and only supports Numpy array / Tensor or a list
-           of Numpy arrays / Tensors as inputs. For details, see the
+           of Numpy arrays / Tensors as inputs. For details, see
            https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/pt2_archive.html.
         kwargs: kwargs to pass to ``torch.save`` method.
 
@@ -468,7 +468,7 @@ def save_model(
     try:
         saved_example = _save_example(mlflow_model, input_example, path)
     except MlflowException:
-        # `_save_example` does not support tensor / list of tensor / list of numpy array as input.
+        # `_save_example` does not support tensor / list of tensors / list of numpy array as input.
         saved_example = None
 
     if signature is None and saved_example is not None:
@@ -523,7 +523,7 @@ def save_model(
             raise MlflowException(
                 "Unsupported signature type for the selected serialization format. "
                 "If the `serialization_format` argument is set to 'pt2', the input signature "
-                "must by specified using `TensorSpec`. Please update the model signature or "
+                "must be specified using `TensorSpec`. Please update the model signature or "
                 "use `pickle` for serialization format."
             )
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1237,7 +1237,7 @@ def test_save_and_load_exported_model(sequential_model, model_path, data, sequen
     mlflow.pytorch.save_model(
         sequential_model,
         model_path,
-        serialization_format='pt2',
+        serialization_format="pt2",
         input_example=input_example,
     )
 
@@ -1271,7 +1271,7 @@ def test_exported_model_infer_dynamic_dim(tmp_path):
     mlflow.pytorch.save_model(
         origin_model,
         save_path1,
-        serialization_format='pt2',
+        serialization_format="pt2",
         input_example=input_example,
     )
 
@@ -1291,7 +1291,7 @@ def test_exported_model_infer_dynamic_dim(tmp_path):
     mlflow.pytorch.save_model(
         origin_model,
         save_path2,
-        serialization_format='pt2',
+        serialization_format="pt2",
         input_example=input_example,
         signature=ModelSignature(
             inputs=Schema([TensorSpec(np.dtype("float32"), (3, -1, 5))]),
@@ -1317,7 +1317,7 @@ def test_load_exported_model_check_device_mismatch(sequential_model, model_path)
     mlflow.pytorch.save_model(
         sequential_model,
         model_path,
-        serialization_format='pt2',
+        serialization_format="pt2",
         input_example=torch.randn(3, 4).numpy(),
     )
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1329,3 +1329,44 @@ def test_load_exported_model_check_device_mismatch(sequential_model, model_path)
         match="it can't be loaded on 'cuda' device.",
     ):
         mlflow.pytorch.load_model(model_path, device="cuda")
+
+
+@pytest.mark.skipif(
+    Version(torch.__version__) < Version("2.4"), reason="This test requires torch>=2"
+)
+def test_save_and_load_exported_model_with_multi_inputs(model_path):
+
+    class CustomModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(4, 1)
+
+        def forward(self, x, y):
+            with torch.no_grad():
+                return self.linear(x + y)
+
+    model = CustomModel()
+    input_example = (torch.randn(10, 4), torch.randn(10, 4))
+
+    mlflow.pytorch.save_model(
+        model,
+        model_path,
+        serialization_format="pt2",
+        input_example=input_example,
+        signature=ModelSignature(
+            inputs=Schema(
+                [
+                    TensorSpec(np.dtype("float32"), (-1, 4), "v1"),
+                    TensorSpec(np.dtype("float32"), (-1, 4), "v2"),
+                ]
+            ),
+        ),
+    )
+
+    model_loaded = mlflow.pytorch.load_model(model_path)
+
+    np.testing.assert_array_almost_equal(
+        model(*input_example),
+        model_loaded(*input_example),
+        decimal=4,
+    )

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1237,7 +1237,7 @@ def test_save_and_load_exported_model(sequential_model, model_path, data, sequen
     mlflow.pytorch.save_model(
         sequential_model,
         model_path,
-        export_model=True,
+        serialization_format='pt2',
         input_example=input_example,
     )
 
@@ -1271,7 +1271,7 @@ def test_exported_model_infer_dynamic_dim(tmp_path):
     mlflow.pytorch.save_model(
         origin_model,
         save_path1,
-        export_model=True,
+        serialization_format='pt2',
         input_example=input_example,
     )
 
@@ -1291,7 +1291,7 @@ def test_exported_model_infer_dynamic_dim(tmp_path):
     mlflow.pytorch.save_model(
         origin_model,
         save_path2,
-        export_model=True,
+        serialization_format='pt2',
         input_example=input_example,
         signature=ModelSignature(
             inputs=Schema([TensorSpec(np.dtype("float32"), (3, -1, 5))]),
@@ -1317,7 +1317,7 @@ def test_load_exported_model_check_device_mismatch(sequential_model, model_path)
     mlflow.pytorch.save_model(
         sequential_model,
         model_path,
-        export_model=True,
+        serialization_format='pt2',
         input_example=torch.randn(3, 4).numpy(),
     )
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1228,7 +1228,7 @@ def test_log_model_with_datetime_input():
 
 
 @pytest.mark.skipif(
-    Version(torch.__version__) < Version("2.4"), reason="This test requires torch>=2"
+    Version(torch.__version__) < Version("2.4"), reason="This test requires torch>=2.4"
 )
 @pytest.mark.parametrize("scripted_model", [False])
 def test_save_and_load_exported_model(sequential_model, model_path, data, sequential_predicted):
@@ -1253,7 +1253,7 @@ def test_save_and_load_exported_model(sequential_model, model_path, data, sequen
 
 
 @pytest.mark.skipif(
-    Version(torch.__version__) < Version("2.4"), reason="This test requires torch>=2"
+    Version(torch.__version__) < Version("2.4"), reason="This test requires torch>=2.4"
 )
 def test_exported_model_infer_dynamic_dim(tmp_path):
     class MyModule(torch.nn.Module):
@@ -1310,7 +1310,7 @@ def test_exported_model_infer_dynamic_dim(tmp_path):
 
 
 @pytest.mark.skipif(
-    Version(torch.__version__) < Version("2.4"), reason="This test requires torch>=2"
+    Version(torch.__version__) < Version("2.4"), reason="This test requires torch>=2.4"
 )
 @pytest.mark.parametrize("scripted_model", [False])
 def test_load_exported_model_check_device_mismatch(sequential_model, model_path):
@@ -1332,7 +1332,7 @@ def test_load_exported_model_check_device_mismatch(sequential_model, model_path)
 
 
 @pytest.mark.skipif(
-    Version(torch.__version__) < Version("2.4"), reason="This test requires torch>=2"
+    Version(torch.__version__) < Version("2.4"), reason="This test requires torch>=2.4"
 )
 def test_save_and_load_exported_model_with_multi_inputs(model_path):
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
- Adds a `serialization_format` parameter to mlflow.pytorch.save_model and mlflow.pytorch.log_model, replacing the boolean `export_model` parameter with an explicit string option:

  - "pickle" (default): Serializes using pickle/cloudpickle (existing behavior).
  - "pt2": Saves via torch.export.save as a traced computation graph, which prevents arbitrary code execution during deserialization.

- The `export_model` parameter is deprecated.

doc preview:
save_model:
<img width="2348" height="396" alt="image" src="https://github.com/user-attachments/assets/8d98c965-7d4e-4b6e-862b-96c11bfac105" />

log_model:
<img width="2312" height="392" alt="image" src="https://github.com/user-attachments/assets/93b2c455-ff1f-4559-8158-b2c943262acf" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Update PyTorch save_model: remove `export_model` param and add `serialization_format` param and refine error message
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
