### PR TITLE
Display notebook trace viewer when workspace is on

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx
@@ -11,6 +11,7 @@ import {
 import { FormattedMessage } from '@databricks/i18n';
 import type { ModelTrace } from '@databricks/web-shared/model-trace-explorer';
 import { ModelTraceExplorer, getTraceArtifact } from '@databricks/web-shared/model-trace-explorer';
+import { getActiveWorkspace } from '@mlflow/mlflow/src/workspaces/utils/WorkspaceUtils';
 
 const MLFLOW_DOCS_URI = 'https://mlflow.org/docs/latest/llms/tracing/index.html?ref=jupyter-notebook-widget';
 
@@ -18,6 +19,10 @@ const getMlflowUILinkForTrace = (traceId: string, experimentId: string) => {
   const queryParams = new URLSearchParams();
   queryParams.append('selectedTraceId', traceId);
   queryParams.append('compareRunsMode', 'TRACES');
+  const workspace = getActiveWorkspace();
+  if (workspace) {
+    queryParams.append('workspace', workspace);
+  }
   return `/#/experiments/${experimentId}?${queryParams.toString()}`;
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer.tsx
@@ -17,13 +17,13 @@ const MLFLOW_DOCS_URI = 'https://mlflow.org/docs/latest/llms/tracing/index.html?
 
 const getMlflowUILinkForTrace = (traceId: string, experimentId: string) => {
   const queryParams = new URLSearchParams();
-  queryParams.append('selectedTraceId', traceId);
+  queryParams.append('selectedEvaluationId', traceId);
   queryParams.append('compareRunsMode', 'TRACES');
   const workspace = getActiveWorkspace();
   if (workspace) {
     queryParams.append('workspace', workspace);
   }
-  return `/#/experiments/${experimentId}?${queryParams.toString()}`;
+  return `/#/experiments/${experimentId}/traces?${queryParams.toString()}`;
 };
 
 export const ModelTraceExplorerOSSNotebookRenderer = () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/bootstrap.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/bootstrap.tsx
@@ -4,10 +4,18 @@ import ReactDOM from 'react-dom';
 import { IntlProvider } from '@databricks/i18n';
 import { SupportsDuBoisThemes } from '@databricks/web-shared/design-system';
 import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
+import { setActiveWorkspace } from '@mlflow/mlflow/src/workspaces/utils/WorkspaceUtils';
 import '@databricks/design-system/dist/index.css';
 import '@databricks/design-system/dist/index-dark.css';
 
 import './index.css';
+
+// Set workspace from URL query params before rendering so that all API calls
+// include the X-MLFLOW-WORKSPACE header.
+const workspaceParam = new URLSearchParams(window.location.search).get('workspace');
+if (workspaceParam) {
+  setActiveWorkspace(workspaceParam);
+}
 
 const LazyModelTraceExplorer = React.lazy(() =>
   import('@databricks/web-shared/model-trace-explorer').then((module) => ({

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -12,6 +12,7 @@ from mlflow.environment_variables import (
 from mlflow.tracing.constant import TRACE_RENDERER_ASSET_PATH
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.uri import is_http_uri
+from mlflow.utils.workspace_context import get_request_workspace
 
 _logger = logging.getLogger(__name__)
 
@@ -83,6 +84,9 @@ def _get_query_string_for_traces(traces: list["Trace"]):
     for trace in traces:
         query_params.append(("trace_id", trace.info.request_id))
         query_params.append(("experiment_id", trace.info.experiment_id))
+
+    if workspace := get_request_workspace():
+        query_params.append(("workspace", workspace))
 
     return urlencode(query_params)
 

--- a/tests/tracing/display/test_ipython.py
+++ b/tests/tracing/display/test_ipython.py
@@ -260,6 +260,20 @@ def test_notebook_trace_renderer_base_url_override(monkeypatch):
     assert "http://mlflow:5000/static-files/lib/notebook-trace-renderer/index.html" not in html
 
 
+def test_notebook_iframe_includes_workspace_query_param(monkeypatch):
+    trace = create_trace("a")
+    mlflow.set_tracking_uri("http://localhost:5000")
+
+    # Without workspace set, the query string should not contain workspace
+    html = get_notebook_iframe_html([trace])
+    assert "workspace=" not in html
+
+    # With workspace set, the query string should contain workspace
+    monkeypatch.setenv("MLFLOW_WORKSPACE", "my-workspace")
+    html = get_notebook_iframe_html([trace])
+    assert "workspace=my-workspace" in html
+
+
 def test_display_in_oss(monkeypatch):
     mock_ipython = MockIPython()
     monkeypatch.setattr("IPython.get_ipython", lambda: mock_ipython)


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Fix the issue that trace viewer on notebooks is not displayed due to the lack of workspace header when workspace is enabled on the tracking server.

<img width="882" height="812" alt="image" src="https://github.com/user-attachments/assets/0065b587-7f3b-4a13-9e23-92855ffe3837" />

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
