### PR TITLE
Fix `check_function_signatures.py` to include `__init__.py` files

### DIFF
--- a/dev/check_function_signatures.py
+++ b/dev/check_function_signatures.py
@@ -318,8 +318,8 @@ def compare_signatures(base_branch: str = "master") -> list[Error]:
         if file_path.parts[0] != "mlflow":
             continue
 
-        # Ignore private modules
-        if any(part.startswith("_") for part in file_path.parts):
+        # Ignore private modules (but not __init__.py)
+        if any(part.startswith("_") and part != "__init__.py" for part in file_path.parts):
             continue
 
         base_content = get_file_content_at_revision(file_path, base_branch)


### PR DESCRIPTION
## Summary

The private-module filter in `check_function_signatures.py` inadvertently skips all `__init__.py` files because `__init__.py` starts with `_`. This means the script never checks signature changes in MLflow's public API modules. Fix by explicitly excluding `__init__.py` from the private module filter.

## Notes

- Manual verification is sufficient (no automated tests needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)