### PR TITLE
Add steer message tracing support for Claude Code

### DIFF
--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -46,6 +46,8 @@ MESSAGE_FIELD_MESSAGE = "message"
 MESSAGE_FIELD_TIMESTAMP = "timestamp"
 MESSAGE_FIELD_TOOL_USE_RESULT = "toolUseResult"
 MESSAGE_FIELD_COMMAND_NAME = "commandName"
+MESSAGE_TYPE_QUEUE_OPERATION = "queue-operation"
+QUEUE_OPERATION_ENQUEUE = "enqueue"
 
 # Custom logging level for Claude tracing
 CLAUDE_TRACING_LEVEL = logging.WARNING - 5
@@ -360,6 +362,15 @@ def _get_input_messages(transcript: list[dict[str, Any]], current_idx: int) -> l
                 )
             if has_text:
                 break
+
+        # Include steer messages (queue-operation enqueue) as user messages
+        if (
+            entry.get(MESSAGE_FIELD_TYPE) == MESSAGE_TYPE_QUEUE_OPERATION
+            and entry.get("operation") == QUEUE_OPERATION_ENQUEUE
+            and (steer_content := entry.get(MESSAGE_FIELD_CONTENT))
+        ):
+            messages.append({"role": "user", "content": steer_content})
+            continue
 
         if msg.get("role") and msg.get(MESSAGE_FIELD_CONTENT):
             messages.append(msg)

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -753,3 +753,58 @@ def test_find_last_user_message_skips_consecutive_skill_injections():
     # Should skip both skill injections (entries 3 and 6) and return entry 0
     assert idx == 0
     assert transcript[idx]["message"]["content"] == "Do the thing."
+
+
+def test_process_transcript_includes_steer_messages(tmp_path):
+    transcript = [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "Tell me about Python."},
+            "timestamp": "2025-01-15T10:00:00.000Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Python is a programming language."}],
+            },
+            "timestamp": "2025-01-15T10:00:01.000Z",
+        },
+        {
+            "type": "queue-operation",
+            "operation": "enqueue",
+            "content": "also tell me about Java",
+            "timestamp": "2025-01-15T10:00:02.000Z",
+            "sessionId": "test-steer-session",
+        },
+        {
+            "type": "queue-operation",
+            "operation": "remove",
+            "timestamp": "2025-01-15T10:00:03.000Z",
+            "sessionId": "test-steer-session",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Java is also a programming language."}],
+            },
+            "timestamp": "2025-01-15T10:00:04.000Z",
+        },
+    ]
+
+    transcript_path = tmp_path / "steer_transcript.jsonl"
+    transcript_path.write_text("\n".join(json.dumps(entry) for entry in transcript) + "\n")
+    trace = process_transcript(str(transcript_path), "test-steer-session")
+    assert trace is not None
+
+    spans = list(trace.search_spans())
+    llm_spans = [s for s in spans if s.span_type == SpanType.LLM]
+    assert len(llm_spans) == 2
+
+    # The second LLM span should include the steer message in its inputs
+    second_llm = llm_spans[1]
+    input_messages = second_llm.inputs["messages"]
+    steer_messages = [m for m in input_messages if m.get("content") == "also tell me about Java"]
+    assert len(steer_messages) == 1
+    assert steer_messages[0]["role"] == "user"


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Claude Code users can send "steer messages" — messages typed while the assistant is mid-response — to redirect the conversation. These appear in the JSONL transcript as `type: "queue-operation"` entries but were previously ignored by the tracing integration, making them invisible in MLflow traces.

This PR includes steer messages as user messages in LLM span inputs so they are captured in the trace.

#### What steer messages look like in the transcript

```json
{"type": "queue-operation", "operation": "enqueue", "content": "also tell me about Java", "timestamp": "2025-01-15T10:00:02.000Z", "sessionId": "..."}
{"type": "queue-operation", "operation": "remove", "timestamp": "2025-01-15T10:00:03.000Z", "sessionId": "..."}
```

- `enqueue`: the user typed a steer message while the assistant was responding (carries the `content`)
- `remove`: the steer message was consumed from the queue

In the screenshot below, `foo`, `bar`, and `baz` are steer messages.

<img width="845" height="337" alt="image" src="https://github.com/user-attachments/assets/2d7830d5-2143-448f-8ca0-5db5b2fe371f" />

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Claude Code steer messages (typed while the assistant is mid-response) are now captured in MLflow traces as user messages in LLM span inputs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)