### PR TITLE
Fix artifact poisoning vulnerability in preview-docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,8 +84,6 @@ jobs:
             ALIAS="pr-$PR_NUMBER"
           fi
           echo "value=$ALIAS" >> $GITHUB_OUTPUT
-          echo "$ALIAS" > /tmp/alias.txt
-          cat /tmp/alias.txt
       - name: Build docs
         env:
           GTM_ID: "GTM-TEST"
@@ -118,15 +116,6 @@ jobs:
         with:
           name: docs-build-${{ github.run_id }}
           path: /tmp/docs-build
-          retention-days: 1
-          if-no-files-found: error
-
-      # `github.event.workflow_run.pull_requests` is empty when a PR is created from a fork:
-      # https://github.com/orgs/community/discussions/25220#discussioncomment-11001085
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: alias
-          path: /tmp/alias.txt
           retention-days: 1
           if-no-files-found: error
 

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -37,7 +37,8 @@ jobs:
             # Derive PR number from the workflow run's head branch via API
             # instead of trusting the artifact (which fork PRs can manipulate)
             PR_NUMBER=$(gh api "repos/$REPO/pulls?head=$HEAD_OWNER:$HEAD_BRANCH&state=open" \
-              --jq '.[0].number')
+            PR_NUMBER=$(gh api "repos/$REPO/pulls?head=$HEAD_OWNER:$HEAD_BRANCH&state=open" \
+              --jq '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
               echo "::error::Could not find PR for $HEAD_OWNER:$HEAD_BRANCH"
               exit 1

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -26,19 +26,20 @@ jobs:
         id: alias
         env:
           EVENT: ${{ github.event.workflow_run.event }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           if [ "$EVENT" = "push" ]; then
             ALIAS="dev"
           else
-            # Derive PR number from the workflow run's head SHA via API
+            # Derive PR number from the workflow run's head branch via API
             # instead of trusting the artifact (which fork PRs can manipulate)
-            PR_NUMBER=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+            PR_NUMBER=$(gh api "repos/$REPO/pulls?head=$HEAD_OWNER:$HEAD_BRANCH&state=open" \
               --jq '.[0].number')
             if [ -z "$PR_NUMBER" ]; then
-              echo "::error::Could not find PR for SHA $HEAD_SHA"
+              echo "::error::Could not find PR for $HEAD_OWNER:$HEAD_BRANCH"
               exit 1
             fi
             ALIAS="pr-$PR_NUMBER"

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -35,9 +35,8 @@ jobs:
           else
             # Derive PR number from the workflow run's head SHA via API
             # instead of trusting the artifact (which fork PRs can manipulate)
-            PR_NUMBER=$(gh api repos/$REPO/pulls \
-              --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" \
-              | head -n 1)
+            PR_NUMBER=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+              --jq '.[0].number')
             if [ -z "$PR_NUMBER" ]; then
               echo "::error::Could not find PR for SHA $HEAD_SHA"
               exit 1

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -22,18 +22,29 @@ jobs:
         with:
           sparse-checkout: |
             .github
-      - name: Download alias
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-          name: alias
-          path: /tmp
       - name: Set alias
         id: alias
+        env:
+          EVENT: ${{ github.event.workflow_run.event }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          cat /tmp/alias.txt
-          echo "value=$(cat /tmp/alias.txt)" >> $GITHUB_OUTPUT
+          if [ "$EVENT" = "push" ]; then
+            ALIAS="dev"
+          else
+            # Derive PR number from the workflow run's head SHA via API
+            # instead of trusting the artifact (which fork PRs can manipulate)
+            PR_NUMBER=$(gh api repos/$REPO/pulls \
+              --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" \
+              | head -n 1)
+            if [ -z "$PR_NUMBER" ]; then
+              echo "::error::Could not find PR for SHA $HEAD_SHA"
+              exit 1
+            fi
+            ALIAS="pr-$PR_NUMBER"
+          fi
+          echo "value=$ALIAS" >> $GITHUB_OUTPUT
       - name: Download build artifact
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:


### PR DESCRIPTION
### Related Issues/PRs

Close #21013

### What changes are proposed in this pull request?

The `preview-docs.yml` workflow downloaded an `alias` artifact from `docs.yml` to determine the Netlify deploy alias. Since `docs.yml` runs on `pull_request` (including from forks), a malicious fork could craft `alias.txt` to target arbitrary PRs or overwrite the `dev` deployment.

This PR removes the `alias` artifact and derives the alias from the trusted `workflow_run` event context via the GitHub API instead.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)