### PR TITLE
fix(docker-compose): replace MinIO with local artifact storage

### DIFF
--- a/docker-compose/.env.dev.example
+++ b/docker-compose/.env.dev.example
@@ -3,20 +3,11 @@ POSTGRES_USER=mlflow
 POSTGRES_PASSWORD=mlflow
 POSTGRES_DB=mlflow
 
-# MinIO
-MINIO_ROOT_USER=minio
-MINIO_ROOT_PASSWORD=minio123
-MINIO_HOST=minio
-MINIO_PORT=9000
-MINIO_BUCKET=mlflow
-
 # MLflow Server
 MLFLOW_BACKEND_STORE_URI=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-MLFLOW_ARTIFACTS_DESTINATION=s3://${MINIO_BUCKET}/
-MLFLOW_S3_ENDPOINT_URL=http://${MINIO_HOST}:${MINIO_PORT}
 
-# AWS region (for Boto3)
-AWS_DEFAULT_REGION=us-east-1
+# Artifacts are stored locally in ./mlartifacts (mounted into the container)
+MLFLOW_ARTIFACTS_DESTINATION=file:///mlflow/mlartifacts
 
 # MLflow listen settings
 MLFLOW_HOST=0.0.0.0

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,6 +1,5 @@
 volumes:
   pgdata:
-  minio-data:
 
 services:
   postgres:
@@ -20,60 +19,18 @@ services:
       timeout: 3s
       retries: 10
 
-  minio:
-    image: minio/minio:latest
-    container_name: mlflow-minio
-    environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
-    volumes:
-      - minio-data:/data
-    command: server /data --console-address ":9001"
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${MINIO_PORT}/minio/health/live"]
-      interval: 5s
-      timeout: 3s
-      retries: 20
-
-  create-bucket:
-    image: minio/mc:latest
-    container_name: mlflow-create-bucket
-    depends_on:
-      minio:
-        condition: service_healthy
-    entrypoint:
-      - /bin/sh
-      - -c
-      - |
-        mc alias set myminio "http://${MINIO_HOST}:${MINIO_PORT}" \
-          "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"
-        mc mb --ignore-existing "myminio/${MINIO_BUCKET:-mlflow}"
-    restart: "no"
-
   mlflow:
     image: ghcr.io/mlflow/mlflow:${MLFLOW_VERSION}
     container_name: mlflow-server
     depends_on:
       postgres:
         condition: service_healthy
-      minio:
-        condition: service_healthy
-      create-bucket:
-        condition: service_completed_successfully
     environment:
       # Backend store URI built from vars
       MLFLOW_BACKEND_STORE_URI: ${MLFLOW_BACKEND_STORE_URI}
 
-      # S3/MinIO settings
-      MLFLOW_S3_ENDPOINT_URL: ${MLFLOW_S3_ENDPOINT_URL}
+      # Local artifact storage
       MLFLOW_ARTIFACTS_DESTINATION: ${MLFLOW_ARTIFACTS_DESTINATION}
-      AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
-      AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
-      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
-      MLFLOW_S3_IGNORE_TLS: "true"
 
       # Server host/port
       MLFLOW_HOST: ${MLFLOW_HOST}
@@ -83,7 +40,7 @@ services:
       - /bin/bash
       - -c
       - |
-        pip install --no-cache-dir psycopg2-binary boto3
+        pip install --no-cache-dir psycopg2-binary
         mlflow server \
           --backend-store-uri "${MLFLOW_BACKEND_STORE_URI}" \
           --artifacts-destination "${MLFLOW_ARTIFACTS_DESTINATION}" \
@@ -92,6 +49,8 @@ services:
           --port "${MLFLOW_PORT}"
     ports:
       - "${MLFLOW_PORT}:${MLFLOW_PORT}"
+    volumes:
+      - ./mlartifacts:/mlflow/mlartifacts
     healthcheck:
       test:
         [


### PR DESCRIPTION
### Related Issues/PRs

N/A (addresses community request: Move away from MinIO in docker compose setup)

### What changes are proposed in this pull request?

Simplifies the local MLflow Docker Compose setup by removing the MinIO and `create-bucket` services. Artifacts are now stored on the local filesystem (`./mlartifacts`) mounted into the container.

This reduces complexity and resource usage for local development â€” users no longer need to configure S3 credentials or wait for MinIO to start.

Changes:
- **`docker-compose.yml`**: Removed `minio` and `create-bucket` services, removed `minio-data` volume, added `./mlartifacts` volume mount, removed all S3/MinIO env vars
- **`.env.dev.example`**: Removed MinIO section, updated `MLFLOW_ARTIFACTS_DESTINATION` to `file:///mlflow/mlartifacts`
- **`README.md`**: Updated overview, env vars table, and how-it-works section to reflect local storage

### How is this PR tested?

- [x] Manual tests

Steps:
1. `cd docker-compose && cp .env.dev.example .env`
2. `docker compose up -d`
3. Verify MLflow UI at http://localhost:5000
4. Log a run and confirm artifacts appear in `./mlartifacts` on the host

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The Docker Compose setup no longer requires MinIO. Artifacts are now stored locally in `./mlartifacts`, simplifying local development setup.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/docs`: MLflow documentation pages

<a name=release-note-category></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
