### PR TITLE
DO NOT REVIEW

### DIFF
--- a/mlflow/store/db/workspace_isolated_model.py
+++ b/mlflow/store/db/workspace_isolated_model.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Query, Session
+
+
+class WorkspaceIsolatedModel:
+    """Mixin for DB models that require workspace-scoped queries.
+
+    Any model that inherits from this must implement ``workspace_query_filter``,
+    which defines how to apply workspace filtering to a query on this model.
+    """
+
+    @classmethod
+    @abstractmethod
+    def workspace_query_filter(cls, query: Query, session: Session, workspace: str) -> Query: ...

--- a/mlflow/store/db/workspace_migration.py
+++ b/mlflow/store/db/workspace_migration.py
@@ -1,6 +1,6 @@
 import sqlalchemy as sa
 
-from mlflow.store.workspace.sqlalchemy_store import _WORKSPACE_ROOT_MODELS
+from mlflow.store.workspace.sqlalchemy_store import _get_workspace_root_models
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 # Derive table names from the shared ORM model list and add child/tags tables that also carry
@@ -14,7 +14,7 @@ _WORKSPACE_CHILD_TABLES = [
 ]
 
 _WORKSPACE_TABLES = [
-    model.__tablename__ for model in _WORKSPACE_ROOT_MODELS
+    model.__tablename__ for model in _get_workspace_root_models()
 ] + _WORKSPACE_CHILD_TABLES
 
 _CONFLICT_SPECS = [

--- a/tests/store/test_workspace_model_coverage.py
+++ b/tests/store/test_workspace_model_coverage.py
@@ -1,13 +1,6 @@
-"""Verify that every SQLAlchemy model with a ``workspace`` column is handled
-by at least one workspace store's ``_get_query`` method.
-
-If a new model is added with a ``workspace`` column but the developer forgets
-to add it to ``_get_query``, that model's queries will bypass workspace
-isolation.  This test catches that gap.
+"""Verify that every SQLAlchemy model with a ``workspace`` column uses the
+``WorkspaceIsolatedModel`` mixin and implements ``workspace_query_filter``.
 """
-
-import ast
-from pathlib import Path
 
 # Explicitly import all dbmodel modules so that every ORM model is registered
 # with Base.registry before we inspect mappers.
@@ -15,76 +8,25 @@ import mlflow.store.model_registry.dbmodels.models  # noqa: F401
 import mlflow.store.tracking.dbmodels.models  # noqa: F401
 import mlflow.store.workspace.dbmodels.models  # noqa: F401
 from mlflow.store.db.base_sql_model import Base
-
-# Locate the repository root relative to this test file so that workspace
-# store paths resolve correctly regardless of the pytest working directory.
-_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-
-# Every workspace store that provides a ``_get_query`` override.
-WORKSPACE_STORE_PATHS = [
-    "mlflow/store/tracking/sqlalchemy_workspace_store.py",
-    "mlflow/store/model_registry/sqlalchemy_workspace_store.py",
-    "mlflow/store/jobs/sqlalchemy_workspace_store.py",
-]
+from mlflow.store.db.workspace_isolated_model import WorkspaceIsolatedModel
 
 
-def _models_handled_by_get_query(ws_path: str) -> set[str]:
-    """Parse a workspace store file and return the ``Sql*`` model names
-    referenced in comparisons inside its ``_get_query`` method.
-    """
-    tree = ast.parse((_REPO_ROOT / ws_path).read_text())
-
-    # Collect module-level variables holding Sql* names (e.g. tuples of models)
-    var_models: dict[str, set[str]] = {}
-    for node in ast.iter_child_nodes(tree):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name):
-                    names = {
-                        n.id
-                        for n in ast.walk(node.value)
-                        if isinstance(n, ast.Name) and n.id.startswith("Sql")
-                    }
-                    if names:
-                        var_models[target.id] = names
-
-    # Extract model names from _get_query comparisons
-    models: set[str] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if node.name != "_get_query":
-            continue
-        for inner in ast.walk(node):
-            if not isinstance(inner, ast.Compare):
-                continue
-            for comp in inner.comparators:
-                models |= {
-                    n.id
-                    for n in ast.walk(comp)
-                    if isinstance(n, ast.Name) and n.id.startswith("Sql")
-                }
-                if isinstance(comp, ast.Name) and comp.id in var_models:
-                    models |= var_models[comp.id]
-    return models
-
-
-def test_all_workspace_models_handled_in_get_query():
-    """Every model with a workspace column must appear in at least one
-    workspace store's ``_get_query``.
-    """
-    handled: set[str] = set()
-    for ws_path in WORKSPACE_STORE_PATHS:
-        handled |= _models_handled_by_get_query(ws_path)
-
-    models_with_column: set[str] = set()
+def test_workspace_column_requires_mixin():
     for mapper in Base.registry.mappers:
-        if "workspace" in {col.key for col in mapper.columns}:
-            models_with_column.add(mapper.class_.__name__)
+        model = mapper.class_
+        columns = {col.key for col in mapper.columns}
+        if "workspace" in columns:
+            assert issubclass(model, WorkspaceIsolatedModel), (
+                f"{model.__name__} has a workspace column but does not "
+                f"inherit from WorkspaceIsolatedModel"
+            )
 
-    missing = models_with_column - handled
-    assert not missing, (
-        f"These models have a `workspace` column but are not handled by any "
-        f"workspace store's _get_query: {sorted(missing)}. "
-        f"Add handling in the appropriate workspace store's _get_query method."
-    )
+
+def test_all_workspace_isolated_models_implement_filter():
+    for mapper in Base.registry.mappers:
+        model = mapper.class_
+        if issubclass(model, WorkspaceIsolatedModel):
+            assert "workspace_query_filter" in model.__dict__, (
+                f"{model.__name__} inherits WorkspaceIsolatedModel but does not "
+                f"implement workspace_query_filter"
+            )


### PR DESCRIPTION
## Summary
- Add `WorkspaceIsolatedModel` mixin for structural workspace isolation on DB models
- Each workspace-isolated model now implements `workspace_query_filter` to declare its filtering strategy
- Replace hardcoded if/elif chains in workspace stores with generic `issubclass` dispatch
- Replace static `_WORKSPACE_ROOT_MODELS` list with dynamic lookup
- Add enforcement tests that verify mixin usage and implementation

## Test plan
- [x] `tests/store/test_workspace_model_coverage.py` — 2 tests pass
- [x] `tests/store/tracking/test_sqlalchemy_workspace_store.py` — 54 tests pass
- [x] `tests/store/model_registry/` workspace tests — 354 tests pass
- [x] `tests/store/workspace/` — 51 tests pass
- [x] `tests/store/tracking/test_sqlalchemy_store.py` — 878 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)