### PR TITLE
Improve workflow switch tooltip to clarify GenAI vs model training use cases

### DIFF
--- a/mlflow/server/js/src/common/components/MlflowSidebarWorkflowSwitch.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarWorkflowSwitch.tsx
@@ -83,7 +83,7 @@ export const MlflowSidebarWorkflowSwitch = ({
       componentId="mlflow.sidebar.workflow_switch.tooltip"
       content={
         <FormattedMessage
-          defaultMessage="Select your workflow type. This changes the tabs that are visible in the navigation sidebar."
+          defaultMessage="Select your workflow type. Choose GenAI when working on apps and agents, and select model training when working on classical ML or deep learning problems."
           description="Tooltip for workflow switch"
         />
       }

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -922,10 +922,6 @@
     "defaultMessage": "No endpoints created",
     "description": "Empty state title for endpoints list"
   },
-  "513m15": {
-    "defaultMessage": "Select your workflow type. This changes the tabs that are visible in the navigation sidebar.",
-    "description": "Tooltip for workflow switch"
-  },
   "53b+wP": {
     "defaultMessage": "Step",
     "description": "Experiment page > view controls > global settings for line chart view > settings for x-axis > label for setting to use step axis in all charts"
@@ -2493,6 +2489,10 @@
   "FpjDSq": {
     "defaultMessage": "Compare",
     "description": "Text for compare button to compare versions under details tab\n                       on the model view page"
+  },
+  "FxQYyX": {
+    "defaultMessage": "Select your workflow type. Choose GenAI when working on apps and agents, and select model training when working on classical ML or deep learning problems.",
+    "description": "Tooltip for workflow switch"
   },
   "G/zTTY": {
     "defaultMessage": "Error",


### PR DESCRIPTION
### Related Issues/PRs

<!-- No related issues for this UI text improvement -->

### What changes are proposed in this pull request?

This PR improves the tooltip text for the sidebar workflow switch to provide clearer guidance on when to use each workflow type:

- **Before**: "Select your workflow type. This changes the tabs that are visible in the navigation sidebar."
- **After**: "Select your workflow type. Choose GenAI when working on apps and agents, and select model training when working on classical ML or deep learning problems."

The new tooltip gives users actionable guidance rather than just describing what the switch does technically.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

This is a text-only change that updates the tooltip message. The i18n JSON file was regenerated to reflect the new message.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved the workflow switch tooltip to provide clearer guidance: GenAI for apps and agents, Model Training for classical ML or deep learning.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)