### PR TITLE
Change the single tenant validation to user confirmation

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -15,6 +15,7 @@ from pathlib import PurePath
 from typing import Any, TypedDict, TypeVar
 from urllib.parse import urlparse
 
+import click
 import sqlalchemy
 import sqlalchemy.orm
 import sqlalchemy.sql.expression as sql
@@ -355,12 +356,15 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 .first()
             )
             if workspace_scoped_experiment:
-                raise MlflowException(
-                    "Cannot disable workspaces because experiments exist outside the default "
-                    "workspace (i.e., assigned to non-default workspaces). Enable workspace "
-                    "support (MLFLOW_ENABLE_WORKSPACES=true) or move those experiments back to the "
-                    "default workspace before starting the tracking store in single-tenant mode.",
-                    error_code=INVALID_STATE,
+                click.confirm(
+                    "Experiments exist outside the default workspace (i.e., assigned to "
+                    "non-default workspaces). Starting the tracking store in single-tenant mode "
+                    "may cause these experiments to become inaccessible. Consider enabling "
+                    "workspace support (MLFLOW_ENABLE_WORKSPACES=true) or moving those "
+                    "experiments back to the default workspace.\n"
+                    "Do you want to proceed anyway?",
+                    default=False,
+                    abort=True,
                 )
 
         try:

--- a/tests/store/tracking/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/test_sqlalchemy_workspace_store.py
@@ -859,7 +859,7 @@ def test_workspace_startup_ignores_default_experiment_reserved_location(
     SqlAlchemyStore._engine_map.pop(db_uri, None)
 
 
-def test_single_tenant_startup_rejects_non_default_workspace_experiments(
+def test_single_tenant_startup_prompts_for_non_default_workspace_experiments(
     tmp_path, db_uri, monkeypatch
 ):
     artifact_root = tmp_path / "artifacts"
@@ -875,13 +875,19 @@ def test_single_tenant_startup_rejects_non_default_workspace_experiments(
     SqlAlchemyStore._engine_map.pop(db_uri, None)
 
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
-    with pytest.raises(
-        MlflowException,
-        match="Cannot disable workspaces because experiments exist outside the default workspace",
-    ) as excinfo:
-        SqlAlchemyStore(db_uri, artifact_root.as_uri())
 
-    assert excinfo.value.error_code == "INVALID_STATE"
+    # User declines the confirmation prompt — startup should abort
+    with mock.patch("click.confirm", side_effect=SystemExit(1)):
+        with pytest.raises(SystemExit):
+            SqlAlchemyStore(db_uri, artifact_root.as_uri())
+
+    SqlAlchemyStore._engine_map.pop(db_uri, None)
+
+    # User accepts the confirmation prompt — startup should succeed
+    with mock.patch("click.confirm"):
+        store = SqlAlchemyStore(db_uri, artifact_root.as_uri())
+        store._dispose_engine()
+
     SqlAlchemyStore._engine_map.pop(db_uri, None)
 
 

--- a/tests/store/tracking/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/test_sqlalchemy_workspace_store.py
@@ -878,7 +878,7 @@ def test_single_tenant_startup_prompts_for_non_default_workspace_experiments(
 
     # User declines the confirmation prompt — startup should abort
     with mock.patch("click.confirm", side_effect=SystemExit(1)):
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit):  # noqa: PT011
             SqlAlchemyStore(db_uri, artifact_root.as_uri())
 
     SqlAlchemyStore._engine_map.pop(db_uri, None)


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Users may want to use 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
