### PR TITLE
Fix: MLFLOW_ALLOW_PICKLE_DESERIALIZATION=False safety control is ineffective for pyfunc flavor

### DIFF
--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -1262,13 +1262,12 @@ def _load_context_model_and_signature(model_path: str, model_config: dict[str, A
             and not is_in_databricks_runtime()
             and not is_in_databricks_model_serving_environment()
         ):
-            mlflow.pyfunc._logger.warning(
-                "Saving the Pyfunc models in the CloudPickle format requires exercising "
-                "caution as Python's object serialization mechanism may execute arbitrary code "
-                "during deserialization. "
-                "The recommended safe alternative is saving it as the model-from-code "
-                "artifacts, see https://mlflow.org/docs/latest/ml/model/models-from-code/ "
-                "for details",
+            raise MlflowException(
+                "Deserializing model using pickle is disallowed, but this model is saved "
+                "in cloudpickle format. To address this issue, you need to set environment "
+                "variable 'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true'; or save the model as "
+                "model-from-code artifacts, see "
+                "https://mlflow.org/docs/latest/ml/model/models-from-code/ for details."
             )
         python_model_cloudpickle_version = pyfunc_config.get(CONFIG_KEY_CLOUDPICKLE_VERSION, None)
         if python_model_cloudpickle_version is None:

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -1266,8 +1266,8 @@ def _load_context_model_and_signature(model_path: str, model_config: dict[str, A
                 "Deserializing model using pickle is disallowed, but this model is saved "
                 "in cloudpickle format. The recommended way is to save the model as "
                 "models-from-code artifacts, see "
-                "https://mlflow.org/docs/latest/ml/model/models-from-code/ for details."
-                " Another workaround is to set environment "
+                "https://mlflow.org/docs/latest/ml/model/models-from-code/ for details. "
+                "Another workaround is to set environment "
                 "variable 'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true' to allow "
                 "deserializing model using pickle."
             )

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -1267,7 +1267,7 @@ def _load_context_model_and_signature(model_path: str, model_config: dict[str, A
                 "in cloudpickle format. The recommended way is to save the model as "
                 "models-from-code artifacts, see "
                 "https://mlflow.org/docs/latest/ml/model/models-from-code/ for details."
-                "Another workaround is to set environment "
+                " Another workaround is to set environment "
                 "variable 'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true' to allow "
                 "deserializing model using pickle."
             )

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -1264,10 +1264,12 @@ def _load_context_model_and_signature(model_path: str, model_config: dict[str, A
         ):
             raise MlflowException(
                 "Deserializing model using pickle is disallowed, but this model is saved "
-                "in cloudpickle format. To address this issue, you need to set environment "
-                "variable 'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true'; or save the model as "
-                "model-from-code artifacts, see "
+                "in cloudpickle format. The recommended way is to save the model as "
+                "models-from-code artifacts, see "
                 "https://mlflow.org/docs/latest/ml/model/models-from-code/ for details."
+                "Another workaround is to set environment "
+                "variable 'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true' to allow "
+                "deserializing model using pickle."
             )
         python_model_cloudpickle_version = pyfunc_config.get(CONFIG_KEY_CLOUDPICKLE_VERSION, None)
         if python_model_cloudpickle_version is None:


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix: MLFLOW_ALLOW_PICKLE_DESERIALIZATION=False safety control is ineffective for pyfunc flavor
### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
