### PR TITLE
Update Action menu: indentation to avoid confusion

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.tsx
@@ -2,7 +2,7 @@ import type { RowSelectionState } from '@tanstack/react-table';
 import { compact, isNil } from 'lodash';
 import { useCallback, useContext, useMemo, useState } from 'react';
 
-import { Button, Tooltip, DropdownMenu, ChevronDownIcon } from '@databricks/design-system';
+import { Button, Tooltip, DropdownMenu, ChevronDownIcon, useDesignSystemTheme } from '@databricks/design-system';
 import { useIntl } from '@databricks/i18n';
 
 import { GenAITracesTableContext } from './GenAITracesTableContext';
@@ -88,6 +88,7 @@ interface TraceActionsDropdownProps {
 const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
   const { experimentId, selectedTraces, traceActions, setRowSelection, sqlWarehouseId } = props;
   const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showCompareModal, setShowCompareModal] = useState(false);
   const isComparisonDrawerEnabled = shouldUseUnifiedModelTraceComparisonUI();
@@ -134,6 +135,14 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
   const noTracesSelected = selectedTraces.length === 0;
   const noActionsAvailable = !hasExportAction && !hasEditTagsAction && !hasDeleteAction;
   const canCompare = selectedTraces.length >= 2 && selectedTraces.length < 4;
+
+  const groupLabelStyles = {
+    color: theme.colors.textSecondary,
+  };
+
+  const groupItemStyles = {
+    paddingLeft: theme.spacing.lg,
+  };
 
   if (noActionsAvailable) {
     return null;
@@ -194,7 +203,7 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
           {hasExportAction && (
             <>
               <DropdownMenu.Group>
-                <DropdownMenu.Label>
+                <DropdownMenu.Label css={groupLabelStyles}>
                   {intl.formatMessage({
                     defaultMessage: 'Use for evaluation',
                     description: 'Trace actions dropdown group label',
@@ -202,6 +211,7 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
                 </DropdownMenu.Label>
                 <DropdownMenu.Item
                   componentId="mlflow.genai-traces-table.export-to-datasets"
+                  css={groupItemStyles}
                   onClick={handleExportToDatasets}
                 >
                   {intl.formatMessage({
@@ -216,7 +226,7 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
             <>
               {hasExportAction && <DropdownMenu.Separator />}
               <DropdownMenu.Group>
-                <DropdownMenu.Label>
+                <DropdownMenu.Label css={groupLabelStyles}>
                   {intl.formatMessage({
                     defaultMessage: 'Edit',
                     description: 'Trace actions dropdown group label',
@@ -225,6 +235,7 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
                 {hasEditTagsAction && (
                   <DropdownMenu.Item
                     componentId="mlflow.genai-traces-table.edit-tags"
+                    css={groupItemStyles}
                     onClick={handleEditTags}
                     disabled={isEditTagsDisabled}
                   >
@@ -237,6 +248,7 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
                 {hasDeleteAction && (
                   <DropdownMenu.Item
                     componentId="mlflow.genai-traces-table.delete-traces"
+                    css={groupItemStyles}
                     onClick={handleDeleteTraces}
                     disabled={traceActions?.deleteTracesAction?.isDisabled}
                     disabledReason={traceActions?.deleteTracesAction?.disabledReason}


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

N/A

### What changes are proposed in this pull request?

The "Use for evaluation" and "Edit" section headers in the traces view Actions dropdown were rendered using `DropdownMenu.Label`, which inherits the same padding, size, and layout as `DropdownMenu.Item` — differing only in text color. This made them look like grayed-out/disabled action buttons, causing confusion for users who expected them to be clickable.

This PR fixes the visual treatment to match the established pattern used in other menus (e.g. the Sort dropdown's "Attributes"/"Assessments" headers):
- Group labels keep the same size and casing, styled with secondary text color to signal they are non-interactive
- Items under each group are indented, making the hierarchy clear without resorting to visual treatments that feel out of place

### How is this PR tested?

- [x] Manual tests

Manually verified:
- "Use for evaluation" and "Edit" labels appear as non-interactive section headers (muted color, no hover/click behavior)
- "Add to evaluation dataset", "Edit tags", and "Delete traces" are visually indented under their respective group headers
- All actions continue to function correctly

Before:
<img width="305" height="303" alt="image" src="https://github.com/user-attachments/assets/041bec4f-0338-41bc-83ef-e771eaa765ef" />


After:
<img width="305" height="303" alt="image" src="https://github.com/user-attachments/assets/4ea72db5-1225-4664-8d12-d7e0a4b52d95" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a UI issue in the traces view where the "Use for evaluation" and "Edit" group headers in the Actions dropdown appeared as disabled buttons instead of section labels.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)