### PR TITLE
Add Markdown rendering in artifact view

### DIFF
--- a/mlflow/server/js/src/common/utils/FileUtils.ts
+++ b/mlflow/server/js/src/common/utils/FileUtils.ts
@@ -45,12 +45,12 @@ export const TEXT_EXTENSIONS = new Set([
   'js',
   'py',
   'py3',
-  'md',
   'rst',
   MLPROJECT_FILE_NAME.toLowerCase(),
   MLMODEL_FILE_NAME.toLowerCase(),
   'jsonnet',
 ]);
+export const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown', 'mdx']);
 export const HTML_EXTENSIONS = new Set(['html']);
 export const MAP_EXTENSIONS = new Set(['geojson']);
 export const PDF_EXTENSIONS = new Set(['pdf']);

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactViewTree.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactViewTree.tsx
@@ -2,7 +2,13 @@
 import type { TreebeardData } from 'react-treebeard';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import { decorators, Treebeard } from 'react-treebeard';
-import { DATA_EXTENSIONS, getExtension, IMAGE_EXTENSIONS, TEXT_EXTENSIONS } from '../../common/utils/FileUtils';
+import {
+  DATA_EXTENSIONS,
+  getExtension,
+  IMAGE_EXTENSIONS,
+  MARKDOWN_EXTENSIONS,
+  TEXT_EXTENSIONS,
+} from '../../common/utils/FileUtils';
 
 import spinner from '../../common/static/mlflow-spinner.png';
 import { useDesignSystemTheme } from '@databricks/design-system';
@@ -47,7 +53,7 @@ decorators.Header = ({ style, node }: DecoratorStyle) => {
       iconType = 'file-image-o';
     } else if (DATA_EXTENSIONS.has(extension)) {
       iconType = 'file-excel-o';
-    } else if (TEXT_EXTENSIONS.has(extension)) {
+    } else if (TEXT_EXTENSIONS.has(extension) || MARKDOWN_EXTENSIONS.has(extension)) {
       iconType = 'file-code-o';
     } else {
       iconType = 'file-text-o';

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/LazyShowArtifactMarkdownView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/LazyShowArtifactMarkdownView.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { LegacySkeleton } from '@databricks/design-system';
+import { SectionErrorBoundary } from '../../../common/components/error-boundaries/SectionErrorBoundary';
+
+const ShowArtifactMarkdownView = React.lazy(() => import('./ShowArtifactMarkdownView'));
+
+export const LazyShowArtifactMarkdownView = (props: React.ComponentProps<typeof ShowArtifactMarkdownView>) => (
+  <SectionErrorBoundary>
+    <React.Suspense fallback={<LegacySkeleton active />}>
+      <ShowArtifactMarkdownView {...props} />
+    </React.Suspense>
+  </SectionErrorBoundary>
+);

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMarkdownView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMarkdownView.test.tsx
@@ -1,0 +1,87 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithDesignSystem } from '../../../common/utils/TestUtils.react18';
+import ShowArtifactMarkdownView from './ShowArtifactMarkdownView';
+import { fetchArtifactUnified } from './utils/fetchArtifactUnified';
+
+jest.mock('./utils/fetchArtifactUnified', () => ({
+  fetchArtifactUnified: jest.fn(),
+}));
+
+const mockFetch = fetchArtifactUnified as jest.MockedFunction<typeof fetchArtifactUnified>;
+
+const renderView = (props = {}) =>
+  renderWithDesignSystem(<ShowArtifactMarkdownView runUuid="run-1" path="notes.md" {...props} />);
+
+describe('ShowArtifactMarkdownView', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('shows skeleton while loading', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    renderView();
+    expect(document.querySelector('.artifact-markdown-view-loading')).toBeInTheDocument();
+  });
+
+  test('renders markdown as formatted content', async () => {
+    mockFetch.mockResolvedValue('# Title\n\nSome **bold** text.');
+    renderView();
+    await waitFor(() => {
+      expect(screen.getByText('Title')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/bold/)).toBeInTheDocument();
+  });
+
+  test('renders tables via remark-gfm', async () => {
+    mockFetch.mockResolvedValue('| A | B |\n|---|---|\n| 1 | 2 |');
+    renderView();
+    await waitFor(() => {
+      expect(screen.getByText('A')).toBeInTheDocument();
+    });
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  test('shows error state on fetch failure', async () => {
+    mockFetch.mockRejectedValue(new Error('network error'));
+    renderView();
+    await waitFor(() => {
+      expect(document.querySelector('.artifact-markdown-view-error')).toBeInTheDocument();
+    });
+  });
+
+  test('refetches when path changes', async () => {
+    mockFetch.mockResolvedValue('first');
+    const { rerender } = renderView({ path: 'a.md' });
+    await waitFor(() => expect(screen.getByText('first')).toBeInTheDocument());
+
+    mockFetch.mockResolvedValue('second');
+    rerender(<ShowArtifactMarkdownView runUuid="run-1" path="b.md" />);
+    await waitFor(() => expect(screen.getByText('second')).toBeInTheDocument());
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('toggles between rendered and source views', async () => {
+    const rawMd = '# Title\n\nSome **bold** text.';
+    mockFetch.mockResolvedValue(rawMd);
+    renderView();
+
+    await waitFor(() => {
+      expect(screen.getByText('Title')).toBeInTheDocument();
+    });
+    // Rendered heading should be in an h1, not a <pre>
+    expect(screen.getByText('Title').tagName).toBe('H1');
+
+    // Switch to source view
+    await userEvent.click(screen.getByTestId('markdown-view-source-button'));
+
+    // Raw markdown source should be visible in a <pre>
+    const pre = document.querySelector('pre');
+    expect(pre).toBeInTheDocument();
+    expect(pre?.textContent).toBe(rawMd);
+
+    // Switch back to rendered view
+    await userEvent.click(screen.getByTestId('markdown-view-rendered-button'));
+    await waitFor(() => {
+      expect(screen.getByText('Title').tagName).toBe('H1');
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMarkdownView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMarkdownView.tsx
@@ -1,0 +1,152 @@
+import { useState, useEffect } from 'react';
+import {
+  MarkdownIcon,
+  SegmentedControlButton,
+  SegmentedControlGroup,
+  TextBoxIcon,
+  Tooltip,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { coy as lightStyle, atomDark as darkStyle } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import { getArtifactContent } from '../../../common/utils/ArtifactUtils';
+import { ArtifactViewSkeleton } from './ArtifactViewSkeleton';
+import { ArtifactViewErrorState } from './ArtifactViewErrorState';
+import type { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.types';
+import { fetchArtifactUnified } from './utils/fetchArtifactUnified';
+import { GenAIMarkdownRenderer } from '../../../shared/web-shared/genai-markdown-renderer';
+import { defaultUrlTransform } from 'react-markdown-10';
+
+const LARGE_MARKDOWN_SIZE = 100 * 1024;
+
+interface ShowArtifactMarkdownViewProps extends Omit<LoggedModelArtifactViewerProps, 'experimentId' | 'entityTags'> {
+  runUuid: string;
+  path: string;
+  size?: number;
+}
+
+const ShowArtifactMarkdownView = ({
+  runUuid,
+  path,
+  isLoggedModelsMode,
+  loggedModelId,
+  size,
+}: ShowArtifactMarkdownViewProps) => {
+  const isLargeFile = (size || 0) > LARGE_MARKDOWN_SIZE;
+  const { theme } = useDesignSystemTheme();
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error>();
+  const [mdContent, setMdContent] = useState<string>('');
+  const [showRendered, setShowRendered] = useState(!isLargeFile);
+
+  useEffect(() => {
+    setShowRendered(!isLargeFile);
+  }, [path, isLargeFile]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(undefined);
+    fetchArtifactUnified(
+      {
+        runUuid,
+        path,
+        isLoggedModelsMode,
+        loggedModelId,
+      },
+      getArtifactContent,
+    )
+      .then((text) => {
+        if (cancelled) return;
+        setMdContent(text as string);
+        setLoading(false);
+      })
+      .catch((error: Error) => {
+        if (cancelled) return;
+        setMdContent('');
+        setError(error);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runUuid, path, isLoggedModelsMode, loggedModelId]);
+
+  if (loading) {
+    return <ArtifactViewSkeleton className="artifact-markdown-view-loading" />;
+  }
+  if (error) {
+    return <ArtifactViewErrorState className="artifact-markdown-view-error" />;
+  }
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', width: '100%', flex: 1, minHeight: 0, overflow: 'hidden' }}>
+      <div css={{ display: 'flex', padding: theme.spacing.xs }}>
+        <SegmentedControlGroup
+          name="markdown-render-mode"
+          size="small"
+          componentId="mlflow.artifact_view.markdown_render_mode"
+          value={showRendered}
+          onChange={(event) => setShowRendered(event.target.value)}
+        >
+          <SegmentedControlButton data-testid="markdown-view-source-button" value={false}>
+            <Tooltip
+              componentId="mlflow.artifact_view.markdown_source_tooltip"
+              content={
+                <FormattedMessage
+                  defaultMessage="View source"
+                  description="Tooltip for button that shows raw markdown source text"
+                />
+              }
+            >
+              <div css={{ display: 'flex', alignItems: 'center' }}>
+                <TextBoxIcon css={{ fontSize: theme.typography.fontSizeLg }} />
+              </div>
+            </Tooltip>
+          </SegmentedControlButton>
+          <SegmentedControlButton data-testid="markdown-view-rendered-button" value>
+            <Tooltip
+              componentId="mlflow.artifact_view.markdown_rendered_tooltip"
+              content={
+                <FormattedMessage
+                  defaultMessage="View rendered"
+                  description="Tooltip for button that shows rendered markdown"
+                />
+              }
+            >
+              <div css={{ display: 'flex', alignItems: 'center' }}>
+                <MarkdownIcon css={{ fontSize: theme.typography.fontSizeLg }} />
+              </div>
+            </Tooltip>
+          </SegmentedControlButton>
+        </SegmentedControlGroup>
+      </div>
+      <div css={{ flex: 1, overflow: 'auto', padding: theme.spacing.md }}>
+        {showRendered ? (
+          <GenAIMarkdownRenderer urlTransform={defaultUrlTransform}>{mdContent}</GenAIMarkdownRenderer>
+        ) : (
+          <SyntaxHighlighter
+            language={isLargeFile ? 'text' : 'markdown'}
+            style={theme.isDarkMode ? darkStyle : lightStyle}
+            customStyle={{
+              fontFamily: 'Source Code Pro, Menlo, monospace',
+              fontSize: theme.typography.fontSizeMd,
+              overflow: 'auto',
+              marginTop: 0,
+              width: '100%',
+              height: '100%',
+              padding: theme.spacing.xs,
+              border: 'none',
+            }}
+          >
+            {mdContent}
+          </SyntaxHighlighter>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ShowArtifactMarkdownView;

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.enzyme.test.tsx
@@ -18,6 +18,7 @@ import ShowArtifactLoggedModelView from './ShowArtifactLoggedModelView';
 import {
   IMAGE_EXTENSIONS,
   TEXT_EXTENSIONS,
+  MARKDOWN_EXTENSIONS,
   MAP_EXTENSIONS,
   HTML_EXTENSIONS,
   DATA_EXTENSIONS,
@@ -25,6 +26,7 @@ import {
 } from '../../../common/utils/FileUtils';
 import { RunTag } from '../../sdk/MlflowMessages';
 import { LazyShowArtifactAudioView } from './LazyShowArtifactAudioView';
+import { LazyShowArtifactMarkdownView } from './LazyShowArtifactMarkdownView';
 
 // Mock these methods because js-dom doesn't implement window.Request
 jest.mock('../../../common/utils/ArtifactUtils', () => ({
@@ -135,6 +137,12 @@ describe('ShowArtifactPage', () => {
     TEXT_EXTENSIONS.forEach((ext) => {
       wrapper.setProps({ path: `image.${ext}`, runUuid: 'runId' });
       expect(wrapper.find(ShowArtifactTextView).length).toBe(1);
+    });
+  });
+  test('should render markdown view for common markdown extensions', () => {
+    MARKDOWN_EXTENSIONS.forEach((ext) => {
+      wrapper.setProps({ path: `image.${ext}`, runUuid: 'runId' });
+      expect(wrapper.find(LazyShowArtifactMarkdownView).length).toBe(1);
     });
   });
   test('should render data table view for common tabular data extensions', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
@@ -16,6 +16,7 @@ import {
   DATA_EXTENSIONS,
   AUDIO_EXTENSIONS,
   VIDEO_EXTENSIONS,
+  MARKDOWN_EXTENSIONS,
 } from '../../../common/utils/FileUtils';
 import { getLoggedModelPathsFromTags, getLoggedTablesFromTags } from '../../../common/utils/TagUtils';
 import { ONE_MB } from '../../constants';
@@ -37,6 +38,7 @@ import { LazyShowArtifactAudioView } from './LazyShowArtifactAudioView';
 import type { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.types';
 import { LazyShowArtifactVideoView } from './LazyShowArtifactVideoView';
 import type { KeyValueEntity } from '../../../common/types';
+import { LazyShowArtifactMarkdownView } from './LazyShowArtifactMarkdownView';
 
 const MAX_PREVIEW_ARTIFACT_SIZE_MB = 50;
 
@@ -101,6 +103,16 @@ class ShowArtifactPage extends Component<ShowArtifactPageProps> {
           return <ShowArtifactImageView {...commonArtifactProps} />;
         } else if (DATA_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <LazyShowArtifactTableView {...commonArtifactProps} />;
+        } else if (MARKDOWN_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
+          return (
+            <LazyShowArtifactMarkdownView
+              loggedModelId={loggedModelId}
+              isLoggedModelsMode={isLoggedModelsMode}
+              path={path}
+              runUuid={runUuid}
+              size={this.props.size}
+            />
+          );
         } else if (TEXT_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <ShowArtifactTextView {...commonArtifactProps} size={this.props.size} />;
         } else if (MAP_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
@@ -138,7 +150,7 @@ const getSelectFileView = () => {
         }
         description={
           <FormattedMessage
-            defaultMessage="Supported formats: image, text, html, pdf, audio, video, geojson files"
+            defaultMessage="Supported formats: image, text, markdown, html, pdf, audio, video, geojson files"
             description="Text to explain users which formats are supported to display the artifacts"
           />
         }

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/utils/fetchArtifactUnified.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/utils/fetchArtifactUnified.tsx
@@ -8,7 +8,7 @@ import {
 import type { KeyValueEntity } from '../../../../common/types';
 
 type FetchArtifactParams = {
-  experimentId: string;
+  experimentId?: string;
   runUuid: string;
   path: string;
   isLoggedModelsMode?: boolean;

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -785,6 +785,10 @@
     "defaultMessage": "Delete",
     "description": "String for the delete button to delete a particular experiment run"
   },
+  "3S361w": {
+    "defaultMessage": "View source",
+    "description": "Tooltip for button that shows raw markdown source text"
+  },
   "3S3Ah4": {
     "defaultMessage": "Download data",
     "description": "String for the download csv button to download metrics from this run offline in a CSV format"
@@ -3570,6 +3574,10 @@
     "defaultMessage": "avg per trace",
     "description": "Subtitle for average tokens per trace"
   },
+  "MXsbcc": {
+    "defaultMessage": "Supported formats: image, text, markdown, html, pdf, audio, video, geojson files",
+    "description": "Text to explain users which formats are supported to display the artifacts"
+  },
   "MZCW9F": {
     "defaultMessage": "Labeling schemas",
     "description": "Label for the labeling schemas tab in the MLflow experiment navbar"
@@ -5166,10 +5174,6 @@
   "WtUqxc": {
     "defaultMessage": "Error",
     "description": "Title for error fallback component in experiment datasets UI"
-  },
-  "Wv3B3G": {
-    "defaultMessage": "Supported formats: image, text, html, pdf, audio, video, geojson files",
-    "description": "Text to explain users which formats are supported to display the artifacts"
   },
   "WvHAEg": {
     "defaultMessage": "Input an artifact location (optional)",
@@ -9122,6 +9126,10 @@
   "wrNl6F": {
     "defaultMessage": "Preview",
     "description": "Label for the preview mode on the registered prompt details page"
+  },
+  "wtcucM": {
+    "defaultMessage": "View rendered",
+    "description": "Tooltip for button that shows rendered markdown"
   },
   "wtpLvY": {
     "defaultMessage": "Load more",


### PR DESCRIPTION
### Related Issues/PRs

Closes:
https://github.com/mlflow/mlflow/issues/10671

### What changes are proposed in this pull request?

<img width="1400" height="679" alt="image" src="https://github.com/user-attachments/assets/7c8aed63-cc46-4c6e-b358-65f321748ede" />
<img width="1400" height="679" alt="image" src="https://github.com/user-attachments/assets/f7ab6f25-c923-49ac-9602-4adf154a6ddf" />

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

When viewing Markdown artifacts for a run, they are now rendered rather than shown as plain text.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
