### PR TITLE
Add store and client methods for UC table-prefix locations

### DIFF
--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -190,10 +190,9 @@ class DatabricksTracingRestStore(RestStore):
             raise
 
     def get_trace_location(self, telemetry_profile_id: str) -> UnityCatalogEntity:
-        req_body = message_to_json(GetLocation(location_id=telemetry_profile_id))
         response_proto = self._call_endpoint(
             GetLocation,
-            req_body,
+            "{}",
             endpoint=f"{_V5_TRACE_LOCATION_ENDPOINT}/{telemetry_profile_id}",
             response_proto=GetLocation.Response(),
         )
@@ -415,7 +414,7 @@ class DatabricksTracingRestStore(RestStore):
                 page_token=page_token,
             )
 
-        contain_uc_schemas = False
+        contains_uc_locations = False
         trace_locations = []
         for location in locations:
             match location.split("."):
@@ -429,7 +428,7 @@ class DatabricksTracingRestStore(RestStore):
                             TraceLocation.from_databricks_uc_schema(catalog, schema)
                         )
                     )
-                    contain_uc_schemas = True
+                    contains_uc_locations = True
                 case [catalog, schema, table_prefix]:
                     trace_locations.append(
                         trace_location_to_proto(
@@ -438,7 +437,7 @@ class DatabricksTracingRestStore(RestStore):
                             )
                         )
                     )
-                    contain_uc_schemas = True
+                    contains_uc_locations = True
                 case _:
                     raise MlflowException.invalid_parameter_value(
                         f"Invalid location type: {location}. Expected type: "
@@ -466,7 +465,7 @@ class DatabricksTracingRestStore(RestStore):
             # 2. Server supports V4 API but the experiment location is not supported yet.
             # For these known cases, MLflow fallback to V3 API.
             if e.error_code == ErrorCode.Name(ENDPOINT_NOT_FOUND):
-                if contain_uc_schemas:
+                if contains_uc_locations:
                     raise MlflowException.invalid_parameter_value(
                         "Searching traces in UC tables is not supported yet. Only experiment IDs "
                         "are supported for searching traces."
@@ -476,7 +475,7 @@ class DatabricksTracingRestStore(RestStore):
                 e.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
                 and "locations not yet supported" in e.message
             ):
-                if contain_uc_schemas:
+                if contains_uc_locations:
                     raise MlflowException.invalid_parameter_value(
                         "The `locations` parameter cannot contain both MLflow experiment and UC "
                         "schema in the same request. Please specify only one type of location "

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -1276,6 +1276,137 @@ def test_update_assessment(sql_warehouse_id):
         assert res.rationale == "updated_rationale"
 
 
+def test_update_assessment_uc_table_prefix(sql_warehouse_id):
+    creds = MlflowHostCreds("https://hello")
+    store = DatabricksTracingRestStore(lambda: creds)
+    response = mock.MagicMock()
+    response.status_code = 200
+    trace_id = "trace:/catalog.schema.prefix/1234"
+    response.text = json.dumps(
+        {
+            "assessment_id": "1234",
+            "assessment_name": "updated_assessment_name",
+            "trace_location": {
+                "type": "UC_TABLE_PREFIX",
+                "uc_table_prefix": {
+                    "catalog_name": "catalog",
+                    "schema_name": "schema",
+                    "table_prefix": "prefix",
+                },
+            },
+            "trace_id": "1234",
+            "source": {
+                "source_type": "LLM_JUDGE",
+                "source_id": "gpt-4o-mini",
+            },
+            "create_time": "2025-02-20T05:47:23Z",
+            "last_update_time": "2025-02-20T05:47:23Z",
+            "feedback": {"value": False},
+            "rationale": "updated_rationale",
+            "metadata": {"model": "gpt-4o-mini"},
+            "error": None,
+            "span_id": None,
+        }
+    )
+
+    request = {
+        "assessment_id": "1234",
+        "trace_location": {
+            "type": "UC_TABLE_PREFIX",
+            "uc_table_prefix": {
+                "catalog_name": "catalog",
+                "schema_name": "schema",
+                "table_prefix": "prefix",
+            },
+        },
+        "trace_id": "1234",
+        "feedback": {"value": False},
+        "rationale": "updated_rationale",
+        "metadata": {"model": "gpt-4o-mini"},
+    }
+    with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
+        res = store.update_assessment(
+            trace_id=trace_id,
+            assessment_id="1234",
+            feedback=FeedbackValue(value=False),
+            rationale="updated_rationale",
+            metadata={"model": "gpt-4o-mini"},
+        )
+
+        _verify_requests(
+            mock_http,
+            creds,
+            f"traces/catalog.schema.prefix/1234/assessments/1234?sql_warehouse_id={sql_warehouse_id}&update_mask=feedback,rationale,metadata",
+            "PATCH",
+            json.dumps(request),
+            version="4.0",
+        )
+        assert isinstance(res, Feedback)
+        assert res.assessment_id == "1234"
+        assert res.value is False
+        assert res.rationale == "updated_rationale"
+
+
+def test_search_traces_uc_table_prefix(monkeypatch):
+    monkeypatch.setenv(MLFLOW_TRACING_SQL_WAREHOUSE_ID.name, "test-warehouse")
+
+    creds = MlflowHostCreds("https://hello")
+    store = DatabricksTracingRestStore(lambda: creds)
+    response = mock.MagicMock()
+    response.status_code = 200
+
+    response.text = json.dumps(
+        {
+            "trace_infos": [
+                {
+                    "trace_id": "1234",
+                    "trace_location": {
+                        "type": "UC_TABLE_PREFIX",
+                        "uc_table_prefix": {
+                            "catalog_name": "catalog",
+                            "schema_name": "schema",
+                            "table_prefix": "prefix",
+                        },
+                    },
+                    "request_time": "1970-01-01T00:00:00.123Z",
+                    "execution_duration_ms": 456,
+                    "state": "OK",
+                    "trace_metadata": {"key": "value"},
+                    "tags": {"k": "v"},
+                }
+            ],
+            "next_page_token": "token",
+        }
+    )
+
+    locations = ["catalog.schema.prefix"]
+
+    with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
+        trace_infos, token = store.search_traces(
+            locations=locations,
+        )
+
+    assert mock_http.call_count == 1
+    call_args = mock_http.call_args[1]
+    assert call_args["endpoint"] == f"{_V4_TRACE_REST_API_PATH_PREFIX}/search"
+
+    json_body = call_args["json"]
+    assert "locations" in json_body
+    assert len(json_body["locations"]) == 1
+    assert json_body["locations"][0]["uc_table_prefix"]["catalog_name"] == "catalog"
+    assert json_body["locations"][0]["uc_table_prefix"]["schema_name"] == "schema"
+    assert json_body["locations"][0]["uc_table_prefix"]["table_prefix"] == "prefix"
+    assert json_body["sql_warehouse_id"] == "test-warehouse"
+
+    assert len(trace_infos) == 1
+    assert isinstance(trace_infos[0], TraceInfo)
+    assert trace_infos[0].trace_id == "trace:/catalog.schema.prefix/1234"
+    assert trace_infos[0].trace_location.uc_table_prefix.catalog_name == "catalog"
+    assert trace_infos[0].trace_location.uc_table_prefix.schema_name == "schema"
+    assert trace_infos[0].trace_location.uc_table_prefix.table_prefix == "prefix"
+    assert token == "token"
+
+
 def test_delete_assessment(sql_warehouse_id):
     creds = MlflowHostCreds("https://hello")
     store = DatabricksTracingRestStore(lambda: creds)


### PR DESCRIPTION
### Related Issues/PRs

Stacked on #21184

### What changes are proposed in this pull request?

Add backend communication methods for UC table-prefix trace locations. This is PR 3/5 in the UC table-prefix stack.

**Store changes (`DatabricksTracingRestStore`):**
- `get_trace_location` — V5 `GET /mlflow/tracing/locations/{location_id}`
- `create_or_get_trace_location` — V5 `POST /mlflow/tracing/locations`
- `link_trace_location` — V5 `POST /mlflow/experiments/{id}/trace-location:link`
- `search_traces` — accept 3-part `catalog.schema.table_prefix` locations
- `update_assessment` — handle 3-part locations via `parse_uc_location`

**Client changes (`TracingClient`):**
- `_get_trace_location`, `_create_or_get_trace_location`, `_link_trace_location`
- `_unset_experiment_trace_location` accepts `UnityCatalog`
- Trace grouping updated for `uc_table_prefix` locations

**PR stack:**
1. Proto definitions (#21178) ✅ merged
2. Entity + Utils (#21184) ✅ merged
3. **[This PR]** Store + Client
4. Destination + Processor
5. `set_experiment` + auto-resolution

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- Tests for all 3 new store methods in `tests/store/tracking/test_databricks_rest_store.py`
- Updated invalid-location test for 3-part format

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)