### PR TITLE
Add auto-dismissing notification for issue detection job submission

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModal.test.tsx
@@ -395,4 +395,31 @@ describe('IssueDetectionModal', () => {
     });
     expect(mockCreateSecret).not.toHaveBeenCalled();
   });
+
+  test('calls onSubmitSuccess callback when form is submitted', async () => {
+    const userEvent = (await import('@testing-library/user-event')).default;
+    const onClose = jest.fn();
+    const onSubmitSuccess = jest.fn();
+
+    renderWithDesignSystem(
+      <IssueDetectionModal
+        {...defaultProps}
+        onClose={onClose}
+        initialSelectedTraceIds={['trace-1']}
+        onSubmitSuccess={onSubmitSuccess}
+      />,
+    );
+
+    await userEvent.selectOptions(screen.getByTestId('provider-select'), 'openai');
+    await userEvent.selectOptions(screen.getByTestId('model-select'), 'gpt-4');
+    await userEvent.click(screen.getByTestId('set-existing-key'));
+
+    const submitButton = screen.getByText('Run Analysis').closest('button')!;
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitSuccess).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModal.test.tsx
@@ -411,7 +411,6 @@ describe('IssueDetectionModal', () => {
     );
 
     await userEvent.selectOptions(screen.getByTestId('provider-select'), 'openai');
-    await userEvent.selectOptions(screen.getByTestId('model-select'), 'gpt-4');
     await userEvent.click(screen.getByTestId('set-existing-key'));
 
     const submitButton = screen.getByText('Run Analysis').closest('button')!;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModal.tsx
@@ -24,6 +24,7 @@ interface IssueDetectionModalProps {
   onClose: () => void;
   experimentId?: string;
   initialSelectedTraceIds?: string[];
+  onSubmitSuccess?: () => void;
 }
 
 const DEFAULT_API_KEY_CONFIG: ApiKeyConfiguration = {
@@ -48,6 +49,7 @@ export const IssueDetectionModal: React.FC<IssueDetectionModalProps> = ({
   onClose,
   experimentId,
   initialSelectedTraceIds = [],
+  onSubmitSuccess,
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -108,6 +110,7 @@ export const IssueDetectionModal: React.FC<IssueDetectionModalProps> = ({
   const handleSubmit = () => {
     const completeSubmit = () => {
       // TODO: Implement backend API call for issue detection
+      onSubmitSuccess?.();
       resetForm();
       onClose();
     };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -64,6 +64,7 @@ import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
 import { AssistantAwareDrawer } from '@mlflow/mlflow/src/common/components/AssistantAwareDrawer';
 import { useRunScorerInTracesViewConfiguration } from '../../../../pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration';
 import { IssueDetectionModal } from './IssueDetectionModal';
+import { useIssueDetectionNotification } from './hooks/useIssueDetectionNotification';
 
 const JudgeContextProvider = ({ children }: { children: React.ReactNode }) => {
   const runJudgeConfiguration = useRunScorerInTracesViewConfiguration();
@@ -139,6 +140,8 @@ const TracesV3LogsImpl = React.memo(
     const enableTraceInsights = shouldEnableTraceInsights();
     const [isGroupedBySession, setIsGroupedBySession] = useState(false);
     const [isIssueDetectionModalOpen, setIsIssueDetectionModalOpen] = useState(false);
+    const { showIssueDetectionNotification, notificationContextHolder } =
+      useIssueDetectionNotification(singleExperimentId);
 
     // Check if we're already inside a provider (e.g., from SelectTracesModal)
     // If so, we won't create our own provider to avoid shadowing the parent's selection state
@@ -458,8 +461,10 @@ const TracesV3LogsImpl = React.memo(
               initialSelectedTraceIds={Object.entries(rowSelection)
                 .filter(([, isSelected]) => isSelected)
                 .map(([traceId]) => traceId)}
+              onSubmitSuccess={showIssueDetectionNotification}
             />
           )}
+          {notificationContextHolder}
         </GenAITracesTableProvider>
       </ModelTraceExplorerContextProvider>
     );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useIssueDetectionNotification.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useIssueDetectionNotification.test.tsx
@@ -1,0 +1,165 @@
+import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { renderHook, act, waitFor, screen } from '@testing-library/react';
+import { renderWithDesignSystem } from '../../../../../../common/utils/TestUtils.react18';
+import { useIssueDetectionNotification } from './useIssueDetectionNotification';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { IntlProvider } from 'react-intl';
+import { MemoryRouter } from '../../../../../../common/utils/RoutingUtils';
+import React from 'react';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>
+    <IntlProvider locale="en" messages={{}}>
+      <DesignSystemProvider>{children}</DesignSystemProvider>
+    </IntlProvider>
+  </MemoryRouter>
+);
+
+describe('useIssueDetectionNotification', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('returns showIssueDetectionNotification function and notificationContextHolder', () => {
+    const { result } = renderHook(() => useIssueDetectionNotification('exp-123'), { wrapper });
+
+    expect(result.current.showIssueDetectionNotification).toBeInstanceOf(Function);
+    expect(result.current.notificationContextHolder).toBeDefined();
+  });
+
+  test('notification is not visible initially', () => {
+    const { result } = renderHook(() => useIssueDetectionNotification('exp-123'), { wrapper });
+
+    const TestComponent = () => <>{result.current.notificationContextHolder}</>;
+    renderWithDesignSystem(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('Issue detection job triggered')).not.toBeInTheDocument();
+  });
+
+  test('notification becomes visible when showIssueDetectionNotification is called', async () => {
+    const { result } = renderHook(() => useIssueDetectionNotification('exp-123'), { wrapper });
+
+    const TestComponent = () => <>{result.current.notificationContextHolder}</>;
+    const { rerender } = renderWithDesignSystem(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      result.current.showIssueDetectionNotification();
+    });
+
+    rerender(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Issue detection job triggered')).toBeInTheDocument();
+    });
+  });
+
+  test('notification shows View status link when experimentId is provided', async () => {
+    const { result } = renderHook(() => useIssueDetectionNotification('exp-123'), { wrapper });
+
+    const TestComponent = () => <>{result.current.notificationContextHolder}</>;
+    const { rerender } = renderWithDesignSystem(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      result.current.showIssueDetectionNotification();
+    });
+
+    rerender(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('View status')).toBeInTheDocument();
+    });
+
+    const link = screen.getByText('View status').closest('a');
+    expect(link).toHaveAttribute('href', expect.stringContaining('/experiments/exp-123/evaluation-runs'));
+  });
+
+  test('notification does not show View status link when experimentId is not provided', async () => {
+    const { result } = renderHook(() => useIssueDetectionNotification(undefined), { wrapper });
+
+    const TestComponent = () => <>{result.current.notificationContextHolder}</>;
+    const { rerender } = renderWithDesignSystem(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      result.current.showIssueDetectionNotification();
+    });
+
+    rerender(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Issue detection job triggered')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('View status')).not.toBeInTheDocument();
+  });
+
+  test('notification auto-dismisses after 10 seconds', async () => {
+    const { result } = renderHook(() => useIssueDetectionNotification('exp-123'), { wrapper });
+
+    const TestComponent = () => <>{result.current.notificationContextHolder}</>;
+    const { rerender } = renderWithDesignSystem(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      result.current.showIssueDetectionNotification();
+    });
+
+    rerender(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Issue detection job triggered')).toBeInTheDocument();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    rerender(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Issue detection job triggered')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useIssueDetectionNotification.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useIssueDetectionNotification.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useState, useEffect, useRef } from 'react';
+import { keyframes } from '@emotion/react';
+import { Notification, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+import { Link } from '../../../../../../common/utils/RoutingUtils';
+import Routes from '../../../../../routes';
+import { ExperimentPageTabName } from '../../../../../constants';
+
+const NOTIFICATION_DURATION_MS = 10000;
+
+const shrinkProgressAnimation = keyframes`
+  from {
+    width: 100%;
+  }
+  to {
+    width: 0%;
+  }
+`;
+
+export const useIssueDetectionNotification = (experimentId?: string) => {
+  const { theme } = useDesignSystemTheme();
+  const [isOpen, setIsOpen] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const evaluationRunsLink = experimentId
+    ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.EvaluationRuns)
+    : undefined;
+
+  const showIssueDetectionNotification = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    setIsOpen(true);
+    timerRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, NOTIFICATION_DURATION_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const notificationContextHolder = (
+    <Notification.Provider>
+      <Notification.Root
+        componentId="mlflow.traces.issue-detection-notification"
+        open={isOpen}
+        onOpenChange={setIsOpen}
+      >
+        <div css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.sm }}>
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, flex: 1 }}>
+            <Notification.Title>
+              <FormattedMessage
+                defaultMessage="Issue detection job triggered"
+                description="Notification message when issue detection job is started"
+              />
+            </Notification.Title>
+            <Notification.Description>
+              <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+                {evaluationRunsLink && (
+                  <Link to={evaluationRunsLink}>
+                    <FormattedMessage
+                      defaultMessage="View status"
+                      description="Link to view issue detection job status"
+                    />
+                  </Link>
+                )}
+                <div
+                  css={{
+                    height: 4,
+                    backgroundColor: theme.colors.backgroundSecondary,
+                    borderRadius: 2,
+                    overflow: 'hidden',
+                    marginTop: theme.spacing.xs,
+                  }}
+                >
+                  {isOpen && (
+                    <div
+                      css={{
+                        height: '100%',
+                        backgroundColor: theme.colors.actionPrimaryBackgroundDefault,
+                        borderRadius: 2,
+                        animation: `${shrinkProgressAnimation} ${NOTIFICATION_DURATION_MS}ms linear forwards`,
+                      }}
+                    />
+                  )}
+                </div>
+              </div>
+            </Notification.Description>
+          </div>
+          <Notification.Close componentId="mlflow.traces.issue-detection-notification.close" />
+        </div>
+      </Notification.Root>
+      <Notification.Viewport css={{ position: 'fixed', top: theme.spacing.lg, right: theme.spacing.lg }} />
+    </Notification.Provider>
+  );
+
+  return {
+    showIssueDetectionNotification,
+    notificationContextHolder,
+  };
+};

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useIssueDetectionNotification.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useIssueDetectionNotification.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useRef } from 'react';
+import { useCallback, useState } from 'react';
 import { keyframes } from '@emotion/react';
 import { Notification, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
@@ -20,28 +20,13 @@ const shrinkProgressAnimation = keyframes`
 export const useIssueDetectionNotification = (experimentId?: string) => {
   const { theme } = useDesignSystemTheme();
   const [isOpen, setIsOpen] = useState(false);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
 
   const evaluationRunsLink = experimentId
     ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.EvaluationRuns)
     : undefined;
 
   const showIssueDetectionNotification = useCallback(() => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-    }
     setIsOpen(true);
-    timerRef.current = setTimeout(() => {
-      setIsOpen(false);
-    }, NOTIFICATION_DURATION_MS);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
   }, []);
 
   const notificationContextHolder = (
@@ -50,8 +35,9 @@ export const useIssueDetectionNotification = (experimentId?: string) => {
         componentId="mlflow.traces.issue-detection-notification"
         open={isOpen}
         onOpenChange={setIsOpen}
+        duration={NOTIFICATION_DURATION_MS}
       >
-        <div css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.sm }}>
+        <div css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.sm, paddingLeft: theme.spacing.sm }}>
           <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, flex: 1 }}>
             <Notification.Title>
               <FormattedMessage

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2606,6 +2606,10 @@
     "defaultMessage": "Prompt Template",
     "description": "Experiment page > new run modal > prompt examples > prompt template title"
   },
+  "GGbdya": {
+    "defaultMessage": "View status",
+    "description": "Link to view issue detection job status"
+  },
   "GJWVBA": {
     "defaultMessage": "Inputs",
     "description": "Table subtitle for schema inputs in the model comparison page"
@@ -8950,6 +8954,10 @@
   "xyQFjH": {
     "defaultMessage": "Prompt Caching",
     "description": "Filter option for prompt caching support"
+  },
+  "y2E9ui": {
+    "defaultMessage": "Issue detection job triggered",
+    "description": "Notification message when issue detection job is started"
   },
   "y2oQyU": {
     "defaultMessage": "Model name",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21209/files) to review incremental changes.
- [**stack/pending_job_display**](https://github.com/mlflow/mlflow/pull/21209) [[Files changed](https://github.com/mlflow/mlflow/pull/21209/files)]
  - [stack/issue_categories](https://github.com/mlflow/mlflow/pull/21398) [[Files changed](https://github.com/mlflow/mlflow/pull/21398/files/86fde66b1a0a3f08f72cd36f9299152a30e748c0..e9d306dcb25e4a75e8c3b03dd2181401cdf64cda)]
    - [stack/enable_issue_button](https://github.com/mlflow/mlflow/pull/21205) [[Files changed](https://github.com/mlflow/mlflow/pull/21205/files/e9d306dcb25e4a75e8c3b03dd2181401cdf64cda..e928cabf20e9c94d19e86c5befb8b8f25741cbe6)]
      - [stack/simplify_with_one_model](https://github.com/mlflow/mlflow/pull/21437) [[Files changed](https://github.com/mlflow/mlflow/pull/21437/files/e928cabf20e9c94d19e86c5befb8b8f25741cbe6..538586f1167e97324622522e19ccdcc82c3baead)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Add notification after the job is triggered, it should show a link to the triggered job/run (currently a placeholder to eval runs tab until the backend is ready), the notification will disappear automatically after 10 seconds.
This is needed because we won't add an explicit tab for issue detection jobs, then it's hard for users to find where the result is.

https://github.com/user-attachments/assets/28955467-5b59-4acd-b69b-cf7d8b53cac1



<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
