### PR TITLE
Fix search_datasets experiment_id filter for Databricks

### DIFF
--- a/mlflow/genai/datasets/__init__.py
+++ b/mlflow/genai/datasets/__init__.py
@@ -391,7 +391,7 @@ def search_datasets(
     order_by: list[str] | None = None,
 ) -> list[EvaluationDataset]:
     """
-    Search for datasets (non-Databricks only).
+    Search for datasets.
 
     .. warning::
         Calling ``search_datasets()`` without any parameters will return ALL datasets
@@ -518,9 +518,6 @@ def search_datasets(
                 print(f"{dataset.name} (ID: {dataset.dataset_id})")
                 print(f"  Tags: {dataset.tags}")
 
-    Note:
-        This API is not available in Databricks environments. Use Unity Catalog
-        search capabilities in Databricks instead.
     """
     if isinstance(experiment_ids, str):
         experiment_ids = [experiment_ids]

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -892,7 +892,7 @@ class DatabricksTracingRestStore(RestStore):
         """Fetch a single page of datasets from the backend."""
         params = {}
         if experiment_ids:
-            params["filter"] = f"experiment_id={experiment_ids[0]}"
+            params["filter"] = f"experiment_id='{experiment_ids[0]}'"
         if page_size:
             params["page_size"] = str(page_size)
         if page_token:

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -1513,8 +1513,8 @@ def test_search_datasets_basic():
         endpoint = call_args[1]["endpoint"]
         assert call_args[1]["method"] == "GET"
         assert "/api/2.0/managed-evals/datasets" in endpoint
-        # URL encoding: = becomes %3D
-        assert "experiment_id%3Dexp_1" in endpoint or "experiment_id=exp_1" in endpoint
+        # URL encoding: = becomes %3D, ' becomes %27
+        assert "experiment_id%3D%27exp_1%27" in endpoint or "experiment_id='exp_1'" in endpoint
         # Verify max_results is passed as page_size
         assert "page_size=100" in endpoint
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
The managed-evals API treats experiment_id as a string field, so the filter value must be quoted. Without quotes, the API rejects it as an invalid numeric filter field.

Also remove the incorrect note stating search_datasets is not available in Databricks environments.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
