### PR TITLE
Add --static-prefix for mlflow models serve

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -1,7 +1,9 @@
 import logging
+import os
 
 import click
 
+from mlflow.cli import _validate_static_prefix
 from mlflow.mcp.decorator import mlflow_mcp
 from mlflow.models import python_api
 from mlflow.models.flavor_backend_registry import get_flavor_backend
@@ -33,6 +35,15 @@ def commands():
 @cli_args.NO_CONDA
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
+@click.option(
+    "--static-prefix",
+    envvar="MLFLOW_STATIC_PREFIX",
+    default=None,
+    callback=_validate_static_prefix,
+    help="A prefix which will be prepended to the path of all routes. "
+    "Not supported with MLServer (ENABLE_MLSERVER=true). "
+    "Example: --static-prefix /api/v1",
+)
 def serve(
     model_uri,
     port,
@@ -43,6 +54,7 @@ def serve(
     no_conda=False,
     install_mlflow=False,
     enable_mlserver=False,
+    static_prefix=None,
 ):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port.
@@ -100,6 +112,9 @@ def serve(
 
     """
     env_manager = _EnvManager.LOCAL if no_conda else env_manager
+
+    if static_prefix:
+        os.environ["MLFLOW_STATIC_PREFIX"] = static_prefix
 
     return get_flavor_backend(
         model_uri, env_manager=env_manager, workers=workers, install_mlflow=install_mlflow

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -183,6 +183,14 @@ def _serve_pyfunc(model, env_manager):
     enable_mlserver = os.getenv(ENABLE_MLSERVER, "false").lower() == "true"
     disable_env_creation = MLFLOW_DISABLE_ENV_CREATION.get()
 
+    if static_prefix := os.getenv("MLFLOW_STATIC_PREFIX", ""):
+        if enable_mlserver:
+            raise ValueError(
+                f"--static-prefix ('{static_prefix}') is not supported with ENABLE_MLSERVER=true. "
+                "MLServer uses the KServe v2 protocol with its own path structure "
+                "(/v2/models/{{model_name}}/...) and does not use the MLflow scoring server."
+            )
+
     conf = model.flavors[pyfunc.FLAVOR_NAME]
     bash_cmds = []
     if pyfunc.ENV in conf:

--- a/mlflow/models/container/scoring_server/nginx.conf
+++ b/mlflow/models/container/scoring_server/nginx.conf
@@ -23,8 +23,8 @@ http {
     client_max_body_size 5m;
 
     keepalive_timeout 75;
-
-    location ~ ^/(ping|invocations) {
+    # Matches /ping, /invocations, /any/prefix/ping, /any/prefix/invocations (anchored)
+    location ~ ^/(.*/)?(?:ping|invocations)$ {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -484,6 +484,13 @@ def _async_catch_mlflow_exception(func):
     return wrapper
 
 
+def _add_static_prefix(route: str) -> str:
+    """Add static prefix to route if MLFLOW_STATIC_PREFIX is set."""
+    if prefix := os.environ.get("MLFLOW_STATIC_PREFIX"):
+        return prefix.rstrip("/") + route
+    return route
+
+
 def init(model: PyFuncModel):
     """
     Initialize the server. Loads pyfunc model from the path.
@@ -508,8 +515,8 @@ def init(model: PyFuncModel):
                 media_type="application/json",
             )
 
-    @app.route("/ping", methods=["GET"])
-    @app.route("/health", methods=["GET"])
+    @app.route(_add_static_prefix("/ping"), methods=["GET"])
+    @app.route(_add_static_prefix("/health"), methods=["GET"])
     async def ping(request: Request):
         """
         Determine if the container is working and healthy.
@@ -519,14 +526,14 @@ def init(model: PyFuncModel):
         status = 200 if health else 404
         return Response(content="\n", status_code=status, media_type="application/json")
 
-    @app.route("/version", methods=["GET"])
+    @app.route(_add_static_prefix("/version"), methods=["GET"])
     async def version(request: Request):
         """
         Returns the current mlflow version.
         """
         return Response(content=VERSION, status_code=200, media_type="application/json")
 
-    @app.route("/invocations", methods=["POST"])
+    @app.route(_add_static_prefix("/invocations"), methods=["POST"])
     @_async_catch_mlflow_exception
     async def transformation(request: Request):
         """

--- a/tests/models/test_static_prefix.py
+++ b/tests/models/test_static_prefix.py
@@ -1,0 +1,225 @@
+"""
+Tests for static_prefix functionality in model serving.
+"""
+
+import json
+from unittest import mock
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+import mlflow
+from mlflow.pyfunc import PythonModel
+from mlflow.pyfunc.scoring_server import init
+
+
+class SimpleTestModel(PythonModel):
+    def predict(self, context, model_input, params=None):
+        return model_input
+
+
+def test_invocations_with_static_prefix(tmp_path, monkeypatch):
+    model_path = str(tmp_path / "model")
+    mlflow.pyfunc.save_model(path=model_path, python_model=SimpleTestModel())
+
+    monkeypatch.setenv("MLFLOW_STATIC_PREFIX", "/api/v1")
+    model = mlflow.pyfunc.load_model(model_path)
+    app = init(model)
+    client = TestClient(app)
+
+    test_df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    data = json.dumps({"dataframe_split": test_df.to_dict(orient="split")})
+
+    response = client.post(
+        "/api/v1/invocations",
+        content=data,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert "predictions" in result
+
+
+def test_ping_with_static_prefix(tmp_path, monkeypatch):
+    model_path = str(tmp_path / "model")
+    mlflow.pyfunc.save_model(path=model_path, python_model=SimpleTestModel())
+
+    monkeypatch.setenv("MLFLOW_STATIC_PREFIX", "/api/v1")
+    model = mlflow.pyfunc.load_model(model_path)
+    app = init(model)
+    client = TestClient(app)
+
+    response = client.get("/api/v1/ping")
+    assert response.status_code == 200
+
+
+def test_version_with_static_prefix(tmp_path, monkeypatch):
+    model_path = str(tmp_path / "model")
+    mlflow.pyfunc.save_model(path=model_path, python_model=SimpleTestModel())
+
+    monkeypatch.setenv("MLFLOW_STATIC_PREFIX", "/api/v1")
+    model = mlflow.pyfunc.load_model(model_path)
+    app = init(model)
+    client = TestClient(app)
+
+    response = client.get("/api/v1/version")
+    assert response.status_code == 200
+    assert response.text
+
+
+def test_invocations_without_static_prefix(tmp_path, monkeypatch):
+    model_path = str(tmp_path / "model")
+    mlflow.pyfunc.save_model(path=model_path, python_model=SimpleTestModel())
+
+    monkeypatch.delenv("MLFLOW_STATIC_PREFIX", raising=False)
+    model = mlflow.pyfunc.load_model(model_path)
+    app = init(model)
+    client = TestClient(app)
+
+    test_df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    data = json.dumps({"dataframe_split": test_df.to_dict(orient="split")})
+
+    response = client.post(
+        "/invocations",
+        content=data,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert "predictions" in result
+
+
+@pytest.mark.parametrize(
+    ("prefix", "endpoint", "expected_path"),
+    [
+        ("/api/v1", "ping", "/api/v1/ping"),
+        ("/api/v1", "invocations", "/api/v1/invocations"),
+        ("/models", "ping", "/models/ping"),
+        ("/ml/v2", "invocations", "/ml/v2/invocations"),
+    ],
+)
+def test_static_prefix_with_various_prefixes(
+    tmp_path, prefix, endpoint, expected_path, monkeypatch
+):
+    model_path = str(tmp_path / "model")
+    mlflow.pyfunc.save_model(path=model_path, python_model=SimpleTestModel())
+
+    monkeypatch.setenv("MLFLOW_STATIC_PREFIX", prefix)
+    model = mlflow.pyfunc.load_model(model_path)
+    app = init(model)
+    client = TestClient(app)
+
+    if endpoint == "invocations":
+        test_df = pd.DataFrame({"x": [1, 2, 3]})
+        data = json.dumps({"dataframe_split": test_df.to_dict(orient="split")})
+        response = client.post(
+            expected_path,
+            content=data,
+            headers={"Content-Type": "application/json"},
+        )
+    else:
+        response = client.get(expected_path)
+
+    assert response.status_code == 200
+
+
+def test_non_prefixed_paths_return_404_when_prefix_set(tmp_path, monkeypatch):
+    model_path = str(tmp_path / "model")
+    mlflow.pyfunc.save_model(path=model_path, python_model=SimpleTestModel())
+
+    monkeypatch.setenv("MLFLOW_STATIC_PREFIX", "/api/v1")
+    model = mlflow.pyfunc.load_model(model_path)
+    app = init(model)
+    client = TestClient(app)
+
+    # Non-prefixed paths should return 404
+    assert client.get("/ping").status_code == 404
+    assert client.get("/version").status_code == 404
+
+
+def test_static_prefix_works_with_nginx_enabled(monkeypatch):
+    from mlflow.models import Model
+    from mlflow.models.container import _serve_pyfunc
+    from mlflow.utils import env_manager as em
+
+    model_dict = {
+        "flavors": {
+            "python_function": {
+                "loader_module": "mlflow.pyfunc.model",
+            }
+        }
+    }
+    model = Model.from_dict(model_dict)
+
+    monkeypatch.setenv("MLFLOW_STATIC_PREFIX", "/api/v1")
+    monkeypatch.delenv("ENABLE_MLSERVER", raising=False)
+
+    with (
+        mock.patch("mlflow.models.container.Popen") as mock_popen,
+        mock.patch("mlflow.pyfunc.scoring_server.get_cmd") as mock_get_cmd,
+        mock.patch("mlflow.models.container._await_subprocess_exit_any"),
+        mock.patch("mlflow.models.container._sigterm_handler"),
+        mock.patch("mlflow.models.container.check_call"),
+    ):
+        mock_popen.return_value.pid = 12345
+        mock_get_cmd.return_value = ("python -m mlflow.pyfunc", {})
+        _serve_pyfunc(model, env_manager=em.LOCAL)
+
+
+def test_static_prefix_works_with_nginx_disabled(monkeypatch):
+    from mlflow.models import Model
+    from mlflow.models.container import _serve_pyfunc
+    from mlflow.utils import env_manager as em
+
+    model_dict = {
+        "flavors": {
+            "python_function": {
+                "loader_module": "mlflow.pyfunc.model",
+            }
+        }
+    }
+    model = Model.from_dict(model_dict)
+
+    monkeypatch.setenv("MLFLOW_STATIC_PREFIX", "/api/v1")
+    monkeypatch.setenv("DISABLE_NGINX", "true")
+    monkeypatch.delenv("ENABLE_MLSERVER", raising=False)
+
+    with (
+        mock.patch("mlflow.models.container.Popen") as mock_popen,
+        mock.patch("mlflow.pyfunc.scoring_server.get_cmd") as mock_get_cmd,
+        mock.patch("mlflow.models.container._await_subprocess_exit_any"),
+        mock.patch("mlflow.models.container._sigterm_handler"),
+    ):
+        mock_popen.return_value.pid = 12345
+        mock_get_cmd.return_value = ("python -m mlflow.pyfunc", {})
+        _serve_pyfunc(model, env_manager=em.LOCAL)
+
+
+def test_static_prefix_not_supported_with_mlserver(monkeypatch):
+    from mlflow.models import Model
+    from mlflow.models.container import _serve_pyfunc
+    from mlflow.utils import env_manager as em
+
+    model_dict = {
+        "flavors": {
+            "python_function": {
+                "loader_module": "mlflow.pyfunc.model",
+            }
+        }
+    }
+    model = Model.from_dict(model_dict)
+
+    monkeypatch.setenv("MLFLOW_STATIC_PREFIX", "/api/v1")
+    monkeypatch.setenv("ENABLE_MLSERVER", "true")
+
+    with (
+        pytest.raises(
+            ValueError,
+            match="--static-prefix.*is not supported with ENABLE_MLSERVER=true",
+        ),
+        mock.patch("mlflow.models.container.Popen"),
+    ):
+        _serve_pyfunc(model, env_manager=em.LOCAL)


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #21241

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
  This PR adds `--static-prefix` support for model serving to enable deployment behind reverse proxies and API gateways with path-based routing.

  Changes include:
  - Add `--static-prefix` CLI option to `mlflow models serve` command
  - Update scoring server route handlers to support path prefixes
  - Update NGINX config regex to match prefixed paths
  - Add comprehensive test coverage
  - not enable for MLServer.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

It reuses the existing [parameter](https://mlflow.org/docs/latest/api_reference/cli.html#cmdoption-mlflow-server-static-prefix).

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->
Don't see anything on this in the skills.
### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Add `--static-prefix` option to `mlflow models serve`. (e.g., `mlflow models serve -m model_uri --static-prefix /api/v1` serves endpoints at `/api/v1/ping`, `/api/v1/invocations`, `/api/v1/version`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
