### PR TITLE
Add harness helpers and supporting infrastructure for rate-limited evaluate

### DIFF
--- a/mlflow/genai/evaluation/session_utils.py
+++ b/mlflow/genai/evaluation/session_utils.py
@@ -1,5 +1,7 @@
 """Utilities for session-level (multi-turn) evaluation."""
 
+from __future__ import annotations
+
 import traceback
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -8,6 +10,12 @@ from typing import TYPE_CHECKING, Any
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_error import AssessmentError
 from mlflow.exceptions import MlflowException
+from mlflow.genai.evaluation.rate_limiter import (
+    NoOpRateLimiter,
+    RateLimiter,
+    call_with_retry,
+    eval_retry_context,
+)
 from mlflow.genai.evaluation.utils import (
     make_code_type_assessment_source,
     standardize_scorer_value,
@@ -91,6 +99,8 @@ def evaluate_session_level_scorers(
     session_id: str,
     session_items: list["EvalItem"],
     multi_turn_scorers: list[Scorer],
+    scorer_rate_limiter: RateLimiter = NoOpRateLimiter(),
+    max_retries: int = 0,
 ) -> dict[str, list[Feedback]]:
     """
     Evaluate all multi-turn scorers for a single session.
@@ -99,6 +109,8 @@ def evaluate_session_level_scorers(
         session_id: The session identifier
         session_items: List of EvalItem objects from the same session
         multi_turn_scorers: List of multi-turn scorer instances
+        scorer_rate_limiter: Rate limiter to throttle scorer invocations.
+        max_retries: Max 429-retry attempts per scorer call.
 
     Returns:
         dict: {first_trace_id: [feedback1, feedback2, ...]}
@@ -109,7 +121,12 @@ def evaluate_session_level_scorers(
 
     def run_scorer(scorer: Scorer) -> list[Feedback]:
         try:
-            value = scorer.run(session=session_traces)
+            with eval_retry_context():
+                value = call_with_retry(
+                    lambda: scorer.run(session=session_traces),
+                    scorer_rate_limiter,
+                    max_retries,
+                )
             feedbacks = standardize_scorer_value(scorer.name, value)
 
             # Add session_id to metadata for each feedback

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -56,7 +56,7 @@ _logger = logging.getLogger(__name__)
 
 USER_DEFINED_ASSESSMENT_NAME_KEY = "_user_defined_assessment_name"
 PGBAR_FORMAT = (
-    "{l_bar}{bar}| {n_fmt}/{total_fmt} [Elapsed: {elapsed}, Remaining: {remaining}] {postfix}"
+    "{l_bar}{bar}| {n_fmt}/{total_fmt} [Elapsed: {elapsed}, Remaining: {remaining}]{postfix}"
 )
 
 

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mlflow.genai.evaluation.harness import _make_rate_limiter, _parse_rate_limit
 from mlflow.genai.evaluation.rate_limiter import (
     NoOpRateLimiter,
     RPSRateLimiter,
@@ -309,6 +310,44 @@ def test_call_with_retry_reports_throttle_and_success():
     assert result == "ok"
     # After throttle: 10.0 * 0.5 = 5.0, then success bumps it back up slightly
     assert limiter._rps < 10.0
+
+
+# ── _make_rate_limiter / _parse_rate_limit tests ──
+
+
+def test_make_rate_limiter_positive_rate():
+    assert isinstance(_make_rate_limiter(10.0), RPSRateLimiter)
+
+
+def test_make_rate_limiter_zero_returns_noop():
+    assert isinstance(_make_rate_limiter(0.0), NoOpRateLimiter)
+
+
+def test_make_rate_limiter_none_returns_noop():
+    assert isinstance(_make_rate_limiter(None), NoOpRateLimiter)
+
+
+def test_make_rate_limiter_adaptive():
+    limiter = _make_rate_limiter(10.0, adaptive=True)
+    assert isinstance(limiter, RPSRateLimiter)
+    assert limiter._adaptive is True
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_rps", "expected_adaptive"),
+    [
+        ("auto", 10.0, True),
+        ("AUTO", 10.0, True),
+        (" Auto ", 10.0, True),
+        ("25", 25.0, False),
+        ("0", None, False),
+        (None, None, False),
+    ],
+)
+def test_parse_rate_limit(raw, expected_rps, expected_adaptive):
+    rps, adaptive = _parse_rate_limit(raw)
+    assert rps == expected_rps
+    assert adaptive == expected_adaptive
 
 
 # ── eval_retry_context tests ──


### PR DESCRIPTION
### Related Issues/PRs

<!-- Resolve --> #20684

### What changes are proposed in this pull request?

Add helper functions and supporting infrastructure to `mlflow.genai.evaluate` for rate-limited pipelined execution (wired in PR 4).

**`mlflow/genai/evaluation/harness.py`** — new standalone helpers:
- `_warmup_databricks_sdk()` — eager main-thread import to avoid import-lock deadlock in worker threads
- Top-level `import litellm` with `try/except` guard (same reason)
- `_parse_rate_limit(raw)` — parses env-var string (`"auto"`, `"25"`, `"0"`) into `(rps, adaptive)` tuple
- `_make_rate_limiter(rps, adaptive, max_rps_multiplier)` — factory for `RPSRateLimiter` / `NoOpRateLimiter`
- `_pool_size(rps)` — derives thread-pool size from rate limit
- `backpressure_buffer(score_workers)` — computes semaphore size for pipeline backpressure
- `_get_scorer_rate_config(...)` — derives scorer rate config from predict config
- `_get_pool_sizes(...)` — derives predict/score thread-pool sizes

**`mlflow/genai/evaluation/session_utils.py`** — add `scorer_rate_limiter` and `max_retries` parameters to `evaluate_session_level_scorers`, wire `call_with_retry` + `eval_retry_context` into scorer execution.

**`mlflow/genai/evaluation/utils.py`** — minor `PGBAR_FORMAT` whitespace fix.

**PR 3 of 4** in a stack implementing rate-limited pipelined execution for `mlflow.genai.evaluate`.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Existing unit/integration tests

10 new tests in `test_rate_limiter.py`:
- `test_parse_rate_limit` (parametrized, 6 cases) — `"auto"`, `"25"`, `"0"`, `None`
- `test_make_rate_limiter_positive_rate`, `test_make_rate_limiter_zero_returns_noop`, `test_make_rate_limiter_none_returns_noop`, `test_make_rate_limiter_adaptive`

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)