### PR TITLE
Fix ungated regressions from improved eval runs comparison PR stack

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -7,7 +7,11 @@ import { useCompareToRunUuid } from './hooks/useCompareToRunUuid';
 import Utils from '@mlflow/mlflow/src/common/utils/Utils';
 import { FormattedMessage } from 'react-intl';
 import { RunColorPill } from '../experiment-page/components/RunColorPill';
-import { getEvalTabTotalTracesLimit } from '@mlflow/mlflow/src/common/utils/FeatureUtils';
+import { EvaluationRunCompareSelector } from './EvaluationRunCompareSelector';
+import {
+  getEvalTabTotalTracesLimit,
+  shouldEnableImprovedEvalRunsComparison,
+} from '@mlflow/mlflow/src/common/utils/FeatureUtils';
 import { getTrace as getTraceV3 } from '@mlflow/mlflow/src/experiment-tracking/utils/TraceUtils';
 import type { TracesTableColumn, TraceActions, GetTraceFunction } from '@databricks/web-shared/genai-traces-table';
 import {
@@ -316,6 +320,22 @@ const RunViewEvaluationsTabInner = ({
         overflowY: 'hidden',
       }}
     >
+      {!shouldEnableImprovedEvalRunsComparison() && !showCompareSelector && (
+        <div
+          css={{
+            width: '100%',
+            padding: `${theme.spacing.xs}px 0`,
+          }}
+        >
+          <EvaluationRunCompareSelector
+            experimentId={experimentId}
+            currentRunUuid={runUuid}
+            compareToRunUuid={compareToRunUuid}
+            setCompareToRunUuid={setCompareToRunUuid}
+            setCurrentRunUuid={setCurrentRunUuid}
+          />
+        </div>
+      )}
       {showCompareSelector && compareToRunUuid && (
         <div
           css={{

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTabArtifacts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTabArtifacts.tsx
@@ -25,6 +25,7 @@ import { useRunLoggedTraceTableArtifacts } from './hooks/useRunLoggedTraceTableA
 import { useMarkdownConverter } from '../../../common/utils/MarkdownUtils';
 import { getTraceLegacy } from '@mlflow/mlflow/src/experiment-tracking/utils/TraceUtils';
 import { useSearchRunsQuery } from '../run-page/hooks/useSearchRunsQuery';
+import { shouldEnableImprovedEvalRunsComparison } from '../../../common/utils/FeatureUtils';
 
 export const RunViewEvaluationsTabArtifacts = ({
   experimentId,
@@ -121,19 +122,21 @@ export const RunViewEvaluationsTabArtifacts = ({
         overflowY: 'hidden',
       }}
     >
-      <div
-        css={{
-          width: '100%',
-          padding: `${theme.spacing.xs}px 0`,
-        }}
-      >
-        <EvaluationRunCompareSelector
-          experimentId={experimentId}
-          currentRunUuid={runUuid}
-          compareToRunUuid={compareToRunUuid}
-          setCompareToRunUuid={setCompareToRunUuid}
-        />
-      </div>
+      {!shouldEnableImprovedEvalRunsComparison() && (
+        <div
+          css={{
+            width: '100%',
+            padding: `${theme.spacing.xs}px 0`,
+          }}
+        >
+          <EvaluationRunCompareSelector
+            experimentId={experimentId}
+            currentRunUuid={runUuid}
+            compareToRunUuid={compareToRunUuid}
+            setCompareToRunUuid={setCompareToRunUuid}
+          />
+        </div>
+      )}
       {getOverviewTableComponent()}
     </div>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -230,7 +230,10 @@ const ExperimentEvaluationRunsPageImpl = () => {
   // to the default state to avoid displaying columns that don't exist
   if (columnDifference.length > 0) {
     const metricColumns = uniqueColumns.filter((col) => col.startsWith(EvalRunsTableKeyedColumnPrefix.METRIC + '.'));
-    const defaultEnabledMetrics = new Set(metricColumns.slice(0, DEFAULT_VISIBLE_METRIC_COLUMNS));
+    // When flag is ON, limit default visible metrics to 5; when OFF, show all (original behavior)
+    const defaultEnabledMetrics = enableImprovedComparison
+      ? new Set(metricColumns.slice(0, DEFAULT_VISIBLE_METRIC_COLUMNS))
+      : new Set(metricColumns);
 
     setSelectedColumns({
       ...EVAL_RUNS_TABLE_BASE_SELECTION_STATE,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -7,6 +7,8 @@ import {
   useDesignSystemTheme,
   Checkbox,
   ParagraphSkeleton,
+  Button,
+  NewWindowIcon,
   SortUnsortedIcon,
   VisibleIcon,
   VisibleOffIcon,
@@ -22,8 +24,11 @@ import { RunColorPill } from '../../components/experiment-page/components/RunCol
 import { TimeAgo } from '@databricks/web-shared/browse';
 import { parseEvalRunsTableKeyedColumnKey } from './ExperimentEvaluationRunsTable.utils';
 import { useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
 import type { RunEntityOrGroupData } from './ExperimentEvaluationRunsPage.utils';
 import { useExperimentEvaluationRunsRowVisibility } from './hooks/useExperimentEvaluationRunsRowVisibility';
+import { RunPageTabName } from '../../constants';
+import { shouldEnableImprovedEvalRunsComparison } from '../../../common/utils/FeatureUtils';
 import { DatasetLink } from '../experiment-evaluation-datasets/DatasetLink';
 
 export const CheckboxCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({
@@ -83,6 +88,43 @@ export const RunNameCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({
       >
         {row.original.info.runName}
       </Typography.Link>
+      {!shouldEnableImprovedEvalRunsComparison() && (
+        <div
+          css={{
+            display: 'none',
+            flexShrink: 0,
+            '.eval-runs-table-row:hover &': { display: 'inline' },
+            svg: {
+              width: theme.typography.fontSizeMd,
+              height: theme.typography.fontSizeMd,
+            },
+          }}
+        >
+          <Link
+            target="_blank"
+            rel="noreferrer"
+            to={Routes.getRunPageTabRoute(row.original.info.experimentId, runUuid, RunPageTabName.EVALUATIONS)}
+          >
+            <Tooltip
+              content={
+                <FormattedMessage
+                  defaultMessage="Go to the run"
+                  description="Tooltip for the run name cell in the evaluation runs table, opening the run page in a new tab"
+                />
+              }
+              componentId="mlflow.eval-runs.run-name-cell.tooltip"
+            >
+              <Button
+                type="link"
+                target="_blank"
+                icon={<NewWindowIcon />}
+                size="small"
+                componentId="mlflow.eval-runs.run-name-cell.open-run-page"
+              />
+            </Tooltip>
+          </Link>
+        </div>
+      )}
     </div>
   );
 };

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4229,6 +4229,10 @@
     "defaultMessage": "Used by",
     "description": "Used by column header"
   },
+  "T3RjOb": {
+    "defaultMessage": "Go to the run",
+    "description": "Tooltip for the run name cell in the evaluation runs table, opening the run page in a new tab"
+  },
   "T4eipT": {
     "defaultMessage": "Line Smoothness",
     "description": "Label for the smoothness slider for the graph plot for metrics"


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Gate additional changes from the eval runs comparison PR stack (#20280-#20285, #20456, #20457, #20525) behind the shouldEnableImprovedEvalRunsComparison flag:

- Restore "Go to the run" NewWindowIcon button in RunNameCell when flag is OFF (removed by #20282 without gating)
- Restore EvaluationRunCompareSelector in RunViewEvaluationsTabInner when flag is OFF (removed by #20285 without gating)
- Gate EvaluationRunCompareSelector in RunViewEvaluationsTabArtifacts to hide when flag is ON (comparison handled by new flow)
- Gate DEFAULT_VISIBLE_METRIC_COLUMNS=5 limit so all metrics show when flag is OFF (original behavior)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

https://github.com/user-attachments/assets/0b115f60-0284-491c-89a9-4698e35a53c1



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
