### PR TITLE
Port labeling sessions to OSS: Store layer implementation

### DIFF
--- a/mlflow/entities/labeling.py
+++ b/mlflow/entities/labeling.py
@@ -1,0 +1,295 @@
+from mlflow.entities._mlflow_object import _MlflowObject
+from mlflow.entities.labeling_item_status import LabelingSessionItemStatus
+from mlflow.protos.service_pb2 import (
+    LabelingSchemaProto,
+    LabelingSessionItemProto,
+    LabelingSessionProto,
+)
+
+
+class LabelingSessionEntity(_MlflowObject):
+    """
+    A labeling session entity that represents a session for labeling traces or dataset records.
+
+    Args:
+        labeling_session_id: The unique identifier for the labeling session.
+        experiment_id: The ID of the experiment this session belongs to.
+        name: The name of the labeling session.
+        creation_time: Unix timestamp (in milliseconds) when this session was created.
+        last_update_time: Unix timestamp (in milliseconds) when this session was last updated.
+    """
+
+    def __init__(
+        self,
+        labeling_session_id: str,
+        experiment_id: int,
+        name: str,
+        creation_time: int,
+        last_update_time: int,
+    ):
+        self._labeling_session_id = labeling_session_id
+        self._experiment_id = experiment_id
+        self._name = name
+        self._creation_time = creation_time
+        self._last_update_time = last_update_time
+
+    @property
+    def labeling_session_id(self):
+        return self._labeling_session_id
+
+    @property
+    def experiment_id(self):
+        return self._experiment_id
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def creation_time(self):
+        return self._creation_time
+
+    @property
+    def last_update_time(self):
+        return self._last_update_time
+
+    @classmethod
+    def from_proto(cls, proto):
+        return cls(
+            labeling_session_id=proto.labeling_session_id,
+            experiment_id=proto.experiment_id,
+            name=proto.name,
+            creation_time=proto.creation_time,
+            last_update_time=proto.last_update_time,
+        )
+
+    def to_proto(self):
+        proto = LabelingSessionProto()
+        proto.labeling_session_id = self.labeling_session_id
+        proto.experiment_id = int(self.experiment_id)
+        proto.name = self.name
+        proto.creation_time = self.creation_time
+        proto.last_update_time = self.last_update_time
+        return proto
+
+    def __repr__(self):
+        return (
+            f"<LabelingSessionEntity(labeling_session_id='{self.labeling_session_id}', "
+            f"experiment_id={self.experiment_id}, "
+            f"name='{self.name}')>"
+        )
+
+
+class LabelingSchema(_MlflowObject):
+    """
+    A labeling schema entity that defines the structure for labeling assessments.
+
+    Args:
+        labeling_schema_id: The unique identifier for the labeling schema.
+        labeling_session_id: The ID of the labeling session this schema belongs to.
+        name: The name of the labeling schema.
+        assessment_type: The type of assessment (feedback/expectation).
+        assessment_value_type: JSON string containing value type and configuration.
+        title: The display title for the schema.
+        instructions: Optional instructions for using this schema.
+        creation_time: Unix timestamp (in milliseconds) when this schema was created.
+        last_update_time: Unix timestamp (in milliseconds) when this schema was last updated.
+    """
+
+    def __init__(
+        self,
+        labeling_schema_id: str,
+        labeling_session_id: str,
+        name: str,
+        assessment_type: str,
+        assessment_value_type: str,
+        title: str,
+        instructions: str | None,
+        creation_time: int,
+        last_update_time: int,
+    ):
+        self._labeling_schema_id = labeling_schema_id
+        self._labeling_session_id = labeling_session_id
+        self._name = name
+        self._assessment_type = assessment_type
+        self._assessment_value_type = assessment_value_type
+        self._title = title
+        self._instructions = instructions
+        self._creation_time = creation_time
+        self._last_update_time = last_update_time
+
+    @property
+    def labeling_schema_id(self):
+        return self._labeling_schema_id
+
+    @property
+    def labeling_session_id(self):
+        return self._labeling_session_id
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def assessment_type(self):
+        return self._assessment_type
+
+    @property
+    def assessment_value_type(self):
+        return self._assessment_value_type
+
+    @property
+    def title(self):
+        return self._title
+
+    @property
+    def instructions(self):
+        return self._instructions
+
+    @property
+    def creation_time(self):
+        return self._creation_time
+
+    @property
+    def last_update_time(self):
+        return self._last_update_time
+
+    @classmethod
+    def from_proto(cls, proto):
+        return cls(
+            labeling_schema_id=proto.labeling_schema_id,
+            labeling_session_id=proto.labeling_session_id,
+            name=proto.name,
+            assessment_type=proto.assessment_type,
+            assessment_value_type=proto.assessment_value_type,
+            title=proto.title,
+            instructions=proto.instructions if proto.HasField("instructions") else None,
+            creation_time=proto.creation_time,
+            last_update_time=proto.last_update_time,
+        )
+
+    def to_proto(self):
+        proto = LabelingSchemaProto()
+        proto.labeling_schema_id = self.labeling_schema_id
+        proto.labeling_session_id = self.labeling_session_id
+        proto.name = self.name
+        proto.assessment_type = self.assessment_type
+        proto.assessment_value_type = self.assessment_value_type
+        proto.title = self.title
+        if self.instructions is not None:
+            proto.instructions = self.instructions
+        proto.creation_time = self.creation_time
+        proto.last_update_time = self.last_update_time
+        return proto
+
+    def __repr__(self):
+        return (
+            f"<LabelingSchema(labeling_schema_id='{self.labeling_schema_id}', "
+            f"labeling_session_id='{self.labeling_session_id}', "
+            f"name='{self.name}')>"
+        )
+
+
+class LabelingSessionItem(_MlflowObject):
+    """
+    A labeling session item entity that represents an item to be labeled in a session.
+
+    Args:
+        labeling_item_id: The unique identifier for the labeling item.
+        labeling_session_id: The ID of the labeling session this item belongs to.
+        trace_id: Optional trace ID associated with this item.
+        dataset_record_id: Optional dataset record ID associated with this item.
+        dataset_id: Optional dataset ID associated with this item.
+        status: The status of the labeling item (PENDING, IN_PROGRESS, COMPLETED, SKIPPED).
+        creation_time: Unix timestamp (in milliseconds) when this item was created.
+        last_update_time: Unix timestamp (in milliseconds) when this item was last updated.
+    """
+
+    def __init__(
+        self,
+        labeling_item_id: str,
+        labeling_session_id: str,
+        trace_id: str | None,
+        dataset_record_id: str | None,
+        dataset_id: str | None,
+        status: int,
+        creation_time: int,
+        last_update_time: int,
+    ):
+        self._labeling_item_id = labeling_item_id
+        self._labeling_session_id = labeling_session_id
+        self._trace_id = trace_id
+        self._dataset_record_id = dataset_record_id
+        self._dataset_id = dataset_id
+        self._status = status
+        self._creation_time = creation_time
+        self._last_update_time = last_update_time
+
+    @property
+    def labeling_item_id(self):
+        return self._labeling_item_id
+
+    @property
+    def labeling_session_id(self):
+        return self._labeling_session_id
+
+    @property
+    def trace_id(self):
+        return self._trace_id
+
+    @property
+    def dataset_record_id(self):
+        return self._dataset_record_id
+
+    @property
+    def dataset_id(self):
+        return self._dataset_id
+
+    @property
+    def status(self):
+        return self._status
+
+    @property
+    def creation_time(self):
+        return self._creation_time
+
+    @property
+    def last_update_time(self):
+        return self._last_update_time
+
+    @classmethod
+    def from_proto(cls, proto):
+        return cls(
+            labeling_item_id=proto.labeling_item_id,
+            labeling_session_id=proto.labeling_session_id,
+            trace_id=proto.trace_id if proto.HasField("trace_id") else None,
+            dataset_record_id=(
+                proto.dataset_record_id if proto.HasField("dataset_record_id") else None
+            ),
+            dataset_id=proto.dataset_id if proto.HasField("dataset_id") else None,
+            status=proto.status,
+            creation_time=proto.creation_time,
+            last_update_time=proto.last_update_time,
+        )
+
+    def to_proto(self):
+        proto = LabelingSessionItemProto()
+        proto.labeling_item_id = self.labeling_item_id
+        proto.labeling_session_id = self.labeling_session_id
+        if self.trace_id is not None:
+            proto.trace_id = self.trace_id
+        if self.dataset_record_id is not None:
+            proto.dataset_record_id = self.dataset_record_id
+        if self.dataset_id is not None:
+            proto.dataset_id = self.dataset_id
+        proto.status = self.status
+        proto.creation_time = self.creation_time
+        proto.last_update_time = self.last_update_time
+        return proto
+
+    def __repr__(self):
+        return (
+            f"<LabelingSessionItem(labeling_item_id='{self.labeling_item_id}', "
+            f"labeling_session_id='{self.labeling_session_id}', "
+            f"status={LabelingSessionItemStatus.to_string(self.status)})>"
+        )

--- a/mlflow/entities/labeling_item_status.py
+++ b/mlflow/entities/labeling_item_status.py
@@ -1,0 +1,38 @@
+from mlflow.protos.service_pb2 import LabelingSessionItemStatus as ProtoLabelingSessionItemStatus
+
+
+class LabelingSessionItemStatus:
+    """Enum for status of a labeling session item."""
+
+    PENDING = ProtoLabelingSessionItemStatus.Value("PENDING")
+    IN_PROGRESS = ProtoLabelingSessionItemStatus.Value("IN_PROGRESS")
+    COMPLETED = ProtoLabelingSessionItemStatus.Value("COMPLETED")
+    SKIPPED = ProtoLabelingSessionItemStatus.Value("SKIPPED")
+
+    _STRING_TO_STATUS = {
+        k: ProtoLabelingSessionItemStatus.Value(k)
+        for k in ProtoLabelingSessionItemStatus.keys()
+    }
+    _STATUS_TO_STRING = {value: key for key, value in _STRING_TO_STATUS.items()}
+
+    @staticmethod
+    def from_string(status_str):
+        if status_str not in LabelingSessionItemStatus._STRING_TO_STATUS:
+            raise Exception(
+                f"Could not get labeling item status corresponding to string {status_str}. "
+                f"Valid statuses: {list(LabelingSessionItemStatus._STRING_TO_STATUS.keys())}"
+            )
+        return LabelingSessionItemStatus._STRING_TO_STATUS[status_str]
+
+    @staticmethod
+    def to_string(status):
+        if status not in LabelingSessionItemStatus._STATUS_TO_STRING:
+            raise Exception(
+                f"Could not get string corresponding to labeling item status {status}. "
+                f"Valid statuses: {list(LabelingSessionItemStatus._STATUS_TO_STRING.keys())}"
+            )
+        return LabelingSessionItemStatus._STATUS_TO_STRING[status]
+
+    @staticmethod
+    def all_status():
+        return list(LabelingSessionItemStatus._STATUS_TO_STRING.keys())

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -1614,6 +1614,262 @@ service MlflowService {
     };
   }
 
+  // =============================================================================
+  // Labeling Management RPCs
+  // =============================================================================
+
+  // Create a labeling session for an experiment.
+  rpc createLabelingSession(CreateLabelingSession) returns (CreateLabelingSession.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "POST"
+          path: "/mlflow/labeling/sessions"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Create Labeling Session"
+    };
+  }
+
+  // Get a labeling session by ID.
+  rpc getLabelingSession(GetLabelingSession) returns (GetLabelingSession.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "GET"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Get Labeling Session"
+    };
+  }
+
+  // List labeling sessions for an experiment.
+  rpc listLabelingSessions(ListLabelingSessions) returns (ListLabelingSessions.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "GET"
+          path: "/mlflow/labeling/sessions"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "List Labeling Sessions"
+    };
+  }
+
+  // Update a labeling session.
+  rpc updateLabelingSession(UpdateLabelingSession) returns (UpdateLabelingSession.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "PATCH"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Update Labeling Session"
+    };
+  }
+
+  // Delete a labeling session.
+  rpc deleteLabelingSession(DeleteLabelingSession) returns (DeleteLabelingSession.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "DELETE"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Delete Labeling Session"
+    };
+  }
+
+  // Create a labeling schema for a session.
+  rpc createLabelingSchema(CreateLabelingSchema) returns (CreateLabelingSchema.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "POST"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}/schemas"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Create Labeling Schema"
+    };
+  }
+
+  // Get a labeling schema by name.
+  rpc getLabelingSchema(GetLabelingSchema) returns (GetLabelingSchema.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "GET"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}/schemas/{name}"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Get Labeling Schema"
+    };
+  }
+
+  // List labeling schemas for a session.
+  rpc listLabelingSchemas(ListLabelingSchemas) returns (ListLabelingSchemas.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "GET"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}/schemas"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "List Labeling Schemas"
+    };
+  }
+
+  // Delete a labeling schema.
+  rpc deleteLabelingSchema(DeleteLabelingSchema) returns (DeleteLabelingSchema.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "DELETE"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}/schemas/{name}"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Delete Labeling Schema"
+    };
+  }
+
+  // Create labeling session items (batch).
+  rpc createLabelingSessionItems(CreateLabelingSessionItems) returns (CreateLabelingSessionItems.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "POST"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}/items"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Create Labeling Session Items"
+    };
+  }
+
+  // Get a labeling session item by ID.
+  rpc getLabelingSessionItem(GetLabelingSessionItem) returns (GetLabelingSessionItem.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "GET"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}/items/{labeling_item_id}"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Get Labeling Session Item"
+    };
+  }
+
+  // List labeling session items (paginated).
+  rpc listLabelingSessionItems(ListLabelingSessionItems) returns (ListLabelingSessionItems.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "GET"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}/items"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "List Labeling Session Items"
+    };
+  }
+
+  // Update a labeling session item.
+  rpc updateLabelingSessionItem(UpdateLabelingSessionItem) returns (UpdateLabelingSessionItem.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "PATCH"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}/items/{labeling_item_id}"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Update Labeling Session Item"
+    };
+  }
+
+  // Delete labeling session items (batch).
+  rpc deleteLabelingSessionItems(DeleteLabelingSessionItems) returns (DeleteLabelingSessionItems.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "DELETE"
+          path: "/mlflow/labeling/sessions/{labeling_session_id}/items"
+          since: {
+            major: 3
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC
+      rpc_doc_title: "Delete Labeling Session Items"
+    };
+  }
+
   // Get records for an evaluation dataset
   rpc getDatasetRecords(GetDatasetRecords) returns (GetDatasetRecords.Response) {
     option (rpc) = {
@@ -4389,6 +4645,291 @@ message Scorer {
   optional int64 creation_time = 5;
   // The unique identifier for the scorer.
   optional string scorer_id = 6;
+}
+
+// =============================================================================
+// Labeling Management Messages
+// =============================================================================
+
+// Status enum for labeling session items.
+enum LabelingSessionItemStatus {
+  // Item is pending labeling.
+  PENDING = 1;
+  // Item labeling is in progress.
+  IN_PROGRESS = 2;
+  // Item labeling is completed.
+  COMPLETED = 3;
+  // Item was skipped.
+  SKIPPED = 4;
+}
+
+// Labeling session entity.
+message LabelingSessionProto {
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+  // The experiment ID.
+  optional int32 experiment_id = 2;
+  // The session name.
+  optional string name = 3;
+  // The creation time (in milliseconds since epoch).
+  optional int64 creation_time = 4;
+  // The last update time (in milliseconds since epoch).
+  optional int64 last_update_time = 5;
+}
+
+// Labeling schema entity.
+message LabelingSchemaProto {
+  // The labeling schema ID.
+  optional string labeling_schema_id = 1;
+  // The labeling session ID.
+  optional string labeling_session_id = 2;
+  // The schema name.
+  optional string name = 3;
+  // The assessment type (feedback/expectation).
+  optional string assessment_type = 4;
+  // The assessment value type (JSON string with value type + config).
+  optional string assessment_value_type = 5;
+  // The schema title.
+  optional string title = 6;
+  // The schema instructions.
+  optional string instructions = 7;
+  // The creation time (in milliseconds since epoch).
+  optional int64 creation_time = 8;
+  // The last update time (in milliseconds since epoch).
+  optional int64 last_update_time = 9;
+}
+
+// Labeling session item entity.
+message LabelingSessionItemProto {
+  // The labeling item ID.
+  optional string labeling_item_id = 1;
+  // The labeling session ID.
+  optional string labeling_session_id = 2;
+  // The trace ID (optional).
+  optional string trace_id = 3;
+  // The dataset record ID (optional).
+  optional string dataset_record_id = 4;
+  // The dataset ID (optional).
+  optional string dataset_id = 5;
+  // The item status.
+  optional LabelingSessionItemStatus status = 6;
+  // The creation time (in milliseconds since epoch).
+  optional int64 creation_time = 7;
+  // The last update time (in milliseconds since epoch).
+  optional int64 last_update_time = 8;
+}
+
+// Create a labeling session.
+message CreateLabelingSession {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The experiment ID.
+  optional int32 experiment_id = 1;
+  // The session name.
+  optional string name = 2;
+
+  message Response {
+    // The created labeling session.
+    optional LabelingSessionProto labeling_session = 1;
+  }
+}
+
+// Get a labeling session by ID.
+message GetLabelingSession {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+
+  message Response {
+    // The labeling session.
+    optional LabelingSessionProto labeling_session = 1;
+  }
+}
+
+// List labeling sessions for an experiment.
+message ListLabelingSessions {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The experiment ID.
+  optional int32 experiment_id = 1;
+
+  message Response {
+    // List of labeling sessions.
+    repeated LabelingSessionProto labeling_sessions = 1;
+  }
+}
+
+// Update a labeling session.
+message UpdateLabelingSession {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+  // The new session name.
+  optional string name = 2;
+
+  message Response {
+    // The updated labeling session.
+    optional LabelingSessionProto labeling_session = 1;
+  }
+}
+
+// Delete a labeling session.
+message DeleteLabelingSession {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+
+  message Response {
+    // Empty response.
+  }
+}
+
+// Create a labeling schema.
+message CreateLabelingSchema {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+  // The schema name.
+  optional string name = 2;
+  // The assessment type (feedback/expectation).
+  optional string assessment_type = 3;
+  // The schema title.
+  optional string title = 4;
+  // The assessment value type (JSON string with value type + config).
+  optional string assessment_value_type = 5;
+  // The schema instructions (optional).
+  optional string instructions = 6;
+
+  message Response {
+    // The created labeling schema.
+    optional LabelingSchemaProto labeling_schema = 1;
+  }
+}
+
+// Get a labeling schema by name.
+message GetLabelingSchema {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+  // The schema name.
+  optional string name = 2;
+
+  message Response {
+    // The labeling schema.
+    optional LabelingSchemaProto labeling_schema = 1;
+  }
+}
+
+// List labeling schemas for a session.
+message ListLabelingSchemas {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+
+  message Response {
+    // List of labeling schemas.
+    repeated LabelingSchemaProto labeling_schemas = 1;
+  }
+}
+
+// Delete a labeling schema.
+message DeleteLabelingSchema {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+  // The schema name.
+  optional string name = 2;
+
+  message Response {
+    // Empty response.
+  }
+}
+
+// Create labeling session items (batch).
+message CreateLabelingSessionItems {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+  // The items to create.
+  repeated LabelingSessionItemProto items = 2;
+
+  message Response {
+    // The created labeling items.
+    repeated LabelingSessionItemProto labeling_items = 1;
+  }
+}
+
+// Get a labeling session item by ID.
+message GetLabelingSessionItem {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+  // The labeling item ID.
+  optional string labeling_item_id = 2;
+
+  message Response {
+    // The labeling item.
+    optional LabelingSessionItemProto labeling_item = 1;
+  }
+}
+
+// List labeling session items (paginated).
+message ListLabelingSessionItems {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+  // The page token for pagination (optional).
+  optional string page_token = 2;
+  // The maximum number of results per page (optional).
+  optional int32 max_results = 3;
+
+  message Response {
+    // List of labeling items.
+    repeated LabelingSessionItemProto labeling_items = 1;
+    // The next page token (if there are more results).
+    optional string next_page_token = 2;
+  }
+}
+
+// Update a labeling session item.
+message UpdateLabelingSessionItem {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+  // The labeling item ID.
+  optional string labeling_item_id = 2;
+  // The new status.
+  optional LabelingSessionItemStatus status = 3;
+
+  message Response {
+    // The updated labeling item.
+    optional LabelingSessionItemProto labeling_item = 1;
+  }
+}
+
+// Delete labeling session items (batch).
+message DeleteLabelingSessionItems {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // The labeling session ID.
+  optional string labeling_session_id = 1;
+  // The labeling item IDs to delete.
+  repeated string labeling_item_ids = 2;
+
+  message Response {
+    // Empty response.
+  }
 }
 
 // ========== Gateway Secrets and Endpoints Entities ==========

--- a/mlflow/store/db_migrations/versions/e1f2a3b4c5d6_add_labeling_tables.py
+++ b/mlflow/store/db_migrations/versions/e1f2a3b4c5d6_add_labeling_tables.py
@@ -1,0 +1,112 @@
+"""add labeling tables
+
+Create Date: 2026-02-15 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e1f2a3b4c5d6"
+down_revision = "d3e4f5a6b7c8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create labeling_sessions table
+    op.create_table(
+        "labeling_sessions",
+        sa.Column("labeling_session_id", sa.String(length=36), nullable=False),
+        sa.Column("experiment_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("creation_time", sa.BigInteger(), nullable=False),
+        sa.Column("last_update_time", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_labeling_sessions_experiment_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("labeling_session_id", name="labeling_session_pk"),
+    )
+    with op.batch_alter_table("labeling_sessions", schema=None) as batch_op:
+        batch_op.create_index(
+            "index_labeling_sessions_experiment_id",
+            ["experiment_id"],
+            unique=False,
+        )
+
+    # Create labeling_schemas table
+    op.create_table(
+        "labeling_schemas",
+        sa.Column("labeling_schema_id", sa.String(length=36), nullable=False),
+        sa.Column("labeling_session_id", sa.String(length=36), nullable=False),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("assessment_type", sa.String(length=32), nullable=False),
+        sa.Column("assessment_value_type", sa.Text(), nullable=False),
+        sa.Column("title", sa.String(length=256), nullable=False),
+        sa.Column("instructions", sa.Text(), nullable=True),
+        sa.Column("creation_time", sa.BigInteger(), nullable=False),
+        sa.Column("last_update_time", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["labeling_session_id"],
+            ["labeling_sessions.labeling_session_id"],
+            name="fk_labeling_schemas_session_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("labeling_schema_id", name="labeling_schema_pk"),
+    )
+    with op.batch_alter_table("labeling_schemas", schema=None) as batch_op:
+        batch_op.create_index(
+            "index_labeling_schemas_session_id",
+            ["labeling_session_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            "unique_labeling_schema_session_name",
+            ["labeling_session_id", "name"],
+            unique=True,
+        )
+
+    # Create labeling_session_items table
+    op.create_table(
+        "labeling_session_items",
+        sa.Column("labeling_item_id", sa.String(length=36), nullable=False),
+        sa.Column("labeling_session_id", sa.String(length=36), nullable=False),
+        sa.Column("trace_id", sa.String(length=50), nullable=True),
+        sa.Column("dataset_record_id", sa.String(length=36), nullable=True),
+        sa.Column("dataset_id", sa.String(length=36), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("creation_time", sa.BigInteger(), nullable=False),
+        sa.Column("last_update_time", sa.BigInteger(), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('PENDING', 'IN_PROGRESS', 'COMPLETED', 'SKIPPED')",
+            name="labeling_item_status",
+        ),
+        sa.ForeignKeyConstraint(
+            ["labeling_session_id"],
+            ["labeling_sessions.labeling_session_id"],
+            name="fk_labeling_items_session_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("labeling_item_id", name="labeling_item_pk"),
+    )
+    with op.batch_alter_table("labeling_session_items", schema=None) as batch_op:
+        batch_op.create_index(
+            "index_labeling_items_session_id",
+            ["labeling_session_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            "index_labeling_items_trace_id",
+            ["trace_id"],
+            unique=False,
+        )
+
+
+def downgrade():
+    op.drop_table("labeling_session_items")
+    op.drop_table("labeling_schemas")
+    op.drop_table("labeling_sessions")

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -1569,3 +1569,232 @@ class AbstractStore(GatewayStoreMixin):
             and filter_string fields populated.
         """
         raise NotImplementedError(self.__class__.__name__)
+
+    def create_labeling_session(self, experiment_id: int, name: str) -> "LabelingSessionEntity":
+        """
+        Create a labeling session for an experiment.
+
+        Args:
+            experiment_id: The experiment ID.
+            name: The session name.
+
+        Returns:
+            mlflow.entities.labeling.LabelingSessionEntity: The created labeling session.
+
+        Raises:
+            MlflowException: If experiment does not exist.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def get_labeling_session(self, labeling_session_id: str) -> "LabelingSessionEntity":
+        """
+        Get a labeling session by ID.
+
+        Args:
+            labeling_session_id: The labeling session ID.
+
+        Returns:
+            mlflow.entities.labeling.LabelingSessionEntity: The labeling session.
+
+        Raises:
+            MlflowException: If session is not found.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def list_labeling_sessions(self, experiment_id: int) -> list["LabelingSessionEntity"]:
+        """
+        List all labeling sessions for an experiment.
+
+        Args:
+            experiment_id: The experiment ID.
+
+        Returns:
+            List of mlflow.entities.labeling.LabelingSessionEntity objects.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def update_labeling_session(
+        self, labeling_session_id: str, name: str
+    ) -> "LabelingSessionEntity":
+        """
+        Update a labeling session.
+
+        Args:
+            labeling_session_id: The labeling session ID.
+            name: The new session name.
+
+        Returns:
+            mlflow.entities.labeling.LabelingSessionEntity: The updated labeling session.
+
+        Raises:
+            MlflowException: If session is not found.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def delete_labeling_session(self, labeling_session_id: str) -> None:
+        """
+        Delete a labeling session.
+
+        Args:
+            labeling_session_id: The labeling session ID.
+
+        Raises:
+            MlflowException: If session is not found.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def create_labeling_schema(
+        self,
+        labeling_session_id: str,
+        name: str,
+        assessment_type: str,
+        title: str,
+        assessment_value_type: str,
+        instructions: str | None = None,
+    ) -> "LabelingSchema":
+        """
+        Create a labeling schema for a session.
+
+        Args:
+            labeling_session_id: The labeling session ID.
+            name: The schema name.
+            assessment_type: The assessment type (feedback/expectation).
+            title: The schema title.
+            assessment_value_type: JSON string containing value type and configuration.
+            instructions: Optional schema instructions.
+
+        Returns:
+            mlflow.entities.labeling.LabelingSchema: The created labeling schema.
+
+        Raises:
+            MlflowException: If session is not found or schema with this name already exists.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def get_labeling_schema(
+        self, labeling_session_id: str, name: str
+    ) -> "LabelingSchema":
+        """
+        Get a labeling schema by name.
+
+        Args:
+            labeling_session_id: The labeling session ID.
+            name: The schema name.
+
+        Returns:
+            mlflow.entities.labeling.LabelingSchema: The labeling schema.
+
+        Raises:
+            MlflowException: If schema is not found.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def list_labeling_schemas(self, labeling_session_id: str) -> list["LabelingSchema"]:
+        """
+        List all labeling schemas for a session.
+
+        Args:
+            labeling_session_id: The labeling session ID.
+
+        Returns:
+            List of mlflow.entities.labeling.LabelingSchema objects.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def delete_labeling_schema(self, labeling_session_id: str, name: str) -> None:
+        """
+        Delete a labeling schema.
+
+        Args:
+            labeling_session_id: The labeling session ID.
+            name: The schema name.
+
+        Raises:
+            MlflowException: If schema is not found.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def create_labeling_session_items(
+        self, labeling_session_id: str, items: list["LabelingSessionItemProto"]
+    ) -> list["LabelingSessionItem"]:
+        """
+        Create labeling session items (batch).
+
+        Args:
+            labeling_session_id: The labeling session ID.
+            items: List of item proto messages to create.
+
+        Returns:
+            List of mlflow.entities.labeling.LabelingSessionItem objects.
+
+        Raises:
+            MlflowException: If session is not found.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def get_labeling_session_item(self, labeling_item_id: str) -> "LabelingSessionItem":
+        """
+        Get a labeling session item by ID.
+
+        Args:
+            labeling_item_id: The labeling item ID.
+
+        Returns:
+            mlflow.entities.labeling.LabelingSessionItem: The labeling item.
+
+        Raises:
+            MlflowException: If item is not found.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def list_labeling_session_items(
+        self,
+        labeling_session_id: str,
+        page_token: str | None = None,
+        max_results: int | None = None,
+    ) -> "PagedList[LabelingSessionItem]":
+        """
+        List labeling session items (paginated).
+
+        Args:
+            labeling_session_id: The labeling session ID.
+            page_token: Optional page token for pagination.
+            max_results: Optional maximum number of results per page.
+
+        Returns:
+            PagedList of mlflow.entities.labeling.LabelingSessionItem objects.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def update_labeling_session_item(
+        self, labeling_item_id: str, status: int
+    ) -> "LabelingSessionItem":
+        """
+        Update a labeling session item status.
+
+        Args:
+            labeling_item_id: The labeling item ID.
+            status: The new status (from LabelingSessionItemStatus enum).
+
+        Returns:
+            mlflow.entities.labeling.LabelingSessionItem: The updated labeling item.
+
+        Raises:
+            MlflowException: If item is not found.
+        """
+        raise NotImplementedError(self.__class__.__name__)
+
+    def delete_labeling_session_items(
+        self, labeling_session_id: str, labeling_item_ids: list[str]
+    ) -> None:
+        """
+        Delete labeling session items (batch).
+
+        Args:
+            labeling_session_id: The labeling session ID.
+            labeling_item_ids: List of labeling item IDs to delete.
+
+        Raises:
+            MlflowException: If session is not found.
+        """
+        raise NotImplementedError(self.__class__.__name__)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2847,6 +2847,333 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 for config, scorer, version in gateway_results
             ]
 
+    #######################################################################################
+    # Labeling Session Methods
+    #######################################################################################
+
+    def create_labeling_session(self, experiment_id: int, name: str):
+        """Create a labeling session for an experiment."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSession
+
+        with self.ManagedSessionMaker() as session:
+            # Validate experiment exists and is active
+            experiment = self.get_experiment(str(experiment_id))
+            self._check_experiment_is_active(experiment)
+
+            labeling_session_id = uuid.uuid4().hex
+            current_time = get_current_time_millis()
+
+            sql_session = SqlLabelingSession(
+                labeling_session_id=labeling_session_id,
+                experiment_id=experiment_id,
+                name=name,
+                creation_time=current_time,
+                last_update_time=current_time,
+            )
+            session.add(sql_session)
+            session.flush()
+
+            return sql_session.to_mlflow_entity()
+
+    def get_labeling_session(self, labeling_session_id: str):
+        """Get a labeling session by ID."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSession
+
+        with self.ManagedSessionMaker() as session:
+            sql_session = session.get(SqlLabelingSession, labeling_session_id)
+            if not sql_session:
+                raise MlflowException(
+                    f"Labeling session with ID {labeling_session_id!r} not found.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+            return sql_session.to_mlflow_entity()
+
+    def list_labeling_sessions(self, experiment_id: int):
+        """List all labeling sessions for an experiment."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSession
+
+        with self.ManagedSessionMaker() as session:
+            # Validate experiment exists
+            self.get_experiment(str(experiment_id))
+
+            sessions = (
+                session.query(SqlLabelingSession)
+                .filter(SqlLabelingSession.experiment_id == experiment_id)
+                .order_by(SqlLabelingSession.creation_time.desc())
+                .all()
+            )
+            return [s.to_mlflow_entity() for s in sessions]
+
+    def update_labeling_session(self, labeling_session_id: str, name: str):
+        """Update a labeling session."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSession
+
+        with self.ManagedSessionMaker() as session:
+            sql_session = session.get(SqlLabelingSession, labeling_session_id)
+            if not sql_session:
+                raise MlflowException(
+                    f"Labeling session with ID {labeling_session_id!r} not found.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+
+            sql_session.name = name
+            sql_session.last_update_time = get_current_time_millis()
+            session.flush()
+
+            return sql_session.to_mlflow_entity()
+
+    def delete_labeling_session(self, labeling_session_id: str):
+        """Delete a labeling session."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSession
+
+        with self.ManagedSessionMaker() as session:
+            sql_session = session.get(SqlLabelingSession, labeling_session_id)
+            if not sql_session:
+                raise MlflowException(
+                    f"Labeling session with ID {labeling_session_id!r} not found.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+            session.delete(sql_session)
+
+    def create_labeling_schema(
+        self,
+        labeling_session_id: str,
+        name: str,
+        assessment_type: str,
+        title: str,
+        assessment_value_type: str,
+        instructions: str | None = None,
+    ):
+        """Create a labeling schema for a session."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSchema
+
+        with self.ManagedSessionMaker() as session:
+            # Validate session exists
+            self.get_labeling_session(labeling_session_id)
+
+            labeling_schema_id = uuid.uuid4().hex
+            current_time = get_current_time_millis()
+
+            sql_schema = SqlLabelingSchema(
+                labeling_schema_id=labeling_schema_id,
+                labeling_session_id=labeling_session_id,
+                name=name,
+                assessment_type=assessment_type,
+                assessment_value_type=assessment_value_type,
+                title=title,
+                instructions=instructions,
+                creation_time=current_time,
+                last_update_time=current_time,
+            )
+
+            try:
+                session.add(sql_schema)
+                session.flush()
+            except IntegrityError:
+                raise MlflowException(
+                    f"Labeling schema with name {name!r} already exists in "
+                    f"session {labeling_session_id!r}.",
+                    RESOURCE_ALREADY_EXISTS,
+                )
+
+            return sql_schema.to_mlflow_entity()
+
+    def get_labeling_schema(self, labeling_session_id: str, name: str):
+        """Get a labeling schema by name."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSchema
+
+        with self.ManagedSessionMaker() as session:
+            sql_schema = (
+                session.query(SqlLabelingSchema)
+                .filter(
+                    SqlLabelingSchema.labeling_session_id == labeling_session_id,
+                    SqlLabelingSchema.name == name,
+                )
+                .first()
+            )
+            if not sql_schema:
+                raise MlflowException(
+                    f"Labeling schema with name {name!r} not found in "
+                    f"session {labeling_session_id!r}.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+            return sql_schema.to_mlflow_entity()
+
+    def list_labeling_schemas(self, labeling_session_id: str):
+        """List all labeling schemas for a session."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSchema
+
+        with self.ManagedSessionMaker() as session:
+            # Validate session exists
+            self.get_labeling_session(labeling_session_id)
+
+            schemas = (
+                session.query(SqlLabelingSchema)
+                .filter(SqlLabelingSchema.labeling_session_id == labeling_session_id)
+                .order_by(SqlLabelingSchema.creation_time)
+                .all()
+            )
+            return [s.to_mlflow_entity() for s in schemas]
+
+    def delete_labeling_schema(self, labeling_session_id: str, name: str):
+        """Delete a labeling schema."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSchema
+
+        with self.ManagedSessionMaker() as session:
+            deleted = (
+                session.query(SqlLabelingSchema)
+                .filter(
+                    SqlLabelingSchema.labeling_session_id == labeling_session_id,
+                    SqlLabelingSchema.name == name,
+                )
+                .delete()
+            )
+            if deleted == 0:
+                raise MlflowException(
+                    f"Labeling schema with name {name!r} not found in "
+                    f"session {labeling_session_id!r}.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+
+    def create_labeling_session_items(self, labeling_session_id: str, items):
+        """Create labeling session items (batch)."""
+        from mlflow.entities.labeling_item_status import LabelingSessionItemStatus
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSessionItem
+
+        with self.ManagedSessionMaker() as session:
+            # Validate session exists
+            self.get_labeling_session(labeling_session_id)
+
+            current_time = get_current_time_millis()
+            sql_items = []
+
+            for item_proto in items:
+                labeling_item_id = uuid.uuid4().hex
+                sql_item = SqlLabelingSessionItem(
+                    labeling_item_id=labeling_item_id,
+                    labeling_session_id=labeling_session_id,
+                    trace_id=item_proto.trace_id if item_proto.HasField("trace_id") else None,
+                    dataset_record_id=(
+                        item_proto.dataset_record_id
+                        if item_proto.HasField("dataset_record_id")
+                        else None
+                    ),
+                    dataset_id=item_proto.dataset_id if item_proto.HasField("dataset_id") else None,
+                    status=(
+                        LabelingSessionItemStatus.to_string(item_proto.status)
+                        if item_proto.HasField("status")
+                        else LabelingSessionItemStatus.to_string(LabelingSessionItemStatus.PENDING)
+                    ),
+                    creation_time=current_time,
+                    last_update_time=current_time,
+                )
+                session.add(sql_item)
+                sql_items.append(sql_item)
+
+            session.flush()
+            return [item.to_mlflow_entity() for item in sql_items]
+
+    def get_labeling_session_item(self, labeling_item_id: str):
+        """Get a labeling session item by ID."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSessionItem
+
+        with self.ManagedSessionMaker() as session:
+            sql_item = session.get(SqlLabelingSessionItem, labeling_item_id)
+            if not sql_item:
+                raise MlflowException(
+                    f"Labeling session item with ID {labeling_item_id!r} not found.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+            return sql_item.to_mlflow_entity()
+
+    def list_labeling_session_items(
+        self,
+        labeling_session_id: str,
+        page_token: str | None = None,
+        max_results: int | None = None,
+    ):
+        """List labeling session items (paginated)."""
+        from mlflow.store.entities.paged_list import PagedList
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSessionItem
+
+        with self.ManagedSessionMaker() as session:
+            # Validate session exists
+            self.get_labeling_session(labeling_session_id)
+
+            query = session.query(SqlLabelingSessionItem).filter(
+                SqlLabelingSessionItem.labeling_session_id == labeling_session_id
+            )
+
+            # Apply pagination
+            offset = 0
+            if page_token:
+                try:
+                    offset = int(page_token)
+                except ValueError:
+                    raise MlflowException(
+                        f"Invalid page_token: {page_token!r}",
+                        INVALID_PARAMETER_VALUE,
+                    )
+
+            query = query.order_by(SqlLabelingSessionItem.creation_time).offset(offset)
+
+            # Apply limit
+            limit = max_results if max_results else 1000  # Default to 1000
+            items = query.limit(limit + 1).all()
+
+            # Check if there are more results
+            next_page_token = None
+            if len(items) > limit:
+                items = items[:limit]
+                next_page_token = str(offset + limit)
+
+            return PagedList([item.to_mlflow_entity() for item in items], next_page_token)
+
+    def update_labeling_session_item(self, labeling_item_id: str, status: int):
+        """Update a labeling session item status."""
+        from mlflow.entities.labeling_item_status import LabelingSessionItemStatus
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSessionItem
+
+        with self.ManagedSessionMaker() as session:
+            sql_item = session.get(SqlLabelingSessionItem, labeling_item_id)
+            if not sql_item:
+                raise MlflowException(
+                    f"Labeling session item with ID {labeling_item_id!r} not found.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+
+            sql_item.status = LabelingSessionItemStatus.to_string(status)
+            sql_item.last_update_time = get_current_time_millis()
+            session.flush()
+
+            return sql_item.to_mlflow_entity()
+
+    def delete_labeling_session_items(
+        self, labeling_session_id: str, labeling_item_ids: list[str]
+    ):
+        """Delete labeling session items (batch)."""
+        from mlflow.store.tracking.dbmodels.models import SqlLabelingSessionItem
+
+        with self.ManagedSessionMaker() as session:
+            # Validate session exists
+            self.get_labeling_session(labeling_session_id)
+
+            deleted = (
+                session.query(SqlLabelingSessionItem)
+                .filter(
+                    SqlLabelingSessionItem.labeling_session_id == labeling_session_id,
+                    SqlLabelingSessionItem.labeling_item_id.in_(labeling_item_ids),
+                )
+                .delete(synchronize_session=False)
+            )
+
+            if deleted == 0:
+                raise MlflowException(
+                    f"No labeling items found in session {labeling_session_id!r} "
+                    f"with the provided IDs.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+
     def _resolve_endpoint_in_serialized_scorer(self, serialized_scorer: str) -> str:
         """
         Resolve gateway endpoint ID to name in a serialized scorer string.


### PR DESCRIPTION
**Second PR in stacked series** (depends on #20834)

This PR implements the store layer for OSS labeling sessions.

## Changes
- Add abstract store methods for labeling operations (14 methods)
- Implement SqlAlchemyStore methods with full error handling  
- Use ManagedSessionMaker, UUID generation, and proper timestamp management

## Dependencies
- Depends on PR #20834 (core data models)

---
**Stack:** #20834 → **this PR** → (REST layer) → (SDK integration)