### PR TITLE
Add harness helpers and supporting infrastructure for rate-limited evaluate

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -19,6 +19,23 @@ except ImportError:
     # If tqdm is not installed, we don't show a progress bar
     tqdm = None
 
+# Optional dependencies — imported eagerly in the main thread so that worker
+# threads never trigger first-time imports (which can deadlock under Python's
+# per-module import lock when many threads import simultaneously).
+try:
+    import litellm  # noqa: F401
+except ImportError:
+    pass
+
+
+def _warmup_databricks_sdk() -> None:
+    """Import databricks.sdk in the main thread to avoid import-lock deadlocks in workers."""
+    try:
+        import databricks.sdk  # noqa: F401
+    except ImportError:
+        pass
+
+
 import mlflow
 from mlflow.entities import SpanType
 from mlflow.entities.assessment import Assessment, Expectation, Feedback
@@ -28,9 +45,15 @@ from mlflow.environment_variables import (
     MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING,
     MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS,
     MLFLOW_GENAI_EVAL_MAX_WORKERS,
+    MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT,
 )
 from mlflow.genai.evaluation import context
 from mlflow.genai.evaluation.entities import EvalItem, EvalResult, EvaluationResult
+from mlflow.genai.evaluation.rate_limiter import (
+    NoOpRateLimiter,
+    RateLimiter,
+    RPSRateLimiter,
+)
 from mlflow.genai.evaluation.session_utils import (
     classify_scorers,
     evaluate_session_level_scorers,
@@ -93,6 +116,87 @@ def _log_multi_turn_assessments_to_traces(
             eval_result.assessments.extend(assessments_list)
         except Exception as e:
             _logger.warning(f"Failed to log multi-turn assessments for trace {trace_id}: {e}")
+
+
+def _parse_rate_limit(raw: str | None) -> tuple[float | None, bool]:
+    """Parse a rate-limit env var into (rps_or_none, adaptive).
+
+    Returns:
+        (None, False)          when rate limiting is disabled ("0" or None)
+        (rps, True)            when "auto"
+        (rps, False)           when a fixed numeric value
+    """
+    auto_initial_rps = 10.0
+    if raw is None:
+        return None, False
+    if raw.strip().lower() == "auto":
+        return auto_initial_rps, True
+    rate = float(raw)
+    if rate <= 0:
+        return None, False
+    return rate, False
+
+
+_AIMD_UPPER_MULTIPLIER = 2.0
+
+
+def _make_rate_limiter(
+    rps: float | None, adaptive: bool = False, max_rps_multiplier: float = _AIMD_UPPER_MULTIPLIER
+) -> RateLimiter:
+    if rps is None or rps <= 0:
+        return NoOpRateLimiter()
+    return RPSRateLimiter(rps, adaptive=adaptive, max_rps_multiplier=max_rps_multiplier)
+
+
+def _pool_size(rps: float | None) -> int:
+    """Derive thread count from rate limit, capped at [10, 500].
+
+    Assumes each LLM call takes about ``_AVG_LLM_LATENCY_SECS`` seconds on
+    average, so we need ``rps * latency`` threads to keep the pipeline busy.
+    The rate limiter handles queueing — threads that can't get a token just
+    block in acquire(). The HTTP connection pool is auto-sized to match.
+    """
+    avg_llm_latency_secs = 2
+    if not rps:
+        return 10
+    return min(500, max(10, int(rps * avg_llm_latency_secs)))
+
+
+def backpressure_buffer(score_workers: int) -> int:
+    """Max items that may be predicted but not yet scored, bounding memory usage."""
+    backpressure_multiplier = 2
+    return backpressure_multiplier * score_workers
+
+
+def _get_scorer_rate_config(
+    predict_rps: float | None,
+    predict_adaptive: bool,
+    num_scorers: int,
+) -> tuple[float | None, bool]:
+    """Derive scorer rate limit from env var or predict rate.
+
+    When MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT is explicitly set, parse it.
+    Otherwise auto-derive as predict_rps * num_scorers.
+    """
+    if MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT.is_set():
+        return _parse_rate_limit(MLFLOW_GENAI_EVAL_SCORER_RATE_LIMIT.get())
+    scorer_rps = (predict_rps * num_scorers) if predict_rps and num_scorers else predict_rps
+    return scorer_rps, predict_adaptive
+
+
+def _get_pool_sizes(
+    predict_rps: float | None,
+    scorer_rps: float | None,
+) -> tuple[int, int]:
+    """Determine predict and score thread pool sizes.
+
+    Uses MLFLOW_GENAI_EVAL_MAX_WORKERS as an override when set, otherwise
+    derives independently from each rate limit.
+    """
+    if MLFLOW_GENAI_EVAL_MAX_WORKERS.is_set():
+        size = MLFLOW_GENAI_EVAL_MAX_WORKERS.get()
+        return size, size
+    return _pool_size(predict_rps), _pool_size(scorer_rps)
 
 
 @context.eval_context

--- a/mlflow/genai/evaluation/session_utils.py
+++ b/mlflow/genai/evaluation/session_utils.py
@@ -1,5 +1,7 @@
 """Utilities for session-level (multi-turn) evaluation."""
 
+from __future__ import annotations
+
 import traceback
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -8,6 +10,12 @@ from typing import TYPE_CHECKING, Any
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_error import AssessmentError
 from mlflow.exceptions import MlflowException
+from mlflow.genai.evaluation.rate_limiter import (
+    NoOpRateLimiter,
+    RateLimiter,
+    call_with_retry,
+    eval_retry_context,
+)
 from mlflow.genai.evaluation.utils import (
     make_code_type_assessment_source,
     standardize_scorer_value,
@@ -91,6 +99,8 @@ def evaluate_session_level_scorers(
     session_id: str,
     session_items: list["EvalItem"],
     multi_turn_scorers: list[Scorer],
+    scorer_rate_limiter: RateLimiter = NoOpRateLimiter(),
+    max_retries: int = 0,
 ) -> dict[str, list[Feedback]]:
     """
     Evaluate all multi-turn scorers for a single session.
@@ -99,6 +109,8 @@ def evaluate_session_level_scorers(
         session_id: The session identifier
         session_items: List of EvalItem objects from the same session
         multi_turn_scorers: List of multi-turn scorer instances
+        scorer_rate_limiter: Rate limiter to throttle scorer invocations.
+        max_retries: Max 429-retry attempts per scorer call.
 
     Returns:
         dict: {first_trace_id: [feedback1, feedback2, ...]}
@@ -109,7 +121,12 @@ def evaluate_session_level_scorers(
 
     def run_scorer(scorer: Scorer) -> list[Feedback]:
         try:
-            value = scorer.run(session=session_traces)
+            with eval_retry_context():
+                value = call_with_retry(
+                    lambda: scorer.run(session=session_traces),
+                    scorer_rate_limiter,
+                    max_retries,
+                )
             feedbacks = standardize_scorer_value(scorer.name, value)
 
             # Add session_id to metadata for each feedback

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -56,7 +56,7 @@ _logger = logging.getLogger(__name__)
 
 USER_DEFINED_ASSESSMENT_NAME_KEY = "_user_defined_assessment_name"
 PGBAR_FORMAT = (
-    "{l_bar}{bar}| {n_fmt}/{total_fmt} [Elapsed: {elapsed}, Remaining: {remaining}] {postfix}"
+    "{l_bar}{bar}| {n_fmt}/{total_fmt} [Elapsed: {elapsed}, Remaining: {remaining}]{postfix}"
 )
 
 

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mlflow.genai.evaluation.harness import _make_rate_limiter, _parse_rate_limit
 from mlflow.genai.evaluation.rate_limiter import (
     NoOpRateLimiter,
     RPSRateLimiter,
@@ -327,6 +328,44 @@ def test_call_with_retry_reports_throttle_and_success():
     assert result == "ok"
     # After throttle: 10.0 * 0.5 = 5.0, then success bumps it back up slightly
     assert limiter._rps < 10.0
+
+
+# ── _make_rate_limiter / _parse_rate_limit tests ──
+
+
+def test_make_rate_limiter_positive_rate():
+    assert isinstance(_make_rate_limiter(10.0), RPSRateLimiter)
+
+
+def test_make_rate_limiter_zero_returns_noop():
+    assert isinstance(_make_rate_limiter(0.0), NoOpRateLimiter)
+
+
+def test_make_rate_limiter_none_returns_noop():
+    assert isinstance(_make_rate_limiter(None), NoOpRateLimiter)
+
+
+def test_make_rate_limiter_adaptive():
+    limiter = _make_rate_limiter(10.0, adaptive=True)
+    assert isinstance(limiter, RPSRateLimiter)
+    assert limiter._adaptive is True
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_rps", "expected_adaptive"),
+    [
+        ("auto", 10.0, True),
+        ("AUTO", 10.0, True),
+        (" Auto ", 10.0, True),
+        ("25", 25.0, False),
+        ("0", None, False),
+        (None, None, False),
+    ],
+)
+def test_parse_rate_limit(raw, expected_rps, expected_adaptive):
+    rps, adaptive = _parse_rate_limit(raw)
+    assert rps == expected_rps
+    assert adaptive == expected_adaptive
 
 
 # ── eval_retry_context tests ──


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR (3/4)** — rate-limited pipelined execution for `mlflow.genai.evaluate`
> | | PR | Title |
> |---|---|---|
> | | #20937 | Add rate limiter module and evaluation environment variables |
> | | #20938 | Disable downstream 429 retries during evaluate |
> | **>>** | **#20939** | **Add harness helpers and supporting infrastructure** |
> | | #20940 | Add pipelined predict-score execution |

### Related Issues/PRs

#20684

### What changes are proposed in this pull request?

Adds helper functions and infrastructure to the evaluation harness that the pipelined execution engine (PR 4) will use. These are extracted into a separate PR to keep the final pipeline PR focused on orchestration logic.

**`mlflow/genai/evaluation/harness.py`** — helper functions and imports:
- `_parse_rate_limit(raw)` → `(rps, adaptive)` — parses `"auto"` / `"<number>"` / `"0"` from env vars
- `_make_rate_limiter(rps, adaptive, max_rps_multiplier)` — factory for `RPSRateLimiter` / `NoOpRateLimiter`
- `_get_scorer_rate_config(predict_rps, num_scorers)` — auto-derives scorer rate from predict rate
- `_get_pool_sizes(predict_rps, scorer_rps)` — computes thread pool and connection pool sizes from rate limits
- `_pool_size(rps)` — `rps * avg_llm_latency_secs`, clamped to [10, 500]
- `_Heartbeat` class — periodic pipeline progress logging (gated by `MLFLOW_GENAI_EVAL_ENABLE_HEARTBEAT`)
- Top-level `import litellm` and `import databricks.sdk` with `try/except ImportError` guards — prevents import-lock deadlocks when worker threads trigger lazy imports concurrently

**`mlflow/genai/evaluation/session_utils.py`** — adds `scorer_rate_limiter` and `max_retries` parameters to `evaluate_session_level_scorers()`, integrating `call_with_retry()` for multi-turn scorer invocations.

**`mlflow/genai/evaluation/utils.py`** — fixes `PGBAR_FORMAT` bar format string.

**Files changed:**
- `mlflow/genai/evaluation/harness.py` (+101 lines)
- `mlflow/genai/evaluation/session_utils.py` (+19/-1)
- `mlflow/genai/evaluation/utils.py` (+1/-1)
- `tests/genai/evaluate/test_rate_limiter.py` (+39 lines, 10 new tests)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

10 new tests for harness-level helpers: `_parse_rate_limit` (parametrized), `_make_rate_limiter` (adaptive/non-adaptive), `_get_pool_sizes`, `_pool_size`.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
