### PR TITLE
Add the workspace provider to the plugins docs page

### DIFF
--- a/docs/docs/classic-ml/plugins/index.mdx
+++ b/docs/docs/classic-ml/plugins/index.mdx
@@ -36,15 +36,16 @@ Plugins let you integrate MLflow with your existing infrastructure without modif
 
 ## Plugin Types & Use Cases
 
-MLflow supports eight types of plugins, each addressing different integration needs:
+MLflow supports several types of plugins, each addressing different integration needs:
 
 ### **Storage & Persistence**
 
-| Plugin Type              | Purpose                        | Example Use Cases                                  |
-| ------------------------ | ------------------------------ | -------------------------------------------------- |
-| **Tracking Store**       | Custom experiment data storage | Enterprise databases, cloud data warehouses        |
-| **Artifact Repository**  | Custom artifact storage        | In-house blob storage, specialized file systems    |
-| **Model Registry Store** | Custom model registry backend  | Enterprise model catalogs, version control systems |
+| Plugin Type              | Purpose                           | Example Use Cases                                  |
+| ------------------------ | --------------------------------- | -------------------------------------------------- |
+| **Tracking Store**       | Custom experiment data storage    | Enterprise databases, cloud data warehouses        |
+| **Artifact Repository**  | Custom artifact storage           | In-house blob storage, specialized file systems    |
+| **Model Registry Store** | Custom model registry backend     | Enterprise model catalogs, version control systems |
+| **Workspace Provider**   | Custom workspace metadata backend | Kubernetes namespaces                              |
 
 ### **Authentication & Headers**
 
@@ -85,6 +86,7 @@ setup(
         "mlflow.model_evaluator": "my-evaluator=my_plugin.evaluator:MyEvaluator",
         "mlflow.project_backend": "my-backend=my_plugin.backend:MyBackend",
         "mlflow.deployments": "my-target=my_plugin.deployment",
+        "mlflow.workspace_provider": "my-scheme=my_plugin.workspace:MyWorkspaceProvider",
         "mlflow.app": "my-app=my_plugin.app:create_app",
     },
 )
@@ -128,6 +130,8 @@ class MyTrackingStore(AbstractStore):
 
 ```python
 # my_plugin/artifacts.py
+from __future__ import annotations
+
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 
 
@@ -153,6 +157,11 @@ class MyArtifactRepo(ArtifactRepository):
     def download_artifacts(self, artifact_path, dst_path=None):
         # Download artifacts from your storage system
         pass
+
+    def for_workspace(self, workspace_name: str | None) -> "ArtifactRepository":
+        # Optional: return a workspace-scoped repository instance.
+        # Only needed when workspace-specific artifact routing is required.
+        return self
 ```
 
   </TabItem>
@@ -187,6 +196,61 @@ class MyModelRegistryStore(AbstractStore):
 
     # Implement other required AbstractStore methods...
 ```
+
+  </TabItem>
+  <TabItem value="workspace-provider" label="Workspace Provider">
+
+```python
+# my_plugin/workspace.py
+from __future__ import annotations
+
+from typing import Iterable
+
+from mlflow.entities import Workspace
+from mlflow.store.workspace.abstract_store import AbstractStore
+
+
+class MyWorkspaceProvider(AbstractStore):
+    """Custom workspace provider for scheme 'my-scheme://'"""
+
+    def __init__(self, workspace_uri):
+        super().__init__()
+        self.workspace_uri = workspace_uri
+        # Initialize your workspace metadata backend
+
+    def list_workspaces(self) -> Iterable[Workspace]:
+        # Return an iterable of Workspace entities
+        pass
+
+    def get_workspace(self, workspace_name: str) -> Workspace:
+        # Return a single Workspace by name
+        pass
+
+    def create_workspace(self, workspace: Workspace) -> Workspace:
+        # Provision a new workspace (raise NotImplementedError if read-only)
+        pass
+
+    def update_workspace(self, workspace: Workspace) -> Workspace:
+        # Update workspace metadata (raise NotImplementedError if read-only)
+        pass
+
+    def delete_workspace(self, workspace_name: str) -> None:
+        # Remove a workspace (raise NotImplementedError if read-only)
+        pass
+
+    def get_default_workspace(self) -> Workspace:
+        # Return the default workspace (raise NotImplementedError if not supported)
+        pass
+
+    def resolve_artifact_root(
+        self, default_artifact_root: str | None, workspace_name: str
+    ) -> tuple[str | None, bool]:
+        # Return (artifact_root, append_workspace_prefix). When the second value is
+        # True, MLflow automatically appends /workspaces/<workspace> to the root.
+        return default_artifact_root, True
+```
+
+For full details on workspace provider architecture, discovery, and configuration, see the [Workspace Providers](/self-hosting/workspaces/workspace-providers) documentation.
 
   </TabItem>
 </Tabs>
@@ -773,6 +837,7 @@ my-mlflow-plugin/
 │   ├── store.py               # Tracking store implementation
 │   ├── artifacts.py           # Artifact repository implementation
 │   ├── auth.py                # Authentication provider
+│   ├── workspace.py           # Workspace provider
 │   └── evaluator.py           # Model evaluator
 ├── tests/
 │   ├── test_store.py


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

This adds the workspace provider documentation to the MLflow plugins page. It was documented elsewhere but this makes it easier to discover.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
