### PR TITLE
[Bug] Fix openai-autolog GLOBAL_TRACE_PROVIDER issue

### DIFF
--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import agents.tracing as oai
 from agents import add_trace_processor
-from agents.tracing.setup import GLOBAL_TRACE_PROVIDER
+from agents.tracing import get_trace_provider
 
 from mlflow.entities.span import SpanType
 from mlflow.entities.span_event import SpanEvent
@@ -56,7 +56,8 @@ _SPAN_TYPE_MAP = {
 
 
 def add_mlflow_trace_processor():
-    processors = GLOBAL_TRACE_PROVIDER._multi_processor._processors
+    provider = get_trace_provider()
+    processors = provider._multi_processor._processors
 
     if any(isinstance(p, MlflowOpenAgentTracingProcessor) for p in processors):
         return
@@ -65,11 +66,12 @@ def add_mlflow_trace_processor():
 
 
 def remove_mlflow_trace_processor():
-    processors = GLOBAL_TRACE_PROVIDER._multi_processor._processors
+    provider = get_trace_provider()
+    processors = provider._multi_processor._processors
     non_mlflow_processors = [
         p for p in processors if not isinstance(p, MlflowOpenAgentTracingProcessor)
     ]
-    GLOBAL_TRACE_PROVIDER._multi_processor._processors = non_mlflow_processors
+    provider._multi_processor._processors = non_mlflow_processors
 
 
 class MlflowOpenAgentTracingProcessor(oai.TracingProcessor):


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> 

Fixes #20995

Upstream references:
- [openai/openai-agents-python#2489](https://github.com/openai/openai-agents-python/issues/2489) — fork-safety issue that motivated the lazy-init change
- [openai/openai-agents-python@a226a0d](https://github.com/openai/openai-agents-python/commit/a226a0d0e93637a21daa3f1e0dc89375e5c78e09) — the commit that changed `GLOBAL_TRACE_PROVIDER` to lazy init

### What changes are proposed in this pull request?
**Fix `AttributeError: 'NoneType' object has no attribute '_multi_processor'` when calling `mlflow.openai.autolog()` with `openai-agents>=0.9.0`.**

Starting with `openai-agents==0.9.0`, the `GLOBAL_TRACE_PROVIDER` module variable in `agents.tracing.setup` was changed from being eagerly initialized at import time to being lazily initialized on first call to `get_trace_provider()`. This was done upstream to fix a fork-safety hazard (openai/openai-agents-python#2489).

`mlflow/openai/_agent_tracer.py` imported `GLOBAL_TRACE_PROVIDER` as a direct variable reference and accessed `._multi_processor._processors` on it in both `add_mlflow_trace_processor()` and `remove_mlflow_trace_processor()`. When `mlflow.openai.autolog()` is called at module level in a code-based pyfunc model (a common pattern), it runs before any `Runner.run()` has been invoked, so `GLOBAL_TRACE_PROVIDER` is still `None` — causing the crash.

**The fix:** Replace the direct `GLOBAL_TRACE_PROVIDER` variable import with calls to `get_trace_provider()`, which is the public API that `openai-agents` provides for safe access. This function uses double-checked locking to lazily create a `DefaultTraceProvider` on first call and never returns `None`.

Changes:
- `mlflow/openai/_agent_tracer.py`: Import `get_trace_provider` from `agents.tracing` instead of `GLOBAL_TRACE_PROVIDER` from `agents.tracing.setup`. Use `get_trace_provider()` in both `add_mlflow_trace_processor()` and `remove_mlflow_trace_processor()`.
- `tests/openai/test_openai_agent_autolog.py`: Add 5 new tests that simulate the lazy-init scenario by setting `GLOBAL_TRACE_PROVIDER = None` and verifying that `add_mlflow_trace_processor`, `remove_mlflow_trace_processor`, `mlflow.openai.autolog()`, and `mlflow.openai.autolog(disable=True)` all succeed without crashing.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `mlflow.openai.autolog()` crashing with `AttributeError: 'NoneType' object has no attribute '_multi_processor'` when used with `openai-agents>=0.9.0`. The crash occurred because the OpenAI Agents SDK changed its trace provider from eager to lazy initialization, and MLflow was reading the uninitialized module variable directly instead of using the safe `get_trace_provider()` accessor.
<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
