### PR TITLE
Fix ConversationSimulator validation for predict_fn signatures and context fields

### DIFF
--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -402,7 +402,7 @@ class ConversationSimulator:
             - "goal": Describing what the simulated user wants to achieve.
             - "persona" (optional): Custom persona for the simulated user.
             - "context" (optional): Dict of additional kwargs to pass to predict_fn.
-              Keys ``"input"``, ``"messages"``, and ``"mlflow_session_id"`` are reserved
+              Keys ``input``, ``messages``, and ``mlflow_session_id`` are reserved
               by the simulator and cannot be used.
             - "expectations" (optional): Dict of expected values (ground truth) for
               session-level evaluation. These are logged to the first trace of the

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import mlflow
+from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets.evaluation_dataset import EvaluationDataset
 from mlflow.genai.simulators import (
     BaseSimulatedUserAgent,
@@ -912,7 +913,7 @@ def test_conversation_simulator_rejects_both_input_and_messages(simple_test_case
 
     simulator = ConversationSimulator(test_cases=[simple_test_case], max_turns=1)
 
-    with pytest.raises(Exception, match="cannot have both 'messages' and 'input' parameters"):
+    with pytest.raises(MlflowException, match="cannot have both 'messages' and 'input' parameters"):
         simulator.simulate(invalid_predict_fn)
 
 
@@ -926,7 +927,7 @@ def test_conversation_simulator_rejects_neither_input_nor_messages(
 
     simulator = ConversationSimulator(test_cases=[simple_test_case], max_turns=1)
 
-    with pytest.raises(Exception, match="must accept either 'messages' or 'input'"):
+    with pytest.raises(MlflowException, match="must accept either 'messages' or 'input'"):
         simulator.simulate(invalid_predict_fn)
 
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #21170

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR hardens `ConversationSimulator` input validation and improves error clarity:

- Add upfront `predict_fn` signature validation so it must declare exactly one of `input` or `messages`.
- Reject reserved `context` keys (`input`, `messages`, `mlflow_session_id`) that conflict with simulator-injected kwargs.
- Validate that `context` is a dict when provided, while allowing missing values from DataFrame inputs (`None` / `NaN`).
- Add regression tests for reserved context keys, invalid context types, DataFrame missing-context handling, and missing `input`/`messages` in `predict_fn`.
- Fix simulation run-name tests to pass a real `predict_fn` fixture.
- 
### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Manual repro for code in #21170
Observed result:
- Raises `MlflowException` at `ConversationSimulator.simulate()` with:
  - `predict_fn must accept either 'messages' or 'input' parameter ...`

### Does this PR require documentation update?

- [X] Yes. I've updated:
  - [X] API references

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No. You can skip the rest of this section.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
`ConversationSimulator` now validates `predict_fn` signatures earlier and reports clear errors when neither `input` nor `messages` is declared. It also validates `context` inputs more robustly, including reserved-key checks and safer handling of missing context values from DataFrame test cases.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
