### PR TITLE
Fix `_deduplicate_requirements` merging marker-differentiated requirements

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -762,11 +762,12 @@ def _deduplicate_requirements(requirements):
         try:
             parsed_req = Requirement(req)
             base_pkg = parsed_req.name
+            key = (base_pkg, str(parsed_req.marker) if parsed_req.marker else "")
 
-            existing_req = deduped_reqs.get(base_pkg)
+            existing_req = deduped_reqs.get(key)
 
             if not existing_req:
-                deduped_reqs[base_pkg] = parsed_req
+                deduped_reqs[key] = parsed_req
             else:
                 # Verify that there are not unresolvable constraints applied if set and combine
                 # if possible
@@ -794,7 +795,7 @@ def _deduplicate_requirements(requirements):
                 elif existing_req.extras and not parsed_req.extras:
                     parsed_req.extras = existing_req.extras
 
-                deduped_reqs[base_pkg] = parsed_req
+                deduped_reqs[key] = parsed_req
 
         except InvalidRequirement:
             # Include non-standard package strings as-is

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -609,7 +609,7 @@ class _MismatchedPackageInfo(NamedTuple):
         return f"{self.package_name} (current: {current_status}, required: {self.requirement})"
 
 
-def _check_requirement_satisfied(requirement_str):
+def _check_requirement_satisfied(requirement_str: str) -> _MismatchedPackageInfo | None:
     """
     Checks whether the current python environment satisfies the given requirement if it is parsable
     as a package name and a set of version specifiers, and returns a `_MismatchedPackageInfo`
@@ -624,6 +624,8 @@ def _check_requirement_satisfied(requirement_str):
         # Extracting the package name from the requirement string is not trivial,
         # so we skip the check.
         return
+    if req.marker and not req.marker.evaluate():
+        return None
     pkg_name = req.name
 
     try:

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -616,16 +616,17 @@ def _check_requirement_satisfied(requirement_str: str) -> _MismatchedPackageInfo
     object containing the mismatched package name, installed version, and requirement if the
     requirement is not satisfied. Otherwise, returns None.
     """
-    _init_packages_to_modules_map()
     try:
         req = Requirement(requirement_str)
     except Exception:
         # We reach here if the requirement string is a file path or a URL.
         # Extracting the package name from the requirement string is not trivial,
         # so we skip the check.
-        return
+        return None
     if req.marker and not req.marker.evaluate():
         return None
+
+    _init_packages_to_modules_map()
     pkg_name = req.name
 
     try:

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -412,6 +412,25 @@ def test_infer_requirements_error_handling(env_var, fallbacks, should_raise, mon
         ),
         # Verify duplicate extras are not preserved
         (["markdown[extras]", "markdown", "markdown[extras]"], ["markdown[extras]"]),
+        # Marker-differentiated versions should be kept separate
+        (
+            [
+                "numpy==2.2.6 ; python_full_version < '3.11'",
+                "numpy==2.4.2 ; python_full_version >= '3.11'",
+            ],
+            [
+                'numpy==2.2.6; python_full_version < "3.11"',
+                'numpy==2.4.2; python_full_version >= "3.11"',
+            ],
+        ),
+        # Same marker should still merge
+        (
+            [
+                "numpy>=1.0 ; python_version >= '3.10'",
+                "numpy<2.0 ; python_version >= '3.10'",
+            ],
+            ['numpy>=1.0,<2.0; python_version >= "3.10"'],
+        ),
     ],
 )
 def test_deduplicate_requirements_resolve_correctly(input_requirements, expected):

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -15,6 +15,7 @@ from mlflow.utils.environment import infer_pip_requirements
 from mlflow.utils.os import is_windows
 from mlflow.utils.requirements_utils import (
     _capture_imported_modules,
+    _check_requirement_satisfied,
     _get_installed_version,
     _get_pinned_requirement,
     _infer_requirements,
@@ -551,6 +552,16 @@ model's environment and install dependencies using the resulting environment fil
         # Test case: ignore file path
         warn_dependency_requirement_mismatches(model_requirements=["/path/to/my.whl"])
         mock_warning.assert_not_called()
+
+
+def test_check_requirement_satisfied_skips_non_matching_marker():
+    result = _check_requirement_satisfied("numpy==999.0.0 ; python_full_version < '3.0'")
+    assert result is None
+
+
+def test_check_requirement_satisfied_checks_matching_marker():
+    result = _check_requirement_satisfied("numpy==999.0.0 ; python_full_version >= '3.0'")
+    assert result is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

`_deduplicate_requirements` keys on package name alone, so when two entries for the same package have different environment markers (e.g., `numpy==2.2.6 ; python_full_version < '3.11'` and `numpy==2.4.2 ; python_full_version >= '3.11'`), they get incorrectly merged into `numpy==2.2.6,==2.4.2; python_full_version >= "3.11"` which is unsatisfiable by pip.

This PR fixes two things:

1. **`_deduplicate_requirements`**: Include the marker string in the dedup key so entries with different markers are kept separate while entries with the same (or no) marker still merge as before.
2. **`_check_requirement_satisfied`**: Evaluate environment markers before checking version satisfaction, so requirements that don't apply to the current environment (e.g., win32-only deps on macOS) don't produce false mismatch warnings.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `_deduplicate_requirements` incorrectly merging marker-differentiated requirements (e.g., platform-specific package versions) into unsatisfiable version constraints, and fixed false dependency mismatch warnings for requirements whose environment markers don't apply to the current platform.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)