### PR TITLE
Add Kubernetes request auth provider plugin

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -367,6 +367,7 @@ def build(package_type: PackageType) -> None:
                 "sqlserver": ["mlflow-dbstore"],
                 "aliyun-oss": ["aliyunstoreplugin"],
                 "jfrog": ["mlflow-jfrog-plugin"],
+                "kubernetes": ["kubernetes"],
                 "langchain": langchain_requirements,
                 "auth": ["Flask-WTF<2"],
             }

--- a/docs/docs/self-hosting/security/kubernetes.md
+++ b/docs/docs/self-hosting/security/kubernetes.md
@@ -1,0 +1,82 @@
+# Kubernetes Authentication
+
+MLflow includes built-in request auth providers for Kubernetes environments. These providers automatically add authorization headers to outgoing MLflow client requests using Kubernetes credentials.
+
+:::important Applicability
+
+This provider is designed for MLflow deployments behind a proxy with Kubernetes-based authentication, such as [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy), or a custom auth MLflow plugin.
+
+If your MLflow deployment does not use Kubernetes-based authentication, this provider is not applicable.
+
+:::
+
+## Overview
+
+Two auth providers are available, selected via `MLFLOW_TRACKING_AUTH`:
+
+| Provider          | `MLFLOW_TRACKING_AUTH` value | Headers added                            |
+| ----------------- | ---------------------------- | ---------------------------------------- |
+| Token-only        | `kubernetes`                 | `Authorization`                          |
+| Token + workspace | `kubernetes-namespaced`      | `Authorization` and `X-MLFLOW-WORKSPACE` |
+
+The `kubernetes` provider adds only a bearer token. The `kubernetes-namespaced` provider also adds an `X-MLFLOW-WORKSPACE` header derived from the Kubernetes namespace.
+
+## Prerequisites
+
+Install the `kubernetes` Python package:
+
+```bash
+pip install mlflow[kubernetes]
+```
+
+## Configuration
+
+For token-only authentication:
+
+```bash
+export MLFLOW_TRACKING_AUTH=kubernetes
+```
+
+To also attach workspace headers (namespace-based workspace routing):
+
+```bash
+export MLFLOW_TRACKING_AUTH=kubernetes-namespaced
+```
+
+No additional configuration is needed. The provider automatically discovers credentials from the environment.
+
+## Credential Sources
+
+The provider tries two credential sources in order for each piece of information, using the first one that succeeds. The namespace and token are resolved independently and may come from different sources.
+
+### 1. Service Account (in-cluster)
+
+When running inside a Kubernetes pod, the provider reads the mounted service account files:
+
+- **Namespace**: `/var/run/secrets/kubernetes.io/serviceaccount/namespace`
+- **Token**: `/var/run/secrets/kubernetes.io/serviceaccount/token`
+
+This is the default path for pods with a service account mounted (which is the standard Kubernetes behavior).
+
+### 2. Kubeconfig
+
+When service account files are not available, the provider falls back to kubeconfig:
+
+- **Namespace**: Extracted from the active context
+- **Token**: Resolved via the Kubernetes Python client's `ApiClient`, which handles exec-based auth flows (EKS, GKE, AKS, OpenShift, OIDC)
+
+## Usage
+
+Once configured, no code changes are needed. All MLflow client calls will automatically include the authorization headers with values sourced from Kubernetes:
+
+```python
+import mlflow
+
+mlflow.set_tracking_uri("http://mlflow-server:5000")
+
+with mlflow.start_run():
+    mlflow.log_param("learning_rate", 0.01)
+    mlflow.log_metric("accuracy", 0.95)
+```
+
+If a workspace is explicitly set (e.g., via `mlflow.set_workspace()`), it takes priority over the Kubernetes namespace. The namespace from Kubernetes credentials is used as a default when no workspace is specified.

--- a/docs/sidebarsSelfHosting.ts
+++ b/docs/sidebarsSelfHosting.ts
@@ -89,6 +89,11 @@ const sidebarsSelfHosting: SidebarsConfig = {
           id: 'security/custom',
           label: 'Custom Authentication',
         },
+        {
+          type: 'doc',
+          id: 'security/kubernetes',
+          label: 'Kubernetes Authentication',
+        },
       ],
     },
     {

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -100,6 +100,7 @@ mcp = ["fastmcp<3,>=2.0.0", "click!=8.3.0"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
+kubernetes = ["kubernetes"]
 langchain = ["langchain>=0.3.20,<=1.2.10"]
 auth = ["Flask-WTF<2"]
 

--- a/mlflow/tracking/request_auth/kubernetes_request_auth_provider.py
+++ b/mlflow/tracking/request_auth/kubernetes_request_auth_provider.py
@@ -1,0 +1,293 @@
+"""Request auth provider for Kubernetes environments.
+
+This module provides two auth plugins activated via ``MLFLOW_TRACKING_AUTH``:
+
+- ``kubernetes`` — adds only the ``Authorization`` header (bearer token).
+- ``kubernetes-namespaced`` — adds both ``Authorization`` and ``X-MLFLOW-WORKSPACE``
+  (derived from the Kubernetes namespace).
+
+Requires the ``kubernetes`` package. Install it with:
+    pip install mlflow[kubernetes]
+"""
+
+import logging
+import os
+import threading
+from pathlib import Path
+
+from mlflow.exceptions import MlflowException
+from mlflow.tracking.request_auth.abstract_request_auth_provider import RequestAuthProvider
+from mlflow.utils.workspace_context import get_request_workspace, set_workspace
+from mlflow.utils.workspace_utils import WORKSPACE_HEADER_NAME
+
+_FILE_CACHE_TTL = 60
+
+_file_cache = None
+_file_cache_lock = threading.Lock()
+
+_kubeconfig_token_cache = None
+_kubeconfig_token_cache_lock = threading.Lock()
+
+_kubeconfig_namespace_cache = None
+_kubeconfig_namespace_cache_lock = threading.Lock()
+
+_logger = logging.getLogger(__name__)
+
+# Kubernetes service account paths
+_SERVICE_ACCOUNT_NAMESPACE_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+_SERVICE_ACCOUNT_TOKEN_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+
+AUTHORIZATION_HEADER_NAME = "Authorization"
+
+
+def _ensure_caches():
+    global _file_cache, _kubeconfig_token_cache, _kubeconfig_namespace_cache
+    if _file_cache is not None:
+        return
+    from cachetools import TTLCache
+
+    _file_cache = TTLCache(maxsize=10, ttl=_FILE_CACHE_TTL)
+    _kubeconfig_token_cache = TTLCache(maxsize=4, ttl=_FILE_CACHE_TTL)
+    _kubeconfig_namespace_cache = TTLCache(maxsize=4, ttl=_FILE_CACHE_TTL)
+
+
+def _cache_lookup(cache, lock, key, compute_fn):
+    with lock:
+        try:
+            return cache[key]
+        except KeyError:
+            pass
+    value = compute_fn()
+    with lock:
+        try:
+            cache[key] = value
+        except ValueError:
+            pass  # value exceeds maxsize — skip caching, still return it
+    return value
+
+
+def _check_kubernetes_installed():
+    try:
+        from kubernetes import client, config  # noqa: F401
+    except ImportError:
+        raise MlflowException(
+            "The 'kubernetes' package is required to use the Kubernetes auth providers "
+            "(MLFLOW_TRACKING_AUTH=kubernetes or MLFLOW_TRACKING_AUTH=kubernetes-namespaced), "
+            "but it is not installed or is incomplete. "
+            "Install it with: pip install mlflow[kubernetes]"
+        )
+
+
+def _read_file_uncached(path: Path) -> str | None:
+    try:
+        if path.exists():
+            return path.read_text().strip() or None
+    except OSError as e:
+        _logger.debug("Could not read file %s: %s", path, e)
+    return None
+
+
+def _read_file_if_exists(path: Path) -> str | None:
+    _ensure_caches()
+    return _cache_lookup(
+        _file_cache, _file_cache_lock, str(path), lambda: _read_file_uncached(path)
+    )
+
+
+def _get_namespace() -> str | None:
+    """Get workspace namespace. Tries service account file then kubeconfig context."""
+    if namespace := _read_file_if_exists(_SERVICE_ACCOUNT_NAMESPACE_PATH):
+        return namespace
+    return _get_namespace_from_kubeconfig()
+
+
+def _get_namespace_from_kubeconfig_uncached() -> str | None:
+    from kubernetes import config
+    from kubernetes.config.config_exception import ConfigException
+
+    try:
+        config.load_kube_config()
+    except (OSError, ConfigException) as e:
+        _logger.warning("Could not load kubeconfig: %s", e)
+        return None
+
+    try:
+        _, active_context = config.list_kube_config_contexts()
+    except (OSError, ConfigException) as e:
+        _logger.warning("Could not list kubeconfig contexts: %s", e)
+        return None
+    if not active_context:
+        return None
+
+    return active_context.get("context", {}).get("namespace", "").strip() or None
+
+
+def _get_namespace_from_kubeconfig() -> str | None:
+    _ensure_caches()
+    key = _get_kubeconfig_cache_key()
+    return _cache_lookup(
+        _kubeconfig_namespace_cache,
+        _kubeconfig_namespace_cache_lock,
+        key,
+        _get_namespace_from_kubeconfig_uncached,
+    )
+
+
+def _get_token() -> str | None:
+    """Get authorization token. Tries service account file then kubeconfig."""
+    if token := _read_file_if_exists(_SERVICE_ACCOUNT_TOKEN_PATH):
+        return f"Bearer {token}"
+    return _get_token_from_kubeconfig()
+
+
+def _get_kubeconfig_cache_key() -> str:
+    """Build a cache key from the kubeconfig path and active context name."""
+    from kubernetes import config
+    from kubernetes.config.config_exception import ConfigException
+
+    kubeconfig_path = os.environ.get("KUBECONFIG", "DEFAULT")
+    try:
+        _, active_context = config.list_kube_config_contexts()
+    except (OSError, ConfigException):
+        return kubeconfig_path
+    context_name = active_context.get("name", "") if active_context else ""
+    return f"{kubeconfig_path}:{context_name}"
+
+
+def _get_token_from_kubeconfig_uncached() -> str | None:
+    from kubernetes import client, config
+    from kubernetes.config.config_exception import ConfigException
+
+    try:
+        config.load_kube_config()
+    except (OSError, ConfigException) as e:
+        _logger.warning("Could not load kubeconfig: %s", e)
+        return None
+
+    with client.ApiClient() as api_client:
+        token = None
+
+        # 1) Try default_headers first (where most auth flows put the resolved token)
+        auth = api_client.default_headers.get("Authorization") or api_client.default_headers.get(
+            "authorization"
+        )
+        if isinstance(auth, str) and auth.lower().startswith("bearer "):
+            token = auth[7:].strip()
+
+        # 2) Fallback: configuration.api_key (some versions/auth flows store it here)
+        if not token:
+            api_key = api_client.configuration.api_key.get("authorization")
+            if isinstance(api_key, str):
+                token = api_key.strip()
+                if token.lower().startswith("bearer "):
+                    token = token[7:].strip()
+
+        if not token:
+            return None
+
+        return f"Bearer {token}"
+
+
+def _get_token_from_kubeconfig() -> str | None:
+    _ensure_caches()
+    key = _get_kubeconfig_cache_key()
+    return _cache_lookup(
+        _kubeconfig_token_cache,
+        _kubeconfig_token_cache_lock,
+        key,
+        _get_token_from_kubeconfig_uncached,
+    )
+
+
+class KubernetesAuth:
+    """Custom authentication class for Kubernetes environments.
+
+    This class is callable and will be invoked by the requests library
+    to add authentication headers to each request.
+
+    Args:
+        enable_workspaces: When True, also adds the X-MLFLOW-WORKSPACE header
+            and sets the workspace context. Defaults to False.
+    """
+
+    def __init__(self, *, enable_workspaces: bool = False):
+        self._enable_workspaces = enable_workspaces
+
+    def __call__(self, request):
+        """Add Kubernetes authentication headers to the request.
+
+        Args:
+            request: The prepared request object from the requests library.
+
+        Returns:
+            The modified request object with authentication headers.
+
+        Raises:
+            MlflowException: If workspace or authorization cannot be determined.
+        """
+        if self._enable_workspaces and WORKSPACE_HEADER_NAME not in request.headers:
+            # Prefer an explicitly configured request workspace over the Kubernetes namespace.
+            if workspace := get_request_workspace():
+                request.headers[WORKSPACE_HEADER_NAME] = workspace
+            else:
+                namespace = _get_namespace()
+                if not namespace:
+                    raise MlflowException(
+                        "Could not determine Kubernetes namespace. "
+                        "Ensure you are running in a Kubernetes pod with a service account "
+                        "or have a valid kubeconfig with a namespace set in the active context."
+                    )
+                request.headers[WORKSPACE_HEADER_NAME] = namespace
+
+        if AUTHORIZATION_HEADER_NAME not in request.headers:
+            token = _get_token()
+            if not token:
+                raise MlflowException(
+                    "Could not determine Kubernetes credentials. "
+                    "Ensure you are running in a Kubernetes pod with a service account "
+                    "or have a valid kubeconfig with credentials set."
+                )
+            request.headers[AUTHORIZATION_HEADER_NAME] = token
+
+        # Propagate the workspace globally so _log_url includes the workspace
+        # query parameter and subprocesses inherit it via the environment variable.
+        if self._enable_workspaces and not get_request_workspace():
+            set_workspace(request.headers.get(WORKSPACE_HEADER_NAME))
+
+        return request
+
+
+class KubernetesRequestAuthProvider(RequestAuthProvider):
+    """Provides token-only authentication for Kubernetes environments.
+
+    This provider adds only the Authorization header from Kubernetes credentials.
+    Use ``MLFLOW_TRACKING_AUTH=kubernetes`` to enable.
+    """
+
+    def get_name(self) -> str:
+        return "kubernetes"
+
+    def get_auth(self):
+        _check_kubernetes_installed()
+        return KubernetesAuth(enable_workspaces=False)
+
+
+class KubernetesNamespacedRequestAuthProvider(RequestAuthProvider):
+    """Provides authentication with workspace headers for Kubernetes environments.
+
+    This provider adds both headers based on Kubernetes environment:
+    - Authorization: Set from service account token file or kubeconfig credentials
+    - X-MLFLOW-WORKSPACE: Set from service account namespace file or kubeconfig context
+
+    Each header is resolved independently — the namespace and token may come from
+    different sources. Either header can also be pre-set by the caller.
+
+    Use ``MLFLOW_TRACKING_AUTH=kubernetes-namespaced`` to enable.
+    """
+
+    def get_name(self) -> str:
+        return "kubernetes-namespaced"
+
+    def get_auth(self):
+        _check_kubernetes_installed()
+        return KubernetesAuth(enable_workspaces=True)

--- a/mlflow/tracking/request_auth/registry.py
+++ b/mlflow/tracking/request_auth/registry.py
@@ -1,5 +1,9 @@
 import warnings
 
+from mlflow.tracking.request_auth.kubernetes_request_auth_provider import (
+    KubernetesNamespacedRequestAuthProvider,
+    KubernetesRequestAuthProvider,
+)
 from mlflow.utils.plugins import get_entry_points
 
 REQUEST_AUTH_PROVIDER_ENTRYPOINT = "mlflow.request_auth_provider"
@@ -29,6 +33,8 @@ class RequestAuthProviderRegistry:
 
 
 _request_auth_provider_registry = RequestAuthProviderRegistry()
+_request_auth_provider_registry.register(KubernetesRequestAuthProvider)
+_request_auth_provider_registry.register(KubernetesNamespacedRequestAuthProvider)
 _request_auth_provider_registry.register_entrypoints()
 
 

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -102,6 +102,7 @@ mcp = ["fastmcp<3,>=2.0.0", "click!=8.3.0"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
+kubernetes = ["kubernetes"]
 langchain = ["langchain>=0.3.20,<=1.2.10"]
 auth = ["Flask-WTF<2"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ mcp = ["fastmcp<3,>=2.0.0", "click!=8.3.0"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
+kubernetes = ["kubernetes"]
 langchain = ["langchain>=0.3.20,<=1.2.10"]
 auth = ["Flask-WTF<2"]
 

--- a/tests/tracking/request_auth/test_kubernetes_request_auth_provider.py
+++ b/tests/tracking/request_auth/test_kubernetes_request_auth_provider.py
@@ -1,0 +1,389 @@
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("kubernetes")
+
+from kubernetes.config.config_exception import ConfigException
+
+import mlflow.tracking.request_auth.kubernetes_request_auth_provider as _k8s_auth
+from mlflow.exceptions import MlflowException
+from mlflow.tracking.request_auth.kubernetes_request_auth_provider import (
+    AUTHORIZATION_HEADER_NAME,
+    WORKSPACE_HEADER_NAME,
+    KubernetesAuth,
+    KubernetesNamespacedRequestAuthProvider,
+    KubernetesRequestAuthProvider,
+    _get_namespace,
+    _get_token,
+    _get_token_from_kubeconfig,
+    _read_file_if_exists,
+)
+from mlflow.utils.workspace_context import get_request_workspace, set_workspace
+
+_MODULE = "mlflow.tracking.request_auth.kubernetes_request_auth_provider"
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    for cache in (
+        _k8s_auth._file_cache,
+        _k8s_auth._kubeconfig_token_cache,
+        _k8s_auth._kubeconfig_namespace_cache,
+    ):
+        if cache is not None:
+            cache.clear()
+    yield
+    for cache in (
+        _k8s_auth._file_cache,
+        _k8s_auth._kubeconfig_token_cache,
+        _k8s_auth._kubeconfig_namespace_cache,
+    ):
+        if cache is not None:
+            cache.clear()
+    set_workspace(None)
+
+
+@contextmanager
+def _patch_service_account(tmp_path, *, namespace=None, token=None):
+    ns_path = tmp_path / "sa-namespace"
+    tk_path = tmp_path / "sa-token"
+    if namespace is not None:
+        ns_path.write_text(namespace)
+    if token is not None:
+        tk_path.write_text(token)
+    with (
+        mock.patch(f"{_MODULE}._SERVICE_ACCOUNT_NAMESPACE_PATH", ns_path),
+        mock.patch(f"{_MODULE}._SERVICE_ACCOUNT_TOKEN_PATH", tk_path),
+    ):
+        yield
+
+
+@contextmanager
+def _patch_kubeconfig(*, namespace=None, token=None, load_error=None):
+    active_context = (
+        {"name": "ctx", "context": {"namespace": namespace}}
+        if namespace is not None
+        else {"name": "ctx", "context": {}}
+    )
+    mock_api_client = mock.MagicMock()
+    mock_api_client.__enter__.return_value = mock_api_client
+    mock_api_client.default_headers = {"Authorization": f"Bearer {token}"} if token else {}
+    mock_api_client.configuration.api_key = {}
+    with (
+        mock.patch(
+            "kubernetes.config.load_kube_config",
+            side_effect=load_error,
+        ),
+        mock.patch(
+            "kubernetes.config.list_kube_config_contexts",
+            return_value=([], active_context),
+        ),
+        mock.patch("kubernetes.client.ApiClient", return_value=mock_api_client),
+    ):
+        yield
+
+
+@pytest.mark.parametrize(
+    ("setup", "expected"),
+    [
+        ("missing", None),
+        ("  content  \n", "content"),
+        ("permission_error", None),
+    ],
+    ids=["missing-file", "strips-whitespace", "permission-error"],
+)
+def test_read_file_if_exists(tmp_path, setup, expected):
+    path = tmp_path / "file"
+    if setup == "missing":
+        pass
+    elif setup == "permission_error":
+        path.write_text("x")
+        with (
+            mock.patch.object(Path, "exists", return_value=True),
+            mock.patch.object(Path, "read_text", side_effect=PermissionError("denied")),
+        ):
+            assert _read_file_if_exists(path) is None
+            return
+    else:
+        path.write_text(setup)
+    assert _read_file_if_exists(path) == expected
+
+
+def test_read_file_caches_result(tmp_path):
+    path = tmp_path / "cached"
+    path.write_text("cached-content")
+    with mock.patch.object(Path, "read_text", wraps=path.read_text) as mock_read:
+        assert _read_file_if_exists(path) == "cached-content"
+        assert _read_file_if_exists(path) == "cached-content"
+        mock_read.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("sa_namespace", "kubeconfig_namespace", "expected"),
+    [
+        ("sa-ns", "kube-ns", "sa-ns"),
+        (None, "kube-ns", "kube-ns"),
+        (None, None, None),
+    ],
+    ids=["prefers-service-account", "falls-back-to-kubeconfig", "none-available"],
+)
+def test_get_namespace_source_priority(tmp_path, sa_namespace, kubeconfig_namespace, expected):
+    with (
+        _patch_service_account(tmp_path, namespace=sa_namespace),
+        _patch_kubeconfig(namespace=kubeconfig_namespace),
+    ):
+        assert _get_namespace() == expected
+
+
+@pytest.mark.parametrize(
+    ("default_headers", "api_key", "expected"),
+    [
+        ({"Authorization": "Bearer tok"}, {}, "Bearer tok"),
+        ({"authorization": "Bearer lower"}, {}, "Bearer lower"),
+        ({}, {"authorization": "raw-tok"}, "Bearer raw-tok"),
+        ({}, {"authorization": "Bearer prefixed"}, "Bearer prefixed"),
+        ({}, {}, None),
+    ],
+    ids=[
+        "default-header-bearer",
+        "lowercase-header",
+        "api-key-fallback",
+        "api-key-strips-bearer",
+        "no-token",
+    ],
+)
+def test_token_from_kubeconfig_extraction(default_headers, api_key, expected):
+    mock_api_client = mock.MagicMock()
+    mock_api_client.__enter__.return_value = mock_api_client
+    mock_api_client.default_headers = default_headers
+    mock_api_client.configuration.api_key = api_key
+    with (
+        mock.patch("kubernetes.config.load_kube_config"),
+        mock.patch("kubernetes.client.ApiClient", return_value=mock_api_client),
+        mock.patch(
+            "kubernetes.config.list_kube_config_contexts",
+            return_value=([], {"name": "ctx"}),
+        ),
+    ):
+        assert _get_token_from_kubeconfig() == expected
+
+
+def test_token_from_kubeconfig_returns_none_on_load_failure():
+    with mock.patch(
+        "kubernetes.config.load_kube_config",
+        side_effect=ConfigException("no kubeconfig"),
+    ):
+        assert _get_token_from_kubeconfig() is None
+
+
+def test_token_from_kubeconfig_caches_by_context():
+    mock_api_client = mock.MagicMock()
+    mock_api_client.__enter__.return_value = mock_api_client
+    mock_api_client.default_headers = {"Authorization": "Bearer cached"}
+
+    with (
+        mock.patch("kubernetes.config.load_kube_config") as mock_load,
+        mock.patch("kubernetes.client.ApiClient", return_value=mock_api_client),
+        mock.patch(
+            "kubernetes.config.list_kube_config_contexts",
+            return_value=([], {"name": "ctx"}),
+        ),
+    ):
+        assert _get_token_from_kubeconfig() == "Bearer cached"
+        assert _get_token_from_kubeconfig() == "Bearer cached"
+        mock_load.assert_called_once()
+
+
+def test_token_from_kubeconfig_cache_invalidates_on_context_change():
+    clients = [mock.MagicMock(), mock.MagicMock()]
+    for c in clients:
+        c.__enter__.return_value = c
+    clients[0].default_headers = {"Authorization": "Bearer token-a"}
+    clients[1].default_headers = {"Authorization": "Bearer token-b"}
+
+    with (
+        mock.patch("kubernetes.config.load_kube_config") as mock_load,
+        mock.patch("kubernetes.client.ApiClient", side_effect=clients),
+        mock.patch(
+            "kubernetes.config.list_kube_config_contexts",
+            side_effect=[
+                ([], {"name": "ctx-a"}),
+                ([], {"name": "ctx-b"}),
+            ],
+        ),
+    ):
+        assert _get_token_from_kubeconfig() == "Bearer token-a"
+        assert _get_token_from_kubeconfig() == "Bearer token-b"
+        assert mock_load.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ("sa_token", "kubeconfig_token", "expected"),
+    [
+        ("sa-tok", "kube-tok", "Bearer sa-tok"),
+        (None, "kube-tok", "Bearer kube-tok"),
+        (None, None, None),
+    ],
+    ids=["prefers-service-account", "falls-back-to-kubeconfig", "none-available"],
+)
+def test_get_token_source_priority(tmp_path, sa_token, kubeconfig_token, expected):
+    with (
+        _patch_service_account(tmp_path, token=sa_token),
+        _patch_kubeconfig(
+            token=kubeconfig_token,
+            load_error=ConfigException("no config") if kubeconfig_token is None else None,
+        ),
+    ):
+        assert _get_token() == expected
+
+
+@pytest.mark.parametrize(
+    (
+        "enable_workspaces",
+        "initial_headers",
+        "sa_namespace",
+        "sa_token",
+        "expected_workspace",
+        "expected_auth",
+    ),
+    [
+        # workspaces disabled — does not inject workspace header
+        (False, {}, None, "tok", None, "Bearer tok"),
+        (False, {WORKSPACE_HEADER_NAME: "caller-ws"}, None, "tok", "caller-ws", "Bearer tok"),
+        (False, {AUTHORIZATION_HEADER_NAME: "preset"}, None, None, None, "preset"),
+        # workspaces enabled — both headers
+        (True, {}, "ns", "tok", "ns", "Bearer tok"),
+        (
+            True,
+            {WORKSPACE_HEADER_NAME: "pre", AUTHORIZATION_HEADER_NAME: "pre-auth"},
+            "ns",
+            "tok",
+            "pre",
+            "pre-auth",
+        ),
+        (True, {WORKSPACE_HEADER_NAME: "pre"}, None, "tok", "pre", "Bearer tok"),
+        (True, {AUTHORIZATION_HEADER_NAME: "pre-auth"}, "ns", None, "ns", "pre-auth"),
+    ],
+    ids=[
+        "disabled-auth-only",
+        "disabled-ignores-caller-workspace",
+        "disabled-preserves-preset-auth",
+        "enabled-both-headers",
+        "enabled-both-preset",
+        "enabled-workspace-preset-auth-resolved",
+        "enabled-auth-preset-workspace-resolved",
+    ],
+)
+def test_auth_headers(
+    tmp_path,
+    enable_workspaces,
+    initial_headers,
+    sa_namespace,
+    sa_token,
+    expected_workspace,
+    expected_auth,
+):
+    request = mock.MagicMock()
+    request.headers = dict(initial_headers)
+
+    with _patch_service_account(tmp_path, namespace=sa_namespace, token=sa_token):
+        auth = KubernetesAuth(enable_workspaces=enable_workspaces)
+        result = auth(request)
+
+    assert result is request
+    assert request.headers.get(AUTHORIZATION_HEADER_NAME) == expected_auth
+    if expected_workspace is None:
+        assert WORKSPACE_HEADER_NAME not in request.headers
+    else:
+        assert request.headers[WORKSPACE_HEADER_NAME] == expected_workspace
+
+
+@pytest.mark.parametrize(
+    ("enable_workspaces", "initial_headers", "sa_namespace", "sa_token", "error_match"),
+    [
+        (True, {}, None, "tok", "Could not determine Kubernetes namespace"),
+        (
+            True,
+            {WORKSPACE_HEADER_NAME: "ws"},
+            None,
+            None,
+            "Could not determine Kubernetes credentials",
+        ),
+        (False, {}, None, None, "Could not determine Kubernetes credentials"),
+    ],
+    ids=[
+        "enabled-missing-namespace",
+        "enabled-missing-token",
+        "disabled-missing-token",
+    ],
+)
+def test_auth_raises_on_missing_credentials(
+    tmp_path, enable_workspaces, initial_headers, sa_namespace, sa_token, error_match
+):
+    request = mock.MagicMock()
+    request.headers = dict(initial_headers)
+
+    with (
+        _patch_service_account(tmp_path, namespace=sa_namespace, token=sa_token),
+        _patch_kubeconfig(load_error=ConfigException("no config")),
+        pytest.raises(MlflowException, match=error_match),
+    ):
+        KubernetesAuth(enable_workspaces=enable_workspaces)(request)
+
+
+@pytest.mark.parametrize(
+    ("enable_workspaces", "pre_existing_workspace", "expected_context", "expected_ws_header"),
+    [
+        (True, None, "ns", "ns"),
+        (True, "pre-existing", "pre-existing", "pre-existing"),
+        (False, None, None, None),
+    ],
+    ids=["sets-workspace-context", "preserves-existing-context", "disabled-no-context"],
+)
+def test_auth_workspace_context(
+    tmp_path, enable_workspaces, pre_existing_workspace, expected_context, expected_ws_header
+):
+    if pre_existing_workspace:
+        set_workspace(pre_existing_workspace)
+
+    request = mock.MagicMock()
+    request.headers = {}
+
+    with _patch_service_account(tmp_path, namespace="ns", token="tok"):
+        KubernetesAuth(enable_workspaces=enable_workspaces)(request)
+
+    assert get_request_workspace() == expected_context
+    if expected_ws_header is not None:
+        assert request.headers[WORKSPACE_HEADER_NAME] == expected_ws_header
+
+
+@pytest.mark.parametrize(
+    ("provider_cls", "expected_name", "expected_workspaces"),
+    [
+        (KubernetesRequestAuthProvider, "kubernetes", False),
+        (KubernetesNamespacedRequestAuthProvider, "kubernetes-namespaced", True),
+    ],
+    ids=["kubernetes", "kubernetes-namespaced"],
+)
+def test_provider_registration(provider_cls, expected_name, expected_workspaces):
+    provider = provider_cls()
+    assert provider.get_name() == expected_name
+    auth = provider.get_auth()
+    assert isinstance(auth, KubernetesAuth)
+    assert auth._enable_workspaces is expected_workspaces
+
+
+@pytest.mark.parametrize(
+    "provider_cls",
+    [KubernetesRequestAuthProvider, KubernetesNamespacedRequestAuthProvider],
+    ids=["kubernetes", "kubernetes-namespaced"],
+)
+def test_provider_raises_without_kubernetes(provider_cls):
+    with (
+        mock.patch.dict("sys.modules", {"kubernetes": None}),
+        pytest.raises(MlflowException, match="kubernetes.*not installed"),
+    ):
+        provider_cls().get_auth()

--- a/uv.lock
+++ b/uv.lock
@@ -4374,6 +4374,9 @@ genai = [
 jfrog = [
     { name = "mlflow-jfrog-plugin" },
 ]
+kubernetes = [
+    { name = "kubernetes" },
+]
 langchain = [
     { name = "langchain" },
 ]
@@ -4541,6 +4544,7 @@ requires-dist = [
     { name = "huey", specifier = ">=2.5.4,<3" },
     { name = "importlib-metadata", specifier = ">=3.7.0,!=4.7.0,<9" },
     { name = "kubernetes", marker = "extra == 'extras'" },
+    { name = "kubernetes", marker = "extra == 'kubernetes'" },
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.20,<=1.2.10" },
     { name = "litellm", marker = "extra == 'genai'", specifier = ">=1.0.0,<2" },
     { name = "matplotlib", specifier = "<4" },
@@ -4584,7 +4588,7 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'gateway'", specifier = "<2" },
     { name = "watchfiles", marker = "extra == 'genai'", specifier = "<2" },
 ]
-provides-extras = ["extras", "db", "databricks", "mlserver", "gateway", "genai", "mcp", "sqlserver", "aliyun-oss", "jfrog", "langchain", "auth"]
+provides-extras = ["extras", "db", "databricks", "mlserver", "gateway", "genai", "mcp", "sqlserver", "aliyun-oss", "jfrog", "kubernetes", "langchain", "auth"]
 
 [package.metadata.requires-dev]
 build = [


### PR DESCRIPTION
### Related Issues/PRs

Closes #21174 

### What changes are proposed in this pull request?

Adds a built-in Kubernetes request auth provider plugin that automatically attaches `X-MLFLOW-WORKSPACE` (namespace) and `Authorization` (bearer token) headers to outgoing MLflow tracking requests. This enables MLflow clients running in Kubernetes to authenticate against MLflow deployments that use a custom workspace provider plugin requiring Kubernetes-based identity.


#### What it does

- **New provider** (`KubernetesRequestAuthProvider`): Activated via `MLFLOW_TRACKING_AUTH=kubernetes`. Implements the existing `RequestAuthProvider` plugin interface.
- **Credential discovery**: Tries in-cluster service account files first (`/var/run/secrets/kubernetes.io/serviceaccount/{namespace,token}`), then falls back to kubeconfig (resolves exec-based auth for EKS, GKE, AKS, OpenShift, OIDC). Both namespace and token always come from the same source for consistency.
- **Caching**: Service account file reads are cached with a 1-minute TTL to avoid repeated I/O.
- **Non-invasive header injection**: Respects existing headers — if both `X-MLFLOW-WORKSPACE` and `Authorization` are already set, the provider is a no-op.
- **Registration**: The provider is registered directly in the `RequestAuthProviderRegistry` alongside the existing entrypoint-based plugin system.

#### Files changed

| File                                                                   | Change                                                                                                      |
|------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
| `mlflow/tracking/request_auth/kubernetes_request_auth_provider.py`     | New provider implementation                                                                                 |
| `mlflow/tracking/request_auth/registry.py`                             | Register `KubernetesRequestAuthProvider` as a built-in provider                                             |
| `tests/tracking/request_auth/test_kubernetes_request_auth_provider.py` | 27 unit tests covering credential sources, header injection, caching, error handling, and workspace context |
| `docs/docs/self-hosting/security/kubernetes.md`                        | Documentation under Self-Hosting > Security                                                                 |
| `docs/sidebarsSelfHosting.ts`                                          | Sidebar entry for the new doc page                                                                          |

#### Applicability note

This provider is intended for MLflow deployments that use a **custom workspace provider plugin requiring Kubernetes authentication** (e.g., a Kubernetes-based workspace provider running alongside MLflow in a K8s cluster). It is not part of MLflow's default auth flow — different users may implement their own Kubernetes workspace providers, but are likely to converge on the mappings of workspace -> namespace and Authorization -> Kubernetes token.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

I've successfully manually tested this with an MLflow server backed by a kubernetes workspace provider that accepts the aforementioned headers, and by: 

* Installing mlflow sdk locally
* Installing the kubernetes package via `pip install mlflow[kubernetes]`
* Setting `MLFLOW_TRACKING_AUTH=kubernetes` 
* Performing basic queries like listing experiments and runs. 
* The same tests performed inside of a pod

The plugin has a dependency on the `kubernetes` package which is an `extras` dep for Mlflow. If the user doesn't install this kubernetes package and tries to set `MLFLOW_TRACKING_AUTH=kubernetes` they will encounter user feedback: 

<details><summary>stdout.log</summary>

```log
Traceback (most recent call last):
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/tracking/request_auth/kubernetes_request_auth_provider.py", line 39, in _check_kubernetes_installed
    from kubernetes import client, config  # noqa: F401
ImportError: cannot import name 'client' from 'kubernetes' (unknown location)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/hukhan/projects/github/rhoai/mlflow/playground/mlflow-auth-plugin.py", line 11, in <module>
    for exp in mlflow.search_experiments(max_results=20):
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/tracking/fluent.py", line 2172, in search_experiments
    return get_results_from_paginated_fn(
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/utils/__init__.py", line 253, in get_results_from_paginated_fn
    page_results = paginated_fn(num_to_get, next_page_token)
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/tracking/fluent.py", line 2164, in pagination_wrapper_func
    return MlflowClient().search_experiments(
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/tracking/client.py", line 1966, in search_experiments
    return self._tracking_client.search_experiments(
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/tracking/_tracking_service/client.py", line 257, in search_experiments
    return self.store.search_experiments(
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/store/tracking/rest_store.py", line 259, in search_experiments
    response_proto = self._call_endpoint(SearchExperiments, req_body)
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/store/tracking/rest_store.py", line 233, in _call_endpoint
    return call_endpoint(
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/utils/rest_utils.py", line 625, in call_endpoint
    response = http_request(**call_kwargs)
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/utils/rest_utils.py", line 255, in http_request
    kwargs["auth"] = fetch_auth(host_creds.auth)
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/tracking/request_auth/registry.py", line 57, in fetch_auth
    return auth_provider.get_auth()
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/tracking/request_auth/kubernetes_request_auth_provider.py", line 209, in get_auth
    _check_kubernetes_installed()
  File "/home/hukhan/projects/github/rhoai/mlflow/mlflow/tracking/request_auth/kubernetes_request_auth_provider.py", line 41, in _check_kubernetes_installed
    raise MlflowException(
mlflow.exceptions.MlflowException: The 'kubernetes' package is required to use the Kubernetes auth provider (MLFLOW_TRACKING_AUTH=kubernetes), but it is not installed or is incomplete. Install it with: pip install mlflow[kubernetes]
```
</details> 

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added a built-in Kubernetes request auth provider (MLFLOW_TRACKING_AUTH=kubernetes) that attaches workspace and authorization headers to tracking requests using service account credentials or kubeconfig.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?
No

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
