### PR TITLE
Fix visibility toggle button in chart tooltip not working

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -38,7 +38,7 @@ import { customMetricBehaviorDefs } from '../../experiment-page/utils/customMetr
 interface RunsChartsContextMenuContentDataType {
   runs: RunsChartsRunData[];
   onTogglePin?: (runUuid: string) => void;
-  onHideRun?: (runUuid: string) => void;
+  onHideRun?: (runUuid: string, isCurrentlyVisible: boolean) => void;
   getDataTraceLink?: (experimentId: string, traceUuid: string) => string;
 }
 
@@ -376,7 +376,7 @@ export const RunsChartsTooltipBody = ({
               data-testid="experiment-view-compare-runs-tooltip-visibility-button"
               size="small"
               onClick={() => {
-                onHideRun(runUuid);
+                onHideRun(runUuid, !activeRun.hidden);
                 closeContextMenu();
               }}
               icon={<VisibleIcon />}

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
@@ -322,7 +322,8 @@ const RunsCompareImpl = ({
   const toggleRunVisibility = useToggleRowVisibilityCallback(comparedRuns);
 
   const onHideRun = useCallback(
-    (runUuid: string) => toggleRunVisibility(RUNS_VISIBILITY_MODE.CUSTOM, runUuid),
+    (runUuid: string, isCurrentlyVisible: boolean) =>
+      toggleRunVisibility(RUNS_VISIBILITY_MODE.CUSTOM, runUuid, isCurrentlyVisible),
     [toggleRunVisibility],
   );
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #21046

### What changes are proposed in this pull request?

Fix the visibility toggle button in `RunsChartsTooltipWrapper` which was not correctly hiding/showing runs.

**Root cause:** The `onHideRun` callback was not passing the current visibility state to the underlying `toggleRunVisibility` function. When `isCurrentlyVisible` is not provided, the code does `!isCurrentlyVisible` which becomes `!undefined` = `true`, causing the run to always be set to visible instead of toggling.

**Changes:**
- Update `onHideRun` interface to accept `isCurrentlyVisible` parameter
- Pass `!activeRun.hidden` state when calling `onHideRun` from tooltip button
- Update `RunsCompare` callback to pass visibility state through to `toggleRunVisibility`

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified that the visibility toggle button now correctly hides runs when clicked in the chart tooltip.


https://github.com/user-attachments/assets/bafe0519-abc4-433b-95a9-269c4920bb54



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix visibility toggle button in chart tooltip not correctly hiding runs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)