### PR TITLE
Fix .dockerignore patterns to exclude nested directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,10 @@
 # to exclude unnecessary files when copying the MLflow source tree for Docker builds.
 # Without this file, Docker images built during testing would be extremely large and
 # could cause disk space issues.
+#
+# NOTE: This file is also parsed by mlflow/utils/file_utils.py:_docker_ignore() using
+# fnmatch, which does NOT support Docker's ** recursive glob syntax.
+# Both root-level and recursive patterns are needed for full compatibility.
 
 .git
 mlruns
@@ -18,17 +22,21 @@ dev
 !requirements/extra-ml-requirements.txt
 
 tests
+**/tests
 # required for Docker build
 !tests/resources/mlflow-test-plugin/
 
 node_modules
+**/node_modules
 coverage
 build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 __pycache__
+**/__pycache__
 .*
+**/.*
 ~*
 *.swp
 *.pyc

--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,7 @@ tests
 !tests/resources/mlflow-test-plugin/
 
 node_modules
+node_modules
 **/node_modules
 coverage
 build


### PR DESCRIPTION
### Related Issues/PRs

Closes #21151

### What changes are proposed in this pull request?

Add `**/` prefix to `.dockerignore` patterns so they match at any directory depth, not just the root of the build context.

**Changes:**
- `tests` → `**/tests`
- `node_modules` → `**/node_modules`
- `__pycache__` → `**/__pycache__`
- `.*` → `**/.*`

Per [Docker documentation](https://docs.docker.com/build/concepts/context/#dockerignore-files), patterns without `**/` only match at the root level. Nested directories like `mlflow/models/__pycache__/` or subdirectory `.venv/` folders are currently included in the build context.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

The `!tests/resources/mlflow-test-plugin/` negation continues to work because Docker processes negation patterns after glob patterns.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)