### PR TITLE
fix:implement dark mode in experiment correctly

### DIFF
--- a/mlflow/server/js/src/common/components/EditableNote.css
+++ b/mlflow/server/js/src/common/components/EditableNote.css
@@ -9,3 +9,54 @@
 .mde-header {
   background: none;
 }
+
+/* Override react-mde library defaults for dark mode */
+
+/* Container border */
+.mlflow-dark-theme .react-mde {
+  border-color: var(--mlflow-dark-border) !important;
+}
+
+/* Toolbar header */
+.mlflow-dark-theme .mde-header {
+  background: var(--mlflow-dark-bg-secondary) !important;
+  border-bottom-color: var(--mlflow-dark-border) !important;
+}
+
+/* Write/Preview tab buttons */
+.mlflow-dark-theme .mde-header .mde-tabs button {
+  color: var(--mlflow-dark-text-primary) !important;
+}
+
+.mlflow-dark-theme .mde-header .mde-tabs button.selected {
+  border-color: var(--mlflow-dark-border) !important;
+  background-color: var(--mlflow-dark-bg-primary) !important;
+}
+
+/* Toolbar icon buttons */
+.mlflow-dark-theme .mde-header ul.mde-header-group li.mde-header-item button {
+  color: var(--mlflow-dark-text-primary) !important;
+}
+
+.mlflow-dark-theme .mde-header ul.mde-header-group li.mde-header-item button:hover {
+  background-color: var(--mlflow-dark-bg-hover) !important;
+}
+
+/* Textarea (write tab) */
+.mlflow-dark-theme .mde-textarea-wrapper textarea.mde-text {
+  background-color: var(--mlflow-dark-bg-primary) !important;
+  color: var(--mlflow-dark-text-primary) !important;
+}
+
+/* Preview pane */
+.mlflow-dark-theme .mde-preview .mde-preview-content {
+  background-color: var(--mlflow-dark-bg-primary) !important;
+  color: var(--mlflow-dark-text-primary) !important;
+}
+
+/* Image drop tip area */
+.mlflow-dark-theme .react-mde .image-tip {
+  background-color: var(--mlflow-dark-bg-secondary) !important;
+  color: var(--mlflow-dark-text-primary) !important;
+  border-top-color: var(--mlflow-dark-border) !important;
+}

--- a/mlflow/server/js/src/common/components/EditableNote.tsx
+++ b/mlflow/server/js/src/common/components/EditableNote.tsx
@@ -239,23 +239,24 @@ type ThemeAwareReactMdeProps = React.ComponentProps<typeof ReactMde>;
 
 export function ThemeAwareReactMde(props: ThemeAwareReactMdeProps) {
   const { theme } = useDesignSystemTheme();
-  
+
   // Apply theme-aware CSS variables for ReactMde
-  const themeAwareStyle = React.useMemo(() => ({
-    '--mlflow-dark-bg-primary': theme.colors.backgroundPrimary,
-    '--mlflow-dark-bg-secondary': theme.colors.backgroundSecondary,
-    '--mlflow-dark-bg-hover': theme.colors.actionDefaultBackgroundHover,
-    '--mlflow-dark-text-primary': theme.colors.textPrimary,
-    '--mlflow-dark-border': theme.colors.border,
-  } as React.CSSProperties), [theme]);
+  const themeAwareStyle = React.useMemo(
+    () =>
+      ({
+        '--mlflow-dark-bg-primary': theme.colors.backgroundPrimary,
+        '--mlflow-dark-bg-secondary': theme.colors.backgroundSecondary,
+        '--mlflow-dark-bg-hover': theme.colors.actionDefaultBackgroundHover,
+        '--mlflow-dark-text-primary': theme.colors.textPrimary,
+        '--mlflow-dark-border': theme.colors.border,
+      }) as React.CSSProperties,
+    [theme],
+  );
 
   const isDarkTheme = theme.isDarkMode;
 
   return (
-    <div 
-      className={isDarkTheme ? 'mlflow-dark-theme' : ''}
-      style={themeAwareStyle}
-    >
+    <div className={isDarkTheme ? 'mlflow-dark-theme' : ''} style={themeAwareStyle}>
       <ReactMde {...props} />
     </div>
   );

--- a/mlflow/server/js/src/common/components/EditableNote.tsx
+++ b/mlflow/server/js/src/common/components/EditableNote.tsx
@@ -173,8 +173,8 @@ export class EditableNoteImpl extends Component<EditableNoteImplProps, EditableN
         {showEditor ? (
           <React.Fragment>
             <div className="note-view-text-area">
-              <ReactMde
-                value={markdown}
+              <ThemeAwareReactMde
+                value={markdown || ''}
                 minEditorHeight={this.props.minEditorHeight}
                 maxEditorHeight={this.props.maxEditorHeight}
                 minPreviewHeight={50}
@@ -232,6 +232,32 @@ function TooltipIcon(props: TooltipIconProps) {
         <SvgIcon icon={name} />
       </span>
     </Tooltip>
+  );
+}
+
+type ThemeAwareReactMdeProps = React.ComponentProps<typeof ReactMde>;
+
+export function ThemeAwareReactMde(props: ThemeAwareReactMdeProps) {
+  const { theme } = useDesignSystemTheme();
+  
+  // Apply theme-aware CSS variables for ReactMde
+  const themeAwareStyle = React.useMemo(() => ({
+    '--mlflow-dark-bg-primary': theme.colors.backgroundPrimary,
+    '--mlflow-dark-bg-secondary': theme.colors.backgroundSecondary,
+    '--mlflow-dark-bg-hover': theme.colors.actionDefaultBackgroundHover,
+    '--mlflow-dark-text-primary': theme.colors.textPrimary,
+    '--mlflow-dark-border': theme.colors.border,
+  } as React.CSSProperties), [theme]);
+
+  const isDarkTheme = theme.isDarkMode;
+
+  return (
+    <div 
+      className={isDarkTheme ? 'mlflow-dark-theme' : ''}
+      style={themeAwareStyle}
+    >
+      <ReactMde {...props} />
+    </div>
   );
 }
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewDescriptionNotes.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewDescriptionNotes.tsx
@@ -14,14 +14,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { getExperimentTags } from '../../../reducers/Reducers';
 import { NOTE_CONTENT_TAG } from '../../../utils/NoteUtils';
 import type { ThunkDispatch } from '../../../../redux-types';
-import React from 'react';
-import 'react-mde/lib/styles/css/react-mde-all.css';
-import ReactMde, { SvgIcon } from 'react-mde';
+import { SvgIcon } from 'react-mde';
 import {
   forceAnchorTagNewTab,
   getMarkdownConverter,
   sanitizeConvertedHtml,
 } from '../../../../common/utils/MarkdownUtils';
+import { ThemeAwareReactMde } from '../../../../common/components/EditableNote';
 import { FormattedMessage } from 'react-intl';
 import { setExperimentTagApi } from '../../../actions';
 import { shouldEnableExperimentPageSideTabs } from '@mlflow/mlflow/src/common/utils/FeatureUtils';
@@ -68,7 +67,7 @@ export const ExperimentViewDescriptionNotes = ({
 
   const effectiveNote = storedNote || defaultValue;
   const [tmpNote, setTmpNote] = useState(effectiveNote);
-  const [selectedTab, setSelectedTab] = useState<'write' | 'preview' | undefined>('write');
+  const [selectedTab, setSelectedTab] = useState<'write' | 'preview'>('write');
   const [isExpanded, setIsExpanded] = useState(false);
 
   const { theme } = useDesignSystemTheme();
@@ -176,26 +175,24 @@ export const ExperimentViewDescriptionNotes = ({
           setEditing(false);
         }}
       >
-        <React.Fragment>
-          <ReactMde
-            value={tmpNote}
-            minEditorHeight={MIN_EDITOR_HEIGHT}
-            maxEditorHeight={MAX_EDITOR_HEIGHT}
-            minPreviewHeight={MIN_PREVIEW_HEIGHT}
-            toolbarCommands={toolbarCommands}
-            onChange={(value) => setTmpNote(value)}
-            selectedTab={selectedTab}
-            onTabChange={(newTab) => setSelectedTab(newTab)}
-            generateMarkdownPreview={() => Promise.resolve(getSanitizedHtmlContent(tmpNote))}
-            getIcon={(name) => (
-              <Tooltip componentId="mlflow.experiment-tracking.experiment-description.edit" content={name}>
-                <span css={{ color: theme.colors.textPrimary }}>
-                  <SvgIcon icon={name} />
-                </span>
-              </Tooltip>
-            )}
-          />
-        </React.Fragment>
+        <ThemeAwareReactMde
+          value={tmpNote || ''}
+          minEditorHeight={MIN_EDITOR_HEIGHT}
+          maxEditorHeight={MAX_EDITOR_HEIGHT}
+          minPreviewHeight={MIN_PREVIEW_HEIGHT}
+          toolbarCommands={toolbarCommands}
+          onChange={(value) => setTmpNote(value)}
+          selectedTab={selectedTab}
+          onTabChange={(newTab) => setSelectedTab(newTab)}
+          generateMarkdownPreview={() => Promise.resolve(getSanitizedHtmlContent(tmpNote))}
+          getIcon={(name) => (
+            <Tooltip componentId="mlflow.experiment-tracking.experiment-description.edit" content={name}>
+              <span css={{ color: theme.colors.textPrimary }}>
+                <SvgIcon icon={name} />
+              </span>
+            </Tooltip>
+          )}
+        />
       </Modal>
     </div>
   );


### PR DESCRIPTION
### Related Issues/PRs

Closes #20874

### What changes are proposed in this pull request?

Fix the "Add description" modal rich text editor (ReactMde) to fully respect dark mode theme. Previously, only toolbar icon colors were themed; the toolbar background, tab buttons, textarea, preview pane, and container border all retained their light-mode defaults.

Changes:
- **`EditableNote.tsx`**: Created and exported a `ThemeAwareReactMde` wrapper component that conditionally applies a `mlflow-dark-theme` CSS class and injects design system theme tokens as CSS custom properties.
- **`EditableNote.css`**: Added dark mode overrides for all ReactMde areas — container border, toolbar header, tab buttons, toolbar icon buttons, textarea, preview pane, and image drop tip area.
- **`ExperimentViewDescriptionNotes.tsx`**: Replaced inline `ReactMde` usage with the shared `ThemeAwareReactMde` wrapper, removing duplicated theme logic.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Manual testing steps:**
1. Start the dev server (`yarn start`)
2. Enable dark mode
3. Navigate to an experiment and click "Add description"
4. Verify the modal editor toolbar, textarea, and preview pane all use dark theme colors
5. Switch back to light mode and verify the editor renders normally

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

<img width="938" height="562" alt="image" src="https://github.com/user-attachments/assets/2e2d0aeb-faf9-4a14-98a0-d5b5cc320756" />

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix the experiment "Add description" modal editor to fully respect dark mode theme, including toolbar, textarea, and preview pane styling.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

