### PR TITLE
Disable downstream 429 retries during evaluate

### DIFF
--- a/mlflow/genai/evaluation/rate_limiter.py
+++ b/mlflow/genai/evaluation/rate_limiter.py
@@ -23,13 +23,8 @@ def eval_retry_context():
     from mlflow.genai.judges.adapters.litellm_adapter import disable_litellm_rate_limit_retries
     from mlflow.utils.rest_utils import disable_429_retry
 
-    litellm_flag = disable_litellm_rate_limit_retries()
-    litellm_token = litellm_flag.set(True)
-    try:
-        with disable_429_retry():
-            yield
-    finally:
-        litellm_flag.reset(litellm_token)
+    with disable_litellm_rate_limit_retries(), disable_429_retry():
+        yield
 
 
 def is_rate_limit_error(exc: BaseException) -> bool:

--- a/mlflow/genai/evaluation/rate_limiter.py
+++ b/mlflow/genai/evaluation/rate_limiter.py
@@ -20,6 +20,7 @@ def eval_retry_context():
     adapter so that rate-limit errors propagate to the evaluate pipeline's
     own retry/AIMD logic.
     """
+    # Lazy imports to avoid circular dependency: genai.evaluation → genai.judges/utils.
     from mlflow.genai.judges.adapters.litellm_adapter import disable_litellm_rate_limit_retries
     from mlflow.utils.rest_utils import disable_429_retry
 

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import re
@@ -49,14 +50,17 @@ _logger = logging.getLogger(__name__)
 _DISABLE_RATE_LIMIT_RETRIES = ContextVar("_DISABLE_RATE_LIMIT_RETRIES", default=False)
 
 
-def disable_litellm_rate_limit_retries() -> ContextVar:
-    """Return the ContextVar that controls litellm rate-limit retry suppression.
+@contextlib.contextmanager
+def disable_litellm_rate_limit_retries():
+    token = _DISABLE_RATE_LIMIT_RETRIES.set(True)
+    try:
+        yield
+    finally:
+        _DISABLE_RATE_LIMIT_RETRIES.reset(token)
 
-    Callers should use ``token = _DISABLE_RATE_LIMIT_RETRIES.set(True)`` and
-    ``_DISABLE_RATE_LIMIT_RETRIES.reset(token)`` (or a context manager) to
-    temporarily disable litellm's RateLimitErrorRetries.
-    """
-    return _DISABLE_RATE_LIMIT_RETRIES
+
+def is_litellm_rate_limit_retries_disabled() -> bool:
+    return _DISABLE_RATE_LIMIT_RETRIES.get()
 
 
 # Global cache to track model capabilities across function calls

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -5,6 +5,7 @@ import logging
 import re
 import threading
 from contextlib import ContextDecorator
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -42,6 +43,21 @@ from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
 from mlflow.tracing.constant import AssessmentMetadataKey
 
 _logger = logging.getLogger(__name__)
+
+# ContextVar that upstream modules (e.g. the evaluate harness) can set to disable
+# litellm's own rate-limit retries, so 429 errors propagate to the caller's retry logic.
+_DISABLE_RATE_LIMIT_RETRIES = ContextVar("_DISABLE_RATE_LIMIT_RETRIES", default=False)
+
+
+def disable_litellm_rate_limit_retries() -> ContextVar:
+    """Return the ContextVar that controls litellm rate-limit retry suppression.
+
+    Callers should use ``token = _DISABLE_RATE_LIMIT_RETRIES.set(True)`` and
+    ``_DISABLE_RATE_LIMIT_RETRIES.reset(token)`` (or a context manager) to
+    temporarily disable litellm's RateLimitErrorRetries.
+    """
+    return _DISABLE_RATE_LIMIT_RETRIES
+
 
 # Global cache to track model capabilities across function calls
 # Key: model URI (e.g., "openai/gpt-4"), Value: boolean indicating response_format support
@@ -494,9 +510,14 @@ def _get_litellm_retry_policy(num_retries: int) -> "litellm.RetryPolicy":
     """
     from litellm import RetryPolicy
 
+    # When an upstream module (e.g. the evaluate harness) has set the flag,
+    # disable litellm's rate-limit retries so 429 errors propagate to the
+    # caller's own retry logic for adaptive rate control.
+    rate_limit_retries = 0 if _DISABLE_RATE_LIMIT_RETRIES.get() else num_retries
+
     return RetryPolicy(
         TimeoutErrorRetries=num_retries,
-        RateLimitErrorRetries=num_retries,
+        RateLimitErrorRetries=rate_limit_retries,
         InternalServerErrorRetries=num_retries,
         ContentPolicyViolationErrorRetries=num_retries,
         # We don't retry on errors that are unlikely to be transient

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -8,7 +8,7 @@ import threading
 from contextlib import ContextDecorator
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterator
 
 import pydantic
 
@@ -51,7 +51,7 @@ _DISABLE_RATE_LIMIT_RETRIES = ContextVar("_DISABLE_RATE_LIMIT_RETRIES", default=
 
 
 @contextlib.contextmanager
-def disable_litellm_rate_limit_retries():
+def disable_litellm_rate_limit_retries() -> Iterator[None]:
     token = _DISABLE_RATE_LIMIT_RETRIES.set(True)
     try:
         yield

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -1,9 +1,11 @@
 import base64
+import contextlib
 import json
 import logging
 import random
 import time
 import warnings
+from contextvars import ContextVar
 from functools import lru_cache
 from typing import Any, Callable
 
@@ -44,6 +46,25 @@ from mlflow.utils.workspace_context import get_request_workspace
 from mlflow.utils.workspace_utils import WORKSPACE_HEADER_NAME
 
 _logger = logging.getLogger(__name__)
+
+# Generic ContextVar to disable HTTP-layer 429 retries. When True,
+# _retry_databricks_sdk_call_with_exponential_backoff skips retrying on 429 so
+# that rate-limit errors propagate immediately to the caller's own retry logic.
+_DISABLE_429_RETRY = ContextVar("_DISABLE_429_RETRY", default=False)
+
+
+@contextlib.contextmanager
+def disable_429_retry():
+    token = _DISABLE_429_RETRY.set(True)
+    try:
+        yield
+    finally:
+        _DISABLE_429_RETRY.reset(token)
+
+
+def is_429_retry_disabled() -> bool:
+    return _DISABLE_429_RETRY.get()
+
 
 RESOURCE_NON_EXISTENT = "RESOURCE_DOES_NOT_EXIST"
 _REST_API_PATH_PREFIX = "/api/2.0"
@@ -470,6 +491,9 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
         DatabricksError: If all retries are exhausted or non-retryable error occurs
     """
     from databricks.sdk.errors import STATUS_CODE_MAPPING, DatabricksError
+
+    if is_429_retry_disabled():
+        retry_codes = frozenset(c for c in retry_codes if c != 429)
 
     start_time = time.time()
     attempt = 0

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -7,7 +7,7 @@ from mlflow.genai.evaluation.rate_limiter import (
     eval_retry_context,
     is_rate_limit_error,
 )
-from mlflow.genai.judges.adapters.litellm_adapter import disable_litellm_rate_limit_retries
+from mlflow.genai.judges.adapters.litellm_adapter import is_litellm_rate_limit_retries_disabled
 from mlflow.utils.rest_utils import is_429_retry_disabled
 
 
@@ -331,8 +331,7 @@ def test_call_with_retry_reports_throttle_and_success():
 
 def _retry_flags_active():
     """Check that both downstream retry-suppression flags are set."""
-    litellm_flag = disable_litellm_rate_limit_retries()
-    return litellm_flag.get() and is_429_retry_disabled()
+    return is_litellm_rate_limit_retries_disabled() and is_429_retry_disabled()
 
 
 def test_eval_retry_context_sets_and_resets():

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -7,6 +7,8 @@ from mlflow.genai.evaluation.rate_limiter import (
     eval_retry_context,
     is_rate_limit_error,
 )
+from mlflow.genai.judges.adapters.litellm_adapter import disable_litellm_rate_limit_retries
+from mlflow.utils.rest_utils import is_429_retry_disabled
 
 
 class FakeClock:
@@ -324,15 +326,31 @@ def test_call_with_retry_reports_throttle_and_success():
     assert limiter._rps < 10.0
 
 
-# ── eval_retry_context tests (no-op stub — real tests in PR 2) ──
+# ── eval_retry_context tests ──
 
 
-def test_eval_retry_context_is_noop():
+def _retry_flags_active():
+    """Check that both downstream retry-suppression flags are set."""
+    litellm_flag = disable_litellm_rate_limit_retries()
+    return litellm_flag.get() and is_429_retry_disabled()
+
+
+def test_eval_retry_context_sets_and_resets():
+    assert not _retry_flags_active()
+
     with eval_retry_context():
-        pass  # Should not raise
+        assert _retry_flags_active()
+
+    assert not _retry_flags_active()
 
 
-def test_eval_retry_context_nests_without_error():
+def test_eval_retry_context_nests():
+    assert not _retry_flags_active()
+
     with eval_retry_context():
+        assert _retry_flags_active()
         with eval_retry_context():
-            pass
+            assert _retry_flags_active()
+        assert _retry_flags_active()
+
+    assert not _retry_flags_active()

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -7,7 +7,10 @@ from mlflow.genai.evaluation.rate_limiter import (
     eval_retry_context,
     is_rate_limit_error,
 )
-from mlflow.genai.judges.adapters.litellm_adapter import is_litellm_rate_limit_retries_disabled
+from mlflow.genai.judges.adapters.litellm_adapter import (
+    _get_litellm_retry_policy,
+    is_litellm_rate_limit_retries_disabled,
+)
 from mlflow.utils.rest_utils import is_429_retry_disabled
 
 
@@ -353,3 +356,10 @@ def test_eval_retry_context_nests():
         assert _retry_flags_active()
 
     assert not _retry_flags_active()
+
+
+def test_litellm_retry_policy_disables_rate_limit_retries_when_flag_set():
+    with eval_retry_context():
+        policy = _get_litellm_retry_policy(3)
+    assert policy.RateLimitErrorRetries == 0
+    assert policy.TimeoutErrorRetries == 3


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR (2/4)** — rate-limited pipelined execution for `mlflow.genai.evaluate`
> | | PR | Title |
> |---|---|---|
> | | #20937 | Add rate limiter module and evaluation environment variables |
> | **>>** | **#20938** | **Disable downstream 429 retries during evaluate** |
> | | #20939 | Add harness helpers and supporting infrastructure |
> | | #20940 | Add pipelined predict-score execution |

### Related Issues/PRs

#20684

### What changes are proposed in this pull request?

Disables downstream 429 retry mechanisms during `mlflow.genai.evaluate` so that rate-limit errors bubble up to our AIMD-aware retry layer instead of being silently retried by lower-level libraries.

**Problem:** When predict/score threads hit 429 (rate limit) responses, two independent retry mechanisms silently handle them:
1. MLflow's `_retry_databricks_sdk_call_with_exponential_backoff` in `rest_utils.py` retries 429s for Databricks endpoints
2. LiteLLM's built-in retry policy retries 429s for scorer calls

This prevents the adaptive rate limiter (AIMD) from observing 429s and reducing the sending rate.

**Solution:** Each layer gets a ContextVar-based disable flag that `eval_retry_context()` activates:

- **`mlflow/utils/rest_utils.py`**: Adds `_DISABLE_429_RETRY` ContextVar + `disable_429_retry()` context manager. When active, the retry wrapper excludes 429 from its retry codes (other transient errors like 500, 503 are unaffected).
- **`mlflow/genai/judges/adapters/litellm_adapter.py`**: Adds `_DISABLE_RATE_LIMIT_RETRIES` ContextVar + `disable_litellm_rate_limit_retries()`. When active, sets `RateLimitErrorRetries=0` in litellm's retry policy.
- **`mlflow/genai/evaluation/rate_limiter.py`**: `eval_retry_context()` now activates both disable flags (replacing the no-op stub from PR 1).

**Dependency direction:** `genai.evaluation.rate_limiter` → `utils.rest_utils` (generic) and `genai.judges.adapters.litellm_adapter` (adapter-specific). Neither downstream module has knowledge of evaluate.

**Files changed:**
- `mlflow/utils/rest_utils.py` (+24 lines)
- `mlflow/genai/judges/adapters/litellm_adapter.py` (+23 lines)
- `mlflow/genai/evaluation/rate_limiter.py` (replace stub with real impl, +18/-4)
- `tests/genai/evaluate/test_rate_limiter.py` (restore full assertions, +28/-5)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Updated `eval_retry_context` tests verify both disable flags are activated and properly reset, including nesting behavior.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
