### PR TITLE
Fix field-based make_judge prompt missing feedback_value_type

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from dataclasses import asdict
-from typing import Any, Literal, get_origin
+from typing import Any, Literal
 
 import pydantic
 from pydantic import PrivateAttr
@@ -24,6 +24,7 @@ from mlflow.genai.judges.instructions_judge.constants import (
 from mlflow.genai.judges.utils import (
     add_output_format_instructions,
     format_prompt,
+    format_type,
     get_default_model,
     invoke_judge_model,
     validate_judge_model,
@@ -337,7 +338,7 @@ class InstructionsJudge(Judge):
             # include the value type in the description too so that models that don't support
             # structured outputs with tool calls can still understand the type.
             evaluation_rating_fields = "\n".join([
-                f"- {field.name} ({self._format_type(field.value_type)}): {field.description}"
+                f"- {field.name} ({format_type(field.value_type)}): {field.description}"
                 for field in output_fields
             ])
             return INSTRUCTIONS_JUDGE_TRACE_PROMPT_TEMPLATE.format(
@@ -369,14 +370,6 @@ class InstructionsJudge(Judge):
             if self._generate_rationale_first
             else [result_field, rationale_field]
         )
-
-    def _format_type(self, value_type: Any) -> str:
-        if value_type in (str, int, float, bool):
-            return value_type.__name__
-        elif get_origin(value_type) is Literal:
-            return str(value_type).replace("typing.", "")
-        # dict and list
-        return str(value_type)
 
     def _build_user_message(
         self,

--- a/mlflow/genai/judges/utils/__init__.py
+++ b/mlflow/genai/judges/utils/__init__.py
@@ -23,6 +23,7 @@ from mlflow.genai.judges.utils.prompt_utils import (
     DatabricksLLMJudgePrompts,
     add_output_format_instructions,
     format_prompt,
+    format_type,
 )
 from mlflow.genai.utils.enum_utils import StrEnum
 from mlflow.utils.uri import is_databricks_uri
@@ -143,6 +144,7 @@ __all__ = [
     "get_chat_completions_with_structured_output",
     # Prompt utils
     "DatabricksLLMJudgePrompts",
+    "format_type",
     "format_prompt",
     "add_output_format_instructions",
 ]

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -998,9 +998,9 @@ def test_output_format_instructions_added(mock_invoke_judge_model):
     assert system_msg.content.startswith(JUDGE_BASE_PROMPT)
     assert "Check if {{ outputs }} is formal" in system_msg.content
     # Tighter assertion for output format instructions
-    assert "Please provide your assessment in the following JSON format only" in system_msg.content
-    assert '"result": "The evaluation rating/result"' in system_msg.content
-    assert '"rationale": "Detailed explanation for the evaluation"' in system_msg.content
+    assert "format your evaluation rating as a JSON object" in system_msg.content
+    assert "- result (str): The evaluation rating/result" in system_msg.content
+    assert "- rationale (str): Detailed explanation for the evaluation" in system_msg.content
 
     assert result.value is True
 
@@ -1033,9 +1033,9 @@ def test_output_format_instructions_with_complex_template(mock_invoke_judge_mode
         in system_msg.content
     )
     # Tighter assertion for output format instructions
-    assert "Please provide your assessment in the following JSON format only" in system_msg.content
-    assert '"result": "The evaluation rating/result"' in system_msg.content
-    assert '"rationale": "Detailed explanation for the evaluation"' in system_msg.content
+    assert "format your evaluation rating as a JSON object" in system_msg.content
+    assert "- result (str): The evaluation rating/result" in system_msg.content
+    assert "- rationale (str): Detailed explanation for the evaluation" in system_msg.content
 
 
 def test_judge_registration_as_scorer(mock_invoke_judge_model):
@@ -1102,7 +1102,7 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     assert prompt[0].role == "system"
     assert prompt[0].content.startswith(JUDGE_BASE_PROMPT)
     assert "Evaluate if the {{ outputs }} is professional and formal." in prompt[0].content
-    assert "JSON format" in prompt[0].content
+    assert "format your evaluation rating as a JSON object" in prompt[0].content
 
     # Check user message
     assert prompt[1].role == "user"
@@ -1203,7 +1203,7 @@ def test_judge_registration_with_reserved_variables(mock_invoke_judge_model):
     assert prompt[0].content.startswith(JUDGE_BASE_PROMPT)
     assert "Check if {{ inputs }} is answered correctly by {{ outputs }}" in prompt[0].content
     assert "according to {{ expectations }}" in prompt[0].content
-    assert "JSON format" in prompt[0].content
+    assert "format your evaluation rating as a JSON object" in prompt[0].content
 
     # Check user message with all reserved variables as JSON
     assert prompt[1].role == "user"
@@ -2642,18 +2642,16 @@ def test_no_duplicate_output_fields_in_system_message():
     field_judge = make_judge(
         name="field_judge",
         instructions="Evaluate {{ inputs }} and {{ outputs }} for quality",
-        feedback_value_type=str,
+        feedback_value_type=Literal["yes", "no"],
         model="openai:/gpt-4",
     )
 
     field_system_msg = field_judge._build_system_message(is_trace_based=False)
 
-    assert field_system_msg.count('"result"') == 1
-    assert field_system_msg.count('"rationale"') == 1
+    assert field_system_msg.count("- result (Literal['yes', 'no']):") == 1
+    assert field_system_msg.count("- rationale (str):") == 1
 
-    assert (
-        field_system_msg.count("Please provide your assessment in the following JSON format") == 1
-    )
+    assert field_system_msg.count("format your evaluation rating as a JSON object") == 1
 
     trace_judge = make_judge(
         name="trace_judge",
@@ -2666,8 +2664,6 @@ def test_no_duplicate_output_fields_in_system_message():
 
     assert trace_system_msg.count("- result (Literal['good', 'bad', 'neutral'])") == 1
     assert trace_system_msg.count("- rationale (str):") == 1
-
-    assert "Please provide your assessment in the following JSON format" not in trace_system_msg
 
 
 def test_instructions_judge_repr():

--- a/tests/genai/judges/utils/test_prompt_utils.py
+++ b/tests/genai/judges/utils/test_prompt_utils.py
@@ -12,9 +12,9 @@ def test_add_output_format_instructions():
     formatted = add_output_format_instructions(simple_prompt, output_fields=output_fields)
 
     assert simple_prompt in formatted
-    assert "JSON format" in formatted
-    assert '"result"' in formatted
-    assert '"rationale"' in formatted
+    assert "format your evaluation rating as a JSON object" in formatted
+    assert "- result" in formatted
+    assert "- rationale" in formatted
     assert "no markdown" in formatted.lower()
     assert "The evaluation rating/result" in formatted
     assert "Detailed explanation for the evaluation" in formatted
@@ -24,11 +24,12 @@ def test_add_output_format_instructions():
 
     assert complex_prompt in formatted
     assert formatted.startswith(complex_prompt)
-    assert formatted.endswith("}")
 
-    assert formatted.index(complex_prompt) < formatted.index("JSON format")
-    assert formatted.index(complex_prompt) < formatted.index('"result"')
-    assert formatted.index(complex_prompt) < formatted.index('"rationale"')
+    assert formatted.index(complex_prompt) < formatted.index(
+        "format your evaluation rating as a JSON object"
+    )
+    assert formatted.index(complex_prompt) < formatted.index("- result")
+    assert formatted.index(complex_prompt) < formatted.index("- rationale")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #21057

### What changes are proposed in this pull request?
Extract `format_type` utility from `InstructionsJudge._format_type` into `prompt_utils.py` and use it in `add_output_format_instructions` to include `feedback_value_type` in the field-based output format prompt. The prompt format and wording are now consistent with the trace-based path.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Existing unit tests
Updated prompt format assertions across existing tests to match the new wording. Updated `test_no_duplicate_output_fields_in_system_message` to use `Literal` type and verify `feedback_value_type` is included in the field-based prompt in `make_judge`.

#### Manual test
Tested with a model that does not support structured outputs.

Before — all fields shown as STRING regardless of feedback_value_type:

<img width="610" height="344" alt="image" src="https://github.com/user-attachments/assets/df0a322a-ed41-4c57-8c03-08fce4e07a52" />


After — fields correctly reflect their specified types (PASS, TRUE, AVG, STRING):
<img width="592" height="376" alt="image" src="https://github.com/user-attachments/assets/b609c952-bc34-485e-be9a-cd56773ba56f" />


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No. You can skip the rest of this section.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fixed field-based `make_judge` to include `feedback_value_type` in the judge prompt for models without structured output support.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
