### PR TITLE
Fix Claude env key for autolog

### DIFF
--- a/mlflow/claude_code/cli.py
+++ b/mlflow/claude_code/cli.py
@@ -4,7 +4,13 @@ from pathlib import Path
 
 import click
 
-from mlflow.claude_code.config import get_tracing_status, setup_environment_config
+from mlflow.claude_code.config import (
+    ENVIRONMENT_FIELD,
+    get_environment_field_name,
+    get_tracing_status,
+    load_claude_config,
+    setup_environment_config,
+)
 from mlflow.claude_code.hooks import disable_tracing_hooks, setup_hooks_config
 
 
@@ -93,6 +99,7 @@ def _show_status(target_dir: Path, settings_file: Path) -> None:
     """Show current tracing status."""
     click.echo(f"📍 Claude tracing status in: {target_dir}")
 
+    env_field = get_environment_field_name(load_claude_config(settings_file))
     status = get_tracing_status(settings_file)
 
     if not status.enabled:
@@ -110,6 +117,8 @@ def _show_status(target_dir: Path, settings_file: Path) -> None:
         click.echo(f"🔬 Experiment Name: {status.experiment_name}")
     else:
         click.echo("🔬 Experiment: Default (experiment 0)")
+    if env_field:
+        click.echo(f"⚙️ Environment key: {env_field}")
 
 
 def _show_setup_status(
@@ -137,6 +146,7 @@ def _show_setup_status(
         click.echo(f"🔬 Experiment Name: {experiment_name}")
     else:
         click.echo("🔬 Experiment: Default (experiment 0)")
+    click.echo(f"⚙️ Environment key: {ENVIRONMENT_FIELD}")
 
     # Show next steps
     click.echo("\n" + "=" * 30)

--- a/mlflow/claude_code/hooks.py
+++ b/mlflow/claude_code/hooks.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from mlflow.claude_code.config import (
-    ENVIRONMENT_FIELD,
+    ENVIRONMENT_FIELDS,
     HOOK_FIELD_COMMAND,
     HOOK_FIELD_HOOKS,
     MLFLOW_EXPERIMENT_ID,
@@ -130,21 +130,23 @@ def disable_tracing_hooks(settings_path: Path) -> bool:
             del config[HOOK_FIELD_HOOKS]["Stop"]
             hooks_removed = True
 
-    # Remove config variables
-    if ENVIRONMENT_FIELD in config:
-        mlflow_vars = [
-            MLFLOW_TRACING_ENABLED,
-            MLFLOW_TRACKING_URI,
-            MLFLOW_EXPERIMENT_ID,
-            MLFLOW_EXPERIMENT_NAME,
-        ]
+    # Remove config variables from both canonical and legacy environment keys.
+    mlflow_vars = [
+        MLFLOW_TRACING_ENABLED,
+        MLFLOW_TRACKING_URI.name,
+        MLFLOW_EXPERIMENT_ID.name,
+        MLFLOW_EXPERIMENT_NAME.name,
+    ]
+    for env_field in ENVIRONMENT_FIELDS:
+        env_vars = config.get(env_field)
+        if not isinstance(env_vars, dict):
+            continue
         for var in mlflow_vars:
-            if var in config[ENVIRONMENT_FIELD]:
-                del config[ENVIRONMENT_FIELD][var]
+            if var in env_vars:
+                del env_vars[var]
                 env_removed = True
-
-        if not config[ENVIRONMENT_FIELD]:
-            del config[ENVIRONMENT_FIELD]
+        if not env_vars:
+            del config[env_field]
 
     # Clean up empty hooks section
     if HOOK_FIELD_HOOKS in config and not config[HOOK_FIELD_HOOKS]:

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -12,8 +12,11 @@ import dateutil.parser
 
 import mlflow
 from mlflow.claude_code.config import (
+    LEGACY_ENVIRONMENT_FIELD,
     MLFLOW_TRACING_ENABLED,
     get_env_var,
+    get_environment_field_name,
+    load_claude_config,
 )
 from mlflow.entities import SpanType
 from mlflow.environment_variables import (
@@ -96,6 +99,15 @@ def setup_mlflow() -> None:
     """Configure MLflow tracking URI and experiment."""
     if not is_tracing_enabled():
         return
+
+    settings_config = load_claude_config(Path(".claude/settings.json"))
+    if get_environment_field_name(settings_config) == LEGACY_ENVIRONMENT_FIELD:
+        get_logger().log(
+            CLAUDE_TRACING_LEVEL,
+            "Detected legacy Claude settings key `%s`; run `mlflow autolog claude` to migrate to `%s`.",
+            LEGACY_ENVIRONMENT_FIELD,
+            "env",
+        )
 
     # Get tracking URI from environment/settings
     mlflow.set_tracking_uri(get_env_var(MLFLOW_TRACKING_URI.name))

--- a/tests/claude_code/test_hooks.py
+++ b/tests/claude_code/test_hooks.py
@@ -1,0 +1,49 @@
+import json
+
+from mlflow.claude_code.config import (
+    ENVIRONMENT_FIELD,
+    LEGACY_ENVIRONMENT_FIELD,
+    MLFLOW_HOOK_IDENTIFIER,
+    MLFLOW_TRACING_ENABLED,
+    MLFLOW_TRACKING_URI,
+)
+from mlflow.claude_code.hooks import disable_tracing_hooks
+
+
+def test_disable_tracing_hooks_removes_vars_from_all_environment_keys(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    config = {
+        "hooks": {
+            "Stop": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": (
+                                "python -c \"from mlflow.claude_code.hooks import stop_hook_handler; "
+                                "stop_hook_handler()\""
+                            ),
+                        }
+                    ]
+                }
+            ]
+        },
+        ENVIRONMENT_FIELD: {
+            MLFLOW_TRACING_ENABLED: "true",
+            "KEEP_ENV": "keep",
+        },
+        LEGACY_ENVIRONMENT_FIELD: {
+            MLFLOW_TRACKING_URI.name: "file://mlruns",
+            "KEEP_LEGACY": "keep",
+        },
+    }
+    with open(settings_path, "w", encoding="utf-8") as f:
+        json.dump(config, f)
+
+    changed = disable_tracing_hooks(settings_path)
+
+    assert changed is True
+    saved = json.loads(settings_path.read_text())
+    assert MLFLOW_HOOK_IDENTIFIER not in json.dumps(saved.get("hooks", {}))
+    assert saved[ENVIRONMENT_FIELD] == {"KEEP_ENV": "keep"}
+    assert saved[LEGACY_ENVIRONMENT_FIELD] == {"KEEP_LEGACY": "keep"}


### PR DESCRIPTION
## Summary
- switch Claude autolog config writes to the canonical `env` key while keeping backward compatibility for legacy `environment` reads
- merge canonical + legacy env maps when resolving MLflow settings so existing projects keep working without manual edits
- clean up MLflow config vars from both env key variants when disabling hooks
- surface which environment key is in use in CLI status output and emit a tracing log hint when legacy keys are detected

## Files changed
- `mlflow/claude_code/config.py`: add canonical/legacy env-key handling helpers and migrate writes to `env`
- `mlflow/claude_code/hooks.py`: remove MLflow vars from both `env` and `environment` keys during disable
- `mlflow/claude_code/cli.py`: display active Claude env key in status/setup output
- `mlflow/claude_code/tracing.py`: log when legacy `environment` key is still present
- `tests/claude_code/test_config.py`: add compatibility and migration tests for env key handling
- `tests/claude_code/test_hooks.py`: add disable-flow coverage for both env key variants

## Test plan
- [x] `.venv/bin/python -m pytest tests/claude_code/test_config.py tests/claude_code/test_cli.py tests/claude_code/test_autolog.py tests/claude_code/test_hooks.py`

issue: https://github.com/mlflow/mlflow/issues/20106
