### PR TITLE
Propagate OTel context across async and thread-pool boundaries in genai evaluation

### DIFF
--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import functools
 import inspect
 import json
@@ -495,7 +496,16 @@ def _wrap_async_predict_fn(async_fn: Callable[..., Any]) -> Callable[..., Any]:
                     "install nest-asyncio: pip install nest-asyncio"
                 )
 
-        return asyncio.run(asyncio.wait_for(async_fn(*args, **kwargs), timeout=timeout))
+        # Capture the current Python contextvars context — which includes the
+        # OTel ContextVar holding the active span — so that asyncio.run() sees
+        # the parent span instead of an empty context.  Without this, every
+        # child LLM span created inside the coroutine is traced as a root span.
+        calling_ctx = contextvars.copy_context()
+
+        def _run():
+            return asyncio.run(asyncio.wait_for(async_fn(*args, **kwargs), timeout=timeout))
+
+        return calling_ctx.run(_run)
 
     return sync_wrapper
 


### PR DESCRIPTION
## Summary

Fixes child spans created inside an async `predict_fn` appearing as root-level traces instead of being nested under the parent evaluation span.

**Root cause:** `_wrap_async_predict_fn` calls `asyncio.run()` which starts a fresh event loop. The new event loop does not inherit the caller's `contextvars` context, so OpenTelemetry's `ContextVar`-stored active span is invisible inside the coroutine. Child LLM spans are created with no parent and appear as independent root traces.

The same propagation gap exists in `_build_eval_fn` (prompt optimization) when `_run_single` is dispatched to a `ThreadPoolExecutor` and MLflow's `mlflow_runtime_context` provider is in use.

**Changes:**

- `mlflow/genai/utils/trace_utils.py` — capture `contextvars.copy_context()` on the calling thread inside `sync_wrapper` and run `asyncio.run()` within that copied context, ensuring the parent span `ContextVar` is visible to the coroutine.
- `mlflow/tracing/provider.py` — add `run_with_otel_context(otel_ctx, fn, ...)`, a utility that attaches an OTel context, calls the function, and detaches on exit.
- `mlflow/genai/optimize/optimize.py` — snapshot the OTel context on the submitter thread and wrap each `executor.submit` call with `run_with_otel_context` so worker-thread spans are correctly parented to the active optimization span.
- `mlflow/tracing/fluent.py` — add `current_otel_context()`, a public helper that returns a snapshot of the current OTel context for propagation across async or thread-pool boundaries without requiring callers to import private provider internals.

Closes https://github.com/mlflow/mlflow/issues/19536
