### PR TITLE
Replace RegExp with string comparison in evaluation artifact filter

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/EvaluationArtifactCompareView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/EvaluationArtifactCompareView.tsx
@@ -219,12 +219,12 @@ const EvaluationArtifactCompareViewImpl = ({
   const isViewConfigured = !isLoading && areTablesSelected && areRunsSelected;
 
   const filteredRows = useMemo(() => {
-    if (!debouncedFilter.trim()) {
+    const trimmedFilter = debouncedFilter.trim().toLowerCase();
+    if (!trimmedFilter) {
       return tableRows;
     }
-    const regexp = new RegExp(debouncedFilter, 'i');
     return tableRows.filter(({ groupByCellValues }) =>
-      Object.values(groupByCellValues).some((groupByValue) => groupByValue?.match(regexp)),
+      Object.values(groupByCellValues).some((groupByValue) => groupByValue?.toLowerCase().includes(trimmedFilter)),
     );
   }, [tableRows, debouncedFilter]);
 

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/EvaluationArtifactCompareView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/EvaluationArtifactCompareView.tsx
@@ -219,12 +219,14 @@ const EvaluationArtifactCompareViewImpl = ({
   const isViewConfigured = !isLoading && areTablesSelected && areRunsSelected;
 
   const filteredRows = useMemo(() => {
-    const trimmedFilter = debouncedFilter.trim().toLowerCase();
-    if (!trimmedFilter) {
+    const trimmedFilterLowerCase = debouncedFilter.trim().toLowerCase();
+    if (!trimmedFilterLowerCase) {
       return tableRows;
     }
     return tableRows.filter(({ groupByCellValues }) =>
-      Object.values(groupByCellValues).some((groupByValue) => groupByValue?.toLowerCase().includes(trimmedFilter)),
+      Object.values(groupByCellValues).some((groupByValue) =>
+        groupByValue?.toLowerCase().includes(trimmedFilterLowerCase),
+      ),
     );
   }, [tableRows, debouncedFilter]);
 

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationArtifactCompareTable.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationArtifactCompareTable.test.tsx
@@ -40,6 +40,7 @@ describe('EvaluationArtifactCompareTable', () => {
     groupByColumns: string[],
     outputColumnName: string,
     isImageColumn: boolean,
+    highlightedText = '',
   ) => {
     const visibleRuns: RunRowType[] = [
       {
@@ -141,7 +142,6 @@ describe('EvaluationArtifactCompareTable', () => {
     ];
     const onHideRun = jest.fn();
     const onDatasetSelected = jest.fn();
-    const highlightedText = '';
 
     const SAMPLE_STATE = {
       evaluationArtifactsBeingUploaded: {},
@@ -334,6 +334,27 @@ describe('EvaluationArtifactCompareTable', () => {
           expect(cells.length).toBeGreaterThan(0);
         });
       });
+    });
+  });
+
+  it('does not crash when highlightedText contains special characters', async () => {
+    const resultList: UseEvaluationArtifactTableDataResult = [
+      {
+        key: 'question_1',
+        groupByCellValues: {
+          data: 'question[_1',
+        },
+        cellValues: {
+          run_b: 'answer_1_run_b',
+          run_a: 'answer_1_run_a',
+        },
+        isPendingInputRow: false,
+      },
+    ];
+    renderComponent(resultList, ['data'], 'output', false, '[');
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: 'data' })).toBeInTheDocument();
     });
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationTextCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationTextCellRenderer.tsx
@@ -1,4 +1,5 @@
 import { TableSkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { escapeRegExp } from 'lodash';
 import type { ICellRendererParams } from '@ag-grid-community/core';
 import { FormattedMessage } from 'react-intl';
 import React from 'react';
@@ -37,7 +38,7 @@ const HighlightedText = React.memo(({ text, highlight }: { text: string; highlig
     return <>{text}</>;
   }
 
-  const parts = text.split(new RegExp(`(${highlight})`, 'gi'));
+  const parts = text.split(new RegExp(`(${escapeRegExp(highlight)})`, 'gi'));
 
   return (
     <>


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->
Closes https://github.com/mlflow/mlflow/issues/21259

### What changes are proposed in this pull request?
The evaluation artifacts compare view (`EvaluationArtifactCompareView.tsx`) constructs a `RegExp` directly from user-provided filter input (`new RegExp(debouncedFilter, 'i')`). This causes the component to crash when the user inputs certain special characters.

<img width="757" height="261" alt="image" src="https://github.com/user-attachments/assets/4b5a4da7-05d9-43e8-b6c3-dba6294e2b15" />

Replacing RegExp with String.toLowerCase().includes() provides the same case-insensitive substring filtering without any regex-related failure modes.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
> Fixed a bug where typing special characters in the evaluation artifacts filter input could crash the UI.


<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
