### PR TITLE
Add telemetry for missing gateway dep guide load

### DIFF
--- a/mlflow/server/js/src/gateway/components/SecretsSetupGuide.tsx
+++ b/mlflow/server/js/src/gateway/components/SecretsSetupGuide.tsx
@@ -2,13 +2,18 @@ import {
   Alert,
   CloudModelIcon,
   CopyIcon,
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
   NewWindowIcon,
   Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
+import { useEffect, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { v4 as uuidv4 } from 'uuid';
 import { CopyButton } from '@mlflow/mlflow/src/shared/building_blocks/CopyButton';
 import { CodeSnippet } from '@databricks/web-shared/snippet';
+import { useLogTelemetryEvent } from '@mlflow/mlflow/src/telemetry/hooks/useLogTelemetryEvent';
 
 const INSTALL_SNIPPET = `pip install "mlflow[genai]"`;
 
@@ -27,6 +32,18 @@ const GATEWAY_DOCS_URL = 'https://mlflow.org/docs/latest';
 
 export const GatewaySetupGuide = () => {
   const { theme } = useDesignSystemTheme();
+  const logTelemetryEvent = useLogTelemetryEvent();
+  const viewId = useMemo(() => uuidv4(), []);
+
+  useEffect(() => {
+    logTelemetryEvent({
+      componentId: 'mlflow.gateway.setup_guide',
+      componentViewId: viewId,
+      componentType: DesignSystemEventProviderComponentTypes.Card,
+      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+      value: 'impression',
+    });
+  }, [logTelemetryEvent, viewId]);
 
   return (
     <div

--- a/mlflow/server/js/src/gateway/components/SecretsSetupGuide.tsx
+++ b/mlflow/server/js/src/gateway/components/SecretsSetupGuide.tsx
@@ -40,7 +40,7 @@ export const GatewaySetupGuide = () => {
       componentId: 'mlflow.gateway.setup_guide',
       componentViewId: viewId,
       componentType: DesignSystemEventProviderComponentTypes.Card,
-      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnView,
       value: 'impression',
     });
   }, [logTelemetryEvent, viewId]);


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Currently there's no direct way to know if users gives up using gateway after seeing the gateway set up page that is shown when gateway dependency is missing. This PR introduces the ui telemetry for the guide.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
