### PR TITLE
Remove demo launch section from workspace page

### DIFF
--- a/mlflow/server/js/src/home/WorkspaceLandingPage.test.tsx
+++ b/mlflow/server/js/src/home/WorkspaceLandingPage.test.tsx
@@ -22,10 +22,6 @@ jest.mock('../common/utils/RoutingUtils', () => ({
 }));
 
 // Mock child components to simplify testing
-jest.mock('./components/features', () => ({
-  FeaturesSection: () => <div data-testid="features-section">Features Section</div>,
-}));
-
 jest.mock('./components/DiscoverNews', () => ({
   __esModule: true,
   default: () => <div data-testid="discover-news">Discover News Component</div>,
@@ -80,9 +76,13 @@ describe('WorkspaceLandingPage', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('telemetry-alert')).toBeInTheDocument();
-      expect(screen.getByTestId('features-section')).toBeInTheDocument();
       expect(screen.getByTestId('log-traces-drawer')).toBeInTheDocument();
     });
+  });
+
+  test('does not render features section (demo not available outside workspace)', () => {
+    renderComponent();
+    expect(screen.queryByTestId('features-section')).not.toBeInTheDocument();
   });
 
   test('renders workspaces section', async () => {

--- a/mlflow/server/js/src/home/WorkspaceLandingPage.tsx
+++ b/mlflow/server/js/src/home/WorkspaceLandingPage.tsx
@@ -4,8 +4,6 @@ import { FormattedMessage } from 'react-intl';
 import { ScrollablePageWrapper } from '../common/components/ScrollablePageWrapper';
 import { useCreateWorkspaceModal } from './components/CreateWorkspaceModal';
 import { setLastUsedWorkspace, WORKSPACE_QUERY_PARAM } from '../workspaces/utils/WorkspaceUtils';
-import { FeaturesSection } from './components/features';
-
 // Loaders and lazy imports for expensive components
 import LogTracesDrawerLoader from './components/LogTracesDrawerLoader';
 import { TelemetryInfoAlert } from '../telemetry/TelemetryInfoAlert';
@@ -37,7 +35,6 @@ const WorkspaceLandingPage = () => {
         title={<FormattedMessage defaultMessage="Welcome to MLflow" description="Workspace landing page title" />}
       />
       <TelemetryInfoAlert />
-      <FeaturesSection />
       <React.Suspense fallback={<HomePageSectionSkeleton />}>
         <WorkspacesHomeView onCreateWorkspace={openModal} />
       </React.Suspense>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Currently we are showing the getting started section in both workspace list page and experiment list page, meaning that users will see the same section twice. Also when they are at the workspace list page, we don't know which workspace we should create the demo experiment. Therefore, this PR removes the section from the workspace list page.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
