### PR TITLE
Add pipelined predict-score execution for mlflow.genai.evaluate

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import logging
+import queue
+import threading
 import time
 import traceback
 import uuid
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, as_completed, wait
 from typing import Any, Callable
 
 import pandas as pd
@@ -40,9 +42,13 @@ from mlflow.entities.assessment import Assessment, Expectation, Feedback
 from mlflow.entities.assessment_error import AssessmentError
 from mlflow.entities.trace import Trace
 from mlflow.environment_variables import (
+    MLFLOW_GENAI_EVAL_ENABLE_HEARTBEAT,
     MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING,
+    MLFLOW_GENAI_EVAL_MAX_RETRIES,
     MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS,
     MLFLOW_GENAI_EVAL_MAX_WORKERS,
+    MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT,
+    MLFLOW_GENAI_EVAL_RATE_LIMIT_UPPER_MULTIPLIER,
     MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT,
 )
 from mlflow.genai.evaluation import context
@@ -51,6 +57,8 @@ from mlflow.genai.evaluation.rate_limiter import (
     NoOpRateLimiter,
     RateLimiter,
     RPSRateLimiter,
+    call_with_retry,
+    eval_retry_context,
 )
 from mlflow.genai.evaluation.session_utils import (
     classify_scorers,
@@ -194,6 +202,413 @@ def _get_pool_sizes(
     return _pool_size(predict_rps), _pool_size(scorer_rps)
 
 
+class _Heartbeat:
+    """Periodic debug-level heartbeat for the pipeline loop.
+
+    Only active when ``MLFLOW_GENAI_EVAL_ENABLE_HEARTBEAT`` is set to True.
+    """
+
+    def __init__(
+        self,
+        predict_limiter: RateLimiter,
+        scorer_limiter: RateLimiter,
+        total_items: int,
+        interval_secs: float = 15,
+    ):
+        self._enabled = MLFLOW_GENAI_EVAL_ENABLE_HEARTBEAT.get()
+        self._predict_limiter = predict_limiter
+        self._scorer_limiter = scorer_limiter
+        self._total = total_items
+        self._interval = interval_secs
+        self._last_time = time.monotonic()
+
+    @staticmethod
+    def _format_rps(limiter: RateLimiter) -> str:
+        rps = limiter.current_rps
+        return f"{rps:.1f}" if rps is not None else "off"
+
+    def tick(self, stats: dict[str, int]) -> None:
+        if not self._enabled:
+            return
+        now = time.monotonic()
+        if now - self._last_time < self._interval:
+            return
+        self._last_time = now
+        _logger.debug(
+            "[heartbeat] predicted=%d/%d, scored=%d/%d, pending=%d "
+            "(%d predict, %d score), rate: predict=%s rps, score=%s rps",
+            stats["predicted"],
+            self._total,
+            stats["scored"],
+            self._total,
+            stats["pending"],
+            stats["predict_pending"],
+            stats["score_pending"],
+            self._format_rps(self._predict_limiter),
+            self._format_rps(self._scorer_limiter),
+        )
+
+
+class _PredictSubmitter:
+    """Owns the submit thread, predict pool, backpressure semaphore, and predict timing."""
+
+    def __init__(
+        self,
+        eval_items: list[EvalItem],
+        predict_fn: Callable[..., Any] | None,
+        run_id: str | None,
+        max_retries: int,
+        rps: float | None,
+        adaptive: bool,
+        max_rps_multiplier: float,
+        pool_workers: int,
+        score_workers: int,
+    ):
+        """
+        Args:
+            eval_items: Items to evaluate — each will be submitted for prediction.
+            predict_fn: User-provided function that produces outputs from inputs.
+                When None, predictions are skipped and existing traces are used.
+            run_id: MLflow run ID for trace/assessment logging.
+            max_retries: Max 429-retry attempts per predict call.
+            rps: Requests-per-second for the predict rate limiter, or None to disable.
+            adaptive: Whether the rate limiter uses AIMD to adapt to 429 signals.
+            max_rps_multiplier: AIMD ceiling as a multiple of the initial rps.
+            pool_workers: Number of threads in the predict pool.
+            score_workers: Number of score-pool threads, used to size the
+                backpressure buffer that bounds predicted-but-not-yet-scored items.
+        """
+        self._eval_items = eval_items
+        self._predict_fn = predict_fn
+        self._run_id = run_id
+        self._max_retries = max_retries
+
+        self._limiter = _make_rate_limiter(
+            rps, adaptive=adaptive, max_rps_multiplier=max_rps_multiplier
+        )
+        self._pool = ThreadPoolExecutor(
+            max_workers=pool_workers, thread_name_prefix="MlflowGenAIEvalPredict"
+        )
+        self._in_flight = threading.Semaphore(backpressure_buffer(score_workers))
+        self._queue: queue.Queue[tuple[Future, int] | None] = queue.Queue()
+        self._futures: dict[Future, int] = {}
+        self._times: list[float] = []
+        self._time_lock = threading.Lock()
+        self._submit_error: Exception | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def limiter(self) -> RateLimiter:
+        return self._limiter
+
+    @property
+    def predict_times(self) -> list[float]:
+        return self._times
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._futures)
+
+    def shutdown(self) -> None:
+        self._pool.shutdown(wait=False, cancel_futures=True)
+
+    def start(self) -> None:
+        """Submit all eval items to the predict pool from a background thread.
+
+        Each submission blocks on the backpressure semaphore to bound the number
+        of predicted-but-not-yet-scored items. Completed futures are placed on
+        ``self._queue`` for the main loop to drain. A None sentinel signals
+        that all items have been submitted (or an error occurred).
+        """
+
+        self._thread = threading.Thread(
+            target=self._submit_all, daemon=True, name="MlflowGenAIEvalSubmit"
+        )
+        self._thread.start()
+
+    def join(self) -> None:
+        if self._thread is not None:
+            self._thread.join()
+
+    def _submit_all(self) -> None:
+        try:
+            for i, eval_item in enumerate(self._eval_items):
+                _logger.debug(f"Submit thread: waiting for backpressure slot (item {i})")
+                self._in_flight.acquire()
+                _logger.debug(f"Submit thread: submitting predict for item {i}")
+                future = self._pool.submit(
+                    self._timed_predict,
+                    eval_item,
+                    self._predict_fn,
+                    self._run_id,
+                    self._limiter,
+                    self._max_retries,
+                )
+                self._queue.put((future, i))
+        except Exception as e:
+            self._submit_error = e
+        finally:
+            self._queue.put(None)  # sentinel
+
+    def _timed_predict(self, *args) -> None:
+        start = time.monotonic()
+        _run_predict(*args)
+        with self._time_lock:
+            self._times.append(time.monotonic() - start)
+
+    def drain(self, *, block: bool = False) -> list[Future]:
+        """Return newly submitted predict futures from the submit thread.
+
+        When *block* is True, waits briefly (10 ms) for new items so the main
+        loop doesn't busy-wait when there is no other pending work.
+        """
+        drained: list[Future] = []
+        while True:
+            try:
+                item = self._queue.get_nowait() if not block else self._queue.get(timeout=0.01)
+            except queue.Empty:
+                break
+            if item is None:
+                break
+            block = False  # only block on the first get
+            future, idx = item
+            self._futures[future] = idx
+            drained.append(future)
+        return drained
+
+    def check_error(self) -> None:
+        if self._submit_error:
+            raise self._submit_error
+
+    def owns(self, future: Future) -> bool:
+        return future in self._futures
+
+    def on_complete(self, future: Future) -> int:
+        """Finalize a completed predict future: propagate exceptions and return its item index."""
+        idx = self._futures.pop(future)
+        future.result()  # propagate exceptions
+        return idx
+
+    def release_slot(self) -> None:
+        """Release one backpressure slot, allowing the submit thread to enqueue another predict."""
+        self._in_flight.release()
+
+
+class _ScoreSubmitter:
+    """Owns the score pool, score futures, multi-turn scoring, and score timing."""
+
+    def __init__(
+        self,
+        eval_items: list[EvalItem],
+        single_turn_scorers: list[Scorer],
+        multi_turn_scorers: list[Scorer],
+        session_groups: dict[str, list[EvalItem]],
+        run_id: str | None,
+        max_retries: int,
+        rps: float | None,
+        adaptive: bool,
+        max_rps_multiplier: float,
+        pool_workers: int,
+    ):
+        """
+        Args:
+            eval_items: Items to evaluate — indexed by position for score dispatch.
+            single_turn_scorers: Scorers applied to each item individually.
+            multi_turn_scorers: Scorers applied to session groups after the
+                single-turn pipeline completes.
+            session_groups: Mapping of session_id to ordered list of eval items
+                for multi-turn scoring.
+            run_id: MLflow run ID for trace/assessment logging.
+            max_retries: Max 429-retry attempts per scorer call.
+            rps: Requests-per-second for the scorer rate limiter, or None to disable.
+            adaptive: Whether the rate limiter uses AIMD to adapt to 429 signals.
+            max_rps_multiplier: AIMD ceiling as a multiple of the initial rps.
+            pool_workers: Number of threads in the score pool.
+        """
+        self._eval_items = eval_items
+        self._single_turn_scorers = single_turn_scorers
+        self._multi_turn_scorers = multi_turn_scorers
+        self._session_groups = session_groups
+        self._run_id = run_id
+        self._max_retries = max_retries
+
+        self._limiter = _make_rate_limiter(
+            rps, adaptive=adaptive, max_rps_multiplier=max_rps_multiplier
+        )
+        self._pool = ThreadPoolExecutor(
+            max_workers=pool_workers, thread_name_prefix="MlflowGenAIEvalScore"
+        )
+        self._futures: dict[Future, int] = {}
+        self._times: list[float] = []
+        self._time_lock = threading.Lock()
+
+    @property
+    def limiter(self) -> RateLimiter:
+        return self._limiter
+
+    @property
+    def score_times(self) -> list[float]:
+        return self._times
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._futures)
+
+    def shutdown(self) -> None:
+        self._pool.shutdown(wait=False, cancel_futures=True)
+
+    def submit(self, idx: int) -> Future:
+        """Submit a score task for eval item *idx* and return the future."""
+        _logger.debug(f"Predict completed for item {idx}, submitting score")
+        future = self._pool.submit(
+            self._timed_score,
+            self._eval_items[idx],
+            self._single_turn_scorers,
+            self._run_id,
+            self._limiter,
+            self._max_retries,
+        )
+        self._futures[future] = idx
+        return future
+
+    def _timed_score(self, *args) -> EvalResult:
+        start = time.monotonic()
+        result = _run_score(*args)
+        with self._time_lock:
+            self._times.append(time.monotonic() - start)
+        return result
+
+    def on_complete(self, future: Future) -> tuple[int, EvalResult]:
+        idx = self._futures.pop(future)
+        return idx, future.result()
+
+    def run_multi_turn(
+        self, multi_turn_assessments: dict[str, list[Feedback]], progress_bar
+    ) -> None:
+        if not self._multi_turn_scorers or not self._session_groups:
+            return
+        futures = [
+            self._pool.submit(
+                evaluate_session_level_scorers,
+                session_id=session_id,
+                session_items=session_items,
+                multi_turn_scorers=self._multi_turn_scorers,
+                scorer_rate_limiter=self._limiter,
+                max_retries=self._max_retries,
+            )
+            for session_id, session_items in self._session_groups.items()
+        ]
+        for future in as_completed(futures):
+            multi_turn_assessments.update(future.result())
+            if progress_bar:
+                progress_bar.update(1)
+
+
+def _run_pipeline(
+    eval_items: list[EvalItem],
+    eval_results: list[EvalResult | None],
+    predict_fn: Callable[..., Any] | None,
+    single_turn_scorers: list[Scorer],
+    multi_turn_scorers: list[Scorer],
+    session_groups: dict[str, list[EvalItem]],
+    run_id: str | None,
+    progress_bar,
+    multi_turn_assessments: dict[str, list[Feedback]],
+) -> tuple[list[float], list[float]]:
+    """Run the predict→score pipeline and multi-turn scoring.
+
+    Creates rate limiters and thread pools from environment variables,
+    runs the pipelined predict→score loop, then multi-turn scoring.
+    Returns (predict_times, score_times) for reporting.
+    """
+    _warmup_databricks_sdk()
+
+    predict_rps, predict_adaptive = _parse_rate_limit(MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT.get())
+    num_scorers = len(single_turn_scorers) + len(multi_turn_scorers)
+    scorer_rps, scorer_adaptive = _get_scorer_rate_config(
+        predict_rps, predict_adaptive, num_scorers
+    )
+    upper_multiplier = MLFLOW_GENAI_EVAL_RATE_LIMIT_UPPER_MULTIPLIER.get()
+    max_retries = MLFLOW_GENAI_EVAL_MAX_RETRIES.get()
+    predict_workers, score_workers = _get_pool_sizes(predict_rps, scorer_rps)
+
+    predictor = _PredictSubmitter(
+        eval_items,
+        predict_fn,
+        run_id,
+        max_retries,
+        rps=predict_rps,
+        adaptive=predict_adaptive,
+        max_rps_multiplier=upper_multiplier,
+        pool_workers=predict_workers,
+        score_workers=score_workers,
+    )
+    scorer = _ScoreSubmitter(
+        eval_items,
+        single_turn_scorers,
+        multi_turn_scorers,
+        session_groups,
+        run_id,
+        max_retries,
+        rps=scorer_rps,
+        adaptive=scorer_adaptive,
+        max_rps_multiplier=upper_multiplier,
+        pool_workers=score_workers,
+    )
+
+    try:
+        heartbeat = _Heartbeat(predictor.limiter, scorer.limiter, len(eval_items))
+
+        predictor.start()
+        pending: set[Future] = set()
+        items_predicted = 0
+        items_scored = 0
+
+        while items_scored < len(eval_items):
+            pending.update(predictor.drain(block=not pending))
+            predictor.check_error()
+            if not pending:
+                continue
+
+            heartbeat.tick(
+                {
+                    "predicted": items_predicted,
+                    "scored": items_scored,
+                    "pending": len(pending),
+                    "predict_pending": predictor.pending_count,
+                    "score_pending": scorer.pending_count,
+                }
+            )
+            _logger.debug(
+                f"Pipeline loop: waiting on {len(pending)} pending futures "
+                f"({predictor.pending_count} predict, {scorer.pending_count} score), "
+                f"scored={items_scored}/{len(eval_items)}"
+            )
+
+            done, pending = wait(pending, timeout=15, return_when=FIRST_COMPLETED)
+            for future in done:
+                if predictor.owns(future):
+                    idx = predictor.on_complete(future)
+                    items_predicted += 1
+                    pending.add(scorer.submit(idx))
+                else:
+                    idx, result = scorer.on_complete(future)
+                    _logger.debug(f"Score completed for item {idx}")
+                    eval_results[idx] = result
+                    predictor.release_slot()
+                    items_scored += 1
+                    if progress_bar:
+                        progress_bar.update(1)
+
+        predictor.join()
+        scorer.run_multi_turn(multi_turn_assessments, progress_bar)
+
+        return predictor.predict_times, scorer.score_times
+    finally:
+        predictor.shutdown()
+        scorer.shutdown()
+
+
 @context.eval_context
 def run(
     *,
@@ -205,92 +620,59 @@ def run(
     """
     Runs GenAI evaluation harness to the given dataset.
 
-    The overall flow is:
-
-    1. Convert the dataset to a list of EvalItem objects
-    2. Classify scorers into single-turn and multi-turn
-    3. Run the prediction and single-turn scoring for each EvalItem in parallel
-        a. If predict_fn is provided, invoke the predict_fn for the EvalItem
-        b. If predict_fn is not provided, create a dummy trace for the EvalItem
-        c. Execute the single-turn scorers to compute assessments.
-        d. Log the assessments to the trace.
-    4. If multi-turn scorers exist, evaluate them on session groups
-    5. Compute the aggregated metrics from the assessments.
+    Rate limiting is controlled via environment variables:
+    - MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT: max predict_fn calls/second
+    - MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT: max scorer calls/second
     """
     eval_items = [EvalItem.from_dataset_row(row) for row in eval_df.to_dict(orient="records")]
     eval_start_time = int(time.time() * 1000)
 
     run_id = context.get_context().get_mlflow_run_id() if run_id is None else run_id
 
-    # Classify scorers into single-turn and multi-turn
     single_turn_scorers, multi_turn_scorers = classify_scorers(scorers)
-
     session_groups = group_traces_by_session(eval_items) if multi_turn_scorers else {}
-
     total_tasks = len(eval_items) + len(session_groups)
 
-    with ThreadPoolExecutor(
-        max_workers=MLFLOW_GENAI_EVAL_MAX_WORKERS.get(),
-        thread_name_prefix="MlflowGenAIEvalHarness",
-    ) as executor:
-        # Submit single-turn tasks
-        single_turn_futures = {
-            executor.submit(
-                _run_single,
-                eval_item=eval_item,
-                scorers=single_turn_scorers,
-                predict_fn=predict_fn,
-                run_id=run_id,
-            ): i
-            for i, eval_item in enumerate(eval_items)
-        }
-
-        # Collect results with unified progress bar
-        eval_results = [None] * len(eval_items)
-        multi_turn_assessments = {}
-
-        # Create progress bar for all tasks
-        progress_bar = (
-            tqdm(
-                total=total_tasks,
-                desc="Evaluating",
-                smoothing=0,
-                bar_format=PGBAR_FORMAT,
-            )
-            if tqdm is not None
-            else None
+    progress_bar = (
+        tqdm(
+            total=total_tasks,
+            desc="Evaluating",
+            smoothing=0,
+            bar_format=PGBAR_FORMAT,
         )
+        if tqdm is not None
+        else None
+    )
 
-        try:
-            # Phase 1: Complete single-turn tasks
-            for future in as_completed(single_turn_futures):
-                idx = single_turn_futures[future]
-                eval_results[idx] = future.result()
-                if progress_bar:
-                    progress_bar.update(1)
+    eval_results = [None] * len(eval_items)
+    multi_turn_assessments = {}
+    predict_times: list[float] = []
+    score_times: list[float] = []
 
-            # Phase 2: Submit and complete multi-turn tasks (after single-turn)
-            # We run multi-turn scorers after single-turn, since single-turn scorers may create new
-            # traces that are needed by multi-turn scorers.
-            if multi_turn_scorers and session_groups:
-                multi_turn_futures = [
-                    executor.submit(
-                        evaluate_session_level_scorers,
-                        session_id=session_id,
-                        session_items=session_items,
-                        multi_turn_scorers=multi_turn_scorers,
-                    )
-                    for session_id, session_items in session_groups.items()
-                ]
-
-                for future in as_completed(multi_turn_futures):
-                    session_result = future.result()
-                    multi_turn_assessments.update(session_result)
-                    if progress_bar:
-                        progress_bar.update(1)
-        finally:
-            if progress_bar:
-                progress_bar.close()
+    try:
+        predict_times, score_times = _run_pipeline(
+            eval_items=eval_items,
+            eval_results=eval_results,
+            predict_fn=predict_fn,
+            single_turn_scorers=single_turn_scorers,
+            multi_turn_scorers=multi_turn_scorers,
+            session_groups=session_groups,
+            run_id=run_id,
+            progress_bar=progress_bar,
+            multi_turn_assessments=multi_turn_assessments,
+        )
+    finally:
+        predict_total = sum(predict_times)
+        score_total = sum(score_times)
+        total_thread_time = predict_total + score_total
+        if progress_bar:
+            if total_thread_time > 0:
+                predict_pct = predict_total / total_thread_time * 100
+                score_pct = score_total / total_thread_time * 100
+                split = f" [predict_fn: {predict_pct:.0f}%, scorers: {score_pct:.0f}%]"
+                progress_bar.bar_format = PGBAR_FORMAT + split
+                progress_bar.refresh()
+            progress_bar.close()
 
     if multi_turn_assessments:
         _log_multi_turn_assessments_to_traces(
@@ -336,17 +718,14 @@ def run(
     )
 
 
-def _run_single(
+def _run_predict(
     eval_item: EvalItem,
-    scorers: list[Scorer],
+    predict_fn: Callable[..., Any] | None,
     run_id: str | None,
-    predict_fn: Callable[..., Any] | None = None,
-) -> EvalResult:
-    """Run the logic of the eval harness for a single eval item."""
-    # Set the MLflow run ID in the context for this thread
+    rate_limiter: RateLimiter,
+    max_retries: int = 0,
+) -> None:
     if run_id:
-        # Manually set the mlflow_run_id for this context to be the same as was set in
-        # the parent thread. This is required because MLflow runs are thread-local.
         ctx = context.get_context()
         ctx.set_mlflow_run_id(run_id)
 
@@ -354,9 +733,16 @@ def _run_single(
         # NB: Setting prediction context let us retrieve the trace by a custom ID. Setting
         # is_evaluate=True disables async trace logging to make sure the trace is available.
         eval_request_id = str(uuid.uuid4())
-        with set_prediction_context(Context(request_id=eval_request_id, is_evaluate=True)):
+        with (
+            set_prediction_context(Context(request_id=eval_request_id, is_evaluate=True)),
+            eval_retry_context(),
+        ):
             try:
-                eval_item.outputs = predict_fn(eval_item.inputs)
+                eval_item.outputs = call_with_retry(
+                    lambda: predict_fn(eval_item.inputs),
+                    rate_limiter,
+                    max_retries,
+                )
             except Exception as e:
                 eval_item.error_message = (
                     f"Failed to invoke the predict_fn with {eval_item.inputs}: {e}"
@@ -375,11 +761,27 @@ def _run_single(
     else:
         # When static dataset (a pair of inputs and outputs) is given, we create a minimal
         # trace with root span only, to log the assessments on it.
-        minimal_trace = create_minimal_trace(eval_item)
-        eval_item.trace = minimal_trace
+        eval_item.trace = create_minimal_trace(eval_item)
 
-    # Execute the scorers
-    assessments = _compute_eval_scores(eval_item=eval_item, scorers=scorers)
+
+def _run_score(
+    eval_item: EvalItem,
+    scorers: list[Scorer],
+    run_id: str | None,
+    scorer_rate_limiter: RateLimiter,
+    max_retries: int = 0,
+) -> EvalResult:
+    if run_id:
+        ctx = context.get_context()
+        ctx.set_mlflow_run_id(run_id)
+
+    with eval_retry_context():
+        assessments = _compute_eval_scores(
+            eval_item=eval_item,
+            scorers=scorers,
+            rate_limiter=scorer_rate_limiter,
+            max_retries=max_retries,
+        )
     assessments.extend(_get_new_expectations(eval_item))
     eval_result = EvalResult(eval_item=eval_item, assessments=assessments)
 
@@ -390,7 +792,6 @@ def _run_single(
         try:
             mlflow.set_trace_tag(trace_id=eval_item.trace.info.trace_id, key=key, value=tags[key])
         except Exception as e:
-            # Failures in logging to MLflow should not fail the entire harness run
             _logger.warning(f"Failed to log tag {key} to MLflow: {e}")
 
     try:
@@ -400,7 +801,6 @@ def _run_single(
             assessments=eval_result.assessments,
         )
     except Exception as e:
-        # Failures in logging to MLflow should not fail the entire harness run
         _logger.warning(f"Failed to log trace and assessments to MLflow: {e}")
 
     return eval_result
@@ -410,16 +810,9 @@ def _compute_eval_scores(
     *,
     eval_item: EvalItem,
     scorers: list[Scorer],
+    rate_limiter: RateLimiter = NoOpRateLimiter(),
+    max_retries: int = 0,
 ) -> list[Feedback]:
-    """Compute the per-eval-item scores.
-
-    Args:
-        eval_item: The evaluation item containing inputs, outputs, expectations, and trace.
-        scorers: List of scorer instances to run.
-
-    Returns:
-        List of Feedback objects from all scorers.
-    """
     if not scorers:
         return []
 
@@ -434,12 +827,15 @@ def _compute_eval_scores(
                     scorer_func
                 )
 
-            value = scorer_func(
-                inputs=eval_item.inputs,
-                outputs=eval_item.outputs,
-                expectations=eval_item.expectations,
-                trace=eval_item.trace,
-            )
+            def _invoke():
+                return scorer_func(
+                    inputs=eval_item.inputs,
+                    outputs=eval_item.outputs,
+                    expectations=eval_item.expectations,
+                    trace=eval_item.trace,
+                )
+
+            value = call_with_retry(_invoke, rate_limiter, max_retries)
             feedbacks = standardize_scorer_value(scorer.name, value)
 
         except Exception as e:

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1,3 +1,4 @@
+import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -16,6 +17,8 @@ from mlflow.entities.span import SpanType
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import EvaluationDataset, create_dataset
 from mlflow.genai.evaluation.entities import EvaluationResult
+from mlflow.genai.evaluation.harness import backpressure_buffer
+from mlflow.genai.evaluation.rate_limiter import RPSRateLimiter
 from mlflow.genai.scorers.base import scorer
 from mlflow.genai.scorers.builtin_scorers import RelevanceToQuery
 from mlflow.genai.simulators import ConversationSimulator
@@ -652,6 +655,10 @@ def test_trace_input_can_contain_string_input(pass_full_dataframe, is_in_databri
 
 
 def test_max_workers_env_var(monkeypatch):
+    # Disable rate limits so auto-derivation doesn't override the default
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT", "0")
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", "0")
+
     def _validate_max_workers(expected_max_workers):
         with mock.patch(
             "mlflow.genai.evaluation.harness.ThreadPoolExecutor", wraps=ThreadPoolExecutor
@@ -1257,9 +1264,12 @@ def test_max_scorer_workers_env_var(monkeypatch):
                 ],
                 scorers=scorers_list,
             )
-            # ThreadPoolExecutor is called twice: harness loop + scorer loop
-            # The second call is for scorers
-            scorer_call = mock_executor.call_args_list[1]
+            # Find the scorer pool call by its thread_name_prefix
+            scorer_call = next(
+                call
+                for call in mock_executor.call_args_list
+                if call[1].get("thread_name_prefix") == "MlflowGenAIEvalScorer"
+            )
             assert scorer_call[1]["max_workers"] == expected_max_workers
 
     # default scorer workers is 10, but limited by number of scorers (3)
@@ -1465,3 +1475,245 @@ def test_evaluate_with_simulator_within_parent_run(tmp_path):
     runs = mlflow.search_runs()
     assert len(runs) == 1
     assert runs.iloc[0]["tags.mlflow.runName"] == "parent-run"
+
+
+# ===================== Rate Limiting & Pipelining Tests =====================
+
+
+def test_predict_rate_limiter_is_wired_to_predict_fn(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT", "100")
+
+    with mock.patch.object(
+        RPSRateLimiter, "acquire", autospec=True, side_effect=lambda self: None
+    ) as mock_acquire:
+        data = [{"inputs": {"q": f"Q{i}"}} for i in range(5)]
+        mlflow.genai.evaluate(data=data, predict_fn=lambda q: "answer", scorers=[always_pass])
+        # Called by both predict (5) and scorers (5), so at least 5
+        assert mock_acquire.call_count >= 5
+
+
+def test_scorer_rate_limiter_is_wired_to_scorers(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", "100")
+
+    with mock.patch.object(
+        RPSRateLimiter, "acquire", autospec=True, side_effect=lambda self: None
+    ) as mock_acquire:
+
+        @scorer
+        def s1(outputs):
+            return True
+
+        @scorer
+        def s2(outputs):
+            return True
+
+        data = [{"inputs": {"q": f"Q{i}"}, "outputs": "a"} for i in range(3)]
+        mlflow.genai.evaluate(data=data, scorers=[s1, s2])
+        # 3 items x 2 scorers = 6 scorer acquire calls (plus predict acquires)
+        assert mock_acquire.call_count >= 6
+
+
+def test_pipelining_scores_while_predicts_pending(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_MAX_WORKERS", "2")
+
+    # Gate that blocks predicts after the first batch completes
+    gate = threading.Event()
+    predict_call_count = 0
+    predict_lock = threading.Lock()
+    scoring_started_while_predicts_pending = threading.Event()
+
+    def gated_predict_fn(q):
+        nonlocal predict_call_count
+        with predict_lock:
+            predict_call_count += 1
+            call_num = predict_call_count
+        # Let the first 2 predictions through immediately, block the rest
+        if call_num > 2:
+            gate.wait(timeout=5)
+        return "answer"
+
+    @scorer
+    def signaling_scorer(outputs):
+        # If we're scoring while predicts are still pending, signal success
+        with predict_lock:
+            current_predicts = predict_call_count
+        if current_predicts < 6:  # 6 total items, so some must still be pending
+            scoring_started_while_predicts_pending.set()
+        return True
+
+    data = [{"inputs": {"q": f"Q{i}"}} for i in range(6)]
+
+    try:
+        # Run evaluate in a background thread so we can release the gate
+        result_holder = []
+
+        def run_eval():
+            result = mlflow.genai.evaluate(
+                data=data, predict_fn=gated_predict_fn, scorers=[signaling_scorer]
+            )
+            result_holder.append(result)
+
+        eval_thread = threading.Thread(target=run_eval)
+        eval_thread.start()
+
+        # Wait for scoring to signal it started while predicts are pending
+        signaled = scoring_started_while_predicts_pending.wait(timeout=10)
+
+        # Release all blocked predicts
+        gate.set()
+        eval_thread.join(timeout=30)
+
+        assert signaled, "Scoring should have started while predictions were still pending"
+    finally:
+        gate.set()  # Ensure we don't leave threads blocked
+
+
+def test_backpressure_limits_in_flight_items(monkeypatch):
+    workers = 2
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_MAX_WORKERS", str(workers))
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT", "0")
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", "0")
+    buffer = backpressure_buffer(workers)
+
+    max_in_flight = 0
+    in_flight = 0
+    lock = threading.Lock()
+    predict_done = threading.Semaphore(0)
+    score_gate = threading.Event()
+
+    def tracking_predict(q):
+        nonlocal in_flight, max_in_flight
+        with lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        predict_done.release()
+        return "answer"
+
+    @scorer
+    def blocking_scorer(outputs):
+        score_gate.wait(timeout=10)
+        nonlocal in_flight
+        with lock:
+            in_flight -= 1
+        return True
+
+    num_items = 3 * buffer
+    data = [{"inputs": {"q": f"Q{i}"}} for i in range(num_items)]
+
+    eval_thread = threading.Thread(
+        target=lambda: mlflow.genai.evaluate(
+            data=data, predict_fn=tracking_predict, scorers=[blocking_scorer]
+        )
+    )
+    eval_thread.start()
+
+    # Wait for exactly `buffer` predicts to complete. After this, the submit
+    # thread is blocked on semaphore.acquire() and no more predicts can run
+    # (scorers are blocked on score_gate).
+    for _ in range(buffer):
+        assert predict_done.acquire(timeout=5)
+
+    with lock:
+        observed_max = max_in_flight
+
+    # Release scorers and let evaluation finish
+    score_gate.set()
+    eval_thread.join(timeout=30)
+
+    # The semaphore bounds in-flight items. Without backpressure all
+    # num_items would pile up.
+    assert observed_max <= buffer
+
+
+def test_no_rate_limit_backward_compat():
+    data = [
+        {
+            "inputs": {"question": "What is MLflow?"},
+            "outputs": "MLflow is a tool for ML",
+            "expectations": {"expected_response": "MLflow is a tool for ML", "max_length": 100},
+        },
+    ]
+
+    result = mlflow.genai.evaluate(data=data, scorers=[exact_match, is_concise])
+
+    assert result.metrics["exact_match/mean"] == 1.0
+    assert result.metrics["is_concise/mean"] == 1.0
+
+
+# ===================== Retry & Adaptive Rate Limiting Tests =====================
+
+
+def test_predict_retries_on_429(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT", "0")
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_MAX_RETRIES", "3")
+
+    # Start counting after validation (first call is the pre-flight check)
+    call_count = 0
+
+    def flaky_predict(q):
+        nonlocal call_count
+        call_count += 1
+        if call_count > 1 and call_count < 4:
+            raise Exception("429 Too Many Requests")
+        return "answer"
+
+    data = [{"inputs": {"q": "Q1"}}]
+    result = mlflow.genai.evaluate(data=data, predict_fn=flaky_predict, scorers=[always_pass])
+
+    # 1 validation + 1 fail + 1 fail + 1 success = 4 total
+    assert call_count == 4
+    assert result.metrics["always_pass/mean"] == 1.0
+
+
+def test_scorer_retries_on_429(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT", "0")
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT", "0")
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_MAX_RETRIES", "3")
+
+    attempts = []
+
+    @scorer
+    def flaky_scorer(outputs):
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise Exception("rate limit exceeded")
+        return True
+
+    data = [{"inputs": {"q": "Q1"}, "outputs": "a"}]
+    result = mlflow.genai.evaluate(data=data, scorers=[flaky_scorer])
+
+    assert len(attempts) == 3
+    assert result.metrics["flaky_scorer/mean"] == 1.0
+
+
+def test_adaptive_rate_reduces_on_429(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT", "auto")
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_MAX_RETRIES", "3")
+
+    rate_after_throttle = []
+
+    original_report_throttle = RPSRateLimiter.report_throttle
+
+    def spy_report_throttle(self):
+        original_report_throttle(self)
+        rate_after_throttle.append(self._rps)
+
+    # First call is the pre-flight validation check — let it pass
+    call_count = 0
+
+    def flaky_predict(q):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise Exception("429 Too Many Requests")
+        return "answer"
+
+    data = [{"inputs": {"q": f"Q{i}"}} for i in range(3)]
+
+    with mock.patch.object(RPSRateLimiter, "report_throttle", spy_report_throttle):
+        result = mlflow.genai.evaluate(data=data, predict_fn=flaky_predict, scorers=[always_pass])
+
+    assert result.metrics["always_pass/mean"] == 1.0
+    # At least one throttle event observed, and the rate was reduced
+    assert len(rate_after_throttle) >= 1
+    assert rate_after_throttle[0] < 10.0  # auto starts at 10 rps


### PR DESCRIPTION
### Related Issues/PRs

<!-- Resolve --> #20684

### What changes are proposed in this pull request?

Replace the sequential predict-then-score loop in `mlflow.genai.evaluate` with a pipelined architecture that overlaps prediction and scoring, using rate limiters and backpressure for throughput control.

**`mlflow/genai/evaluation/harness.py`** — pipeline core:
- `_PredictSubmitter` class — owns predict ThreadPoolExecutor + rate limiter, submits predict tasks, feeds completed items to scoring via a thread-safe queue
- `_ScoreSubmitter` class — owns score ThreadPoolExecutor + rate limiter, consumes from predict queue, submits scoring tasks
- `_Heartbeat` class — periodic progress logging (gated behind `MLFLOW_GENAI_EVAL_ENABLE_HEARTBEAT`)
- `_run_pipeline` orchestrator — wires submitters with backpressure (Semaphore), manages lifecycle
- `_run_predict` / `_run_score` — individual item predict/score logic extracted from old `_run_single`
- Simplified `run()` — delegates to `_run_pipeline`, adds timing and progress bar

**`tests/genai/evaluate/test_evaluation.py`** — 8 new integration tests:
- `test_predict_rate_limiter_is_wired_to_predict_fn`
- `test_scorer_rate_limiter_is_wired_to_scorers`
- `test_pipelining_scores_while_predicts_pending`
- `test_backpressure_limits_in_flight_items`
- `test_no_rate_limit_backward_compat`
- `test_predict_retries_on_429` / `test_scorer_retries_on_429`
- `test_adaptive_rate_reduces_on_429`

**PR 4 of 4** in a stack implementing rate-limited pipelined execution for `mlflow.genai.evaluate`.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Existing unit/integration tests

8 new integration tests plus all 121 existing evaluate tests pass.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.genai.evaluate()` now uses a pipelined architecture that overlaps prediction and scoring with automatic rate limiting. Configure via `MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT` (default: `"auto"` = 10 RPS with adaptive AIMD) and `MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT` environment variables.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)