### PR TITLE
fix: DOM-based XSS in job and notebook source URLs

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.test.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.test.tsx
@@ -151,16 +151,7 @@ test('renderNotebookSource', () => {
     </a>,
   );
   expect(
-    Utils.renderNotebookSource(
-      queryParams,
-      notebookId,
-      revisionId,
-      runUuid,
-      sourceName,
-      // @ts-expect-error TS(2345): Argument of type '"http://databricks"' is not assi... Remove this comment to see the full error message
-      'http://databricks',
-      null,
-    ),
+    Utils.renderNotebookSource(queryParams, notebookId, revisionId, runUuid, sourceName, 'http://databricks', null),
   ).toEqual(
     <a
       title={sourceName}
@@ -214,10 +205,7 @@ test('renderJobSource', () => {
       {jobName}
     </a>,
   );
-  expect(
-    // @ts-expect-error TS(2345): Argument of type '"https://databricks"' is not ass... Remove this comment to see the full error message
-    Utils.renderJobSource(queryParams, jobId, jobRunId, jobName, 'https://databricks', null),
-  ).toEqual(
+  expect(Utils.renderJobSource(queryParams, jobId, jobRunId, jobName, 'https://databricks', null)).toEqual(
     <a title={jobName} href={`https://databricks/${queryParams}#job/${jobId}/run/${jobRunId}`} target="_top">
       {jobName}
     </a>,
@@ -956,4 +944,50 @@ test('isValidHttpUrl', () => {
   // disable no-script-url rule to test that javascript protocol is not seen as valid url
   /* eslint-disable no-script-url*/
   expect(Utils.isValidHttpUrl('javascript:void(0)')).toEqual(false);
+});
+
+test('getJobSourceUrl rejects dangerous workspaceUrl', () => {
+  expect(Utils.getJobSourceUrl(null, '123', '456', 'https://databricks.com')).toEqual(
+    'https://databricks.com/#job/123/run/456',
+  );
+
+  /* eslint-disable no-script-url */
+  expect(Utils.getJobSourceUrl(null, '123', '456', 'javascript://evil.com')).toEqual('');
+  /* eslint-enable no-script-url */
+});
+
+test('getNotebookSourceUrl rejects dangerous workspaceUrl', () => {
+  expect(Utils.getNotebookSourceUrl(null, '789', 'rev1', 'run1', 'https://databricks.com')).toEqual(
+    'https://databricks.com/#notebook/789/revision/rev1/mlflow/run/run1',
+  );
+
+  /* eslint-disable no-script-url */
+  expect(Utils.getNotebookSourceUrl(null, '789', 'rev1', null, 'javascript://evil.com')).toEqual('');
+  /* eslint-enable no-script-url */
+});
+
+test('renderJobSource renders plain text for dangerous workspaceUrl', () => {
+  expect(Utils.renderJobSource(null, '123', '456', 'my job', null)).toEqual(
+    <a title="my job" href="http://localhost/#job/123/run/456" target="_top">
+      my job
+    </a>,
+  );
+
+  /* eslint-disable no-script-url */
+  expect(Utils.renderJobSource(null, '123', '456', 'my job', 'javascript://evil.com', null)).toEqual('my job');
+  /* eslint-enable no-script-url */
+});
+
+test('renderNotebookSource renders plain text for dangerous workspaceUrl', () => {
+  expect(Utils.renderNotebookSource(null, '789', 'rev1', null, '/Users/test/iris', null)).toEqual(
+    <a title="/Users/test/iris" href="http://localhost/#notebook/789/revision/rev1" target="_top">
+      iris
+    </a>,
+  );
+
+  /* eslint-disable no-script-url */
+  expect(
+    Utils.renderNotebookSource(null, '789', 'rev1', null, '/Users/test/iris', 'javascript://evil.com', null),
+  ).toEqual('iris');
+  /* eslint-enable no-script-url */
 });

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -494,7 +494,7 @@ class Utils {
     revisionId: any,
     runUuid: any,
     sourceName: any,
-    workspaceUrl = null,
+    workspaceUrl: string | null = null,
     nameOverride: string | null = null,
   ) {
     // sourceName may not be present when rendering feature table notebook consumers from remote
@@ -507,20 +507,28 @@ class Utils {
 
     if (notebookId) {
       const url = Utils.getNotebookSourceUrl(queryParams, notebookId, revisionId, runUuid, workspaceUrl);
+      if (!url) {
+        return name;
+      }
       return (
         <a title={sourceName || Utils.getDefaultNotebookRevisionName(notebookId, revisionId)} href={url} target="_top">
           {name}
         </a>
       );
-    } else {
-      return name;
     }
+    return name;
   }
 
   /**
    * Returns the URL for the notebook source.
    */
-  static getNotebookSourceUrl(queryParams: any, notebookId: any, revisionId: any, runUuid: any, workspaceUrl = null) {
+  static getNotebookSourceUrl(
+    queryParams: any,
+    notebookId: any,
+    revisionId: any,
+    runUuid: any,
+    workspaceUrl: string | null = null,
+  ) {
     let url = Utils.setQueryParams(workspaceUrl || window.location.origin, queryParams);
     url += `#notebook/${notebookId}`;
     if (revisionId) {
@@ -529,7 +537,7 @@ class Utils {
         url += `/mlflow/run/${runUuid}`;
       }
     }
-    return url;
+    return Utils.isValidHttpUrl(url) ? url : '';
   }
 
   /**
@@ -540,7 +548,7 @@ class Utils {
     jobId: any,
     jobRunId: any,
     jobName: any,
-    workspaceUrl = null,
+    workspaceUrl: string | null = null,
     nameOverride: string | null = null,
   ) {
     // jobName may not be present when rendering feature table job consumers from remote
@@ -551,26 +559,28 @@ class Utils {
 
     if (jobId) {
       const url = Utils.getJobSourceUrl(queryParams, jobId, jobRunId, workspaceUrl);
+      if (!url) {
+        return name;
+      }
       return (
         <a title={reformatJobName} href={url} target="_top">
           {name}
         </a>
       );
-    } else {
-      return name;
     }
+    return name;
   }
 
   /**
    * Returns the URL for the job source.
    */
-  static getJobSourceUrl(queryParams: any, jobId: any, jobRunId: any, workspaceUrl = null) {
+  static getJobSourceUrl(queryParams: any, jobId: any, jobRunId: any, workspaceUrl: string | null = null) {
     let url = Utils.setQueryParams(workspaceUrl || window.location.origin, queryParams);
     url += `#job/${jobId}`;
     if (jobRunId) {
       url += `/run/${jobRunId}`;
     }
-    return url;
+    return Utils.isValidHttpUrl(url) ? url : '';
   }
 
   /**


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #21231

### What changes are proposed in this pull request?

- Reuse existing `isValidHttpUrl` in `getJobSourceUrl` and `getNotebookSourceUrl` to reject non-`http`/`https` URI schemes, preventing DOM-based XSS (CWE-79) via `javascript:`, `data:`, or `vbscript:` URLs in dynamic `href` attributes
- Add early return in `renderJobSource` and `renderNotebookSource` to fall back to plain text when the URL is unsafe
- Add `string | null` type annotation to `workspaceUrl` parameters across all four affected functions
- Add tests covering safe URLs, dangerous schemes, and render fallback behavior

How is this patch tested?

- Unit tests verify that `getJobSourceUrl` and `getNotebookSourceUrl` return empty string for unsafe workspace URLs
- Unit tests verify that `renderJobSource` and `renderNotebookSource` render plain text (no anchor tag) when given a malicious workspace URL

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Fixed a DOM-based Cross-Site Scripting (XSS) vulnerability (CWE-79) where unsanitized workspace URLs could be injected into `href` attributes when rendering notebook and job source links. URLs are now validated to only allow `http` and `https` protocols; unsafe URLs are rendered as plain text instead of clickable links.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
