### PR TITLE
Support resource handling for workspace deletion

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -578,6 +578,7 @@ mlflow.entities.Workspace.from_dict
 mlflow.entities.Workspace.from_proto
 mlflow.entities.Workspace.to_dict
 mlflow.entities.Workspace.to_proto
+mlflow.entities.WorkspaceDeletionMode
 mlflow.entities.assessment.Assessment
 mlflow.entities.assessment.Expectation
 mlflow.entities.assessment.Feedback
@@ -695,6 +696,7 @@ mlflow.entities.webhook.WebhookEvent
 mlflow.entities.webhook.WebhookStatus
 mlflow.entities.webhook.WebhookTestResult
 mlflow.entities.workspace.Workspace
+mlflow.entities.workspace.WorkspaceDeletionMode
 mlflow.evaluate
 mlflow.exceptions.get_error_code
 mlflow.finalize_logged_model
@@ -1444,12 +1446,6 @@ mlflow.pyfunc.save_model
 mlflow.pyfunc.spark_udf
 mlflow.pyfunc.update_signature_for_type_hint_from_example
 mlflow.pyspark.ml.autolog
-mlflow.pytorch.MlflowModelCheckpointCallback
-mlflow.pytorch.MlflowModelCheckpointCallback.on_fit_start
-mlflow.pytorch.MlflowModelCheckpointCallback.on_train_batch_end
-mlflow.pytorch.MlflowModelCheckpointCallback.on_train_epoch_end
-mlflow.pytorch.MlflowModelCheckpointCallback.save_checkpoint
-mlflow.pytorch._lightning_autolog.MlflowModelCheckpointCallback
 mlflow.pytorch.autolog
 mlflow.pytorch.get_default_conda_env
 mlflow.pytorch.get_default_pip_requirements

--- a/mlflow/entities/__init__.py
+++ b/mlflow/entities/__init__.py
@@ -77,7 +77,7 @@ from mlflow.entities.webhook import (
     WebhookStatus,
     WebhookTestResult,
 )
-from mlflow.entities.workspace import Workspace
+from mlflow.entities.workspace import Workspace, WorkspaceDeletionMode
 
 __all__ = [
     "Experiment",
@@ -155,6 +155,7 @@ __all__ = [
     "WebhookStatus",
     "WebhookTestResult",
     "Workspace",
+    "WorkspaceDeletionMode",
 ]
 
 

--- a/mlflow/entities/workspace.py
+++ b/mlflow/entities/workspace.py
@@ -3,9 +3,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from mlflow.protos.service_pb2 import Workspace as ProtoWorkspace
+
+
+class WorkspaceDeletionMode(str, Enum):
+    """Controls what happens to resources when a workspace is deleted."""
+
+    SET_DEFAULT = "SET_DEFAULT"
+    """Reassign all resources in the workspace to the default workspace."""
+
+    CASCADE = "CASCADE"
+    """Delete all resources in the workspace."""
+
+    RESTRICT = "RESTRICT"
+    """Refuse to delete the workspace if it still contains resources."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -39,6 +39,7 @@ from mlflow.entities import (
     RunTag,
     ViewType,
     Workspace,
+    WorkspaceDeletionMode,
 )
 from mlflow.entities import (
     RoutingStrategy as RoutingStrategyEntity,
@@ -1228,8 +1229,6 @@ def _update_workspace_handler(workspace_name: str):
 @catch_mlflow_exception
 @_disable_if_workspaces_disabled
 def _delete_workspace_handler(workspace_name: str):
-    from mlflow.entities.workspace import WorkspaceDeletionMode
-
     if workspace_name == DEFAULT_WORKSPACE_NAME:
         raise MlflowException.invalid_parameter_value(
             f"The '{DEFAULT_WORKSPACE_NAME}' workspace is reserved and cannot be deleted"

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1234,7 +1234,7 @@ def _delete_workspace_handler(workspace_name: str):
             f"The '{DEFAULT_WORKSPACE_NAME}' workspace is reserved and cannot be deleted"
         )
     WorkspaceNameValidator.validate(workspace_name)
-    mode_str = request.args.get("mode", WorkspaceDeletionMode.SET_DEFAULT.value)
+    mode_str = request.args.get("mode", WorkspaceDeletionMode.RESTRICT.value)
     try:
         mode = WorkspaceDeletionMode(mode_str)
     except ValueError:

--- a/mlflow/store/db/workspace_migration.py
+++ b/mlflow/store/db/workspace_migration.py
@@ -1,21 +1,21 @@
 import sqlalchemy as sa
 
+from mlflow.store.workspace.sqlalchemy_store import _WORKSPACE_ROOT_MODELS
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
-_WORKSPACE_TABLES = [
-    "experiments",
-    "registered_models",
+# Derive table names from the shared ORM model list and add child/tags tables that also carry
+# a workspace column but are not "root" tables (they are updated via FK cascades during
+# delete_workspace, but the migration script must handle them explicitly).
+_WORKSPACE_CHILD_TABLES = [
     "model_versions",
     "registered_model_tags",
     "model_version_tags",
     "registered_model_aliases",
-    "evaluation_datasets",
-    "webhooks",
-    "secrets",
-    "endpoints",
-    "model_definitions",
-    "jobs",
 ]
+
+_WORKSPACE_TABLES = [
+    model.__tablename__ for model in _WORKSPACE_ROOT_MODELS
+] + _WORKSPACE_CHILD_TABLES
 
 _CONFLICT_SPECS = [
     ("experiments", ("name",), "experiments with the same name"),

--- a/mlflow/store/workspace/abstract_store.py
+++ b/mlflow/store/workspace/abstract_store.py
@@ -53,7 +53,7 @@ class AbstractStore(ABC):
     def delete_workspace(
         self,
         workspace_name: str,
-        mode: WorkspaceDeletionMode = WorkspaceDeletionMode.SET_DEFAULT,
+        mode: WorkspaceDeletionMode = WorkspaceDeletionMode.RESTRICT,
     ) -> None:
         """Delete an existing workspace.
 

--- a/mlflow/store/workspace/abstract_store.py
+++ b/mlflow/store/workspace/abstract_store.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from typing import Iterable
 
 from mlflow.entities import Workspace
+from mlflow.entities.workspace import WorkspaceDeletionMode
 from mlflow.exceptions import MlflowException
 
 
@@ -49,8 +50,20 @@ class AbstractStore(ABC):
 
         raise NotImplementedError
 
-    def delete_workspace(self, workspace_name: str) -> None:
-        """Delete an existing workspace."""
+    def delete_workspace(
+        self,
+        workspace_name: str,
+        mode: WorkspaceDeletionMode = WorkspaceDeletionMode.SET_DEFAULT,
+    ) -> None:
+        """Delete an existing workspace.
+
+        Args:
+            workspace_name: Name of the workspace to delete.
+            mode: Controls what happens to resources in the workspace:
+                - SET_DEFAULT: Reassign resources to the default workspace.
+                - CASCADE: Delete all resources in the workspace.
+                - RESTRICT: Refuse if the workspace still contains resources.
+        """
 
         raise NotImplementedError
 

--- a/mlflow/store/workspace/rest_store.py
+++ b/mlflow/store/workspace/rest_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from urllib.parse import quote
 
 from mlflow.entities import Workspace
+from mlflow.entities.workspace import WorkspaceDeletionMode
 from mlflow.exceptions import MlflowException, RestException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.databricks_pb2 import INVALID_STATE, RESOURCE_ALREADY_EXISTS
@@ -100,10 +101,17 @@ class RestWorkspaceStore(AbstractStore):
         )
         return self._workspace_from_proto(proto)
 
-    def delete_workspace(self, workspace_name: str) -> None:
+    def delete_workspace(
+        self,
+        workspace_name: str,
+        mode: WorkspaceDeletionMode = WorkspaceDeletionMode.SET_DEFAULT,
+    ) -> None:
+        endpoint = f"{WORKSPACES_ENDPOINT}/{_quote_workspace(workspace_name)}"
+        if mode != WorkspaceDeletionMode.SET_DEFAULT:
+            endpoint += f"?mode={mode.value}"
         call_endpoint(
             host_creds=self.get_host_creds(),
-            endpoint=f"{WORKSPACES_ENDPOINT}/{_quote_workspace(workspace_name)}",
+            endpoint=endpoint,
             method="DELETE",
             json_body=None,
             response_proto=DeleteWorkspace.Response(),

--- a/mlflow/store/workspace/rest_store.py
+++ b/mlflow/store/workspace/rest_store.py
@@ -104,10 +104,10 @@ class RestWorkspaceStore(AbstractStore):
     def delete_workspace(
         self,
         workspace_name: str,
-        mode: WorkspaceDeletionMode = WorkspaceDeletionMode.SET_DEFAULT,
+        mode: WorkspaceDeletionMode = WorkspaceDeletionMode.RESTRICT,
     ) -> None:
         endpoint = f"{WORKSPACES_ENDPOINT}/{_quote_workspace(workspace_name)}"
-        if mode != WorkspaceDeletionMode.SET_DEFAULT:
+        if mode != WorkspaceDeletionMode.RESTRICT:
             endpoint += f"?mode={mode.value}"
         call_endpoint(
             host_creds=self.get_host_creds(),

--- a/mlflow/store/workspace/sqlalchemy_store.py
+++ b/mlflow/store/workspace/sqlalchemy_store.py
@@ -155,9 +155,7 @@ class SqlAlchemyStore(AbstractStore):
                 elif mode == WorkspaceDeletionMode.CASCADE:
                     for model in _WORKSPACE_ROOT_MODELS:
                         instances = (
-                            session.query(model)
-                            .filter(model.workspace == workspace_name)
-                            .all()
+                            session.query(model).filter(model.workspace == workspace_name).all()
                         )
                         for obj in instances:
                             session.delete(obj)
@@ -225,7 +223,8 @@ class SqlAlchemyStore(AbstractStore):
     @staticmethod
     def _check_set_default_conflicts(session, workspace_name: str) -> None:
         """Preflight check: report all name conflicts that would arise from reassigning
-        resources in *workspace_name* to the default workspace."""
+        resources in *workspace_name* to the default workspace.
+        """
         conflicts: list[str] = []
         for model in _WORKSPACE_ROOT_MODELS:
             if not hasattr(model, "name"):
@@ -235,9 +234,7 @@ class SqlAlchemyStore(AbstractStore):
                 .filter(model.workspace == workspace_name)
                 .filter(
                     model.name.in_(
-                        session.query(model.name).filter(
-                            model.workspace == DEFAULT_WORKSPACE_NAME
-                        )
+                        session.query(model.name).filter(model.workspace == DEFAULT_WORKSPACE_NAME)
                     )
                 )
                 .all()

--- a/mlflow/tracking/_workspace/client.py
+++ b/mlflow/tracking/_workspace/client.py
@@ -82,6 +82,6 @@ class WorkspaceProviderClient:
     def delete_workspace(
         self,
         name: str,
-        mode: WorkspaceDeletionMode = WorkspaceDeletionMode.SET_DEFAULT,
+        mode: WorkspaceDeletionMode = WorkspaceDeletionMode.RESTRICT,
     ) -> None:
         self.store.delete_workspace(name, mode=mode)

--- a/mlflow/tracking/_workspace/client.py
+++ b/mlflow/tracking/_workspace/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from mlflow.entities.workspace import Workspace
+from mlflow.entities.workspace import Workspace, WorkspaceDeletionMode
 from mlflow.tracking._workspace.registry import get_workspace_store
 
 
@@ -79,5 +79,9 @@ class WorkspaceProviderClient:
             )
         )
 
-    def delete_workspace(self, name: str) -> None:
-        self.store.delete_workspace(name)
+    def delete_workspace(
+        self,
+        name: str,
+        mode: WorkspaceDeletionMode = WorkspaceDeletionMode.SET_DEFAULT,
+    ) -> None:
+        self.store.delete_workspace(name, mode=mode)

--- a/mlflow/tracking/_workspace/fluent.py
+++ b/mlflow/tracking/_workspace/fluent.py
@@ -117,7 +117,7 @@ def update_workspace(
 
 
 @experimental(version="3.10.0")
-def delete_workspace(name: str, *, mode: str = "RESTRICT") -> None:
+def delete_workspace(name: str, *, mode: str = WorkspaceDeletionMode.RESTRICT) -> None:
     """Delete an existing workspace.
 
     Args:

--- a/mlflow/tracking/_workspace/fluent.py
+++ b/mlflow/tracking/_workspace/fluent.py
@@ -122,8 +122,7 @@ def delete_workspace(name: str, *, mode: str = WorkspaceDeletionMode.RESTRICT) -
 
     Args:
         name: Name of the workspace to delete.
-        mode: Deletion mode — ``"SET_DEFAULT"`` (reassign resources to the default workspace),
-            ``"CASCADE"`` (delete all resources), or ``"RESTRICT"`` (refuse if resources exist).
+        mode: Deletion mode. One of SET_DEFAULT, CASCADE, or RESTRICT.
     """
     try:
         deletion_mode = WorkspaceDeletionMode(mode)

--- a/mlflow/tracking/_workspace/fluent.py
+++ b/mlflow/tracking/_workspace/fluent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import threading
 from typing import Callable, TypeVar
 
-from mlflow.entities.workspace import Workspace
+from mlflow.entities.workspace import Workspace, WorkspaceDeletionMode
 from mlflow.exceptions import MlflowException, RestException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.databricks_pb2 import FEATURE_DISABLED
@@ -125,8 +125,6 @@ def delete_workspace(name: str, *, mode: str = "SET_DEFAULT") -> None:
         mode: Deletion mode — ``"SET_DEFAULT"`` (reassign resources to the default workspace),
             ``"CASCADE"`` (delete all resources), or ``"RESTRICT"`` (refuse if resources exist).
     """
-    from mlflow.entities.workspace import WorkspaceDeletionMode
-
     deletion_mode = WorkspaceDeletionMode(mode)
     if name != DEFAULT_WORKSPACE_NAME:
         WorkspaceNameValidator.validate(name)

--- a/mlflow/tracking/_workspace/fluent.py
+++ b/mlflow/tracking/_workspace/fluent.py
@@ -117,7 +117,7 @@ def update_workspace(
 
 
 @experimental(version="3.10.0")
-def delete_workspace(name: str, *, mode: str = "SET_DEFAULT") -> None:
+def delete_workspace(name: str, *, mode: str = "RESTRICT") -> None:
     """Delete an existing workspace.
 
     Args:
@@ -125,7 +125,13 @@ def delete_workspace(name: str, *, mode: str = "SET_DEFAULT") -> None:
         mode: Deletion mode — ``"SET_DEFAULT"`` (reassign resources to the default workspace),
             ``"CASCADE"`` (delete all resources), or ``"RESTRICT"`` (refuse if resources exist).
     """
-    deletion_mode = WorkspaceDeletionMode(mode)
+    try:
+        deletion_mode = WorkspaceDeletionMode(mode)
+    except ValueError:
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid deletion mode '{mode}'. "
+            f"Must be one of: {', '.join(m.value for m in WorkspaceDeletionMode)}"
+        )
     if name != DEFAULT_WORKSPACE_NAME:
         WorkspaceNameValidator.validate(name)
     _workspace_client_call(lambda client: client.delete_workspace(name=name, mode=deletion_mode))

--- a/mlflow/tracking/_workspace/fluent.py
+++ b/mlflow/tracking/_workspace/fluent.py
@@ -117,12 +117,20 @@ def update_workspace(
 
 
 @experimental(version="3.10.0")
-def delete_workspace(name: str) -> None:
-    """Delete an existing workspace."""
+def delete_workspace(name: str, *, mode: str = "SET_DEFAULT") -> None:
+    """Delete an existing workspace.
 
+    Args:
+        name: Name of the workspace to delete.
+        mode: Deletion mode — ``"SET_DEFAULT"`` (reassign resources to the default workspace),
+            ``"CASCADE"`` (delete all resources), or ``"RESTRICT"`` (refuse if resources exist).
+    """
+    from mlflow.entities.workspace import WorkspaceDeletionMode
+
+    deletion_mode = WorkspaceDeletionMode(mode)
     if name != DEFAULT_WORKSPACE_NAME:
         WorkspaceNameValidator.validate(name)
-    _workspace_client_call(lambda client: client.delete_workspace(name=name))
+    _workspace_client_call(lambda client: client.delete_workspace(name=name, mode=deletion_mode))
 
 
 __all__ = [

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -373,10 +373,16 @@ class MlflowClient:
             name, description, default_artifact_root=default_artifact_root
         )
 
-    def delete_workspace(self, name: str) -> None:
-        """Delete an existing workspace."""
+    def delete_workspace(self, name: str, mode: str = "SET_DEFAULT") -> None:
+        """Delete an existing workspace.
 
-        self._get_workspace_client().delete_workspace(name)
+        Args:
+            name: Name of the workspace to delete.
+            mode: Deletion mode — ``"SET_DEFAULT"``, ``"CASCADE"``, or ``"RESTRICT"``.
+        """
+        from mlflow.entities.workspace import WorkspaceDeletionMode
+
+        self._get_workspace_client().delete_workspace(name, mode=WorkspaceDeletionMode(mode))
 
     def get_run(self, run_id: str) -> Run:
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -45,6 +45,7 @@ from mlflow.entities import (
     Trace,
     ViewType,
     Workspace,
+    WorkspaceDeletionMode,
 )
 from mlflow.entities.model_registry import ModelVersion, Prompt, PromptVersion, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
@@ -373,15 +374,13 @@ class MlflowClient:
             name, description, default_artifact_root=default_artifact_root
         )
 
-    def delete_workspace(self, name: str, mode: str = "RESTRICT") -> None:
+    def delete_workspace(self, name: str, mode: str = WorkspaceDeletionMode.RESTRICT) -> None:
         """Delete an existing workspace.
 
         Args:
             name: Name of the workspace to delete.
             mode: Deletion mode — ``"SET_DEFAULT"``, ``"CASCADE"``, or ``"RESTRICT"``.
         """
-        from mlflow.entities.workspace import WorkspaceDeletionMode
-
         try:
             deletion_mode = WorkspaceDeletionMode(mode)
         except ValueError:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -373,7 +373,7 @@ class MlflowClient:
             name, description, default_artifact_root=default_artifact_root
         )
 
-    def delete_workspace(self, name: str, mode: str = "SET_DEFAULT") -> None:
+    def delete_workspace(self, name: str, mode: str = "RESTRICT") -> None:
         """Delete an existing workspace.
 
         Args:
@@ -382,7 +382,14 @@ class MlflowClient:
         """
         from mlflow.entities.workspace import WorkspaceDeletionMode
 
-        self._get_workspace_client().delete_workspace(name, mode=WorkspaceDeletionMode(mode))
+        try:
+            deletion_mode = WorkspaceDeletionMode(mode)
+        except ValueError:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid deletion mode '{mode}'. "
+                f"Must be one of: {', '.join(m.value for m in WorkspaceDeletionMode)}"
+            )
+        self._get_workspace_client().delete_workspace(name, mode=deletion_mode)
 
     def get_run(self, run_id: str) -> Run:
         """

--- a/tests/server/test_workspace_endpoints.py
+++ b/tests/server/test_workspace_endpoints.py
@@ -7,7 +7,7 @@ import pytest
 from flask import Flask
 
 from mlflow.entities import Experiment
-from mlflow.entities.workspace import Workspace
+from mlflow.entities.workspace import Workspace, WorkspaceDeletionMode
 from mlflow.server.handlers import get_endpoints
 
 
@@ -158,7 +158,9 @@ def test_delete_workspace_endpoint(app, mock_workspace_store):
         response = client.delete("/api/3.0/mlflow/workspaces/team-e")
 
     assert response.status_code == 204
-    mock_workspace_store.delete_workspace.assert_called_once_with("team-e")
+    mock_workspace_store.delete_workspace.assert_called_once_with(
+        "team-e", mode=WorkspaceDeletionMode.RESTRICT
+    )
 
 
 def test_delete_default_workspace_rejected_by_validation(app, mock_workspace_store):

--- a/tests/store/workspace/test_rest_store.py
+++ b/tests/store/workspace/test_rest_store.py
@@ -135,9 +135,9 @@ def test_delete_workspace_returns_on_success(store, host_creds):
 @pytest.mark.parametrize(
     ("mode", "expected_suffix"),
     [
-        (WorkspaceDeletionMode.SET_DEFAULT, ""),
+        (WorkspaceDeletionMode.RESTRICT, ""),
         (WorkspaceDeletionMode.CASCADE, "?mode=CASCADE"),
-        (WorkspaceDeletionMode.RESTRICT, "?mode=RESTRICT"),
+        (WorkspaceDeletionMode.SET_DEFAULT, "?mode=SET_DEFAULT"),
     ],
 )
 def test_delete_workspace_sends_mode_query_param(store, host_creds, mode, expected_suffix):


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

`workspace` column doesn't have a FK constraint, so the deletion of a workspace causes an invalid reference. This PR introduces the handling for the child resources with three available options.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
