### PR TITLE
Add `sum_gateway_trace_cost` method in gateway mixin

### DIFF
--- a/mlflow/store/tracking/gateway/abstract_mixin.py
+++ b/mlflow/store/tracking/gateway/abstract_mixin.py
@@ -530,3 +530,23 @@ class GatewayStoreMixin:
             PagedList of GatewayBudgetPolicy entities.
         """
         raise NotImplementedError(self.__class__.__name__)
+
+    def sum_gateway_trace_cost(
+        self,
+        start_time_ms: int,
+        end_time_ms: int,
+        workspace: str | None = None,
+    ) -> float:
+        """
+        Sum total_cost from span metrics for gateway traces within a time range.
+
+        Args:
+            start_time_ms: Window start in epoch milliseconds (inclusive).
+            end_time_ms: Window end in epoch milliseconds (exclusive).
+            workspace: If provided, filter to traces in experiments belonging
+                to this workspace.
+
+        Returns:
+            Total cost in USD.
+        """
+        raise NotImplementedError(self.__class__.__name__)

--- a/tests/store/tracking/test_gateway_sql_store.py
+++ b/tests/store/tracking/test_gateway_sql_store.py
@@ -44,6 +44,10 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlOnlineScoringConfig,
     SqlScorer,
     SqlScorerVersion,
+    SqlSpan,
+    SqlSpanMetrics,
+    SqlTraceInfo,
+    SqlTraceMetadata,
 )
 from mlflow.store.tracking.gateway.config_resolver import (
     get_endpoint_config,
@@ -51,6 +55,7 @@ from mlflow.store.tracking.gateway.config_resolver import (
 )
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.tracking.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyStore
+from mlflow.tracing.constant import SpanMetricKey, TraceMetadataKey
 from mlflow.utils.workspace_context import WorkspaceContext
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
@@ -79,6 +84,10 @@ def _cleanup_database(store: SqlAlchemyStore):
             SqlOnlineScoringConfig,
             SqlScorerVersion,
             SqlScorer,
+            SqlSpanMetrics,
+            SqlSpan,
+            SqlTraceMetadata,
+            SqlTraceInfo,
             SqlExperimentTag,
             SqlExperiment,
         ):
@@ -2220,3 +2229,102 @@ def test_create_budget_policy_all_budget_actions(store: SqlAlchemyStore):
             budget_action=action,
         )
         assert policy.budget_action == action
+
+
+# =============================================================================
+# sum_gateway_trace_cost Tests
+# =============================================================================
+
+
+def _insert_trace_with_cost(
+    session,
+    experiment_id,
+    trace_id,
+    timestamp_ms,
+    span_costs,
+    is_gateway=True,
+    endpoint_id="ep-test",
+):
+    trace = SqlTraceInfo(
+        request_id=trace_id,
+        experiment_id=experiment_id,
+        timestamp_ms=timestamp_ms,
+        execution_time_ms=100,
+        status="OK",
+    )
+    session.add(trace)
+    session.flush()
+
+    if is_gateway:
+        metadata = SqlTraceMetadata(
+            request_id=trace_id,
+            key=TraceMetadataKey.GATEWAY_ENDPOINT_ID,
+            value=endpoint_id,
+        )
+        session.add(metadata)
+
+    for span_id, cost in span_costs:
+        span = SqlSpan(
+            trace_id=trace_id,
+            experiment_id=experiment_id,
+            span_id=span_id,
+            status="OK",
+            start_time_unix_nano=timestamp_ms * 1_000_000,
+            end_time_unix_nano=(timestamp_ms + 100) * 1_000_000,
+            content="{}",
+        )
+        session.add(span)
+        session.flush()
+
+        metric = SqlSpanMetrics(
+            trace_id=trace_id,
+            span_id=span_id,
+            key=SpanMetricKey.TOTAL_COST,
+            value=cost,
+        )
+        session.add(metric)
+
+    session.flush()
+
+
+def test_sum_gateway_trace_cost_basic(store: SqlAlchemyStore):
+    exp = store.create_experiment("cost-test-basic")
+    exp_id = int(exp)
+
+    with store.ManagedSessionMaker() as session:
+        _insert_trace_with_cost(session, exp_id, "t1", 1000, [("s1", 0.05), ("s2", 0.03)])
+        _insert_trace_with_cost(session, exp_id, "t2", 2000, [("s1", 0.10)])
+
+    total = store.sum_gateway_trace_cost(start_time_ms=0, end_time_ms=5000)
+    assert abs(total - 0.18) < 1e-9
+
+
+def test_sum_gateway_trace_cost_excludes_non_gateway(store: SqlAlchemyStore):
+    exp = store.create_experiment("cost-test-non-gw")
+    exp_id = int(exp)
+
+    with store.ManagedSessionMaker() as session:
+        _insert_trace_with_cost(session, exp_id, "gw1", 1000, [("s1", 0.10)], is_gateway=True)
+        _insert_trace_with_cost(session, exp_id, "nongw1", 1000, [("s1", 0.50)], is_gateway=False)
+
+    total = store.sum_gateway_trace_cost(start_time_ms=0, end_time_ms=5000)
+    assert abs(total - 0.10) < 1e-9
+
+
+def test_sum_gateway_trace_cost_time_window(store: SqlAlchemyStore):
+    exp = store.create_experiment("cost-test-window")
+    exp_id = int(exp)
+
+    with store.ManagedSessionMaker() as session:
+        _insert_trace_with_cost(session, exp_id, "early", 500, [("s1", 0.01)])
+        _insert_trace_with_cost(session, exp_id, "in-window", 1500, [("s1", 0.05)])
+        _insert_trace_with_cost(session, exp_id, "late", 3000, [("s1", 0.99)])
+
+    # Only in-window trace should be included
+    total = store.sum_gateway_trace_cost(start_time_ms=1000, end_time_ms=2000)
+    assert abs(total - 0.05) < 1e-9
+
+
+def test_sum_gateway_trace_cost_empty(store: SqlAlchemyStore):
+    total = store.sum_gateway_trace_cost(start_time_ms=0, end_time_ms=5000)
+    assert total == 0.0

--- a/tests/store/tracking/test_gateway_sql_store.py
+++ b/tests/store/tracking/test_gateway_sql_store.py
@@ -2347,11 +2347,15 @@ def test_sum_gateway_trace_cost_workspace_filter(store: SqlAlchemyStore):
         _insert_trace_with_cost(session, exp_ws_b.experiment_id, "t-b", 1000, [("s1", 0.25)])
 
     # Filtering by workspace-a should only include 0.10
-    total_a = store.sum_gateway_trace_cost(start_time_ms=0, end_time_ms=5000, workspace="workspace-a")
+    total_a = store.sum_gateway_trace_cost(
+        start_time_ms=0, end_time_ms=5000, workspace="workspace-a"
+    )
     assert abs(total_a - 0.10) < 1e-9
 
     # Filtering by workspace-b should only include 0.25
-    total_b = store.sum_gateway_trace_cost(start_time_ms=0, end_time_ms=5000, workspace="workspace-b")
+    total_b = store.sum_gateway_trace_cost(
+        start_time_ms=0, end_time_ms=5000, workspace="workspace-b"
+    )
     assert abs(total_b - 0.25) < 1e-9
 
     # No workspace filter should include both

--- a/tests/store/tracking/test_gateway_sql_store.py
+++ b/tests/store/tracking/test_gateway_sql_store.py
@@ -2325,6 +2325,40 @@ def test_sum_gateway_trace_cost_time_window(store: SqlAlchemyStore):
     assert abs(total - 0.05) < 1e-9
 
 
+def test_sum_gateway_trace_cost_workspace_filter(store: SqlAlchemyStore):
+    with store.ManagedSessionMaker() as session:
+        # Create two experiments in different workspaces
+        exp_ws_a = SqlExperiment(
+            name=f"cost-ws-a-{uuid.uuid4().hex}",
+            artifact_location="/tmp/a",
+            lifecycle_stage="active",
+            workspace="workspace-a",
+        )
+        exp_ws_b = SqlExperiment(
+            name=f"cost-ws-b-{uuid.uuid4().hex}",
+            artifact_location="/tmp/b",
+            lifecycle_stage="active",
+            workspace="workspace-b",
+        )
+        session.add_all([exp_ws_a, exp_ws_b])
+        session.flush()
+
+        _insert_trace_with_cost(session, exp_ws_a.experiment_id, "t-a", 1000, [("s1", 0.10)])
+        _insert_trace_with_cost(session, exp_ws_b.experiment_id, "t-b", 1000, [("s1", 0.25)])
+
+    # Filtering by workspace-a should only include 0.10
+    total_a = store.sum_gateway_trace_cost(start_time_ms=0, end_time_ms=5000, workspace="workspace-a")
+    assert abs(total_a - 0.10) < 1e-9
+
+    # Filtering by workspace-b should only include 0.25
+    total_b = store.sum_gateway_trace_cost(start_time_ms=0, end_time_ms=5000, workspace="workspace-b")
+    assert abs(total_b - 0.25) < 1e-9
+
+    # No workspace filter should include both
+    total_all = store.sum_gateway_trace_cost(start_time_ms=0, end_time_ms=5000)
+    assert abs(total_all - 0.35) < 1e-9
+
+
 def test_sum_gateway_trace_cost_empty(store: SqlAlchemyStore):
     total = store.sum_gateway_trace_cost(start_time_ms=0, end_time_ms=5000)
     assert total == 0.0


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21198/files) to review incremental changes.
- [**stack/budget/4-2-refactor**](https://github.com/mlflow/mlflow/pull/21198) [[Files changed](https://github.com/mlflow/mlflow/pull/21198/files)]
  - [stack/budget/5-webhook-fire](https://github.com/mlflow/mlflow/pull/21112) [[Files changed](https://github.com/mlflow/mlflow/pull/21112/files/ec1b3b0fb587384ddf492b6ea0184be021eb9629..eca7ce9012b16a6198607181ed2f3f4646ba47cd)]
    - [stack/budget/6-rejection](https://github.com/mlflow/mlflow/pull/21114) [[Files changed](https://github.com/mlflow/mlflow/pull/21114/files/eca7ce9012b16a6198607181ed2f3f4646ba47cd..b14260b948f2898c6d51b25edf6516944e65a224)]
      - [stack/budget/7-ui](https://github.com/mlflow/mlflow/pull/21116) [[Files changed](https://github.com/mlflow/mlflow/pull/21116/files/b14260b948f2898c6d51b25edf6516944e65a224..5a430ce758fda9b8b76ab6d8e5354bcb6436871d)]
        - [stack/budget/8-auth](https://github.com/mlflow/mlflow/pull/21120) [[Files changed](https://github.com/mlflow/mlflow/pull/21120/files/5a430ce758fda9b8b76ab6d8e5354bcb6436871d..aca1adcb6ca9880d4fe38b4120f8d617cf0b3a79)]
          - [stack/budget/9-docs](https://github.com/mlflow/mlflow/pull/21121) [[Files changed](https://github.com/mlflow/mlflow/pull/21121/files/aca1adcb6ca9880d4fe38b4120f8d617cf0b3a79..3855696afc9a3ceecf127273c21d577dd9e0b0a6)]

---------
### What changes are proposed in this pull request?

Add `sum_gateway_trace_cost` to the gateway store layer for querying historical spend within a budget window. This is used by the budget tracker to backfill cumulative spend on server restart or when new policies are created, so budgets aren't effectively reset.

Changes:
- Add `sum_gateway_trace_cost(start_time_ms, end_time_ms, workspace)` abstract method to `GatewayStoreMixin`
- Implement in `SqlAlchemyGatewayStoreMixin`: joins trace info → trace metadata (filtering by gateway endpoint ID) → span metrics (summing `total_cost`), with optional workspace filtering via experiment
- Hoist lazy imports in `sqlalchemy_mixin.py` to top-level (`func`, `select`, `SqlExperiment`, `SqlSpanMetrics`, `SqlTraceInfo`, `SqlTraceMetadata`, `SpanMetricKey`, `TraceMetadataKey`)
- Add tests covering basic cost summation, workspace filtering, time range filtering, empty results, and multiple traces

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
