### PR TITLE
fix: raise MlflowException when logging a boolean metric value

### DIFF
--- a/mlflow/tracking/metric_value_conversion_utils.py
+++ b/mlflow/tracking/metric_value_conversion_utils.py
@@ -38,6 +38,18 @@ def convert_metric_value_to_float_if_possible(x) -> float:
     if x is None or type(x) == float:
         return x
 
+    # Explicitly reject booleans. In Python, bool is a subclass of int, so
+    # float(True) = 1.0 and float(False) = 0.0 silently. This is almost always
+    # a user mistake (e.g., logging a condition result as a metric). Users
+    # should use mlflow.set_tag() for boolean flags instead.
+    if isinstance(x, bool):
+        raise MlflowException(
+            f"Invalid metric value '{x!r}' (type: bool). "
+            "Metrics must be numeric (int or float). "
+            "If you intended to log a boolean flag, use mlflow.set_tag() instead.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
     converter_fns_to_try = [
         convert_metric_value_to_float_if_ndarray,
         convert_metric_value_to_float_if_tensorflow_tensor,


### PR DESCRIPTION
### Related Issues/PRs

N/A (new bug discovered during code review)

### What changes are proposed in this pull request?

`mlflow.log_metric(flag, True)` silently converts boolean values to float (`True -> 1.0`, `False -> 0.0`) without any error or warning. This is a silent data corruption issue.

**Root Cause**: In `metric_value_conversion_utils.py`, the function uses `type(x) == float` (strict check). Since `bool` is a subclass of `int` in Python, `type(True) == float` is `False`, so booleans fall through to `float(x)` silently.

**Fix**: Added an explicit `isinstance(x, bool)` guard that raises a clear `MlflowException` directing users to use `mlflow.set_tag()` for boolean flags instead.

### How is this PR tested?

- [x] Manual tests

Before fix: `mlflow.log_metric(flag, True)` silently stores `1.0`

After fix: raises `MlflowException: Invalid metric value 'True' (type: bool). Metrics must be numeric (int or float). If you intended to log a boolean flag, use mlflow.set_tag() instead.`

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.log_metric()` now raises a clear `MlflowException` when a boolean value is passed, instead of silently converting it to `1.0` or `0.0`. Users should use `mlflow.set_tag()` for boolean flags.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name=release-note-category></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)