### PR TITLE
Fix MCP fn_wrapper to pass None for optional params with UNSET defaults

### DIFF
--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -94,8 +94,11 @@ def fn_wrapper(command: click.Command) -> Callable[..., str]:
         ):
             # Fill in defaults for missing optional arguments
             for param in command.params:
-                if param.name not in kwargs and param.default is not click_unset:
-                    kwargs[param.name] = param.default
+                if param.name not in kwargs:
+                    if param.default is click_unset:
+                        kwargs[param.name] = None
+                    else:
+                        kwargs[param.name] = param.default
             command.callback(**kwargs)  # type: ignore[misc]
         return string_io.getvalue().strip()
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve  #21050

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR fixes `mlflow/mcp/server.py:fn_wrapper` to handle Click 8.3.0+ `click.core.Sentinel.UNSET` defaults without breaking callback invocation.

When a parameter is missing from `kwargs`:

- If `param.default is Sentinel.UNSET`, this PR sets `kwargs[param.name] = None`.
- Otherwise, it sets `kwargs[param.name] = param.default` (existing behavior).

This avoids passing `UNSET` into callbacks while ensuring omitted optional params are still present for `command.callback(**kwargs)`.

### How is this PR tested?

- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Verified on Click 8.3.1.

**Python-level**

```python
from mlflow.mcp.server import fn_wrapper
from mlflow.experiments import commands as experiments_cli

wrapped = fn_wrapper(experiments_cli.commands["get"])
wrapped(experiment_id="4", output="json")
```

* **Before this PR:** raises `TypeError: get_experiment() missing 1 required positional argument: 'experiment_name'`
* **With this PR:** succeeds and returns the expected JSON response.

**End-to-end MCP tool calls**

* `get_experiment` succeeds when exactly one of `experiment_id` / `experiment_name` is provided, and fails with the expected Click validation error when both/neither are provided.
* `search_traces`, `list_scorers`, and `create_run` behave as expected with optional params omitted / flags set / defaults applied.



### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No. You can skip the rest of this section.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Fixes MCP tool invocation on Click 8.3.0+ when optional parameters are omitted by treating `Sentinel.UNSET` defaults as `None` in `fn_wrapper`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
