### PR TITLE
disable openai agents tracing by default

### DIFF
--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 import agents.tracing as oai
-from agents import add_trace_processor
+from agents import add_trace_processor, set_trace_processors
 from agents.tracing.setup import GLOBAL_TRACE_PROVIDER
 
 from mlflow.entities.span import SpanType
@@ -53,6 +53,17 @@ _SPAN_TYPE_MAP = {
     OpenAISpanType.GUARDRAIL: SpanType.TOOL,
     # Default to chain type
 }
+
+
+def clear_other_trace_processors():
+    """
+    Clear other trace processors to avoid warnings.
+    https://github.com/openai/openai-agents-python/issues/1387#issuecomment-3165660183
+    """
+    try:
+        set_trace_processors([])
+    except ImportError:
+        pass
 
 
 def add_mlflow_trace_processor():

--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -55,15 +55,12 @@ _SPAN_TYPE_MAP = {
 }
 
 
-def clear_other_trace_processors():
+def clear_trace_processors():
     """
     Clear other trace processors to avoid warnings.
     https://github.com/openai/openai-agents-python/issues/1387#issuecomment-3165660183
     """
-    try:
-        set_trace_processors([])
-    except ImportError:
-        pass
+    set_trace_processors([])
 
 
 def add_mlflow_trace_processor():

--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -63,8 +63,19 @@ def clear_trace_processors():
     set_trace_processors([])
 
 
+def restore_default_trace_processor():
+    from agents.tracing.processors import default_processor
+
+    provider = get_trace_provider()
+    processors = provider._multi_processor._processors
+    default = default_processor()
+
+    if default not in processors:
+        add_trace_processor(default)
+
+
 def add_mlflow_trace_processor():
-    processors = GLOBAL_TRACE_PROVIDER._multi_processor._processors
+    processors = get_trace_provider()._multi_processor._processors
 
     if any(isinstance(p, MlflowOpenAgentTracingProcessor) for p in processors):
         return
@@ -73,11 +84,11 @@ def add_mlflow_trace_processor():
 
 
 def remove_mlflow_trace_processor():
-    processors = GLOBAL_TRACE_PROVIDER._multi_processor._processors
+    processors = get_trace_provider()._multi_processor._processors
     non_mlflow_processors = [
         p for p in processors if not isinstance(p, MlflowOpenAgentTracingProcessor)
     ]
-    GLOBAL_TRACE_PROVIDER._multi_processor._processors = non_mlflow_processors
+    get_trace_provider()._multi_processor._processors = non_mlflow_processors
 
 
 class MlflowOpenAgentTracingProcessor(oai.TracingProcessor):

--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -63,16 +63,6 @@ def clear_trace_processors():
     set_trace_processors([])
 
 
-def restore_default_trace_processor():
-    from agents.tracing.processors import default_processor
-
-    provider = get_trace_provider()
-    processors = provider._multi_processor._processors
-    default = default_processor()
-
-    if default not in processors:
-        add_trace_processor(default)
-
 
 def add_mlflow_trace_processor():
     processors = get_trace_provider()._multi_processor._processors

--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import agents.tracing as oai
 from agents import add_trace_processor, set_trace_processors
-from agents.tracing.setup import GLOBAL_TRACE_PROVIDER
+from agents.tracing.setup import get_trace_provider
 
 from mlflow.entities.span import SpanType
 from mlflow.entities.span_event import SpanEvent

--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -63,7 +63,6 @@ def clear_trace_processors():
     set_trace_processors([])
 
 
-
 def add_mlflow_trace_processor():
     processors = get_trace_provider()._multi_processor._processors
 

--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -57,7 +57,8 @@ _SPAN_TYPE_MAP = {
 
 def clear_trace_processors():
     """
-    Clear other trace processors to avoid warnings.
+    Clear all trace processors (including the default OpenAI agents tracer)
+    to avoid warnings when the OpenAI API key is not set.
     https://github.com/openai/openai-agents-python/issues/1387#issuecomment-3165660183
     """
     set_trace_processors([])

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -89,12 +89,13 @@ def autolog(
 
         from mlflow.openai._agent_tracer import (
             add_mlflow_trace_processor,
-            clear_other_trace_processors,
+            clear_trace_processors,
             remove_mlflow_trace_processor,
         )
 
-        if disable_openai_agent_tracer:
-            clear_other_trace_processors()
+        # if disable_openai_agent_tracer:
+        #     print("Im clearing trace processors")
+        #     clear_trace_processors()
 
         if log_traces and not disable:
             add_mlflow_trace_processor()

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -11,7 +11,6 @@ from mlflow.entities.span import LiveSpan
 from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.exceptions import MlflowException
-from mlflow.openai._agent_tracer import clear_other_trace_processors
 from mlflow.openai.constant import FLAVOR_NAME
 from mlflow.openai.utils.chat_schema import set_span_chat_attributes
 from mlflow.telemetry.events import AutologgingEvent
@@ -90,6 +89,7 @@ def autolog(
 
         from mlflow.openai._agent_tracer import (
             add_mlflow_trace_processor,
+            clear_other_trace_processors,
             remove_mlflow_trace_processor,
         )
 

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -11,6 +11,7 @@ from mlflow.entities.span import LiveSpan
 from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.exceptions import MlflowException
+from mlflow.openai._agent_tracer import clear_other_trace_processors
 from mlflow.openai.constant import FLAVOR_NAME
 from mlflow.openai.utils.chat_schema import set_span_chat_attributes
 from mlflow.telemetry.events import AutologgingEvent
@@ -38,6 +39,7 @@ def autolog(
     disable_for_unsupported_versions=False,
     silent=False,
     log_traces=True,
+    disable_openai_agent_tracer=True,
 ):
     """
     Enables (or disables) and configures autologging from OpenAI to MLflow.
@@ -58,6 +60,8 @@ def autolog(
             autologging.
         log_traces: If ``True``, traces are logged for OpenAI models. If ``False``, no traces are
             collected during inference. Default to ``True``.
+        disable_openai_agent_tracer: If ``True``, disable the OpenAI Agent SDK tracer. If ``False``,
+            enable the OpenAI Agent SDK tracer. Default to ``True``.
     """
     if Version(importlib.metadata.version("openai")).major < 1:
         raise MlflowException("OpenAI autologging is only supported for openai >= 1.0.0")
@@ -88,6 +92,9 @@ def autolog(
             add_mlflow_trace_processor,
             remove_mlflow_trace_processor,
         )
+
+        if disable_openai_agent_tracer:
+            clear_other_trace_processors()
 
         if log_traces and not disable:
             add_mlflow_trace_processor()

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -91,18 +91,14 @@ def autolog(
             add_mlflow_trace_processor,
             clear_trace_processors,
             remove_mlflow_trace_processor,
-            restore_default_trace_processor,
         )
 
-        if disable_openai_agent_tracer:
-            clear_trace_processors()
-        else:
-            restore_default_trace_processor()
-
-        if log_traces and not disable:
-            add_mlflow_trace_processor()
-        else:
+        if disable:
             remove_mlflow_trace_processor()
+        else:
+            if disable_openai_agent_tracer:
+                clear_trace_processors()
+            add_mlflow_trace_processor()
     except ImportError:
         pass
 

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -93,9 +93,8 @@ def autolog(
             remove_mlflow_trace_processor,
         )
 
-        # if disable_openai_agent_tracer:
-        #     print("Im clearing trace processors")
-        #     clear_trace_processors()
+        if disable_openai_agent_tracer:
+            clear_trace_processors()
 
         if log_traces and not disable:
             add_mlflow_trace_processor()

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -93,7 +93,7 @@ def autolog(
             remove_mlflow_trace_processor,
         )
 
-        if disable:
+        if disable or not log_traces:
             remove_mlflow_trace_processor()
         else:
             if disable_openai_agent_tracer:

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -91,10 +91,13 @@ def autolog(
             add_mlflow_trace_processor,
             clear_trace_processors,
             remove_mlflow_trace_processor,
+            restore_default_trace_processor,
         )
 
         if disable_openai_agent_tracer:
             clear_trace_processors()
+        else:
+            restore_default_trace_processor()
 
         if log_traces and not disable:
             add_mlflow_trace_processor()

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -11,7 +11,6 @@ except ImportError:
     pytest.skip("OpenAI SDK is not installed. Skipping tests.", allow_module_level=True)
 
 from agents import Agent, Runner, function_tool, set_default_openai_client, trace
-from agents.tracing import set_trace_processors
 from openai.types.responses.function_tool import FunctionTool
 from openai.types.responses.response import Response
 from openai.types.responses.response_output_item import (
@@ -38,12 +37,6 @@ def set_dummy_client(expected_responses):
     async_client.responses.create = _mocked_create
 
     set_default_openai_client(async_client)
-
-
-@pytest.fixture(autouse=True)
-def disable_default_tracing():
-    # Disable default OpenAI tracer
-    set_trace_processors([])
 
 
 @pytest.mark.asyncio
@@ -389,3 +382,138 @@ async def test_disable_enable_autolog():
     await Runner.run(agent, messages)
 
     assert get_traces() == []
+
+
+@pytest.mark.asyncio
+async def test_autolog_agent_with_enabled_openai_agent_tracer():
+    mlflow.openai.autolog(disable_openai_agent_tracer=False)
+
+    # NB: We have to mock the OpenAI SDK responses to make agent works
+    DUMMY_RESPONSES = [
+        Response(
+            id="123",
+            created_at=12345678.0,
+            error=None,
+            model="gpt-4o-mini",
+            object="response",
+            instructions="Handoff to the appropriate agent based on the language of the request.",
+            output=[
+                ResponseFunctionToolCall(
+                    id="123",
+                    arguments="{}",
+                    call_id="123",
+                    name="transfer_to_spanish_agent",
+                    type="function_call",
+                    status="completed",
+                )
+            ],
+            tools=[
+                FunctionTool(
+                    name="transfer_to_spanish_agent",
+                    parameters={"type": "object", "properties": {}, "required": []},
+                    type="function",
+                    description="Handoff to the Spanish_Agent agent to handle the request.",
+                    strict=False,
+                ),
+            ],
+            tool_choice="auto",
+            temperature=1,
+            parallel_tool_calls=True,
+        ),
+        Response(
+            id="123",
+            created_at=12345678.0,
+            error=None,
+            model="gpt-4o-mini",
+            object="response",
+            instructions="You only speak Spanish",
+            output=[
+                ResponseOutputMessage(
+                    id="123",
+                    content=[
+                        ResponseOutputText(
+                            annotations=[],
+                            text="¡Hola! Estoy bien, gracias. ¿Y tú, cómo estás?",
+                            type="output_text",
+                        )
+                    ],
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                )
+            ],
+            tools=[],
+            tool_choice="auto",
+            temperature=1,
+            parallel_tool_calls=True,
+        ),
+    ]
+
+    set_dummy_client(DUMMY_RESPONSES)
+
+    english_agent = Agent(name="English Agent", instructions="You only speak English")
+    spanish_agent = Agent(name="Spanish Agent", instructions="You only speak Spanish")
+    triage_agent = Agent(
+        name="Triage Agent",
+        instructions="Handoff to the appropriate agent based on the language of the request.",
+        handoffs=[spanish_agent, english_agent],
+    )
+
+    messages = [{"role": "user", "content": "Hola.  ¿Como estás?"}]
+    response = await Runner.run(starting_agent=triage_agent, input=messages)
+
+    assert response.final_output == "¡Hola! Estoy bien, gracias. ¿Y tú, cómo estás?"
+    traces = get_traces()
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.info.status == "OK"
+    assert json.loads(trace.info.request_preview) == messages
+    assert json.loads(trace.info.response_preview) == response.final_output
+    spans = trace.data.spans
+    assert len(spans) == 6  # 1 root + 2 agent + 1 handoff + 2 response
+    assert spans[0].name == "AgentRunner.run"
+    assert spans[0].span_type == SpanType.AGENT
+    assert spans[0].inputs == messages
+    assert spans[0].outputs == response.final_output
+    assert spans[1].name == "Triage Agent"
+    assert spans[1].parent_id == spans[0].span_id
+    assert spans[2].name == "Response_1"
+    assert spans[2].parent_id == spans[1].span_id
+    assert spans[2].inputs == [{"role": "user", "content": "Hola.  ¿Como estás?"}]
+    assert spans[2].outputs == [
+        {
+            "id": "123",
+            "arguments": "{}",
+            "call_id": "123",
+            "name": "transfer_to_spanish_agent",
+            "type": "function_call",
+            "status": "completed",
+        }
+    ]
+    assert spans[2].attributes["temperature"] == 1
+    assert spans[3].name == "Handoff"
+    assert spans[3].span_type == SpanType.CHAIN
+    assert spans[3].parent_id == spans[1].span_id
+    assert spans[4].name == "Spanish Agent"
+    assert spans[4].parent_id == spans[0].span_id
+    assert spans[5].name == "Response_2"
+    assert spans[5].parent_id == spans[4].span_id
+
+    # Validate chat attributes
+    assert spans[2].attributes[SpanAttributeKey.CHAT_TOOLS] == [
+        {
+            "function": {
+                "description": "Handoff to the Spanish_Agent agent to handle the request.",
+                "name": "transfer_to_spanish_agent",
+                "parameters": {
+                    "additionalProperties": None,
+                    "properties": {},
+                    "required": [],
+                    "type": "object",
+                },
+                "strict": False,
+            },
+            "type": "function",
+        },
+    ]
+    assert SpanAttributeKey.CHAT_TOOLS not in spans[5].attributes

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -401,6 +401,12 @@ async def test_autolog_disable_openai_agent_tracer():
 
     # When disable_openai_agent_tracer=False, the default OpenAI tracer should be preserved
     mlflow.openai.autolog(disable=True)
+
+    # Re-add the default processor to simulate a fresh state
+    from agents.tracing.processors import default_processor
+
+    get_trace_provider().register_processor(default_processor())
+
     mlflow.openai.autolog(disable_openai_agent_tracer=False)
     processors = _get_processors()
     assert len(processors) >= 2

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -119,6 +119,8 @@ async def test_autolog_agent():
 
     assert response.final_output == "¡Hola! Estoy bien, gracias. ¿Y tú, cómo estás?"
     traces = get_traces()
+    print([t.to_dict() for t in traces])
+    assert False
     assert len(traces) == 1
     trace = traces[0]
     assert trace.info.status == "OK"
@@ -386,6 +388,22 @@ async def test_disable_enable_autolog():
 
 @pytest.mark.asyncio
 async def test_autolog_agent_with_enabled_openai_agent_tracer():
+    import logging
+
+    # Set up logging capture for the openai.agents logger
+    class LogCapture(logging.Handler):
+        def __init__(self):
+            super().__init__()
+            self.records = []
+
+        def emit(self, record):
+            self.records.append(record)
+
+    log_capture = LogCapture()
+    openai_agents_logger = logging.getLogger("openai.agents")
+    openai_agents_logger.addHandler(log_capture)
+    openai_agents_logger.setLevel(logging.DEBUG)
+
     mlflow.openai.autolog(disable_openai_agent_tracer=False)
 
     # NB: We have to mock the OpenAI SDK responses to make agent works
@@ -464,6 +482,8 @@ async def test_autolog_agent_with_enabled_openai_agent_tracer():
 
     assert response.final_output == "¡Hola! Estoy bien, gracias. ¿Y tú, cómo estás?"
     traces = get_traces()
+    print([t.to_dict() for t in traces])
+    # assert False
     assert len(traces) == 1
     trace = traces[0]
     assert trace.info.status == "OK"
@@ -477,7 +497,7 @@ async def test_autolog_agent_with_enabled_openai_agent_tracer():
     assert spans[0].outputs == response.final_output
     assert spans[1].name == "Triage Agent"
     assert spans[1].parent_id == spans[0].span_id
-    assert spans[2].name == "Response_1"
+    assert spans[2].name == "Response"
     assert spans[2].parent_id == spans[1].span_id
     assert spans[2].inputs == [{"role": "user", "content": "Hola.  ¿Como estás?"}]
     assert spans[2].outputs == [
@@ -496,7 +516,7 @@ async def test_autolog_agent_with_enabled_openai_agent_tracer():
     assert spans[3].parent_id == spans[1].span_id
     assert spans[4].name == "Spanish Agent"
     assert spans[4].parent_id == spans[0].span_id
-    assert spans[5].name == "Response_2"
+    assert spans[5].name == "Response"
     assert spans[5].parent_id == spans[4].span_id
 
     # Validate chat attributes
@@ -517,3 +537,28 @@ async def test_autolog_agent_with_enabled_openai_agent_tracer():
         },
     ]
     assert SpanAttributeKey.CHAT_TOOLS not in spans[5].attributes
+
+    # Validate that the non-fatal API key error was logged
+    import time
+
+    time.sleep(5.0)  # Give background thread time to log the error
+
+    # Check captured logs from openai.agents logger
+    captured_messages = [record.getMessage() for record in log_capture.records]
+    api_key_errors = [msg for msg in captured_messages if "Incorrect API key provided" in msg]
+
+    # Print debug information
+    print(f"DEBUG: Captured {len(captured_messages)} log messages")
+    print(f"DEBUG: API key errors found: {len(api_key_errors)}")
+    if captured_messages:
+        print(f"DEBUG: Sample captured messages: {captured_messages[:5]}")
+
+    # Clean up first before assertions to avoid interference
+    openai_agents_logger.removeHandler(log_capture)
+
+    error_msg = api_key_errors[0]
+    print(f"SUCCESS: Captured expected API key error: {error_msg}")
+    assert "401" in error_msg
+    assert "Incorrect API key provided: test" in error_msg
+    assert "invalid_api_key" in error_msg
+    assert "[non-fatal]" in error_msg

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -386,12 +386,12 @@ async def test_disable_enable_autolog():
 
 @pytest.mark.asyncio
 async def test_autolog_disable_openai_agent_tracer():
-    from agents.tracing.setup import GLOBAL_TRACE_PROVIDER
+    from agents.tracing.setup import get_trace_provider
 
     from mlflow.openai._agent_tracer import MlflowOpenAgentTracingProcessor
 
     def _get_processors():
-        return GLOBAL_TRACE_PROVIDER._multi_processor._processors
+        return get_trace_provider()._multi_processor._processors
 
     # By default, autolog should clear the OpenAI agents tracer
     mlflow.openai.autolog()

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -11,6 +11,9 @@ except ImportError:
     pytest.skip("OpenAI SDK is not installed. Skipping tests.", allow_module_level=True)
 
 from agents import Agent, Runner, function_tool, set_default_openai_client, trace
+from agents.tracing import set_trace_processors
+from agents.tracing.processors import default_processor
+from agents.tracing.setup import get_trace_provider
 from openai.types.responses.function_tool import FunctionTool
 from openai.types.responses.response import Response
 from openai.types.responses.response_output_item import (
@@ -21,9 +24,17 @@ from openai.types.responses.response_output_text import ResponseOutputText
 
 import mlflow
 from mlflow.entities import SpanType
+from mlflow.openai._agent_tracer import MlflowOpenAgentTracingProcessor
 from mlflow.tracing.constant import SpanAttributeKey
 
 from tests.tracing.helper import get_traces, purge_traces
+
+
+@pytest.fixture(autouse=True)
+def restore_default_trace_processors():
+    yield
+    # Restore the default OpenAI agents tracer after each test
+    set_trace_processors([default_processor()])
 
 
 def set_dummy_client(expected_responses):
@@ -386,29 +397,21 @@ async def test_disable_enable_autolog():
 
 @pytest.mark.asyncio
 async def test_autolog_disable_openai_agent_tracer():
-    from agents.tracing.setup import get_trace_provider
-
-    from mlflow.openai._agent_tracer import MlflowOpenAgentTracingProcessor
-
     def _get_processors():
         return get_trace_provider()._multi_processor._processors
+
+    # Verify default processor exists before autolog
+    assert any(not isinstance(p, MlflowOpenAgentTracingProcessor) for p in _get_processors())
+
+    # When disable_openai_agent_tracer=False, the default OpenAI tracer should be preserved
+    mlflow.openai.autolog(disable_openai_agent_tracer=False)
+    processors = _get_processors()
+    assert len(processors) >= 2
+    assert any(isinstance(p, MlflowOpenAgentTracingProcessor) for p in processors)
+    assert any(not isinstance(p, MlflowOpenAgentTracingProcessor) for p in processors)
 
     # By default, autolog should clear the OpenAI agents tracer
     mlflow.openai.autolog()
     processors = _get_processors()
     assert len(processors) == 1
     assert isinstance(processors[0], MlflowOpenAgentTracingProcessor)
-
-    # When disable_openai_agent_tracer=False, the default OpenAI tracer should be preserved
-    mlflow.openai.autolog(disable=True)
-
-    # Re-add the default processor to simulate a fresh state
-    from agents.tracing.processors import default_processor
-
-    get_trace_provider().register_processor(default_processor())
-
-    mlflow.openai.autolog(disable_openai_agent_tracer=False)
-    processors = _get_processors()
-    assert len(processors) >= 2
-    assert any(isinstance(p, MlflowOpenAgentTracingProcessor) for p in processors)
-    assert any(not isinstance(p, MlflowOpenAgentTracingProcessor) for p in processors)

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -395,8 +395,7 @@ async def test_disable_enable_autolog():
     assert get_traces() == []
 
 
-@pytest.mark.asyncio
-async def test_autolog_disable_openai_agent_tracer():
+def test_autolog_disable_openai_agent_tracer():
     def _get_processors():
         return get_trace_provider()._multi_processor._processors
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

https://github.com/mlflow/mlflow/pull/18562/changes
https://github.com/openai/openai-agents-python/issues/1387#issuecomment-3165660183

### What changes are proposed in this pull request?
- disable openai-agents-sdk tracing by default

> [!WARNING]  
> The CUJ of exporting traces to the openai platform when using Databricks LLMs does not work, even when you fill in the OPENAI_API_KEY env var because of schema misalignment:
> <details>
> 
> <summary>Error when valid `OPENAI_API_KEY` and using Databricks LLM</summary>
> ```
> ERROR:openai.agents:[non-fatal] Tracing client error 400: {
>   "error": {
>     "message": "Unknown parameter: 'data[0].span_data.usage.total_tokens'.",
>     "type": "invalid_request_error",
>     "param": "data[0].span_data.usage.total_tokens",
>     "code": "unknown_parameter"
>   }
> }
> ```


</details>

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

#### Databricks LLM CUJ, export to both MLflow and OpenAI (set `OPENAI_API_KEY`):
before and after dont work due to schema misalignment:
```
ERROR:openai.agents:[non-fatal] Tracing client error 400: {
  "error": {
    "message": "Unknown parameter: 'data[0].span_data.usage.total_tokens'.",
    "type": "invalid_request_error",
    "param": "data[0].span_data.usage.total_tokens",
    "code": "unknown_parameter"
  }
}
```

#### Databricks LLM CUJ, export only to MLflow
before:
```
ERROR:openai.agents:[non-fatal] Tracing client error 401: {
  "error": {
    "message": "Incorrect API key provided: no-token. You can find your API key at https://platform.openai.com/account/api-keys.",
    "type": "invalid_request_error",
    "param": null,
    "code": "invalid_api_key"
  }
}
```
after: no errors in the logs bc the openai agents sdk is disabled by default

#### Use OpenAI LLM, export to both MLflow and OpenAI
before and after both work. manual test after:
my openai traces console:
<img width="2172" height="158" alt="image" src="https://github.com/user-attachments/assets/c8d3f80b-ddeb-45ce-b116-5b8207c4c12d" />

mlflow traces:
<img width="1495" height="108" alt="image" src="https://github.com/user-attachments/assets/6335afb6-119d-463c-87f1-007fc25362e5" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
