### PR TITLE
Enrich telemetry `tracking_uri_scheme` with server backend type for http/https

### DIFF
--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -30,6 +30,8 @@ from mlflow.utils.logging_utils import should_suppress_logs_in_thread, suppress_
 from mlflow.utils.rest_utils import http_request
 
 
+# Cache per tracking URI; 16 is more than enough for any realistic number of
+# distinct tracking URIs within a single process.
 @lru_cache(maxsize=16)
 def _fetch_server_store_type(tracking_uri: str) -> str | None:
     host_creds = get_default_host_creds(tracking_uri)

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -51,9 +51,7 @@ def _fetch_server_store_type(tracking_uri: str) -> str | None:
     return None
 
 
-def _enrich_scheme_with_store_type(
-    scheme: Literal["http", "https"], store_type: Literal["FileStore", "SqlStore"] | None
-) -> str:
+def _enrich_http_scheme(scheme: Literal["http", "https"], store_type: str | None) -> str:
     store_type_to_suffix = {"FileStore": "file", "SqlStore": "sql"}
     if suffix := store_type_to_suffix.get(store_type):
         return f"{scheme}-{suffix}"
@@ -430,7 +428,7 @@ class TelemetryClient:
         from mlflow.tracking._tracking_service.utils import get_tracking_uri
 
         store_type = _fetch_server_store_type(get_tracking_uri())
-        return _enrich_scheme_with_store_type(scheme, store_type)
+        return _enrich_http_scheme(scheme, store_type)
 
     def _update_backend_store(self):
         """

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -34,20 +34,19 @@ from mlflow.utils.rest_utils import http_request
 # distinct tracking URIs within a single process.
 @lru_cache(maxsize=16)
 def _fetch_server_store_type(tracking_uri: str) -> str | None:
-    host_creds = get_default_host_creds(tracking_uri)
     try:
         response = http_request(
-            host_creds=host_creds,
+            host_creds=get_default_host_creds(tracking_uri),
             endpoint="/api/3.0/mlflow/server-info",
             method="GET",
             timeout=3,
             max_retries=0,
             raise_on_status=False,
         )
+        if response.status_code == 200:
+            return response.json().get("store_type")
     except Exception:
-        return None
-    if response.status_code == 200:
-        return response.json().get("store_type")
+        pass
     return None
 
 

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -3,8 +3,20 @@ from unittest.mock import Mock, patch
 import pytest
 
 import mlflow.telemetry.utils
-from mlflow.telemetry.client import TelemetryClient, _set_telemetry_client, get_telemetry_client
+from mlflow.telemetry.client import (
+    TelemetryClient,
+    _fetch_server_store_type,
+    _set_telemetry_client,
+    get_telemetry_client,
+)
 from mlflow.version import VERSION
+
+
+@pytest.fixture(autouse=True)
+def clear_server_store_type_cache():
+    _fetch_server_store_type.cache_clear()
+    yield
+    _fetch_server_store_type.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import mlflow.telemetry.utils
 from mlflow.telemetry.client import (
     TelemetryClient,
-    _fetch_server_store_type,
+    _fetch_server_info,
     _set_telemetry_client,
     get_telemetry_client,
 )
@@ -14,9 +14,9 @@ from mlflow.version import VERSION
 
 @pytest.fixture(autouse=True)
 def clear_server_store_type_cache():
-    _fetch_server_store_type.cache_clear()
+    _fetch_server_info.cache_clear()
     yield
-    _fetch_server_store_type.cache_clear()
+    _fetch_server_info.cache_clear()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

When the tracking URI is `http` or `https`, the telemetry `tracking_uri_scheme` field only reports the transport protocol, making it impossible to distinguish whether a remote server is backed by a file store or a SQL store.

This PR calls the existing `/api/3.0/mlflow/server-info` endpoint to fetch the server info and produce composite scheme values:

| Server backend      | Scheme value     |
| ------------------- | ---------------- |
| http(s) + FileStore | `http(s)-file`   |
| http(s) + SqlStore  | `http(s)-sql`    |
| error / 404 / null  | `http` / `https` |

The server info is cached per tracking URI using `@lru_cache(maxsize=16)` and uses `http_request` with `get_default_host_creds` for proper authentication handling. The function returns the full response dict for future extensibility.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)