### PR TITLE
Fix runs table column selector CTA when rows are selected

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRuns.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRuns.tsx
@@ -38,6 +38,7 @@ import { useLoggedModelsForExperimentRunsTable } from '../../hooks/useLoggedMode
 import { ExperimentViewRunsRequestError } from '../ExperimentViewRunsRequestError';
 import { useLoggedModelsForExperimentRunsTableV2 } from '../../hooks/useLoggedModelsForExperimentRunsTableV2';
 import { useResizableMaxWidth } from '@mlflow/mlflow/src/shared/web-shared/hooks/useResizableMaxWidth';
+import { createOpenColumnSelectorViewStatePatch } from '../../utils/experimentPage.view-state-utils';
 
 export interface ExperimentViewRunsOwnProps {
   isLoading: boolean;
@@ -144,7 +145,7 @@ export const ExperimentViewRuns = React.memo((props: ExperimentViewRunsProps) =>
   );
 
   const addColumnClicked = useCallback(() => {
-    updateViewState({ columnSelectorVisible: true });
+    updateViewState(createOpenColumnSelectorViewStatePatch());
   }, [updateViewState]);
 
   const shouldNestChildrenAndFetchParents = useMemo(

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControls.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControls.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import type { ReactNode } from 'react';
+import { createExperimentPageSearchFacetsState } from '../../models/ExperimentPageSearchFacetsState';
+import { createExperimentPageUIState } from '../../models/ExperimentPageUIState';
+import { ExperimentPageViewState } from '../../models/ExperimentPageViewState';
+import { ExperimentViewRunsControls } from './ExperimentViewRunsControls';
+
+jest.mock('./ExperimentViewRunsControlsActions', () => ({
+  ExperimentViewRunsControlsActions: () => <div data-testid="runs-actions" />,
+}));
+
+jest.mock('./ExperimentViewRunsControlsFilters', () => ({
+  ExperimentViewRunsControlsFilters: ({ additionalControls }: { additionalControls: ReactNode }) => (
+    <div data-testid="runs-filters">{additionalControls}</div>
+  ),
+}));
+
+jest.mock('./ExperimentViewRunsColumnSelector', () => ({
+  ExperimentViewRunsColumnSelector: () => <div data-testid="column-selector" />,
+}));
+
+jest.mock('./ExperimentViewRunsSortSelectorV2', () => ({
+  ExperimentViewRunsSortSelectorV2: () => <div data-testid="sort-selector" />,
+}));
+
+jest.mock('./ExperimentViewRunsGroupBySelector', () => ({
+  ExperimentViewRunsGroupBySelector: () => <div data-testid="group-by-selector" />,
+}));
+
+jest.mock('../../hooks/useExperimentPageViewMode', () => ({
+  useExperimentPageViewMode: () => ['TABLE', jest.fn()],
+}));
+
+jest.mock('../../contexts/ExperimentPageUIStateContext', () => ({
+  useUpdateExperimentViewUIState: () => jest.fn(),
+}));
+
+const runsData = {
+  paramKeyList: [],
+  metricKeyList: [],
+  tagsList: [],
+  datasetsList: [],
+} as any;
+
+const searchFacetsState = createExperimentPageSearchFacetsState();
+const uiState = createExperimentPageUIState();
+
+const renderComponent = (viewStateOverride: Partial<ExperimentPageViewState> = {}) => {
+  const viewState = Object.assign(new ExperimentPageViewState(), viewStateOverride);
+
+  render(
+    <IntlProvider locale="en">
+      <DesignSystemProvider>
+        <ExperimentViewRunsControls
+          runsData={runsData}
+          viewState={viewState}
+          updateViewState={jest.fn()}
+          searchFacetsState={searchFacetsState}
+          experimentId="123"
+          requestError={null}
+          expandRows={false}
+          updateExpandRows={jest.fn()}
+          refreshRuns={jest.fn()}
+          uiState={uiState}
+          isLoading={false}
+          isComparingExperiments={false}
+        />
+      </DesignSystemProvider>
+    </IntlProvider>,
+  );
+};
+
+describe('ExperimentViewRunsControls', () => {
+  test('shows selection action buttons when runs are selected and column selector is hidden', () => {
+    renderComponent({
+      runsSelected: { 'run-1': true },
+      columnSelectorVisible: false,
+    });
+
+    expect(screen.getByTestId('runs-actions')).toBeInTheDocument();
+    expect(screen.queryByTestId('runs-filters')).not.toBeInTheDocument();
+  });
+
+  test('shows filter controls and column selector when selector is visible, even with selected runs', () => {
+    renderComponent({
+      runsSelected: { 'run-1': true },
+      columnSelectorVisible: true,
+    });
+
+    expect(screen.queryByTestId('runs-actions')).not.toBeInTheDocument();
+    expect(screen.getByTestId('runs-filters')).toBeInTheDocument();
+    expect(screen.getByTestId('column-selector')).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControls.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
 import type { UpdateExperimentViewStateFn } from '../../../../types';
-import { useRunSortOptions } from '../../hooks/useRunSortOptions';
 import type { ExperimentPageViewState } from '../../models/ExperimentPageViewState';
 import type { ExperimentRunsSelectorResult } from '../../utils/experimentRuns.selector';
 import { ExperimentViewRunsControlsActions } from './ExperimentViewRunsControlsActions';
@@ -17,6 +16,7 @@ import { ExperimentViewRunsGroupBySelector } from './ExperimentViewRunsGroupBySe
 import { useUpdateExperimentViewUIState } from '../../contexts/ExperimentPageUIStateContext';
 import type { ExperimentPageSearchFacetsState } from '../../models/ExperimentPageSearchFacetsState';
 import { ExperimentViewRunsSortSelectorV2 } from './ExperimentViewRunsSortSelectorV2';
+import { shouldShowRunsBulkActions } from '../../utils/experimentPage.view-state-utils';
 
 type ExperimentViewRunsControlsProps = {
   viewState: ExperimentPageViewState;
@@ -80,13 +80,7 @@ export const ExperimentViewRunsControls = React.memo(
       [filteredMetricKeys, filteredParamKeys, filteredTagKeys, runsData],
     );
 
-    const sortOptions = useRunSortOptions(filteredMetricKeys, filteredParamKeys);
-
-    const selectedRunsCount = Object.values(viewState.runsSelected).filter(Boolean).length;
-    const canRestoreRuns = selectedRunsCount > 0;
-    const canRenameRuns = selectedRunsCount === 1;
-    const canCompareRuns = selectedRunsCount > 1;
-    const showActionButtons = canCompareRuns || canRenameRuns || canRestoreRuns;
+    const showActionButtons = shouldShowRunsBulkActions(viewState.runsSelected, viewState.columnSelectorVisible);
 
     const showGroupBySelector = !isEvaluationMode;
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTableAddColumnCTA.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTableAddColumnCTA.tsx
@@ -219,7 +219,11 @@ export const ExperimentViewRunsTableAddColumnCTA = ({
             componentId="codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunstableaddcolumncta.tsx_218"
             css={styles.button}
             type="link"
-            onClick={onClick}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onClick();
+            }}
           >
             <PlusCircleIcon css={styles.buttonIcon} />
             <div css={styles.caption}>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentTableSelectRowHandler.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentTableSelectRowHandler.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, test, jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import { useExperimentTableSelectRowHandler } from './useExperimentTableSelectRowHandler';
+
+describe('useExperimentTableSelectRowHandler', () => {
+  test('closes column selector when at least one run is selected', () => {
+    const updateViewState = jest.fn();
+    const { result } = renderHook(() => useExperimentTableSelectRowHandler(updateViewState));
+
+    result.current.onSelectionChange({
+      api: {
+        getSelectedRows: () => [{ runInfo: { runUuid: 'run-1' } }],
+      },
+    } as any);
+
+    expect(updateViewState).toHaveBeenCalledWith({
+      runsSelected: { 'run-1': true },
+      columnSelectorVisible: false,
+    });
+  });
+
+  test('only updates runsSelected when there are no selected rows', () => {
+    const updateViewState = jest.fn();
+    const { result } = renderHook(() => useExperimentTableSelectRowHandler(updateViewState));
+
+    result.current.onSelectionChange({
+      api: {
+        getSelectedRows: () => [],
+      },
+    } as any);
+
+    expect(updateViewState).toHaveBeenCalledWith({
+      runsSelected: {},
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentTableSelectRowHandler.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentTableSelectRowHandler.tsx
@@ -1,8 +1,9 @@
 import type { GridApi, RowSelectedEvent, SelectionChangedEvent } from '@ag-grid-community/core';
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import type { ExperimentPageViewState } from '../models/ExperimentPageViewState';
 import type { RunRowType } from '../utils/experimentPage.row-types';
 import { uniqBy } from 'lodash';
+import { mapSelectedRunUuids } from '../utils/experimentPage.view-state-utils';
 
 /**
  * Helper function that select particular run rows in the ag-grid.
@@ -67,8 +68,11 @@ export const useExperimentTableSelectRowHandler = (
         // Filter out "load more" and group rows
         .filter((row) => row.runInfo)
         .map(({ runInfo }) => runInfo.runUuid);
+      const selectedRunsMap = mapSelectedRunUuids(selectedUUIDs);
+
       updateViewState({
-        runsSelected: selectedUUIDs.reduce((aggregate, curr) => ({ ...aggregate, [curr]: true }), {}),
+        runsSelected: selectedRunsMap,
+        ...(selectedUUIDs.length ? { columnSelectorVisible: false } : {}),
       });
     },
     [updateViewState],

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.view-state-utils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.view-state-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  createOpenColumnSelectorViewStatePatch,
+  mapSelectedRunUuids,
+  shouldShowRunsBulkActions,
+} from './experimentPage.view-state-utils';
+
+describe('experimentPage.view-state-utils', () => {
+  test('maps selected run UUIDs to a lookup map', () => {
+    expect(mapSelectedRunUuids(['run-1', 'run-2'])).toEqual({
+      'run-1': true,
+      'run-2': true,
+    });
+  });
+
+  test('shows bulk actions only when runs are selected and column selector is hidden', () => {
+    const selectedRuns = mapSelectedRunUuids(['run-1']);
+
+    expect(shouldShowRunsBulkActions(selectedRuns, false)).toBe(true);
+    expect(shouldShowRunsBulkActions(selectedRuns, true)).toBe(false);
+    expect(shouldShowRunsBulkActions({}, false)).toBe(false);
+  });
+
+  test('creates a patch that opens the column selector', () => {
+    expect(createOpenColumnSelectorViewStatePatch()).toEqual({
+      columnSelectorVisible: true,
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.view-state-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.view-state-utils.ts
@@ -1,0 +1,24 @@
+import type { ExperimentPageViewState } from '../models/ExperimentPageViewState';
+
+export const mapSelectedRunUuids = (
+  runUuids: string[],
+): ExperimentPageViewState['runsSelected'] =>
+  runUuids.reduce<ExperimentPageViewState['runsSelected']>((selected, runUuid) => {
+    selected[runUuid] = true;
+    return selected;
+  }, {});
+
+export const getSelectedRunsCount = (runsSelected: ExperimentPageViewState['runsSelected']) =>
+  Object.values(runsSelected).filter(Boolean).length;
+
+export const shouldShowRunsBulkActions = (
+  runsSelected: ExperimentPageViewState['runsSelected'],
+  columnSelectorVisible: boolean,
+) => getSelectedRunsCount(runsSelected) > 0 && !columnSelectorVisible;
+
+export const createOpenColumnSelectorViewStatePatch = (): Pick<
+  ExperimentPageViewState,
+  'columnSelectorVisible'
+> => ({
+  columnSelectorVisible: true,
+});


### PR DESCRIPTION
**Task inspiration/Seed Task:**

Issue: [BUG] "Show more columns" dropdown does not open when a run row is selected

PR: [to be updated]
issue: https://github.com/mlflow/mlflow/issues/20873

**Major differences from seed task (skip if original task):**

Reworked runs-table control state routing so the column selector can open from the table CTA while selected-run bulk actions are active, then added focused utility and hook tests for the selection and visibility transitions.

**Agent analysis:**

- [x] Agreed with the agent result analysis.
- [ ] Disagreed with the agent result analysis. (Provide explanation and evidence below)


**Other checks:**

- [x] I've gone through the [checklist](https://docs.google.com/document/d/19riH_WBy8GFBm6jQx8E4uxCSaQ3MlAN1YlMeYV9mge4/edit?tab=t.0).
- [x] The task idea was originated from me, not an LLM.
- [x] All behavior checked in the test cases is described in the task instruction.
- [x] All behavior described in the task instruction is checked in the unit tests.
- [x] If the agent produces structured data (e.g. it is tasked with building an API) the exact schema is described in the task.yaml or a separate file.

Fixes #20873
