### PR TITLE
Move 'Add to dataset' to next to 'Show assessments' button in trace ui

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3494,6 +3494,10 @@
     "defaultMessage": "Is the text grammatically correct and naturally flowing?",
     "description": "Hint for Fluency template"
   },
+  "NekUba": {
+    "defaultMessage": "Add to dataset",
+    "description": "Button text for adding a trace to an evaluation dataset"
+  },
   "NhEmyj": {
     "defaultMessage": "Training runs",
     "description": "Label for the training runs tab in the MLflow experiment navbar"
@@ -5166,10 +5170,6 @@
   "ZlokCq": {
     "defaultMessage": "Cancel",
     "description": "A label for the cancel button in the delete prompt modal"
-  },
-  "ZmiY49": {
-    "defaultMessage": "Add to dataset",
-    "description": "Button text for adding a trace to a evaluation dataset"
   },
   "ZoBXpz": {
     "defaultMessage": "Model attributes",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerContext.tsx
@@ -22,14 +22,21 @@ export type DrawerComponentType = {
   Content: (props: Drawer.DrawerContentProps) => React.ReactElement;
 };
 
+export interface AddToDatasetAction {
+  openModal: () => void;
+}
+
 export interface ModelTraceExplorerContextValue {
   renderExportTracesToDatasetsModal?: (params: RenderExportTracesToDatasetsModalParams) => React.ReactNode;
   DrawerComponent: DrawerComponentType;
+  /** When set (e.g. by the evaluation review drawer), content can show "Add to dataset" that calls openModal */
+  addToDatasetAction?: AddToDatasetAction;
 }
 
 const ModelTraceExplorerContext = createContext<ModelTraceExplorerContextValue>({
   renderExportTracesToDatasetsModal: () => null,
   DrawerComponent: Drawer,
+  addToDatasetAction: undefined,
 });
 
 interface ModelTraceExplorerContextProviderProps {
@@ -51,6 +58,19 @@ export const ModelTraceExplorerContextProvider: React.FC<ModelTraceExplorerConte
     [renderExportTracesToDatasetsModal, DrawerComponent],
   );
 
+  return <ModelTraceExplorerContext.Provider value={value}>{children}</ModelTraceExplorerContext.Provider>;
+};
+
+/** Use inside the drawer to expose "Add to dataset" to trace content (e.g. next to Show assessments). */
+export const ModelTraceExplorerAddToDatasetProvider: React.FC<{
+  openModal: () => void;
+  children: ReactNode;
+}> = ({ openModal, children }) => {
+  const parent = useContext(ModelTraceExplorerContext);
+  const value = useMemo(
+    () => ({ ...parent, addToDatasetAction: { openModal } }),
+    [parent, openModal],
+  );
   return <ModelTraceExplorerContext.Provider value={value}>{children}</ModelTraceExplorerContext.Provider>;
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerContext.tsx
@@ -67,10 +67,7 @@ export const ModelTraceExplorerAddToDatasetProvider: React.FC<{
   children: ReactNode;
 }> = ({ openModal, children }) => {
   const parent = useContext(ModelTraceExplorerContext);
-  const value = useMemo(
-    () => ({ ...parent, addToDatasetAction: { openModal } }),
-    [parent, openModal],
-  );
+  const value = useMemo(() => ({ ...parent, addToDatasetAction: { openModal } }), [parent, openModal]);
   return <ModelTraceExplorerContext.Provider value={value}>{children}</ModelTraceExplorerContext.Provider>;
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
@@ -5,13 +5,11 @@ import {
   Button,
   ChevronLeftIcon,
   ChevronRightIcon,
-  PlusIcon,
   useDesignSystemTheme,
 } from '@databricks/design-system';
-import { FormattedMessage } from '@databricks/i18n';
 
 import { ModelTraceExplorerSkeleton } from './ModelTraceExplorerSkeleton';
-import { useModelTraceExplorerContext } from './ModelTraceExplorerContext';
+import { ModelTraceExplorerAddToDatasetProvider, useModelTraceExplorerContext } from './ModelTraceExplorerContext';
 import type { ModelTraceInfoV3 } from './ModelTrace.types';
 
 export interface ModelTraceExplorerDrawerProps {
@@ -103,18 +101,6 @@ export const ModelTraceExplorerDrawer = ({
               <ChevronRightIcon />
             </Button>
             <div css={{ flex: 1, overflow: 'hidden' }}>{renderModalTitle()}</div>
-            {showAddToDatasetButton && (
-              <Button
-                componentId="mlflow.evaluations_review.modal.add_to_evaluation_dataset"
-                onClick={() => setShowDatasetModal(true)}
-                icon={<PlusIcon />}
-              >
-                <FormattedMessage
-                  defaultMessage="Add to dataset"
-                  description="Button text for adding a trace to a evaluation dataset"
-                />
-              </Button>
-            )}
           </div>
         }
         expandContentToFullHeight
@@ -135,7 +121,15 @@ export const ModelTraceExplorerDrawer = ({
         ]}
       >
         <ApplyDesignSystemContextOverrides zIndexBase={2 * theme.options.zIndexBase}>
-          {isLoading ? <ModelTraceExplorerSkeleton /> : <>{children}</>}
+          {isLoading ? (
+            <ModelTraceExplorerSkeleton />
+          ) : showAddToDatasetButton ? (
+            <ModelTraceExplorerAddToDatasetProvider openModal={() => setShowDatasetModal(true)}>
+              {children}
+            </ModelTraceExplorerAddToDatasetProvider>
+          ) : (
+            <>{children}</>
+          )}
         </ApplyDesignSystemContextOverrides>
         {renderExportTracesToDatasetsModal?.({
           selectedTraceInfos: traceInfo ? [traceInfo] : [],

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AddToDatasetButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AddToDatasetButton.tsx
@@ -1,0 +1,26 @@
+import { Button, PlusIcon } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import { useModelTraceExplorerContext } from '../ModelTraceExplorerContext';
+
+export const AddToDatasetButton = () => {
+  const { addToDatasetAction } = useModelTraceExplorerContext();
+
+  if (!addToDatasetAction) {
+    return null;
+  }
+
+  return (
+    <Button
+      componentId="mlflow.evaluations_review.modal.add_to_evaluation_dataset"
+      onClick={addToDatasetAction.openModal}
+      icon={<PlusIcon />}
+      size="small"
+    >
+      <FormattedMessage
+        defaultMessage="Add to dataset"
+        description="Button text for adding a trace to an evaluation dataset"
+      />
+    </Button>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
@@ -16,6 +16,7 @@ import { getSpanExceptionCount, getTraceLevelAssessments } from '../ModelTraceEx
 import { ModelTraceExplorerBadge } from '../ModelTraceExplorerBadge';
 import ModelTraceExplorerResizablePane from '../ModelTraceExplorerResizablePane';
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
+import { AddToDatasetButton } from '../assessments-pane/AddToDatasetButton';
 import { AssessmentPaneToggle } from '../assessments-pane/AssessmentPaneToggle';
 import { AssessmentsPane } from '../assessments-pane/AssessmentsPane';
 import { ASSESSMENT_PANE_MIN_WIDTH } from '../assessments-pane/AssessmentsPane.utils';
@@ -95,8 +96,12 @@ function ModelTraceExplorerRightPaneTabsImpl({
             top: theme.spacing.xs,
             zIndex: 1,
             backgroundColor: theme.colors.backgroundPrimary,
+            display: 'flex',
+            gap: theme.spacing.sm,
+            alignItems: 'center',
           }}
         >
+          <AddToDatasetButton />
           <AssessmentPaneToggle />
         </div>
       )}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
@@ -9,6 +9,7 @@ import { ModelTraceExplorerSummaryViewExceptionsSection } from './ModelTraceExpl
 import type { ModelTraceExplorerRenderMode, ModelTraceSpanNode } from '../ModelTrace.types';
 import { createListFromObject, getSpanExceptionEvents } from '../ModelTraceExplorer.utils';
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
+import { AddToDatasetButton } from '../assessments-pane/AddToDatasetButton';
 import { AssessmentPaneToggle } from '../assessments-pane/AssessmentPaneToggle';
 import { ModelTraceExplorerFieldRenderer } from '../field-renderers/ModelTraceExplorerFieldRenderer';
 
@@ -74,7 +75,12 @@ export const ModelTraceExplorerSummarySpans = ({
                 />
               </SegmentedControlButton>
             </SegmentedControlGroup>
-            {!readOnly && <AssessmentPaneToggle />}
+            {!readOnly && (
+              <>
+                <AddToDatasetButton />
+                <AssessmentPaneToggle />
+              </>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
As titled.
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Summary UI

<img width="1091" height="622" alt="image" src="https://github.com/user-attachments/assets/c4cd8cd4-45d4-4dba-8a39-c50c33748819" />

#### Details and Timeline
<img width="1091" height="622" alt="image" src="https://github.com/user-attachments/assets/2e74054a-3c30-4d76-a695-605f41e6b473" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

The “Add to dataset” action is moved from the trace drawer header to sit next to “Show assessments” in both the Summary and Details & Timeline views.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
