### PR TITLE
Fix retrieval_relevance assessments logged to wrong span with missing chunk index

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -418,11 +418,11 @@ def _log_assessments(
                 AssessmentMetadataKey.SOURCE_RUN_ID: run_id,
             }
 
-        # NB: Root span ID is necessarily to show assessment results in DBX eval UI.
-        if root_span := trace.data._get_root_span():
-            assessment.span_id = root_span.span_id
-        else:
-            _logger.debug(f"No root span found for trace {trace.info.trace_id}")
+        if not assessment.span_id:
+            if root_span := trace.data._get_root_span():
+                assessment.span_id = root_span.span_id
+            else:
+                _logger.debug(f"No root span found for trace {trace.info.trace_id}")
 
         mlflow.log_assessment(trace_id=assessment.trace_id, assessment=assessment)
 

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -501,10 +501,14 @@ class RetrievalRelevance(BuiltInScorer):
                 request=request, retrieved_context=chunks, assessment_name=self.name
             )
         else:
-            for chunk in chunks:
+            for i, chunk in enumerate(chunks):
                 prompt = get_prompt(request=request, context=chunk["content"])
                 feedback = invoke_judge_model(model, prompt, assessment_name=self.name)
                 sanitized_feedback = _sanitize_scorer_feedback(feedback)
+                sanitized_feedback.metadata = {
+                    **(sanitized_feedback.metadata or {}),
+                    "chunk_index": i,
+                }
                 chunk_feedbacks.append(sanitized_feedback)
 
         for feedback in chunk_feedbacks:


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Two bugs:
1. _log_assessments unconditionally overwrote assessment span_id to root span, even when the scorer already set it to the retriever span. Now only falls back to root span when span_id is not already set.
2. Non-Databricks model path in RetrievalRelevance did not include chunk_index in feedback metadata. Now adds it consistent with the Databricks path.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

MLflow OSS UI:
<img width="2852" height="1098" alt="image" src="https://github.com/user-attachments/assets/f4f68ae6-999e-4480-b048-fafbfd5ee8c3" />


DBX UI:
<img width="2958" height="732" alt="image" src="https://github.com/user-attachments/assets/e67f8734-6aa9-490b-b515-79abb07782eb" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
