### PR TITLE
fix: replace 1 bare except clause with except Exception

### DIFF
--- a/dev/clint/tests/rules/test_except_bool_op.py
+++ b/dev/clint/tests/rules/test_except_bool_op.py
@@ -40,7 +40,7 @@ except ValueError:
 # Good - bare except
 try:
     pass
-except:
+except Exception:
     pass
 """
     config = Config(select={ExceptBoolOp.name})


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.