### PR TITLE
disable litellm debug messages for databricks models

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -307,7 +307,8 @@ def calculate_cost_by_model_and_token_usage(
     # Suppress litellm debug messages (e.g. "Provider List: ...") that are printed
     # when litellm doesn't recognize a model name like "databricks-claude-sonnet-4-5".
     original_suppress = getattr(litellm, "suppress_debug_info", False)
-    litellm.suppress_debug_info = True
+    if model_name.startswith("databricks"):
+        litellm.suppress_debug_info = True
     try:
         try:
             input_cost_usd, output_cost_usd = cost_per_token(

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -318,8 +318,8 @@ def calculate_cost_by_model_and_token_usage(
     except Exception as e:
         if model_provider:
             # pass model_provider only in exception case to avoid invalid model_provider
-            # being used when model_name itself is enough to calculate cost, since
-            # model_provider field can be with any value and litellm may not support it.
+            # being used when model_name itself is enough to calculate cost, since model_provider
+            # field can be with any value and litellm may not support it.
             try:
                 input_cost_usd, output_cost_usd = cost_per_token(
                     model=model_name,

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -304,11 +304,12 @@ def calculate_cost_by_model_and_token_usage(
     if (created := usage.get(TokenUsageKey.CACHE_CREATION_INPUT_TOKENS)) is not None:
         cache_kwargs["cache_creation_input_tokens"] = created
 
-    # Suppress litellm debug messages (e.g. "Provider List: ...") unless
-    # MLflow's logger is set to DEBUG level.
-    original_suppress = getattr(litellm, "suppress_debug_info", False)
-    litellm.suppress_debug_info = not _logger.isEnabledFor(logging.DEBUG)
+    original_suppress = None
     try:
+        # Suppress litellm debug messages (e.g. "Provider List: ...") unless
+        # MLflow's logger is set to DEBUG level.
+        original_suppress = getattr(litellm, "suppress_debug_info")
+        litellm.suppress_debug_info = not _logger.isEnabledFor(logging.DEBUG)
         input_cost_usd, output_cost_usd = cost_per_token(
             model=model_name,
             prompt_tokens=prompt_tokens,
@@ -340,7 +341,8 @@ def calculate_cost_by_model_and_token_usage(
             )
             return None
     finally:
-        litellm.suppress_debug_info = original_suppress
+        if original_suppress is not None:
+            litellm.suppress_debug_info = original_suppress
 
     return {
         CostKey.INPUT_COST: input_cost_usd,

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -664,4 +664,6 @@ def test_litellm_provider_list_printed_when_debug_logging(capsys):
 
     captured = capsys.readouterr()
     assert "Provider List" in captured.out
+    # During the call to calculate cost, suppress was set to False
+    # We are asserting that suppress is reset to the original value after
     assert litellm.suppress_debug_info is True

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -690,3 +690,31 @@ def test_litellm_debug_info_not_suppressed_when_debug_logging():
         _logger.setLevel(original_level)
 
     assert captured["suppress_debug_info"] is False
+
+
+def test_litellm_provider_list_not_printed_during_cost_calculation(capsys):
+    calculate_cost_by_model_and_token_usage(
+        model_name="databricks-claude-sonnet-4-5",
+        usage={TokenUsageKey.INPUT_TOKENS: 10, TokenUsageKey.OUTPUT_TOKENS: 5},
+    )
+
+    captured = capsys.readouterr()
+    assert "Provider List" not in captured.out
+
+
+def test_litellm_provider_list_printed_when_debug_logging(capsys):
+    import logging
+
+    _logger = logging.getLogger("mlflow.tracing.utils")
+    original_level = _logger.level
+    _logger.setLevel(logging.DEBUG)
+    try:
+        calculate_cost_by_model_and_token_usage(
+            model_name="databricks-claude-sonnet-4-5",
+            usage={TokenUsageKey.INPUT_TOKENS: 10, TokenUsageKey.OUTPUT_TOKENS: 5},
+        )
+    finally:
+        _logger.setLevel(original_level)
+
+    captured = capsys.readouterr()
+    assert "Provider List" in captured.out

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -649,8 +649,9 @@ def test_litellm_provider_list_not_printed_during_cost_calculation(capsys):
 
 
 def test_litellm_provider_list_printed_when_debug_logging(capsys):
-    import litellm
     import logging
+
+    import litellm
 
     litellm.suppress_debug_info = True
 

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -1,7 +1,9 @@
 import json
+import logging
 from unittest import mock
 from unittest.mock import Mock, patch
 
+import litellm
 import pytest
 from opentelemetry import trace as trace_api
 from pydantic import ValidationError
@@ -634,8 +636,6 @@ def test_generate_trace_id_v4_from_otel_trace_id():
 
 
 def test_litellm_provider_list_not_printed_during_cost_calculation(capsys):
-    import litellm
-
     litellm.suppress_debug_info = False
 
     calculate_cost_by_model_and_token_usage(
@@ -649,10 +649,6 @@ def test_litellm_provider_list_not_printed_during_cost_calculation(capsys):
 
 
 def test_litellm_provider_list_printed_when_debug_logging(capsys):
-    import logging
-
-    import litellm
-
     litellm.suppress_debug_info = True
 
     _logger = logging.getLogger("mlflow.tracing.utils")


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
slack thread context: https://databricks.slack.com/archives/C022KUWGVQS/p1771842499541559

when using autologging with a Databricks LLM, logs like the following are being printed: `Provider List: https://docs.litellm.ai/docs/providers`. this PR disables those messages when using a databricks LLM by default, as it is unintuitive to end users why they're getting a litellm message when nothing in their code uses litellm.


### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

before in logs:
also after when MLflow logging is set to DEBUG:
```
Provider List: https://docs.litellm.ai/docs/providers
```

after: no unexpected logs



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
