### PR TITLE
Fix UniqueViolation race condition in entity_associations linking

### DIFF
--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -20,6 +20,7 @@ from mlflow.environment_variables import (
     MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION,
 )
 from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.judges.utils import get_chat_completions_with_structured_output
 from mlflow.genai.utils.data_validation import check_model_prediction
 from mlflow.genai.utils.prompts.available_tools_extraction import (
@@ -968,9 +969,19 @@ def batch_link_traces_to_run(
         try:
             MlflowClient().link_traces_to_run(run_id=run_id, trace_ids=batch)
         except Exception as e:
-            # FileStore doesn't support trace linking, so we skip it
-            if "Linking traces to runs is not supported in FileStore." in str(e):
+            error_str = str(e)
+            # FileStore doesn't support trace linking — skip silently.
+            if "Linking traces to runs is not supported in FileStore." in error_str:
                 return
+            # A concurrent evaluate() call already linked the same traces.
+            # The desired association already exists — no action required.
+            from mlflow.exceptions import MlflowException
+
+            if isinstance(e, MlflowException):
+                from mlflow.protos.databricks_pb2 import ALREADY_EXISTS, RESOURCE_ALREADY_EXISTS
+
+                if e.error_code in (ALREADY_EXISTS, RESOURCE_ALREADY_EXISTS):
+                    continue
 
             _logger.warning(f"Failed to link batch of traces to run: {e}")
 
@@ -1120,9 +1131,7 @@ def _try_extract_available_tools_with_llm(
     """
     if model is None:
         if is_databricks_uri(mlflow.get_tracking_uri()):
-            # TODO: Add support for Databricks tool extraction with LLM fallback.
-            _logger.warning("Databricks is not supported for tool extraction with LLM fallback.")
-            return []
+            model = _DATABRICKS_DEFAULT_JUDGE_MODEL
         else:
             model = "openai:/gpt-4.1-mini"
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -7,6 +7,7 @@ import pathlib
 import posixpath
 import re
 import tempfile
+import threading
 import time
 import urllib
 from functools import partial, wraps
@@ -22,7 +23,6 @@ from mlflow.entities import (
     Assessment,
     DatasetInput,
     Expectation,
-    Experiment,
     ExperimentTag,
     FallbackConfig,
     FallbackStrategy,
@@ -38,6 +38,7 @@ from mlflow.entities import (
     RunTag,
     ViewType,
     Workspace,
+    WorkspaceDeletionMode,
 )
 from mlflow.entities import (
     RoutingStrategy as RoutingStrategyEntity,
@@ -60,11 +61,13 @@ from mlflow.environment_variables import (
     MLFLOW_CREATE_MODEL_VERSION_SOURCE_VALIDATION_REGEX,
     MLFLOW_DEPLOYMENTS_TARGET,
     MLFLOW_ENABLE_WORKSPACES,
+    MLFLOW_PRESIGNED_DOWNLOAD_URL_TTL_SECONDS,
 )
 from mlflow.exceptions import (
     MlflowException,
     MlflowNotImplementedException,
     MlflowTracingException,
+    _UnsupportedMultipartDownloadException,
     _UnsupportedMultipartUploadException,
 )
 from mlflow.gateway.utils import is_valid_endpoint_name
@@ -85,6 +88,7 @@ from mlflow.protos.mlflow_artifacts_pb2 import (
     CreateMultipartUpload,
     DeleteArtifact,
     DownloadArtifact,
+    GetPresignedDownloadUrl,
     MlflowArtifactsService,
     UploadArtifact,
 )
@@ -243,7 +247,7 @@ from mlflow.server.validation import _validate_content_type
 from mlflow.server.workspace_helpers import (
     _get_workspace_store,
 )
-from mlflow.store.artifact.artifact_repo import MultipartUploadMixin
+from mlflow.store.artifact.artifact_repo import MultipartDownloadMixin, MultipartUploadMixin
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.jobs.abstract_store import AbstractJobStore
@@ -1101,24 +1105,6 @@ def _ensure_artifact_root_available(workspace_artifact_root: str | None) -> None
 
 
 @catch_mlflow_exception
-def _server_features_handler():
-    """
-    Returns a dictionary containing the server features state.
-
-    This helps clients determine if workspaces are enabled.
-    """
-    response = Response(mimetype="application/json")
-    response.set_data(
-        json.dumps(
-            {
-                "workspaces_enabled": MLFLOW_ENABLE_WORKSPACES.get(),
-            }
-        )
-    )
-    return response
-
-
-@catch_mlflow_exception
 @_disable_if_workspaces_disabled
 def _list_workspaces_handler():
     _get_request_message(ListWorkspaces())
@@ -1164,17 +1150,6 @@ def _create_workspace_handler():
         )
     except NotImplementedError:
         raise _workspace_not_supported("Workspace creation is not supported by this provider")
-
-    tracking_store = _get_tracking_store()
-    with workspace_context.WorkspaceContext(workspace.name):
-        if tracking_store.get_experiment_by_name(Experiment.DEFAULT_EXPERIMENT_NAME) is None:
-            try:
-                tracking_store.create_experiment(Experiment.DEFAULT_EXPERIMENT_NAME)
-            except MlflowException as exc:
-                if exc.error_code != databricks_pb2.ErrorCode.Name(
-                    databricks_pb2.RESOURCE_ALREADY_EXISTS
-                ):
-                    raise
 
     response_message = CreateWorkspace.Response()
     response_message.workspace.MergeFrom(workspace.to_proto())
@@ -1247,9 +1222,17 @@ def _delete_workspace_handler(workspace_name: str):
             f"The '{DEFAULT_WORKSPACE_NAME}' workspace is reserved and cannot be deleted"
         )
     WorkspaceNameValidator.validate(workspace_name)
+    mode_str = request.args.get("mode", WorkspaceDeletionMode.RESTRICT.value)
+    try:
+        mode = WorkspaceDeletionMode(mode_str)
+    except ValueError:
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid deletion mode '{mode_str}'. "
+            f"Must be one of: {', '.join(m.value for m in WorkspaceDeletionMode)}"
+        )
     store = _get_workspace_store()
     try:
-        store.delete_workspace(workspace_name)
+        store.delete_workspace(workspace_name, mode=mode)
     except NotImplementedError:
         raise _workspace_not_supported("Workspace deletion is not supported by this provider")
     return Response(status=204)
@@ -2644,9 +2627,24 @@ def _create_model_version():
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
-    # If the model version is a prompt, we don't validate the source
     is_prompt = _is_prompt_request(request_message)
-    if not is_prompt:
+    if is_prompt:
+        # Prompt sources must not point to local filesystem paths.
+        # Block file:// URIs and absolute paths (e.g. /etc/passwd) but allow
+        # the legitimate schemeless placeholder sources used internally
+        # (e.g. "prompt-template", "dummy-source").
+        source = request_message.source
+        parsed = urllib.parse.urlparse(source)
+        if parsed.scheme == "file" or (parsed.scheme == "" and source.startswith("/")):
+            raise MlflowException(
+                f"Invalid prompt source: '{source}'. "
+                "Local source paths are not allowed for prompts.",
+                INVALID_PARAMETER_VALUE,
+            )
+        # Only validate traversal for sources with a URL scheme (http, https, etc.)
+        if parsed.scheme:
+            _validate_non_local_source_contains_relative_paths(source)
+    else:
         if request_message.model_id:
             _validate_source_model(request_message.source, request_message.model_id)
         else:
@@ -3372,6 +3370,11 @@ def _validate_support_multipart_upload(artifact_repo):
         raise _UnsupportedMultipartUploadException()
 
 
+def _validate_support_multipart_download(artifact_repo):
+    if not isinstance(artifact_repo, MultipartDownloadMixin):
+        raise _UnsupportedMultipartDownloadException()
+
+
 @catch_mlflow_exception
 @_disable_unless_serve_artifacts
 def _create_multipart_upload_artifact(artifact_path):
@@ -3469,6 +3472,27 @@ def _abort_multipart_upload_artifact(artifact_path):
         artifact_path,
     )
     return _wrap_response(AbortMultipartUpload.Response())
+
+
+@catch_mlflow_exception
+@_disable_unless_serve_artifacts
+def _get_presigned_download_url(artifact_path):
+    """
+    A request handler for `GET /mlflow-artifacts/presigned/<artifact_path>` to get
+    a presigned URL for downloading an artifact directly from cloud storage.
+    """
+    artifact_path = validate_path_is_safe(artifact_path)
+
+    artifact_repo = _get_artifact_repo_mlflow_artifacts()
+    _validate_support_multipart_download(artifact_repo)
+
+    expiration = MLFLOW_PRESIGNED_DOWNLOAD_URL_TTL_SECONDS.get()
+    presigned_response = artifact_repo.get_download_presigned_url(
+        artifact_path, expiration=expiration
+    )
+    response = Response(mimetype="application/json")
+    response.set_data(json.dumps(presigned_response.to_dict()))
+    return response
 
 
 # MLflow Tracing APIs
@@ -3720,6 +3744,8 @@ def _link_traces_to_run():
     """
     A request handler for `POST /mlflow/traces/link-to-run` to link traces to a run.
     """
+    from sqlalchemy.exc import IntegrityError as SqlAlchemyIntegrityError
+
     request_message = _get_request_message(
         LinkTracesToRun(),
         schema={
@@ -3727,10 +3753,15 @@ def _link_traces_to_run():
             "run_id": [_assert_string, _assert_required],
         },
     )
-    _get_tracking_store().link_traces_to_run(
-        trace_ids=request_message.trace_ids,
-        run_id=request_message.run_id,
-    )
+    try:
+        _get_tracking_store().link_traces_to_run(
+            trace_ids=request_message.trace_ids,
+            run_id=request_message.run_id,
+        )
+    except SqlAlchemyIntegrityError:
+        # A concurrent request already created the same association(s).
+        # The desired state already exists — return success.
+        pass
     return _wrap_response(LinkTracesToRun.Response())
 
 
@@ -3741,6 +3772,7 @@ def _link_prompts_to_trace():
     A request handler for `POST /mlflow/traces/link-prompts` to link prompt versions to a trace.
     """
     from mlflow.entities.model_registry import PromptVersion
+    from sqlalchemy.exc import IntegrityError as SqlAlchemyIntegrityError
 
     request_message = _get_request_message(
         LinkPromptsToTrace(),
@@ -3757,10 +3789,15 @@ def _link_prompts_to_trace():
         for pv in request_message.prompt_versions
     ]
 
-    _get_tracking_store().link_prompts_to_trace(
-        trace_id=request_message.trace_id,
-        prompt_versions=prompt_versions,
-    )
+    try:
+        _get_tracking_store().link_prompts_to_trace(
+            trace_id=request_message.trace_id,
+            prompt_versions=prompt_versions,
+        )
+    except SqlAlchemyIntegrityError:
+        # A concurrent request already created the same association(s).
+        # The desired state already exists — return success.
+        pass
     return _wrap_response(LinkPromptsToTrace.Response())
 
 
@@ -5035,6 +5072,7 @@ def _delete_gateway_endpoint_tag():
     return response
 
 
+@catch_mlflow_exception
 def _get_server_info():
     from mlflow.store.tracking.file_store import FileStore
     from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
@@ -5047,7 +5085,12 @@ def _get_server_info():
         store_type = "SqlStore"
     else:
         store_type = None
-    return jsonify({"store_type": store_type})
+    return jsonify(
+        {
+            "store_type": store_type,
+            "workspaces_enabled": MLFLOW_ENABLE_WORKSPACES.get(),
+        }
+    )
 
 
 @catch_mlflow_exception
@@ -5224,19 +5267,20 @@ def get_endpoints(get_handler=get_handler):
     Returns:
         List of tuples (path, handler, methods)
     """
-    server_feature_paths = [
-        (_path, _server_features_handler, ["GET"])
-        for _path in _get_paths("/mlflow/server-features", version=3)
-    ]
     return (
         get_service_endpoints(MlflowService, get_handler)
         + get_internal_online_scoring_endpoints()
         + get_service_endpoints(ModelRegistryService, get_handler)
         + get_service_endpoints(MlflowArtifactsService, get_handler)
         + get_service_endpoints(WebhookService, get_handler)
-        + server_feature_paths
         + [(_add_static_prefix("/graphql"), _graphql, ["GET", "POST"])]
-        + [(_add_static_prefix("/server-info"), _get_server_info, ["GET"])]
+        # NB: Use _get_paths() (not _add_static_prefix()) so that the endpoint is reachable
+        # both at /api/3.0/mlflow/server-info (for the Python client, unaffected by static prefix)
+        # and at <static-prefix>/ajax-api/3.0/mlflow/server-info (for the frontend).
+        + [
+            (_path, _get_server_info, ["GET"])
+            for _path in _get_paths("/mlflow/server-info", version=3)
+        ]
         + get_gateway_endpoints()
         + get_demo_endpoints()
     )
@@ -5274,6 +5318,11 @@ def get_gateway_endpoints():
 
 
 # Demo APIs
+
+# Serialize demo generation so concurrent requests (e.g. FastAPI running Flask
+# handlers in a thread pool) cannot race on the process-wide MLFLOW_WORKSPACE
+# env var that WorkspaceContext temporarily sets during generate_all_demos.
+_demo_generate_lock = threading.Lock()
 
 
 def get_demo_endpoints():
@@ -5329,7 +5378,8 @@ def _generate_demo():
             }
         )
 
-    results = generate_all_demos(features=features)
+    with _demo_generate_lock:
+        results = generate_all_demos(features=features)
 
     experiment = store.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
     experiment_id = experiment.experiment_id if experiment else None
@@ -6135,6 +6185,7 @@ HANDLERS = {
     CreateMultipartUpload: _create_multipart_upload_artifact,
     CompleteMultipartUpload: _complete_multipart_upload_artifact,
     AbortMultipartUpload: _abort_multipart_upload_artifact,
+    GetPresignedDownloadUrl: _get_presigned_download_url,
     # MLflow Tracing APIs (V3)
     StartTraceV3: _start_trace_v3,
     GetTraceInfoV3: _get_trace_info_v3,


### PR DESCRIPTION
## Summary

Fixes a race condition where concurrent calls to `mlflow.genai.evaluate` could raise a `psycopg2.errors.UniqueViolation` / SQLAlchemy `IntegrityError` when multiple callers attempted to link the same traces to a run simultaneously.

**Root cause:** `link_traces_to_run` and `link_prompts_to_trace` in `sqlalchemy_store.py` used a check-then-insert pattern. Two concurrent callers could both pass the "already exists" SELECT query and then both issue the same INSERT, causing a unique-constraint violation on `entity_associations_pk`.

**Changes:**

- `mlflow/store/tracking/sqlalchemy_store.py` — replaces the check-then-insert with a new `_upsert_entity_associations` helper that inserts each row inside a savepoint and silently ignores `IntegrityError` on duplicates, making the operation idempotent at the database level.
- `mlflow/server/handlers.py` — adds an `IntegrityError` catch in `_link_traces_to_run` and `_link_prompts_to_trace` so any duplicate-key exception that escapes the store layer returns HTTP 200 instead of 500.
- `mlflow/store/tracking/rest_store.py` — treats `ALREADY_EXISTS` / `RESOURCE_ALREADY_EXISTS` server responses as a successful no-op in the REST client, preventing spurious exceptions when using a Databricks-backed tracking server.
- `mlflow/genai/utils/trace_utils.py` — skips `ALREADY_EXISTS` / `RESOURCE_ALREADY_EXISTS` `MlflowException` in `batch_link_traces_to_run` so a parallel evaluate job does not surface a warning or abort.

Closes https://github.com/mlflow/mlflow/issues/21002
