### PR TITLE
Disable downstream 429 retries during evaluate

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -1,9 +1,11 @@
 import base64
+import contextlib
 import json
 import logging
 import random
 import time
 import warnings
+from contextvars import ContextVar
 from functools import lru_cache
 from typing import Any, Callable
 
@@ -44,6 +46,25 @@ from mlflow.utils.workspace_context import get_request_workspace
 from mlflow.utils.workspace_utils import WORKSPACE_HEADER_NAME
 
 _logger = logging.getLogger(__name__)
+
+# Generic ContextVar to disable HTTP-layer 429 retries. When True,
+# _retry_databricks_sdk_call_with_exponential_backoff skips retrying on 429 so
+# that rate-limit errors propagate immediately to the caller's own retry logic.
+_DISABLE_429_RETRY = ContextVar("_DISABLE_429_RETRY", default=False)
+
+
+@contextlib.contextmanager
+def disable_429_retry():
+    token = _DISABLE_429_RETRY.set(True)
+    try:
+        yield
+    finally:
+        _DISABLE_429_RETRY.reset(token)
+
+
+def is_429_retry_disabled() -> bool:
+    return _DISABLE_429_RETRY.get()
+
 
 RESOURCE_NON_EXISTENT = "RESOURCE_DOES_NOT_EXIST"
 _REST_API_PATH_PREFIX = "/api/2.0"
@@ -471,6 +492,9 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
         DatabricksError: If all retries are exhausted or non-retryable error occurs
     """
     from databricks.sdk.errors import STATUS_CODE_MAPPING, DatabricksError
+
+    if is_429_retry_disabled():
+        retry_codes = frozenset(c for c in retry_codes if c != 429)
 
     start_time = time.time()
     attempt = 0

--- a/tests/genai/scorers/guardrails/test_guardrails.py
+++ b/tests/genai/scorers/guardrails/test_guardrails.py
@@ -1,8 +1,7 @@
 from unittest.mock import patch
 
+import guardrails
 import pytest
-
-guardrails = pytest.importorskip("guardrails")
 from guardrails import Validator, register_validator
 from guardrails.classes.validation.validation_result import FailResult, PassResult
 

--- a/tests/genai/scorers/guardrails/test_registry.py
+++ b/tests/genai/scorers/guardrails/test_registry.py
@@ -2,8 +2,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-pytest.importorskip("guardrails")
-
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers.guardrails.registry import get_validator_class
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Resolve --> #20684

### What changes are proposed in this pull request?

Add context-var based mechanisms to disable downstream 429 retries during `mlflow.genai.evaluate`, so that the evaluate-level retry loop (from PR 1) is the single point of retry control.

**Changes:**
- `mlflow/utils/rest_utils.py` — `_DISABLE_429_RETRY` ContextVar, `disable_429_retry()` context manager, `is_429_retry_disabled()` check, and a guard in `_retry_databricks_sdk_call_with_exponential_backoff` to exclude 429 from retry codes when the flag is set
- `mlflow/genai/judges/adapters/litellm_adapter.py` — `_DISABLE_RATE_LIMIT_RETRIES` ContextVar, `disable_litellm_rate_limit_retries()` accessor, and a guard in `_get_litellm_retry_policy` to zero out rate-limit retries when the flag is set
- `mlflow/genai/evaluation/rate_limiter.py` — Replace the no-op `eval_retry_context()` stub from PR 1 with the real implementation that sets both suppression flags

**PR 2 of 4** in a stack implementing rate-limited pipelined execution for `mlflow.genai.evaluate`.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Existing unit/integration tests

`test_eval_retry_context_sets_and_resets` and `test_eval_retry_context_nests` in `test_rate_limiter.py` verify that both suppression flags are properly set inside the context and reset afterward, including nested usage.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)