### PR TITLE
Allow boto3 default credential chain for Bedrock in mlflow.evaluate()

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -831,6 +831,11 @@ MLFLOW_BOTO_CLIENT_ADDRESSING_STYLE = _EnvironmentVariable(
     "MLFLOW_BOTO_CLIENT_ADDRESSING_STYLE", str, "auto"
 )
 
+#: Specifies an IAM role ARN for explicit cross-account role assumption when using
+#: Amazon Bedrock as a judge in ``mlflow.evaluate()``. When unset, boto3's default
+#: credential chain is used (env vars, IRSA, instance profiles, ``~/.aws/credentials``).
+MLFLOW_BEDROCK_ROLE_ARN = _EnvironmentVariable("MLFLOW_BEDROCK_ROLE_ARN", str, None)
+
 #: Specify the timeout in seconds for Databricks endpoint HTTP request retries.
 MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT", int, 500


### PR DESCRIPTION
### Related Issues/PRs

Resolve #20189 #15098
Supersedes #15096

### What changes are proposed in this pull request?

Simplify Bedrock credential resolution in `mlflow.metrics.genai` (the `mlflow.evaluate()` code path) to delegate to boto3's default credential chain (env vars, IRSA, instance profiles, `~/.aws/credentials`). This fixes `AccessDenied` errors on EKS with IRSA where `AWS_ROLE_ARN` triggers an unnecessary `sts:AssumeRole` call.

Changes:
- Introduce `MLFLOW_BEDROCK_ROLE_ARN` environment variable (registered in `mlflow/environment_variables.py`) for explicit cross-account role assumption
- Simplify `model_utils.py`: check `MLFLOW_BEDROCK_ROLE_ARN` for `AWSRole`, otherwise fall through to `AWSBaseConfig` (boto3 default chain)
- Remove manual reading of `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` - boto3 reads these natively

No other credential construction paths are affected. The gateway provider (`bedrock.py:_construct_client_args`) receives config objects and does not read env vars directly. The `mlflow/utils/providers.py` auth modes and `mlflow/bedrock/_autolog.py` are unrelated to this credential resolution path.

> [!IMPORTANT]
> _TL;DR It's. a breaking change. Admins who relied on `AWS_ROLE_ARN` for automatic role assumption should use `MLFLOW_BEDROCK_ROLE_ARN` instead to avoid collision with default boto3 credential chain_
>
> Previously, when using Bedrock as a judge model in `mlflow.evaluate()`, MLflow explicitly read `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` and `AWS_ROLE_ARN` from environment variables and passed them directly to the boto3 client. With this PR, credential resolution is now fully delegated to boto3's default credential chain.
>
> - `AWS_ROLE_ARN` is no longer explicitly consumed by mlflow. boto3's default chain does not automatically call `sts:AssumeRole` just because `AWS_ROLE_ARN` is set, since that env var is only meaningful to specific credential providers like the web identity token provider (IRSA). Users who relied on `AWS_ROLE_ARN` for explicit cross-account role assumption (without IRSA/web identity) should use the new `MLFLOW_BEDROCK_ROLE_ARN` env var instead.
> - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` still work, boto3's `EnvironmentProvider` reads them natively as a part of default credential chain, so there is no functional change for users authenticating via these env vars.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix: Allow boto3 default credential chain for Amazon Bedrock provider in `mlflow.evaluate()`. Previously, MLflow forced explicit `sts:AssumeRole` when `AWS_ROLE_ARN` was set (e.g., by EKS IRSA), causing `AccessDenied` errors. Credential resolution is now delegated to boto3's built-in credential chain. Use the new `MLFLOW_BEDROCK_ROLE_ARN` env var for explicit cross-account role assumption (#20189 #15098).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)