### PR TITLE
Fix Claude stop-hook race for first transcript message

### DIFF
--- a/tests/claude_code/test_autolog.py
+++ b/tests/claude_code/test_autolog.py
@@ -66,3 +66,19 @@ async def test_sdk_hook_handler_when_disabled():
         # Should return early without calling _process_stop_hook
         mock_process.assert_not_called()
         assert result == {"continue": True}
+
+
+def test_process_stop_hook_continues_when_trace_creation_fails():
+    from mlflow.claude_code.hooks import _process_stop_hook
+
+    with patch("mlflow.claude_code.hooks.process_transcript", return_value=None):
+        result = _process_stop_hook("session-1", "/tmp/transcript.jsonl")
+
+    assert result == {"continue": True}
+
+
+def test_process_stop_hook_continues_without_transcript_path():
+    from mlflow.claude_code.hooks import _process_stop_hook
+
+    result = _process_stop_hook("session-1", None)
+    assert result == {"continue": True}

--- a/tests/claude_code/test_cli.py
+++ b/tests/claude_code/test_cli.py
@@ -23,6 +23,8 @@ def test_trace_command_help(runner):
     assert "Set up Claude Code tracing" in result.output
     assert "--tracking-uri" in result.output
     assert "--experiment-id" in result.output
+    assert "--transcript-read-retries" in result.output
+    assert "--transcript-read-delay-ms" in result.output
     assert "--disable" in result.output
     assert "--status" in result.output
 
@@ -38,4 +40,4 @@ def test_trace_disable_with_no_config(runner):
     with runner.isolated_filesystem():
         result = runner.invoke(commands, ["claude", "--disable"])
         assert result.exit_code == 0
-        # Should handle gracefully even if no config exists
+        assert "No Claude configuration found" in result.output


### PR DESCRIPTION
## Summary
- add configurable transcript read retries for Claude stop hooks to handle racey transcript writes
- tolerate incomplete trailing JSONL lines while Claude is still flushing transcript output
- keep stop hooks non-blocking when trace creation fails so user workflows continue uninterrupted

## File-level changes
- `mlflow/claude_code/tracing.py`: add retry-based transcript reads and partial-line tolerance
- `mlflow/claude_code/config.py`: add retry env vars + integer env parsing helpers
- `mlflow/claude_code/hooks.py`: continue hook execution even if trace creation is skipped
- `mlflow/claude_code/cli.py`: expose retry tuning flags and show configured values in status/setup output

## Test plan
- `.venv/bin/python -m pytest tests/claude_code/test_tracing.py tests/claude_code/test_config.py tests/claude_code/test_cli.py tests/claude_code/test_autolog.py`

Closes #20654
