### PR TITLE
Enforce presigned-URL-only artifact transfers when multipart is enabled

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -404,6 +404,21 @@ MLFLOW_PRESIGNED_DOWNLOAD_URL_TTL_SECONDS = _EnvironmentVariable(
     "MLFLOW_PRESIGNED_DOWNLOAD_URL_TTL_SECONDS", int, 300
 )
 
+#: Server-side: when True, reject proxied artifact uploads and require clients to use
+#: multipart upload. Only enforced when the backend artifact store supports multipart.
+#: (default: ``False``)
+MLFLOW_ENFORCE_PROXY_MULTIPART_UPLOAD = _BooleanEnvironmentVariable(
+    "MLFLOW_ENFORCE_PROXY_MULTIPART_UPLOAD", False
+)
+
+#: Server-side: when True, reject proxied artifact downloads and require clients to use
+#: multipart download via presigned URLs. Only enforced when the backend artifact store
+#: supports presigned downloads.
+#: (default: ``False``)
+MLFLOW_ENFORCE_PROXY_MULTIPART_DOWNLOAD = _BooleanEnvironmentVariable(
+    "MLFLOW_ENFORCE_PROXY_MULTIPART_DOWNLOAD", False
+)
+
 #: Private environment variable that's set to ``True`` while running tests.
 _MLFLOW_TESTING = _BooleanEnvironmentVariable("MLFLOW_TESTING", False)
 


### PR DESCRIPTION
### Related Issues/PRs

Resolves #19731

Follow-up to #20352 .

### What changes are proposed in this pull request?

When multipart upload/download is enabled (via client env var or server-side enforcement), all artifact transfers now strictly use presigned URLs with no proxy fallback. Added `MLFLOW_ENFORCE_PROXY_MULTIPART_UPLOAD` and `MLFLOW_ENFORCE_PROXY_MULTIPART_DOWNLOAD` boolean env vars to enable enforcement on the server.

Before: When multipart was enabled, the client would silently fall back to proxied upload/download if multipart failed (e.g., server returned 501) or if the file was below the size threshold.

After: When multipart is enabled, all files (regardless of size) use presigned URLs. Errors propagate instead of falling back to proxy. Server-side HTTP 409 blocks direct uploads/downloads for older clients with an instructional message. 

**ATTENTION**: in the current implementation, if enforcement env vars are set to `true`, the enforcement will be effective only for backend artifact stores that implement `MultipartUploadMixin`, so other backends will still process the uploads/downlaods directly via `/mlflow-artifacts/artifacts/<path>`. Thus, these env vars do not disable `/mlflow-artifacts/artifacts/<path>` route entirely! 

#### Enforcement flow

Server advertises enforcement via `/api/3.0/mlflow/server-info`:

```
GET /api/3.0/mlflow/server-info

{
  "enforce_proxy_multipart_upload": true,
  "enforce_proxy_multipart_download": true,
  "store_type": "SqlStore",
  "workspaces_enabled": false
}
```

Updated client:

```
1. Client calls /server-info -> sees enforce_proxy_multipart_upload=true
2. Client auto-enables multipart upload (no env var needed)
3. Client uploads ALL files via presigned URLs (create -> upload parts -> complete)
4. No fallback to proxied PUT - errors propagate
```

```
1. Client calls /server-info -> sees enforce_proxy_multipart_download=true
2. Client auto-enables multipart download (no env var needed)
3. Client downloads ALL files via presigned URLs
4. No fallback to proxied GET - errors propagate
```

Outdated client:

```
1. Client does NOT call /server-info (unaware of enforcement)
2. Client attempts proxied PUT /mlflow-artifacts/artifacts/<path>
3. Server returns HTTP 409:
   "Server requires multipart upload. Set
    MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD=true on the client,
    or upgrade your MLflow client."
4. Client sees a clear error message with instructions to upgrade or set the env var.
```

Same applies to downloads, old clients attempting proxied GET receive a 409 with instructions.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**New tests in `tests/store/artifact/test_http_artifact_repo.py`:**
- `test_log_artifact_small_file_uses_multipart_when_enabled` - small files use multipart when enabled
- `test_log_artifact_no_fallback_when_multipart_enabled` - unsupported multipart raises instead of falling back
- `test_log_artifact_empty_file_uses_multipart_when_enabled` - empty files go through multipart
- `test_download_file_raises_when_presigned_not_supported` - presigned download failure raises instead of falling back
- `test_download_file_no_fallback_when_multipart_enabled` - no proxy fallback on download failure

**New tests in `tests/server/test_handlers.py`:**
- Server-side 409 enforcement tests for upload and download endpoints

**Manual tests:**
- Tested with local MLflow server (S3-backed artifact store)
- Verified 10MB file upload, 1-byte file upload, 10GB upload and empty file upload - all succeed via multipart
- Verified server enforcement auto-enables multipart on clients without the env var set

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

New environment variables `MLFLOW_ENFORCE_PROXY_MULTIPART_UPLOAD` and `MLFLOW_ENFORCE_PROXY_MULTIPART_DOWNLOAD` should be documented.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

When multipart upload/download is enabled, all artifact transfers now strictly use presigned URLs with no proxy fallback. Added server-side environment variables `MLFLOW_ENFORCE_PROXY_MULTIPART_UPLOAD` and `MLFLOW_ENFORCE_PROXY_MULTIPART_DOWNLOAD` to enforce presigned-URL-only mode, with automatic client detection via the server-info endpoint.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
