### PR TITLE
Add `update_issue()` method to tracking store

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -647,6 +647,7 @@ class AbstractStore(GatewayStoreMixin):
         status: str | None = None,
         name: str | None = None,
         description: str | None = None,
+        confidence: str | None = None,
     ) -> Issue:
         """
         Update an existing issue.
@@ -656,6 +657,7 @@ class AbstractStore(GatewayStoreMixin):
             status: Optional new status.
             name: Optional new name for the issue.
             description: Optional new description.
+            confidence: Optional new confidence level.
 
         Returns:
             The updated Issue entity.

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -641,6 +641,27 @@ class AbstractStore(GatewayStoreMixin):
         """
         raise MlflowNotImplementedException()
 
+    def update_issue(
+        self,
+        issue_id: str,
+        status: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> Issue:
+        """
+        Update an existing issue.
+
+        Args:
+            issue_id: The ID of the issue to update.
+            status: Optional new status.
+            name: Optional new name for the issue.
+            description: Optional new description.
+
+        Returns:
+            The updated Issue entity.
+        """
+        raise MlflowNotImplementedException()
+
     def log_spans(self, location: str, spans: list[Span], tracking_uri=None) -> list[Span]:
         """
         Log multiple span entities to the tracking store.

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5860,6 +5860,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         status: str | None = None,
         name: str | None = None,
         description: str | None = None,
+        confidence: str | None = None,
     ) -> Issue:
         """
         Update an existing issue.
@@ -5869,6 +5870,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             status: Optional new status.
             name: Optional new name for the issue.
             description: Optional new description.
+            confidence: Optional new confidence level.
 
         Returns:
             The updated Issue entity.
@@ -5889,16 +5891,15 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 sql_issue.name = name
             if description is not None:
                 sql_issue.description = description
+            if confidence is not None:
+                sql_issue.confidence = confidence
 
             # Update last_updated_timestamp
             sql_issue.last_updated_timestamp = get_current_time_millis()
 
             session.flush()
 
-            # Fetch trace_ids for the updated issue
-            trace_ids = self._get_trace_ids_for_issue(session, issue_id)
-
-            return sql_issue.to_mlflow_entity(trace_ids=trace_ids or None)
+            return sql_issue.to_mlflow_entity()
 
     # ===================================================================================
     # Helper Methods for Secrets & Endpoints

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5898,29 +5898,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             # Fetch trace_ids for the updated issue
             trace_ids = self._get_trace_ids_for_issue(session, issue_id)
 
-            return Issue(
-                issue_id=sql_issue.issue_id,
-                experiment_id=sql_issue.experiment_id,
-                run_id=sql_issue.run_id,
-                name=sql_issue.name,
-                description=sql_issue.description,
-                root_cause=sql_issue.root_cause,
-                status=sql_issue.status,
-                frequency=sql_issue.frequency,
-                confidence=sql_issue.confidence,
-                rationale_examples=(
-                    json.loads(sql_issue.rationale_examples)
-                    if sql_issue.rationale_examples
-                    else None
-                ),
-                example_trace_ids=(
-                    json.loads(sql_issue.example_trace_ids) if sql_issue.example_trace_ids else None
-                ),
-                trace_ids=trace_ids or None,
-                created_timestamp=sql_issue.created_timestamp,
-                last_updated_timestamp=sql_issue.last_updated_timestamp,
-                created_by=sql_issue.created_by,
-            )
+            return sql_issue.to_mlflow_entity(trace_ids=trace_ids or None)
 
     # ===================================================================================
     # Helper Methods for Secrets & Endpoints

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5854,6 +5854,74 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
             return sql_issue.to_mlflow_entity()
 
+    def update_issue(
+        self,
+        issue_id: str,
+        status: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> Issue:
+        """
+        Update an existing issue.
+
+        Args:
+            issue_id: The ID of the issue to update.
+            status: Optional new status.
+            name: Optional new name for the issue.
+            description: Optional new description.
+
+        Returns:
+            The updated Issue entity.
+        """
+        with self.ManagedSessionMaker() as session:
+            # Fetch the existing issue
+            sql_issue = session.query(SqlIssue).filter_by(issue_id=issue_id).first()
+            if not sql_issue:
+                raise MlflowException(
+                    f"Issue with ID '{issue_id}' not found",
+                    error_code=RESOURCE_DOES_NOT_EXIST,
+                )
+
+            # Update fields if provided
+            if status is not None:
+                sql_issue.status = status
+            if name is not None:
+                sql_issue.name = name
+            if description is not None:
+                sql_issue.description = description
+
+            # Update last_updated_timestamp
+            sql_issue.last_updated_timestamp = get_current_time_millis()
+
+            session.flush()
+
+            # Fetch trace_ids for the updated issue
+            trace_ids = self._get_trace_ids_for_issue(session, issue_id)
+
+            return Issue(
+                issue_id=sql_issue.issue_id,
+                experiment_id=sql_issue.experiment_id,
+                run_id=sql_issue.run_id,
+                name=sql_issue.name,
+                description=sql_issue.description,
+                root_cause=sql_issue.root_cause,
+                status=sql_issue.status,
+                frequency=sql_issue.frequency,
+                confidence=sql_issue.confidence,
+                rationale_examples=(
+                    json.loads(sql_issue.rationale_examples)
+                    if sql_issue.rationale_examples
+                    else None
+                ),
+                example_trace_ids=(
+                    json.loads(sql_issue.example_trace_ids) if sql_issue.example_trace_ids else None
+                ),
+                trace_ids=trace_ids or None,
+                created_timestamp=sql_issue.created_timestamp,
+                last_updated_timestamp=sql_issue.last_updated_timestamp,
+                created_by=sql_issue.created_by,
+            )
+
     # ===================================================================================
     # Helper Methods for Secrets & Endpoints
     # ===================================================================================

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5877,7 +5877,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         """
         with self.ManagedSessionMaker() as session:
             # Fetch the existing issue
-            sql_issue = session.query(SqlIssue).filter_by(issue_id=issue_id).first()
+            sql_issue = (
+                self._get_query(session, SqlIssue).filter(SqlIssue.issue_id == issue_id).first()
+            )
             if not sql_issue:
                 raise MlflowException(
                     f"Issue with ID '{issue_id}' not found",

--- a/tests/store/tracking/test_sqlalchemy_store_issues.py
+++ b/tests/store/tracking/test_sqlalchemy_store_issues.py
@@ -136,12 +136,13 @@ def test_update_issue(store):
         confidence="low",
     )
 
-    # Update all supported fields (status, name, description)
+    # Update all supported fields (status, name, description, confidence)
     updated_issue = store.update_issue(
         issue_id=created_issue.issue_id,
         status="accepted",
         name="Updated name",
         description="Updated description",
+        confidence="high",
     )
 
     # Verify updated fields
@@ -150,10 +151,10 @@ def test_update_issue(store):
     assert updated_issue.status == "accepted"
     assert updated_issue.name == "Updated name"
     assert updated_issue.description == "Updated description"
+    assert updated_issue.confidence == "high"
 
     # Verify other fields remain unchanged
     assert updated_issue.root_causes == ["Initial root cause"]
-    assert updated_issue.confidence == "low"
     assert updated_issue.source_run_id is None
     assert updated_issue.created_by == created_issue.created_by
     assert updated_issue.created_timestamp == created_issue.created_timestamp
@@ -164,8 +165,8 @@ def test_update_issue(store):
     assert retrieved_issue.status == "accepted"
     assert retrieved_issue.name == "Updated name"
     assert retrieved_issue.description == "Updated description"
+    assert retrieved_issue.confidence == "high"
     assert retrieved_issue.root_causes == ["Initial root cause"]
-    assert retrieved_issue.confidence == "low"
     assert retrieved_issue.last_updated_timestamp == updated_issue.last_updated_timestamp
 
 

--- a/tests/store/tracking/test_sqlalchemy_store_issues.py
+++ b/tests/store/tracking/test_sqlalchemy_store_issues.py
@@ -122,3 +122,79 @@ def test_get_issue(store):
 def test_get_issue_nonexistent(store):
     with pytest.raises(MlflowException, match=r"Issue with ID 'nonexistent-id' not found"):
         store.get_issue("nonexistent-id")
+
+
+def test_update_issue(store):
+    exp_id = store.create_experiment("test")
+
+    created_issue = store.create_issue(
+        experiment_id=exp_id,
+        name="Original name",
+        description="Original description",
+        status="draft",
+        root_causes=["Initial root cause"],
+        confidence="low",
+    )
+
+    # Update all supported fields (status, name, description)
+    updated_issue = store.update_issue(
+        issue_id=created_issue.issue_id,
+        status="accepted",
+        name="Updated name",
+        description="Updated description",
+    )
+
+    # Verify updated fields
+    assert updated_issue.issue_id == created_issue.issue_id
+    assert updated_issue.experiment_id == exp_id
+    assert updated_issue.status == "accepted"
+    assert updated_issue.name == "Updated name"
+    assert updated_issue.description == "Updated description"
+
+    # Verify other fields remain unchanged
+    assert updated_issue.root_causes == ["Initial root cause"]
+    assert updated_issue.confidence == "low"
+    assert updated_issue.source_run_id is None
+    assert updated_issue.created_by == created_issue.created_by
+    assert updated_issue.created_timestamp == created_issue.created_timestamp
+    assert updated_issue.last_updated_timestamp > created_issue.last_updated_timestamp
+
+    # Verify the updates are persisted by retrieving the issue again
+    retrieved_issue = store.get_issue(created_issue.issue_id)
+    assert retrieved_issue.status == "accepted"
+    assert retrieved_issue.name == "Updated name"
+    assert retrieved_issue.description == "Updated description"
+    assert retrieved_issue.root_causes == ["Initial root cause"]
+    assert retrieved_issue.confidence == "low"
+    assert retrieved_issue.last_updated_timestamp == updated_issue.last_updated_timestamp
+
+
+def test_update_issue_partial(store):
+    exp_id = store.create_experiment("test")
+
+    created_issue = store.create_issue(
+        experiment_id=exp_id,
+        name="Test issue",
+        description="Test description",
+        status="draft",
+        root_causes=["Initial root cause"],
+    )
+
+    # Update only status field
+    updated_issue = store.update_issue(
+        issue_id=created_issue.issue_id,
+        status="accepted",
+    )
+
+    # Verify updated field changed
+    assert updated_issue.status == "accepted"
+
+    # Verify other fields unchanged
+    assert updated_issue.name == "Test issue"
+    assert updated_issue.description == "Test description"
+    assert updated_issue.root_causes == ["Initial root cause"]
+
+
+def test_update_issue_nonexistent(store):
+    with pytest.raises(MlflowException, match=r"Issue with ID 'nonexistent-id' not found"):
+        store.update_issue(issue_id="nonexistent-id", status="accepted")

--- a/tests/store/tracking/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/test_sqlalchemy_workspace_store.py
@@ -2149,3 +2149,31 @@ def test_create_issue_is_workspace_scoped(workspace_tracking_store):
 
         with pytest.raises(MlflowException, match=f"Issue with ID '{issue_a.issue_id}' not found"):
             workspace_tracking_store.get_issue(issue_a.issue_id)
+
+
+def test_update_issue_is_workspace_scoped(workspace_tracking_store):
+    with WorkspaceContext("team-a"):
+        exp_id_a = workspace_tracking_store.create_experiment("issue-exp-update-a")
+        issue_a = workspace_tracking_store.create_issue(
+            experiment_id=exp_id_a,
+            name="Original Name",
+            description="Original description",
+            status="open",
+        )
+        updated_issue = workspace_tracking_store.update_issue(
+            issue_id=issue_a.issue_id,
+            name="Updated Name A",
+            status="in_progress",
+        )
+        assert updated_issue.name == "Updated Name A"
+        assert updated_issue.status == "in_progress"
+
+    with WorkspaceContext("team-b"):
+        with pytest.raises(
+            MlflowException, match=f"Issue with ID '{issue_a.issue_id}' not found"
+        ) as excinfo:
+            workspace_tracking_store.update_issue(
+                issue_id=issue_a.issue_id,
+                name="Should not update",
+            )
+        assert excinfo.value.error_code == "RESOURCE_DOES_NOT_EXIST"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21187/files) to review incremental changes.
- [**stack/update_issue_store**](https://github.com/mlflow/mlflow/pull/21187) [[Files changed](https://github.com/mlflow/mlflow/pull/21187/files)]
  - [stack/search_issues_store](https://github.com/mlflow/mlflow/pull/21189) [[Files changed](https://github.com/mlflow/mlflow/pull/21189/files/2f67200e040f0a8bd91894939acc41377a122e47..5ffd0c2b35310f1ead0a20804ddb79dc6ea97d17)]
    - [stack/add_status](https://github.com/mlflow/mlflow/pull/21360) [[Files changed](https://github.com/mlflow/mlflow/pull/21360/files/5ffd0c2b35310f1ead0a20804ddb79dc6ea97d17..671a65d8c73567e12385e06c06b6c0232b265614)]
      - [stack/handlers](https://github.com/mlflow/mlflow/pull/21361) [[Files changed](https://github.com/mlflow/mlflow/pull/21361/files/671a65d8c73567e12385e06c06b6c0232b265614..ad4ad02572f95d2da5f889820182f0c9a9b92c79)]
        - [stack/search_traces_with_issue_id](https://github.com/mlflow/mlflow/pull/21363) [[Files changed](https://github.com/mlflow/mlflow/pull/21363/files/ad4ad02572f95d2da5f889820182f0c9a9b92c79..47d82824f3a75763376ae06bac9b30c1af3f069f)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Support update issue
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
