### PR TITLE
Add sliding animation to workflow switch component

### DIFF
--- a/mlflow/server/js/src/common/components/MlflowSidebarWorkflowSwitch.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarWorkflowSwitch.tsx
@@ -1,6 +1,15 @@
-import { Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+  Tooltip,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 import { WorkflowType } from '../contexts/WorkflowTypeContext';
 import { FormattedMessage } from '@databricks/i18n';
+import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
+import { useCallback, useMemo } from 'react';
 
 export const MlflowSidebarWorkflowSwitch = ({
   workflowType,
@@ -10,9 +19,26 @@ export const MlflowSidebarWorkflowSwitch = ({
   setWorkflowType: (workflowType: WorkflowType) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
+  const viewId = useMemo(() => uuidv4(), []);
 
   const isGenAi = workflowType === WorkflowType.GENAI;
   const borderColor = isGenAi ? theme.gradients.aiBorderGradient : theme.colors.actionDefaultBorderDefault;
+
+  const logTelemetryEvent = useLogTelemetryEvent();
+  const handleChangeWorkflowType = useCallback(
+    (workflowType: WorkflowType) => {
+      setWorkflowType(workflowType);
+      logTelemetryEvent({
+        componentId: 'mlflow.sidebar.workflow_switch',
+        componentViewId: viewId,
+        componentType: DesignSystemEventProviderComponentTypes.ToggleButton,
+        componentSubType: null,
+        eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+        value: workflowType,
+      });
+    },
+    [setWorkflowType, logTelemetryEvent, viewId],
+  );
 
   return (
     <Tooltip
@@ -77,10 +103,10 @@ export const MlflowSidebarWorkflowSwitch = ({
           }}
           role="button"
           tabIndex={0}
-          onClick={() => setWorkflowType(WorkflowType.GENAI)}
+          onClick={() => handleChangeWorkflowType(WorkflowType.GENAI)}
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
-              setWorkflowType(WorkflowType.GENAI);
+              handleChangeWorkflowType(WorkflowType.GENAI);
             }
           }}
         >
@@ -104,10 +130,10 @@ export const MlflowSidebarWorkflowSwitch = ({
           }}
           role="button"
           tabIndex={0}
-          onClick={() => setWorkflowType(WorkflowType.MACHINE_LEARNING)}
+          onClick={() => handleChangeWorkflowType(WorkflowType.MACHINE_LEARNING)}
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
-              setWorkflowType(WorkflowType.MACHINE_LEARNING);
+              handleChangeWorkflowType(WorkflowType.MACHINE_LEARNING);
             }
           }}
         >

--- a/mlflow/server/js/src/common/components/MlflowSidebarWorkflowSwitch.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarWorkflowSwitch.tsx
@@ -75,7 +75,14 @@ export const MlflowSidebarWorkflowSwitch = ({
             paddingLeft: theme.spacing.md,
             whiteSpace: 'nowrap' as const,
           }}
+          role="button"
+          tabIndex={0}
           onClick={() => setWorkflowType(WorkflowType.GENAI)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              setWorkflowType(WorkflowType.GENAI);
+            }
+          }}
         >
           <Typography.Text color={isGenAi ? undefined : 'secondary'}>
             <FormattedMessage defaultMessage="GenAI" description="Label for GenAI workflow type option" />
@@ -95,7 +102,14 @@ export const MlflowSidebarWorkflowSwitch = ({
             paddingLeft: theme.spacing.sm,
             whiteSpace: 'nowrap' as const,
           }}
+          role="button"
+          tabIndex={0}
           onClick={() => setWorkflowType(WorkflowType.MACHINE_LEARNING)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              setWorkflowType(WorkflowType.MACHINE_LEARNING);
+            }
+          }}
         >
           <Typography.Text color={isGenAi ? 'secondary' : undefined}>
             <FormattedMessage

--- a/mlflow/server/js/src/common/components/MlflowSidebarWorkflowSwitch.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarWorkflowSwitch.tsx
@@ -2,73 +2,6 @@ import { Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-sy
 import { WorkflowType } from '../contexts/WorkflowTypeContext';
 import { FormattedMessage } from '@databricks/i18n';
 
-const Pill = ({
-  isActive,
-  workflowType,
-  setWorkflowType,
-}: {
-  isActive: boolean;
-  workflowType: WorkflowType;
-  setWorkflowType: (workflowType: WorkflowType) => void;
-}) => {
-  const { theme } = useDesignSystemTheme();
-  const borderColor =
-    workflowType === WorkflowType.GENAI ? theme.gradients.aiBorderGradient : theme.colors.actionDefaultBorderDefault;
-  const label =
-    workflowType === WorkflowType.GENAI ? (
-      <FormattedMessage defaultMessage="GenAI" description="Label for GenAI workflow type option" />
-    ) : (
-      <FormattedMessage defaultMessage="Model training" description="Label for model training workflow type option" />
-    );
-
-  if (isActive) {
-    return (
-      <div
-        css={{
-          position: 'relative',
-          background: borderColor,
-          margin: -1,
-          borderRadius: theme.borders.borderRadiusFull,
-          padding: 1,
-          cursor: 'pointer',
-        }}
-        onClick={() => setWorkflowType(workflowType)}
-      >
-        <div
-          css={{
-            background: theme.colors.backgroundPrimary,
-            borderRadius: theme.borders.borderRadiusFull,
-            padding: theme.spacing.xs,
-            paddingRight: theme.spacing.md,
-            paddingLeft: theme.spacing.md,
-          }}
-        >
-          <Typography.Text>{label}</Typography.Text>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      css={{
-        display: 'flex',
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-        cursor: 'pointer',
-        // magic number to prevent the text from jumping around
-        // when switching between workflow types
-        paddingRight: workflowType === WorkflowType.GENAI ? 0 : 7,
-        paddingLeft: workflowType === WorkflowType.GENAI ? 7 : 0,
-      }}
-      onClick={() => setWorkflowType(workflowType)}
-    >
-      <Typography.Text color="secondary">{label}</Typography.Text>
-    </div>
-  );
-};
-
 export const MlflowSidebarWorkflowSwitch = ({
   workflowType,
   setWorkflowType,
@@ -77,6 +10,9 @@ export const MlflowSidebarWorkflowSwitch = ({
   setWorkflowType: (workflowType: WorkflowType) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
+
+  const isGenAi = workflowType === WorkflowType.GENAI;
+  const borderColor = isGenAi ? theme.gradients.aiBorderGradient : theme.colors.actionDefaultBorderDefault;
 
   return (
     <Tooltip
@@ -92,6 +28,7 @@ export const MlflowSidebarWorkflowSwitch = ({
       <div
         css={{
           display: 'flex',
+          width: 'min-content',
           position: 'relative',
           alignItems: 'center',
           background: theme.colors.backgroundSecondary,
@@ -99,16 +36,74 @@ export const MlflowSidebarWorkflowSwitch = ({
           border: `1px solid ${theme.colors.actionDefaultBorderDefault}`,
         }}
       >
-        <Pill
-          isActive={workflowType === WorkflowType.GENAI}
-          workflowType={WorkflowType.GENAI}
-          setWorkflowType={setWorkflowType}
-        />
-        <Pill
-          isActive={workflowType === WorkflowType.MACHINE_LEARNING}
-          workflowType={WorkflowType.MACHINE_LEARNING}
-          setWorkflowType={setWorkflowType}
-        />
+        {/* Sliding thumb indicator */}
+        <div
+          css={{
+            position: 'absolute',
+            top: -1,
+            bottom: -1,
+            left: -1,
+            width: `${isGenAi ? 39 : 67}%`,
+            background: borderColor,
+            borderRadius: theme.borders.borderRadiusFull,
+            padding: 1,
+            transition: 'transform 200ms ease-out, width 200ms ease-out, background 200ms ease-out',
+            transform: isGenAi ? 'translateX(0)' : `translateX(calc(51%))`,
+            pointerEvents: 'none',
+          }}
+        >
+          <div
+            css={{
+              width: '100%',
+              height: '100%',
+              background: theme.colors.backgroundPrimary,
+              borderRadius: theme.borders.borderRadiusFull,
+            }}
+          />
+        </div>
+
+        {/* GenAI option */}
+        <div
+          css={{
+            zIndex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+            padding: theme.spacing.xs,
+            paddingRight: theme.spacing.md,
+            paddingLeft: theme.spacing.md,
+            whiteSpace: 'nowrap' as const,
+          }}
+          onClick={() => setWorkflowType(WorkflowType.GENAI)}
+        >
+          <Typography.Text color={isGenAi ? undefined : 'secondary'}>
+            <FormattedMessage defaultMessage="GenAI" description="Label for GenAI workflow type option" />
+          </Typography.Text>
+        </div>
+
+        {/* Model training option */}
+        <div
+          css={{
+            zIndex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+            padding: theme.spacing.xs,
+            paddingRight: theme.spacing.md,
+            paddingLeft: theme.spacing.sm,
+            whiteSpace: 'nowrap' as const,
+          }}
+          onClick={() => setWorkflowType(WorkflowType.MACHINE_LEARNING)}
+        >
+          <Typography.Text color={isGenAi ? 'secondary' : undefined}>
+            <FormattedMessage
+              defaultMessage="Model training"
+              description="Label for model training workflow type option"
+            />
+          </Typography.Text>
+        </div>
       </div>
     </Tooltip>
   );


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a smooth sliding animation to the sidebar workflow switch when toggling between GenAI and Model training modes. The thumb indicator now slides between positions with a 200ms ease-out CSS transition, providing better visual feedback during interaction.



### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

[Manually tested by switching between workflow types in the sidebar and verifying the sliding animation works smoothly.](https://github.com/user-attachments/assets/9037dd01-2d96-4866-a33f-518453278543)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add sliding animation to the workflow type switch in the sidebar for smoother visual feedback when toggling between GenAI and Model training modes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)