### PR TITLE
Make Model.log resilient to logged-model metric limits

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1056,6 +1056,19 @@ _MLFLOW_LOG_LOGGED_MODEL_PARAMS_BATCH_SIZE = _EnvironmentVariable(
     "_MLFLOW_LOG_LOGGED_MODEL_PARAMS_BATCH_SIZE", int, 100
 )
 
+#: Maximum number of metrics to copy from a run to a logged model when calling
+#: ``Model.log(step=...)``. Set to ``0`` to disable logged-model metric copying.
+#: (default: ``1000``)
+_MLFLOW_LOG_LOGGED_MODEL_METRICS_MAX_PER_MODEL = _EnvironmentVariable(
+    "_MLFLOW_LOG_LOGGED_MODEL_METRICS_MAX_PER_MODEL", int, 1000
+)
+
+#: Maximum number of metrics per request when copying run metrics to a logged model.
+#: (default: ``100``)
+_MLFLOW_LOG_LOGGED_MODEL_METRICS_BATCH_SIZE = _EnvironmentVariable(
+    "_MLFLOW_LOG_LOGGED_MODEL_METRICS_BATCH_SIZE", int, 100
+)
+
 #: A boolean flag that enables printing URLs for logged and registered models when
 #: they are created.
 #: (default: ``True``)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2686,6 +2686,21 @@ class MlflowClient:
             run_id, metrics, params, tags, synchronous=synchronous
         )
 
+    def log_model_metrics(
+        self,
+        run_id: str,
+        metrics: list[Metric],
+        max_metrics_per_model: int | None = None,
+        batch_size: int | None = None,
+    ) -> tuple[int, int]:
+        """Log metrics for a logged model with optional cap and batching."""
+        return self._tracking_client.log_model_metrics(
+            run_id=run_id,
+            metrics=metrics,
+            max_metrics_per_model=max_metrics_per_model,
+            batch_size=batch_size,
+        )
+
     def log_inputs(
         self,
         run_id: str,


### PR DESCRIPTION
## Summary
- avoid `Model.log(step=...)` failures when copying run metrics into logged-model metrics hits backend limits
- add configurable cap and batch size for logged-model metric linking, including support for disabling metric linking with a cap of `0`
- keep model logging resilient by warning instead of failing when metric linking raises backend exceptions

## File-level changes
- `mlflow/models/model.py`: route step-metric linking through bounded metric logging and add non-fatal fallback
- `mlflow/tracking/client.py`: add `log_model_metrics()` wrapper API
- `mlflow/tracking/_tracking_service/client.py`: implement capped + batched metric logging helper with logged/skipped counts
- `mlflow/environment_variables.py`: add internal env vars for metric cap and batching controls

## Test plan
- `.venv/bin/python -m pytest tests/tracking/_tracking_service/test_tracking_service_client.py -k log_model_metrics`
- `.venv/bin/python -m pytest tests/models/test_model.py -k "metric_linking"`

Closes #20715
