### PR TITLE
fix(tracing-typescript-anthropic): unsupported content blocks

### DIFF
--- a/libs/typescript/integrations/anthropic/src/index.ts
+++ b/libs/typescript/integrations/anthropic/src/index.ts
@@ -55,7 +55,7 @@ function sanitizeInputsForTracing(inputs: any): any {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       for (const block of msg.content as any[]) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (block.type && !MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string)) {
+        if (block && block.type && !MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string)) {
           needsSanitization = true;
           break;
         }
@@ -83,7 +83,8 @@ function sanitizeInputsForTracing(inputs: any): any {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const hasUnsupported = (msg.content as any[]).some(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      (block: any) => block.type && !MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string),
+      (block: any) =>
+        block && block.type && !MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string),
     );
     if (!hasUnsupported) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -93,7 +94,7 @@ function sanitizeInputsForTracing(inputs: any): any {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const sanitizedContent = (msg.content as any[]).map((block: any) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (!block.type || MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string)) {
+      if (!block || !block.type || MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string)) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return block;
       }
@@ -126,7 +127,8 @@ function sanitizeOutputsForTracing(output: any): any {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const hasUnsupported = (output.content as any[]).some(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    (block: any) => block.type && !MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string),
+    (block: any) =>
+      block && block.type && !MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string),
   );
   if (!hasUnsupported) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -136,7 +138,7 @@ function sanitizeOutputsForTracing(output: any): any {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const sanitizedContent = (output.content as any[]).map((block: any) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (!block.type || MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string)) {
+    if (!block || !block.type || MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string)) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return block;
     }

--- a/libs/typescript/integrations/anthropic/src/index.ts
+++ b/libs/typescript/integrations/anthropic/src/index.ts
@@ -17,6 +17,138 @@ const SUPPORTED_MODULES = ['Messages'];
 const SUPPORTED_METHODS = ['create', 'stream'];
 
 /**
+ * Content block types that the MLflow UI's Anthropic chat normalizer supports.
+ * Any other types (e.g. `redacted_thinking`, `document`) cause the normalizer
+ * to reject the entire message, which prevents the Chat tab from rendering.
+ */
+const MLFLOW_UI_SUPPORTED_CONTENT_TYPES = new Set([
+  'text',
+  'image',
+  'tool_use',
+  'tool_result',
+  'thinking',
+]);
+
+/**
+ * Sanitize Anthropic API inputs for MLflow span storage.
+ * Replaces content block types not supported by the MLflow UI normalizer
+ * with text placeholders so the Chat tab renders correctly.
+ *
+ * Handles `redacted_thinking` (large base64 signatures from extended thinking)
+ * and `document` (base64 PDF data) blocks that would otherwise cause the
+ * normalizer to fail.
+ */
+function sanitizeInputsForTracing(inputs: any): any {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  if (!inputs?.messages || !Array.isArray(inputs.messages)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return inputs;
+  }
+
+  let needsSanitization = false;
+
+  // Quick scan: check if any message has unsupported content blocks
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  for (const msg of inputs.messages as any[]) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (Array.isArray(msg.content)) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      for (const block of msg.content as any[]) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (block.type && !MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string)) {
+          needsSanitization = true;
+          break;
+        }
+      }
+      if (needsSanitization) {
+        break;
+      }
+    }
+  }
+
+  if (!needsSanitization) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return inputs;
+  }
+
+  // Build a shallow copy with sanitized messages
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const sanitizedMessages = (inputs.messages as any[]).map((msg: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (!Array.isArray(msg.content)) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return msg;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const hasUnsupported = (msg.content as any[]).some(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (block: any) => block.type && !MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string),
+    );
+    if (!hasUnsupported) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return msg;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const sanitizedContent = (msg.content as any[]).map((block: any) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (!block.type || MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return block;
+      }
+      // Replace unsupported block with a text placeholder
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      return { type: 'text', text: `[${block.type as string}]` };
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return { ...msg, content: sanitizedContent };
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return { ...inputs, messages: sanitizedMessages };
+}
+
+/**
+ * Sanitize Anthropic API outputs for MLflow span storage.
+ * The output is a single message object with content blocks.
+ * Replaces unsupported content block types with text placeholders
+ * so the Chat tab renders correctly.
+ */
+function sanitizeOutputsForTracing(output: any): any {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  if (!output?.content || !Array.isArray(output.content)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return output;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const hasUnsupported = (output.content as any[]).some(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (block: any) => block.type && !MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string),
+  );
+  if (!hasUnsupported) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return output;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const sanitizedContent = (output.content as any[]).map((block: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (!block.type || MLFLOW_UI_SUPPORTED_CONTENT_TYPES.has(block.type as string)) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return block;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return { type: 'text', text: `[${block.type as string}]` };
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return { ...output, content: sanitizedContent };
+}
+
+/**
  * Create a traced version of Anthropic client with MLflow tracing
  * @param anthropicClient - The Anthropic client instance to trace
  * @returns Traced Anthropic client with tracing capabilities
@@ -87,11 +219,11 @@ function wrapWithTracing(fn: Function, moduleName: string): Function {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return withSpan(
       async (span: LiveSpan) => {
-        span.setInputs(args[0]);
+        span.setInputs(sanitizeInputsForTracing(args[0]));
 
         const result = await fn.apply(this, args);
 
-        span.setOutputs(result);
+        span.setOutputs(sanitizeOutputsForTracing(result));
 
         try {
           const usage = extractTokenUsage(result);
@@ -137,7 +269,7 @@ function wrapStreamWithTracing(fn: Function, moduleName: string): Function {
 
     // Return a proxy that wraps the stream with tracing
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return wrapMessageStream(stream, args[0], name, spanType);
+    return wrapMessageStream(stream, sanitizeInputsForTracing(args[0]), name, spanType);
   };
 }
 
@@ -170,7 +302,7 @@ function wrapMessageStream(stream: any, inputs: any, name: string, spanType: Spa
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
               const message = await target.finalMessage();
 
-              span.setOutputs(message);
+              span.setOutputs(sanitizeOutputsForTracing(message));
 
               try {
                 const usage = extractTokenUsage(message);
@@ -266,7 +398,7 @@ async function* wrapAsyncIterator(
         }
 
         if (finalMessage !== undefined) {
-          span.setOutputs(finalMessage);
+          span.setOutputs(sanitizeOutputsForTracing(finalMessage));
 
           const usage = extractTokenUsage(finalMessage);
           if (usage) {

--- a/libs/typescript/integrations/anthropic/tests/index.test.ts
+++ b/libs/typescript/integrations/anthropic/tests/index.test.ts
@@ -7,7 +7,11 @@ import Anthropic from '@anthropic-ai/sdk';
 import { tracedAnthropic } from '../src';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { anthropicMockHandlers, createStreamingErrorHandler } from './mockAnthropicServer';
+import {
+  anthropicMockHandlers,
+  createStreamingErrorHandler,
+  createStreamingWithUnsupportedContentHandler,
+} from './mockAnthropicServer';
 import { createAuthProvider } from '@mlflow/core/src/auth';
 
 const TEST_TRACKING_URI = 'http://localhost:5000';
@@ -546,6 +550,60 @@ describe('tracedAnthropic', () => {
 
       expect(span.outputs.content).toEqual([
         { type: 'thinking', thinking: 'Let me think about this...' },
+        { type: 'text', text: '[redacted_thinking]' },
+        { type: 'text', text: 'Here is my response.' },
+      ]);
+    });
+
+    it('should sanitize outputs when streaming via async iteration', async () => {
+      server.use(createStreamingWithUnsupportedContentHandler());
+
+      const anthropic = new Anthropic({ apiKey: 'test-key' });
+      const wrappedAnthropic = tracedAnthropic(anthropic);
+
+      const stream = wrappedAnthropic.messages.stream({
+        model: 'claude-3-7-sonnet-20250219',
+        max_tokens: 256,
+        messages: [{ role: 'user', content: 'Test streaming output sanitization.' }],
+      });
+
+      for await (const _event of stream) {
+        // consume all events
+      }
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+
+      // The streamed final message contained a redacted_thinking block;
+      // outputs stored on the span should have it replaced with a text placeholder
+      expect(span.outputs.content).toEqual([
+        { type: 'thinking', thinking: 'Let me think...' },
+        { type: 'text', text: '[redacted_thinking]' },
+        { type: 'text', text: 'Here is my response.' },
+      ]);
+    });
+
+    it('should sanitize outputs when streaming via finalMessage()', async () => {
+      server.use(createStreamingWithUnsupportedContentHandler());
+
+      const anthropic = new Anthropic({ apiKey: 'test-key' });
+      const wrappedAnthropic = tracedAnthropic(anthropic);
+
+      const stream = wrappedAnthropic.messages.stream({
+        model: 'claude-3-7-sonnet-20250219',
+        max_tokens: 256,
+        messages: [{ role: 'user', content: 'Test streaming finalMessage output sanitization.' }],
+      });
+
+      const message = await stream.finalMessage();
+      expect(message).toBeDefined();
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+
+      // Outputs stored on the span should have redacted_thinking replaced
+      expect(span.outputs.content).toEqual([
+        { type: 'thinking', thinking: 'Let me think...' },
         { type: 'text', text: '[redacted_thinking]' },
         { type: 'text', text: 'Here is my response.' },
       ]);

--- a/libs/typescript/integrations/anthropic/tests/index.test.ts
+++ b/libs/typescript/integrations/anthropic/tests/index.test.ts
@@ -381,6 +381,213 @@ describe('tracedAnthropic', () => {
     }
   });
 
+  describe('content sanitization for MLflow UI', () => {
+    it('should replace redacted_thinking blocks with text placeholders in inputs', async () => {
+      const anthropic = new Anthropic({ apiKey: 'test-key' });
+      const wrappedAnthropic = tracedAnthropic(anthropic);
+
+      await wrappedAnthropic.messages.create({
+        model: 'claude-3-7-sonnet-20250219',
+        max_tokens: 256,
+        messages: [
+          { role: 'user', content: 'Think carefully.' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'Deep thought...', signature: 'sig123' },
+              { type: 'redacted_thinking', data: 'base64encodeddata' },
+              { type: 'text', text: 'My answer.' },
+            ],
+          },
+          { role: 'user', content: 'Continue.' },
+        ] as any,
+      });
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+
+      const assistantMsg = span.inputs.messages[1];
+      expect(assistantMsg.content).toEqual([
+        { type: 'thinking', thinking: 'Deep thought...', signature: 'sig123' },
+        { type: 'text', text: '[redacted_thinking]' },
+        { type: 'text', text: 'My answer.' },
+      ]);
+
+      // Other messages should be unchanged
+      expect(span.inputs.messages[0]).toEqual({ role: 'user', content: 'Think carefully.' });
+      expect(span.inputs.messages[2]).toEqual({ role: 'user', content: 'Continue.' });
+    });
+
+    it('should replace document blocks with text placeholders in inputs', async () => {
+      const anthropic = new Anthropic({ apiKey: 'test-key' });
+      const wrappedAnthropic = tracedAnthropic(anthropic);
+
+      await wrappedAnthropic.messages.create({
+        model: 'claude-3-7-sonnet-20250219',
+        max_tokens: 256,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'document',
+                source: { type: 'base64', media_type: 'application/pdf', data: 'base64pdfdata' },
+              },
+              { type: 'text', text: 'Summarize this document.' },
+            ],
+          },
+        ] as any,
+      });
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+
+      const userMsg = span.inputs.messages[0];
+      expect(userMsg.content).toEqual([
+        { type: 'text', text: '[document]' },
+        { type: 'text', text: 'Summarize this document.' },
+      ]);
+    });
+
+    it('should preserve all supported content types in inputs unchanged', async () => {
+      const anthropic = new Anthropic({ apiKey: 'test-key' });
+      const wrappedAnthropic = tracedAnthropic(anthropic);
+
+      const messages = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hello' },
+            {
+              type: 'image',
+              source: { type: 'base64', media_type: 'image/png', data: 'imagedata' },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'Thinking...' },
+            { type: 'text', text: 'Response' },
+            { type: 'tool_use', id: 'tool_1', name: 'search', input: { query: 'test' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tool_1', content: 'Result' }],
+        },
+      ];
+
+      await wrappedAnthropic.messages.create({
+        model: 'claude-3-7-sonnet-20250219',
+        max_tokens: 256,
+        messages: messages as any,
+      });
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+
+      // All content should be preserved as-is since all types are supported
+      expect(span.inputs.messages).toEqual(messages);
+    });
+
+    it('should pass through string message content without modification', async () => {
+      const anthropic = new Anthropic({ apiKey: 'test-key' });
+      const wrappedAnthropic = tracedAnthropic(anthropic);
+
+      await wrappedAnthropic.messages.create({
+        model: 'claude-3-7-sonnet-20250219',
+        max_tokens: 256,
+        messages: [{ role: 'user', content: 'Just a plain string message.' }],
+      });
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+
+      expect(span.inputs.messages[0]).toEqual({
+        role: 'user',
+        content: 'Just a plain string message.',
+      });
+    });
+
+    it('should replace unsupported content blocks in outputs', async () => {
+      server.use(
+        http.post('https://api.anthropic.com/v1/messages', async ({ request }) => {
+          const body = (await request.json()) as any;
+          return HttpResponse.json({
+            id: 'msg_test_sanitize_output',
+            type: 'message',
+            role: 'assistant',
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            model: body.model,
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 100, output_tokens: 200, total_tokens: 300 },
+            content: [
+              { type: 'thinking', thinking: 'Let me think about this...' },
+              { type: 'redacted_thinking', data: 'base64signaturedata' },
+              { type: 'text', text: 'Here is my response.' },
+            ],
+          });
+        }),
+      );
+
+      const anthropic = new Anthropic({ apiKey: 'test-key' });
+      const wrappedAnthropic = tracedAnthropic(anthropic);
+
+      await wrappedAnthropic.messages.create({
+        model: 'claude-3-7-sonnet-20250219',
+        max_tokens: 256,
+        messages: [{ role: 'user', content: 'Test output sanitization.' }],
+      });
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+
+      expect(span.outputs.content).toEqual([
+        { type: 'thinking', thinking: 'Let me think about this...' },
+        { type: 'text', text: '[redacted_thinking]' },
+        { type: 'text', text: 'Here is my response.' },
+      ]);
+    });
+
+    it('should sanitize inputs when streaming', async () => {
+      const anthropic = new Anthropic({ apiKey: 'test-key' });
+      const wrappedAnthropic = tracedAnthropic(anthropic);
+
+      const stream = wrappedAnthropic.messages.stream({
+        model: 'claude-3-7-sonnet-20250219',
+        max_tokens: 256,
+        messages: [
+          { role: 'user', content: 'Think about this.' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'Hmm...' },
+              { type: 'redacted_thinking', data: 'redacteddata' },
+              { type: 'text', text: 'Previous answer.' },
+            ],
+          },
+          { role: 'user', content: 'Now continue.' },
+        ] as any,
+      });
+
+      const message = await stream.finalMessage();
+      expect(message).toBeDefined();
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+
+      // Inputs should have redacted_thinking replaced
+      const assistantMsg = span.inputs.messages[1];
+      expect(assistantMsg.content).toEqual([
+        { type: 'thinking', thinking: 'Hmm...' },
+        { type: 'text', text: '[redacted_thinking]' },
+        { type: 'text', text: 'Previous answer.' },
+      ]);
+    });
+  });
+
   it('should trace streaming request wrapped in a parent span', async () => {
     const anthropic = new Anthropic({ apiKey: 'test-key' });
     const wrappedAnthropic = tracedAnthropic(anthropic);

--- a/libs/typescript/integrations/anthropic/tests/mockAnthropicServer.ts
+++ b/libs/typescript/integrations/anthropic/tests/mockAnthropicServer.ts
@@ -151,6 +151,112 @@ export function createStreamingErrorHandler() {
   });
 }
 
+export function createStreamingWithUnsupportedContentHandler() {
+  return http.post('https://api.anthropic.com/v1/messages', async ({ request }) => {
+    const body = (await request.json()) as MessagesCreateRequest;
+
+    if (body.stream) {
+      const messageId = `msg_${Math.random().toString(36).slice(2)}`;
+
+      const events = [
+        `event: message_start\ndata: ${JSON.stringify({
+          type: 'message_start',
+          message: {
+            id: messageId,
+            type: 'message',
+            role: 'assistant',
+            model: body.model,
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 128, output_tokens: 0 },
+          },
+        })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'thinking', thinking: '' },
+        })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'thinking_delta', thinking: 'Let me think...' },
+        })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({
+          type: 'content_block_stop',
+          index: 0,
+        })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'redacted_thinking', data: 'base64signaturedata' },
+        })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({
+          type: 'content_block_stop',
+          index: 1,
+        })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({
+          type: 'content_block_start',
+          index: 2,
+          content_block: { type: 'text', text: '' },
+        })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({
+          type: 'content_block_delta',
+          index: 2,
+          delta: { type: 'text_delta', text: 'Here is my response.' },
+        })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({
+          type: 'content_block_stop',
+          index: 2,
+        })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({
+          type: 'message_delta',
+          delta: { stop_reason: 'end_turn', stop_sequence: null },
+          usage: { output_tokens: 256 },
+        })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({
+          type: 'message_stop',
+        })}\n\n`,
+      ];
+
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        async start(controller) {
+          for (const event of events) {
+            controller.enqueue(encoder.encode(event));
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+          controller.close();
+        },
+      });
+
+      return new HttpResponse(stream, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+        },
+      });
+    }
+
+    // Non-streaming: return response with unsupported content blocks
+    return HttpResponse.json({
+      id: `msg_${Math.random().toString(36).slice(2)}`,
+      type: 'message',
+      role: 'assistant',
+      model: body.model,
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: { input_tokens: 128, output_tokens: 256, total_tokens: 384 },
+      content: [
+        { type: 'thinking', thinking: 'Let me think...' },
+        { type: 'redacted_thinking', data: 'base64signaturedata' },
+        { type: 'text', text: 'Here is my response.' },
+      ],
+    });
+  });
+}
+
 export const anthropicMockHandlers = [
   http.post('https://api.anthropic.com/v1/messages', async ({ request }) => {
     const body = (await request.json()) as MessagesCreateRequest;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.test.ts
@@ -145,4 +145,101 @@ describe('normalizeConversation', () => {
       expect(result?.[0]).not.toHaveProperty('reasoning');
     });
   });
+
+  describe('Unsupported content block handling', () => {
+    it('renders redacted_thinking blocks as text placeholders in inputs', () => {
+      const input = {
+        messages: [
+          { role: 'user', content: 'Think carefully.' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'Deep thought...' },
+              { type: 'redacted_thinking', data: 'base64encodeddata' },
+              { type: 'text', text: 'My answer.' },
+            ],
+          },
+          { role: 'user', content: 'Continue.' },
+        ],
+      };
+      const result = normalizeConversation(input, 'anthropic');
+      expect(result).not.toBeNull();
+      // The assistant message should contain the placeholder and preserve thinking
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: 'assistant',
+            content: expect.stringContaining('[redacted_thinking]'),
+            reasoning: 'Deep thought...',
+          }),
+        ]),
+      );
+    });
+
+    it('renders document blocks as text placeholders in inputs', () => {
+      const input = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'document', source: { type: 'base64', media_type: 'application/pdf', data: 'pdfdata' } },
+              { type: 'text', text: 'Summarize this.' },
+            ],
+          },
+        ],
+      };
+      const result = normalizeConversation(input, 'anthropic');
+      expect(result).not.toBeNull();
+      expect(result).toEqual([
+        expect.objectContaining({
+          role: 'user',
+          content: expect.stringContaining('[document]'),
+        }),
+      ]);
+    });
+
+    it('renders unsupported blocks as text placeholders in outputs', () => {
+      const output = {
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'Let me think...' },
+          { type: 'redacted_thinking', data: 'base64sig' },
+          { type: 'text', text: 'Here is my answer.' },
+        ],
+      };
+      const result = normalizeConversation(output, 'anthropic');
+      expect(result).not.toBeNull();
+      expect(result).toEqual([
+        expect.objectContaining({
+          role: 'assistant',
+          content: expect.stringContaining('[redacted_thinking]'),
+          reasoning: 'Let me think...',
+        }),
+      ]);
+    });
+
+    it('handles arbitrary unknown block types gracefully', () => {
+      const input = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'some_future_type', data: 'whatever' },
+              { type: 'text', text: 'Hello' },
+            ],
+          },
+        ],
+      };
+      const result = normalizeConversation(input, 'anthropic');
+      expect(result).not.toBeNull();
+      expect(result).toEqual([
+        expect.objectContaining({
+          role: 'user',
+          content: expect.stringContaining('[some_future_type]'),
+        }),
+      ]);
+    });
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/anthropic.ts
@@ -24,6 +24,7 @@ type AnthropicThinkingBlock = {
 };
 
 type AnthropicContentBlock = AnthropicTextBlock | AnthropicToolUseBlock | AnthropicThinkingBlock;
+// These types are handled at runtime via a catch-all that renders them as [type] text placeholders.
 // | RedactedThinkingBlock
 // | ServerToolUseBlock
 // | WebSearchToolResultBlock;
@@ -39,6 +40,7 @@ type AnthropicContentBlockParam =
   | AnthropicToolUseBlockParam
   | AnthropicToolResultBlockParam
   | AnthropicThinkingBlock;
+// These types are handled at runtime via a catch-all that renders them as [type] text placeholders.
 // | DocumentBlockParam
 // | RedactedThinkingBlockParam
 // | ServerToolUseBlockParam
@@ -160,6 +162,12 @@ const isAnthropicContentBlockParam = (obj: unknown): obj is AnthropicContentBloc
     if (obj.type === 'thinking' && has(obj, 'thinking') && isString(obj.thinking)) {
       return true;
     }
+
+    // Accept any block with a string type — unknown types will be rendered
+    // as text placeholders rather than rejecting the entire message.
+    if (isString(obj.type)) {
+      return true;
+    }
   }
   return false;
 };
@@ -196,7 +204,9 @@ const normalizeAnthropicContentBlockParam = (item: AnthropicContentBlockParam): 
       }
     }
   }
-  throw new Error(`Unsupported content block type: ${(item as any).type}`);
+  // Fallback for unrecognized content block types — return a text placeholder
+  // instead of throwing so the Chat tab degrades gracefully.
+  return { type: 'text', text: `[${(item as any).type}]` };
 };
 
 const processAnthropicMessageContent = (
@@ -241,6 +251,9 @@ const processAnthropicMessageContent = (
       }
     } else if (item.type === 'thinking') {
       thinkingParts.push((item as any).thinking);
+    } else {
+      // Unknown/unsupported content block — render as text placeholder
+      textParts.push({ type: 'text', text: `[${(item as any).type}]` });
     }
   }
 


### PR DESCRIPTION
Replace content block types not supported by the MLflow UI chat normalizer (e.g. redacted_thinking, document) with text placeholders so the Chat tab renders correctly. Add tests covering input/output sanitization for both streaming and non-streaming paths.

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #21244

### What changes are proposed in this pull request?

Replace content block types not supported by the MLflow UI chat normalizer (e.g. [`redacted_thinking`](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#thinking-redaction), document) with text placeholders so the Chat tab renders correctly.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Before:
<img width="499" height="810" alt="mlflow-anthropic-ts-sdk-missing-chat" src="https://github.com/user-attachments/assets/4ce8a95d-a125-4226-811d-55d9b26a9b9c" />

After:
<img width="552" height="685" alt="mlflow-anthropic-ts-sdk-missing-chat-fixed" src="https://github.com/user-attachments/assets/52b2fc8e-ec13-4164-8409-2261c2bd5f55" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes @mlflow/anthropic spans sometimes not rendering Chat tab in tracing UI due to ui-unsupported content blocks like `redacted_thinking`

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
