### PR TITLE
Add `mlflow db move-resources` command to move resources between workspaces

### DIFF
--- a/docs/docs/self-hosting/workspaces/configuration.mdx
+++ b/docs/docs/self-hosting/workspaces/configuration.mdx
@@ -43,6 +43,46 @@ mlflow db migrate-to-default-workspace <database_uri> --dry-run
 
 Use `--verbose` to list all conflicts instead of a truncated sample.
 
+### Admin Utility: move resources between workspaces
+
+To selectively move resources from one workspace to another, use:
+
+```bash
+mlflow db move-resources <database_uri> \
+  --from <source_workspace> --to <target_workspace> \
+  --resource-type <table_name>
+```
+
+The `--resource-type` value is the database table name (`experiments`, `registered_models`,
+`evaluation_datasets`, `webhooks`, `jobs`).
+
+:::note Gateway resources not supported
+Gateway resources (`secrets`, `endpoints`, `model_definitions`, `budget_policies`) are not
+supported by this command because they have inter-table foreign-key dependencies that make moving
+them independently unsafe.
+:::
+
+Filter which resources to move by name or tag:
+
+```bash
+# Move specific experiments by name
+mlflow db move-resources <database_uri> \
+  --from default --to team-a --resource-type experiments \
+  --name training-v1 --name training-v2
+
+# Move experiments matching tags (AND logic when multiple tags are given)
+mlflow db move-resources <database_uri> \
+  --from default --to team-a --resource-type experiments \
+  --tag team=team-a --tag env=prod
+```
+
+When neither `--name` nor `--tag` is specified, all resources of the given type in the source
+workspace are moved. Tag filtering is supported for `experiments` and `registered_models` only.
+
+Use `--dry-run` to preview what would be moved without making changes, and `-y` to skip the
+confirmation prompt. The command aborts if any resource name would conflict with an existing
+resource in the target workspace.
+
 ## Client Workspace Selection (summary)
 
 - Explicit: `mlflow.set_workspace("team-a")`

--- a/mlflow/db.py
+++ b/mlflow/db.py
@@ -56,6 +56,8 @@ def migrate_to_default_workspace(url, dry_run, verbose, yes):
     **IMPORTANT**: This operation runs in a single transaction, but can still be long-running.
     Always take a backup of your database before running this command.
     """
+    import sqlalchemy.exc
+
     import mlflow.store.db.utils
     from mlflow.store.db.workspace_migration import migrate_to_default_workspace as migrate
 
@@ -88,6 +90,195 @@ def migrate_to_default_workspace(url, dry_run, verbose, yes):
         click.echo(f"Moved {total} rows to the default workspace.")
     except RuntimeError as e:
         raise click.ClickException(str(e)) from e
+    except sqlalchemy.exc.SQLAlchemyError as e:
+        raise click.ClickException(f"Database error: {e}") from e
+    finally:
+        if engine is not None:
+            engine.dispose()
+
+
+def _parse_tag(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise click.BadParameter(
+            f"Tag {value!r} must be in key=value format (e.g. --tag team=team-a)."
+        )
+    key, _, val = value.partition("=")
+    if not key:
+        raise click.BadParameter(f"Tag {value!r} has an empty key. Use key=value format.")
+    return key, val
+
+
+@commands.command("move-resources")
+@click.argument("url")
+@click.option(
+    "--from",
+    "source_workspace",
+    required=True,
+    help="Source workspace name.",
+)
+@click.option(
+    "--to",
+    "target_workspace",
+    required=True,
+    help="Target workspace name.",
+)
+@click.option(
+    "--resource-type",
+    required=True,
+    help="Table name of the resource type to move (e.g. experiments, registered_models).",
+)
+@click.option(
+    "--name",
+    multiple=True,
+    help="Resource name(s) to move. Repeatable.",
+)
+@click.option(
+    "--tag",
+    multiple=True,
+    help=(
+        "Tag filter as key=value. Repeatable. "
+        "When multiple tags are given, only resources matching ALL tags are included."
+    ),
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    show_default=True,
+    help="Show what would be moved without making changes.",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="List all conflicts instead of truncating the output.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+def move_resources(
+    url, source_workspace, target_workspace, resource_type, name, tag, dry_run, verbose, yes
+):
+    """
+    Move resources from one workspace to another.
+
+    Selectively move workspace-scoped resources between workspaces by name
+    or tag filter (mutually exclusive). When neither --name nor --tag is
+    specified, all resources of the given type in the source workspace are moved.
+
+    The --resource-type value is the database table name (e.g. experiments,
+    registered_models, evaluation_datasets, webhooks, jobs).
+
+    Tag filtering (--tag) is supported for experiments and registered_models
+    only. When multiple --tag flags are given, only resources matching ALL tags
+    are included (AND logic).
+
+    \b
+    Examples:
+      # Move specific experiments by name
+      mlflow db move-resources sqlite:///mlflow.db \\
+        --from default --to team-a --resource-type experiments \\
+        --name training-v1 --name training-v2
+      # Move experiments matching ALL specified tags
+      mlflow db move-resources sqlite:///mlflow.db \\
+        --from default --to team-a --resource-type experiments \\
+        --tag team=team-a --tag env=prod
+      # Move all registered models from one workspace to another
+      mlflow db move-resources sqlite:///mlflow.db \\
+        --from default --to team-a --resource-type registered_models
+
+    **IMPORTANT**: Always take a backup of your database before running this command.
+    """
+    import sqlalchemy.exc
+
+    import mlflow.store.db.utils
+    from mlflow.store.db.workspace_move import RESOURCE_TYPE_CHOICES
+    from mlflow.store.db.workspace_move import move_resources as move
+    from mlflow.store.db.workspace_utils import format_truncated_list
+
+    if resource_type not in RESOURCE_TYPE_CHOICES:
+        raise click.ClickException(
+            f"Unknown resource type {resource_type!r}. "
+            f"Valid types: {', '.join(RESOURCE_TYPE_CHOICES)}"
+        )
+
+    parsed_tags = [_parse_tag(t) for t in tag] if tag else None
+    parsed_names = list(name) if name else None
+
+    engine = None
+    try:
+        engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(url)
+        needs_confirmation = not dry_run and not yes
+
+        result = move(
+            engine,
+            source_workspace=source_workspace,
+            target_workspace=target_workspace,
+            resource_type=resource_type,
+            names=parsed_names,
+            tags=parsed_tags,
+            dry_run=dry_run or needs_confirmation,
+            verbose=verbose,
+        )
+
+        if not result.names:
+            click.echo(f"No {resource_type} to move.")
+            return
+
+        max_display = None if verbose else 20
+        name_list = format_truncated_list(result.names, max_rows=max_display)
+
+        extra_notes: list[str] = []
+        if result.row_count > len(result.names):
+            extra_notes.append(
+                f"Note: {result.row_count} rows match {len(result.names)} distinct "
+                f"name(s). All rows with a matching name will be moved."
+            )
+
+        if dry_run:
+            click.echo(
+                f"Dry run completed. {result.row_count} {resource_type} row(s) would be moved "
+                f"from {source_workspace!r} to {target_workspace!r}:{name_list}"
+            )
+            for note in extra_notes:
+                click.echo(note)
+            return
+
+        if needs_confirmation:
+            click.echo(
+                f"{result.row_count} {resource_type} row(s) to move from "
+                f"{source_workspace!r} to {target_workspace!r}:{name_list}"
+            )
+            for note in extra_notes:
+                click.echo(note)
+            click.confirm("Proceed with move?", default=False, abort=True)
+            # Re-run the full move (including conflict detection) in a new
+            # transaction. The preview counts above may differ from the
+            # actual move if another admin modified the data in between,
+            # but the second call is self-consistent and safe.
+            result = move(
+                engine,
+                source_workspace=source_workspace,
+                target_workspace=target_workspace,
+                resource_type=resource_type,
+                names=parsed_names,
+                tags=parsed_tags,
+                dry_run=False,
+                verbose=verbose,
+            )
+
+        click.echo(
+            f"Moved {result.row_count} {resource_type} row(s) "
+            f"from {source_workspace!r} to {target_workspace!r}."
+        )
+    except RuntimeError as e:
+        raise click.ClickException(str(e)) from e
+    except sqlalchemy.exc.SQLAlchemyError as e:
+        raise click.ClickException(f"Database error: {e}") from e
     finally:
         if engine is not None:
             engine.dispose()

--- a/mlflow/store/db/workspace_migration.py
+++ b/mlflow/store/db/workspace_migration.py
@@ -1,21 +1,14 @@
 import sqlalchemy as sa
 
+from mlflow.store.db.workspace_utils import (
+    MODEL_CHILD_TABLES,
+    format_truncated_list,
+    get_workspace_table,
+)
 from mlflow.store.workspace.sqlalchemy_store import _WORKSPACE_ROOT_MODELS
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
-# Derive table names from the shared ORM model list and add child/tags tables that also carry
-# a workspace column but are not "root" tables (they are updated via FK cascades during
-# delete_workspace, but the migration script must handle them explicitly).
-_WORKSPACE_CHILD_TABLES = [
-    "model_versions",
-    "registered_model_tags",
-    "model_version_tags",
-    "registered_model_aliases",
-]
-
-_WORKSPACE_TABLES = [
-    model.__tablename__ for model in _WORKSPACE_ROOT_MODELS
-] + _WORKSPACE_CHILD_TABLES
+_WORKSPACE_TABLES = [model.__tablename__ for model in _WORKSPACE_ROOT_MODELS] + MODEL_CHILD_TABLES
 
 _CONFLICT_SPECS = [
     ("experiments", ("name",), "experiments with the same name"),
@@ -49,26 +42,13 @@ def _format_conflicts(
     *,
     max_rows: int | None,
 ) -> str:
-    rows = conflicts if max_rows is None else conflicts[:max_rows]
-    formatted_conflicts = "\n  ".join(
-        ", ".join(f"{column}={value!r}" for column, value in zip(columns, row)) for row in rows
-    )
-    if formatted_conflicts:
-        formatted_conflicts = f"\n  {formatted_conflicts}"
+    display = conflicts if max_rows is None else conflicts[:max_rows]
+    items = [
+        ", ".join(f"{column}={value!r}" for column, value in zip(columns, row)) for row in display
+    ]
     if max_rows is not None and len(conflicts) > max_rows:
-        formatted_conflicts += f"\n  ... ({len(conflicts) - max_rows} more)"
-    return formatted_conflicts
-
-
-def _get_table(conn, table_name: str) -> sa.Table:
-    table = sa.Table(table_name, sa.MetaData(), autoload_with=conn)
-    if "workspace" not in table.c:
-        raise RuntimeError(
-            "Move aborted: the specified tracking server does not have workspaces enabled. "
-            "This command is intended for a workspace-enabled tracking server. Please make sure "
-            "the specified tracking URI is correct."
-        )
-    return table
+        items.append(f"... ({len(conflicts) - max_rows} more)")
+    return format_truncated_list(items, max_rows=None)
 
 
 def _assert_no_workspace_conflicts(
@@ -79,7 +59,7 @@ def _assert_no_workspace_conflicts(
     *,
     verbose: bool,
 ) -> None:
-    table = _get_table(conn, table_name)
+    table = get_workspace_table(conn, table_name)
     group_columns = [table.c[column] for column in columns]
     conflict_keys = (
         sa.select(*group_columns).group_by(*group_columns).having(sa.func.count() > 1).subquery()
@@ -131,7 +111,7 @@ def migrate_to_default_workspace(
 
         counts = {}
         for table_name in _WORKSPACE_TABLES:
-            table = _get_table(conn, table_name)
+            table = get_workspace_table(conn, table_name)
             stmt = (
                 sa
                 .select(sa.func.count())

--- a/mlflow/store/db/workspace_move.py
+++ b/mlflow/store/db/workspace_move.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import sqlalchemy as sa
+
+from mlflow.store.db.workspace_utils import (
+    MODEL_CHILD_TABLES,
+    format_truncated_list,
+    get_workspace_table,
+    validate_workspace_exists,
+)
+from mlflow.store.model_registry.dbmodels.models import (
+    SqlRegisteredModel,
+    SqlRegisteredModelTag,
+    SqlWebhook,
+)
+from mlflow.store.tracking.dbmodels.models import (
+    SqlEvaluationDataset,
+    SqlExperiment,
+    SqlExperimentTag,
+    SqlJob,
+)
+from mlflow.store.workspace.sqlalchemy_store import _WORKSPACE_ROOT_MODELS
+
+
+@dataclass(frozen=True)
+class MoveResult:
+    """Result of a move-resources operation."""
+
+    names: list[str]
+    row_count: int
+
+
+@dataclass(frozen=True)
+class _ResourceSpec:
+    """Metadata for a movable resource type."""
+
+    model: type
+    name_column: str = "name"
+    tag_model: type | None = None
+    # Column used to join the tag table back to the resource table.
+    # For experiments the tag table joins via experiment_id, not workspace+name.
+    tag_join_column: str | None = None
+    child_tables: tuple[str, ...] = ()
+    child_name_column: str = "name"
+    has_unique_name: bool = True
+
+    @property
+    def table(self) -> sa.Table:
+        return self.model.__table__
+
+    @property
+    def tag_table(self) -> sa.Table | None:
+        return self.tag_model.__table__ if self.tag_model else None
+
+
+# Per-model spec.  Keyed by ORM model class; the CLI resource type is derived
+# from model.__tablename__ (e.g. "experiments", "registered_models").
+# Models in _WORKSPACE_ROOT_MODELS without an entry here are silently skipped;
+# a unit test verifies the omissions are intentional.
+#
+# Gateway resources (secrets, endpoints, model_definitions, budget_policies)
+# are intentionally excluded because they have inter-table FK dependencies
+# that make moving them independently unsafe.  They can be added later with
+# proper dependency-aware handling.
+_SPEC_BY_MODEL: dict[type, _ResourceSpec] = {
+    SqlExperiment: _ResourceSpec(
+        model=SqlExperiment,
+        name_column=SqlExperiment.name.key,
+        tag_model=SqlExperimentTag,
+        tag_join_column=SqlExperimentTag.experiment_id.key,
+    ),
+    SqlRegisteredModel: _ResourceSpec(
+        model=SqlRegisteredModel,
+        name_column=SqlRegisteredModel.name.key,
+        tag_model=SqlRegisteredModelTag,
+        child_tables=tuple(MODEL_CHILD_TABLES),
+    ),
+    SqlEvaluationDataset: _ResourceSpec(
+        model=SqlEvaluationDataset,
+        name_column=SqlEvaluationDataset.name.key,
+        has_unique_name=False,
+    ),
+    SqlWebhook: _ResourceSpec(
+        model=SqlWebhook,
+        name_column=SqlWebhook.name.key,
+        has_unique_name=False,
+    ),
+    SqlJob: _ResourceSpec(
+        model=SqlJob,
+        name_column=SqlJob.job_name.key,
+        has_unique_name=False,
+    ),
+}
+
+_RESOURCE_SPECS: dict[str, _ResourceSpec] = {
+    model.__tablename__: _SPEC_BY_MODEL[model]
+    for model in _WORKSPACE_ROOT_MODELS
+    if model in _SPEC_BY_MODEL
+}
+RESOURCE_TYPE_CHOICES = sorted(_RESOURCE_SPECS)
+
+
+def _tag_names_subquery(
+    spec: _ResourceSpec,
+    source_workspace: str,
+    tags: list[tuple[str, str]],
+) -> sa.Select:
+    """Build a SELECT subquery of resource names matching ALL given tags.
+
+    The intersection logic uses ``GROUP BY … HAVING COUNT`` so the entire
+    resolution stays in SQL and avoids materializing a large parameter list.
+    """
+    table = spec.table
+    tag_table = spec.tag_table
+    unique_tags = list(dict.fromkeys(tags))
+
+    tag_conditions = sa.or_(*[
+        sa.and_(tag_table.c.key == k, tag_table.c.value == v) for k, v in unique_tags
+    ])
+
+    if spec.tag_join_column:
+        # Experiments: tags reference the resource via a surrogate key
+        # (experiment_id), so we JOIN back to the resource table to get
+        # the name and scope by the resource table's workspace column.
+        id_col = spec.tag_join_column
+        name_col = table.c[spec.name_column]
+        subq = (
+            sa
+            .select(name_col)
+            .select_from(table.join(tag_table, table.c[id_col] == tag_table.c[id_col]))
+            .where(table.c.workspace == source_workspace)
+            .where(tag_conditions)
+            .group_by(name_col)
+        )
+    else:
+        # Registered models: the tag table carries workspace + name
+        # directly, so we can query it without joining the parent table.
+        name_col = tag_table.c[spec.name_column]
+        subq = (
+            sa
+            .select(name_col)
+            .where(tag_table.c.workspace == source_workspace)
+            .where(tag_conditions)
+            .group_by(name_col)
+        )
+
+    if len(unique_tags) > 1:
+        subq = subq.having(sa.func.count() == len(unique_tags))
+
+    return subq
+
+
+def _resolve_names(
+    conn,
+    spec: _ResourceSpec,
+    workspace: str,
+    names: list[str] | None = None,
+) -> set[str]:
+    """Return resource names in *workspace*, optionally filtered to *names*."""
+    table = spec.table
+    name_col = table.c[spec.name_column]
+    stmt = sa.select(name_col).where(table.c.workspace == workspace)
+    if names is not None:
+        stmt = stmt.where(name_col.in_(names))
+    return {row[0] for row in conn.execute(stmt).fetchall()}
+
+
+def _find_conflicts(
+    conn,
+    spec: _ResourceSpec,
+    source_workspace: str,
+    target_workspace: str,
+    name_filter: list[str] | sa.Select | None = None,
+) -> list[str]:
+    """Return source resource names that already exist in *target_workspace*.
+
+    *name_filter* can be a ``list`` (literal names), a ``Select`` subquery,
+    or ``None`` (move-all, falls back to a source-workspace subquery).
+    SQLAlchemy's ``in_()`` handles both lists and subqueries transparently.
+    """
+    if not spec.has_unique_name:
+        return []
+    table = spec.table
+    name_col = table.c[spec.name_column]
+    stmt = sa.select(name_col).where(table.c.workspace == target_workspace)
+
+    if name_filter is not None:
+        stmt = stmt.where(name_col.in_(name_filter))
+    else:
+        source_subq = sa.select(name_col).where(table.c.workspace == source_workspace)
+        stmt = stmt.where(name_col.in_(source_subq))
+
+    return [row[0] for row in conn.execute(stmt.order_by(name_col)).fetchall()]
+
+
+def move_resources(
+    engine: sa.Engine,
+    source_workspace: str,
+    target_workspace: str,
+    resource_type: str,
+    names: list[str] | None = None,
+    tags: list[tuple[str, str]] | None = None,
+    dry_run: bool = False,
+    *,
+    verbose: bool = False,
+) -> MoveResult:
+    """
+    Move resources of *resource_type* from *source_workspace* to *target_workspace*.
+
+    Filter by *names* or *tags* (mutually exclusive).  When neither is provided
+    all resources of the type in the source workspace are moved.
+
+    Returns a :class:`MoveResult` with ``names`` (sorted list of distinct
+    resource names that were moved or would be moved) and ``row_count`` (the
+    number of rows in the root resource table that were moved; child-table
+    rows such as model versions or tags are not included in this count).
+    For resource types whose names are not unique, ``row_count`` may exceed
+    ``len(names)`` when multiple rows share the same name.
+    """
+    if source_workspace == target_workspace:
+        raise RuntimeError("Source and target workspaces must be different.")
+
+    spec = _RESOURCE_SPECS.get(resource_type)
+    if spec is None:
+        raise RuntimeError(
+            f"Unknown resource type {resource_type!r}. "
+            f"Valid types: {', '.join(RESOURCE_TYPE_CHOICES)}"
+        )
+
+    if names and tags:
+        raise RuntimeError("--name and --tag are mutually exclusive.")
+
+    if tags and spec.tag_table is None:
+        raise RuntimeError(f"Resource type {resource_type!r} does not support tag filtering.")
+
+    with engine.begin() as conn:
+        validate_workspace_exists(conn, source_workspace)
+        validate_workspace_exists(conn, target_workspace)
+
+        # Fail fast with a clear message if the resource table lacks a
+        # workspace column (DB not migrated to workspace-enabled schema).
+        get_workspace_table(conn, spec.table.name)
+
+        # Build a unified name filter: a SQL subquery (--tag), a small
+        # literal list (--name), or None (move-all).  SQLAlchemy's in_()
+        # handles lists and Select objects identically, so every subsequent
+        # query uses the same one-branch pattern.
+        if tags:
+            name_filter = _tag_names_subquery(spec, source_workspace, tags)
+            matched = {row[0] for row in conn.execute(name_filter).fetchall()}
+        elif names:
+            matched = _resolve_names(conn, spec, source_workspace, names)
+            name_filter = list(matched)
+        else:
+            matched = _resolve_names(conn, spec, source_workspace)
+            name_filter = None
+
+        if not matched:
+            return MoveResult(names=[], row_count=0)
+
+        if conflicts := _find_conflicts(
+            conn, spec, source_workspace, target_workspace, name_filter
+        ):
+            formatted = format_truncated_list(
+                [repr(name) for name in conflicts],
+                max_rows=None if verbose else 10,
+            )
+            raise RuntimeError(
+                f"Move aborted: the following {resource_type} already exist "
+                f"in workspace {target_workspace!r} and would conflict: "
+                f"{formatted}\n"
+                "Rename or remove the conflicting resources in the target "
+                "workspace, then retry."
+            )
+
+        table = spec.table
+        name_col = table.c[spec.name_column]
+
+        def _filtered(stmt, col, _nf=name_filter):
+            return stmt.where(col.in_(_nf)) if _nf is not None else stmt
+
+        row_count = conn.execute(
+            _filtered(
+                sa
+                .select(sa.func.count())
+                .select_from(table)
+                .where(table.c.workspace == source_workspace),
+                name_col,
+            )
+        ).scalar()
+
+        if not dry_run:
+            conn.execute(
+                _filtered(
+                    table
+                    .update()
+                    .where(table.c.workspace == source_workspace)
+                    .values(workspace=target_workspace),
+                    name_col,
+                )
+            )
+
+            # Explicitly update child tables because not all backends honour
+            # ON UPDATE CASCADE (e.g. SQLite without the foreign_keys pragma).
+            for child_table_name in spec.child_tables:
+                child = get_workspace_table(conn, child_table_name)
+                conn.execute(
+                    _filtered(
+                        child
+                        .update()
+                        .where(child.c.workspace == source_workspace)
+                        .values(workspace=target_workspace),
+                        child.c[spec.child_name_column],
+                    )
+                )
+
+    return MoveResult(names=sorted(matched), row_count=row_count)

--- a/mlflow/store/db/workspace_utils.py
+++ b/mlflow/store/db/workspace_utils.py
@@ -1,0 +1,66 @@
+"""Shared helpers for workspace-related database operations.
+
+Used by both ``workspace_migration`` (migrate-to-default-workspace) and
+``workspace_move`` (move-resources).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+# Child tables of registered_models that carry their own workspace column.
+# These must be updated explicitly because not all backends honour
+# ON UPDATE CASCADE at the SQL level (e.g. SQLite without foreign_keys pragma).
+MODEL_CHILD_TABLES = [
+    "model_versions",
+    "registered_model_tags",
+    "model_version_tags",
+    "registered_model_aliases",
+]
+
+
+_NOT_ENABLED_MSG = (
+    "Aborted: the database does not have workspaces enabled. This command "
+    "operates directly on the SQL database used by the default workspace "
+    "provider. Please make sure the specified database URI is correct and "
+    "that workspaces have been enabled via `mlflow db upgrade`."
+)
+
+
+def get_workspace_table(conn, table_name: str) -> sa.Table:
+    """Reflect *table_name* and verify it contains a ``workspace`` column."""
+    try:
+        table = sa.Table(table_name, sa.MetaData(), autoload_with=conn)
+    except sa.exc.NoSuchTableError:
+        raise RuntimeError(f"{_NOT_ENABLED_MSG} (missing table {table_name!r}).")
+    if "workspace" not in table.c:
+        raise RuntimeError(_NOT_ENABLED_MSG)
+    return table
+
+
+def validate_workspace_exists(conn, workspace_name: str) -> None:
+    """Raise ``RuntimeError`` if *workspace_name* is not in the workspaces table."""
+    try:
+        workspaces = sa.Table("workspaces", sa.MetaData(), autoload_with=conn)
+    except sa.exc.NoSuchTableError:
+        raise RuntimeError(_NOT_ENABLED_MSG)
+    exists = conn.execute(
+        sa.select(sa.literal(1)).select_from(workspaces).where(workspaces.c.name == workspace_name)
+    ).first()
+    if not exists:
+        raise RuntimeError(f"Workspace {workspace_name!r} does not exist.")
+
+
+def format_truncated_list(
+    items: list[str],
+    *,
+    max_rows: int | None,
+) -> str:
+    """Format a list of display strings with optional truncation."""
+    rows = items if max_rows is None else items[:max_rows]
+    formatted = "\n  ".join(rows)
+    if formatted:
+        formatted = f"\n  {formatted}"
+    if max_rows is not None and len(items) > max_rows:
+        formatted += f"\n  ... ({len(items) - max_rows} more)"
+    return formatted

--- a/tests/db/test_workspace_move.py
+++ b/tests/db/test_workspace_move.py
@@ -1,0 +1,424 @@
+import uuid
+
+import pytest
+
+from mlflow.entities import ExperimentTag
+from mlflow.entities.model_registry import ModelVersionTag, RegisteredModelTag
+from mlflow.entities.workspace import Workspace
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+from mlflow.store.db.workspace_move import _SPEC_BY_MODEL, MoveResult, move_resources
+from mlflow.store.model_registry.sqlalchemy_workspace_store import (
+    WorkspaceAwareSqlAlchemyStore as WorkspaceAwareRegistryStore,
+)
+from mlflow.store.workspace.sqlalchemy_store import (
+    SqlAlchemyStore as WorkspaceStore,
+)
+from mlflow.tracking._tracking_service import utils as tracking_utils
+from mlflow.utils.workspace_context import WorkspaceContext
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+
+@pytest.fixture(autouse=True)
+def _enable_workspaces(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+
+
+@pytest.fixture
+def tracking_store(tmp_path, db_uri, _enable_workspaces):
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    store = tracking_utils._get_sqlalchemy_store(db_uri, artifact_dir.as_uri())
+    try:
+        yield store
+    finally:
+        store._dispose_engine()
+
+
+@pytest.fixture
+def registry_store(db_uri, _enable_workspaces):
+    store = WorkspaceAwareRegistryStore(db_uri)
+    try:
+        yield store
+    finally:
+        store.engine.dispose()
+
+
+@pytest.fixture
+def workspace_store(db_uri, _enable_workspaces):
+    store = WorkspaceStore(db_uri)
+    try:
+        yield store
+    finally:
+        store._engine.dispose()
+
+
+@pytest.fixture
+def engine(tracking_store):
+    return tracking_store.engine
+
+
+def _create_workspace(ws_store, name):
+    ws_store.create_workspace(Workspace(name=name))
+
+
+# ---------------------------------------------------------------------------
+# Experiments
+# ---------------------------------------------------------------------------
+
+
+def test_move_experiments_by_name(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("exp-1")
+        tracking_store.create_experiment("exp-2")
+        tracking_store.create_experiment("exp-3")
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        names=["exp-1", "exp-3"],
+    )
+
+    assert result.names == ["exp-1", "exp-3"]
+    assert result.row_count == 2
+
+    with WorkspaceContext("team-a"):
+        assert tracking_store.get_experiment_by_name("exp-1") is not None
+        assert tracking_store.get_experiment_by_name("exp-3") is not None
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        assert tracking_store.get_experiment_by_name("exp-2") is not None
+        assert tracking_store.get_experiment_by_name("exp-1") is None
+
+
+def test_move_experiment_by_tag(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        exp_id_1 = tracking_store.create_experiment("exp-1")
+        tracking_store.create_experiment("exp-2")
+        tracking_store.set_experiment_tag(exp_id_1, ExperimentTag("team", "team-a"))
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        tags=[("team", "team-a")],
+    )
+
+    assert result.names == ["exp-1"]
+    assert result.row_count == 1
+
+
+def test_error_name_and_tag_mutually_exclusive(workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with pytest.raises(RuntimeError, match="mutually exclusive"):
+        move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace="team-a",
+            resource_type="experiments",
+            names=["exp-1"],
+            tags=[("team", "team-a")],
+        )
+
+
+def test_move_experiment_by_multiple_tags_and(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        exp_id_1 = tracking_store.create_experiment("exp-1")
+        exp_id_2 = tracking_store.create_experiment("exp-2")
+        tracking_store.set_experiment_tag(exp_id_1, ExperimentTag("team", "team-a"))
+        tracking_store.set_experiment_tag(exp_id_1, ExperimentTag("env", "prod"))
+        tracking_store.set_experiment_tag(exp_id_2, ExperimentTag("team", "team-a"))
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        tags=[("team", "team-a"), ("env", "prod")],
+    )
+
+    assert result.names == ["exp-1"]
+    assert result.row_count == 1
+
+
+def test_move_all_experiments_no_filter(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("exp-1")
+        tracking_store.create_experiment("exp-2")
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+    )
+
+    assert len(result.names) >= 2
+    assert "exp-1" in result.names
+    assert "exp-2" in result.names
+    assert result.row_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# Registered models
+# ---------------------------------------------------------------------------
+
+
+def test_move_model_by_tag(registry_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        registry_store.create_registered_model("model-1")
+        registry_store.create_registered_model("model-2")
+        registry_store.set_registered_model_tag("model-1", RegisteredModelTag("team", "team-a"))
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="registered_models",
+        tags=[("team", "team-a")],
+    )
+
+    assert result.names == ["model-1"]
+    assert result.row_count == 1
+
+    with WorkspaceContext("team-a"):
+        assert registry_store.get_registered_model("model-1") is not None
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        assert registry_store.get_registered_model("model-2") is not None
+
+
+def test_move_model_cascades_to_child_tables(registry_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        registry_store.create_registered_model("model-1")
+        mv1 = registry_store.create_model_version(
+            "model-1", "s3://bucket/v1", run_id=uuid.uuid4().hex
+        )
+        registry_store.create_model_version("model-1", "s3://bucket/v2", run_id=uuid.uuid4().hex)
+        registry_store.set_registered_model_tag("model-1", RegisteredModelTag("stage", "prod"))
+        registry_store.set_registered_model_alias("model-1", "champion", str(mv1.version))
+        registry_store.set_model_version_tag(
+            "model-1", str(mv1.version), ModelVersionTag("metric", "0.95")
+        )
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="registered_models",
+        names=["model-1"],
+    )
+
+    assert result.names == ["model-1"]
+    assert result.row_count == 1
+
+    with WorkspaceContext("team-a"):
+        rm = registry_store.get_registered_model("model-1")
+        assert rm.tags == {"stage": "prod"}
+        assert rm.aliases == {"champion": mv1.version}
+
+        versions = registry_store.search_model_versions(filter_string="name='model-1'")
+        assert len(versions) == 2
+
+        mv = registry_store.get_model_version("model-1", str(mv1.version))
+        assert mv.tags == {"metric": "0.95"}
+
+
+# ---------------------------------------------------------------------------
+# Conflict detection, dry run, and error handling
+# ---------------------------------------------------------------------------
+
+
+def test_conflict_detection(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("dup-exp")
+    with WorkspaceContext("team-a"):
+        tracking_store.create_experiment("dup-exp")
+
+    with pytest.raises(RuntimeError, match="already exist in workspace"):
+        move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace="team-a",
+            resource_type="experiments",
+            names=["dup-exp"],
+        )
+
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        assert tracking_store.get_experiment_by_name("dup-exp") is not None
+
+
+def test_dry_run_does_not_modify(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("exp-1")
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        names=["exp-1"],
+        dry_run=True,
+    )
+
+    assert result.names == ["exp-1"]
+    assert result.row_count == 1
+
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        assert tracking_store.get_experiment_by_name("exp-1") is not None
+
+
+def test_validation_errors(engine):
+    with pytest.raises(RuntimeError, match="does not exist"):
+        move_resources(
+            engine,
+            source_workspace="nonexistent",
+            target_workspace=DEFAULT_WORKSPACE_NAME,
+            resource_type="experiments",
+        )
+
+    with pytest.raises(RuntimeError, match="does not exist"):
+        move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace="nonexistent",
+            resource_type="experiments",
+        )
+
+    with pytest.raises(RuntimeError, match="must be different"):
+        move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace=DEFAULT_WORKSPACE_NAME,
+            resource_type="experiments",
+        )
+
+
+def test_error_tag_on_unsupported_resource_type(workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with pytest.raises(RuntimeError, match="does not support tag filtering"):
+        move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace="team-a",
+            resource_type="webhooks",
+            tags=[("team", "team-a")],
+        )
+
+
+def test_noop_when_nothing_matches(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("exp-1")
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        names=["nonexistent"],
+    )
+    assert result == MoveResult(names=[], row_count=0)
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        tags=[("team", "nonexistent")],
+    )
+    assert result == MoveResult(names=[], row_count=0)
+
+
+# ---------------------------------------------------------------------------
+# All resource types
+# ---------------------------------------------------------------------------
+
+
+def test_move_all_resource_types(
+    tracking_store, registry_store, workspace_store, engine, monkeypatch
+):
+    from mlflow.entities.webhook import WebhookAction, WebhookEntity, WebhookEvent
+    from mlflow.store.jobs.sqlalchemy_workspace_store import (
+        WorkspaceAwareSqlAlchemyJobStore,
+    )
+
+    monkeypatch.setattr(
+        "mlflow.store.model_registry.sqlalchemy_store._validate_webhook_url", lambda url: None
+    )
+    _create_workspace(workspace_store, "target")
+    job_store = WorkspaceAwareSqlAlchemyJobStore(str(engine.url))
+
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("move-exp")
+        tracking_store.create_dataset("move-ds")
+        registry_store.create_registered_model("move-model")
+        registry_store.create_webhook(
+            name="move-webhook",
+            url="https://example.com/hook",
+            events=[WebhookEvent(WebhookEntity.MODEL_VERSION, WebhookAction.CREATED)],
+        )
+        job_store.create_job(job_name="move-job", params="{}")
+
+    resource_names = {
+        "experiments": "move-exp",
+        "evaluation_datasets": "move-ds",
+        "registered_models": "move-model",
+        "webhooks": "move-webhook",
+        "jobs": "move-job",
+    }
+
+    for resource_type, name in resource_names.items():
+        result = move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace="target",
+            resource_type=resource_type,
+            names=[name],
+        )
+        assert name in result.names, f"Expected {name!r} in moved list for {resource_type}"
+        assert result.row_count >= 1, f"Expected row_count >= 1 for {resource_type}"
+
+
+# ---------------------------------------------------------------------------
+# Spec coverage
+# ---------------------------------------------------------------------------
+
+
+def test_all_workspace_root_models_have_spec():
+    from mlflow.store.tracking.dbmodels.models import (
+        SqlGatewayBudgetPolicy,
+        SqlGatewayEndpoint,
+        SqlGatewayModelDefinition,
+        SqlGatewaySecret,
+    )
+    from mlflow.store.workspace.sqlalchemy_store import _WORKSPACE_ROOT_MODELS
+
+    # Gateway resources are intentionally excluded due to inter-table FK
+    # dependencies that make moving them independently unsafe.
+    _INTENTIONALLY_OMITTED = {
+        SqlGatewaySecret,
+        SqlGatewayEndpoint,
+        SqlGatewayModelDefinition,
+        SqlGatewayBudgetPolicy,
+    }
+
+    missing = {
+        model.__name__
+        for model in _WORKSPACE_ROOT_MODELS
+        if model not in _SPEC_BY_MODEL and model not in _INTENTIONALLY_OMITTED
+    }
+    assert not missing, (
+        f"These models are in _WORKSPACE_ROOT_MODELS but have no entry in "
+        f"_SPEC_BY_MODEL (mlflow/store/db/workspace_move.py): {sorted(missing)}. "
+        f"Add a _ResourceSpec so move-resources can handle them, or add "
+        f"to _INTENTIONALLY_OMITTED if they cannot be moved independently."
+    )


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21250

### What changes are proposed in this pull request?

Add a CLI command that selectively moves workspace-scoped resources from one workspace to another by name or tag filter, with conflict detection, dry-run support, and transactional safety.

Supported resource types: experiments, registered_models, evaluation_datasets, webhooks, jobs. Gateway resources (secrets, endpoints, model_definitions, budget_policies) are excluded for now due to inter-table FK dependencies that require dependency-aware handling.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add `mlflow db move-resources` command to move resources between workspaces

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
