### PR TITLE
Fix 'Select traces' do not show new traces in Judge UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
@@ -185,13 +185,8 @@ export const SelectTracesModal = (props: SelectTracesModalProps) => {
     () => ({ params: monitoringFilters, setParams: setMonitoringFilters, disableAutomaticInitialization: true }),
     [monitoringFilters, setMonitoringFilters],
   );
-  // Use current time for the modal's range so "Last 7 days" etc. end at "now", not at page load time.
-  const monitoringConfig = useMemo(
-    () => ({ lastRefreshTime: Date.now() }),
-    [], // Fresh time when modal mounts; modal unmounts on close so next open gets a new mount and new time
-  );
   return (
-    <MonitoringConfigProvider config={monitoringConfig}>
+    <MonitoringConfigProvider>
       <MonitoringFiltersUpdateContext.Provider value={contextValue}>
         <SelectTracesModalImpl {...props} />
       </MonitoringFiltersUpdateContext.Provider>

--- a/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/SelectTracesModal.tsx
@@ -19,6 +19,7 @@ import {
   useMonitoringFilters,
   useMonitoringFiltersTimeRange,
 } from '../hooks/useMonitoringFilters';
+import { MonitoringConfigProvider } from '../hooks/useMonitoringConfig';
 
 /**
  * Default columns to be visible when selecting traces.
@@ -184,9 +185,16 @@ export const SelectTracesModal = (props: SelectTracesModalProps) => {
     () => ({ params: monitoringFilters, setParams: setMonitoringFilters, disableAutomaticInitialization: true }),
     [monitoringFilters, setMonitoringFilters],
   );
+  // Use current time for the modal's range so "Last 7 days" etc. end at "now", not at page load time.
+  const monitoringConfig = useMemo(
+    () => ({ lastRefreshTime: Date.now() }),
+    [], // Fresh time when modal mounts; modal unmounts on close so next open gets a new mount and new time
+  );
   return (
-    <MonitoringFiltersUpdateContext.Provider value={contextValue}>
-      <SelectTracesModalImpl {...props} />
-    </MonitoringFiltersUpdateContext.Provider>
+    <MonitoringConfigProvider config={monitoringConfig}>
+      <MonitoringFiltersUpdateContext.Provider value={contextValue}>
+        <SelectTracesModalImpl {...props} />
+      </MonitoringFiltersUpdateContext.Provider>
+    </MonitoringConfigProvider>
   );
 };


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

**Problem**: After opening “Select traces”, closing it, creating a new trace, and opening again, the new trace didn’t appear. The time range’s end time was stuck at an old value (e.g. when the page loaded or when “Refresh” was last clicked).
**Root cause**: The modal was using the parent page’s MonitoringConfig. In that config, dateNow (and thus the range end time) only updates on page load or when the user clicks “Refresh”. So the filter was effectively “last 7 days up to that old time”, and new traces after that time were excluded.
**Fix (single change)**: Use a fresh end time when the modal opens by giving it its own MonitoringConfig with current lastRefreshTime.
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

https://github.com/user-attachments/assets/1a3ed82b-1d11-44b7-a894-cde30fdc5e8f


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Opening "Select traces" for evaluation now show the up-to-date list of traces without requiring a refresh.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
