### PR TITLE
Add session-level support for custom @scorer decorator

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -5,7 +5,7 @@ import logging
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Any, Callable, Literal, TypeAlias, TypeVar, overload
+from typing import Any, Callable, ClassVar, Literal, TypeAlias, TypeVar, overload
 
 from pydantic import BaseModel, PrivateAttr
 
@@ -16,11 +16,10 @@ from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.telemetry.events import ScorerCallEvent
 from mlflow.telemetry.track import record_usage_event
-from mlflow.tracking import get_tracking_uri
+from mlflow.tracking._tracking_service.utils import get_tracking_uri
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.annotations import experimental
-from mlflow.utils.databricks_utils import is_in_databricks_runtime
-from mlflow.utils.uri import is_databricks_uri
+from mlflow.utils.databricks_utils import is_databricks_uri, is_in_databricks_runtime
 
 _logger = logging.getLogger(__name__)
 
@@ -1190,6 +1189,7 @@ def scorer(
     class CustomScorer(Scorer):
         # Store reference to the original function
         _original_func: Callable[..., Any] | None = PrivateAttr(default=None)
+        _is_session_level_scorer: ClassVar[bool] = _is_session_level
 
         def __init__(self, **data):
             super().__init__(**data)
@@ -1204,7 +1204,7 @@ def scorer(
 
         @property
         def is_session_level_scorer(self) -> bool:
-            return _is_session_level
+            return self._is_session_level_scorer
 
         @property
         def kind(self) -> ScorerKind:

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1194,8 +1194,7 @@ def scorer(
     _is_session_level = "session" in func_params
 
     if _is_session_level:
-        invalid_params = func_params & {"inputs", "outputs", "trace"}
-        if invalid_params:
+        if invalid_params := func_params & {"inputs", "outputs", "trace"}:
             raise MlflowException.invalid_parameter_value(
                 f"Session-level scorers (functions with a `session` parameter) cannot "
                 f"also accept {', '.join(sorted(f'`{p}`' for p in invalid_params))}. "

--- a/tests/cli/test_scorers.py
+++ b/tests/cli/test_scorers.py
@@ -16,7 +16,6 @@ from mlflow.utils.string_utils import _create_table
 def mock_databricks_environment():
     with (
         patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
-        patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True),
     ):
         yield
 

--- a/tests/genai/optimize/test_job.py
+++ b/tests/genai/optimize/test_job.py
@@ -106,7 +106,6 @@ def test_load_builtin_scorers():
 
 def test_load_custom_scorers():
     with (
-        mock.patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True),
         mock.patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
     ):
         experiment_id = mlflow.create_experiment("test_load_custom_scorers")

--- a/tests/genai/scorers/test_registered_scorers_scheduling.py
+++ b/tests/genai/scorers/test_registered_scorers_scheduling.py
@@ -16,7 +16,6 @@ def mock_databricks_runtime():
         patch(
             "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
         ),
-        patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True),
         patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
         patch("mlflow.genai.scorers.registry._get_scorer_store") as mock_get_store,
     ):

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -458,26 +458,25 @@ def test_single_turn_scorer_not_session_level():
     assert single_turn.is_session_level_scorer is False
 
 
-@pytest.mark.parametrize(
-    "func_def",
-    [
-        "def bad(session, trace): pass",
-        "def bad(session, inputs): pass",
-        "def bad(session, outputs): pass",
-        "def bad(session, trace, inputs): pass",
-        "def bad(session, inputs, outputs, trace): pass",
-    ],
-)
-def test_session_param_with_single_turn_params_raises(func_def):
-    namespace = {}
-    exec(func_def, namespace)
-    func = namespace["bad"]
+def test_session_param_with_single_turn_params_raises():
+    def with_trace(session, trace):
+        pass
 
-    with pytest.raises(
-        mlflow.exceptions.MlflowException,
-        match="Session-level scorers.*cannot also accept",
-    ):
-        scorer(func)
+    def with_inputs(session, inputs):
+        pass
+
+    def with_outputs(session, outputs):
+        pass
+
+    def with_all(session, inputs, outputs, trace):
+        pass
+
+    for func in [with_trace, with_inputs, with_outputs, with_all]:
+        with pytest.raises(
+            mlflow.exceptions.MlflowException,
+            match="Session-level scorers.*cannot also accept",
+        ):
+            scorer(func)
 
 
 def test_session_level_scorer_serialization_roundtrip(is_in_databricks):

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -382,10 +382,7 @@ def test_custom_scorer_loading_allowed_for_databricks_remote_access():
         original_func_name="test_scorer",
     )
 
-    with (
-        patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=False),
-        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
-    ):
+    with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
         result = Scorer._reconstruct_decorator_scorer(serialized)
         assert result.name == "test_scorer"
 

--- a/tests/genai/scorers/test_scorer_CRUD.py
+++ b/tests/genai/scorers/test_scorer_CRUD.py
@@ -24,7 +24,6 @@ def test_scorer_registry_functions_accessible_from_mlflow_genai():
 
 def test_mlflow_backend_scorer_operations():
     with (
-        patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True),
         patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
     ):
         experiment_id = mlflow.create_experiment("test_scorer_mlflow_backend_experiment")
@@ -106,7 +105,6 @@ def test_databricks_backend_scorer_operations():
 
     with (
         patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
-        patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True),
         patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
         patch("mlflow.genai.scorers.registry._get_scorer_store") as mock_get_store,
         patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add,

--- a/tests/genai/scorers/test_scorer_description.py
+++ b/tests/genai/scorers/test_scorer_description.py
@@ -10,7 +10,7 @@ from mlflow.genai.scorers import RelevanceToQuery
 
 @pytest.fixture(autouse=True)
 def mock_databricks_runtime():
-    with patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True):
+    with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
         yield
 
 

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -11,7 +11,7 @@ from mlflow.genai.scorers.builtin_scorers import Guidelines
 
 @pytest.fixture(autouse=True)
 def mock_databricks_runtime():
-    with patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True):
+    with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
         yield
 
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Auto-detect session-level scorers by inspecting the function signature for a `session` parameter. Validate at decoration time that `session` is not combined with single-turn parameters (inputs, outputs, trace).


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
**OSS**
```python
import time
import uuid

import mlflow
from mlflow.entities import Feedback, SpanType
from mlflow.genai.scorers import scorer
from mlflow.genai.scorers.registry import get_scorer, list_scorers
from mlflow.tracing.constant import TraceMetadataKey

mlflow.set_tracking_uri("http://localhost:5000")

# ── Define scorers ───────────────────────────────────────────────────────────


@scorer
def response_length(outputs) -> Feedback:
    length = len(str(outputs))
    return Feedback(value=length > 20, rationale=f"Response length: {length}")


@scorer
def conversation_completeness(session) -> Feedback:
    total_turns = len(session)
    error_turns = sum(1 for t in session if t.info.status == "ERROR")
    return Feedback(value=error_turns == 0, rationale=f"{total_turns} turns, {error_turns} errors")


@scorer
def session_goal_met(session, expectations) -> Feedback:
    last_trace = max(session, key=lambda t: t.info.request_time)
    goal = expectations.get("goal", "")
    response = str(last_trace.data.response) if last_trace.data else ""
    met = goal.lower() in response.lower() if goal else True
    return Feedback(value=met, rationale=f"Goal '{goal}' in final response: {met}")


# ── Auto-detection ───────────────────────────────────────────────────────────

assert response_length.is_session_level_scorer is False
assert conversation_completeness.is_session_level_scorer is True
assert session_goal_met.is_session_level_scorer is True
print("Auto-detection OK")

# ── Register scorers ────────────────────────────────────────────────────────

experiment_name = f"demo-session-scorer-{uuid.uuid4().hex[:8]}"
mlflow.set_experiment(experiment_name)
experiment_id = mlflow.get_experiment_by_name(experiment_name).experiment_id

reg_single = response_length.register(name="response_length", experiment_id=experiment_id)
reg_session = conversation_completeness.register(
    name="conversation_completeness", experiment_id=experiment_id
)
reg_goal = session_goal_met.register(name="session_goal_met", experiment_id=experiment_id)
print(f"Registered: {reg_single.name}, {reg_session.name}, {reg_goal.name}")

scorers = list_scorers(experiment_id=experiment_id)
assert len(scorers) == 3
print(f"Listed {len(scorers)} scorers")

retrieved = get_scorer(name="response_length", experiment_id=experiment_id)
assert retrieved.name == "response_length"
print(f"Retrieved: {retrieved.name}")

# ── Create session traces ────────────────────────────────────────────────────

session_id = f"session-{uuid.uuid4().hex[:8]}"


def create_trace(name, user_input, bot_response, sid=None):
    metadata = {TraceMetadataKey.TRACE_SESSION: sid} if sid else None
    span = mlflow.start_span_no_context(
        name, span_type=SpanType.CHAIN, inputs={"user_input": user_input}, metadata=metadata
    )
    time.sleep(0.05)
    span.set_outputs({"bot_response": bot_response})
    span.end()


create_trace("turn_1", "What is MLflow?", "MLflow is an open-source ML platform.", session_id)
create_trace("turn_2", "How do I track experiments?", "Use mlflow.log_param().", session_id)
create_trace("turn_3", "Thanks!", "You're welcome!", session_id)
create_trace("standalone", "Quick question", "Short answer")

time.sleep(3)
all_traces = mlflow.search_traces(locations=[experiment_id], return_type="list")
session_traces = [
    t for t in all_traces if t.info.trace_metadata.get(TraceMetadataKey.TRACE_SESSION) == session_id
]
assert len(all_traces) == 4
assert len(session_traces) == 3
print(f"Created {len(all_traces)} traces ({len(session_traces)} in session)")

# ── Run scorers ──────────────────────────────────────────────────────────────

r = response_length.run(outputs="MLflow is an open-source platform for ML lifecycle management.")
print(f"response_length: value={r.value}, rationale='{r.rationale}'")
assert r.value is True

r = conversation_completeness.run(session=session_traces)
print(f"conversation_completeness: value={r.value}, rationale='{r.rationale}'")
assert r.value is True

r = session_goal_met.run(session=session_traces, expectations={"goal": "welcome"})
print(f"session_goal_met: value={r.value}, rationale='{r.rationale}'")
assert r.value is True

```

<img width="743" height="224" alt="image" src="https://github.com/user-attachments/assets/d001b4e6-a0df-497d-aea0-80ba6e14db7e" />

<img width="1640" height="648" alt="image" src="https://github.com/user-attachments/assets/603e99a0-1246-439c-9df8-02b9174606f6" />


**Databricks**

```python
import os
import time
import uuid

import mlflow
from mlflow.entities import Feedback, SpanType
from mlflow.genai.scorers import ScorerSamplingConfig, scorer
from mlflow.tracing.constant import TraceMetadataKey

EXPERIMENT_ID = "98459650931566"

mlflow.set_tracking_uri("databricks")
mlflow.set_experiment(experiment_id=EXPERIMENT_ID)

# ── Define scorers

@scorer
def response_length(outputs) -> bool:
    return len(str(outputs)) > 20


@scorer
def conversation_completeness(session) -> Feedback:
    total_turns = len(session)
    error_turns = sum(1 for t in session if t.info.status == "ERROR")
    return Feedback(value=error_turns == 0, rationale=f"{total_turns} turns, {error_turns} errors")


assert response_length.is_session_level_scorer is False
assert conversation_completeness.is_session_level_scorer is True
print("Auto-detection OK")

# ── Register & start scorers

run_id = uuid.uuid4().hex[:8]

reg_single = response_length.register(name=f"response_length_{run_id}", experiment_id=EXPERIMENT_ID)
reg_session = conversation_completeness.register(
    name=f"conversation_completeness_{run_id}", experiment_id=EXPERIMENT_ID
)
print(f"Registered {reg_single.name} -> {reg_single.status}")
print(f"Registered {reg_session.name} -> {reg_session.status}")

started_single = reg_single.start(
    experiment_id=EXPERIMENT_ID,
    sampling_config=ScorerSamplingConfig(sample_rate=1.0),
)
print(f"Started {started_single.name} -> {started_single.status}")

# Session-level scorers can be registered but not yet scheduled on the Databricks backend
try:
    reg_session.start(
        experiment_id=EXPERIMENT_ID,
        sampling_config=ScorerSamplingConfig(sample_rate=1.0),
    )
except Exception as e:
    print(f"Session scorer start() not yet supported server-side: {type(e).__name__}")

# ── Create session traces

session_id = f"session-{uuid.uuid4().hex[:8]}"


def create_trace(name, user_input, bot_response, sid=None):
    metadata = {TraceMetadataKey.TRACE_SESSION: sid} if sid else None
    span = mlflow.start_span_no_context(
        name, span_type=SpanType.CHAIN, inputs={"user_input": user_input}, metadata=metadata
    )
    time.sleep(0.05)
    span.set_outputs({"bot_response": bot_response})
    span.end()


create_trace("turn_1", "What is MLflow?", "MLflow is an open-source ML platform.", session_id)
create_trace("turn_2", "How do I track experiments?", "Use mlflow.log_param().", session_id)
create_trace("turn_3", "Thanks!", "You're welcome!", session_id)
create_trace("standalone", "Quick question", "Short answer")

time.sleep(5)
all_traces = mlflow.search_traces(locations=[EXPERIMENT_ID], return_type="list")
session_traces = [
    t for t in all_traces if t.info.trace_metadata.get(TraceMetadataKey.TRACE_SESSION) == session_id
]
print(f"Created traces ({len(session_traces)} in session)")

# ── Run scorers directly

r = response_length.run(outputs="MLflow is an open-source platform for ML lifecycle management.")
print(f"response_length: value={r}")

r = conversation_completeness.run(session=session_traces)
print(f"conversation_completeness: value={r.value}, rationale='{r.rationale}'")

# ── Clean up: stop scorers

started_single.stop(experiment_id=EXPERIMENT_ID)
print("Stopped scorer")

print("\nAll checks passed!")
```

<img width="1244" height="895" alt="image" src="https://github.com/user-attachments/assets/c53c2b16-2f1f-439a-a0c5-94561fe9f489" />



### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Support custom-code session-level scorers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
