### PR TITLE
Add authentication support to OTLP exporter headers

### DIFF
--- a/mlflow/agno/autolog_v2.py
+++ b/mlflow/agno/autolog_v2.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER
+from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER, build_otlp_headers
 
 _logger = logging.getLogger(__name__)
 _agno_instrumentor = None
@@ -63,7 +63,7 @@ def _setup_otel_instrumentation() -> None:
         experiment_id = _get_experiment_id()
 
         exporter = OTLPSpanExporter(
-            endpoint=endpoint, headers={MLFLOW_EXPERIMENT_ID_HEADER: experiment_id}
+            endpoint=endpoint, headers=build_otlp_headers(experiment_id)
         )
 
         tracer_provider = trace.get_tracer_provider()

--- a/mlflow/agno/autolog_v2.py
+++ b/mlflow/agno/autolog_v2.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER, build_otlp_headers
+from mlflow.tracing.utils.otlp import build_otlp_headers
 
 _logger = logging.getLogger(__name__)
 _agno_instrumentor = None
@@ -62,9 +62,7 @@ def _setup_otel_instrumentation() -> None:
 
         experiment_id = _get_experiment_id()
 
-        exporter = OTLPSpanExporter(
-            endpoint=endpoint, headers=build_otlp_headers(experiment_id)
-        )
+        exporter = OTLPSpanExporter(endpoint=endpoint, headers=build_otlp_headers(experiment_id))
 
         tracer_provider = trace.get_tracer_provider()
         if not isinstance(tracer_provider, TracerProvider):

--- a/mlflow/otel/__init__.py
+++ b/mlflow/otel/__init__.py
@@ -27,7 +27,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcess
 
 import mlflow
 from mlflow.environment_variables import MLFLOW_ENABLE_ASYNC_TRACE_LOGGING
-from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER, OTLP_TRACES_PATH
+from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER, OTLP_TRACES_PATH, build_otlp_headers
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.autologging_utils import autologging_integration
 from mlflow.utils.autologging_utils.safety import _AUTOLOGGING_CLEANUP_CALLBACKS
@@ -122,7 +122,7 @@ def setup_otel_processor(batch: bool | None = None) -> None:
 
     exporter = OTLPSpanExporter(
         endpoint=endpoint,
-        headers={MLFLOW_EXPERIMENT_ID_HEADER: experiment_id},
+        headers=build_otlp_headers(experiment_id),
     )
 
     inner = BatchSpanProcessor(exporter) if batch else SimpleSpanProcessor(exporter)

--- a/mlflow/otel/__init__.py
+++ b/mlflow/otel/__init__.py
@@ -27,7 +27,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcess
 
 import mlflow
 from mlflow.environment_variables import MLFLOW_ENABLE_ASYNC_TRACE_LOGGING
-from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER, OTLP_TRACES_PATH, build_otlp_headers
+from mlflow.tracing.utils.otlp import OTLP_TRACES_PATH, build_otlp_headers
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.autologging_utils import autologging_integration
 from mlflow.utils.autologging_utils.safety import _AUTOLOGGING_CLEANUP_CALLBACKS

--- a/mlflow/tracing/utils/otlp.py
+++ b/mlflow/tracing/utils/otlp.py
@@ -12,6 +12,7 @@ from opentelemetry.sdk.trace.export import SpanExporter
 from mlflow.environment_variables import MLFLOW_ENABLE_OTLP_EXPORTER, MLFLOW_TRACKING_TOKEN
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.utils.credentials import read_mlflow_creds
 
 # Constants for OpenTelemetry integration
 MLFLOW_EXPERIMENT_ID_HEADER = "x-mlflow-experiment-id"
@@ -20,22 +21,7 @@ OTLP_METRICS_PATH = "/v1/metrics"
 
 
 def build_otlp_headers(experiment_id: str) -> dict[str, str]:
-    """Build OTLP exporter headers including authentication credentials.
-
-    Reads tracking credentials from the MLflow credential system (environment
-    variables and ``~/.mlflow/credentials``) and returns a header dict suitable
-    for ``OTLPSpanExporter(headers=...)``.
-
-    Supports Bearer token (preferred) and Basic username/password auth.
-
-    Args:
-        experiment_id: The MLflow experiment ID to include in the headers.
-
-    Returns:
-        A dict of HTTP headers.
-    """
-    from mlflow.utils.credentials import read_mlflow_creds
-
+    """Build OTLP exporter headers with experiment ID and auth credentials."""
     headers: dict[str, str] = {MLFLOW_EXPERIMENT_ID_HEADER: experiment_id}
 
     if token := MLFLOW_TRACKING_TOKEN.get():

--- a/mlflow/tracing/utils/otlp.py
+++ b/mlflow/tracing/utils/otlp.py
@@ -38,8 +38,7 @@ def build_otlp_headers(experiment_id: str) -> dict[str, str]:
 
     headers: dict[str, str] = {MLFLOW_EXPERIMENT_ID_HEADER: experiment_id}
 
-    token = MLFLOW_TRACKING_TOKEN.get()
-    if token:
+    if token := MLFLOW_TRACKING_TOKEN.get():
         headers["Authorization"] = f"Bearer {token}"
         return headers
 

--- a/mlflow/tracing/utils/otlp.py
+++ b/mlflow/tracing/utils/otlp.py
@@ -24,14 +24,12 @@ def build_otlp_headers(experiment_id: str) -> dict[str, str]:
     """Build OTLP exporter headers with experiment ID and auth credentials."""
     headers: dict[str, str] = {MLFLOW_EXPERIMENT_ID_HEADER: experiment_id}
 
-    if token := MLFLOW_TRACKING_TOKEN.get():
-        headers["Authorization"] = f"Bearer {token}"
-        return headers
-
     creds = read_mlflow_creds()
     if creds.username and creds.password:
-        encoded = base64.b64encode(f"{creds.username}:{creds.password}".encode()).decode()
-        headers["Authorization"] = f"Basic {encoded}"
+        basic_auth_str = f"{creds.username}:{creds.password}".encode()
+        headers["Authorization"] = f"Basic {base64.standard_b64encode(basic_auth_str).decode()}"
+    elif token := MLFLOW_TRACKING_TOKEN.get():
+        headers["Authorization"] = f"Bearer {token}"
 
     return headers
 

--- a/tests/tracing/utils/test_otlp_auth.py
+++ b/tests/tracing/utils/test_otlp_auth.py
@@ -1,0 +1,46 @@
+"""Tests for build_otlp_headers — authentication for OTLP exporters."""
+
+import base64
+
+from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER, build_otlp_headers
+
+
+class TestBuildOtlpHeaders:
+    def test_no_credentials(self, monkeypatch):
+        """Without any credentials, only the experiment-id header is returned."""
+        monkeypatch.delenv("MLFLOW_TRACKING_TOKEN", raising=False)
+        monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
+        monkeypatch.delenv("MLFLOW_TRACKING_PASSWORD", raising=False)
+
+        headers = build_otlp_headers("42")
+        assert headers == {MLFLOW_EXPERIMENT_ID_HEADER: "42"}
+        assert "Authorization" not in headers
+
+    def test_basic_auth(self, monkeypatch):
+        """Username + password produce a Basic auth header."""
+        monkeypatch.delenv("MLFLOW_TRACKING_TOKEN", raising=False)
+        monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "admin")
+        monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "s3cret")
+
+        headers = build_otlp_headers("7")
+        expected = base64.b64encode(b"admin:s3cret").decode()
+        assert headers[MLFLOW_EXPERIMENT_ID_HEADER] == "7"
+        assert headers["Authorization"] == f"Basic {expected}"
+
+    def test_bearer_token(self, monkeypatch):
+        """A tracking token produces a Bearer auth header."""
+        monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "tok-abc")
+        monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
+        monkeypatch.delenv("MLFLOW_TRACKING_PASSWORD", raising=False)
+
+        headers = build_otlp_headers("1")
+        assert headers["Authorization"] == "Bearer tok-abc"
+
+    def test_token_takes_precedence_over_basic(self, monkeypatch):
+        """When both token and username/password are set, token wins."""
+        monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "tok-xyz")
+        monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "admin")
+        monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "pass")
+
+        headers = build_otlp_headers("5")
+        assert headers["Authorization"] == "Bearer tok-xyz"

--- a/tests/tracing/utils/test_otlp_auth.py
+++ b/tests/tracing/utils/test_otlp_auth.py
@@ -21,7 +21,7 @@ def test_build_otlp_headers_basic_auth(monkeypatch):
     monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "s3cret")
 
     headers = build_otlp_headers("7")
-    expected = base64.b64encode(b"admin:s3cret").decode()
+    expected = base64.standard_b64encode(b"admin:s3cret").decode()
     assert headers[MLFLOW_EXPERIMENT_ID_HEADER] == "7"
     assert headers["Authorization"] == f"Basic {expected}"
 
@@ -36,11 +36,12 @@ def test_build_otlp_headers_bearer_token(monkeypatch):
     assert headers["Authorization"] == "Bearer tok-abc"
 
 
-def test_build_otlp_headers_token_takes_precedence_over_basic(monkeypatch):
+def test_build_otlp_headers_basic_auth_takes_precedence_over_token(monkeypatch):
     monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "tok-xyz")
     monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "admin")
     monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "pass")
 
     headers = build_otlp_headers("5")
+    expected = base64.standard_b64encode(b"admin:pass").decode()
     assert headers[MLFLOW_EXPERIMENT_ID_HEADER] == "5"
-    assert headers["Authorization"] == "Bearer tok-xyz"
+    assert headers["Authorization"] == f"Basic {expected}"

--- a/tests/tracing/utils/test_otlp_auth.py
+++ b/tests/tracing/utils/test_otlp_auth.py
@@ -1,46 +1,42 @@
-"""Tests for build_otlp_headers — authentication for OTLP exporters."""
-
 import base64
 
 from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER, build_otlp_headers
 
 
-class TestBuildOtlpHeaders:
-    def test_no_credentials(self, monkeypatch):
-        """Without any credentials, only the experiment-id header is returned."""
-        monkeypatch.delenv("MLFLOW_TRACKING_TOKEN", raising=False)
-        monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
-        monkeypatch.delenv("MLFLOW_TRACKING_PASSWORD", raising=False)
+def test_build_otlp_headers_no_credentials(monkeypatch):
+    monkeypatch.delenv("MLFLOW_TRACKING_TOKEN", raising=False)
+    monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
+    monkeypatch.delenv("MLFLOW_TRACKING_PASSWORD", raising=False)
 
-        headers = build_otlp_headers("42")
-        assert headers == {MLFLOW_EXPERIMENT_ID_HEADER: "42"}
-        assert "Authorization" not in headers
+    headers = build_otlp_headers("42")
+    assert headers == {MLFLOW_EXPERIMENT_ID_HEADER: "42"}
+    assert "Authorization" not in headers
 
-    def test_basic_auth(self, monkeypatch):
-        """Username + password produce a Basic auth header."""
-        monkeypatch.delenv("MLFLOW_TRACKING_TOKEN", raising=False)
-        monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "admin")
-        monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "s3cret")
 
-        headers = build_otlp_headers("7")
-        expected = base64.b64encode(b"admin:s3cret").decode()
-        assert headers[MLFLOW_EXPERIMENT_ID_HEADER] == "7"
-        assert headers["Authorization"] == f"Basic {expected}"
+def test_build_otlp_headers_basic_auth(monkeypatch):
+    monkeypatch.delenv("MLFLOW_TRACKING_TOKEN", raising=False)
+    monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "admin")
+    monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "s3cret")
 
-    def test_bearer_token(self, monkeypatch):
-        """A tracking token produces a Bearer auth header."""
-        monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "tok-abc")
-        monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
-        monkeypatch.delenv("MLFLOW_TRACKING_PASSWORD", raising=False)
+    headers = build_otlp_headers("7")
+    expected = base64.b64encode(b"admin:s3cret").decode()
+    assert headers[MLFLOW_EXPERIMENT_ID_HEADER] == "7"
+    assert headers["Authorization"] == f"Basic {expected}"
 
-        headers = build_otlp_headers("1")
-        assert headers["Authorization"] == "Bearer tok-abc"
 
-    def test_token_takes_precedence_over_basic(self, monkeypatch):
-        """When both token and username/password are set, token wins."""
-        monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "tok-xyz")
-        monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "admin")
-        monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "pass")
+def test_build_otlp_headers_bearer_token(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "tok-abc")
+    monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
+    monkeypatch.delenv("MLFLOW_TRACKING_PASSWORD", raising=False)
 
-        headers = build_otlp_headers("5")
-        assert headers["Authorization"] == "Bearer tok-xyz"
+    headers = build_otlp_headers("1")
+    assert headers["Authorization"] == "Bearer tok-abc"
+
+
+def test_build_otlp_headers_token_takes_precedence_over_basic(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "tok-xyz")
+    monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "admin")
+    monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "pass")
+
+    headers = build_otlp_headers("5")
+    assert headers["Authorization"] == "Bearer tok-xyz"

--- a/tests/tracing/utils/test_otlp_auth.py
+++ b/tests/tracing/utils/test_otlp_auth.py
@@ -3,10 +3,12 @@ import base64
 from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER, build_otlp_headers
 
 
-def test_build_otlp_headers_no_credentials(monkeypatch):
+def test_build_otlp_headers_no_credentials(monkeypatch, tmp_path):
     monkeypatch.delenv("MLFLOW_TRACKING_TOKEN", raising=False)
     monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
     monkeypatch.delenv("MLFLOW_TRACKING_PASSWORD", raising=False)
+    # Prevent ~/.mlflow/credentials from leaking into the test
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     headers = build_otlp_headers("42")
     assert headers == {MLFLOW_EXPERIMENT_ID_HEADER: "42"}
@@ -30,6 +32,7 @@ def test_build_otlp_headers_bearer_token(monkeypatch):
     monkeypatch.delenv("MLFLOW_TRACKING_PASSWORD", raising=False)
 
     headers = build_otlp_headers("1")
+    assert headers[MLFLOW_EXPERIMENT_ID_HEADER] == "1"
     assert headers["Authorization"] == "Bearer tok-abc"
 
 
@@ -39,4 +42,5 @@ def test_build_otlp_headers_token_takes_precedence_over_basic(monkeypatch):
     monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "pass")
 
     headers = build_otlp_headers("5")
+    assert headers[MLFLOW_EXPERIMENT_ID_HEADER] == "5"
     assert headers["Authorization"] == "Bearer tok-xyz"

--- a/tests/tracing/utils/test_otlp_auth.py
+++ b/tests/tracing/utils/test_otlp_auth.py
@@ -1,26 +1,34 @@
 import base64
+from collections.abc import Generator
+from contextlib import contextmanager
+from unittest.mock import patch
 
 from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER, build_otlp_headers
+from mlflow.utils.credentials import MlflowCreds
 
 
-def test_build_otlp_headers_no_credentials(monkeypatch, tmp_path):
+@contextmanager
+def mock_creds(username: str | None = None, password: str | None = None) -> Generator[None]:
+    with patch(
+        "mlflow.tracing.utils.otlp.read_mlflow_creds",
+        return_value=MlflowCreds(username=username, password=password),
+    ) as m:
+        yield
+    m.assert_called_once()
+
+
+def test_build_otlp_headers_no_credentials(monkeypatch):
     monkeypatch.delenv("MLFLOW_TRACKING_TOKEN", raising=False)
-    monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
-    monkeypatch.delenv("MLFLOW_TRACKING_PASSWORD", raising=False)
-    # Prevent ~/.mlflow/credentials from leaking into the test
-    monkeypatch.setenv("HOME", str(tmp_path))
-
-    headers = build_otlp_headers("42")
+    with mock_creds():
+        headers = build_otlp_headers("42")
     assert headers == {MLFLOW_EXPERIMENT_ID_HEADER: "42"}
     assert "Authorization" not in headers
 
 
 def test_build_otlp_headers_basic_auth(monkeypatch):
     monkeypatch.delenv("MLFLOW_TRACKING_TOKEN", raising=False)
-    monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "admin")
-    monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "s3cret")
-
-    headers = build_otlp_headers("7")
+    with mock_creds(username="admin", password="s3cret"):
+        headers = build_otlp_headers("7")
     expected = base64.standard_b64encode(b"admin:s3cret").decode()
     assert headers[MLFLOW_EXPERIMENT_ID_HEADER] == "7"
     assert headers["Authorization"] == f"Basic {expected}"
@@ -28,20 +36,16 @@ def test_build_otlp_headers_basic_auth(monkeypatch):
 
 def test_build_otlp_headers_bearer_token(monkeypatch):
     monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "tok-abc")
-    monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
-    monkeypatch.delenv("MLFLOW_TRACKING_PASSWORD", raising=False)
-
-    headers = build_otlp_headers("1")
+    with mock_creds():
+        headers = build_otlp_headers("1")
     assert headers[MLFLOW_EXPERIMENT_ID_HEADER] == "1"
     assert headers["Authorization"] == "Bearer tok-abc"
 
 
 def test_build_otlp_headers_basic_auth_takes_precedence_over_token(monkeypatch):
     monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "tok-xyz")
-    monkeypatch.setenv("MLFLOW_TRACKING_USERNAME", "admin")
-    monkeypatch.setenv("MLFLOW_TRACKING_PASSWORD", "pass")
-
-    headers = build_otlp_headers("5")
+    with mock_creds(username="admin", password="pass"):
+        headers = build_otlp_headers("5")
     expected = base64.standard_b64encode(b"admin:pass").decode()
     assert headers[MLFLOW_EXPERIMENT_ID_HEADER] == "5"
     assert headers["Authorization"] == f"Basic {expected}"


### PR DESCRIPTION
### Related Issues/PRs

Closes #21221

### What changes are proposed in this pull request?

When MLflow server has authentication enabled (Basic or Bearer), the `OTLPSpanExporter` created by `agno.autolog()` and `otel.autolog()` did not include tracking credentials in the request headers. This caused `401 Unauthorized` errors on the `/v1/traces` endpoint.

This PR:
- Adds a `build_otlp_headers()` helper in `mlflow/tracing/utils/otlp.py` that builds OTLP exporter headers including authentication credentials (Bearer token or Basic auth) using MLflow's standard credential system
- Updates `mlflow/agno/autolog_v2.py` and `mlflow/otel/__init__.py` to use `build_otlp_headers()` instead of manually constructing headers

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New test suite in `tests/tracing/utils/test_otlp_auth.py` covering:
- No credentials → only experiment-id header
- Basic auth (username + password)
- Bearer token
- Token takes precedence over basic auth

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `401 Unauthorized` errors when using `agno.autolog()` or `otel.autolog()` with an MLflow server that has authentication enabled. The OTLP span exporter now includes auth credentials from the standard MLflow credential system.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)