### PR TITLE
docs: Add single quotes to install commands with extras to prevent zsh errors

### DIFF
--- a/docs/docs/classic-ml/community-model-flavors/index.mdx
+++ b/docs/docs/classic-ml/community-model-flavors/index.mdx
@@ -13,7 +13,7 @@ Most community flavors are available via PyPI:
 
 ```bash
 # Time series forecasting
-pip install mlflow[sktime]
+pip install 'mlflow[sktime]'
 pip install mlflavors
 
 # Visualization and plotting
@@ -21,7 +21,7 @@ pip install mlflow-vizmod
 
 # Big data and cloud platforms
 pip install bigmlflow
-pip install mlflow[aliyun-oss]
+pip install 'mlflow[aliyun-oss]'
 ```
 
 ### Basic Usage Pattern
@@ -55,7 +55,7 @@ predictions = loaded_model.predict(new_data)
 Unified interface for time series forecasting, classification, and transformation.
 
 ```bash
-pip install sktime[mlflow]
+pip install 'sktime[mlflow]'
 ```
 
 ```python

--- a/docs/docs/classic-ml/deep-learning/sentence-transformers/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/sentence-transformers/index.mdx
@@ -43,7 +43,7 @@ The MLflow Sentence Transformers flavor provides integration with the [Sentence 
 ## Installation
 
 ```bash
-pip install mlflow[sentence-transformers]
+pip install 'mlflow[sentence-transformers]'
 ```
 
 ## Basic Usage

--- a/docs/docs/classic-ml/deployment/deploy-model-locally/index.mdx
+++ b/docs/docs/classic-ml/deployment/deploy-model-locally/index.mdx
@@ -301,7 +301,7 @@ auto scaling out of the box.
 </Table>
 
 MLServer exposes the same scoring API through the `/invocations` endpoint.
-To deploy with MLServer, first install additional dependencies with `pip install mlflow[extras]`,
+To deploy with MLServer, first install additional dependencies with `pip install 'mlflow[extras]'`,
 then execute the deployment command with the `--enable-mlserver` option. For example,
 
 ```bash

--- a/docs/docs/classic-ml/deployment/deploy-model-to-kubernetes/tutorial.mdx
+++ b/docs/docs/classic-ml/deployment/deploy-model-to-kubernetes/tutorial.mdx
@@ -49,7 +49,7 @@ as a single place to manage the entire ML lifecycle. This includes [experiment t
 First, please install mlflow to your local machine using the following command:
 
 ```bash
-pip install mlflow[mlserver]
+pip install 'mlflow[mlserver]'
 ```
 
 `[extras]` will install additional dependencies required for this tutorial including [mlserver](https://mlserver.readthedocs.io/en/latest) and

--- a/docs/docs/classic-ml/getting-started/running-notebooks/index.mdx
+++ b/docs/docs/classic-ml/getting-started/running-notebooks/index.mdx
@@ -160,7 +160,7 @@ This guide shows you how to connect your development environment to an MLflow Ex
     Install MLflow with Databricks connectivity:
 
     ```bash
-    pip install --upgrade "mlflow[databricks]>=3.1"
+    pip install --upgrade 'mlflow[databricks]>=3.1'
     ```
 
     <br/>
@@ -237,7 +237,7 @@ This guide shows you how to connect your development environment to an MLflow Ex
     Databricks runtimes include MLflow, but for the best experience, update to the latest version:
 
     ```bash
-    %pip install --upgrade "mlflow[databricks]>=3.1"
+    %pip install --upgrade 'mlflow[databricks]>=3.1'
     dbutils.library.restartPython()
     ```
     <br/>

--- a/docs/docs/classic-ml/plugins/index.mdx
+++ b/docs/docs/classic-ml/plugins/index.mdx
@@ -494,7 +494,7 @@ class MyEvaluator(ModelEvaluator):
 Store artifacts directly in SQL Server databases:
 
 ```bash
-pip install mlflow[sqlserver]
+pip install 'mlflow[sqlserver]'
 ```
 
 ```python
@@ -513,7 +513,7 @@ with mlflow.start_run():
 Integrate with Aliyun Object Storage Service:
 
 ```bash
-pip install mlflow[aliyun-oss]
+pip install 'mlflow[aliyun-oss]'
 ```
 
 ```python
@@ -534,7 +534,7 @@ mlflow.create_experiment("oss_experiment", artifact_location="oss://bucket/path"
 Use XetHub for versioned artifact storage:
 
 ```bash
-pip install mlflow[xethub]
+pip install 'mlflow[xethub]'
 ```
 
 ```python
@@ -648,7 +648,7 @@ mlflow run . --backend yarn --backend-config yarn-config.json
 Enterprise artifact governance:
 
 ```bash
-pip install mlflow[jfrog]
+pip install 'mlflow[jfrog]'
 ```
 
 **Key Features:**

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/memalign.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/memalign.mdx
@@ -55,7 +55,7 @@ When evaluating new inputs, MemAlign constructs a dynamic context by gathering a
 MemAlign requires additional dependencies:
 
 ```bash
-pip install mlflow[genai] dspy jinja2 tqdm
+pip install 'mlflow[genai]' dspy jinja2 tqdm
 ```
 
 ## Basic Usage

--- a/docs/docs/genai/tracing/integrations/listing/mlflow-ai-gateway.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/mlflow-ai-gateway.mdx
@@ -37,7 +37,7 @@ When both are used together with a `traceparent` header, the gateway creates a l
 To start MLflow server with AI Gateway, you need to install the `mlflow[genai]` package.
 
 ```bash
-pip install mlflow[genai]
+pip install 'mlflow[genai]'
 ```
 
 Then start the MLflow server as usual, no additional configuration is needed.

--- a/docs/docs/genai/tracing/lightweight-sdk.mdx
+++ b/docs/docs/genai/tracing/lightweight-sdk.mdx
@@ -72,7 +72,7 @@ The Production Tracing SDK works with various observability platforms. Choose yo
           In self-hosting mode, you will be responsible for running the tracking server instance and scaling it to your needs. We **strongly recommend** using a SQL-based tracking server on top of a performant database to minimize operational overhead and ensure high availability.
 
           **Setup Steps:**
-          1. Install MLflow server: `pip install mlflow[extras]`
+          1. Install MLflow server: `pip install 'mlflow[extras]'`
           2. Configure backend store (PostgreSQL/MySQL recommended)
           3. Configure artifact store (S3, Azure Blob, GCS, etc.)
           4. Start server: `mlflow server --backend-store-uri postgresql://... --default-artifact-root s3://...`

--- a/docs/docs/genai/tracing/token-usage-cost/index.mdx
+++ b/docs/docs/genai/tracing/token-usage-cost/index.mdx
@@ -45,7 +45,7 @@ mlflow server
   </TabItem>
   <TabItem value="uv" label="uv">
 ```bash
-uv add mlflow[genai]>=3.10.0
+uv add 'mlflow[genai]'>=3.10.0
 uv run mlflow server
 ```
   </TabItem>

--- a/docs/docs/quickstart_drilldown/index.mdx
+++ b/docs/docs/quickstart_drilldown/index.mdx
@@ -34,7 +34,7 @@ Rather than the default MLflow library, you can install the following variations
     </tr>
     <tr>
       <td>mlflow[extras]</td>
-      <td>`pip install mlflow[extras]`</td>
+      <td>`pip install 'mlflow[extras]'`</td>
       <td>MLflow package with all dependencies needed to run various MLflow flavors. These dependencies are listed in [this document](https://github.com/mlflow/mlflow/blob/master/requirements/extra-ml-requirements.txt).</td>
     </tr>
     <tr>

--- a/docs/docs/self-hosting/security/basic-http-auth.mdx
+++ b/docs/docs/self-hosting/security/basic-http-auth.mdx
@@ -19,7 +19,7 @@ MLflow Authentication provides Python and REST API for managing users and permis
 First, install all dependencies required for the basic auth app:
 
 ```bash
-pip install mlflow[auth]
+pip install 'mlflow[auth]'
 ```
 
 :::note

--- a/docs/docs/self-hosting/security/custom.md
+++ b/docs/docs/self-hosting/security/custom.md
@@ -82,7 +82,7 @@ You can configure the server to use a custom authentication function extending M
 First, install the auth extension:
 
 ```bash
-pip install mlflow[auth]
+pip install 'mlflow[auth]'
 ```
 
 Create a custom authentication function. The function should return a `werkzeug.datastructures.Authorization` object if

--- a/docs/docs/self-hosting/security/sso.mdx
+++ b/docs/docs/self-hosting/security/sso.mdx
@@ -145,7 +145,7 @@ The plugin Python file will be used by the mlflow server's OIDC auth plugin, see
 Install mlflow OIDC auth plugin as follows:
 
 ```bash
-pip install "mlflow-oidc-auth[full]"
+pip install 'mlflow-oidc-auth[full]'
 ```
 
 Before launching the mlflow server with the OIDC plugin, a couple of environment variables must be set.


### PR DESCRIPTION
This PR updates the docs to wrap dependency specifiers that include extras (e.g., `package[extra]`) in single quotes. Without quotes, shells like zsh can treat `[]` as glob patterns and fail with errors like `zsh: no matches found: mlflow[genai]`. Quoting ensures commands work consistently across shells.

What changed  
- Replaced all occurrences of:
  - `pip install anything[extra]` → `pip install 'anything[extra]'`
  - `uv add anything[extra]` → `uv add 'anything[extra]'`
- Applied the same quoting style wherever extras appear in install/add commands to keep the docs consistent.