### PR TITLE
Fix arbitrary file read via prompt tag validation bypass in Model Registry

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2637,7 +2637,7 @@ def _create_model_version():
         parsed = urllib.parse.urlparse(source)
         if parsed.scheme == "file" or (parsed.scheme == "" and source.startswith("/")):
             raise MlflowException(
-                f"Invalid model version source: '{source}'. "
+                f"Invalid prompt source: '{source}'. "
                 "Local source paths are not allowed for prompts.",
                 INVALID_PARAMETER_VALUE,
             )

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2630,7 +2630,14 @@ def _create_model_version():
     is_prompt = _is_prompt_request(request_message)
     if is_prompt:
         # Prompt sources must not point to local filesystem paths
-        if is_local_uri(request_message.source, is_tracking_or_registry_uri=False):
+        try:
+            is_local = is_local_uri(request_message.source, is_tracking_or_registry_uri=False)
+        except MlflowException as exc:
+            raise MlflowException(
+                f"Invalid model version source: '{request_message.source}'. {exc}",
+                error_code=INVALID_PARAMETER_VALUE,
+            ) from exc
+        if is_local:
             raise MlflowException(
                 f"Invalid model version source: '{request_message.source}'. "
                 "Local source paths are not allowed for prompts.",

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -792,8 +792,7 @@ def test_create_model_version_rejects_local_source_for_prompts(
     )
     resp = _create_model_version()
     assert resp.status_code == 400
-    data = json.loads(resp.get_data())
-    assert "Invalid model version source" in data["message"]
+    assert "Invalid prompt source" in resp.get_json()["message"]
 
 
 @pytest.mark.parametrize(
@@ -813,8 +812,7 @@ def test_create_model_version_rejects_traversal_source_for_prompts(
     )
     resp = _create_model_version()
     assert resp.status_code == 400
-    data = json.loads(resp.get_data())
-    assert "Invalid model version source" in data["message"]
+    assert "Invalid model version source" in resp.get_json()["message"]
 
 
 def test_set_registered_model_tag(mock_get_request_message, mock_model_registry_store):


### PR DESCRIPTION
### Related Issues/PRs

Fixes #20818

### What changes are proposed in this pull request?

See [this ticket](https://huntr.com/bounties/5491dca7-ec28-4589-bc17-8ce22e5f4b36) for the security vulnerability

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No. You can skip the rest of this section.
- [x] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
