### PR TITLE
Fix NoneType error in claude_code tracing hook

### DIFF
--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -485,37 +485,46 @@ def _finalize_trace(
     try:
         # Set trace previews and metadata for UI display
         with InMemoryTraceManager.get_instance().get_trace(parent_span.trace_id) as in_memory_trace:
-            if user_prompt:
-                in_memory_trace.info.request_preview = user_prompt[:MAX_PREVIEW_LENGTH]
-            if final_response:
-                in_memory_trace.info.response_preview = final_response[:MAX_PREVIEW_LENGTH]
-
-            metadata = {
-                TraceMetadataKey.TRACE_USER: os.environ.get("USER", ""),
-                "mlflow.trace.working_directory": os.getcwd(),
-            }
-            if session_id:
-                metadata[TraceMetadataKey.TRACE_SESSION] = session_id
-
-            # Set token usage directly on trace metadata so it survives
-            # even if span-level aggregation doesn't pick it up
-            if usage:
-                input_tokens = usage.get("input_tokens", 0) + usage.get(
-                    "cache_creation_input_tokens", 0
+            # in_memory_trace is None when the span is a NoOpSpan (e.g. tracing
+            # backend is unreachable) because the trace was never registered.
+            if in_memory_trace is None:
+                get_logger().warning(
+                    "Trace %s not found in memory; skipping metadata update. "
+                    "This usually means the tracing backend is unreachable.",
+                    parent_span.trace_id,
                 )
-                output_tokens = usage.get("output_tokens", 0)
-                metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(
-                    {
-                        TokenUsageKey.INPUT_TOKENS: input_tokens,
-                        TokenUsageKey.OUTPUT_TOKENS: output_tokens,
-                        TokenUsageKey.TOTAL_TOKENS: input_tokens + output_tokens,
-                    }
-                )
+            else:
+                if user_prompt:
+                    in_memory_trace.info.request_preview = user_prompt[:MAX_PREVIEW_LENGTH]
+                if final_response:
+                    in_memory_trace.info.response_preview = final_response[:MAX_PREVIEW_LENGTH]
 
-            in_memory_trace.info.trace_metadata = {
-                **in_memory_trace.info.trace_metadata,
-                **metadata,
-            }
+                metadata = {
+                    TraceMetadataKey.TRACE_USER: os.environ.get("USER", ""),
+                    "mlflow.trace.working_directory": os.getcwd(),
+                }
+                if session_id:
+                    metadata[TraceMetadataKey.TRACE_SESSION] = session_id
+
+                # Set token usage directly on trace metadata so it survives
+                # even if span-level aggregation doesn't pick it up
+                if usage:
+                    input_tokens = usage.get("input_tokens", 0) + usage.get(
+                        "cache_creation_input_tokens", 0
+                    )
+                    output_tokens = usage.get("output_tokens", 0)
+                    metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(
+                        {
+                            TokenUsageKey.INPUT_TOKENS: input_tokens,
+                            TokenUsageKey.OUTPUT_TOKENS: output_tokens,
+                            TokenUsageKey.TOTAL_TOKENS: input_tokens + output_tokens,
+                        }
+                    )
+
+                in_memory_trace.info.trace_metadata = {
+                    **in_memory_trace.info.trace_metadata,
+                    **metadata,
+                }
     except Exception as e:
         get_logger().warning("Failed to update trace metadata and previews: %s", e)
 

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -158,6 +158,32 @@ def test_flush_trace_async_logging_skips_without_async_queue(monkeypatch):
 
 
 # ============================================================================
+# FINALIZE TRACE WITH NOOP SPAN TESTS
+# ============================================================================
+
+
+def test_finalize_trace_handles_noop_span(monkeypatch):
+    """Regression test for #21222: _finalize_trace should not raise
+    AttributeError when the parent span is a NoOpSpan and the trace is
+    not found in the in-memory trace manager."""
+    from mlflow.entities.span import NoOpSpan
+
+    noop_span = NoOpSpan()
+    monkeypatch.setattr(
+        tracing_module, "_flush_trace_async_logging", lambda: None
+    )
+    # _finalize_trace should not raise; it returns None because
+    # mlflow.get_trace returns None for a no-op trace id.
+    result = tracing_module._finalize_trace(
+        parent_span=noop_span,
+        user_prompt="hello",
+        final_response="world",
+        session_id="test-noop-session",
+    )
+    assert result is None
+
+
+# ============================================================================
 # INTEGRATION TESTS
 # ============================================================================
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #21222

### What changes are proposed in this pull request?

In _finalize_trace, the code calls InMemoryTraceManager.get_trace(parent_span.trace_id) which yields None when the trace was never registered in memory. This happens when the MLflow tracing backend is unreachable -- start_span_no_context returns a NoOpSpan (with trace_id MLFLOW_NO_OP_SPAN_TRACE_ID) and the trace is never stored in the InMemoryTraceManager. The code then tries to access .info on the None object, raising NoneType object has no attribute info.

This PR adds a null check for the in_memory_trace object so that _finalize_trace gracefully skips the metadata update and logs a descriptive warning instead of raising an unhandled AttributeError.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added test_finalize_trace_handles_noop_span which verifies that _finalize_trace does not raise when given a NoOpSpan (simulating an unreachable tracing backend).

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the MLflow Skills repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug in mlflow.claude_code.tracing where _finalize_trace would crash with NoneType object has no attribute info when the MLflow tracing backend is unreachable, causing Claude Code stop hooks to fail.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] area/tracking: Tracking Service, tracking client APIs, autologging
- [x] area/tracing: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x] rn/bug-fix - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)