### PR TITLE
Fix tag key validation UI contradiction

### DIFF
--- a/mlflow/server/js/src/common/components/TagSelectDropdown.test.tsx
+++ b/mlflow/server/js/src/common/components/TagSelectDropdown.test.tsx
@@ -60,18 +60,26 @@ describe('TagKeySelectDropdown', () => {
     });
   });
 
-  test('it should not allow to add a new tag with invalid characters', async () => {
-    const { result } = renderHook(() => useForm<KeyValueEntity>());
-    renderTestComponent(['tag1', 'tag2'], result.current.control);
-    const input = screen.getByRole('combobox');
-    await userEvent.type(input, 'invalid-tag');
-    // user-event v14 does not pass down keyCode, so we need to use fireEvent
-    fireEvent.keyDown(input, { keyCode: 13 });
-    await waitFor(() => {
-      // Do not add the value
-      expect(result.current.getValues().key).toBe(undefined);
-    });
-  });
+  test(
+    'it should not allow to add a new tag with invalid characters',
+    async () => {
+      const { result } = renderHook(() => useForm<KeyValueEntity>());
+      renderTestComponent(['tag1', 'tag2'], result.current.control);
+      const input = screen.getByRole('combobox');
+      // Comma is not allowed by tag key validation (backend and frontend)
+      await userEvent.type(input, 'tag,key');
+      // user-event v14 does not pass down keyCode, so we need to use fireEvent
+      fireEvent.keyDown(input, { keyCode: 13 });
+      await waitFor(
+        () => {
+          // Do not add the value
+          expect(result.current.getValues().key).toBe(undefined);
+        },
+        { timeout: 10000 },
+      );
+    },
+    10000,
+  );
 
   test('it should call handleChange with selected tag', async () => {
     const { result } = renderHook(() => useForm<KeyValueEntity>());

--- a/mlflow/server/js/src/common/components/TagSelectDropdown.test.tsx
+++ b/mlflow/server/js/src/common/components/TagSelectDropdown.test.tsx
@@ -60,26 +60,22 @@ describe('TagKeySelectDropdown', () => {
     });
   });
 
-  test(
-    'it should not allow to add a new tag with invalid characters',
-    async () => {
-      const { result } = renderHook(() => useForm<KeyValueEntity>());
-      renderTestComponent(['tag1', 'tag2'], result.current.control);
-      const input = screen.getByRole('combobox');
-      // Comma is not allowed by tag key validation (backend and frontend)
-      await userEvent.type(input, 'tag,key');
-      // user-event v14 does not pass down keyCode, so we need to use fireEvent
-      fireEvent.keyDown(input, { keyCode: 13 });
-      await waitFor(
-        () => {
-          // Do not add the value
-          expect(result.current.getValues().key).toBe(undefined);
-        },
-        { timeout: 10000 },
-      );
-    },
-    10000,
-  );
+  test('it should not allow to add a new tag with invalid characters', async () => {
+    const { result } = renderHook(() => useForm<KeyValueEntity>());
+    renderTestComponent(['tag1', 'tag2'], result.current.control);
+    const input = screen.getByRole('combobox');
+    // Comma is not allowed by tag key validation (backend and frontend)
+    await userEvent.type(input, 'tag,key');
+    // user-event v14 does not pass down keyCode, so we need to use fireEvent
+    fireEvent.keyDown(input, { keyCode: 13 });
+    await waitFor(
+      () => {
+        // Do not add the value
+        expect(result.current.getValues().key).toBe(undefined);
+      },
+      { timeout: 10000 },
+    );
+  }, 10000);
 
   test('it should call handleChange with selected tag', async () => {
     const { result } = renderHook(() => useForm<KeyValueEntity>());

--- a/mlflow/server/js/src/common/components/TagSelectDropdown.tsx
+++ b/mlflow/server/js/src/common/components/TagSelectDropdown.tsx
@@ -6,6 +6,7 @@ import { useIntl } from 'react-intl';
 
 import { PlusIcon, LegacySelect, Tooltip, useDesignSystemTheme } from '@databricks/design-system';
 import type { KeyValueEntity } from '../types';
+import { isValidTagKey } from '../utils/tagKeyValidation';
 
 /**
  * Will show an extra row at the bottom of the dropdown menu to create a new tag when
@@ -26,7 +27,7 @@ function DropdownMenu(menu: React.ReactElement, allAvailableTags: string[]) {
     const doesTagExists = sortedIndexOf(allAvailableTags, searchValue) >= 0;
     if (doesTagExists) return menu;
 
-    const isValidTagKey = /^[^,.:/=\-\s]+$/.test(searchValue);
+    const tagKeyValid = isValidTagKey(searchValue);
 
     // Overriding the menu to add a new option at the top
     return React.cloneElement(menu, {
@@ -34,17 +35,18 @@ function DropdownMenu(menu: React.ReactElement, allAvailableTags: string[]) {
         {
           data: {
             value: searchValue,
-            disabled: !isValidTagKey,
+            disabled: !tagKeyValid,
             style: {
-              color: isValidTagKey ? theme.colors.actionTertiaryTextDefault : theme.colors.actionDisabledText,
+              color: tagKeyValid ? theme.colors.actionTertiaryTextDefault : theme.colors.actionDisabledText,
             },
             children: (
               <Tooltip
                 content={
-                  isValidTagKey
+                  tagKeyValid
                     ? undefined
                     : intl.formatMessage({
-                        defaultMessage: ', . : / - = and blank spaces are not allowed',
+                        defaultMessage:
+                          "Tag key may only contain alphanumeric characters, underscores (_), dashes (-), periods (.), spaces ( ), colons (:) and slashes (/). Key must not start with '/'.",
                         description:
                           'Key-value tag editor modal > Tag dropdown Manage Modal > Invalid characters error',
                       })

--- a/mlflow/server/js/src/common/utils/tagKeyValidation.test.ts
+++ b/mlflow/server/js/src/common/utils/tagKeyValidation.test.ts
@@ -37,10 +37,9 @@ describe('isValidTagKey', () => {
     expect(isValidTagKey('../key')).toBe(false);
   });
 
-  it('rejects path traversal segments', () => {
-    expect(isValidTagKey('a/./b')).toBe(false);
-    expect(isValidTagKey('a/../b')).toBe(false);
-    expect(isValidTagKey('a//b')).toBe(false);
+  it('allows path-like keys (e.g. test/.test); backend validates path rules and returns error if invalid', () => {
+    expect(isValidTagKey('test/.test')).toBe(true);
+    expect(isValidTagKey('a/./b')).toBe(true);
   });
 
   it('rejects characters not allowed by backend', () => {

--- a/mlflow/server/js/src/common/utils/tagKeyValidation.test.ts
+++ b/mlflow/server/js/src/common/utils/tagKeyValidation.test.ts
@@ -1,0 +1,51 @@
+import { isValidTagKey } from './tagKeyValidation';
+
+describe('isValidTagKey', () => {
+  it('allows empty string', () => {
+    expect(isValidTagKey('')).toBe(true);
+  });
+
+  it('allows alphanumeric and underscore', () => {
+    expect(isValidTagKey('key')).toBe(true);
+    expect(isValidTagKey('key_1')).toBe(true);
+    expect(isValidTagKey('env2')).toBe(true);
+  });
+
+  it('allows slash in the middle (aligned with backend)', () => {
+    expect(isValidTagKey('env/prod')).toBe(true);
+    expect(isValidTagKey('team/name')).toBe(true);
+  });
+
+  it('allows period, dash, space, colon (aligned with backend)', () => {
+    expect(isValidTagKey('my.key')).toBe(true);
+    expect(isValidTagKey('my-key')).toBe(true);
+    expect(isValidTagKey('my key')).toBe(true);
+    expect(isValidTagKey('key:value')).toBe(true);
+  });
+
+  it('rejects leading slash (path_not_unique)', () => {
+    expect(isValidTagKey('/key')).toBe(false);
+    expect(isValidTagKey('/')).toBe(false);
+  });
+
+  it('rejects single dot', () => {
+    expect(isValidTagKey('.')).toBe(false);
+  });
+
+  it('rejects starting with ..', () => {
+    expect(isValidTagKey('..')).toBe(false);
+    expect(isValidTagKey('../key')).toBe(false);
+  });
+
+  it('rejects path traversal segments', () => {
+    expect(isValidTagKey('a/./b')).toBe(false);
+    expect(isValidTagKey('a/../b')).toBe(false);
+    expect(isValidTagKey('a//b')).toBe(false);
+  });
+
+  it('rejects characters not allowed by backend', () => {
+    expect(isValidTagKey('key,value')).toBe(false);
+    expect(isValidTagKey('key=value')).toBe(false);
+    expect(isValidTagKey('key@domain')).toBe(false);
+  });
+});

--- a/mlflow/server/js/src/common/utils/tagKeyValidation.ts
+++ b/mlflow/server/js/src/common/utils/tagKeyValidation.ts
@@ -2,7 +2,9 @@
  * Tag key validation aligned with MLflow backend (utils/validation.py).
  * Backend allows: alphanumerics, underscores (_), dashes (-), periods (.),
  * spaces ( ), colons (:) and slashes (/). Keys must not start with "/",
- * must not be "." or start with "..", and must not contain path traversal (e.g. "/." or "/..").
+ * must not be "." or start with "..".
+ * Path-like patterns (e.g. "/.", "/..", "//") are not validated here; the backend
+ * will reject invalid keys and the UI displays the backend error message.
  */
 
 /**
@@ -12,16 +14,15 @@
 const TAG_KEY_ALLOWED_CHARS_REGEX = /^[\w.\- :/]*$/;
 
 /**
- * Returns true if the tag key is valid (allowed characters and path rules).
- * Mirrors backend _validate_tag_name + path_not_unique logic.
+ * Returns true if the tag key passes basic character and path rules.
+ * Stricter path rules (e.g. path traversal) are enforced by the backend; the UI
+ * shows the backend error when save fails.
  */
 export function isValidTagKey(key: string): boolean {
   if (key === '') return true;
   if (!TAG_KEY_ALLOWED_CHARS_REGEX.test(key)) return false;
-  // path_not_unique: no leading slash, not ".", not "..", no path traversal
   if (key.startsWith('/')) return false;
   if (key === '.') return false;
   if (key.startsWith('..')) return false;
-  if (key.includes('/.') || key.includes('/..') || key.includes('//')) return false;
   return true;
 }

--- a/mlflow/server/js/src/common/utils/tagKeyValidation.ts
+++ b/mlflow/server/js/src/common/utils/tagKeyValidation.ts
@@ -1,0 +1,27 @@
+/**
+ * Tag key validation aligned with MLflow backend (utils/validation.py).
+ * Backend allows: alphanumerics, underscores (_), dashes (-), periods (.),
+ * spaces ( ), colons (:) and slashes (/). Keys must not start with "/",
+ * must not be "." or start with "..", and must not contain path traversal (e.g. "/." or "/..").
+ */
+
+/**
+ * Allowed characters for tag keys (matches backend validate_param_and_metric_name).
+ * Backend regex: ^[/\w.\- :]*$ (non-Windows)
+ */
+const TAG_KEY_ALLOWED_CHARS_REGEX = /^[\w.\- :/]*$/;
+
+/**
+ * Returns true if the tag key is valid (allowed characters and path rules).
+ * Mirrors backend _validate_tag_name + path_not_unique logic.
+ */
+export function isValidTagKey(key: string): boolean {
+  if (key === '') return true;
+  if (!TAG_KEY_ALLOWED_CHARS_REGEX.test(key)) return false;
+  // path_not_unique: no leading slash, not ".", not "..", no path traversal
+  if (key.startsWith('/')) return false;
+  if (key === '.') return false;
+  if (key.startsWith('..')) return false;
+  if (key.includes('/.') || key.includes('/..') || key.includes('//')) return false;
+  return true;
+}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControlsActionsAddNewTagModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControlsActionsAddNewTagModal.tsx
@@ -2,6 +2,7 @@ import { FormUI, Input, Modal, useDesignSystemTheme } from '@databricks/design-s
 import { FormattedMessage } from 'react-intl';
 import type { KeyValueEntity } from '../../../../../common/types';
 import { useState } from 'react';
+import { isValidTagKey } from '../../../../../common/utils/tagKeyValidation';
 
 export const ExperimentViewRunsControlsActionsAddNewTagModal = ({
   isOpen,
@@ -18,9 +19,9 @@ export const ExperimentViewRunsControlsActionsAddNewTagModal = ({
   const [tagKey, setTagKey] = useState<string>('');
   const [tagValue, setTagValue] = useState<string>('');
 
-  const isTagKeyAllowedChars = tagKey === '' || /^[^,.:/=\-\s]+$/.test(tagKey);
+  const isTagKeyValidChars = tagKey === '' || isValidTagKey(tagKey);
   const isTagKeyDuplicate = selectedRunsExistingTagKeys.includes(tagKey);
-  const isTagKeyValid = isTagKeyAllowedChars && !isTagKeyDuplicate;
+  const isTagKeyValid = isTagKeyValidChars && !isTagKeyDuplicate;
   const isTagNonEmptyAndTagKeyValid = tagKey.length > 0 && tagValue.length > 0 && isTagKeyValid;
 
   const onConfirmTag = () => {
@@ -58,11 +59,11 @@ export const ExperimentViewRunsControlsActionsAddNewTagModal = ({
               validationState={isTagKeyValid ? undefined : 'warning'}
               data-testid="add-new-tag-key-input"
             />
-            {!isTagKeyAllowedChars && (
+            {!isTagKeyValidChars && (
               <FormUI.Hint>
                 <FormattedMessage
-                  defaultMessage=", . : / - = and blank spaces are not allowed"
-                  description="Add new key-value tag modal > Invalid characters error"
+                  defaultMessage="Tag key may only contain alphanumeric characters, underscores (_), dashes (-), periods (.), spaces ( ), colons (:) and slashes (/). Key must not start with '/'."
+                  description="Add new key-value tag modal > Invalid characters or path error"
                 />
               </FormUI.Hint>
             )}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4173,10 +4173,6 @@
     "defaultMessage": "Model configuration stores the LLM settings associated with this prompt.",
     "description": "Help text explaining model configuration purpose"
   },
-  "Sb0Z4Z": {
-    "defaultMessage": ", . : / - = and blank spaces are not allowed",
-    "description": "Add new key-value tag modal > Invalid characters error"
-  },
   "SbMdmm": {
     "defaultMessage": "{spanName} was called",
     "description": "Label for an intermediate node in the trace explorer summary view, indicating that a span/function was called in the course of execution."
@@ -4375,6 +4371,10 @@
   "U0joaT": {
     "defaultMessage": "Select traces",
     "description": "Title for the select traces modal"
+  },
+  "U189tZ": {
+    "defaultMessage": "Tag key may only contain alphanumeric characters, underscores (_), dashes (-), periods (.), spaces ( ), colons (:) and slashes (/). Key must not start with '/'.",
+    "description": "Key-value tag editor modal > Tag dropdown Manage Modal > Invalid characters error"
   },
   "U2x2cM": {
     "defaultMessage": "Endpoint:",
@@ -4950,6 +4950,10 @@
   "XwkX9B": {
     "defaultMessage": "No metrics recorded",
     "description": "Placeholder text when no metrics are recorded for a logged model"
+  },
+  "Y++w0Q": {
+    "defaultMessage": "Tag key may only contain alphanumeric characters, underscores (_), dashes (-), periods (.), spaces ( ), colons (:) and slashes (/). Key must not start with '/'.",
+    "description": "Add new key-value tag modal > Invalid characters or path error"
   },
   "Y1eg9D": {
     "defaultMessage": "In progress",
@@ -6042,10 +6046,6 @@
   "fUwLyA": {
     "defaultMessage": "Sample judge output",
     "description": "Title for sample judge output panel"
-  },
-  "fWEvZL": {
-    "defaultMessage": ", . : / - = and blank spaces are not allowed",
-    "description": "Key-value tag editor modal > Tag dropdown Manage Modal > Invalid characters error"
   },
   "fWPlO9": {
     "defaultMessage": "About this logged model",


### PR DESCRIPTION
- Add shared tagKeyValidation.ts aligned with backend (allow /, ., -, :, space; path rules)
- Update Add New Tag modal and TagSelectDropdown to use it and show backend-consistent message
- Add unit tests for isValidTagKey

Before:
![Before](https://github.com/user-attachments/assets/2b161e77-8c85-46c7-b89a-a1be0813cd96)


After:
![After](https://github.com/user-attachments/assets/a89bc345-e42e-4777-aaea-40e956a1e2e7)
![After-2](https://github.com/user-attachments/assets/b5b0ed64-d66d-40d0-9ec2-a9193e93fd81)


<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Fixes #21075

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
