### PR TITLE
Move user session id logic to uc table processor

### DIFF
--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -25,7 +25,6 @@ from mlflow.environment_variables import (
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey, TraceMetadataKey
 from mlflow.tracing.provider import _get_trace_exporter
 from mlflow.tracing.trace_manager import InMemoryTraceManager
-from mlflow.tracing.utils import is_uc_table_tracing
 
 # ============================================================================
 # CONSTANTS
@@ -573,13 +572,6 @@ def _finalize_trace(
                 **in_memory_trace.info.trace_metadata,
                 **metadata,
             }
-            if is_uc_table_tracing():
-                for meta_key, attr_key in (
-                    (TraceMetadataKey.TRACE_USER, SpanAttributeKey.USER_ID),
-                    (TraceMetadataKey.TRACE_SESSION, SpanAttributeKey.SESSION_ID),
-                ):
-                    if value := in_memory_trace.info.trace_metadata.get(meta_key):
-                        parent_span.set_attribute(attr_key, value)
     except Exception as e:
         get_logger().warning("Failed to update trace metadata and previews: %s", e)
 

--- a/mlflow/demo/generators/traces.py
+++ b/mlflow/demo/generators/traces.py
@@ -607,10 +607,6 @@ class TracesDemoGenerator(BaseDemoGenerator):
                 DEMO_VERSION_TAG: version,
                 DEMO_TRACE_TYPE_TAG: "session",
             },
-            attributes={
-                SpanAttributeKey.USER_ID: trace_def.session_user or "user",
-                SpanAttributeKey.SESSION_ID: versioned_session_id,
-            },
             start_time_ns=start_ns,
         )
 

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -47,7 +47,6 @@ from mlflow.tracing.utils import (
     encode_span_id,
     exclude_immutable_tags,
     get_otel_attribute,
-    is_uc_table_tracing,
 )
 from mlflow.tracing.utils.search import traces_to_df
 from mlflow.utils import get_results_from_paginated_fn
@@ -1405,17 +1404,6 @@ def update_current_trace(
         trace.info.trace_metadata.update(metadata)
         if client_request_id is not None:
             trace.info.client_request_id = str(client_request_id)
-
-        # For UC table (V4) traces, propagate user/session IDs to root span attributes
-        # so they are available in the standard OTLP span payload.
-        if is_uc_table_tracing():
-            if root_span := trace.get_root_span():
-                for meta_key, attr_key in (
-                    (TraceMetadataKey.TRACE_USER, SpanAttributeKey.USER_ID),
-                    (TraceMetadataKey.TRACE_SESSION, SpanAttributeKey.SESSION_ID),
-                ):
-                    if value := trace.info.trace_metadata.get(meta_key):
-                        root_span.set_attribute(attr_key, value)
 
 
 @deprecated_parameter("request_id", "trace_id")

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -707,24 +707,16 @@ def get_experiment_id_for_trace(span: OTelReadableSpan) -> str:
     return _get_experiment_id()
 
 
-def is_uc_table_tracing() -> bool:
-    """Returns True if the active trace destination is a Unity Catalog table (V4)."""
-    from mlflow.entities.trace_location import UCSchemaLocation
-    from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
-
-    if destination := _MLFLOW_TRACE_USER_DESTINATION.get():
-        return isinstance(destination, UCSchemaLocation)
-    return False
-
-
 def get_active_spans_table_name() -> str | None:
     """
     Get active Unity Catalog spans table name that's set by `mlflow.tracing.set_destination`.
     """
+    from mlflow.entities.trace_location import UCSchemaLocation
     from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
 
-    if is_uc_table_tracing():
-        return _MLFLOW_TRACE_USER_DESTINATION.get().full_otel_spans_table_name
+    if destination := _MLFLOW_TRACE_USER_DESTINATION.get():
+        if isinstance(destination, UCSchemaLocation):
+            return destination.full_otel_spans_table_name
 
     return None
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1610,39 +1610,6 @@ def test_update_current_trace_with_model_id():
 
 
 @skip_when_testing_trace_sdk
-def test_update_current_trace_sets_user_session_span_attributes_for_uc_table():
-    from mlflow.entities.trace_location import UCSchemaLocation
-
-    mock_destination = UCSchemaLocation(catalog_name="catalog", schema_name="schema")
-
-    with mock.patch.object(_MLFLOW_TRACE_USER_DESTINATION, "get", return_value=mock_destination):
-        with mlflow.start_span("root") as root_span:
-            mlflow.update_current_trace(
-                metadata={
-                    TraceMetadataKey.TRACE_USER: "test_user",
-                    TraceMetadataKey.TRACE_SESSION: "session_123",
-                }
-            )
-
-    assert root_span.attributes.get(SpanAttributeKey.USER_ID) == "test_user"
-    assert root_span.attributes.get(SpanAttributeKey.SESSION_ID) == "session_123"
-
-
-@skip_when_testing_trace_sdk
-def test_update_current_trace_does_not_set_user_session_span_attributes_for_v3():
-    with mlflow.start_span("root") as root_span:
-        mlflow.update_current_trace(
-            metadata={
-                TraceMetadataKey.TRACE_USER: "test_user",
-                TraceMetadataKey.TRACE_SESSION: "session_123",
-            }
-        )
-
-    assert SpanAttributeKey.USER_ID not in root_span.attributes
-    assert SpanAttributeKey.SESSION_ID not in root_span.attributes
-
-
-@skip_when_testing_trace_sdk
 def test_update_current_trace_should_not_raise_during_model_logging():
     """
     Tracing is disabled while model logging. When the model includes

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -33,7 +33,6 @@ from mlflow.tracing.utils import (
     generate_trace_id_v4_from_otel_trace_id,
     get_active_spans_table_name,
     get_otel_attribute,
-    is_uc_table_tracing,
     maybe_get_request_id,
     parse_trace_id_v4,
 )
@@ -578,22 +577,6 @@ def test_get_spans_table_name_for_trace_no_destination():
 
         result = get_active_spans_table_name()
         assert result is None
-
-
-def test_is_uc_table_tracing_with_uc_destination():
-    mock_destination = UCSchemaLocation(catalog_name="catalog", schema_name="schema")
-
-    with mock.patch("mlflow.tracing.provider._MLFLOW_TRACE_USER_DESTINATION") as mock_ctx:
-        mock_ctx.get.return_value = mock_destination
-
-        assert is_uc_table_tracing() is True
-
-
-def test_is_uc_table_tracing_with_no_destination():
-    with mock.patch("mlflow.tracing.provider._MLFLOW_TRACE_USER_DESTINATION") as mock_ctx:
-        mock_ctx.get.return_value = None
-
-        assert is_uc_table_tracing() is False
 
 
 def test_generate_trace_id_v4_from_otel_trace_id():


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21003/files) to review incremental changes.
- [**stack/move-user-session-id-logic-to-uc-table-processor**](https://github.com/mlflow/mlflow/pull/21003) [[Files changed](https://github.com/mlflow/mlflow/pull/21003/files)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> 
#20936

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Centralizes the logic that propagates mlflow.trace.user and mlflow.trace.session trace metadata values to root span OTel attributes (user.id, session.id) into DatabricksUCTableSpanProcessor.                                                                                                                                    
                                                   
#### Before:
This logic was scattered across two user-facing call sites — update_current_trace() in fluent.py and _finalize_trace() in claude_code/tracing.py. Both paths manually checked is_uc_table_tracing() and set span attributes inline.

#### After:
DatabricksUCTableSpanProcessor overrides on_end() and calls a new _set_user_session_span_attributes() helper for root spans. The helper uses get_mlflow_span_for_otel_span() to retrieve the live span, then applies _bypass_attribute_guard to set the attributes on the underlying OTel span before export — consistent
with the pattern used by strands, semantic_kernel, and haystack autolog integrations.

#### Changes:
- Add on_end() override and _set_user_session_span_attributes() to DatabricksUCTableSpanProcessor
- Remove is_uc_table_tracing() helper (no longer needed) and restore get_active_spans_table_name() to its original inline form
- Remove the scattered attribute-setting blocks from fluent.py and claude_code/tracing.py
- Revert the demo generator change that manually set user.id/session.id as span attributes
- Replace/remove tests that covered the old scattered behavior; add new processor-level tests using mlflow.start_span + mlflow.update_current_trace

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Manual Testing:
https://dogfood.staging.databricks.com/editor/notebooks/4409276273141862?o=6051921418418893

**Verified both root span and metadata event contains user id and session id for UC traces:**
<img width="1335" height="605" alt="Screenshot 2026-02-19 at 1 45 56 PM" src="https://github.com/user-attachments/assets/db6174dd-c05c-4d45-ac53-728605369b6b" />
<img width="1363" height="639" alt="Screenshot 2026-02-19 at 1 46 29 PM" src="https://github.com/user-attachments/assets/a40c0b19-0907-4966-b013-2cb34283c0e6" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
