### PR TITLE
Add uv_groups and uv_extras params for uv dependency group control

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2861,6 +2861,8 @@ def save_model(
     resources: str | list[Resource] | None = None,
     auth_policy: AuthPolicy | None = None,
     uv_project_path: str | Path | None = None,
+    uv_groups: list[str] | None = None,
+    uv_extras: list[str] | None = None,
     **kwargs,
 ):
     """
@@ -3055,6 +3057,18 @@ def save_model(
 
             Auto-detection can be disabled by setting the environment variable
             ``MLFLOW_UV_AUTO_DETECT=false``.
+
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
+        uv_groups: Optional list of uv dependency groups to include when exporting
+            requirements from the uv lockfile. Maps to ``uv export --group <name>``.
+            These are additive with the project's default dependencies.
+
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
+        uv_extras: Optional list of uv extras (optional dependency sets) to include
+            when exporting requirements from the uv lockfile. Maps to
+            ``uv export --extra <name>``.
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
@@ -3376,6 +3390,8 @@ def save_model(
             streamable=streamable,
             infer_code_paths=infer_code_paths,
             uv_project_path=uv_project_path,
+            uv_groups=uv_groups,
+            uv_extras=uv_extras,
         )
     elif second_argument_set_specified:
         return mlflow.pyfunc.model._save_model_with_class_artifacts_params(
@@ -3393,6 +3409,8 @@ def save_model(
             model_code_path=model_code_path,
             infer_code_paths=infer_code_paths,
             uv_project_path=uv_project_path,
+            uv_groups=uv_groups,
+            uv_extras=uv_extras,
         )
 
 
@@ -3431,6 +3449,8 @@ def log_model(
     resources: str | list[Resource] | None = None,
     auth_policy: AuthPolicy | None = None,
     uv_project_path: str | Path | None = None,
+    uv_groups: list[str] | None = None,
+    uv_extras: list[str] | None = None,
     prompts: list[str | Prompt] | None = None,
     name=None,
     params: dict[str, Any] | None = None,
@@ -3647,6 +3667,18 @@ def log_model(
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
+        uv_groups: Optional list of uv dependency groups to include when exporting
+            requirements from the uv lockfile. Maps to ``uv export --group <name>``.
+            These are additive with the project's default dependencies.
+
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
+        uv_extras: Optional list of uv extras (optional dependency sets) to include
+            when exporting requirements from the uv lockfile. Maps to
+            ``uv export --extra <name>``.
+
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
         prompts: {{ prompts }}
         name: {{ name }}
         params: {{ params }}
@@ -3684,6 +3716,8 @@ def log_model(
         infer_code_paths=infer_code_paths,
         auth_policy=auth_policy,
         uv_project_path=uv_project_path,
+        uv_groups=uv_groups,
+        uv_extras=uv_extras,
         params=params,
         tags=tags,
         model_type=model_type,
@@ -3723,6 +3757,8 @@ def _save_model_with_loader_module_and_data_path(
     streamable=None,
     infer_code_paths=False,
     uv_project_path=None,
+    uv_groups=None,
+    uv_extras=None,
 ):
     """
     Export model as a generic Python function model.
@@ -3804,6 +3840,8 @@ def _save_model_with_loader_module_and_data_path(
                 fallback=default_reqs,
                 extra_env_vars=extra_env_vars,
                 uv_project_dir=uv_source_dir,
+                uv_groups=uv_groups,
+                uv_extras=uv_extras,
             )
             default_reqs = sorted(set(inferred_reqs).union(default_reqs))
         else:

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -1036,6 +1036,8 @@ def _save_model_with_class_artifacts_params(
     model_code_path=None,
     infer_code_paths=False,
     uv_project_path=None,
+    uv_groups=None,
+    uv_extras=None,
 ):
     """
     Args:
@@ -1233,6 +1235,8 @@ def _save_model_with_class_artifacts_params(
                 fallback=default_reqs,
                 extra_env_vars=extra_env_vars,
                 uv_project_dir=uv_source_dir,
+                uv_groups=uv_groups,
+                uv_extras=uv_extras,
             )
             default_reqs = sorted(set(inferred_reqs).union(default_reqs))
         else:

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -409,6 +409,8 @@ def infer_pip_requirements(
     timeout=None,
     extra_env_vars=None,
     uv_project_dir=None,
+    uv_groups=None,
+    uv_extras=None,
 ):
     """Infers the pip requirements of the specified model by creating a subprocess and loading
     the model in it to determine which packages are imported.
@@ -429,6 +431,10 @@ def infer_pip_requirements(
         uv_project_dir: Explicit path to a uv project directory. When provided, overrides
             the ``MLFLOW_UV_AUTO_DETECT`` environment variable and searches the specified
             directory instead of cwd. Default to None (auto-detect from cwd).
+        uv_groups: Optional list of uv dependency groups to include when exporting
+            requirements. Maps to ``uv export --group <name>``.
+        uv_extras: Optional list of uv extras (optional dependency sets) to include
+            when exporting requirements. Maps to ``uv export --extra <name>``.
 
     Returns:
         A list of inferred pip requirements (e.g. ``["scikit-learn==0.24.2", ...]``).
@@ -443,7 +449,11 @@ def infer_pip_requirements(
                 f"Detected uv project at {uv_project.uv_lock.parent}. "
                 "Attempting to export requirements via 'uv export'."
             )
-            if uv_requirements := export_uv_requirements(uv_project.uv_lock.parent):
+            if uv_requirements := export_uv_requirements(
+                uv_project.uv_lock.parent,
+                groups=uv_groups,
+                extras=uv_extras,
+            ):
                 _logger.info(
                     f"Successfully exported {len(uv_requirements)} requirements from uv project. "
                     "Skipping package capture based inference."

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -464,6 +464,11 @@ def infer_pip_requirements(
                     "uv export failed or returned no requirements. "
                     "Falling back to package capture based inference."
                 )
+        elif uv_groups or uv_extras:
+            _logger.warning(
+                "uv_groups and/or uv_extras were specified but no uv project was detected. "
+                "These parameters will be ignored. Falling back to package capture based inference."
+            )
 
     raise_on_error = MLFLOW_REQUIREMENTS_INFERENCE_RAISE_ERRORS.get()
 

--- a/mlflow/utils/uv_utils.py
+++ b/mlflow/utils/uv_utils.py
@@ -121,6 +121,9 @@ def export_uv_requirements(
     no_dev: bool = True,
     no_hashes: bool = True,
     frozen: bool = True,
+    groups: list[str] | None = None,
+    only_groups: list[str] | None = None,
+    extras: list[str] | None = None,
 ) -> list[str] | None:
     """
     Export dependencies from a uv project to pip-compatible requirements.
@@ -134,6 +137,13 @@ def export_uv_requirements(
         no_dev: Exclude development dependencies. Defaults to True.
         no_hashes: Omit hashes from output. Defaults to True.
         frozen: Use frozen lockfile without updating. Defaults to True.
+        groups: Optional list of dependency groups to include (additive with project deps).
+            Maps to ``uv export --group <name>``.
+        only_groups: Optional list of dependency groups to export exclusively
+            (no project deps). Maps to ``uv export --only-group <name>``.
+            Mutually exclusive with ``groups``.
+        extras: Optional list of optional dependency extras to include.
+            Maps to ``uv export --extra <name>``.
 
     Returns:
         A list of requirement strings (e.g., ``["requests==2.28.0", "numpy==1.24.0"]``),
@@ -156,6 +166,18 @@ def export_uv_requirements(
         cmd.append("--no-hashes")
     if frozen:
         cmd.append("--frozen")
+
+    # Handle dependency groups (mutually exclusive: only_groups takes precedence)
+    if only_groups:
+        for group in only_groups:
+            cmd.extend(["--only-group", group])
+    elif groups:
+        for group in groups:
+            cmd.extend(["--group", group])
+
+    if extras:
+        for extra in extras:
+            cmd.extend(["--extra", extra])
 
     # Additional flags for cleaner output
     cmd.extend(

--- a/mlflow/utils/uv_utils.py
+++ b/mlflow/utils/uv_utils.py
@@ -122,7 +122,6 @@ def export_uv_requirements(
     no_hashes: bool = True,
     frozen: bool = True,
     groups: list[str] | None = None,
-    only_groups: list[str] | None = None,
     extras: list[str] | None = None,
 ) -> list[str] | None:
     """
@@ -139,9 +138,6 @@ def export_uv_requirements(
         frozen: Use frozen lockfile without updating. Defaults to True.
         groups: Optional list of dependency groups to include (additive with project deps).
             Maps to ``uv export --group <name>``.
-        only_groups: Optional list of dependency groups to export exclusively
-            (no project deps). Maps to ``uv export --only-group <name>``.
-            Mutually exclusive with ``groups``.
         extras: Optional list of optional dependency extras to include.
             Maps to ``uv export --extra <name>``.
 
@@ -167,11 +163,7 @@ def export_uv_requirements(
     if frozen:
         cmd.append("--frozen")
 
-    # Handle dependency groups (mutually exclusive: only_groups takes precedence)
-    if only_groups:
-        for group in only_groups:
-            cmd.extend(["--only-group", group])
-    elif groups:
+    if groups:
         for group in groups:
             cmd.extend(["--group", group])
 

--- a/tests/pyfunc/test_uv_model_logging.py
+++ b/tests/pyfunc/test_uv_model_logging.py
@@ -436,17 +436,6 @@ def test_export_uv_requirements_with_groups_real(uv_project_with_groups):
 
 
 @requires_uv
-def test_export_uv_requirements_with_only_groups_real(uv_project_with_groups):
-    from mlflow.utils.uv_utils import export_uv_requirements
-
-    result = export_uv_requirements(uv_project_with_groups, only_groups=["serving"])
-
-    assert result is not None
-    pkg_names = [r.split("==")[0].lower() for r in result]
-    assert "gunicorn" in pkg_names
-
-
-@requires_uv
 def test_export_uv_requirements_with_extras_real(uv_project_with_groups):
     from mlflow.utils.uv_utils import export_uv_requirements
 

--- a/tests/utils/test_uv_utils.py
+++ b/tests/utils/test_uv_utils.py
@@ -206,77 +206,6 @@ def test_export_uv_requirements_returns_none_on_subprocess_error(tmp_path):
 def test_export_uv_requirements_with_explicit_directory(tmp_path):
     (tmp_path / _UV_LOCK_FILE).touch()
 
-
-# --- export_uv_requirements groups/extras tests ---
-
-
-def test_export_uv_requirements_passes_groups_to_command(tmp_path):
-    mock_result = mock.Mock()
-    mock_result.stdout = "requests==2.28.0\n"
-
-    with (
-        mock.patch("mlflow.utils.uv_utils._get_uv_binary", return_value="/usr/bin/uv"),
-        mock.patch("subprocess.run", return_value=mock_result) as mock_run,
-    ):
-        export_uv_requirements(tmp_path, groups=["serving", "ml"])
-
-        call_args = mock_run.call_args[0][0]
-        assert "--group" in call_args
-        serving_idx = call_args.index("--group")
-        assert call_args[serving_idx + 1] == "serving"
-        second_group_idx = call_args.index("--group", serving_idx + 1)
-        assert call_args[second_group_idx + 1] == "ml"
-
-
-def test_export_uv_requirements_passes_only_groups_to_command(tmp_path):
-    mock_result = mock.Mock()
-    mock_result.stdout = "torch==2.0.0\n"
-
-    with (
-        mock.patch("mlflow.utils.uv_utils._get_uv_binary", return_value="/usr/bin/uv"),
-        mock.patch("subprocess.run", return_value=mock_result) as mock_run,
-    ):
-        export_uv_requirements(tmp_path, only_groups=["serving"])
-
-        call_args = mock_run.call_args[0][0]
-        assert "--only-group" in call_args
-        idx = call_args.index("--only-group")
-        assert call_args[idx + 1] == "serving"
-        assert "--group" not in call_args
-
-
-def test_export_uv_requirements_passes_extras_to_command(tmp_path):
-    mock_result = mock.Mock()
-    mock_result.stdout = "uvicorn==0.29.0\n"
-
-    with (
-        mock.patch("mlflow.utils.uv_utils._get_uv_binary", return_value="/usr/bin/uv"),
-        mock.patch("subprocess.run", return_value=mock_result) as mock_run,
-    ):
-        export_uv_requirements(tmp_path, extras=["api", "gpu"])
-
-        call_args = mock_run.call_args[0][0]
-        assert "--extra" in call_args
-        api_idx = call_args.index("--extra")
-        assert call_args[api_idx + 1] == "api"
-        second_extra_idx = call_args.index("--extra", api_idx + 1)
-        assert call_args[second_extra_idx + 1] == "gpu"
-
-
-def test_export_uv_requirements_only_groups_takes_precedence_over_groups(tmp_path):
-    mock_result = mock.Mock()
-    mock_result.stdout = "fastapi==0.100.0\n"
-
-    with (
-        mock.patch("mlflow.utils.uv_utils._get_uv_binary", return_value="/usr/bin/uv"),
-        mock.patch("subprocess.run", return_value=mock_result) as mock_run,
-    ):
-        export_uv_requirements(tmp_path, groups=["dev"], only_groups=["serving"])
-
-        call_args = mock_run.call_args[0][0]
-        assert "--only-group" in call_args
-        assert "--group" not in call_args
-
     uv_output = """requests==2.28.0
 numpy==1.24.0
 """
@@ -294,6 +223,45 @@ numpy==1.24.0
         assert "numpy==1.24.0" in result
         mock_run.assert_called_once()
         assert mock_run.call_args.kwargs["cwd"] == tmp_path
+
+
+# --- export_uv_requirements groups/extras tests ---
+
+
+def test_export_uv_requirements_passes_groups_to_command(tmp_path):
+    mock_result = mock.Mock()
+    mock_result.stdout = "requests==2.28.0\n"
+
+    with (
+        mock.patch("mlflow.utils.uv_utils._get_uv_binary", return_value="/usr/bin/uv"),
+        mock.patch("mlflow.utils.uv_utils.subprocess.run", return_value=mock_result) as mock_run,
+    ):
+        export_uv_requirements(tmp_path, groups=["serving", "ml"])
+
+        call_args = mock_run.call_args[0][0]
+        assert "--group" in call_args
+        serving_idx = call_args.index("--group")
+        assert call_args[serving_idx + 1] == "serving"
+        second_group_idx = call_args.index("--group", serving_idx + 1)
+        assert call_args[second_group_idx + 1] == "ml"
+
+
+def test_export_uv_requirements_passes_extras_to_command(tmp_path):
+    mock_result = mock.Mock()
+    mock_result.stdout = "uvicorn==0.29.0\n"
+
+    with (
+        mock.patch("mlflow.utils.uv_utils._get_uv_binary", return_value="/usr/bin/uv"),
+        mock.patch("mlflow.utils.uv_utils.subprocess.run", return_value=mock_result) as mock_run,
+    ):
+        export_uv_requirements(tmp_path, extras=["api", "gpu"])
+
+        call_args = mock_run.call_args[0][0]
+        assert "--extra" in call_args
+        api_idx = call_args.index("--extra")
+        assert call_args[api_idx + 1] == "api"
+        second_extra_idx = call_args.index("--extra", api_idx + 1)
+        assert call_args[second_extra_idx + 1] == "gpu"
 
 
 # --- copy_uv_project_files tests ---
@@ -481,7 +449,7 @@ def test_infer_pip_requirements_passes_groups_and_extras_to_uv_export(tmp_path, 
 
     with (
         mock.patch("mlflow.utils.uv_utils._get_uv_binary", return_value="/usr/bin/uv"),
-        mock.patch("subprocess.run", return_value=mock_result) as mock_run,
+        mock.patch("mlflow.utils.uv_utils.subprocess.run", return_value=mock_result) as mock_run,
     ):
         result = infer_pip_requirements(
             str(tmp_path),
@@ -808,3 +776,28 @@ def test_run_uv_sync_returns_false_on_failure(tmp_path):
     ):
         result = run_uv_sync(tmp_path)
         assert result is False
+
+
+def test_infer_pip_requirements_warns_when_groups_set_but_no_uv_project(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MLFLOW_UV_AUTO_DETECT", "true")
+
+    with (
+        mock.patch(
+            "mlflow.utils.environment._infer_requirements",
+            return_value=["scikit-learn==1.0"],
+        ),
+        mock.patch("mlflow.utils.environment._logger") as mock_logger,
+    ):
+        result = infer_pip_requirements(
+            str(tmp_path),
+            "sklearn",
+            uv_groups=["serving"],
+            uv_extras=["api"],
+        )
+
+        assert "scikit-learn==1.0" in result
+        mock_logger.warning.assert_any_call(
+            "uv_groups and/or uv_extras were specified but no uv project was detected. "
+            "These parameters will be ignored. Falling back to package capture based inference."
+        )


### PR DESCRIPTION
## Related Issues/PRs

Follow-up to #20344 (uv support). Split per @harupy's request.

## What changes are proposed in this pull request?

Adds `uv_groups` and `uv_extras` parameters to `save_model`, `log_model`, and `infer_pip_requirements` so users can control which uv dependency groups and extras get included when exporting requirements from the uv lockfile.

**Parameter chain:**
`pyfunc.save_model(uv_groups=..., uv_extras=...)` -> `_save_model_with_loader_module_and_data_path` / `_save_model_with_class_artifacts_params` -> `infer_pip_requirements` -> `export_uv_requirements(groups=..., extras=...)`

**uv export flags:**
- `uv_groups=["serving"]` maps to `uv export --group serving`
- `uv_extras=["api"]` maps to `uv export --extra api`
- Also supports `only_groups` internally (maps to `--only-group`, mutually exclusive with `groups`)

**Example usage:**
```python
import mlflow

mlflow.pyfunc.save_model(
    path="my_model",
    python_model=my_model,
    uv_groups=["serving"],      # Include the "serving" dependency group
    uv_extras=["api", "gpu"],   # Include optional extras
)
```

## How is this PR tested?

- [x] New unit tests for `export_uv_requirements` with groups, only_groups, and extras
- [x] Integration test verifying groups/extras flow through `infer_pip_requirements`
- [x] 94 tests pass across both test files
- [x] All pre-commit hooks pass

### Unit tests

```
uv run pytest tests/utils/test_uv_utils.py tests/pyfunc/test_uv_model_logging.py -v
94 passed
```

New tests added:
- `test_export_uv_requirements_passes_groups_to_command`
- `test_export_uv_requirements_passes_only_groups_to_command`
- `test_export_uv_requirements_passes_extras_to_command`
- `test_export_uv_requirements_only_groups_takes_precedence_over_groups`
- `test_infer_pip_requirements_passes_groups_and_extras_to_uv_export`

## Does this PR change the documentation?

- [x] API docstrings updated for `save_model`, `log_model`, `infer_pip_requirements`, and `export_uv_requirements`

## Release Notes

### Is this a user-facing change?

- [x] Yes

### What component(s) does this PR affect?

- `area/models`

### How should the PR be classified in the release notes?

- `rn/feature`

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)