### PR TITLE
fix: scale artifacts to fit parent frame in comparison view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -86,7 +86,7 @@ const ShowArtifactImageView = ({
 const classNames = {
   imageOuterContainer: {
     padding: '10px',
-    overflow: 'scroll',
+    overflow: 'auto',
     // Let's keep images (esp. transparent PNGs) on the white background regardless of the theme
     background: 'white',
     minHeight: '100%',
@@ -94,6 +94,9 @@ const classNames = {
   imageWrapper: { display: 'inline-block' },
   image: {
     cursor: 'pointer',
+    maxWidth: '100%',
+    height: 'auto',
+    display: 'block',
     '&:hover': {
       boxShadow: '0 0 4px gray',
     },


### PR DESCRIPTION
### Related Issues/PRs

Resolve #20703

### What changes are proposed in this pull request?

Images in the runs comparison view were not scaling to fit their column width, causing horizontal overflow and making side-by-side comparison difficult.

Modified `ShowArtifactImageView.tsx`:
- Added `maxWidth: '100%'` to scale image down to fit column width
- Added `height: 'auto'` to maintain aspect ratio
- Added `display: 'block'` to remove inline baseline gap
- Changed `overflow: 'scroll'` to `overflow: 'auto'` on the outer container to avoid permanent scrollbars when the image fits

### How is this PR tested?

- [x] Manual tests

Steps:
1. Log an image artifact to two runs
2. Open the comparison view and select the image artifact
3. Verify the image scales to fit the column without horizontal overflow

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Image artifacts in the runs comparison view now scale to fit their column width, fixing horizontal overflow and improving side-by-side comparison.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name=release-note-category></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)