### PR TITLE
Enhance path validation in check_tarfile_security for windows

### DIFF
--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -1027,7 +1027,9 @@ def check_tarfile_security(archive_path: str) -> None:
     with tarfile.open(archive_path, "r") as tar:
         symlink_set = set()
         for m in tar.getmembers():
-            path = posixpath.normpath(m.name)
+            # Normalize backslashes to forward slashes before path validation to prevent
+            # bypass on Windows where backslashes are treated as directory separators.
+            path = posixpath.normpath(m.name.replace("\\", "/"))
             if m.issym():
                 symlink_set.add(path)
             else:
@@ -1044,6 +1046,8 @@ def check_tarfile_security(archive_path: str) -> None:
                     )
         for m in tar.getmembers():
             if not m.issym():
+                path = posixpath.normpath(m.name.replace("\\", "/"))
+                path_parts = path.split("/")
                 for prefix_len in range(1, len(path_parts) + 1):
                     prefix_path = "/".join(path_parts[:prefix_len])
                     if prefix_path in symlink_set:

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -287,7 +287,7 @@ def test_check_tarfile_security(tmp_path):
     ):
         check_tarfile_security(tar3_path)
 
-    # Backslash path traversal (Windows Zip Slip bypass)
+    # Backslash-based path traversal in tar (Windows tar slip / path traversal)
     tar4_path = str(tmp_path.joinpath("file4.tar"))
     create_tar_with_escaped_path(tar4_path, "..\\..\\pwned.txt", b"ABX")
     with pytest.raises(

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -286,3 +286,11 @@ def test_check_tarfile_security(tmp_path):
         MlflowException, match="Absolute path destination in the archive file is not allowed"
     ):
         check_tarfile_security(tar3_path)
+
+    # Backslash path traversal (Windows Zip Slip bypass)
+    tar4_path = str(tmp_path.joinpath("file4.tar"))
+    create_tar_with_escaped_path(tar4_path, "..\\..\\pwned.txt", b"ABX")
+    with pytest.raises(
+        MlflowException, match="Escaped path destination in the archive file is not allowed"
+    ):
+        check_tarfile_security(tar4_path)


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

https://huntr.com/bounties/5d83cc95-1d97-4780-ad16-62756eb0914f

### What changes are proposed in this pull request?

See [this ticket](https://huntr.com/bounties/5d83cc95-1d97-4780-ad16-62756eb0914f) for details

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
