### PR TITLE
ResponsesAgent: require annotations for the ResponsesOutputText type

### DIFF
--- a/mlflow/types/responses.py
+++ b/mlflow/types/responses.py
@@ -200,9 +200,8 @@ def create_text_output_item(
     content_item = {
         "text": text,
         "type": "output_text",
+        "annotations": annotations or [],
     }
-    if annotations is not None:
-        content_item["annotations"] = annotations
     return {
         "id": id,
         "content": [content_item],

--- a/mlflow/types/responses_helpers.py
+++ b/mlflow/types/responses_helpers.py
@@ -74,7 +74,7 @@ class Annotation(BaseModel):
 
 
 class ResponseOutputText(BaseModel):
-    annotations: list[Annotation] | None = None
+    annotations: list[Annotation] = []
     text: str
     type: str = "output_text"
 

--- a/mlflow/types/responses_helpers.py
+++ b/mlflow/types/responses_helpers.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 """
 Classes are inspired by classes for Response and ResponseStreamEvent in openai-python
@@ -74,7 +74,7 @@ class Annotation(BaseModel):
 
 
 class ResponseOutputText(BaseModel):
-    annotations: list[Annotation] = []
+    annotations: list[Annotation] = Field(default_factory=list)
     text: str
     type: str = "output_text"
 

--- a/tests/pyfunc/test_responses_agent.py
+++ b/tests/pyfunc/test_responses_agent.py
@@ -597,7 +597,7 @@ def test_responses_agent_non_mlflow_decorators():
                     custom_outputs=None,
                     item={
                         "id": "chatcmpl_fd04a20f-f348-45e1-af37-68cf3bb08bdb",
-                        "content": [{"text": "Hello!", "type": "output_text"}],
+                        "content": [{"text": "Hello!", "type": "output_text", "annotations": []}],
                         "role": "assistant",
                         "type": "message",
                     },
@@ -697,7 +697,11 @@ def test_responses_agent_non_mlflow_decorators():
                     item={
                         "id": "chatcmpl_fd04a20f-f348-45e1-af37-68cf3bb08bdb",
                         "content": [
-                            {"text": "Hello! How can I help you today?", "type": "output_text"}
+                            {
+                                "text": "Hello! How can I help you today?",
+                                "type": "output_text",
+                                "annotations": [],
+                            }
                         ],
                         "role": "assistant",
                         "type": "message",
@@ -748,7 +752,9 @@ def test_responses_agent_non_mlflow_decorators():
                     custom_outputs=None,
                     item={
                         "id": "msg_bdrk_016AC1ojH743YLHDfgnf4B7Y",
-                        "content": [{"text": "Hello there! I'", "type": "output_text"}],
+                        "content": [
+                            {"text": "Hello there! I'", "type": "output_text", "annotations": []}
+                        ],
                         "role": "assistant",
                         "type": "message",
                     },
@@ -906,7 +912,13 @@ def test_responses_agent_non_mlflow_decorators():
                     custom_outputs=None,
                     item={
                         "id": "msg_bdrk_015YdA8hjVSHWxpAdecgHqj3",
-                        "content": [{"text": "I can help you calculate 4*", "type": "output_text"}],
+                        "content": [
+                            {
+                                "text": "I can help you calculate 4*",
+                                "type": "output_text",
+                                "annotations": [],
+                            }
+                        ],
                         "role": "assistant",
                         "type": "message",
                     },
@@ -1140,9 +1152,11 @@ def test_responses_agent_non_mlflow_decorators():
                     type="response.output_item.done",
                     item={
                         "id": "msg1",
-                        "type": "message",
+                        "content": [
+                            {"text": "Calling tools.", "type": "output_text", "annotations": []}
+                        ],
                         "role": "assistant",
-                        "content": [{"text": "Calling tools.", "type": "output_text"}],
+                        "type": "message",
                     },
                 ),
                 ResponsesAgentStreamEvent(

--- a/tests/pyfunc/test_responses_agent.py
+++ b/tests/pyfunc/test_responses_agent.py
@@ -1238,6 +1238,7 @@ def test_create_text_output_item():
             {
                 "text": "Hello world",
                 "type": "output_text",
+                "annotations": [],
             }
         ],
         "role": "assistant",


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

requiring the annotations field, with a default

this change should be backwards compatible for everyone that doesn't explicitly set annotations = None

same class in openai-python class with a required field: https://github.com/openai/openai-python/blob/3e0c05b84a2056870abf3bd6a5e7849020209cc3/src/openai/types/responses/response_output_text.py#L122

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

previously, encountered issues with MLflow ResponsesAgent outputs not having annotations:
```
cause: _TypeValidationError [AI_TypeValidationError]: Type validation failed: Value: {"object":"response","output":[{"type":"message","id":"lc_run--019c733d-780b-7122-a4ea-e94f9896f100","content":[{"text":"I'm a helpful AI assistant with several capabilities:\n\n**General Assistance:**\n- Answer questions on a wide range of topics\n- Provide explanations and information\n- Help with problem-solving and decision-making\n- Offer creative ideas and suggestions\n\n**Technical Skills:**\n- Execute Python code for calculations, data analysis, and programming tasks\n- Solve math problems\n- Work with data and create visualizations\n- Help with coding questions\n\n**Memory Features:**\n- Remember important information about you across conversations\n- Recall your preferences, interests, and past discussions\n- Provide personalized responses based on what I know about you\n\n**Writing & Communication:**\n- Help draft emails, documents, or creative content\n- Proofread and edit text\n- Explain complex topics in simple terms\n- Translate concepts between different contexts\n\n**Planning & Organization:**\n- Help break down complex tasks\n- Provide structured approaches to problems\n- Assist with research and information gathering\n\nIs there something specific you'd like help with today? I'm here to assist with whatever you need!","type":"output_text"}],"role":"assistant"}]}.
[frontend]   Error message: [
[frontend]     {
[frontend]       "expected": "array",
[frontend]       "code": "invalid_type",
[frontend]       "path": [
[frontend]         "output",
[frontend]         0,
[frontend]         "content",
[frontend]         0,
[frontend]         "annotations"
[frontend]       ],
[frontend]       "message": "Invalid input: expected array, received undefined"
[frontend]     }
[frontend]   ]
```

after, no issues

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
