### PR TITLE
Auto-select Session/Goal/Persona columns when grouped by session

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -41,6 +41,7 @@ import {
   useFetchTraceV4LazyQuery,
   doesTraceSupportV4API,
   getSimulationColumnsToAdd,
+  SESSION_COLUMN_ID,
 } from '@databricks/web-shared/genai-traces-table';
 import { GenAiTraceTableRowSelectionProvider } from '@databricks/web-shared/genai-traces-table/hooks/useGenAiTraceTableRowSelection';
 import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
@@ -199,57 +200,50 @@ const RunViewEvaluationsTabInner = ({
     isQueryDisabled,
   });
 
-  // Helper to add goal/persona columns if traces have the metadata
-  const maybeAddGoalPersonaColumns = useCallback(
-    (traces: ModelTraceInfoV3[]) => {
-      if (hasAutoSelectedGoalPersona.current) {
-        return;
-      }
-
-      const columnsToAdd = getSimulationColumnsToAdd(traces, allColumns, selectedColumns);
-      if (columnsToAdd.length > 0) {
-        toggleColumns(columnsToAdd);
-        hasAutoSelectedGoalPersona.current = true;
-      }
-    },
-    [allColumns, selectedColumns, toggleColumns],
-  );
-
   // Handler for toggling session grouping
   const onToggleSessionGrouping = useCallback(() => {
-    const newIsGrouped = !isGroupedBySession;
-    setIsGroupedBySession(newIsGrouped);
+    setIsGroupedBySession((prev) => !prev);
+  }, []);
 
-    // When enabling grouping while comparing, auto-select goal/persona columns
-    if (newIsGrouped && compareToRunUuid) {
-      const allTraces = (traceInfos || []).concat(compareToRunData || []);
-      maybeAddGoalPersonaColumns(allTraces);
-    }
-
-    // Reset the ref when ungrouping so columns can be auto-selected again later
-    if (!newIsGrouped) {
-      hasAutoSelectedGoalPersona.current = false;
-    }
-  }, [isGroupedBySession, compareToRunUuid, traceInfos, compareToRunData, maybeAddGoalPersonaColumns]);
-
-  // Wrapper for setCompareToRunUuid that handles auto-selecting columns
+  // Wrapper for setCompareToRunUuid
   const setCompareToRunUuid = useCallback(
     (newCompareToRunUuid: string | undefined) => {
       setCompareToRunUuidBase(newCompareToRunUuid);
-
-      // When starting comparison while grouped, auto-select columns
-      // Note: compareToRunData won't be available yet, so we use current traces
-      if (newCompareToRunUuid && isGroupedBySession && traceInfos) {
-        maybeAddGoalPersonaColumns(traceInfos);
-      }
-
-      // Reset the ref when stopping comparison so columns can be auto-selected again later
       if (!newCompareToRunUuid) {
         hasAutoSelectedGoalPersona.current = false;
       }
     },
-    [setCompareToRunUuidBase, isGroupedBySession, traceInfos, maybeAddGoalPersonaColumns],
+    [setCompareToRunUuidBase],
   );
+
+  // Auto-select session, goal, and persona columns when session grouping is active
+  useEffect(() => {
+    if (!isGroupedBySession || hasAutoSelectedGoalPersona.current) {
+      if (!isGroupedBySession) {
+        hasAutoSelectedGoalPersona.current = false;
+      }
+      return;
+    }
+
+    const columnsToAdd: TracesTableColumn[] = [];
+
+    const sessionColumn = allColumns.find((col) => col.id === SESSION_COLUMN_ID);
+    if (sessionColumn && !selectedColumns.some((col) => col.id === SESSION_COLUMN_ID)) {
+      columnsToAdd.push(sessionColumn);
+    }
+
+    const allTraces = (traceInfos || []).concat(compareToRunData || []);
+    const simulationColumns = getSimulationColumnsToAdd(allTraces, allColumns, selectedColumns);
+    columnsToAdd.push(...simulationColumns);
+
+    if (columnsToAdd.length > 0) {
+      setSelectedColumns([...selectedColumns, ...columnsToAdd]);
+    }
+    // Only mark as done once we've had trace data to check for simulation columns
+    if (allTraces.length > 0) {
+      hasAutoSelectedGoalPersona.current = true;
+    }
+  }, [isGroupedBySession, allColumns, selectedColumns, setSelectedColumns, traceInfos, compareToRunData]);
 
   const hasSetInitialGrouping = useRef(false);
   useEffect(() => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { isEmpty as isEmptyFn } from 'lodash';
 import { Empty, ParagraphSkeleton, DangerIcon } from '@databricks/design-system';
@@ -38,6 +38,9 @@ import {
   invalidateMlflowSearchTracesCache,
   createTraceLocationForExperiment,
   doesTraceSupportV4API,
+  getSimulationColumnsToAdd,
+  SIMULATION_GOAL_COLUMN_ID,
+  SIMULATION_PERSONA_COLUMN_ID,
 } from '@databricks/web-shared/genai-traces-table';
 import {
   GenAiTraceTableRowSelectionProvider,
@@ -203,20 +206,40 @@ const TracesV3LogsImpl = React.memo(
       columnStorageKeyPrefix,
     );
 
-    // Toggle session grouping and auto-select session column when enabling
     const onToggleSessionGrouping = useCallback(() => {
-      const newIsGroupedBySession = !isGroupedBySession;
-      setIsGroupedBySession(newIsGroupedBySession);
+      setIsGroupedBySession((prev) => !prev);
+    }, []);
 
-      // Auto-select session column when enabling grouping
-      if (newIsGroupedBySession) {
-        const sessionColumn = allColumns.find((col) => col.id === SESSION_COLUMN_ID);
-        const isSessionColumnSelected = selectedColumns.some((col) => col.id === SESSION_COLUMN_ID);
-        if (sessionColumn && !isSessionColumnSelected) {
-          setSelectedColumns([...selectedColumns, sessionColumn]);
+    // Auto-select session, goal, and persona columns when session grouping is active
+    const hasAutoSelectedSessionColumns = useRef(false);
+    useEffect(() => {
+      const isEffectivelyGrouped = forceGroupBySession || isGroupedBySession;
+      if (!isEffectivelyGrouped || hasAutoSelectedSessionColumns.current) {
+        if (!isEffectivelyGrouped) {
+          hasAutoSelectedSessionColumns.current = false;
         }
+        return;
       }
-    }, [isGroupedBySession, allColumns, selectedColumns, setSelectedColumns]);
+
+      const columnsToAdd: TracesTableColumn[] = [];
+
+      const sessionColumn = allColumns.find((col) => col.id === SESSION_COLUMN_ID);
+      if (sessionColumn && !selectedColumns.some((col) => col.id === SESSION_COLUMN_ID)) {
+        columnsToAdd.push(sessionColumn);
+      }
+
+      const traceInfos = evaluatedTraces.map((e) => e.traceInfo).filter((t): t is NonNullable<typeof t> => Boolean(t));
+      const simulationColumns = getSimulationColumnsToAdd(traceInfos, allColumns, selectedColumns);
+      columnsToAdd.push(...simulationColumns);
+
+      if (columnsToAdd.length > 0) {
+        setSelectedColumns([...selectedColumns, ...columnsToAdd]);
+      }
+      // Only mark as done once we've had trace data to check for simulation columns
+      if (traceInfos.length > 0) {
+        hasAutoSelectedSessionColumns.current = true;
+      }
+    }, [forceGroupBySession, isGroupedBySession, allColumns, selectedColumns, setSelectedColumns, evaluatedTraces]);
 
     const [tableSort, setTableSort] = useTableSort(selectedColumns, {
       key: REQUEST_TIME_COLUMN_ID,

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTable.utils.ts
@@ -71,8 +71,8 @@ export function sortGroupedColumns(
       if (colB.id === SESSION_COLUMN_ID) return 1;
     }
 
-    // If grouped by session AND comparing, put goal and persona columns near the front (after session)
-    if (isGroupedBySession && isComparing) {
+    // If grouped by session, put goal and persona columns near the front (after session)
+    if (isGroupedBySession) {
       const isGoalOrPersonaA = colA.id === SIMULATION_GOAL_COLUMN_ID || colA.id === SIMULATION_PERSONA_COLUMN_ID;
       const isGoalOrPersonaB = colB.id === SIMULATION_GOAL_COLUMN_ID || colB.id === SIMULATION_PERSONA_COLUMN_ID;
       if (isGoalOrPersonaA && !isGoalOrPersonaB) return -1;

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
@@ -39,6 +39,8 @@ import {
   RESPONSE_COLUMN_ID,
   RUN_NAME_COLUMN_ID,
   SESSION_COLUMN_ID,
+  SIMULATION_GOAL_COLUMN_ID,
+  SIMULATION_PERSONA_COLUMN_ID,
   SOURCE_COLUMN_ID,
   STATE_COLUMN_ID,
   TAGS_COLUMN_ID,
@@ -962,6 +964,9 @@ export const traceInfoCellRenderer = (
         }
       />
     );
+  } else if (colId === SIMULATION_GOAL_COLUMN_ID || colId === SIMULATION_PERSONA_COLUMN_ID) {
+    // Goal/Persona are session-level columns, only rendered in session header rows
+    return <NullCell isComparing={isComparing} />;
   }
 
   const value = currentTraceInfo ? stringifyValue(getTraceInfoValueWithColId(currentTraceInfo, colId)) : '';


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
When "Group by session" is active, the Session, Goal, and Persona columns now auto-appear on the Traces page, Sessions page, and Evaluation runs page. Goal/Persona columns are ordered right after Session regardless of compare mode.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

https://github.com/user-attachments/assets/341dc764-ef6a-402e-bff2-336ed9b6e3a4


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
