### PR TITLE
Support UC table-prefix locations in MLflow tracing SDK

### DIFF
--- a/mlflow/entities/__init__.py
+++ b/mlflow/entities/__init__.py
@@ -68,6 +68,7 @@ from mlflow.entities.trace_location import (
     TraceLocation,
     TraceLocationType,
     UCSchemaLocation,
+    UnityCatalog,
 )
 from mlflow.entities.trace_state import TraceState
 from mlflow.entities.view_type import ViewType
@@ -115,6 +116,7 @@ __all__ = [
     "MlflowExperimentLocation",
     "InferenceTableLocation",
     "UCSchemaLocation",
+    "UnityCatalog",
     "TraceState",
     "SpanStatusCode",
     "_DatasetSummary",

--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -136,10 +136,17 @@ class TraceInfo(_MlflowObject):
 
         trace_location = TraceLocation.from_proto(proto.trace_location)
         if trace_location.uc_schema:
-            trace_id = construct_trace_id_v4(
-                location=f"{trace_location.uc_schema.catalog_name}.{trace_location.uc_schema.schema_name}",
-                trace_id=proto.trace_id,
+            location = (
+                f"{trace_location.uc_schema.catalog_name}.{trace_location.uc_schema.schema_name}"
             )
+            trace_id = construct_trace_id_v4(location=location, trace_id=proto.trace_id)
+        elif trace_location.uc_table_prefix:
+            location = (
+                f"{trace_location.uc_table_prefix.catalog_name}."
+                f"{trace_location.uc_table_prefix.schema_name}."
+                f"{trace_location.uc_table_prefix.table_prefix}"
+            )
+            trace_id = construct_trace_id_v4(location=location, trace_id=proto.trace_id)
         else:
             trace_id = proto.trace_id
 
@@ -258,4 +265,7 @@ class TraceInfo(_MlflowObject):
         return None
 
     def _is_v4(self) -> bool:
-        return self.trace_location.uc_schema is not None
+        return (
+            self.trace_location.uc_schema is not None
+            or self.trace_location.uc_table_prefix is not None
+        )

--- a/mlflow/entities/trace_location.py
+++ b/mlflow/entities/trace_location.py
@@ -10,6 +10,7 @@ from mlflow.utils.annotations import deprecated
 
 _UC_SCHEMA_DEFAULT_SPANS_TABLE_NAME = "mlflow_experiment_trace_otel_spans"
 _UC_SCHEMA_DEFAULT_LOGS_TABLE_NAME = "mlflow_experiment_trace_otel_logs"
+_UC_TABLE_PREFIX_DEFAULT = "mlflow_traces"
 
 
 @dataclass
@@ -124,9 +125,69 @@ class UCSchemaLocation(TraceLocationBase):
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "UCSchemaLocation":
+        location = cls(catalog_name=d["catalog_name"], schema_name=d["schema_name"])
+        if otel_spans_table_name := d.get("otel_spans_table_name"):
+            location._otel_spans_table_name = otel_spans_table_name
+        if otel_logs_table_name := d.get("otel_logs_table_name"):
+            location._otel_logs_table_name = otel_logs_table_name
+        return location
+
+
+@dataclass
+class UnityCatalog(TraceLocationBase):
+    """
+    Represents a Databricks Unity Catalog location with a table prefix.
+
+    Args:
+        catalog_name: The name of the Unity Catalog catalog.
+        schema_name: The name of the Unity Catalog schema.
+        table_prefix: The prefix for tables in this location.
+    """
+
+    catalog_name: str
+    schema_name: str
+    table_prefix: str = _UC_TABLE_PREFIX_DEFAULT
+
+    # These table names are set by the backend.
+    _otel_spans_table_name: str | None = _UC_SCHEMA_DEFAULT_SPANS_TABLE_NAME
+    _otel_logs_table_name: str | None = _UC_SCHEMA_DEFAULT_LOGS_TABLE_NAME
+
+    @property
+    def schema_location(self) -> str:
+        return f"{self.catalog_name}.{self.schema_name}"
+
+    @property
+    def full_table_prefix(self) -> str:
+        return f"{self.catalog_name}.{self.schema_name}.{self.table_prefix}"
+
+    @property
+    def full_otel_spans_table_name(self) -> str | None:
+        if self._otel_spans_table_name:
+            return f"{self.catalog_name}.{self.schema_name}.{self._otel_spans_table_name}"
+
+    @property
+    def full_otel_logs_table_name(self) -> str | None:
+        if self._otel_logs_table_name:
+            return f"{self.catalog_name}.{self.schema_name}.{self._otel_logs_table_name}"
+
+    def to_dict(self) -> dict[str, Any]:
+        d = {
+            "catalog_name": self.catalog_name,
+            "schema_name": self.schema_name,
+            "table_prefix": self.table_prefix,
+        }
+        if self._otel_spans_table_name:
+            d["otel_spans_table_name"] = self._otel_spans_table_name
+        if self._otel_logs_table_name:
+            d["otel_logs_table_name"] = self._otel_logs_table_name
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "UnityCatalog":
         location = cls(
             catalog_name=d["catalog_name"],
             schema_name=d["schema_name"],
+            table_prefix=d.get("table_prefix", _UC_TABLE_PREFIX_DEFAULT),
         )
         if otel_spans_table_name := d.get("otel_spans_table_name"):
             location._otel_spans_table_name = otel_spans_table_name
@@ -140,6 +201,7 @@ class TraceLocationType(str, Enum):
     MLFLOW_EXPERIMENT = "MLFLOW_EXPERIMENT"
     INFERENCE_TABLE = "INFERENCE_TABLE"
     UC_SCHEMA = "UC_SCHEMA"
+    UC_TABLE_PREFIX = "UC_TABLE_PREFIX"
 
     def to_proto(self):
         return pb.TraceLocation.TraceLocationType.Value(self)
@@ -176,6 +238,7 @@ class TraceLocation(_MlflowObject):
     mlflow_experiment: MlflowExperimentLocation | None = None
     inference_table: InferenceTableLocation | None = None
     uc_schema: UCSchemaLocation | None = None
+    uc_table_prefix: UnityCatalog | None = None
 
     def __post_init__(self) -> None:
         if (
@@ -184,22 +247,30 @@ class TraceLocation(_MlflowObject):
                     self.mlflow_experiment is not None,
                     self.inference_table is not None,
                     self.uc_schema is not None,
+                    self.uc_table_prefix is not None,
                 ]
             )
             > 1
         ):
             raise MlflowException.invalid_parameter_value(
-                "Only one of mlflow_experiment, inference_table, or uc_schema can be provided."
+                "Only one of mlflow_experiment, inference_table, uc_schema, "
+                "or uc_table_prefix can be provided."
             )
 
         if (
             (self.mlflow_experiment and self.type != TraceLocationType.MLFLOW_EXPERIMENT)
             or (self.inference_table and self.type != TraceLocationType.INFERENCE_TABLE)
             or (self.uc_schema and self.type != TraceLocationType.UC_SCHEMA)
+            or (self.uc_table_prefix and self.type != TraceLocationType.UC_TABLE_PREFIX)
         ):
+            location = (
+                self.mlflow_experiment
+                or self.inference_table
+                or self.uc_schema
+                or self.uc_table_prefix
+            )
             raise MlflowException.invalid_parameter_value(
-                f"Trace location type {self.type} does not match the provided location "
-                f"{self.mlflow_experiment or self.inference_table or self.uc_schema}."
+                f"Trace location type {self.type} does not match the provided location {location}."
             )
 
     def to_dict(self) -> dict[str, Any]:
@@ -210,6 +281,8 @@ class TraceLocation(_MlflowObject):
             d["inference_table"] = self.inference_table.to_dict()
         elif self.uc_schema:
             d["uc_schema"] = self.uc_schema.to_dict()
+        elif self.uc_table_prefix:
+            d["uc_table_prefix"] = self.uc_table_prefix.to_dict()
         return d
 
     @classmethod
@@ -223,6 +296,9 @@ class TraceLocation(_MlflowObject):
                 InferenceTableLocation.from_dict(v) if (v := d.get("inference_table")) else None
             ),
             uc_schema=(UCSchemaLocation.from_dict(v) if (v := d.get("uc_schema")) else None),
+            uc_table_prefix=(
+                UnityCatalog.from_dict(v) if (v := d.get("uc_table_prefix")) else None
+            ),
         )
 
     def to_proto(self) -> pb.TraceLocation:
@@ -236,6 +312,8 @@ class TraceLocation(_MlflowObject):
                 type=self.type.to_proto(),
                 inference_table=self.inference_table.to_proto(),
             )
+        elif self.uc_table_prefix:
+            return pb.TraceLocation(type=self.type.to_proto())
         # uc schema is not supported in to_proto since it's databricks specific, should use
         # databricks_service_utils to convert to proto
         else:
@@ -258,5 +336,21 @@ class TraceLocation(_MlflowObject):
     def from_databricks_uc_schema(cls, catalog_name: str, schema_name: str) -> "TraceLocation":
         return cls(
             type=TraceLocationType.UC_SCHEMA,
-            uc_schema=UCSchemaLocation(catalog_name=catalog_name, schema_name=schema_name),
+            uc_schema=UCSchemaLocation(
+                catalog_name=catalog_name,
+                schema_name=schema_name,
+            ),
+        )
+
+    @classmethod
+    def from_databricks_uc_table_prefix(
+        cls, catalog_name: str, schema_name: str, table_prefix: str
+    ) -> "TraceLocation":
+        return cls(
+            type=TraceLocationType.UC_TABLE_PREFIX,
+            uc_table_prefix=UnityCatalog(
+                catalog_name=catalog_name,
+                schema_name=schema_name,
+                table_prefix=table_prefix,
+            ),
         )

--- a/mlflow/protos/databricks_tracing.proto
+++ b/mlflow/protos/databricks_tracing.proto
@@ -177,6 +177,60 @@ service DatabricksTrackingService {
     };
   }
 
+  // Resolve a trace storage location by location ID.
+  rpc getLocation(GetLocation) returns (GetLocation.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "GET"
+          path: "/mlflow/tracing/locations/{location_id}"
+          since: {
+            major: 5
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC_UNDOCUMENTED
+      rpc_doc_title: "Get Location"
+    };
+  }
+
+  // Create a trace storage location. This endpoint has create-or-get semantics.
+  rpc createLocation(CreateLocation) returns (CreateLocation.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "POST"
+          path: "/mlflow/tracing/locations"
+          since: {
+            major: 5
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC_UNDOCUMENTED
+      rpc_doc_title: "Create Location"
+    };
+  }
+
+  // Link an experiment to a trace location.
+  rpc linkTraceLocation(LinkTraceLocation) returns (LinkTraceLocation.Response) {
+    option (rpc) = {
+      endpoints: [
+        {
+          method: "POST"
+          path: "/mlflow/experiments/{experiment_id}/trace-location:link"
+          since: {
+            major: 5
+            minor: 0
+          }
+        }
+      ]
+      visibility: PUBLIC_UNDOCUMENTED
+      rpc_doc_title: "Link Trace Location"
+    };
+  }
+
   // =============================================================================
   // Assessment RPCs
   // =============================================================================
@@ -305,6 +359,20 @@ message UCSchemaLocation {
   optional string otel_logs_table_name = 4;
 }
 
+message UcTablePrefixLocation {
+  optional string catalog_name = 1;
+  optional string schema_name = 2;
+  optional string table_prefix = 3;
+  // spans table name, only for output
+  optional string spans_table_name = 4;
+  // logs table name, only for output
+  optional string logs_table_name = 5;
+  // metrics table name, only for output
+  optional string metrics_table_name = 6;
+  // The location ID (telemetry profile UUID), only for output
+  optional string location_id = 7;
+}
+
 message MlflowExperimentLocation {
   // MLflow experiment ID which is the ACL container holding the trace.
   optional string experiment_id = 1;
@@ -322,6 +390,7 @@ message TraceLocation {
     MLFLOW_EXPERIMENT = 1;
     INFERENCE_TABLE = 2;
     UC_SCHEMA = 3;
+    UC_TABLE_PREFIX = 4;
   }
   optional TraceLocationType type = 1;
 
@@ -329,6 +398,7 @@ message TraceLocation {
     MlflowExperimentLocation mlflow_experiment = 2;
     InferenceTableLocation inference_table = 3;
     UCSchemaLocation uc_schema = 4;
+    UcTablePrefixLocation uc_table_prefix = 5;
   }
 }
 
@@ -561,6 +631,52 @@ message UnLinkExperimentToUCTraceLocation {
   // Location to unlink.
   oneof location {
     UCSchemaLocation uc_schema = 2;
+  }
+
+  message Response {}
+}
+
+message GetLocation {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // Trace location identifier.
+  optional string location_id = 1 [(validate_required) = true];
+
+  message Response {
+    // Resolved UC table-prefix location.
+    optional UcTablePrefixLocation uc_table_prefix = 1;
+  }
+}
+
+message CreateLocation {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // Location to create/get.
+  oneof location {
+    UCSchemaLocation uc_schema = 1;
+    UcTablePrefixLocation uc_table_prefix = 2;
+  }
+
+  // SQL warehouse ID for location creation and lookup.
+  optional string sql_warehouse_id = 3;
+
+  message Response {
+    // Resolved location.
+    oneof location {
+      UCSchemaLocation uc_schema = 1;
+      UcTablePrefixLocation uc_table_prefix = 2;
+    }
+  }
+}
+
+message LinkTraceLocation {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  optional string experiment_id = 1 [(validate_required) = true];
+
+  oneof location {
+    UCSchemaLocation uc_schema = 2;
+    UcTablePrefixLocation uc_table_prefix = 3;
   }
 
   message Response {}

--- a/mlflow/protos/databricks_tracing_pb2.py
+++ b/mlflow/protos/databricks_tracing_pb2.py
@@ -25,7 +25,7 @@ if Version(google.protobuf.__version__).major >= 5:
   from .scalapb import scalapb_pb2 as scalapb_dot_scalapb__pb2
 
 
-  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18\x64\x61tabricks_tracing.proto\x12\x11mlflow.databricks\x1a\x11\x61ssessments.proto\x1a\x10\x64\x61tabricks.proto\x1a\x1egoogle/protobuf/duration.proto\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a(opentelemetry/proto/trace/v1/trace.proto\x1a\x15scalapb/scalapb.proto\"z\n\x10UCSchemaLocation\x12\x14\n\x0c\x63\x61talog_name\x18\x01 \x01(\t\x12\x13\n\x0bschema_name\x18\x02 \x01(\t\x12\x1d\n\x15otel_spans_table_name\x18\x03 \x01(\t\x12\x1c\n\x14otel_logs_table_name\x18\x04 \x01(\t\"1\n\x18MlflowExperimentLocation\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\"1\n\x16InferenceTableLocation\x12\x17\n\x0f\x66ull_table_name\x18\x01 \x01(\t\"\x9e\x03\n\rTraceLocation\x12@\n\x04type\x18\x01 \x01(\x0e\x32\x32.mlflow.databricks.TraceLocation.TraceLocationType\x12H\n\x11mlflow_experiment\x18\x02 \x01(\x0b\x32+.mlflow.databricks.MlflowExperimentLocationH\x00\x12\x44\n\x0finference_table\x18\x03 \x01(\x0b\x32).mlflow.databricks.InferenceTableLocationH\x00\x12\x38\n\tuc_schema\x18\x04 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\"s\n\x11TraceLocationType\x12#\n\x1fTRACE_LOCATION_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11MLFLOW_EXPERIMENT\x10\x01\x12\x13\n\x0fINFERENCE_TABLE\x10\x02\x12\r\n\tUC_SCHEMA\x10\x03\x42\x0c\n\nidentifier\"\x9b\x05\n\tTraceInfo\x12\x10\n\x08trace_id\x18\x01 \x01(\t\x12\x19\n\x11\x63lient_request_id\x18\x02 \x01(\t\x12\x38\n\x0etrace_location\x18\x03 \x01(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x17\n\x0frequest_preview\x18\x04 \x01(\t\x12\x18\n\x10response_preview\x18\x05 \x01(\t\x12\x30\n\x0crequest_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x35\n\x12\x65xecution_duration\x18\x07 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x31\n\x05state\x18\x08 \x01(\x0e\x32\".mlflow.databricks.TraceInfo.State\x12G\n\x0etrace_metadata\x18\t \x03(\x0b\x32/.mlflow.databricks.TraceInfo.TraceMetadataEntry\x12\x32\n\x0b\x61ssessments\x18\n \x03(\x0b\x32\x1d.mlflow.databricks.Assessment\x12\x34\n\x04tags\x18\x0b \x03(\x0b\x32&.mlflow.databricks.TraceInfo.TagsEntry\x1a\x34\n\x12TraceMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a+\n\tTagsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"B\n\x05State\x12\x15\n\x11STATE_UNSPECIFIED\x10\x00\x12\x06\n\x02OK\x10\x01\x12\t\n\x05\x45RROR\x10\x02\x12\x0f\n\x0bIN_PROGRESS\x10\x03\"\xcf\x01\n\x0f\x43reateTraceInfo\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x36\n\ntrace_info\x18\x02 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfoB\x04\xf8\x86\x19\x01\x1a<\n\x08Response\x12\x30\n\ntrace_info\x18\x01 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"c\n\tTracePath\x12>\n\x0etrace_location\x18\x01 \x01(\x0b\x32 .mlflow.databricks.TraceLocationB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\"l\n\x05Trace\x12\x30\n\ntrace_info\x18\x01 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfo\x12\x31\n\x05spans\x18\x02 \x03(\x0b\x32\".opentelemetry.proto.trace.v1.Span\"\xbb\x01\n\x0e\x42\x61tchGetTraces\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a\x34\n\x08Response\x12(\n\x06traces\x18\x01 \x03(\x0b\x32\x18.mlflow.databricks.Trace:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x0cGetTraceInfo\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08location\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a\x33\n\x08Response\x12\'\n\x05trace\x18\x01 \x01(\x0b\x32\x18.mlflow.databricks.Trace:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\x0bSetTraceTag\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0blocation_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\r\n\x05value\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x0e\x44\x65leteTraceTag\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0blocation_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb2\x02\n\x0cSearchTraces\x12\x33\n\tlocations\x18\x01 \x03(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x18\n\x0bmax_results\x18\x03 \x01(\x05:\x03\x31\x30\x30\x12\x10\n\x08order_by\x18\x04 \x03(\t\x12\x18\n\x10sql_warehouse_id\x18\x05 \x01(\t\x12\x12\n\npage_token\x18\x06 \x01(\t\x1aV\n\x08Response\x12\x31\n\x0btrace_infos\x18\x01 \x03(\x0b\x32\x1c.mlflow.databricks.TraceInfo\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xf5\x01\n\x1c\x43reateTraceUCStorageLocation\x12\x38\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x1e\n\x10sql_warehouse_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x42\n\x08Response\x12\x36\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocation:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xbd\x01\n\x1fLinkExperimentToUCTraceLocation\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\tuc_schema\x18\x02 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xbf\x01\n!UnLinkExperimentToUCTraceLocation\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\tuc_schema\x18\x02 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xe0\x04\n\nAssessment\x12\x15\n\rassessment_id\x18\x01 \x01(\t\x12\x1d\n\x0f\x61ssessment_name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\x0etrace_location\x18\x04 \x01(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x0f\n\x07span_id\x18\x05 \x01(\t\x12\x34\n\x06source\x18\x06 \x01(\x0b\x32$.mlflow.assessments.AssessmentSource\x12/\n\x0b\x63reate_time\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x34\n\x10last_update_time\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\x08\x66\x65\x65\x64\x62\x61\x63k\x18\t \x01(\x0b\x32\x1c.mlflow.assessments.FeedbackH\x00\x12\x36\n\x0b\x65xpectation\x18\n \x01(\x0b\x32\x1f.mlflow.assessments.ExpectationH\x00\x12\x11\n\trationale\x18\x0b \x01(\t\x12=\n\x08metadata\x18\x0c \x03(\x0b\x32+.mlflow.databricks.Assessment.MetadataEntry\x12\x11\n\toverrides\x18\r \x01(\t\x12\x13\n\x05valid\x18\x0e \x01(\x08:\x04true\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x07\n\x05value\"\xec\x01\n\x10\x43reateAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\nassessment\x18\x02 \x01(\x0b\x32\x1d.mlflow.databricks.AssessmentB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe5\x01\n\rGetAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x1b\n\rassessment_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa3\x02\n\x10UpdateAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\nassessment\x18\x02 \x01(\x0b\x32\x1d.mlflow.databricks.AssessmentB\x04\xf8\x86\x19\x01\x12\x35\n\x0bupdate_mask\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.FieldMaskB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb5\x01\n\x10\x44\x65leteAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x1b\n\rassessment_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x92\x01\n\x13\x42\x61tchLinkTraceToRun\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x14\n\x06run_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x17\x42\x61tchUnlinkTraceFromRun\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x14\n\x06run_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]2\xb0\x18\n\x19\x44\x61tabricksTrackingService\x12\xb8\x01\n\x0f\x63reateTraceInfo\x12\".mlflow.databricks.CreateTraceInfo\x1a\x1c.mlflow.databricks.TraceInfo\"c\xf2\x86\x19_\nE\n\x04POST\x12\x37/mlflow/traces/{location_id}/{trace_info.trace_id}/info\x1a\x04\x08\x04\x10\x00\x10\x03*\x14\x43reate Trace Info v4\x12\xaa\x01\n\x0e\x62\x61tchGetTraces\x12!.mlflow.databricks.BatchGetTraces\x1a*.mlflow.databricks.BatchGetTraces.Response\"I\xf2\x86\x19\x45\n2\n\x03GET\x12%/mlflow/traces/{location_id}/batchGet\x1a\x04\x08\x04\x10\x00\x10\x03*\rGet Traces V4\x12\xa8\x01\n\x0cgetTraceInfo\x12\x1f.mlflow.databricks.GetTraceInfo\x1a(.mlflow.databricks.GetTraceInfo.Response\"M\xf2\x86\x19I\n6\n\x03GET\x12)/mlflow/traces/{location}/{trace_id}/info\x1a\x04\x08\x04\x10\x00\x10\x03*\rGet TraceInfo\x12\xaa\x01\n\x0bsetTraceTag\x12\x1e.mlflow.databricks.SetTraceTag\x1a\'.mlflow.databricks.SetTraceTag.Response\"R\xf2\x86\x19N\n;\n\x05PATCH\x12,/mlflow/traces/{location_id}/{trace_id}/tags\x1a\x04\x08\x04\x10\x00\x10\x03*\rSet Trace Tag\x12\xbd\x01\n\x0e\x64\x65leteTraceTag\x12!.mlflow.databricks.DeleteTraceTag\x1a*.mlflow.databricks.DeleteTraceTag.Response\"\\\xf2\x86\x19X\nB\n\x06\x44\x45LETE\x12\x32/mlflow/traces/{location_id}/{trace_id}/tags/{key}\x1a\x04\x08\x04\x10\x00\x10\x03*\x10\x44\x65lete Trace Tag\x12\x95\x01\n\x0csearchTraces\x12\x1f.mlflow.databricks.SearchTraces\x1a(.mlflow.databricks.SearchTraces.Response\":\xf2\x86\x19\x36\n#\n\x04POST\x12\x15/mlflow/traces/search\x1a\x04\x08\x04\x10\x00\x10\x03*\rSearch Traces\x12\xda\x01\n\x1c\x63reateTraceUCStorageLocation\x12/.mlflow.databricks.CreateTraceUCStorageLocation\x1a\x38.mlflow.databricks.CreateTraceUCStorageLocation.Response\"O\xf2\x86\x19K\n%\n\x04POST\x12\x17/mlflow/traces/location\x1a\x04\x08\x04\x10\x00\x10\x03* Create Trace UC Storage Location\x12\xfc\x01\n\x1flinkExperimentToUCTraceLocation\x12\x32.mlflow.databricks.LinkExperimentToUCTraceLocation\x1a;.mlflow.databricks.LinkExperimentToUCTraceLocation.Response\"h\xf2\x86\x19\x64\n:\n\x04POST\x12,/mlflow/traces/{experiment_id}/link-location\x1a\x04\x08\x04\x10\x00\x10\x03*$Link Experiment to UC Trace Location\x12\x86\x02\n!unlinkExperimentToUCTraceLocation\x12\x34.mlflow.databricks.UnLinkExperimentToUCTraceLocation\x1a=.mlflow.databricks.UnLinkExperimentToUCTraceLocation.Response\"l\xf2\x86\x19h\n<\n\x04POST\x12./mlflow/traces/{experiment_id}/unlink-location\x1a\x04\x08\x04\x10\x00\x10\x03*&Unlink Experiment to UC Trace Location\x12\xce\x01\n\x10\x63reateAssessment\x12#.mlflow.databricks.CreateAssessment\x1a,.mlflow.databricks.CreateAssessment.Response\"g\xf2\x86\x19\x63\nL\n\x04POST\x12>/mlflow/traces/{location_id}/{assessment.trace_id}/assessments\x1a\x04\x08\x04\x10\x00\x10\x03*\x11\x43reate Assessment\x12\xc6\x01\n\rgetAssessment\x12 .mlflow.databricks.GetAssessment\x1a).mlflow.databricks.GetAssessment.Response\"h\xf2\x86\x19\x64\nP\n\x03GET\x12\x43/mlflow/traces/{location_id}/{trace_id}/assessments/{assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x0eGet Assessment\x12\xeb\x01\n\x10updateAssessment\x12#.mlflow.databricks.UpdateAssessment\x1a,.mlflow.databricks.UpdateAssessment.Response\"\x83\x01\xf2\x86\x19\x7f\nh\n\x05PATCH\x12Y/mlflow/traces/{location_id}/{assessment.trace_id}/assessments/{assessment.assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x11Update Assessment\x12\xd5\x01\n\x10\x64\x65leteAssessment\x12#.mlflow.databricks.DeleteAssessment\x1a,.mlflow.databricks.DeleteAssessment.Response\"n\xf2\x86\x19j\nS\n\x06\x44\x45LETE\x12\x43/mlflow/traces/{location_id}/{trace_id}/assessments/{assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x11\x44\x65lete Assessment\x12\xce\x01\n\x13\x62\x61tchLinkTraceToRun\x12&.mlflow.databricks.BatchLinkTraceToRun\x1a/.mlflow.databricks.BatchLinkTraceToRun.Response\"^\xf2\x86\x19Z\nB\n\x04POST\x12\x34/mlflow/traces/{location_id}/link-to-run/batchCreate\x1a\x04\x08\x04\x10\x00\x10\x03*\x12Link Traces to Run\x12\xe4\x01\n\x17\x62\x61tchUnlinkTraceFromRun\x12*.mlflow.databricks.BatchUnlinkTraceFromRun\x1a\x33.mlflow.databricks.BatchUnlinkTraceFromRun.Response\"h\xf2\x86\x19\x64\nH\n\x06\x44\x45LETE\x12\x38/mlflow/traces/{location_id}/unlink-from-run/batchDelete\x1a\x04\x08\x04\x10\x00\x10\x03*\x16Unlink Traces from RunB\x03\x90\x01\x01')
+  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18\x64\x61tabricks_tracing.proto\x12\x11mlflow.databricks\x1a\x11\x61ssessments.proto\x1a\x10\x64\x61tabricks.proto\x1a\x1egoogle/protobuf/duration.proto\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a(opentelemetry/proto/trace/v1/trace.proto\x1a\x15scalapb/scalapb.proto\"z\n\x10UCSchemaLocation\x12\x14\n\x0c\x63\x61talog_name\x18\x01 \x01(\t\x12\x13\n\x0bschema_name\x18\x02 \x01(\t\x12\x1d\n\x15otel_spans_table_name\x18\x03 \x01(\t\x12\x1c\n\x14otel_logs_table_name\x18\x04 \x01(\t\"\xbc\x01\n\x15UcTablePrefixLocation\x12\x14\n\x0c\x63\x61talog_name\x18\x01 \x01(\t\x12\x13\n\x0bschema_name\x18\x02 \x01(\t\x12\x14\n\x0ctable_prefix\x18\x03 \x01(\t\x12\x18\n\x10spans_table_name\x18\x04 \x01(\t\x12\x17\n\x0flogs_table_name\x18\x05 \x01(\t\x12\x1a\n\x12metrics_table_name\x18\x06 \x01(\t\x12\x13\n\x0blocation_id\x18\x07 \x01(\t\"1\n\x18MlflowExperimentLocation\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\"1\n\x16InferenceTableLocation\x12\x17\n\x0f\x66ull_table_name\x18\x01 \x01(\t\"\xf9\x03\n\rTraceLocation\x12@\n\x04type\x18\x01 \x01(\x0e\x32\x32.mlflow.databricks.TraceLocation.TraceLocationType\x12H\n\x11mlflow_experiment\x18\x02 \x01(\x0b\x32+.mlflow.databricks.MlflowExperimentLocationH\x00\x12\x44\n\x0finference_table\x18\x03 \x01(\x0b\x32).mlflow.databricks.InferenceTableLocationH\x00\x12\x38\n\tuc_schema\x18\x04 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x43\n\x0fuc_table_prefix\x18\x05 \x01(\x0b\x32(.mlflow.databricks.UcTablePrefixLocationH\x00\"\x88\x01\n\x11TraceLocationType\x12#\n\x1fTRACE_LOCATION_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11MLFLOW_EXPERIMENT\x10\x01\x12\x13\n\x0fINFERENCE_TABLE\x10\x02\x12\r\n\tUC_SCHEMA\x10\x03\x12\x13\n\x0fUC_TABLE_PREFIX\x10\x04\x42\x0c\n\nidentifier\"\x9b\x05\n\tTraceInfo\x12\x10\n\x08trace_id\x18\x01 \x01(\t\x12\x19\n\x11\x63lient_request_id\x18\x02 \x01(\t\x12\x38\n\x0etrace_location\x18\x03 \x01(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x17\n\x0frequest_preview\x18\x04 \x01(\t\x12\x18\n\x10response_preview\x18\x05 \x01(\t\x12\x30\n\x0crequest_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x35\n\x12\x65xecution_duration\x18\x07 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x31\n\x05state\x18\x08 \x01(\x0e\x32\".mlflow.databricks.TraceInfo.State\x12G\n\x0etrace_metadata\x18\t \x03(\x0b\x32/.mlflow.databricks.TraceInfo.TraceMetadataEntry\x12\x32\n\x0b\x61ssessments\x18\n \x03(\x0b\x32\x1d.mlflow.databricks.Assessment\x12\x34\n\x04tags\x18\x0b \x03(\x0b\x32&.mlflow.databricks.TraceInfo.TagsEntry\x1a\x34\n\x12TraceMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a+\n\tTagsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"B\n\x05State\x12\x15\n\x11STATE_UNSPECIFIED\x10\x00\x12\x06\n\x02OK\x10\x01\x12\t\n\x05\x45RROR\x10\x02\x12\x0f\n\x0bIN_PROGRESS\x10\x03\"\xcf\x01\n\x0f\x43reateTraceInfo\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x36\n\ntrace_info\x18\x02 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfoB\x04\xf8\x86\x19\x01\x1a<\n\x08Response\x12\x30\n\ntrace_info\x18\x01 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"c\n\tTracePath\x12>\n\x0etrace_location\x18\x01 \x01(\x0b\x32 .mlflow.databricks.TraceLocationB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\"l\n\x05Trace\x12\x30\n\ntrace_info\x18\x01 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfo\x12\x31\n\x05spans\x18\x02 \x03(\x0b\x32\".opentelemetry.proto.trace.v1.Span\"\xbb\x01\n\x0e\x42\x61tchGetTraces\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a\x34\n\x08Response\x12(\n\x06traces\x18\x01 \x03(\x0b\x32\x18.mlflow.databricks.Trace:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x0cGetTraceInfo\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08location\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a\x33\n\x08Response\x12\'\n\x05trace\x18\x01 \x01(\x0b\x32\x18.mlflow.databricks.Trace:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\x0bSetTraceTag\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0blocation_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\r\n\x05value\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x0e\x44\x65leteTraceTag\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0blocation_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb2\x02\n\x0cSearchTraces\x12\x33\n\tlocations\x18\x01 \x03(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x18\n\x0bmax_results\x18\x03 \x01(\x05:\x03\x31\x30\x30\x12\x10\n\x08order_by\x18\x04 \x03(\t\x12\x18\n\x10sql_warehouse_id\x18\x05 \x01(\t\x12\x12\n\npage_token\x18\x06 \x01(\t\x1aV\n\x08Response\x12\x31\n\x0btrace_infos\x18\x01 \x03(\x0b\x32\x1c.mlflow.databricks.TraceInfo\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xf5\x01\n\x1c\x43reateTraceUCStorageLocation\x12\x38\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x1e\n\x10sql_warehouse_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x42\n\x08Response\x12\x36\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocation:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xbd\x01\n\x1fLinkExperimentToUCTraceLocation\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\tuc_schema\x18\x02 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xbf\x01\n!UnLinkExperimentToUCTraceLocation\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\tuc_schema\x18\x02 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xa4\x01\n\x0bGetLocation\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1aM\n\x08Response\x12\x41\n\x0fuc_table_prefix\x18\x01 \x01(\x0b\x32(.mlflow.databricks.UcTablePrefixLocation:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xfa\x02\n\x0e\x43reateLocation\x12\x38\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x43\n\x0fuc_table_prefix\x18\x02 \x01(\x0b\x32(.mlflow.databricks.UcTablePrefixLocationH\x00\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a\x95\x01\n\x08Response\x12\x38\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x43\n\x0fuc_table_prefix\x18\x02 \x01(\x0b\x32(.mlflow.databricks.UcTablePrefixLocationH\x00\x42\n\n\x08location:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xf4\x01\n\x11LinkTraceLocation\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\tuc_schema\x18\x02 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x43\n\x0fuc_table_prefix\x18\x03 \x01(\x0b\x32(.mlflow.databricks.UcTablePrefixLocationH\x00\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xe0\x04\n\nAssessment\x12\x15\n\rassessment_id\x18\x01 \x01(\t\x12\x1d\n\x0f\x61ssessment_name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\x0etrace_location\x18\x04 \x01(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x0f\n\x07span_id\x18\x05 \x01(\t\x12\x34\n\x06source\x18\x06 \x01(\x0b\x32$.mlflow.assessments.AssessmentSource\x12/\n\x0b\x63reate_time\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x34\n\x10last_update_time\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\x08\x66\x65\x65\x64\x62\x61\x63k\x18\t \x01(\x0b\x32\x1c.mlflow.assessments.FeedbackH\x00\x12\x36\n\x0b\x65xpectation\x18\n \x01(\x0b\x32\x1f.mlflow.assessments.ExpectationH\x00\x12\x11\n\trationale\x18\x0b \x01(\t\x12=\n\x08metadata\x18\x0c \x03(\x0b\x32+.mlflow.databricks.Assessment.MetadataEntry\x12\x11\n\toverrides\x18\r \x01(\t\x12\x13\n\x05valid\x18\x0e \x01(\x08:\x04true\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x07\n\x05value\"\xec\x01\n\x10\x43reateAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\nassessment\x18\x02 \x01(\x0b\x32\x1d.mlflow.databricks.AssessmentB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe5\x01\n\rGetAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x1b\n\rassessment_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa3\x02\n\x10UpdateAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\nassessment\x18\x02 \x01(\x0b\x32\x1d.mlflow.databricks.AssessmentB\x04\xf8\x86\x19\x01\x12\x35\n\x0bupdate_mask\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.FieldMaskB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb5\x01\n\x10\x44\x65leteAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x1b\n\rassessment_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x92\x01\n\x13\x42\x61tchLinkTraceToRun\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x14\n\x06run_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x17\x42\x61tchUnlinkTraceFromRun\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x14\n\x06run_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]2\xc8\x1c\n\x19\x44\x61tabricksTrackingService\x12\xb8\x01\n\x0f\x63reateTraceInfo\x12\".mlflow.databricks.CreateTraceInfo\x1a\x1c.mlflow.databricks.TraceInfo\"c\xf2\x86\x19_\nE\n\x04POST\x12\x37/mlflow/traces/{location_id}/{trace_info.trace_id}/info\x1a\x04\x08\x04\x10\x00\x10\x03*\x14\x43reate Trace Info v4\x12\xaa\x01\n\x0e\x62\x61tchGetTraces\x12!.mlflow.databricks.BatchGetTraces\x1a*.mlflow.databricks.BatchGetTraces.Response\"I\xf2\x86\x19\x45\n2\n\x03GET\x12%/mlflow/traces/{location_id}/batchGet\x1a\x04\x08\x04\x10\x00\x10\x03*\rGet Traces V4\x12\xa8\x01\n\x0cgetTraceInfo\x12\x1f.mlflow.databricks.GetTraceInfo\x1a(.mlflow.databricks.GetTraceInfo.Response\"M\xf2\x86\x19I\n6\n\x03GET\x12)/mlflow/traces/{location}/{trace_id}/info\x1a\x04\x08\x04\x10\x00\x10\x03*\rGet TraceInfo\x12\xaa\x01\n\x0bsetTraceTag\x12\x1e.mlflow.databricks.SetTraceTag\x1a\'.mlflow.databricks.SetTraceTag.Response\"R\xf2\x86\x19N\n;\n\x05PATCH\x12,/mlflow/traces/{location_id}/{trace_id}/tags\x1a\x04\x08\x04\x10\x00\x10\x03*\rSet Trace Tag\x12\xbd\x01\n\x0e\x64\x65leteTraceTag\x12!.mlflow.databricks.DeleteTraceTag\x1a*.mlflow.databricks.DeleteTraceTag.Response\"\\\xf2\x86\x19X\nB\n\x06\x44\x45LETE\x12\x32/mlflow/traces/{location_id}/{trace_id}/tags/{key}\x1a\x04\x08\x04\x10\x00\x10\x03*\x10\x44\x65lete Trace Tag\x12\x95\x01\n\x0csearchTraces\x12\x1f.mlflow.databricks.SearchTraces\x1a(.mlflow.databricks.SearchTraces.Response\":\xf2\x86\x19\x36\n#\n\x04POST\x12\x15/mlflow/traces/search\x1a\x04\x08\x04\x10\x00\x10\x03*\rSearch Traces\x12\xda\x01\n\x1c\x63reateTraceUCStorageLocation\x12/.mlflow.databricks.CreateTraceUCStorageLocation\x1a\x38.mlflow.databricks.CreateTraceUCStorageLocation.Response\"O\xf2\x86\x19K\n%\n\x04POST\x12\x17/mlflow/traces/location\x1a\x04\x08\x04\x10\x00\x10\x03* Create Trace UC Storage Location\x12\xfc\x01\n\x1flinkExperimentToUCTraceLocation\x12\x32.mlflow.databricks.LinkExperimentToUCTraceLocation\x1a;.mlflow.databricks.LinkExperimentToUCTraceLocation.Response\"h\xf2\x86\x19\x64\n:\n\x04POST\x12,/mlflow/traces/{experiment_id}/link-location\x1a\x04\x08\x04\x10\x00\x10\x03*$Link Experiment to UC Trace Location\x12\x86\x02\n!unlinkExperimentToUCTraceLocation\x12\x34.mlflow.databricks.UnLinkExperimentToUCTraceLocation\x1a=.mlflow.databricks.UnLinkExperimentToUCTraceLocation.Response\"l\xf2\x86\x19h\n<\n\x04POST\x12./mlflow/traces/{experiment_id}/unlink-location\x1a\x04\x08\x04\x10\x00\x10\x03*&Unlink Experiment to UC Trace Location\x12\xa2\x01\n\x0bgetLocation\x12\x1e.mlflow.databricks.GetLocation\x1a\'.mlflow.databricks.GetLocation.Response\"J\xf2\x86\x19\x46\n4\n\x03GET\x12\'/mlflow/tracing/locations/{location_id}\x1a\x04\x08\x05\x10\x00\x10\x03*\x0cGet Location\x12\xa1\x01\n\x0e\x63reateLocation\x12!.mlflow.databricks.CreateLocation\x1a*.mlflow.databricks.CreateLocation.Response\"@\xf2\x86\x19<\n\'\n\x04POST\x12\x19/mlflow/tracing/locations\x1a\x04\x08\x05\x10\x00\x10\x03*\x0f\x43reate Location\x12\xcc\x01\n\x11linkTraceLocation\x12$.mlflow.databricks.LinkTraceLocation\x1a-.mlflow.databricks.LinkTraceLocation.Response\"b\xf2\x86\x19^\nE\n\x04POST\x12\x37/mlflow/experiments/{experiment_id}/trace-location:link\x1a\x04\x08\x05\x10\x00\x10\x03*\x13Link Trace Location\x12\xce\x01\n\x10\x63reateAssessment\x12#.mlflow.databricks.CreateAssessment\x1a,.mlflow.databricks.CreateAssessment.Response\"g\xf2\x86\x19\x63\nL\n\x04POST\x12>/mlflow/traces/{location_id}/{assessment.trace_id}/assessments\x1a\x04\x08\x04\x10\x00\x10\x03*\x11\x43reate Assessment\x12\xc6\x01\n\rgetAssessment\x12 .mlflow.databricks.GetAssessment\x1a).mlflow.databricks.GetAssessment.Response\"h\xf2\x86\x19\x64\nP\n\x03GET\x12\x43/mlflow/traces/{location_id}/{trace_id}/assessments/{assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x0eGet Assessment\x12\xeb\x01\n\x10updateAssessment\x12#.mlflow.databricks.UpdateAssessment\x1a,.mlflow.databricks.UpdateAssessment.Response\"\x83\x01\xf2\x86\x19\x7f\nh\n\x05PATCH\x12Y/mlflow/traces/{location_id}/{assessment.trace_id}/assessments/{assessment.assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x11Update Assessment\x12\xd5\x01\n\x10\x64\x65leteAssessment\x12#.mlflow.databricks.DeleteAssessment\x1a,.mlflow.databricks.DeleteAssessment.Response\"n\xf2\x86\x19j\nS\n\x06\x44\x45LETE\x12\x43/mlflow/traces/{location_id}/{trace_id}/assessments/{assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x11\x44\x65lete Assessment\x12\xce\x01\n\x13\x62\x61tchLinkTraceToRun\x12&.mlflow.databricks.BatchLinkTraceToRun\x1a/.mlflow.databricks.BatchLinkTraceToRun.Response\"^\xf2\x86\x19Z\nB\n\x04POST\x12\x34/mlflow/traces/{location_id}/link-to-run/batchCreate\x1a\x04\x08\x04\x10\x00\x10\x03*\x12Link Traces to Run\x12\xe4\x01\n\x17\x62\x61tchUnlinkTraceFromRun\x12*.mlflow.databricks.BatchUnlinkTraceFromRun\x1a\x33.mlflow.databricks.BatchUnlinkTraceFromRun.Response\"h\xf2\x86\x19\x64\nH\n\x06\x44\x45LETE\x12\x38/mlflow/traces/{location_id}/unlink-from-run/batchDelete\x1a\x04\x08\x04\x10\x00\x10\x03*\x16Unlink Traces from RunB\x03\x90\x01\x01')
 
   _globals = globals()
   _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -87,6 +87,16 @@ if Version(google.protobuf.__version__).major >= 5:
     _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION'].fields_by_name['experiment_id']._serialized_options = b'\370\206\031\001'
     _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION']._loaded_options = None
     _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION']._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
+    _globals['_GETLOCATION'].fields_by_name['location_id']._loaded_options = None
+    _globals['_GETLOCATION'].fields_by_name['location_id']._serialized_options = b'\370\206\031\001'
+    _globals['_GETLOCATION']._loaded_options = None
+    _globals['_GETLOCATION']._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
+    _globals['_CREATELOCATION']._loaded_options = None
+    _globals['_CREATELOCATION']._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
+    _globals['_LINKTRACELOCATION'].fields_by_name['experiment_id']._loaded_options = None
+    _globals['_LINKTRACELOCATION'].fields_by_name['experiment_id']._serialized_options = b'\370\206\031\001'
+    _globals['_LINKTRACELOCATION']._loaded_options = None
+    _globals['_LINKTRACELOCATION']._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
     _globals['_ASSESSMENT_METADATAENTRY']._loaded_options = None
     _globals['_ASSESSMENT_METADATAENTRY']._serialized_options = b'8\001'
     _globals['_ASSESSMENT'].fields_by_name['assessment_name']._loaded_options = None
@@ -153,6 +163,12 @@ if Version(google.protobuf.__version__).major >= 5:
     _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['linkExperimentToUCTraceLocation']._serialized_options = b'\362\206\031d\n:\n\004POST\022,/mlflow/traces/{experiment_id}/link-location\032\004\010\004\020\000\020\003*$Link Experiment to UC Trace Location'
     _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['unlinkExperimentToUCTraceLocation']._loaded_options = None
     _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['unlinkExperimentToUCTraceLocation']._serialized_options = b'\362\206\031h\n<\n\004POST\022./mlflow/traces/{experiment_id}/unlink-location\032\004\010\004\020\000\020\003*&Unlink Experiment to UC Trace Location'
+    _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['getLocation']._loaded_options = None
+    _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['getLocation']._serialized_options = b'\362\206\031F\n4\n\003GET\022\'/mlflow/tracing/locations/{location_id}\032\004\010\005\020\000\020\003*\014Get Location'
+    _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['createLocation']._loaded_options = None
+    _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['createLocation']._serialized_options = b'\362\206\031<\n\'\n\004POST\022\031/mlflow/tracing/locations\032\004\010\005\020\000\020\003*\017Create Location'
+    _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['linkTraceLocation']._loaded_options = None
+    _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['linkTraceLocation']._serialized_options = b'\362\206\031^\nE\n\004POST\0227/mlflow/experiments/{experiment_id}/trace-location:link\032\004\010\005\020\000\020\003*\023Link Trace Location'
     _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['createAssessment']._loaded_options = None
     _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['createAssessment']._serialized_options = b'\362\206\031c\nL\n\004POST\022>/mlflow/traces/{location_id}/{assessment.trace_id}/assessments\032\004\010\004\020\000\020\003*\021Create Assessment'
     _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['getAssessment']._loaded_options = None
@@ -167,92 +183,106 @@ if Version(google.protobuf.__version__).major >= 5:
     _globals['_DATABRICKSTRACKINGSERVICE'].methods_by_name['batchUnlinkTraceFromRun']._serialized_options = b'\362\206\031d\nH\n\006DELETE\0228/mlflow/traces/{location_id}/unlink-from-run/batchDelete\032\004\010\004\020\000\020\003*\026Unlink Traces from Run'
     _globals['_UCSCHEMALOCATION']._serialized_start=248
     _globals['_UCSCHEMALOCATION']._serialized_end=370
-    _globals['_MLFLOWEXPERIMENTLOCATION']._serialized_start=372
-    _globals['_MLFLOWEXPERIMENTLOCATION']._serialized_end=421
-    _globals['_INFERENCETABLELOCATION']._serialized_start=423
-    _globals['_INFERENCETABLELOCATION']._serialized_end=472
-    _globals['_TRACELOCATION']._serialized_start=475
-    _globals['_TRACELOCATION']._serialized_end=889
-    _globals['_TRACELOCATION_TRACELOCATIONTYPE']._serialized_start=760
-    _globals['_TRACELOCATION_TRACELOCATIONTYPE']._serialized_end=875
-    _globals['_TRACEINFO']._serialized_start=892
-    _globals['_TRACEINFO']._serialized_end=1559
-    _globals['_TRACEINFO_TRACEMETADATAENTRY']._serialized_start=1394
-    _globals['_TRACEINFO_TRACEMETADATAENTRY']._serialized_end=1446
-    _globals['_TRACEINFO_TAGSENTRY']._serialized_start=1448
-    _globals['_TRACEINFO_TAGSENTRY']._serialized_end=1491
-    _globals['_TRACEINFO_STATE']._serialized_start=1493
-    _globals['_TRACEINFO_STATE']._serialized_end=1559
-    _globals['_CREATETRACEINFO']._serialized_start=1562
-    _globals['_CREATETRACEINFO']._serialized_end=1769
-    _globals['_CREATETRACEINFO_RESPONSE']._serialized_start=1664
-    _globals['_CREATETRACEINFO_RESPONSE']._serialized_end=1724
-    _globals['_TRACEPATH']._serialized_start=1771
-    _globals['_TRACEPATH']._serialized_end=1870
-    _globals['_TRACE']._serialized_start=1872
-    _globals['_TRACE']._serialized_end=1980
-    _globals['_BATCHGETTRACES']._serialized_start=1983
-    _globals['_BATCHGETTRACES']._serialized_end=2170
-    _globals['_BATCHGETTRACES_RESPONSE']._serialized_start=2073
-    _globals['_BATCHGETTRACES_RESPONSE']._serialized_end=2125
-    _globals['_GETTRACEINFO']._serialized_start=2173
-    _globals['_GETTRACEINFO']._serialized_end=2359
-    _globals['_GETTRACEINFO_RESPONSE']._serialized_start=2263
-    _globals['_GETTRACEINFO_RESPONSE']._serialized_end=2314
-    _globals['_SETTRACETAG']._serialized_start=2362
-    _globals['_SETTRACETAG']._serialized_end=2517
-    _globals['_SETTRACETAG_RESPONSE']._serialized_start=1664
-    _globals['_SETTRACETAG_RESPONSE']._serialized_end=1674
-    _globals['_DELETETRACETAG']._serialized_start=2520
-    _globals['_DELETETRACETAG']._serialized_end=2689
-    _globals['_DELETETRACETAG_RESPONSE']._serialized_start=1664
-    _globals['_DELETETRACETAG_RESPONSE']._serialized_end=1674
-    _globals['_SEARCHTRACES']._serialized_start=2692
-    _globals['_SEARCHTRACES']._serialized_end=2998
-    _globals['_SEARCHTRACES_RESPONSE']._serialized_start=2867
-    _globals['_SEARCHTRACES_RESPONSE']._serialized_end=2953
-    _globals['_CREATETRACEUCSTORAGELOCATION']._serialized_start=3001
-    _globals['_CREATETRACEUCSTORAGELOCATION']._serialized_end=3246
-    _globals['_CREATETRACEUCSTORAGELOCATION_RESPONSE']._serialized_start=3123
-    _globals['_CREATETRACEUCSTORAGELOCATION_RESPONSE']._serialized_end=3189
-    _globals['_LINKEXPERIMENTTOUCTRACELOCATION']._serialized_start=3249
-    _globals['_LINKEXPERIMENTTOUCTRACELOCATION']._serialized_end=3438
-    _globals['_LINKEXPERIMENTTOUCTRACELOCATION_RESPONSE']._serialized_start=1664
-    _globals['_LINKEXPERIMENTTOUCTRACELOCATION_RESPONSE']._serialized_end=1674
-    _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION']._serialized_start=3441
-    _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION']._serialized_end=3632
-    _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION_RESPONSE']._serialized_start=1664
-    _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION_RESPONSE']._serialized_end=1674
-    _globals['_ASSESSMENT']._serialized_start=3635
-    _globals['_ASSESSMENT']._serialized_end=4243
-    _globals['_ASSESSMENT_METADATAENTRY']._serialized_start=4187
-    _globals['_ASSESSMENT_METADATAENTRY']._serialized_end=4234
-    _globals['_CREATEASSESSMENT']._serialized_start=4246
-    _globals['_CREATEASSESSMENT']._serialized_end=4482
-    _globals['_CREATEASSESSMENT_RESPONSE']._serialized_start=4376
-    _globals['_CREATEASSESSMENT_RESPONSE']._serialized_end=4437
-    _globals['_GETASSESSMENT']._serialized_start=4485
-    _globals['_GETASSESSMENT']._serialized_end=4714
-    _globals['_GETASSESSMENT_RESPONSE']._serialized_start=4376
-    _globals['_GETASSESSMENT_RESPONSE']._serialized_end=4437
-    _globals['_UPDATEASSESSMENT']._serialized_start=4717
-    _globals['_UPDATEASSESSMENT']._serialized_end=5008
-    _globals['_UPDATEASSESSMENT_RESPONSE']._serialized_start=4376
-    _globals['_UPDATEASSESSMENT_RESPONSE']._serialized_end=4437
-    _globals['_DELETEASSESSMENT']._serialized_start=5011
-    _globals['_DELETEASSESSMENT']._serialized_end=5192
-    _globals['_DELETEASSESSMENT_RESPONSE']._serialized_start=1664
-    _globals['_DELETEASSESSMENT_RESPONSE']._serialized_end=1674
-    _globals['_BATCHLINKTRACETORUN']._serialized_start=5195
-    _globals['_BATCHLINKTRACETORUN']._serialized_end=5341
-    _globals['_BATCHLINKTRACETORUN_RESPONSE']._serialized_start=1664
-    _globals['_BATCHLINKTRACETORUN_RESPONSE']._serialized_end=1674
-    _globals['_BATCHUNLINKTRACEFROMRUN']._serialized_start=5344
-    _globals['_BATCHUNLINKTRACEFROMRUN']._serialized_end=5494
-    _globals['_BATCHUNLINKTRACEFROMRUN_RESPONSE']._serialized_start=1664
-    _globals['_BATCHUNLINKTRACEFROMRUN_RESPONSE']._serialized_end=1674
-    _globals['_DATABRICKSTRACKINGSERVICE']._serialized_start=5497
-    _globals['_DATABRICKSTRACKINGSERVICE']._serialized_end=8617
+    _globals['_UCTABLEPREFIXLOCATION']._serialized_start=373
+    _globals['_UCTABLEPREFIXLOCATION']._serialized_end=561
+    _globals['_MLFLOWEXPERIMENTLOCATION']._serialized_start=563
+    _globals['_MLFLOWEXPERIMENTLOCATION']._serialized_end=612
+    _globals['_INFERENCETABLELOCATION']._serialized_start=614
+    _globals['_INFERENCETABLELOCATION']._serialized_end=663
+    _globals['_TRACELOCATION']._serialized_start=666
+    _globals['_TRACELOCATION']._serialized_end=1171
+    _globals['_TRACELOCATION_TRACELOCATIONTYPE']._serialized_start=1021
+    _globals['_TRACELOCATION_TRACELOCATIONTYPE']._serialized_end=1157
+    _globals['_TRACEINFO']._serialized_start=1174
+    _globals['_TRACEINFO']._serialized_end=1841
+    _globals['_TRACEINFO_TRACEMETADATAENTRY']._serialized_start=1676
+    _globals['_TRACEINFO_TRACEMETADATAENTRY']._serialized_end=1728
+    _globals['_TRACEINFO_TAGSENTRY']._serialized_start=1730
+    _globals['_TRACEINFO_TAGSENTRY']._serialized_end=1773
+    _globals['_TRACEINFO_STATE']._serialized_start=1775
+    _globals['_TRACEINFO_STATE']._serialized_end=1841
+    _globals['_CREATETRACEINFO']._serialized_start=1844
+    _globals['_CREATETRACEINFO']._serialized_end=2051
+    _globals['_CREATETRACEINFO_RESPONSE']._serialized_start=1946
+    _globals['_CREATETRACEINFO_RESPONSE']._serialized_end=2006
+    _globals['_TRACEPATH']._serialized_start=2053
+    _globals['_TRACEPATH']._serialized_end=2152
+    _globals['_TRACE']._serialized_start=2154
+    _globals['_TRACE']._serialized_end=2262
+    _globals['_BATCHGETTRACES']._serialized_start=2265
+    _globals['_BATCHGETTRACES']._serialized_end=2452
+    _globals['_BATCHGETTRACES_RESPONSE']._serialized_start=2355
+    _globals['_BATCHGETTRACES_RESPONSE']._serialized_end=2407
+    _globals['_GETTRACEINFO']._serialized_start=2455
+    _globals['_GETTRACEINFO']._serialized_end=2641
+    _globals['_GETTRACEINFO_RESPONSE']._serialized_start=2545
+    _globals['_GETTRACEINFO_RESPONSE']._serialized_end=2596
+    _globals['_SETTRACETAG']._serialized_start=2644
+    _globals['_SETTRACETAG']._serialized_end=2799
+    _globals['_SETTRACETAG_RESPONSE']._serialized_start=1946
+    _globals['_SETTRACETAG_RESPONSE']._serialized_end=1956
+    _globals['_DELETETRACETAG']._serialized_start=2802
+    _globals['_DELETETRACETAG']._serialized_end=2971
+    _globals['_DELETETRACETAG_RESPONSE']._serialized_start=1946
+    _globals['_DELETETRACETAG_RESPONSE']._serialized_end=1956
+    _globals['_SEARCHTRACES']._serialized_start=2974
+    _globals['_SEARCHTRACES']._serialized_end=3280
+    _globals['_SEARCHTRACES_RESPONSE']._serialized_start=3149
+    _globals['_SEARCHTRACES_RESPONSE']._serialized_end=3235
+    _globals['_CREATETRACEUCSTORAGELOCATION']._serialized_start=3283
+    _globals['_CREATETRACEUCSTORAGELOCATION']._serialized_end=3528
+    _globals['_CREATETRACEUCSTORAGELOCATION_RESPONSE']._serialized_start=3405
+    _globals['_CREATETRACEUCSTORAGELOCATION_RESPONSE']._serialized_end=3471
+    _globals['_LINKEXPERIMENTTOUCTRACELOCATION']._serialized_start=3531
+    _globals['_LINKEXPERIMENTTOUCTRACELOCATION']._serialized_end=3720
+    _globals['_LINKEXPERIMENTTOUCTRACELOCATION_RESPONSE']._serialized_start=1946
+    _globals['_LINKEXPERIMENTTOUCTRACELOCATION_RESPONSE']._serialized_end=1956
+    _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION']._serialized_start=3723
+    _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION']._serialized_end=3914
+    _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION_RESPONSE']._serialized_start=1946
+    _globals['_UNLINKEXPERIMENTTOUCTRACELOCATION_RESPONSE']._serialized_end=1956
+    _globals['_GETLOCATION']._serialized_start=3917
+    _globals['_GETLOCATION']._serialized_end=4081
+    _globals['_GETLOCATION_RESPONSE']._serialized_start=3959
+    _globals['_GETLOCATION_RESPONSE']._serialized_end=4036
+    _globals['_CREATELOCATION']._serialized_start=4084
+    _globals['_CREATELOCATION']._serialized_end=4462
+    _globals['_CREATELOCATION_RESPONSE']._serialized_start=4256
+    _globals['_CREATELOCATION_RESPONSE']._serialized_end=4405
+    _globals['_LINKTRACELOCATION']._serialized_start=4465
+    _globals['_LINKTRACELOCATION']._serialized_end=4709
+    _globals['_LINKTRACELOCATION_RESPONSE']._serialized_start=1946
+    _globals['_LINKTRACELOCATION_RESPONSE']._serialized_end=1956
+    _globals['_ASSESSMENT']._serialized_start=4712
+    _globals['_ASSESSMENT']._serialized_end=5320
+    _globals['_ASSESSMENT_METADATAENTRY']._serialized_start=5264
+    _globals['_ASSESSMENT_METADATAENTRY']._serialized_end=5311
+    _globals['_CREATEASSESSMENT']._serialized_start=5323
+    _globals['_CREATEASSESSMENT']._serialized_end=5559
+    _globals['_CREATEASSESSMENT_RESPONSE']._serialized_start=5453
+    _globals['_CREATEASSESSMENT_RESPONSE']._serialized_end=5514
+    _globals['_GETASSESSMENT']._serialized_start=5562
+    _globals['_GETASSESSMENT']._serialized_end=5791
+    _globals['_GETASSESSMENT_RESPONSE']._serialized_start=5453
+    _globals['_GETASSESSMENT_RESPONSE']._serialized_end=5514
+    _globals['_UPDATEASSESSMENT']._serialized_start=5794
+    _globals['_UPDATEASSESSMENT']._serialized_end=6085
+    _globals['_UPDATEASSESSMENT_RESPONSE']._serialized_start=5453
+    _globals['_UPDATEASSESSMENT_RESPONSE']._serialized_end=5514
+    _globals['_DELETEASSESSMENT']._serialized_start=6088
+    _globals['_DELETEASSESSMENT']._serialized_end=6269
+    _globals['_DELETEASSESSMENT_RESPONSE']._serialized_start=1946
+    _globals['_DELETEASSESSMENT_RESPONSE']._serialized_end=1956
+    _globals['_BATCHLINKTRACETORUN']._serialized_start=6272
+    _globals['_BATCHLINKTRACETORUN']._serialized_end=6418
+    _globals['_BATCHLINKTRACETORUN_RESPONSE']._serialized_start=1946
+    _globals['_BATCHLINKTRACETORUN_RESPONSE']._serialized_end=1956
+    _globals['_BATCHUNLINKTRACEFROMRUN']._serialized_start=6421
+    _globals['_BATCHUNLINKTRACEFROMRUN']._serialized_end=6571
+    _globals['_BATCHUNLINKTRACEFROMRUN_RESPONSE']._serialized_start=1946
+    _globals['_BATCHUNLINKTRACEFROMRUN_RESPONSE']._serialized_end=1956
+    _globals['_DATABRICKSTRACKINGSERVICE']._serialized_start=6574
+    _globals['_DATABRICKSTRACKINGSERVICE']._serialized_end=10230
   _builder.BuildServices(DESCRIPTOR, 'databricks_tracing_pb2', _globals)
   # @@protoc_insertion_point(module_scope)
 
@@ -282,11 +312,12 @@ else:
   from .scalapb import scalapb_pb2 as scalapb_dot_scalapb__pb2
 
 
-  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18\x64\x61tabricks_tracing.proto\x12\x11mlflow.databricks\x1a\x11\x61ssessments.proto\x1a\x10\x64\x61tabricks.proto\x1a\x1egoogle/protobuf/duration.proto\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a(opentelemetry/proto/trace/v1/trace.proto\x1a\x15scalapb/scalapb.proto\"z\n\x10UCSchemaLocation\x12\x14\n\x0c\x63\x61talog_name\x18\x01 \x01(\t\x12\x13\n\x0bschema_name\x18\x02 \x01(\t\x12\x1d\n\x15otel_spans_table_name\x18\x03 \x01(\t\x12\x1c\n\x14otel_logs_table_name\x18\x04 \x01(\t\"1\n\x18MlflowExperimentLocation\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\"1\n\x16InferenceTableLocation\x12\x17\n\x0f\x66ull_table_name\x18\x01 \x01(\t\"\x9e\x03\n\rTraceLocation\x12@\n\x04type\x18\x01 \x01(\x0e\x32\x32.mlflow.databricks.TraceLocation.TraceLocationType\x12H\n\x11mlflow_experiment\x18\x02 \x01(\x0b\x32+.mlflow.databricks.MlflowExperimentLocationH\x00\x12\x44\n\x0finference_table\x18\x03 \x01(\x0b\x32).mlflow.databricks.InferenceTableLocationH\x00\x12\x38\n\tuc_schema\x18\x04 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\"s\n\x11TraceLocationType\x12#\n\x1fTRACE_LOCATION_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11MLFLOW_EXPERIMENT\x10\x01\x12\x13\n\x0fINFERENCE_TABLE\x10\x02\x12\r\n\tUC_SCHEMA\x10\x03\x42\x0c\n\nidentifier\"\x9b\x05\n\tTraceInfo\x12\x10\n\x08trace_id\x18\x01 \x01(\t\x12\x19\n\x11\x63lient_request_id\x18\x02 \x01(\t\x12\x38\n\x0etrace_location\x18\x03 \x01(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x17\n\x0frequest_preview\x18\x04 \x01(\t\x12\x18\n\x10response_preview\x18\x05 \x01(\t\x12\x30\n\x0crequest_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x35\n\x12\x65xecution_duration\x18\x07 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x31\n\x05state\x18\x08 \x01(\x0e\x32\".mlflow.databricks.TraceInfo.State\x12G\n\x0etrace_metadata\x18\t \x03(\x0b\x32/.mlflow.databricks.TraceInfo.TraceMetadataEntry\x12\x32\n\x0b\x61ssessments\x18\n \x03(\x0b\x32\x1d.mlflow.databricks.Assessment\x12\x34\n\x04tags\x18\x0b \x03(\x0b\x32&.mlflow.databricks.TraceInfo.TagsEntry\x1a\x34\n\x12TraceMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a+\n\tTagsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"B\n\x05State\x12\x15\n\x11STATE_UNSPECIFIED\x10\x00\x12\x06\n\x02OK\x10\x01\x12\t\n\x05\x45RROR\x10\x02\x12\x0f\n\x0bIN_PROGRESS\x10\x03\"\xcf\x01\n\x0f\x43reateTraceInfo\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x36\n\ntrace_info\x18\x02 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfoB\x04\xf8\x86\x19\x01\x1a<\n\x08Response\x12\x30\n\ntrace_info\x18\x01 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"c\n\tTracePath\x12>\n\x0etrace_location\x18\x01 \x01(\x0b\x32 .mlflow.databricks.TraceLocationB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\"l\n\x05Trace\x12\x30\n\ntrace_info\x18\x01 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfo\x12\x31\n\x05spans\x18\x02 \x03(\x0b\x32\".opentelemetry.proto.trace.v1.Span\"\xbb\x01\n\x0e\x42\x61tchGetTraces\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a\x34\n\x08Response\x12(\n\x06traces\x18\x01 \x03(\x0b\x32\x18.mlflow.databricks.Trace:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x0cGetTraceInfo\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08location\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a\x33\n\x08Response\x12\'\n\x05trace\x18\x01 \x01(\x0b\x32\x18.mlflow.databricks.Trace:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\x0bSetTraceTag\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0blocation_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\r\n\x05value\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x0e\x44\x65leteTraceTag\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0blocation_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb2\x02\n\x0cSearchTraces\x12\x33\n\tlocations\x18\x01 \x03(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x18\n\x0bmax_results\x18\x03 \x01(\x05:\x03\x31\x30\x30\x12\x10\n\x08order_by\x18\x04 \x03(\t\x12\x18\n\x10sql_warehouse_id\x18\x05 \x01(\t\x12\x12\n\npage_token\x18\x06 \x01(\t\x1aV\n\x08Response\x12\x31\n\x0btrace_infos\x18\x01 \x03(\x0b\x32\x1c.mlflow.databricks.TraceInfo\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xf5\x01\n\x1c\x43reateTraceUCStorageLocation\x12\x38\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x1e\n\x10sql_warehouse_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x42\n\x08Response\x12\x36\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocation:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xbd\x01\n\x1fLinkExperimentToUCTraceLocation\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\tuc_schema\x18\x02 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xbf\x01\n!UnLinkExperimentToUCTraceLocation\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\tuc_schema\x18\x02 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xe0\x04\n\nAssessment\x12\x15\n\rassessment_id\x18\x01 \x01(\t\x12\x1d\n\x0f\x61ssessment_name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\x0etrace_location\x18\x04 \x01(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x0f\n\x07span_id\x18\x05 \x01(\t\x12\x34\n\x06source\x18\x06 \x01(\x0b\x32$.mlflow.assessments.AssessmentSource\x12/\n\x0b\x63reate_time\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x34\n\x10last_update_time\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\x08\x66\x65\x65\x64\x62\x61\x63k\x18\t \x01(\x0b\x32\x1c.mlflow.assessments.FeedbackH\x00\x12\x36\n\x0b\x65xpectation\x18\n \x01(\x0b\x32\x1f.mlflow.assessments.ExpectationH\x00\x12\x11\n\trationale\x18\x0b \x01(\t\x12=\n\x08metadata\x18\x0c \x03(\x0b\x32+.mlflow.databricks.Assessment.MetadataEntry\x12\x11\n\toverrides\x18\r \x01(\t\x12\x13\n\x05valid\x18\x0e \x01(\x08:\x04true\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x07\n\x05value\"\xec\x01\n\x10\x43reateAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\nassessment\x18\x02 \x01(\x0b\x32\x1d.mlflow.databricks.AssessmentB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe5\x01\n\rGetAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x1b\n\rassessment_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa3\x02\n\x10UpdateAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\nassessment\x18\x02 \x01(\x0b\x32\x1d.mlflow.databricks.AssessmentB\x04\xf8\x86\x19\x01\x12\x35\n\x0bupdate_mask\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.FieldMaskB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb5\x01\n\x10\x44\x65leteAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x1b\n\rassessment_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x92\x01\n\x13\x42\x61tchLinkTraceToRun\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x14\n\x06run_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x17\x42\x61tchUnlinkTraceFromRun\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x14\n\x06run_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]2\xb0\x18\n\x19\x44\x61tabricksTrackingService\x12\xb8\x01\n\x0f\x63reateTraceInfo\x12\".mlflow.databricks.CreateTraceInfo\x1a\x1c.mlflow.databricks.TraceInfo\"c\xf2\x86\x19_\nE\n\x04POST\x12\x37/mlflow/traces/{location_id}/{trace_info.trace_id}/info\x1a\x04\x08\x04\x10\x00\x10\x03*\x14\x43reate Trace Info v4\x12\xaa\x01\n\x0e\x62\x61tchGetTraces\x12!.mlflow.databricks.BatchGetTraces\x1a*.mlflow.databricks.BatchGetTraces.Response\"I\xf2\x86\x19\x45\n2\n\x03GET\x12%/mlflow/traces/{location_id}/batchGet\x1a\x04\x08\x04\x10\x00\x10\x03*\rGet Traces V4\x12\xa8\x01\n\x0cgetTraceInfo\x12\x1f.mlflow.databricks.GetTraceInfo\x1a(.mlflow.databricks.GetTraceInfo.Response\"M\xf2\x86\x19I\n6\n\x03GET\x12)/mlflow/traces/{location}/{trace_id}/info\x1a\x04\x08\x04\x10\x00\x10\x03*\rGet TraceInfo\x12\xaa\x01\n\x0bsetTraceTag\x12\x1e.mlflow.databricks.SetTraceTag\x1a\'.mlflow.databricks.SetTraceTag.Response\"R\xf2\x86\x19N\n;\n\x05PATCH\x12,/mlflow/traces/{location_id}/{trace_id}/tags\x1a\x04\x08\x04\x10\x00\x10\x03*\rSet Trace Tag\x12\xbd\x01\n\x0e\x64\x65leteTraceTag\x12!.mlflow.databricks.DeleteTraceTag\x1a*.mlflow.databricks.DeleteTraceTag.Response\"\\\xf2\x86\x19X\nB\n\x06\x44\x45LETE\x12\x32/mlflow/traces/{location_id}/{trace_id}/tags/{key}\x1a\x04\x08\x04\x10\x00\x10\x03*\x10\x44\x65lete Trace Tag\x12\x95\x01\n\x0csearchTraces\x12\x1f.mlflow.databricks.SearchTraces\x1a(.mlflow.databricks.SearchTraces.Response\":\xf2\x86\x19\x36\n#\n\x04POST\x12\x15/mlflow/traces/search\x1a\x04\x08\x04\x10\x00\x10\x03*\rSearch Traces\x12\xda\x01\n\x1c\x63reateTraceUCStorageLocation\x12/.mlflow.databricks.CreateTraceUCStorageLocation\x1a\x38.mlflow.databricks.CreateTraceUCStorageLocation.Response\"O\xf2\x86\x19K\n%\n\x04POST\x12\x17/mlflow/traces/location\x1a\x04\x08\x04\x10\x00\x10\x03* Create Trace UC Storage Location\x12\xfc\x01\n\x1flinkExperimentToUCTraceLocation\x12\x32.mlflow.databricks.LinkExperimentToUCTraceLocation\x1a;.mlflow.databricks.LinkExperimentToUCTraceLocation.Response\"h\xf2\x86\x19\x64\n:\n\x04POST\x12,/mlflow/traces/{experiment_id}/link-location\x1a\x04\x08\x04\x10\x00\x10\x03*$Link Experiment to UC Trace Location\x12\x86\x02\n!unlinkExperimentToUCTraceLocation\x12\x34.mlflow.databricks.UnLinkExperimentToUCTraceLocation\x1a=.mlflow.databricks.UnLinkExperimentToUCTraceLocation.Response\"l\xf2\x86\x19h\n<\n\x04POST\x12./mlflow/traces/{experiment_id}/unlink-location\x1a\x04\x08\x04\x10\x00\x10\x03*&Unlink Experiment to UC Trace Location\x12\xce\x01\n\x10\x63reateAssessment\x12#.mlflow.databricks.CreateAssessment\x1a,.mlflow.databricks.CreateAssessment.Response\"g\xf2\x86\x19\x63\nL\n\x04POST\x12>/mlflow/traces/{location_id}/{assessment.trace_id}/assessments\x1a\x04\x08\x04\x10\x00\x10\x03*\x11\x43reate Assessment\x12\xc6\x01\n\rgetAssessment\x12 .mlflow.databricks.GetAssessment\x1a).mlflow.databricks.GetAssessment.Response\"h\xf2\x86\x19\x64\nP\n\x03GET\x12\x43/mlflow/traces/{location_id}/{trace_id}/assessments/{assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x0eGet Assessment\x12\xeb\x01\n\x10updateAssessment\x12#.mlflow.databricks.UpdateAssessment\x1a,.mlflow.databricks.UpdateAssessment.Response\"\x83\x01\xf2\x86\x19\x7f\nh\n\x05PATCH\x12Y/mlflow/traces/{location_id}/{assessment.trace_id}/assessments/{assessment.assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x11Update Assessment\x12\xd5\x01\n\x10\x64\x65leteAssessment\x12#.mlflow.databricks.DeleteAssessment\x1a,.mlflow.databricks.DeleteAssessment.Response\"n\xf2\x86\x19j\nS\n\x06\x44\x45LETE\x12\x43/mlflow/traces/{location_id}/{trace_id}/assessments/{assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x11\x44\x65lete Assessment\x12\xce\x01\n\x13\x62\x61tchLinkTraceToRun\x12&.mlflow.databricks.BatchLinkTraceToRun\x1a/.mlflow.databricks.BatchLinkTraceToRun.Response\"^\xf2\x86\x19Z\nB\n\x04POST\x12\x34/mlflow/traces/{location_id}/link-to-run/batchCreate\x1a\x04\x08\x04\x10\x00\x10\x03*\x12Link Traces to Run\x12\xe4\x01\n\x17\x62\x61tchUnlinkTraceFromRun\x12*.mlflow.databricks.BatchUnlinkTraceFromRun\x1a\x33.mlflow.databricks.BatchUnlinkTraceFromRun.Response\"h\xf2\x86\x19\x64\nH\n\x06\x44\x45LETE\x12\x38/mlflow/traces/{location_id}/unlink-from-run/batchDelete\x1a\x04\x08\x04\x10\x00\x10\x03*\x16Unlink Traces from RunB\x03\x90\x01\x01')
+  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18\x64\x61tabricks_tracing.proto\x12\x11mlflow.databricks\x1a\x11\x61ssessments.proto\x1a\x10\x64\x61tabricks.proto\x1a\x1egoogle/protobuf/duration.proto\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a(opentelemetry/proto/trace/v1/trace.proto\x1a\x15scalapb/scalapb.proto\"z\n\x10UCSchemaLocation\x12\x14\n\x0c\x63\x61talog_name\x18\x01 \x01(\t\x12\x13\n\x0bschema_name\x18\x02 \x01(\t\x12\x1d\n\x15otel_spans_table_name\x18\x03 \x01(\t\x12\x1c\n\x14otel_logs_table_name\x18\x04 \x01(\t\"\xbc\x01\n\x15UcTablePrefixLocation\x12\x14\n\x0c\x63\x61talog_name\x18\x01 \x01(\t\x12\x13\n\x0bschema_name\x18\x02 \x01(\t\x12\x14\n\x0ctable_prefix\x18\x03 \x01(\t\x12\x18\n\x10spans_table_name\x18\x04 \x01(\t\x12\x17\n\x0flogs_table_name\x18\x05 \x01(\t\x12\x1a\n\x12metrics_table_name\x18\x06 \x01(\t\x12\x13\n\x0blocation_id\x18\x07 \x01(\t\"1\n\x18MlflowExperimentLocation\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\"1\n\x16InferenceTableLocation\x12\x17\n\x0f\x66ull_table_name\x18\x01 \x01(\t\"\xf9\x03\n\rTraceLocation\x12@\n\x04type\x18\x01 \x01(\x0e\x32\x32.mlflow.databricks.TraceLocation.TraceLocationType\x12H\n\x11mlflow_experiment\x18\x02 \x01(\x0b\x32+.mlflow.databricks.MlflowExperimentLocationH\x00\x12\x44\n\x0finference_table\x18\x03 \x01(\x0b\x32).mlflow.databricks.InferenceTableLocationH\x00\x12\x38\n\tuc_schema\x18\x04 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x43\n\x0fuc_table_prefix\x18\x05 \x01(\x0b\x32(.mlflow.databricks.UcTablePrefixLocationH\x00\"\x88\x01\n\x11TraceLocationType\x12#\n\x1fTRACE_LOCATION_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11MLFLOW_EXPERIMENT\x10\x01\x12\x13\n\x0fINFERENCE_TABLE\x10\x02\x12\r\n\tUC_SCHEMA\x10\x03\x12\x13\n\x0fUC_TABLE_PREFIX\x10\x04\x42\x0c\n\nidentifier\"\x9b\x05\n\tTraceInfo\x12\x10\n\x08trace_id\x18\x01 \x01(\t\x12\x19\n\x11\x63lient_request_id\x18\x02 \x01(\t\x12\x38\n\x0etrace_location\x18\x03 \x01(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x17\n\x0frequest_preview\x18\x04 \x01(\t\x12\x18\n\x10response_preview\x18\x05 \x01(\t\x12\x30\n\x0crequest_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x35\n\x12\x65xecution_duration\x18\x07 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x31\n\x05state\x18\x08 \x01(\x0e\x32\".mlflow.databricks.TraceInfo.State\x12G\n\x0etrace_metadata\x18\t \x03(\x0b\x32/.mlflow.databricks.TraceInfo.TraceMetadataEntry\x12\x32\n\x0b\x61ssessments\x18\n \x03(\x0b\x32\x1d.mlflow.databricks.Assessment\x12\x34\n\x04tags\x18\x0b \x03(\x0b\x32&.mlflow.databricks.TraceInfo.TagsEntry\x1a\x34\n\x12TraceMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a+\n\tTagsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"B\n\x05State\x12\x15\n\x11STATE_UNSPECIFIED\x10\x00\x12\x06\n\x02OK\x10\x01\x12\t\n\x05\x45RROR\x10\x02\x12\x0f\n\x0bIN_PROGRESS\x10\x03\"\xcf\x01\n\x0f\x43reateTraceInfo\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x36\n\ntrace_info\x18\x02 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfoB\x04\xf8\x86\x19\x01\x1a<\n\x08Response\x12\x30\n\ntrace_info\x18\x01 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"c\n\tTracePath\x12>\n\x0etrace_location\x18\x01 \x01(\x0b\x32 .mlflow.databricks.TraceLocationB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\"l\n\x05Trace\x12\x30\n\ntrace_info\x18\x01 \x01(\x0b\x32\x1c.mlflow.databricks.TraceInfo\x12\x31\n\x05spans\x18\x02 \x03(\x0b\x32\".opentelemetry.proto.trace.v1.Span\"\xbb\x01\n\x0e\x42\x61tchGetTraces\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a\x34\n\x08Response\x12(\n\x06traces\x18\x01 \x03(\x0b\x32\x18.mlflow.databricks.Trace:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x0cGetTraceInfo\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08location\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a\x33\n\x08Response\x12\'\n\x05trace\x18\x01 \x01(\x0b\x32\x18.mlflow.databricks.Trace:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\x0bSetTraceTag\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0blocation_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\r\n\x05value\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x0e\x44\x65leteTraceTag\x12\x16\n\x08trace_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0blocation_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb2\x02\n\x0cSearchTraces\x12\x33\n\tlocations\x18\x01 \x03(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x18\n\x0bmax_results\x18\x03 \x01(\x05:\x03\x31\x30\x30\x12\x10\n\x08order_by\x18\x04 \x03(\t\x12\x18\n\x10sql_warehouse_id\x18\x05 \x01(\t\x12\x12\n\npage_token\x18\x06 \x01(\t\x1aV\n\x08Response\x12\x31\n\x0btrace_infos\x18\x01 \x03(\x0b\x32\x1c.mlflow.databricks.TraceInfo\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xf5\x01\n\x1c\x43reateTraceUCStorageLocation\x12\x38\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x1e\n\x10sql_warehouse_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x42\n\x08Response\x12\x36\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocation:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xbd\x01\n\x1fLinkExperimentToUCTraceLocation\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\tuc_schema\x18\x02 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xbf\x01\n!UnLinkExperimentToUCTraceLocation\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\tuc_schema\x18\x02 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xa4\x01\n\x0bGetLocation\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1aM\n\x08Response\x12\x41\n\x0fuc_table_prefix\x18\x01 \x01(\x0b\x32(.mlflow.databricks.UcTablePrefixLocation:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xfa\x02\n\x0e\x43reateLocation\x12\x38\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x43\n\x0fuc_table_prefix\x18\x02 \x01(\x0b\x32(.mlflow.databricks.UcTablePrefixLocationH\x00\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a\x95\x01\n\x08Response\x12\x38\n\tuc_schema\x18\x01 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x43\n\x0fuc_table_prefix\x18\x02 \x01(\x0b\x32(.mlflow.databricks.UcTablePrefixLocationH\x00\x42\n\n\x08location:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xf4\x01\n\x11LinkTraceLocation\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\tuc_schema\x18\x02 \x01(\x0b\x32#.mlflow.databricks.UCSchemaLocationH\x00\x12\x43\n\x0fuc_table_prefix\x18\x03 \x01(\x0b\x32(.mlflow.databricks.UcTablePrefixLocationH\x00\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]B\n\n\x08location\"\xe0\x04\n\nAssessment\x12\x15\n\rassessment_id\x18\x01 \x01(\t\x12\x1d\n\x0f\x61ssessment_name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\x0etrace_location\x18\x04 \x01(\x0b\x32 .mlflow.databricks.TraceLocation\x12\x0f\n\x07span_id\x18\x05 \x01(\t\x12\x34\n\x06source\x18\x06 \x01(\x0b\x32$.mlflow.assessments.AssessmentSource\x12/\n\x0b\x63reate_time\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x34\n\x10last_update_time\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\x08\x66\x65\x65\x64\x62\x61\x63k\x18\t \x01(\x0b\x32\x1c.mlflow.assessments.FeedbackH\x00\x12\x36\n\x0b\x65xpectation\x18\n \x01(\x0b\x32\x1f.mlflow.assessments.ExpectationH\x00\x12\x11\n\trationale\x18\x0b \x01(\t\x12=\n\x08metadata\x18\x0c \x03(\x0b\x32+.mlflow.databricks.Assessment.MetadataEntry\x12\x11\n\toverrides\x18\r \x01(\t\x12\x13\n\x05valid\x18\x0e \x01(\x08:\x04true\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x07\n\x05value\"\xec\x01\n\x10\x43reateAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\nassessment\x18\x02 \x01(\x0b\x32\x1d.mlflow.databricks.AssessmentB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x03 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe5\x01\n\rGetAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x1b\n\rassessment_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa3\x02\n\x10UpdateAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\nassessment\x18\x02 \x01(\x0b\x32\x1d.mlflow.databricks.AssessmentB\x04\xf8\x86\x19\x01\x12\x35\n\x0bupdate_mask\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.FieldMaskB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a=\n\x08Response\x12\x31\n\nassessment\x18\x01 \x01(\x0b\x32\x1d.mlflow.databricks.Assessment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb5\x01\n\x10\x44\x65leteAssessment\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x16\n\x08trace_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x1b\n\rassessment_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x18\n\x10sql_warehouse_id\x18\x04 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x92\x01\n\x13\x42\x61tchLinkTraceToRun\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x14\n\x06run_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x17\x42\x61tchUnlinkTraceFromRun\x12\x19\n\x0blocation_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\ttrace_ids\x18\x02 \x03(\t\x12\x14\n\x06run_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]2\xc8\x1c\n\x19\x44\x61tabricksTrackingService\x12\xb8\x01\n\x0f\x63reateTraceInfo\x12\".mlflow.databricks.CreateTraceInfo\x1a\x1c.mlflow.databricks.TraceInfo\"c\xf2\x86\x19_\nE\n\x04POST\x12\x37/mlflow/traces/{location_id}/{trace_info.trace_id}/info\x1a\x04\x08\x04\x10\x00\x10\x03*\x14\x43reate Trace Info v4\x12\xaa\x01\n\x0e\x62\x61tchGetTraces\x12!.mlflow.databricks.BatchGetTraces\x1a*.mlflow.databricks.BatchGetTraces.Response\"I\xf2\x86\x19\x45\n2\n\x03GET\x12%/mlflow/traces/{location_id}/batchGet\x1a\x04\x08\x04\x10\x00\x10\x03*\rGet Traces V4\x12\xa8\x01\n\x0cgetTraceInfo\x12\x1f.mlflow.databricks.GetTraceInfo\x1a(.mlflow.databricks.GetTraceInfo.Response\"M\xf2\x86\x19I\n6\n\x03GET\x12)/mlflow/traces/{location}/{trace_id}/info\x1a\x04\x08\x04\x10\x00\x10\x03*\rGet TraceInfo\x12\xaa\x01\n\x0bsetTraceTag\x12\x1e.mlflow.databricks.SetTraceTag\x1a\'.mlflow.databricks.SetTraceTag.Response\"R\xf2\x86\x19N\n;\n\x05PATCH\x12,/mlflow/traces/{location_id}/{trace_id}/tags\x1a\x04\x08\x04\x10\x00\x10\x03*\rSet Trace Tag\x12\xbd\x01\n\x0e\x64\x65leteTraceTag\x12!.mlflow.databricks.DeleteTraceTag\x1a*.mlflow.databricks.DeleteTraceTag.Response\"\\\xf2\x86\x19X\nB\n\x06\x44\x45LETE\x12\x32/mlflow/traces/{location_id}/{trace_id}/tags/{key}\x1a\x04\x08\x04\x10\x00\x10\x03*\x10\x44\x65lete Trace Tag\x12\x95\x01\n\x0csearchTraces\x12\x1f.mlflow.databricks.SearchTraces\x1a(.mlflow.databricks.SearchTraces.Response\":\xf2\x86\x19\x36\n#\n\x04POST\x12\x15/mlflow/traces/search\x1a\x04\x08\x04\x10\x00\x10\x03*\rSearch Traces\x12\xda\x01\n\x1c\x63reateTraceUCStorageLocation\x12/.mlflow.databricks.CreateTraceUCStorageLocation\x1a\x38.mlflow.databricks.CreateTraceUCStorageLocation.Response\"O\xf2\x86\x19K\n%\n\x04POST\x12\x17/mlflow/traces/location\x1a\x04\x08\x04\x10\x00\x10\x03* Create Trace UC Storage Location\x12\xfc\x01\n\x1flinkExperimentToUCTraceLocation\x12\x32.mlflow.databricks.LinkExperimentToUCTraceLocation\x1a;.mlflow.databricks.LinkExperimentToUCTraceLocation.Response\"h\xf2\x86\x19\x64\n:\n\x04POST\x12,/mlflow/traces/{experiment_id}/link-location\x1a\x04\x08\x04\x10\x00\x10\x03*$Link Experiment to UC Trace Location\x12\x86\x02\n!unlinkExperimentToUCTraceLocation\x12\x34.mlflow.databricks.UnLinkExperimentToUCTraceLocation\x1a=.mlflow.databricks.UnLinkExperimentToUCTraceLocation.Response\"l\xf2\x86\x19h\n<\n\x04POST\x12./mlflow/traces/{experiment_id}/unlink-location\x1a\x04\x08\x04\x10\x00\x10\x03*&Unlink Experiment to UC Trace Location\x12\xa2\x01\n\x0bgetLocation\x12\x1e.mlflow.databricks.GetLocation\x1a\'.mlflow.databricks.GetLocation.Response\"J\xf2\x86\x19\x46\n4\n\x03GET\x12\'/mlflow/tracing/locations/{location_id}\x1a\x04\x08\x05\x10\x00\x10\x03*\x0cGet Location\x12\xa1\x01\n\x0e\x63reateLocation\x12!.mlflow.databricks.CreateLocation\x1a*.mlflow.databricks.CreateLocation.Response\"@\xf2\x86\x19<\n\'\n\x04POST\x12\x19/mlflow/tracing/locations\x1a\x04\x08\x05\x10\x00\x10\x03*\x0f\x43reate Location\x12\xcc\x01\n\x11linkTraceLocation\x12$.mlflow.databricks.LinkTraceLocation\x1a-.mlflow.databricks.LinkTraceLocation.Response\"b\xf2\x86\x19^\nE\n\x04POST\x12\x37/mlflow/experiments/{experiment_id}/trace-location:link\x1a\x04\x08\x05\x10\x00\x10\x03*\x13Link Trace Location\x12\xce\x01\n\x10\x63reateAssessment\x12#.mlflow.databricks.CreateAssessment\x1a,.mlflow.databricks.CreateAssessment.Response\"g\xf2\x86\x19\x63\nL\n\x04POST\x12>/mlflow/traces/{location_id}/{assessment.trace_id}/assessments\x1a\x04\x08\x04\x10\x00\x10\x03*\x11\x43reate Assessment\x12\xc6\x01\n\rgetAssessment\x12 .mlflow.databricks.GetAssessment\x1a).mlflow.databricks.GetAssessment.Response\"h\xf2\x86\x19\x64\nP\n\x03GET\x12\x43/mlflow/traces/{location_id}/{trace_id}/assessments/{assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x0eGet Assessment\x12\xeb\x01\n\x10updateAssessment\x12#.mlflow.databricks.UpdateAssessment\x1a,.mlflow.databricks.UpdateAssessment.Response\"\x83\x01\xf2\x86\x19\x7f\nh\n\x05PATCH\x12Y/mlflow/traces/{location_id}/{assessment.trace_id}/assessments/{assessment.assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x11Update Assessment\x12\xd5\x01\n\x10\x64\x65leteAssessment\x12#.mlflow.databricks.DeleteAssessment\x1a,.mlflow.databricks.DeleteAssessment.Response\"n\xf2\x86\x19j\nS\n\x06\x44\x45LETE\x12\x43/mlflow/traces/{location_id}/{trace_id}/assessments/{assessment_id}\x1a\x04\x08\x04\x10\x00\x10\x03*\x11\x44\x65lete Assessment\x12\xce\x01\n\x13\x62\x61tchLinkTraceToRun\x12&.mlflow.databricks.BatchLinkTraceToRun\x1a/.mlflow.databricks.BatchLinkTraceToRun.Response\"^\xf2\x86\x19Z\nB\n\x04POST\x12\x34/mlflow/traces/{location_id}/link-to-run/batchCreate\x1a\x04\x08\x04\x10\x00\x10\x03*\x12Link Traces to Run\x12\xe4\x01\n\x17\x62\x61tchUnlinkTraceFromRun\x12*.mlflow.databricks.BatchUnlinkTraceFromRun\x1a\x33.mlflow.databricks.BatchUnlinkTraceFromRun.Response\"h\xf2\x86\x19\x64\nH\n\x06\x44\x45LETE\x12\x38/mlflow/traces/{location_id}/unlink-from-run/batchDelete\x1a\x04\x08\x04\x10\x00\x10\x03*\x16Unlink Traces from RunB\x03\x90\x01\x01')
 
 
 
   _UCSCHEMALOCATION = DESCRIPTOR.message_types_by_name['UCSchemaLocation']
+  _UCTABLEPREFIXLOCATION = DESCRIPTOR.message_types_by_name['UcTablePrefixLocation']
   _MLFLOWEXPERIMENTLOCATION = DESCRIPTOR.message_types_by_name['MlflowExperimentLocation']
   _INFERENCETABLELOCATION = DESCRIPTOR.message_types_by_name['InferenceTableLocation']
   _TRACELOCATION = DESCRIPTOR.message_types_by_name['TraceLocation']
@@ -313,6 +344,12 @@ else:
   _LINKEXPERIMENTTOUCTRACELOCATION_RESPONSE = _LINKEXPERIMENTTOUCTRACELOCATION.nested_types_by_name['Response']
   _UNLINKEXPERIMENTTOUCTRACELOCATION = DESCRIPTOR.message_types_by_name['UnLinkExperimentToUCTraceLocation']
   _UNLINKEXPERIMENTTOUCTRACELOCATION_RESPONSE = _UNLINKEXPERIMENTTOUCTRACELOCATION.nested_types_by_name['Response']
+  _GETLOCATION = DESCRIPTOR.message_types_by_name['GetLocation']
+  _GETLOCATION_RESPONSE = _GETLOCATION.nested_types_by_name['Response']
+  _CREATELOCATION = DESCRIPTOR.message_types_by_name['CreateLocation']
+  _CREATELOCATION_RESPONSE = _CREATELOCATION.nested_types_by_name['Response']
+  _LINKTRACELOCATION = DESCRIPTOR.message_types_by_name['LinkTraceLocation']
+  _LINKTRACELOCATION_RESPONSE = _LINKTRACELOCATION.nested_types_by_name['Response']
   _ASSESSMENT = DESCRIPTOR.message_types_by_name['Assessment']
   _ASSESSMENT_METADATAENTRY = _ASSESSMENT.nested_types_by_name['MetadataEntry']
   _CREATEASSESSMENT = DESCRIPTOR.message_types_by_name['CreateAssessment']
@@ -335,6 +372,13 @@ else:
     # @@protoc_insertion_point(class_scope:mlflow.databricks.UCSchemaLocation)
     })
   _sym_db.RegisterMessage(UCSchemaLocation)
+
+  UcTablePrefixLocation = _reflection.GeneratedProtocolMessageType('UcTablePrefixLocation', (_message.Message,), {
+    'DESCRIPTOR' : _UCTABLEPREFIXLOCATION,
+    '__module__' : 'databricks_tracing_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.databricks.UcTablePrefixLocation)
+    })
+  _sym_db.RegisterMessage(UcTablePrefixLocation)
 
   MlflowExperimentLocation = _reflection.GeneratedProtocolMessageType('MlflowExperimentLocation', (_message.Message,), {
     'DESCRIPTOR' : _MLFLOWEXPERIMENTLOCATION,
@@ -529,6 +573,51 @@ else:
   _sym_db.RegisterMessage(UnLinkExperimentToUCTraceLocation)
   _sym_db.RegisterMessage(UnLinkExperimentToUCTraceLocation.Response)
 
+  GetLocation = _reflection.GeneratedProtocolMessageType('GetLocation', (_message.Message,), {
+
+    'Response' : _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), {
+      'DESCRIPTOR' : _GETLOCATION_RESPONSE,
+      '__module__' : 'databricks_tracing_pb2'
+      # @@protoc_insertion_point(class_scope:mlflow.databricks.GetLocation.Response)
+      })
+    ,
+    'DESCRIPTOR' : _GETLOCATION,
+    '__module__' : 'databricks_tracing_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.databricks.GetLocation)
+    })
+  _sym_db.RegisterMessage(GetLocation)
+  _sym_db.RegisterMessage(GetLocation.Response)
+
+  CreateLocation = _reflection.GeneratedProtocolMessageType('CreateLocation', (_message.Message,), {
+
+    'Response' : _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), {
+      'DESCRIPTOR' : _CREATELOCATION_RESPONSE,
+      '__module__' : 'databricks_tracing_pb2'
+      # @@protoc_insertion_point(class_scope:mlflow.databricks.CreateLocation.Response)
+      })
+    ,
+    'DESCRIPTOR' : _CREATELOCATION,
+    '__module__' : 'databricks_tracing_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.databricks.CreateLocation)
+    })
+  _sym_db.RegisterMessage(CreateLocation)
+  _sym_db.RegisterMessage(CreateLocation.Response)
+
+  LinkTraceLocation = _reflection.GeneratedProtocolMessageType('LinkTraceLocation', (_message.Message,), {
+
+    'Response' : _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), {
+      'DESCRIPTOR' : _LINKTRACELOCATION_RESPONSE,
+      '__module__' : 'databricks_tracing_pb2'
+      # @@protoc_insertion_point(class_scope:mlflow.databricks.LinkTraceLocation.Response)
+      })
+    ,
+    'DESCRIPTOR' : _LINKTRACELOCATION,
+    '__module__' : 'databricks_tracing_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.databricks.LinkTraceLocation)
+    })
+  _sym_db.RegisterMessage(LinkTraceLocation)
+  _sym_db.RegisterMessage(LinkTraceLocation.Response)
+
   Assessment = _reflection.GeneratedProtocolMessageType('Assessment', (_message.Message,), {
 
     'MetadataEntry' : _reflection.GeneratedProtocolMessageType('MetadataEntry', (_message.Message,), {
@@ -693,6 +782,16 @@ else:
     _UNLINKEXPERIMENTTOUCTRACELOCATION.fields_by_name['experiment_id']._serialized_options = b'\370\206\031\001'
     _UNLINKEXPERIMENTTOUCTRACELOCATION._options = None
     _UNLINKEXPERIMENTTOUCTRACELOCATION._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
+    _GETLOCATION.fields_by_name['location_id']._options = None
+    _GETLOCATION.fields_by_name['location_id']._serialized_options = b'\370\206\031\001'
+    _GETLOCATION._options = None
+    _GETLOCATION._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
+    _CREATELOCATION._options = None
+    _CREATELOCATION._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
+    _LINKTRACELOCATION.fields_by_name['experiment_id']._options = None
+    _LINKTRACELOCATION.fields_by_name['experiment_id']._serialized_options = b'\370\206\031\001'
+    _LINKTRACELOCATION._options = None
+    _LINKTRACELOCATION._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
     _ASSESSMENT_METADATAENTRY._options = None
     _ASSESSMENT_METADATAENTRY._serialized_options = b'8\001'
     _ASSESSMENT.fields_by_name['assessment_name']._options = None
@@ -759,6 +858,12 @@ else:
     _DATABRICKSTRACKINGSERVICE.methods_by_name['linkExperimentToUCTraceLocation']._serialized_options = b'\362\206\031d\n:\n\004POST\022,/mlflow/traces/{experiment_id}/link-location\032\004\010\004\020\000\020\003*$Link Experiment to UC Trace Location'
     _DATABRICKSTRACKINGSERVICE.methods_by_name['unlinkExperimentToUCTraceLocation']._options = None
     _DATABRICKSTRACKINGSERVICE.methods_by_name['unlinkExperimentToUCTraceLocation']._serialized_options = b'\362\206\031h\n<\n\004POST\022./mlflow/traces/{experiment_id}/unlink-location\032\004\010\004\020\000\020\003*&Unlink Experiment to UC Trace Location'
+    _DATABRICKSTRACKINGSERVICE.methods_by_name['getLocation']._options = None
+    _DATABRICKSTRACKINGSERVICE.methods_by_name['getLocation']._serialized_options = b'\362\206\031F\n4\n\003GET\022\'/mlflow/tracing/locations/{location_id}\032\004\010\005\020\000\020\003*\014Get Location'
+    _DATABRICKSTRACKINGSERVICE.methods_by_name['createLocation']._options = None
+    _DATABRICKSTRACKINGSERVICE.methods_by_name['createLocation']._serialized_options = b'\362\206\031<\n\'\n\004POST\022\031/mlflow/tracing/locations\032\004\010\005\020\000\020\003*\017Create Location'
+    _DATABRICKSTRACKINGSERVICE.methods_by_name['linkTraceLocation']._options = None
+    _DATABRICKSTRACKINGSERVICE.methods_by_name['linkTraceLocation']._serialized_options = b'\362\206\031^\nE\n\004POST\0227/mlflow/experiments/{experiment_id}/trace-location:link\032\004\010\005\020\000\020\003*\023Link Trace Location'
     _DATABRICKSTRACKINGSERVICE.methods_by_name['createAssessment']._options = None
     _DATABRICKSTRACKINGSERVICE.methods_by_name['createAssessment']._serialized_options = b'\362\206\031c\nL\n\004POST\022>/mlflow/traces/{location_id}/{assessment.trace_id}/assessments\032\004\010\004\020\000\020\003*\021Create Assessment'
     _DATABRICKSTRACKINGSERVICE.methods_by_name['getAssessment']._options = None
@@ -773,92 +878,106 @@ else:
     _DATABRICKSTRACKINGSERVICE.methods_by_name['batchUnlinkTraceFromRun']._serialized_options = b'\362\206\031d\nH\n\006DELETE\0228/mlflow/traces/{location_id}/unlink-from-run/batchDelete\032\004\010\004\020\000\020\003*\026Unlink Traces from Run'
     _UCSCHEMALOCATION._serialized_start=248
     _UCSCHEMALOCATION._serialized_end=370
-    _MLFLOWEXPERIMENTLOCATION._serialized_start=372
-    _MLFLOWEXPERIMENTLOCATION._serialized_end=421
-    _INFERENCETABLELOCATION._serialized_start=423
-    _INFERENCETABLELOCATION._serialized_end=472
-    _TRACELOCATION._serialized_start=475
-    _TRACELOCATION._serialized_end=889
-    _TRACELOCATION_TRACELOCATIONTYPE._serialized_start=760
-    _TRACELOCATION_TRACELOCATIONTYPE._serialized_end=875
-    _TRACEINFO._serialized_start=892
-    _TRACEINFO._serialized_end=1559
-    _TRACEINFO_TRACEMETADATAENTRY._serialized_start=1394
-    _TRACEINFO_TRACEMETADATAENTRY._serialized_end=1446
-    _TRACEINFO_TAGSENTRY._serialized_start=1448
-    _TRACEINFO_TAGSENTRY._serialized_end=1491
-    _TRACEINFO_STATE._serialized_start=1493
-    _TRACEINFO_STATE._serialized_end=1559
-    _CREATETRACEINFO._serialized_start=1562
-    _CREATETRACEINFO._serialized_end=1769
-    _CREATETRACEINFO_RESPONSE._serialized_start=1664
-    _CREATETRACEINFO_RESPONSE._serialized_end=1724
-    _TRACEPATH._serialized_start=1771
-    _TRACEPATH._serialized_end=1870
-    _TRACE._serialized_start=1872
-    _TRACE._serialized_end=1980
-    _BATCHGETTRACES._serialized_start=1983
-    _BATCHGETTRACES._serialized_end=2170
-    _BATCHGETTRACES_RESPONSE._serialized_start=2073
-    _BATCHGETTRACES_RESPONSE._serialized_end=2125
-    _GETTRACEINFO._serialized_start=2173
-    _GETTRACEINFO._serialized_end=2359
-    _GETTRACEINFO_RESPONSE._serialized_start=2263
-    _GETTRACEINFO_RESPONSE._serialized_end=2314
-    _SETTRACETAG._serialized_start=2362
-    _SETTRACETAG._serialized_end=2517
-    _SETTRACETAG_RESPONSE._serialized_start=1664
-    _SETTRACETAG_RESPONSE._serialized_end=1674
-    _DELETETRACETAG._serialized_start=2520
-    _DELETETRACETAG._serialized_end=2689
-    _DELETETRACETAG_RESPONSE._serialized_start=1664
-    _DELETETRACETAG_RESPONSE._serialized_end=1674
-    _SEARCHTRACES._serialized_start=2692
-    _SEARCHTRACES._serialized_end=2998
-    _SEARCHTRACES_RESPONSE._serialized_start=2867
-    _SEARCHTRACES_RESPONSE._serialized_end=2953
-    _CREATETRACEUCSTORAGELOCATION._serialized_start=3001
-    _CREATETRACEUCSTORAGELOCATION._serialized_end=3246
-    _CREATETRACEUCSTORAGELOCATION_RESPONSE._serialized_start=3123
-    _CREATETRACEUCSTORAGELOCATION_RESPONSE._serialized_end=3189
-    _LINKEXPERIMENTTOUCTRACELOCATION._serialized_start=3249
-    _LINKEXPERIMENTTOUCTRACELOCATION._serialized_end=3438
-    _LINKEXPERIMENTTOUCTRACELOCATION_RESPONSE._serialized_start=1664
-    _LINKEXPERIMENTTOUCTRACELOCATION_RESPONSE._serialized_end=1674
-    _UNLINKEXPERIMENTTOUCTRACELOCATION._serialized_start=3441
-    _UNLINKEXPERIMENTTOUCTRACELOCATION._serialized_end=3632
-    _UNLINKEXPERIMENTTOUCTRACELOCATION_RESPONSE._serialized_start=1664
-    _UNLINKEXPERIMENTTOUCTRACELOCATION_RESPONSE._serialized_end=1674
-    _ASSESSMENT._serialized_start=3635
-    _ASSESSMENT._serialized_end=4243
-    _ASSESSMENT_METADATAENTRY._serialized_start=4187
-    _ASSESSMENT_METADATAENTRY._serialized_end=4234
-    _CREATEASSESSMENT._serialized_start=4246
-    _CREATEASSESSMENT._serialized_end=4482
-    _CREATEASSESSMENT_RESPONSE._serialized_start=4376
-    _CREATEASSESSMENT_RESPONSE._serialized_end=4437
-    _GETASSESSMENT._serialized_start=4485
-    _GETASSESSMENT._serialized_end=4714
-    _GETASSESSMENT_RESPONSE._serialized_start=4376
-    _GETASSESSMENT_RESPONSE._serialized_end=4437
-    _UPDATEASSESSMENT._serialized_start=4717
-    _UPDATEASSESSMENT._serialized_end=5008
-    _UPDATEASSESSMENT_RESPONSE._serialized_start=4376
-    _UPDATEASSESSMENT_RESPONSE._serialized_end=4437
-    _DELETEASSESSMENT._serialized_start=5011
-    _DELETEASSESSMENT._serialized_end=5192
-    _DELETEASSESSMENT_RESPONSE._serialized_start=1664
-    _DELETEASSESSMENT_RESPONSE._serialized_end=1674
-    _BATCHLINKTRACETORUN._serialized_start=5195
-    _BATCHLINKTRACETORUN._serialized_end=5341
-    _BATCHLINKTRACETORUN_RESPONSE._serialized_start=1664
-    _BATCHLINKTRACETORUN_RESPONSE._serialized_end=1674
-    _BATCHUNLINKTRACEFROMRUN._serialized_start=5344
-    _BATCHUNLINKTRACEFROMRUN._serialized_end=5494
-    _BATCHUNLINKTRACEFROMRUN_RESPONSE._serialized_start=1664
-    _BATCHUNLINKTRACEFROMRUN_RESPONSE._serialized_end=1674
-    _DATABRICKSTRACKINGSERVICE._serialized_start=5497
-    _DATABRICKSTRACKINGSERVICE._serialized_end=8617
+    _UCTABLEPREFIXLOCATION._serialized_start=373
+    _UCTABLEPREFIXLOCATION._serialized_end=561
+    _MLFLOWEXPERIMENTLOCATION._serialized_start=563
+    _MLFLOWEXPERIMENTLOCATION._serialized_end=612
+    _INFERENCETABLELOCATION._serialized_start=614
+    _INFERENCETABLELOCATION._serialized_end=663
+    _TRACELOCATION._serialized_start=666
+    _TRACELOCATION._serialized_end=1171
+    _TRACELOCATION_TRACELOCATIONTYPE._serialized_start=1021
+    _TRACELOCATION_TRACELOCATIONTYPE._serialized_end=1157
+    _TRACEINFO._serialized_start=1174
+    _TRACEINFO._serialized_end=1841
+    _TRACEINFO_TRACEMETADATAENTRY._serialized_start=1676
+    _TRACEINFO_TRACEMETADATAENTRY._serialized_end=1728
+    _TRACEINFO_TAGSENTRY._serialized_start=1730
+    _TRACEINFO_TAGSENTRY._serialized_end=1773
+    _TRACEINFO_STATE._serialized_start=1775
+    _TRACEINFO_STATE._serialized_end=1841
+    _CREATETRACEINFO._serialized_start=1844
+    _CREATETRACEINFO._serialized_end=2051
+    _CREATETRACEINFO_RESPONSE._serialized_start=1946
+    _CREATETRACEINFO_RESPONSE._serialized_end=2006
+    _TRACEPATH._serialized_start=2053
+    _TRACEPATH._serialized_end=2152
+    _TRACE._serialized_start=2154
+    _TRACE._serialized_end=2262
+    _BATCHGETTRACES._serialized_start=2265
+    _BATCHGETTRACES._serialized_end=2452
+    _BATCHGETTRACES_RESPONSE._serialized_start=2355
+    _BATCHGETTRACES_RESPONSE._serialized_end=2407
+    _GETTRACEINFO._serialized_start=2455
+    _GETTRACEINFO._serialized_end=2641
+    _GETTRACEINFO_RESPONSE._serialized_start=2545
+    _GETTRACEINFO_RESPONSE._serialized_end=2596
+    _SETTRACETAG._serialized_start=2644
+    _SETTRACETAG._serialized_end=2799
+    _SETTRACETAG_RESPONSE._serialized_start=1946
+    _SETTRACETAG_RESPONSE._serialized_end=1956
+    _DELETETRACETAG._serialized_start=2802
+    _DELETETRACETAG._serialized_end=2971
+    _DELETETRACETAG_RESPONSE._serialized_start=1946
+    _DELETETRACETAG_RESPONSE._serialized_end=1956
+    _SEARCHTRACES._serialized_start=2974
+    _SEARCHTRACES._serialized_end=3280
+    _SEARCHTRACES_RESPONSE._serialized_start=3149
+    _SEARCHTRACES_RESPONSE._serialized_end=3235
+    _CREATETRACEUCSTORAGELOCATION._serialized_start=3283
+    _CREATETRACEUCSTORAGELOCATION._serialized_end=3528
+    _CREATETRACEUCSTORAGELOCATION_RESPONSE._serialized_start=3405
+    _CREATETRACEUCSTORAGELOCATION_RESPONSE._serialized_end=3471
+    _LINKEXPERIMENTTOUCTRACELOCATION._serialized_start=3531
+    _LINKEXPERIMENTTOUCTRACELOCATION._serialized_end=3720
+    _LINKEXPERIMENTTOUCTRACELOCATION_RESPONSE._serialized_start=1946
+    _LINKEXPERIMENTTOUCTRACELOCATION_RESPONSE._serialized_end=1956
+    _UNLINKEXPERIMENTTOUCTRACELOCATION._serialized_start=3723
+    _UNLINKEXPERIMENTTOUCTRACELOCATION._serialized_end=3914
+    _UNLINKEXPERIMENTTOUCTRACELOCATION_RESPONSE._serialized_start=1946
+    _UNLINKEXPERIMENTTOUCTRACELOCATION_RESPONSE._serialized_end=1956
+    _GETLOCATION._serialized_start=3917
+    _GETLOCATION._serialized_end=4081
+    _GETLOCATION_RESPONSE._serialized_start=3959
+    _GETLOCATION_RESPONSE._serialized_end=4036
+    _CREATELOCATION._serialized_start=4084
+    _CREATELOCATION._serialized_end=4462
+    _CREATELOCATION_RESPONSE._serialized_start=4256
+    _CREATELOCATION_RESPONSE._serialized_end=4405
+    _LINKTRACELOCATION._serialized_start=4465
+    _LINKTRACELOCATION._serialized_end=4709
+    _LINKTRACELOCATION_RESPONSE._serialized_start=1946
+    _LINKTRACELOCATION_RESPONSE._serialized_end=1956
+    _ASSESSMENT._serialized_start=4712
+    _ASSESSMENT._serialized_end=5320
+    _ASSESSMENT_METADATAENTRY._serialized_start=5264
+    _ASSESSMENT_METADATAENTRY._serialized_end=5311
+    _CREATEASSESSMENT._serialized_start=5323
+    _CREATEASSESSMENT._serialized_end=5559
+    _CREATEASSESSMENT_RESPONSE._serialized_start=5453
+    _CREATEASSESSMENT_RESPONSE._serialized_end=5514
+    _GETASSESSMENT._serialized_start=5562
+    _GETASSESSMENT._serialized_end=5791
+    _GETASSESSMENT_RESPONSE._serialized_start=5453
+    _GETASSESSMENT_RESPONSE._serialized_end=5514
+    _UPDATEASSESSMENT._serialized_start=5794
+    _UPDATEASSESSMENT._serialized_end=6085
+    _UPDATEASSESSMENT_RESPONSE._serialized_start=5453
+    _UPDATEASSESSMENT_RESPONSE._serialized_end=5514
+    _DELETEASSESSMENT._serialized_start=6088
+    _DELETEASSESSMENT._serialized_end=6269
+    _DELETEASSESSMENT_RESPONSE._serialized_start=1946
+    _DELETEASSESSMENT_RESPONSE._serialized_end=1956
+    _BATCHLINKTRACETORUN._serialized_start=6272
+    _BATCHLINKTRACETORUN._serialized_end=6418
+    _BATCHLINKTRACETORUN_RESPONSE._serialized_start=1946
+    _BATCHLINKTRACETORUN_RESPONSE._serialized_end=1956
+    _BATCHUNLINKTRACEFROMRUN._serialized_start=6421
+    _BATCHUNLINKTRACEFROMRUN._serialized_end=6571
+    _BATCHUNLINKTRACEFROMRUN_RESPONSE._serialized_start=1946
+    _BATCHUNLINKTRACEFROMRUN_RESPONSE._serialized_end=1956
+    _DATABRICKSTRACKINGSERVICE._serialized_start=6574
+    _DATABRICKSTRACKINGSERVICE._serialized_end=10230
   DatabricksTrackingService = service_reflection.GeneratedServiceType('DatabricksTrackingService', (_service.Service,), dict(
     DESCRIPTOR = _DATABRICKSTRACKINGSERVICE,
     __module__ = 'databricks_tracing_pb2'

--- a/mlflow/protos/databricks_tracing_pb2.pyi
+++ b/mlflow/protos/databricks_tracing_pb2.pyi
@@ -26,6 +26,24 @@ class UCSchemaLocation(_message.Message):
     otel_logs_table_name: str
     def __init__(self, catalog_name: _Optional[str] = ..., schema_name: _Optional[str] = ..., otel_spans_table_name: _Optional[str] = ..., otel_logs_table_name: _Optional[str] = ...) -> None: ...
 
+class UcTablePrefixLocation(_message.Message):
+    __slots__ = ("catalog_name", "schema_name", "table_prefix", "spans_table_name", "logs_table_name", "metrics_table_name", "location_id")
+    CATALOG_NAME_FIELD_NUMBER: _ClassVar[int]
+    SCHEMA_NAME_FIELD_NUMBER: _ClassVar[int]
+    TABLE_PREFIX_FIELD_NUMBER: _ClassVar[int]
+    SPANS_TABLE_NAME_FIELD_NUMBER: _ClassVar[int]
+    LOGS_TABLE_NAME_FIELD_NUMBER: _ClassVar[int]
+    METRICS_TABLE_NAME_FIELD_NUMBER: _ClassVar[int]
+    LOCATION_ID_FIELD_NUMBER: _ClassVar[int]
+    catalog_name: str
+    schema_name: str
+    table_prefix: str
+    spans_table_name: str
+    logs_table_name: str
+    metrics_table_name: str
+    location_id: str
+    def __init__(self, catalog_name: _Optional[str] = ..., schema_name: _Optional[str] = ..., table_prefix: _Optional[str] = ..., spans_table_name: _Optional[str] = ..., logs_table_name: _Optional[str] = ..., metrics_table_name: _Optional[str] = ..., location_id: _Optional[str] = ...) -> None: ...
+
 class MlflowExperimentLocation(_message.Message):
     __slots__ = ("experiment_id",)
     EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
@@ -39,26 +57,30 @@ class InferenceTableLocation(_message.Message):
     def __init__(self, full_table_name: _Optional[str] = ...) -> None: ...
 
 class TraceLocation(_message.Message):
-    __slots__ = ("type", "mlflow_experiment", "inference_table", "uc_schema")
+    __slots__ = ("type", "mlflow_experiment", "inference_table", "uc_schema", "uc_table_prefix")
     class TraceLocationType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
         __slots__ = ()
         TRACE_LOCATION_TYPE_UNSPECIFIED: _ClassVar[TraceLocation.TraceLocationType]
         MLFLOW_EXPERIMENT: _ClassVar[TraceLocation.TraceLocationType]
         INFERENCE_TABLE: _ClassVar[TraceLocation.TraceLocationType]
         UC_SCHEMA: _ClassVar[TraceLocation.TraceLocationType]
+        UC_TABLE_PREFIX: _ClassVar[TraceLocation.TraceLocationType]
     TRACE_LOCATION_TYPE_UNSPECIFIED: TraceLocation.TraceLocationType
     MLFLOW_EXPERIMENT: TraceLocation.TraceLocationType
     INFERENCE_TABLE: TraceLocation.TraceLocationType
     UC_SCHEMA: TraceLocation.TraceLocationType
+    UC_TABLE_PREFIX: TraceLocation.TraceLocationType
     TYPE_FIELD_NUMBER: _ClassVar[int]
     MLFLOW_EXPERIMENT_FIELD_NUMBER: _ClassVar[int]
     INFERENCE_TABLE_FIELD_NUMBER: _ClassVar[int]
     UC_SCHEMA_FIELD_NUMBER: _ClassVar[int]
+    UC_TABLE_PREFIX_FIELD_NUMBER: _ClassVar[int]
     type: TraceLocation.TraceLocationType
     mlflow_experiment: MlflowExperimentLocation
     inference_table: InferenceTableLocation
     uc_schema: UCSchemaLocation
-    def __init__(self, type: _Optional[_Union[TraceLocation.TraceLocationType, str]] = ..., mlflow_experiment: _Optional[_Union[MlflowExperimentLocation, _Mapping]] = ..., inference_table: _Optional[_Union[InferenceTableLocation, _Mapping]] = ..., uc_schema: _Optional[_Union[UCSchemaLocation, _Mapping]] = ...) -> None: ...
+    uc_table_prefix: UcTablePrefixLocation
+    def __init__(self, type: _Optional[_Union[TraceLocation.TraceLocationType, str]] = ..., mlflow_experiment: _Optional[_Union[MlflowExperimentLocation, _Mapping]] = ..., inference_table: _Optional[_Union[InferenceTableLocation, _Mapping]] = ..., uc_schema: _Optional[_Union[UCSchemaLocation, _Mapping]] = ..., uc_table_prefix: _Optional[_Union[UcTablePrefixLocation, _Mapping]] = ...) -> None: ...
 
 class TraceInfo(_message.Message):
     __slots__ = ("trace_id", "client_request_id", "trace_location", "request_preview", "response_preview", "request_time", "execution_duration", "state", "trace_metadata", "assessments", "tags")
@@ -256,6 +278,47 @@ class UnLinkExperimentToUCTraceLocation(_message.Message):
     experiment_id: str
     uc_schema: UCSchemaLocation
     def __init__(self, experiment_id: _Optional[str] = ..., uc_schema: _Optional[_Union[UCSchemaLocation, _Mapping]] = ...) -> None: ...
+
+class GetLocation(_message.Message):
+    __slots__ = ("location_id",)
+    class Response(_message.Message):
+        __slots__ = ("uc_table_prefix",)
+        UC_TABLE_PREFIX_FIELD_NUMBER: _ClassVar[int]
+        uc_table_prefix: UcTablePrefixLocation
+        def __init__(self, uc_table_prefix: _Optional[_Union[UcTablePrefixLocation, _Mapping]] = ...) -> None: ...
+    LOCATION_ID_FIELD_NUMBER: _ClassVar[int]
+    location_id: str
+    def __init__(self, location_id: _Optional[str] = ...) -> None: ...
+
+class CreateLocation(_message.Message):
+    __slots__ = ("uc_schema", "uc_table_prefix", "sql_warehouse_id")
+    class Response(_message.Message):
+        __slots__ = ("uc_schema", "uc_table_prefix")
+        UC_SCHEMA_FIELD_NUMBER: _ClassVar[int]
+        UC_TABLE_PREFIX_FIELD_NUMBER: _ClassVar[int]
+        uc_schema: UCSchemaLocation
+        uc_table_prefix: UcTablePrefixLocation
+        def __init__(self, uc_schema: _Optional[_Union[UCSchemaLocation, _Mapping]] = ..., uc_table_prefix: _Optional[_Union[UcTablePrefixLocation, _Mapping]] = ...) -> None: ...
+    UC_SCHEMA_FIELD_NUMBER: _ClassVar[int]
+    UC_TABLE_PREFIX_FIELD_NUMBER: _ClassVar[int]
+    SQL_WAREHOUSE_ID_FIELD_NUMBER: _ClassVar[int]
+    uc_schema: UCSchemaLocation
+    uc_table_prefix: UcTablePrefixLocation
+    sql_warehouse_id: str
+    def __init__(self, uc_schema: _Optional[_Union[UCSchemaLocation, _Mapping]] = ..., uc_table_prefix: _Optional[_Union[UcTablePrefixLocation, _Mapping]] = ..., sql_warehouse_id: _Optional[str] = ...) -> None: ...
+
+class LinkTraceLocation(_message.Message):
+    __slots__ = ("experiment_id", "uc_schema", "uc_table_prefix")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    UC_SCHEMA_FIELD_NUMBER: _ClassVar[int]
+    UC_TABLE_PREFIX_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    uc_schema: UCSchemaLocation
+    uc_table_prefix: UcTablePrefixLocation
+    def __init__(self, experiment_id: _Optional[str] = ..., uc_schema: _Optional[_Union[UCSchemaLocation, _Mapping]] = ..., uc_table_prefix: _Optional[_Union[UcTablePrefixLocation, _Mapping]] = ...) -> None: ...
 
 class Assessment(_message.Message):
     __slots__ = ("assessment_id", "assessment_name", "trace_id", "trace_location", "span_id", "source", "create_time", "last_update_time", "feedback", "expectation", "rationale", "metadata", "overrides", "valid")

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -843,7 +843,8 @@ def search_traces(
 
         locations: A list of locations to search over. To search over experiments, provide
             a list of experiment IDs. To search over UC tables on databricks, provide
-            a list of locations in the format `<catalog_name>.<schema_name>`.
+            a list of locations in the format
+            `<catalog_name>.<schema_name>[.<table_prefix>]`.
             If not provided, the search will be performed across the current active experiment.
 
     Returns:
@@ -999,7 +1000,8 @@ def search_sessions(
             the trace metadata is returned. Default is ``True``.
         locations: A list of locations to search over. To search over experiments, provide
             a list of experiment IDs. To search over UC tables on databricks, provide
-            a list of locations in the format `<catalog_name>.<schema_name>`.
+            a list of locations in the format
+            `<catalog_name>.<schema_name>[.<table_prefix>]`.
             If not provided, the search will be performed across the current active experiment.
 
     Returns:

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -26,6 +26,7 @@ from mlflow.entities.trace_location import (
     MlflowExperimentLocation,
     TraceLocationBase,
     UCSchemaLocation,
+    UnityCatalog,
 )
 from mlflow.environment_variables import (
     MLFLOW_TRACE_ENABLE_OTLP_DUAL_EXPORT,
@@ -318,8 +319,9 @@ def set_destination(destination: TraceLocationBase, *, context_local: bool = Fal
 
             - :py:class:`~mlflow.entities.trace_location.MlflowExperimentLocation`: Logs traces to
                 an MLflow experiment.
-            - :py:class:`~mlflow.entities.trace_location.UCSchemaLocation`: Logs traces to a
-                Databricks Unity Catalog schema. Only available in Databricks.
+            - :py:func:`~mlflow.entities.trace_location.UnityCatalog`: Logs traces to a
+                Databricks Unity Catalog schema or table-prefix location. Only available in
+                Databricks.
 
         context_local: If False (default), the destination is set globally. If True, the destination
             is isolated per async task or thread, providing isolation in concurrent applications.
@@ -342,10 +344,10 @@ def set_destination(destination: TraceLocationBase, *, context_local: bool = Fal
 
         .. code-block:: python
 
-            from mlflow.entities.trace_location import UCSchemaLocation
+            from mlflow.entities.trace_location import UnityCatalog
 
             mlflow.tracing.set_destination(
-                UCSchemaLocation(catalog_name="catalog", schema_name="schema")
+                UnityCatalog(catalog_name="catalog", schema_name="schema")
             )
 
         **Isolate the destination between async tasks or threads:**
@@ -381,7 +383,7 @@ def set_destination(destination: TraceLocationBase, *, context_local: bool = Fal
             "The destination must be an instance of TraceLocation."
         )
 
-    if isinstance(destination, UCSchemaLocation) and (
+    if isinstance(destination, (UCSchemaLocation, UnityCatalog)) and (
         mlflow.get_tracking_uri() is None or not mlflow.get_tracking_uri().startswith("databricks")
     ):
         mlflow.set_tracking_uri("databricks")
@@ -392,6 +394,33 @@ def set_destination(destination: TraceLocationBase, *, context_local: bool = Fal
 
     _MLFLOW_TRACE_USER_DESTINATION.set(destination, context_local=context_local)
     _initialize_tracer_provider()
+
+
+def _set_experiment_derived_destination(destination: TraceLocationBase | None):
+    experiment_id = None
+    if destination is not None:
+        try:
+            # Lazy import to avoid circular dependency (tracking.fluent -> tracing.provider).
+            from mlflow.tracking.fluent import _get_experiment_id
+
+            experiment_id = _get_experiment_id()
+        except Exception:
+            _logger.debug(
+                "Failed to determine active experiment ID for experiment-derived destination.",
+                exc_info=True,
+            )
+    _MLFLOW_TRACE_USER_DESTINATION.set_experiment_derived(
+        destination,
+        experiment_id=experiment_id,
+    )
+    _initialize_tracer_provider()
+
+
+def _clear_experiment_derived_destination():
+    _MLFLOW_TRACE_USER_DESTINATION.clear_experiment_derived()
+    # Reset the provider so it re-initializes lazily on the next trace,
+    # allowing _resolve_experiment_uc_location to run with the new experiment.
+    provider.reset()
 
 
 def _get_tracer(module_name: str) -> trace.Tracer:
@@ -533,6 +562,55 @@ def _get_trace_sampler() -> _MlflowSampler | None:
     return None
 
 
+def _resolve_experiment_uc_location() -> UnityCatalog | None:
+    """Lazily resolve the active experiment's UC location from its backend tags.
+
+    Called during provider initialization when no explicit destination has been
+    set. If the active experiment is linked to a UC table-prefix location (via
+    the databricksTelemetryDestinationId tag), resolve it and populate the
+    experiment-derived destination slot so that traces route to UC.
+    """
+    # Lazy imports to avoid circular dependency (tracking.fluent -> tracing.provider).
+    from mlflow.tracking.fluent import _get_experiment_id
+    from mlflow.utils.uri import is_databricks_uri
+
+    tracking_uri = mlflow.get_tracking_uri()
+    if not tracking_uri or not is_databricks_uri(tracking_uri):
+        return None
+
+    experiment_id = _get_experiment_id()
+    if not experiment_id:
+        return None
+
+    try:
+        from mlflow.tracking._tracking_service.utils import _get_store
+
+        store = _get_store(tracking_uri)
+        experiment = store.get_experiment(experiment_id)
+        if not experiment:
+            return None
+
+        tags = experiment.tags or {}
+        telemetry_profile_id = tags.get("mlflow.experiment.databricksTelemetryDestinationId")
+        if not telemetry_profile_id:
+            return None
+
+        from mlflow.tracing.client import TracingClient
+
+        location = TracingClient(tracking_uri)._get_trace_location(telemetry_profile_id)
+        _MLFLOW_TRACE_USER_DESTINATION.set_experiment_derived(
+            location,
+            experiment_id=experiment_id,
+        )
+        return location
+    except Exception:
+        _logger.debug(
+            "Failed to auto-resolve UC location for active experiment",
+            exc_info=True,
+        )
+        return None
+
+
 def _get_span_processors(disabled: bool = False) -> list[SpanProcessor]:
     """
     Get the list of span processors based on configuration.
@@ -552,9 +630,16 @@ def _get_span_processors(disabled: bool = False) -> list[SpanProcessor]:
     #  1. Partners can implement span processor/exporter and destination class.
     #  2. They can register their implementation to the registry via entry points.
     #  3. MLflow will pick the implementation based on given destination id.
-    if trace_destination := _MLFLOW_TRACE_USER_DESTINATION.get():
-        # In PrPr, users must set the destination to UCSchemaLocation to export traces to UC
-        if isinstance(trace_destination, UCSchemaLocation):
+    trace_destination = _MLFLOW_TRACE_USER_DESTINATION.get()
+
+    # If no explicit destination is set, check whether the active experiment is
+    # linked to a UC table-prefix location and auto-resolve it.
+    if trace_destination is None:
+        trace_destination = _resolve_experiment_uc_location()
+
+    if trace_destination:
+        # In PrPr, users must set the destination to a Unity Catalog location to export traces.
+        if isinstance(trace_destination, (UCSchemaLocation, UnityCatalog)):
             from mlflow.tracing.export.uc_table import DatabricksUCTableSpanExporter
             from mlflow.tracing.processor.uc_table import DatabricksUCTableSpanProcessor
 

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -711,11 +711,11 @@ def get_active_spans_table_name() -> str | None:
     """
     Get active Unity Catalog spans table name that's set by `mlflow.tracing.set_destination`.
     """
-    from mlflow.entities.trace_location import UCSchemaLocation
+    from mlflow.entities.trace_location import UCSchemaLocation, UnityCatalog
     from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
 
     if destination := _MLFLOW_TRACE_USER_DESTINATION.get():
-        if isinstance(destination, UCSchemaLocation):
+        if isinstance(destination, (UCSchemaLocation, UnityCatalog)):
             return destination.full_otel_spans_table_name
 
     return None

--- a/mlflow/utils/databricks_tracing_utils.py
+++ b/mlflow/utils/databricks_tracing_utils.py
@@ -11,6 +11,7 @@ from mlflow.entities.trace_location import (
     TraceLocation,
     TraceLocationType,
     UCSchemaLocation,
+    UnityCatalog,
 )
 from mlflow.protos import assessments_pb2
 from mlflow.protos import databricks_tracing_pb2 as pb
@@ -22,7 +23,24 @@ from mlflow.tracing.utils import (
 _logger = logging.getLogger(__name__)
 
 
-def uc_schema_location_to_proto(uc_schema_location: UCSchemaLocation) -> pb.UCSchemaLocation:
+def parse_uc_location(location: str) -> tuple[str, str, str | None]:
+    parts = location.split(".")
+    if len(parts) == 2:
+        return parts[0], parts[1], None
+    if len(parts) == 3:
+        return parts[0], parts[1], parts[2]
+    raise ValueError(
+        f"Invalid UC location: {location}. Expected format: <catalog>.<schema>[.<table_prefix>]."
+    )
+
+
+def uc_location_to_str(catalog: str, schema: str, table_prefix: str | None = None) -> str:
+    return f"{catalog}.{schema}.{table_prefix}" if table_prefix else f"{catalog}.{schema}"
+
+
+def uc_schema_location_to_proto(
+    uc_schema_location: UCSchemaLocation,
+) -> pb.UCSchemaLocation:
     return pb.UCSchemaLocation(
         catalog_name=uc_schema_location.catalog_name,
         schema_name=uc_schema_location.schema_name,
@@ -31,13 +49,46 @@ def uc_schema_location_to_proto(uc_schema_location: UCSchemaLocation) -> pb.UCSc
     )
 
 
-def uc_schema_location_from_proto(proto: pb.UCSchemaLocation) -> UCSchemaLocation:
-    location = UCSchemaLocation(catalog_name=proto.catalog_name, schema_name=proto.schema_name)
+def uc_schema_location_from_proto(
+    proto: pb.UCSchemaLocation,
+) -> UCSchemaLocation:
+    location = UCSchemaLocation(
+        catalog_name=proto.catalog_name,
+        schema_name=proto.schema_name,
+    )
 
     if proto.HasField("otel_spans_table_name"):
         location._otel_spans_table_name = proto.otel_spans_table_name
     if proto.HasField("otel_logs_table_name"):
         location._otel_logs_table_name = proto.otel_logs_table_name
+    return location
+
+
+def uc_table_prefix_location_to_proto(
+    location: UnityCatalog,
+) -> pb.UcTablePrefixLocation:
+    proto = pb.UcTablePrefixLocation(
+        catalog_name=location.catalog_name,
+        schema_name=location.schema_name,
+        table_prefix=location.table_prefix,
+    )
+    if location._otel_spans_table_name:
+        proto.spans_table_name = location._otel_spans_table_name
+    if location._otel_logs_table_name:
+        proto.logs_table_name = location._otel_logs_table_name
+    return proto
+
+
+def uc_table_prefix_location_from_proto(proto: pb.UcTablePrefixLocation) -> UnityCatalog:
+    location = UnityCatalog(
+        catalog_name=proto.catalog_name,
+        schema_name=proto.schema_name,
+        table_prefix=proto.table_prefix,
+    )
+    if proto.HasField("spans_table_name"):
+        location._otel_spans_table_name = proto.spans_table_name
+    if proto.HasField("logs_table_name"):
+        location._otel_logs_table_name = proto.logs_table_name
     return location
 
 
@@ -58,6 +109,11 @@ def trace_location_to_proto(trace_location: TraceLocation) -> pb.TraceLocation:
         return pb.TraceLocation(
             type=pb.TraceLocation.TraceLocationType.UC_SCHEMA,
             uc_schema=uc_schema_location_to_proto(trace_location.uc_schema),
+        )
+    elif trace_location.type == TraceLocationType.UC_TABLE_PREFIX:
+        return pb.TraceLocation(
+            type=pb.TraceLocation.TraceLocationType.UC_TABLE_PREFIX,
+            uc_table_prefix=uc_table_prefix_location_to_proto(trace_location.uc_table_prefix),
         )
     elif trace_location.type == TraceLocationType.MLFLOW_EXPERIMENT:
         return pb.TraceLocation(
@@ -85,6 +141,11 @@ def trace_location_from_proto(proto: pb.TraceLocation) -> TraceLocation:
             type=type_,
             uc_schema=uc_schema_location_from_proto(proto.uc_schema),
         )
+    elif proto.WhichOneof("identifier") == "uc_table_prefix":
+        return TraceLocation(
+            type=type_,
+            uc_table_prefix=uc_table_prefix_location_from_proto(proto.uc_table_prefix),
+        )
     elif proto.WhichOneof("identifier") == "mlflow_experiment":
         return TraceLocation(
             type=type_,
@@ -107,7 +168,7 @@ def trace_info_to_v4_proto(trace_info: TraceInfo) -> pb.TraceInfo:
         execution_duration = Duration()
         execution_duration.FromMilliseconds(trace_info.execution_duration)
 
-    if trace_info.trace_location.uc_schema:
+    if trace_info.trace_location.uc_schema or trace_info.trace_location.uc_table_prefix:
         _, trace_id = parse_trace_id_v4(trace_info.trace_id)
     else:
         trace_id = trace_info.trace_id
@@ -146,13 +207,27 @@ def assessment_to_proto(assessment: Assessment) -> pb.Assessment:
     assessment_proto.assessment_name = assessment.name
     location, trace_id = parse_trace_id_v4(assessment.trace_id)
     if location:
-        catalog, schema = location.split(".")
-        assessment_proto.trace_location.CopyFrom(
-            pb.TraceLocation(
-                type=pb.TraceLocation.TraceLocationType.UC_SCHEMA,
-                uc_schema=pb.UCSchemaLocation(catalog_name=catalog, schema_name=schema),
+        catalog, schema, table_prefix = parse_uc_location(location)
+        if table_prefix:
+            uc_table_prefix = pb.UcTablePrefixLocation(
+                catalog_name=catalog,
+                schema_name=schema,
+                table_prefix=table_prefix,
             )
-        )
+            assessment_proto.trace_location.CopyFrom(
+                pb.TraceLocation(
+                    type=pb.TraceLocation.TraceLocationType.UC_TABLE_PREFIX,
+                    uc_table_prefix=uc_table_prefix,
+                )
+            )
+        else:
+            uc_schema = pb.UCSchemaLocation(catalog_name=catalog, schema_name=schema)
+            assessment_proto.trace_location.CopyFrom(
+                pb.TraceLocation(
+                    type=pb.TraceLocation.TraceLocationType.UC_SCHEMA,
+                    uc_schema=uc_schema,
+                )
+            )
     assessment_proto.trace_id = trace_id
 
     assessment_proto.source.CopyFrom(assessment.source.to_proto())
@@ -190,7 +265,22 @@ def get_trace_id_from_assessment_proto(proto: pb.Assessment | assessments_pb2.As
     ):
         trace_location = proto.trace_location
         return construct_trace_id_v4(
-            f"{trace_location.uc_schema.catalog_name}.{trace_location.uc_schema.schema_name}",
+            uc_location_to_str(
+                trace_location.uc_schema.catalog_name,
+                trace_location.uc_schema.schema_name,
+            ),
+            proto.trace_id,
+        )
+    elif "trace_location" in proto.DESCRIPTOR.fields_by_name and proto.trace_location.HasField(
+        "uc_table_prefix"
+    ):
+        trace_location = proto.trace_location
+        return construct_trace_id_v4(
+            uc_location_to_str(
+                trace_location.uc_table_prefix.catalog_name,
+                trace_location.uc_table_prefix.schema_name,
+                trace_location.uc_table_prefix.table_prefix,
+            ),
             proto.trace_id,
         )
     else:

--- a/tests/entities/test_trace_location.py
+++ b/tests/entities/test_trace_location.py
@@ -6,6 +6,7 @@ from mlflow.entities.trace_location import (
     TraceLocation,
     TraceLocationType,
     UCSchemaLocation,
+    UnityCatalog,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos import service_pb2 as pb
@@ -31,7 +32,10 @@ def test_trace_location():
 
     with pytest.raises(
         MlflowException,
-        match="Only one of mlflow_experiment, inference_table, or uc_schema can be provided",
+        match=(
+            "Only one of mlflow_experiment, inference_table, uc_schema, "
+            "or uc_table_prefix can be provided"
+        ),
     ):
         TraceLocation(
             type=TraceLocationType.TRACE_LOCATION_TYPE_UNSPECIFIED,
@@ -96,3 +100,34 @@ def test_uc_schema_location_full_otel_spans_table_name():
     )
     uc_schema._otel_spans_table_name = "otel_spans"
     assert uc_schema.full_otel_spans_table_name == "test_catalog.test_schema.otel_spans"
+
+
+def test_uc_schema_location_round_trip():
+    uc_schema = UCSchemaLocation(
+        catalog_name="test_catalog",
+        schema_name="test_schema",
+    )
+    assert uc_schema.schema_location == "test_catalog.test_schema"
+    assert UCSchemaLocation.from_dict(uc_schema.to_dict()) == uc_schema
+
+
+def test_unity_catalog_factory_for_default_table_prefix():
+    location = UnityCatalog(catalog_name="catalog", schema_name="schema")
+    assert isinstance(location, UnityCatalog)
+    assert location.full_table_prefix == "catalog.schema.mlflow_traces"
+
+
+def test_unity_catalog_factory_for_table_prefix():
+    location = UnityCatalog(catalog_name="catalog", schema_name="schema", table_prefix="pref")
+    assert isinstance(location, UnityCatalog)
+    assert location.full_table_prefix == "catalog.schema.pref"
+
+
+def test_uc_table_prefix_location_round_trip():
+    location = UnityCatalog(
+        catalog_name="catalog",
+        schema_name="schema",
+        table_prefix="prefix",
+    )
+    assert location.full_table_prefix == "catalog.schema.prefix"
+    assert UnityCatalog.from_dict(location.to_dict()) == location

--- a/tests/tracing/processor/test_uc_table_processor.py
+++ b/tests/tracing/processor/test_uc_table_processor.py
@@ -69,7 +69,7 @@ def test_on_start_without_uc_table_name(monkeypatch):
         "mlflow.tracing.processor.uc_table.get_active_spans_table_name", return_value=None
     ):
         processor = DatabricksUCTableSpanProcessor(span_exporter=mock.MagicMock())
-        with pytest.raises(MlflowException, match="Unity Catalog spans table name is not set"):
+        with pytest.raises(MlflowException, match="Unity Catalog destination is not set"):
             processor.on_start(span)
 
     # Check that trace was still created in trace manager

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -5,7 +5,11 @@ import pytest
 from opentelemetry import trace
 
 import mlflow
-from mlflow.entities.trace_location import MlflowExperimentLocation, UCSchemaLocation
+from mlflow.entities.trace_location import (
+    MlflowExperimentLocation,
+    UCSchemaLocation,
+    UnityCatalog,
+)
 from mlflow.environment_variables import (
     MLFLOW_TRACE_ENABLE_OTLP_DUAL_EXPORT,
     MLFLOW_TRACE_SAMPLING_RATIO,
@@ -194,6 +198,64 @@ def test_set_destination_from_env_var_databricks_uc(monkeypatch):
     assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
     assert isinstance(processors[0].span_exporter, DatabricksUCTableSpanExporter)
     assert get_active_spans_table_name() == "catalog.schema.mlflow_experiment_trace_otel_spans"
+
+
+def test_set_destination_from_env_var_databricks_uc_with_table_prefix(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACING_DESTINATION", "catalog.schema.prefix")
+
+    from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
+
+    destination = _MLFLOW_TRACE_USER_DESTINATION.get()
+    assert isinstance(destination, UnityCatalog)
+    assert destination.catalog_name == "catalog"
+    assert destination.schema_name == "schema"
+    assert destination.table_prefix == "prefix"
+
+
+def test_destination_resolution_precedence_with_experiment_derived(monkeypatch):
+    from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
+
+    _MLFLOW_TRACE_USER_DESTINATION.reset()
+    monkeypatch.setenv("MLFLOW_TRACING_DESTINATION", "catalog.schema.env")
+    monkeypatch.setattr("mlflow.tracking.fluent._get_experiment_id", lambda: "exp-1")
+
+    experiment_derived = UnityCatalog("catalog", "schema", table_prefix="exp")
+    global_destination = UnityCatalog("catalog", "schema", table_prefix="global")
+    local_destination = UnityCatalog("catalog", "schema", table_prefix="local")
+
+    _MLFLOW_TRACE_USER_DESTINATION.set_experiment_derived(
+        experiment_derived,
+        experiment_id="exp-1",
+    )
+    assert _MLFLOW_TRACE_USER_DESTINATION.get().table_prefix == "exp"
+
+    _MLFLOW_TRACE_USER_DESTINATION.set(global_destination)
+    assert _MLFLOW_TRACE_USER_DESTINATION.get().table_prefix == "global"
+
+    _MLFLOW_TRACE_USER_DESTINATION.set(local_destination, context_local=True)
+    assert _MLFLOW_TRACE_USER_DESTINATION.get().table_prefix == "local"
+    _MLFLOW_TRACE_USER_DESTINATION.reset()
+
+
+def test_experiment_derived_destination_invalidates_when_experiment_changes(monkeypatch):
+    from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
+
+    _MLFLOW_TRACE_USER_DESTINATION.reset()
+    monkeypatch.setenv("MLFLOW_TRACING_DESTINATION", "catalog.schema.env")
+    monkeypatch.setattr("mlflow.tracking.fluent._get_experiment_id", lambda: "exp-2")
+
+    experiment_derived = UnityCatalog("catalog", "schema", table_prefix="exp")
+    _MLFLOW_TRACE_USER_DESTINATION.set_experiment_derived(
+        experiment_derived,
+        experiment_id="exp-1",
+    )
+
+    # Cached experiment-derived value no longer matches active experiment.
+    # Registry should invalidate it and fall through to env resolution.
+    destination = _MLFLOW_TRACE_USER_DESTINATION.get()
+    assert isinstance(destination, UnityCatalog)
+    assert destination.table_prefix == "env"
+    assert _MLFLOW_TRACE_USER_DESTINATION._experiment_derived_value is None
 
 
 def test_set_destination_in_model_serving(mock_databricks_serving_with_tracing_env, monkeypatch):
@@ -587,3 +649,106 @@ def test_otel_resource_attributes(monkeypatch):
         "telemetry.sdk.name": "mlflow",
         "telemetry.sdk.version": mlflow.__version__,
     }
+
+
+_RESOLVE_UC_DEST_TAG = "mlflow.experiment.databricksTelemetryDestinationId"
+
+
+def _make_experiment(tags=None):
+    from mlflow.entities import Experiment
+    from mlflow.entities.experiment_tag import ExperimentTag
+
+    tag_entities = [ExperimentTag(k, v) for k, v in (tags or {}).items()] if tags else []
+    return Experiment(
+        experiment_id="123",
+        name="test",
+        artifact_location="file:/tmp",
+        lifecycle_stage="active",
+        tags=tag_entities,
+    )
+
+
+def test_resolve_uc_location_from_experiment_tag():
+    from mlflow.tracing.provider import _resolve_experiment_uc_location
+
+    mlflow.tracing.reset()
+    resolved = UnityCatalog("cat", "sch", table_prefix="pfx")
+
+    with (
+        mock.patch(
+            "mlflow.tracing.provider.mlflow.get_tracking_uri",
+            return_value="databricks",
+        ),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="123"),
+        mock.patch("mlflow.tracking._tracking_service.utils._get_store") as mock_store_fn,
+        mock.patch("mlflow.tracing.client.TracingClient") as tc_cls,
+    ):
+        mock_store_fn.return_value.get_experiment.return_value = _make_experiment(
+            tags={_RESOLVE_UC_DEST_TAG: "some-uuid"}
+        )
+        tc_cls.return_value._get_trace_location.return_value = resolved
+
+        result = _resolve_experiment_uc_location()
+
+        assert result == resolved
+        tc_cls.return_value._get_trace_location.assert_called_once_with("some-uuid")
+
+    mlflow.tracing.reset()
+
+
+def test_resolve_uc_location_returns_none_when_no_tag():
+    from mlflow.tracing.provider import _resolve_experiment_uc_location
+
+    mlflow.tracing.reset()
+
+    with (
+        mock.patch(
+            "mlflow.tracing.provider.mlflow.get_tracking_uri",
+            return_value="databricks",
+        ),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="123"),
+        mock.patch("mlflow.tracking._tracking_service.utils._get_store") as mock_store_fn,
+    ):
+        mock_store_fn.return_value.get_experiment.return_value = _make_experiment()
+
+        assert _resolve_experiment_uc_location() is None
+
+    mlflow.tracing.reset()
+
+
+def test_resolve_uc_location_returns_none_for_non_databricks():
+    from mlflow.tracing.provider import _resolve_experiment_uc_location
+
+    mlflow.tracing.reset()
+
+    with mock.patch(
+        "mlflow.tracing.provider.mlflow.get_tracking_uri",
+        return_value="http://local",
+    ):
+        assert _resolve_experiment_uc_location() is None
+
+    mlflow.tracing.reset()
+
+
+def test_resolve_uc_location_returns_none_when_lookup_fails():
+    from mlflow.tracing.provider import _resolve_experiment_uc_location
+
+    mlflow.tracing.reset()
+
+    with (
+        mock.patch(
+            "mlflow.tracing.provider.mlflow.get_tracking_uri",
+            return_value="databricks",
+        ),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="123"),
+        mock.patch("mlflow.tracking._tracking_service.utils._get_store") as mock_store_fn,
+        mock.patch("mlflow.tracing.client.TracingClient") as tc_cls,
+    ):
+        mock_store_fn.return_value.get_experiment.return_value = _make_experiment(
+            tags={_RESOLVE_UC_DEST_TAG: "some-uuid"}
+        )
+        tc_cls.return_value._get_trace_location.side_effect = RuntimeError("boom")
+
+        assert _resolve_experiment_uc_location() is None
+
+    mlflow.tracing.reset()

--- a/tests/tracking/fluent/test_set_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_set_experiment_trace_location.py
@@ -1,0 +1,132 @@
+from unittest import mock
+
+import pytest
+
+from mlflow.entities import Experiment
+from mlflow.entities.experiment_tag import ExperimentTag
+from mlflow.entities.trace_location import UnityCatalog
+from mlflow.exceptions import MlflowException
+from mlflow.tracking.fluent import _configure_experiment_trace_destination
+
+_DEST_TAG = "mlflow.experiment.databricksTelemetryDestinationId"
+
+
+def _experiment(tags=None):
+    tag_entities = [ExperimentTag(k, v) for k, v in (tags or {}).items()]
+    return Experiment(
+        experiment_id="123",
+        name="test-experiment",
+        artifact_location="file:/tmp",
+        lifecycle_stage="active",
+        tags=tag_entities,
+    )
+
+
+def test_invalid_type_raises():
+    with pytest.raises(MlflowException, match="UnityCatalog"):
+        _configure_experiment_trace_destination(
+            experiment=_experiment(),
+            trace_location="not-a-location",
+            client=mock.MagicMock(),
+        )
+
+
+def test_uc_schema_location_is_rejected():
+    from mlflow.entities.trace_location import UCSchemaLocation
+
+    with pytest.raises(MlflowException, match="UnityCatalog"):
+        _configure_experiment_trace_destination(
+            experiment=_experiment(),
+            trace_location=UCSchemaLocation("catalog", "schema"),
+            client=mock.MagicMock(),
+        )
+
+
+def test_no_trace_location_clears_destination():
+    with (
+        mock.patch("mlflow.tracking.fluent._clear_experiment_derived_destination") as clear_dest,
+        mock.patch("mlflow.tracking.fluent._set_experiment_derived_destination") as set_dest,
+    ):
+        _configure_experiment_trace_destination(
+            experiment=_experiment(),
+            trace_location=None,
+            client=mock.MagicMock(),
+        )
+
+        set_dest.assert_not_called()
+        clear_dest.assert_called_once()
+
+
+def test_creates_and_links_when_no_existing_location():
+    requested = UnityCatalog("catalog", "schema", table_prefix="prefix")
+    resolved = UnityCatalog("catalog", "schema", table_prefix="prefix")
+
+    with (
+        mock.patch("mlflow.tracking.fluent._resolve_tracking_uri", return_value="databricks"),
+        mock.patch("mlflow.tracking.fluent.is_databricks_uri", return_value=True),
+        mock.patch("mlflow.tracking.fluent._set_experiment_derived_destination") as set_dest,
+        mock.patch("mlflow.tracking.fluent.TracingClient") as tc_cls,
+    ):
+        tc = tc_cls.return_value
+        tc._get_trace_location.return_value = None
+        tc._create_or_get_trace_location.return_value = resolved
+
+        _configure_experiment_trace_destination(
+            experiment=_experiment(),
+            trace_location=requested,
+            client=mock.MagicMock(),
+        )
+
+        tc._create_or_get_trace_location.assert_called_once_with(requested)
+        tc._link_trace_location.assert_called_once_with(
+            experiment_id="123",
+            location=resolved,
+        )
+        set_dest.assert_called_once_with(resolved)
+
+
+def test_noop_when_existing_location_matches():
+    requested = UnityCatalog("catalog", "schema", table_prefix="prefix")
+    existing = UnityCatalog("catalog", "schema", table_prefix="prefix")
+    experiment = _experiment(tags={_DEST_TAG: "some-uuid"})
+
+    with (
+        mock.patch("mlflow.tracking.fluent._resolve_tracking_uri", return_value="databricks"),
+        mock.patch("mlflow.tracking.fluent.is_databricks_uri", return_value=True),
+        mock.patch("mlflow.tracking.fluent._set_experiment_derived_destination") as set_dest,
+        mock.patch("mlflow.tracking.fluent.TracingClient") as tc_cls,
+    ):
+        tc = tc_cls.return_value
+        tc._get_trace_location.return_value = existing
+
+        _configure_experiment_trace_destination(
+            experiment=experiment,
+            trace_location=requested,
+            client=mock.MagicMock(),
+        )
+
+        tc._get_trace_location.assert_called_once_with("some-uuid")
+        tc._create_or_get_trace_location.assert_not_called()
+        tc._link_trace_location.assert_not_called()
+        set_dest.assert_called_once_with(existing)
+
+
+def test_errors_when_existing_location_differs():
+    requested = UnityCatalog("catalog", "schema", table_prefix="new_prefix")
+    existing = UnityCatalog("catalog", "schema", table_prefix="old_prefix")
+    experiment = _experiment(tags={_DEST_TAG: "some-uuid"})
+
+    with (
+        mock.patch("mlflow.tracking.fluent._resolve_tracking_uri", return_value="databricks"),
+        mock.patch("mlflow.tracking.fluent.is_databricks_uri", return_value=True),
+        mock.patch("mlflow.tracking.fluent.TracingClient") as tc_cls,
+    ):
+        tc = tc_cls.return_value
+        tc._get_trace_location.return_value = existing
+
+        with pytest.raises(MlflowException, match="already linked to a different"):
+            _configure_experiment_trace_destination(
+                experiment=experiment,
+                trace_location=requested,
+                client=mock.MagicMock(),
+            )

--- a/tests/utils/test_databricks_tracing_utils.py
+++ b/tests/utils/test_databricks_tracing_utils.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 
 import mlflow
@@ -34,10 +35,12 @@ from mlflow.utils.databricks_tracing_utils import (
     get_trace_id_from_assessment_proto,
     inference_table_location_to_proto,
     mlflow_experiment_location_to_proto,
+    parse_uc_location,
     trace_from_proto,
     trace_location_from_proto,
     trace_location_to_proto,
     trace_to_proto,
+    uc_location_to_str,
     uc_schema_location_from_proto,
     uc_schema_location_to_proto,
 )
@@ -51,6 +54,19 @@ def test_trace_location_to_proto_uc_schema():
     assert proto.type == pb.TraceLocation.TraceLocationType.UC_SCHEMA
     assert proto.uc_schema.catalog_name == "test_catalog"
     assert proto.uc_schema.schema_name == "test_schema"
+
+
+def test_parse_uc_location():
+    assert parse_uc_location("catalog.schema") == ("catalog", "schema", None)
+    assert parse_uc_location("catalog.schema.prefix") == ("catalog", "schema", "prefix")
+
+    with pytest.raises(ValueError, match="Invalid UC location"):
+        parse_uc_location("a.b.c.d")
+
+
+def test_uc_location_to_str():
+    assert uc_location_to_str("catalog", "schema") == "catalog.schema"
+    assert uc_location_to_str("catalog", "schema", "prefix") == "catalog.schema.prefix"
 
 
 def test_trace_location_to_proto_mlflow_experiment():


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add support for Unity Catalog trace destinations identified by `catalog.schema.table_prefix`, extending the existing UC schema (2-part) support to 3-part locations.

**Write path:**
- Add `UnityCatalog` entity class and `UC_TABLE_PREFIX` trace location type
- Add experiment-derived destination slot in `UserTraceDestinationRegistry` with precedence: context-local > global > experiment-derived > env
- Wire `set_experiment(..., trace_location=UnityCatalog(...))` with backend create/get/link flow via V5 location APIs (`getLocation`, `createLocation`, `linkTraceLocation`)
- Update UC table processor to generate 3-part V4 trace IDs (`trace:/catalog.schema.prefix/hex`) for `UnityCatalog` destinations
- Add lazy auto-resolution of UC location from experiment tags at provider init time

**Read path:**
- Add centralized `parse_uc_location` helper for 2-part and 3-part UC location parsing
- Update `search_traces`, assessment, and tag APIs for 3-part locations
- Fix `TraceInfo._is_v4()` to recognize `uc_table_prefix` locations for correct V4 serialization
- Fix `TracingClient._group_trace_infos_by_location` to handle `uc_table_prefix` traces (previously silently skipped)
- Update trace ID reconstruction in `TraceInfo.from_proto` for `uc_table_prefix`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests in:
- `tests/tracking/fluent/test_set_experiment_trace_location.py` — tests for `_configure_experiment_trace_destination` (create/link, match, conflict, clear)
- `tests/tracing/test_provider.py` — tests for `_resolve_experiment_uc_location` (tag resolution, no-tag, non-databricks, lookup failure)
- Updated tests in `test_databricks_rest_store.py`, `test_trace_location.py`, `test_databricks_tracing_utils.py`, `test_provider.py`, `test_uc_table_processor.py`

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add support for UC table-prefix trace destinations (`UnityCatalog(catalog, schema, table_prefix)`) in `set_experiment` and `set_destination`, enabling traces to be routed to specific table-prefix locations within a Unity Catalog schema.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)