### PR TITLE
Prevent module logger setup from overriding user root logging

### DIFF
--- a/mlflow/pyfunc/stdin_server.py
+++ b/mlflow/pyfunc/stdin_server.py
@@ -6,9 +6,9 @@ import sys
 
 from mlflow.pyfunc import scoring_server
 from mlflow.pyfunc.model import _log_warning_if_params_not_in_predict_signature
+from mlflow.utils.logging_utils import configure_module_logger
 
-_logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+_logger = configure_module_logger(__name__, logging.INFO)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--model-uri")

--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -21,8 +21,9 @@ from mlflow.utils.autologging_utils import (
     get_autologging_config,
 )
 from mlflow.utils.checkpoint_utils import MlflowModelCheckpointCallbackBase
+from mlflow.utils.logging_utils import configure_module_logger
 
-logging.basicConfig(level=logging.ERROR)
+_logger = configure_module_logger(__name__, logging.ERROR)
 MIN_REQ_VERSION = Version(_ML_PACKAGE_VERSIONS["pytorch-lightning"]["autologging"]["minimum"])
 MAX_REQ_VERSION = Version(_ML_PACKAGE_VERSIONS["pytorch-lightning"]["autologging"]["maximum"])
 
@@ -39,8 +40,6 @@ from pytorch_lightning.utilities import rank_zero_only
 # tracking uri, experiment_id and run_id which may lead to a race condition.
 # TODO: Replace __MlflowPLCallback with Pytorch Lightning's built-in MlflowLogger
 # once the above mentioned issues have been addressed
-
-_logger = logging.getLogger(__name__)
 
 _pl_version = Version(pl.__version__)
 if _pl_version < Version("1.5.0"):

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -173,6 +173,16 @@ def _configure_mlflow_loggers(root_module_name):
     )
 
 
+def configure_module_logger(module_name: str, level: int) -> logging.Logger:
+    """
+    Configure an individual module logger without mutating global/root logging
+    configuration (for example, by calling ``logging.basicConfig``).
+    """
+    module_logger = logging.getLogger(module_name)
+    module_logger.setLevel(level)
+    return module_logger
+
+
 def eprint(*args, **kwargs):
     print(*args, file=MLFLOW_LOGGING_STREAM, **kwargs)
 

--- a/tests/pyfunc/test_stdin_server_logging.py
+++ b/tests/pyfunc/test_stdin_server_logging.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_stdin_server_does_not_use_global_basicconfig():
+    repo_root = Path(__file__).resolve().parents[2]
+    source = (repo_root / "mlflow" / "pyfunc" / "stdin_server.py").read_text(encoding="utf-8")
+    assert "logging.basicConfig(" not in source


### PR DESCRIPTION
**Task inspiration/Seed Task:**

Issue: [BUG] Calling logging.basicConfig globally overwrites users logging Config

PR: [to be updated]
issue: https://github.com/mlflow/mlflow/issues/20922

**Major differences from seed task (skip if original task):**

Replaced module-level global logging setup with scoped logger configuration helpers and added regression tests to ensure importing MLflow runtime modules no longer mutates root logging handlers.

**Agent analysis:**

- [x] Agreed with the agent result analysis.
- [ ] Disagreed with the agent result analysis. (Provide explanation and evidence below)


**Other checks:**

- [x] I've gone through the [checklist](https://docs.google.com/document/d/19riH_WBy8GFBm6jQx8E4uxCSaQ3MlAN1YlMeYV9mge4/edit?tab=t.0).
- [x] The task idea was originated from me, not an LLM.
- [x] All behavior checked in the test cases is described in the task instruction.
- [x] All behavior described in the task instruction is checked in the unit tests.
- [x] If the agent produces structured data (e.g. it is tasked with building an API) the exact schema is described in the task.yaml or a separate file.

Fixes #20922
