### PR TITLE
Fix Tags functionality in Recent Experiments table on Home page

### DIFF
--- a/mlflow/server/js/src/home/HomePage.tsx
+++ b/mlflow/server/js/src/home/HomePage.tsx
@@ -66,6 +66,7 @@ const HomePage = () => {
           error={error}
           onCreateExperiment={handleOpenCreateModal}
           onRetry={refetch}
+          onTagsUpdated={refetch}
         />
       </React.Suspense>
 

--- a/mlflow/server/js/src/home/components/ExperimentsHomeView.test.tsx
+++ b/mlflow/server/js/src/home/components/ExperimentsHomeView.test.tsx
@@ -6,16 +6,31 @@ import type { ExperimentEntity } from '../../experiment-tracking/types';
 import { ExperimentsHomeView } from './ExperimentsHomeView';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
 
+const mockShowEditExperimentTagsModal = jest.fn();
+
 jest.mock('../../experiment-tracking/components/ExperimentListTable', () => ({
-  ExperimentListTable: ({ experiments }: { experiments: ExperimentEntity[] }) => (
-    <div data-testid="experiment-list-table">{`rows:${experiments.length}`}</div>
+  ExperimentListTable: ({
+    experiments,
+    onEditTags,
+  }: {
+    experiments: ExperimentEntity[];
+    onEditTags: (experiment: ExperimentEntity) => void;
+  }) => (
+    <div data-testid="experiment-list-table">
+      {`rows:${experiments.length}`}
+      {experiments.length > 0 && (
+        <button data-testid="edit-tags-button" onClick={() => onEditTags(experiments[0])}>
+          Edit tags
+        </button>
+      )}
+    </div>
   ),
 }));
 
 jest.mock('../../experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags', () => ({
   useUpdateExperimentTags: () => ({
     EditTagsModal: null,
-    showEditExperimentTagsModal: jest.fn(),
+    showEditExperimentTagsModal: mockShowEditExperimentTagsModal,
     isLoading: false,
   }),
 }));
@@ -23,6 +38,10 @@ jest.mock('../../experiment-tracking/components/experiment-page/hooks/useUpdateE
 const renderWithRouter = (ui: React.ReactElement) => renderWithDesignSystem(<MemoryRouter>{ui}</MemoryRouter>);
 
 describe('ExperimentsHomeView', () => {
+  beforeEach(() => {
+    mockShowEditExperimentTagsModal.mockClear();
+  });
+
   const sampleExperiment: ExperimentEntity = {
     allowedActions: [],
     artifactLocation: 'dbfs:/experiment',
@@ -74,6 +93,21 @@ describe('ExperimentsHomeView', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
     expect(onRetry).toHaveBeenCalled();
+  });
+
+  it('calls showEditExperimentTagsModal when editing tags', async () => {
+    renderWithRouter(
+      <ExperimentsHomeView
+        experiments={[sampleExperiment]}
+        isLoading={false}
+        error={null}
+        onCreateExperiment={jest.fn()}
+        onRetry={jest.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByTestId('edit-tags-button'));
+    expect(mockShowEditExperimentTagsModal).toHaveBeenCalledWith(sampleExperiment);
   });
 
   it('renders experiment preview when data is available', () => {

--- a/mlflow/server/js/src/home/components/ExperimentsHomeView.test.tsx
+++ b/mlflow/server/js/src/home/components/ExperimentsHomeView.test.tsx
@@ -12,6 +12,14 @@ jest.mock('../../experiment-tracking/components/ExperimentListTable', () => ({
   ),
 }));
 
+jest.mock('../../experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags', () => ({
+  useUpdateExperimentTags: () => ({
+    EditTagsModal: null,
+    showEditExperimentTagsModal: jest.fn(),
+    isLoading: false,
+  }),
+}));
+
 const renderWithRouter = (ui: React.ReactElement) => renderWithDesignSystem(<MemoryRouter>{ui}</MemoryRouter>);
 
 describe('ExperimentsHomeView', () => {

--- a/mlflow/server/js/src/home/components/ExperimentsHomeView.tsx
+++ b/mlflow/server/js/src/home/components/ExperimentsHomeView.tsx
@@ -16,6 +16,7 @@ import Routes from '../../experiment-tracking/routes';
 import { Link } from '../../common/utils/RoutingUtils';
 import type { ExperimentEntity } from '../../experiment-tracking/types';
 import { isDemoExperiment } from '../../experiment-tracking/utils/isDemoExperiment';
+import { useUpdateExperimentTags } from '../../experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags';
 
 type ExperimentsHomeViewProps = {
   experiments?: ExperimentEntity[];
@@ -23,6 +24,7 @@ type ExperimentsHomeViewProps = {
   error?: Error | null;
   onCreateExperiment: () => void;
   onRetry: () => void;
+  onTagsUpdated?: () => void;
 };
 
 const ExperimentsEmptyState = ({ onCreateExperiment }: { onCreateExperiment: () => void }) => {
@@ -72,10 +74,14 @@ export const ExperimentsHomeView = ({
   error,
   onCreateExperiment,
   onRetry,
+  onTagsUpdated,
 }: ExperimentsHomeViewProps) => {
   const { theme } = useDesignSystemTheme();
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [sorting, setSorting] = useState<SortingState>([]);
+  const { EditTagsModal, showEditExperimentTagsModal } = useUpdateExperimentTags({
+    onSuccess: onTagsUpdated,
+  });
 
   const topExperiments = useMemo(() => {
     const sliced = experiments?.slice(0, 5) ?? [];
@@ -140,11 +146,12 @@ export const ExperimentsHomeView = ({
             rowSelection={rowSelection}
             setRowSelection={setRowSelection}
             sortingProps={{ sorting, setSorting }}
-            onEditTags={() => undefined}
+            onEditTags={showEditExperimentTagsModal}
           />
         )}
       </div>
       <Spacer shrinks={false} />
+      {EditTagsModal}
     </section>
   );
 };


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

Fix #20870 

### What changes are proposed in this pull request?

Fix Tags not working in recent experiment

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/e2ddce86-4e11-4b67-9c35-f2786a720f83



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
