### PR TITLE
Fix MlflowClient.copy_model_version for the case that copy UC model across workspaces

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -678,13 +678,7 @@ class Model:
         model metadata.
         """
         if logged_model is None and self.model_id is not None:
-            try:
-                logged_model = mlflow.get_logged_model(model_id=self.model_id)
-            except MlflowException as e:
-                if e.error_code != ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
-                    raise
-                # model_id may belong to a different workspace (e.g. during cross-workspace
-                # model version copy). Proceed without the logged model.
+            logged_model = mlflow.get_logged_model(model_id=self.model_id)
         return ModelInfo(
             artifact_path=self.artifact_path,
             flavors=self.flavors,

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -25,7 +25,6 @@ from mlflow.models.resources import Resource, ResourceType, _ResourceBuilder
 from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
     RESOURCE_DOES_NOT_EXIST,
-    ErrorCode,
 )
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -958,12 +958,6 @@ class UcModelRegistryStore(BaseRestStore):
         _require_arg_unspecified(arg_name="run_link", arg_value=run_link)
         if logged_model := self._get_logged_model_from_model_id(model_id):
             run_id = logged_model.source_run_id
-        elif model_id is not None:
-            # _get_logged_model_from_model_id returned None with a non-None model_id, meaning
-            # mlflow.get_logged_model raised RESOURCE_DOES_NOT_EXIST (e.g. model_id belongs to
-            # another workspace during a cross-workspace copy). Clear model_id so the backend
-            # doesn't attempt to resolve an ID that doesn't exist locally.
-            model_id = None
         headers, run = self._get_run_and_headers(run_id)
         if source_workspace_id is None:
             source_workspace_id = self._get_workspace_id(headers)

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -958,6 +958,12 @@ class UcModelRegistryStore(BaseRestStore):
         _require_arg_unspecified(arg_name="run_link", arg_value=run_link)
         if logged_model := self._get_logged_model_from_model_id(model_id):
             run_id = logged_model.source_run_id
+        elif model_id is not None:
+            # _get_logged_model_from_model_id returned None with a non-None model_id, meaning
+            # mlflow.get_logged_model raised RESOURCE_DOES_NOT_EXIST (e.g. model_id belongs to
+            # another workspace during a cross-workspace copy). Clear model_id so the backend
+            # doesn't attempt to resolve an ID that doesn't exist locally.
+            model_id = None
         headers, run = self._get_run_and_headers(run_id)
         if source_workspace_id is None:
             source_workspace_id = self._get_workspace_id(headers)

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -995,10 +995,7 @@ class UcModelRegistryStore(BaseRestStore):
                 self._validate_model_signature(local_model_dir)
             self._download_model_weights_if_not_saved(local_model_dir)
             feature_deps = get_feature_dependencies(local_model_dir)
-            if model_id:
-                other_model_deps = get_model_version_dependencies(local_model_dir)
-            else:
-                other_model_deps = []
+            other_model_deps = get_model_version_dependencies(local_model_dir) if model_id else []
             req_body = message_to_json(
                 CreateModelVersionRequest(
                     name=full_name,

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -956,6 +956,7 @@ class UcModelRegistryStore(BaseRestStore):
             created in the backend.
         """
         _require_arg_unspecified(arg_name="run_link", arg_value=run_link)
+        model_id_cleared = False
         if logged_model := self._get_logged_model_from_model_id(model_id):
             run_id = logged_model.source_run_id
         elif model_id is not None:
@@ -964,6 +965,7 @@ class UcModelRegistryStore(BaseRestStore):
             # another workspace during a cross-workspace copy). Clear model_id so the backend
             # doesn't attempt to resolve an ID that doesn't exist locally.
             model_id = None
+            model_id_cleared = True
         headers, run = self._get_run_and_headers(run_id)
         if source_workspace_id is None:
             source_workspace_id = self._get_workspace_id(headers)
@@ -995,7 +997,7 @@ class UcModelRegistryStore(BaseRestStore):
                 self._validate_model_signature(local_model_dir)
             self._download_model_weights_if_not_saved(local_model_dir)
             feature_deps = get_feature_dependencies(local_model_dir)
-            other_model_deps = get_model_version_dependencies(local_model_dir) if model_id else []
+            other_model_deps = [] if model_id_cleared else get_model_version_dependencies(local_model_dir)
             req_body = message_to_json(
                 CreateModelVersionRequest(
                     name=full_name,

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -995,7 +995,10 @@ class UcModelRegistryStore(BaseRestStore):
                 self._validate_model_signature(local_model_dir)
             self._download_model_weights_if_not_saved(local_model_dir)
             feature_deps = get_feature_dependencies(local_model_dir)
-            other_model_deps = get_model_version_dependencies(local_model_dir)
+            if model_id:
+                other_model_deps = get_model_version_dependencies(local_model_dir)
+            else:
+                other_model_deps = []
             req_body = message_to_json(
                 CreateModelVersionRequest(
                     name=full_name,

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -997,7 +997,9 @@ class UcModelRegistryStore(BaseRestStore):
                 self._validate_model_signature(local_model_dir)
             self._download_model_weights_if_not_saved(local_model_dir)
             feature_deps = get_feature_dependencies(local_model_dir)
-            other_model_deps = [] if model_id_cleared else get_model_version_dependencies(local_model_dir)
+            other_model_deps = (
+                [] if model_id_cleared else get_model_version_dependencies(local_model_dir)
+            )
             req_body = message_to_json(
                 CreateModelVersionRequest(
                     name=full_name,

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -20,6 +20,7 @@ from mlflow.protos.databricks_pb2 import (
     ALREADY_EXISTS,
     NOT_FOUND,
     RESOURCE_ALREADY_EXISTS,
+    RESOURCE_DOES_NOT_EXIST,
     ErrorCode,
 )
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
@@ -270,14 +271,25 @@ def _register_model(
                 "version": create_version_response.version,
             }
         ]
-        model = client.get_logged_model(model_id)
-        if existing_value := model.tags.get(mlflow_tags.MLFLOW_MODEL_VERSIONS):
-            new_value = json.loads(existing_value) + new_value
+        try:
+            model = client.get_logged_model(model_id)
+            if existing_value := model.tags.get(mlflow_tags.MLFLOW_MODEL_VERSIONS):
+                new_value = json.loads(existing_value) + new_value
 
-        client.set_logged_model_tags(
-            model_id,
-            {mlflow_tags.MLFLOW_MODEL_VERSIONS: json.dumps(new_value)},
-        )
+            client.set_logged_model_tags(
+                model_id,
+                {mlflow_tags.MLFLOW_MODEL_VERSIONS: json.dumps(new_value)},
+            )
+        except MlflowException as e:
+            if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                _logger.warning(
+                    "Unable to update logged model tags for model ID '%s': the logged model "
+                    "does not exist in the current workspace. No model version link will be "
+                    "recorded on the logged model.",
+                    model_id,
+                )
+            else:
+                raise
 
     if validated_env_pack:
         eprint(

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -1015,7 +1015,6 @@ def test_create_model_version_succeeds_when_logged_model_not_found(store, local_
                 temp_credentials=aws_temp_creds,
                 storage_location=storage_location,
                 source=source,
-                model_id="nonexistent_model_id",
             ),
         ) as request_mock,
         mock.patch(
@@ -1030,7 +1029,7 @@ def test_create_model_version_succeeds_when_logged_model_not_found(store, local_
             name=model_name,
             source=source,
             version=version,
-            model_id="nonexistent_model_id",
+            model_id=None,
         )
 
 

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -1015,6 +1015,7 @@ def test_create_model_version_succeeds_when_logged_model_not_found(store, local_
                 temp_credentials=aws_temp_creds,
                 storage_location=storage_location,
                 source=source,
+                model_id="nonexistent_model_id",
             ),
         ) as request_mock,
         mock.patch(
@@ -1029,7 +1030,7 @@ def test_create_model_version_succeeds_when_logged_model_not_found(store, local_
             name=model_name,
             source=source,
             version=version,
-            model_id=None,
+            model_id="nonexistent_model_id",
         )
 
 

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -14,6 +14,7 @@ from mlflow.protos.databricks_pb2 import (
     ALREADY_EXISTS,
     INTERNAL_ERROR,
     RESOURCE_ALREADY_EXISTS,
+    RESOURCE_DOES_NOT_EXIST,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.databricks_utils import DatabricksRuntimeVersion
@@ -169,6 +170,73 @@ def test_register_model_prints_uc_model_version_url(monkeypatch):
         mock_eprint.assert_called_with("Created version '1' of model 'name.mlflow.test_model'.")
 
     # Clean up the global variables set by the server
+    mlflow.set_registry_uri(orig_registry_uri)
+
+
+def test_register_model_skips_logged_model_tag_when_not_found(monkeypatch):
+    # When the source logged model doesn't exist (e.g., cross-workspace copy),
+    # register_model should succeed and log a warning instead of raising.
+    orig_registry_uri = mlflow.get_registry_uri()
+    mlflow.set_registry_uri("databricks-uc")
+    model_id = "m-cross-ws"
+    name = "name.mlflow.cross_ws_model"
+    version = "1"
+    with (
+        mock.patch("mlflow.tracking._model_registry.fluent.eprint"),
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.get_workspace_url", return_value=None
+        ),
+        mock.patch(
+            "mlflow.MlflowClient.create_registered_model",
+            return_value=RegisteredModel(name),
+        ),
+        mock.patch(
+            "mlflow.MlflowClient._create_model_version",
+            return_value=ModelVersion(name, version, creation_timestamp=123),
+        ),
+        mock.patch(
+            "mlflow.MlflowClient.get_logged_model",
+            side_effect=MlflowException("not found", error_code=RESOURCE_DOES_NOT_EXIST),
+        ) as mock_get_logged_model,
+        mock.patch("mlflow.MlflowClient.set_logged_model_tags") as mock_set_tags,
+    ):
+        # Should not raise even though get_logged_model fails
+        mv = register_model(f"models:/{model_id}", name)
+        assert mv.version == version
+        mock_get_logged_model.assert_called_once()
+        mock_set_tags.assert_not_called()
+
+    mlflow.set_registry_uri(orig_registry_uri)
+
+
+def test_register_model_reraises_non_not_found_errors(monkeypatch):
+    # Only RESOURCE_DOES_NOT_EXIST is swallowed; other errors propagate.
+    orig_registry_uri = mlflow.get_registry_uri()
+    mlflow.set_registry_uri("databricks-uc")
+    model_id = "m-err"
+    name = "name.mlflow.err_model"
+    version = "1"
+    with (
+        mock.patch("mlflow.tracking._model_registry.fluent.eprint"),
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.get_workspace_url", return_value=None
+        ),
+        mock.patch(
+            "mlflow.MlflowClient.create_registered_model",
+            return_value=RegisteredModel(name),
+        ),
+        mock.patch(
+            "mlflow.MlflowClient._create_model_version",
+            return_value=ModelVersion(name, version, creation_timestamp=123),
+        ),
+        mock.patch(
+            "mlflow.MlflowClient.get_logged_model",
+            side_effect=MlflowException("internal error", error_code=INTERNAL_ERROR),
+        ),
+    ):
+        with pytest.raises(MlflowException, match="internal error"):
+            register_model(f"models:/{model_id}", name)
+
     mlflow.set_registry_uri(orig_registry_uri)
 
 

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -183,9 +183,7 @@ def test_register_model_skips_logged_model_tag_when_not_found(monkeypatch):
     version = "1"
     with (
         mock.patch("mlflow.tracking._model_registry.fluent.eprint"),
-        mock.patch(
-            "mlflow.tracking._model_registry.fluent.get_workspace_url", return_value=None
-        ),
+        mock.patch("mlflow.tracking._model_registry.fluent.get_workspace_url", return_value=None),
         mock.patch(
             "mlflow.MlflowClient.create_registered_model",
             return_value=RegisteredModel(name),

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -209,37 +209,6 @@ def test_register_model_skips_logged_model_tag_when_not_found(monkeypatch):
     mlflow.set_registry_uri(orig_registry_uri)
 
 
-def test_register_model_reraises_non_not_found_errors(monkeypatch):
-    # Only RESOURCE_DOES_NOT_EXIST is swallowed; other errors propagate.
-    orig_registry_uri = mlflow.get_registry_uri()
-    mlflow.set_registry_uri("databricks-uc")
-    model_id = "m-err"
-    name = "name.mlflow.err_model"
-    version = "1"
-    with (
-        mock.patch("mlflow.tracking._model_registry.fluent.eprint"),
-        mock.patch(
-            "mlflow.tracking._model_registry.fluent.get_workspace_url", return_value=None
-        ),
-        mock.patch(
-            "mlflow.MlflowClient.create_registered_model",
-            return_value=RegisteredModel(name),
-        ),
-        mock.patch(
-            "mlflow.MlflowClient._create_model_version",
-            return_value=ModelVersion(name, version, creation_timestamp=123),
-        ),
-        mock.patch(
-            "mlflow.MlflowClient.get_logged_model",
-            side_effect=MlflowException("internal error", error_code=INTERNAL_ERROR),
-        ),
-    ):
-        with pytest.raises(MlflowException, match="internal error"):
-            register_model(f"models:/{model_id}", name)
-
-    mlflow.set_registry_uri(orig_registry_uri)
-
-
 def test_set_model_version_tag():
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, model_input):


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

**Use case**: The user want to copy model across different workspaces. Model artifacts in UC storage can be accessed across workspaces, but the model metadata in tracking store can't be accessed across workspaces.
MlflowClient.copy_model_version fails when the source model version's model_id belongs to a different workspace, the destination workspace cannot resolve it, raising RESOURCE_DOES_NOT_EXIST. This PR fixes the two affected code paths:

  - mlflow/store/_unity_catalog/registry/rest_store.py: When _get_logged_model_from_model_id returns None for a non-None model_id (i.e., the logged model doesn't exist in the current workspace), clears model_id to None so the backend does not attempt to resolve an ID that doesn't exist locally.
  - mlflow/tracking/_model_registry/fluent.py: In _create_model_version, wraps the get_logged_model + set_logged_model_tags calls in a try/except that logs a warning and skips the tag update on RESOURCE_DOES_NOT_EXIST, since the source logged model may not exist in the current workspace.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
