### PR TITLE
Fix RecursionError in strands, semantic_kernel, and haystack autologgers with shared tracer provider

### DIFF
--- a/mlflow/semantic_kernel/autolog.py
+++ b/mlflow/semantic_kernel/autolog.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 
 from opentelemetry import trace as otel_trace
 from opentelemetry.context import Context
@@ -85,46 +86,65 @@ class SemanticKernelSpanProcessor(SimpleSpanProcessor):
         self.span_exporter = SpanExporter()
         # Store context tokens for each span so we can detach them in on_end
         self._context_tokens: dict[int, object] = {}
+        self._processing_local = threading.local()
 
     def on_start(self, span: OTelSpan, parent_context: Context | None = None):
-        # Trigger MLflow's span processor
-        tracer = _get_tracer(__name__)
-        tracer.span_processor.on_start(span, parent_context)
+        # Recursion guard: with MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false (shared provider),
+        # tracer.span_processor.on_start() routes back through the same composite processor,
+        # re-entering this method and causing infinite recursion.
+        if getattr(self._processing_local, "in_on_start", False):
+            return
+        self._processing_local.in_on_start = True
+        try:
+            # Trigger MLflow's span processor
+            tracer = _get_tracer(__name__)
+            tracer.span_processor.on_start(span, parent_context)
 
-        trace_id = get_otel_attribute(span, SpanAttributeKey.REQUEST_ID)
-        mlflow_span = create_mlflow_span(span, trace_id)
+            trace_id = get_otel_attribute(span, SpanAttributeKey.REQUEST_ID)
+            mlflow_span = create_mlflow_span(span, trace_id)
 
-        # Register new span in the in-memory trace manager
-        InMemoryTraceManager.get_instance().register_span(mlflow_span)
+            # Register new span in the in-memory trace manager
+            InMemoryTraceManager.get_instance().register_span(mlflow_span)
 
-        # Also set this span in MLflow's runtime context so that other autolog integrations
-        # (like OpenAI) can correctly parent their spans to Semantic Kernel spans.
-        # NB: We use otel_trace.set_span_in_context() directly instead of
-        # mlflow.tracing.provider.set_span_in_context() because the latter can produce
-        # two separate traces when MLFLOW_USE_DEFAULT_TRACER_PROVIDER is set to False.
-        # Using the OpenTelemetry API directly ensures consistent behavior for autologging.
-        context = otel_trace.set_span_in_context(span)
-        token = mlflow_runtime_context.attach(context)
-        self._context_tokens[span.context.span_id] = token
+            # Also set this span in MLflow's runtime context so that other autolog integrations
+            # (like OpenAI) can correctly parent their spans to Semantic Kernel spans.
+            # NB: We use otel_trace.set_span_in_context() directly instead of
+            # mlflow.tracing.provider.set_span_in_context() because the latter can produce
+            # two separate traces when MLFLOW_USE_DEFAULT_TRACER_PROVIDER is set to False.
+            # Using the OpenTelemetry API directly ensures consistent behavior for autologging.
+            context = otel_trace.set_span_in_context(span)
+            token = mlflow_runtime_context.attach(context)
+            self._context_tokens[span.context.span_id] = token
+        finally:
+            self._processing_local.in_on_start = False
 
     def on_end(self, span: OTelReadableSpan) -> None:
-        # Detach the span from MLflow's runtime context
-        token = self._context_tokens.pop(span.context.span_id, None)
-        if token is not None:
-            mlflow_runtime_context.detach(token)
-
-        mlflow_span = get_mlflow_span_for_otel_span(span)
-        if mlflow_span is None:
-            _logger.debug("Span not found in the map. Skipping end.")
+        # Recursion guard: with MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false (shared provider),
+        # tracer.span_processor.on_end() routes back through the same composite processor,
+        # re-entering this method and causing infinite recursion.
+        if getattr(self._processing_local, "in_on_end", False):
             return
+        self._processing_local.in_on_end = True
+        try:
+            # Detach the span from MLflow's runtime context
+            token = self._context_tokens.pop(span.context.span_id, None)
+            if token is not None:
+                mlflow_runtime_context.detach(token)
 
-        with _bypass_attribute_guard(mlflow_span._span):
-            set_span_type(mlflow_span)
-            set_model(mlflow_span)
-            set_token_usage(mlflow_span)
-            # set cost here explicitly because it doesn't go through mlflow_span.end method
-            set_span_cost_attribute(mlflow_span)
+            mlflow_span = get_mlflow_span_for_otel_span(span)
+            if mlflow_span is None:
+                _logger.debug("Span not found in the map. Skipping end.")
+                return
 
-        # Export the span using MLflow's span processor
-        tracer = _get_tracer(__name__)
-        tracer.span_processor.on_end(span)
+            with _bypass_attribute_guard(mlflow_span._span):
+                set_span_type(mlflow_span)
+                set_model(mlflow_span)
+                set_token_usage(mlflow_span)
+                # set cost here explicitly because it doesn't go through mlflow_span.end method
+                set_span_cost_attribute(mlflow_span)
+
+            # Export the span using MLflow's span processor
+            tracer = _get_tracer(__name__)
+            tracer.span_processor.on_end(span)
+        finally:
+            self._processing_local.in_on_end = False

--- a/tests/haystack/conftest.py
+++ b/tests/haystack/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+from opentelemetry import trace as otel_trace
+
+import mlflow
+from mlflow.tracing.provider import provider
+from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
+
+
+@pytest.fixture(autouse=True)
+def clear_autolog_state(reset_tracing):
+
+    for key in list(AUTOLOGGING_INTEGRATIONS.keys()):
+        AUTOLOGGING_INTEGRATIONS[key].clear()
+    mlflow.utils.import_hooks._post_import_hooks = {}
+
+    yield
+
+    # Reset OTel provider state for test isolation when switching between
+    # MLFLOW_USE_DEFAULT_TRACER_PROVIDER modes (pattern from test_integration.py)
+    otel_trace._TRACER_PROVIDER = None
+    otel_trace._TRACER_PROVIDER_SET_ONCE._done = False
+    provider._global_provider_init_once._done = False
+    provider._isolated_tracer_provider_once._done = False

--- a/tests/strands/conftest.py
+++ b/tests/strands/conftest.py
@@ -1,6 +1,8 @@
 import pytest
+from opentelemetry import trace as otel_trace
 
 import mlflow
+from mlflow.tracing.provider import provider
 
 
 @pytest.fixture(autouse=True)
@@ -18,3 +20,12 @@ def clear_autolog_state(reset_tracing):
     for key in list(AUTOLOGGING_INTEGRATIONS.keys()):
         AUTOLOGGING_INTEGRATIONS[key].clear()
     mlflow.utils.import_hooks._post_import_hooks = {}
+
+    yield
+
+    # Reset OTel provider state for test isolation when switching between
+    # MLFLOW_USE_DEFAULT_TRACER_PROVIDER modes (pattern from test_integration.py)
+    otel_trace._TRACER_PROVIDER = None
+    otel_trace._TRACER_PROVIDER_SET_ONCE._done = False
+    provider._global_provider_init_once._done = False
+    provider._isolated_tracer_provider_once._done = False

--- a/tests/strands/test_strands_tracing.py
+++ b/tests/strands/test_strands_tracing.py
@@ -306,7 +306,7 @@ def test_autolog_does_not_raise_npe_when_tracing_disabled():
 
 
 def test_strands_autolog_shared_provider_no_recursion(monkeypatch):
-    """Verify strands.autolog() works with shared tracer provider (no RecursionError)."""
+    # Verify strands.autolog() works with shared tracer provider (no RecursionError)
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "false")
 
     mlflow.strands.autolog()

--- a/tests/strands/test_strands_tracing.py
+++ b/tests/strands/test_strands_tracing.py
@@ -8,6 +8,7 @@ from strands.tools.tools import PythonAgentTool
 
 import mlflow
 from mlflow.entities import SpanType
+from mlflow.environment_variables import MLFLOW_USE_DEFAULT_TRACER_PROVIDER
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.provider import trace_disabled
 
@@ -302,3 +303,20 @@ def test_autolog_does_not_raise_npe_when_tracing_disabled():
 
     run()
     assert len(get_traces()) == 0
+
+
+def test_strands_autolog_shared_provider_no_recursion(monkeypatch):
+    """Verify strands.autolog() works with shared tracer provider (no RecursionError)."""
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "false")
+
+    mlflow.strands.autolog()
+
+    agent = Agent(model=DummyModel("hi"), name="agent")
+    agent("hello")
+
+    traces = get_traces()
+    assert len(traces) == 1
+    spans = traces[0].data.spans
+    agent_span = next(span for span in spans if span.span_type == SpanType.AGENT)
+    assert agent_span.inputs == [{"role": "user", "content": [{"text": "hello"}]}]
+    assert agent_span.outputs.strip() == "hi"


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->

Fixes #20808

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR fixes a `RecursionError` that occurs when using `mlflow.strands.autolog()`, `mlflow.semantic_kernel.autolog()`, or `mlflow.haystack.autolog()` while using a shared OpenTelemetry tracer provider (`MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false`).

**Root Cause**: `StrandsSpanProcessor`, `SemanticKernelSpanProcessor`, and `HaystackSpanProcessor` all share the same pattern — their `on_start()` methods call `tracer.span_processor.on_start(span, parent_context)`, and their `on_end()` methods call `tracer.span_processor.on_end(span)`. With shared provider mode, this tracer's span processor is the same composite processor that includes the calling processor itself, creating infinite recursion:

    Provider.on_start()
      -> XxxSpanProcessor.on_start()
        -> tracer.span_processor.on_start()
          -> Provider.on_start()
            -> XxxSpanProcessor.on_start()
              -> ... (infinite loop)

With isolated provider mode (the default), each autologger gets its own tracer provider, so `tracer.span_processor` points to MLflow's internal processor rather than the composite one — no recursion occurs.

**Solution**: Add a `threading.local()` recursion guard as an instance attribute on each span processor. On first entry, the guard flag is set; if a re-entrant call is detected, it returns early. A `finally` block ensures the flag is always reset.

**Motivation**: Shared tracer provider mode is required to get unified traces where spans from different autologgers appear together. In agentic AI applications using Strands + Bedrock, Semantic Kernel + OpenAI, or Haystack pipelines, this enables end-to-end observability — latency tracking, causal relationships between agent and LLM spans, and token usage attribution — that is lost when each autologger produces separate traces.

**Affected integrations:**

| Integration | Span Processor | File |
|-------------|---------------|------|
| Strands | `StrandsSpanProcessor` | `mlflow/strands/autolog.py` |
| Semantic Kernel | `SemanticKernelSpanProcessor` | `mlflow/semantic_kernel/autolog.py` |
| Haystack | `HaystackSpanProcessor` | `mlflow/haystack/autolog.py` |

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

**New automated tests** — one per integration, each enabling shared provider mode via `monkeypatch.setenv` and verifying the autologger produces a valid trace without `RecursionError`:

- `tests/strands/test_strands_tracing.py::test_strands_autolog_shared_provider_no_recursion`
- `tests/haystack/test_haystack_tracing.py::test_haystack_autolog_shared_provider_no_recursion`
- `tests/semantic_kernel/test_semantic_kernel_autolog.py::test_sk_shared_provider_no_recursion`

**Test verification**: With the fix reverted (source files restored to master, tests kept), all three new tests fail with `RecursionError`, confirming they correctly reproduce the bug. All existing tests across the three integrations continue to pass.

**Manual testing** (strands only, all 4 combinations):

| Library | `MLFLOW_USE_DEFAULT_TRACER_PROVIDER` | Result |
|---------|--------------------------------------|--------|
| Stock | `true` | ✅ Works |
| Stock | `false` | ❌ RecursionError |
| Patched | `true` | ✅ Works |
| Patched | `false` | ✅ Works |

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Fix `RecursionError` in `mlflow.strands.autolog()`, `mlflow.semantic_kernel.autolog()`, and `mlflow.haystack.autolog()` when using shared tracer provider mode (`MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false`), enabling unified traces across multiple autologgers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)
