### PR TITLE
Fix image artifact filename mangling caused by URL encoding of `%` separator

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -11,9 +11,7 @@ import json
 import logging
 import os
 import posixpath
-import random
 import re
-import string
 import sys
 import tempfile
 import threading
@@ -3234,14 +3232,13 @@ class MlflowClient:
             # Sanitize key to use in filename (replace / with # to avoid subdirectories)
             sanitized_key = re.sub(r"/", "#", key)
             filename_uuid = str(uuid.uuid4())
-            # TODO: reconsider the separator used here since % has special meaning in URL encoding.
-            # See https://github.com/mlflow/mlflow/issues/14136 for more details.
-            # Construct a filename uuid that does not start with hex digits
-            filename_uuid = f"{random.choice(string.ascii_lowercase[6:])}{filename_uuid[1:]}"
+            # Use + as separator instead of % to avoid conflicts with URL encoding.
+            # The frontend supports both + and % delimiters for backwards compatibility.
+            # See https://github.com/mlflow/mlflow/issues/21085 for more details.
             uncompressed_filename = (
-                f"images/{sanitized_key}%step%{step}%timestamp%{timestamp}%{filename_uuid}"
+                f"images/{sanitized_key}+step+{step}+timestamp+{timestamp}+{filename_uuid}"
             )
-            compressed_filename = f"{uncompressed_filename}%compressed"
+            compressed_filename = f"{uncompressed_filename}+compressed"
 
             # Save full-resolution image
             image_filepath = f"{uncompressed_filename}.png"

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -2,6 +2,7 @@ import json
 import os
 import posixpath
 
+import numpy as np
 import pytest
 
 import mlflow
@@ -192,6 +193,27 @@ def test_log_image_with_steps():
                     assert metadata["key"] == "dog"
                     assert metadata["step"] == 0
                     assert metadata["timestamp"] <= get_current_time_millis()
+
+
+@pytest.mark.parametrize("step", [20, 26, 27])
+def test_log_image_with_url_encoding_prone_steps(step):
+    """Regression test: steps like 20, 26, 27 previously created %20, %26, %27 patterns
+    in filenames that got URL-decoded, corrupting the artifact path.
+    See https://github.com/mlflow/mlflow/issues/21085
+    """
+    image = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
+
+    with mlflow.start_run():
+        mlflow.log_image(image, key="dog", step=step, synchronous=True)
+
+        artifact_uri = mlflow.get_artifact_uri("images/")
+        run_artifact_dir = local_file_uri_to_path(artifact_uri)
+        files = os.listdir(run_artifact_dir)
+
+        assert len(files) == 2
+        for file in files:
+            assert file.startswith(f"dog+step+{step}+timestamp+")
+            assert "%" not in file
 
 
 def test_log_image_with_timestamp():

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -180,7 +180,7 @@ def test_log_image_with_steps():
         # .png file for the image and .webp file for compressed image
         assert len(files) == 2
         for file in files:
-            assert file.startswith("dog%step%0")
+            assert file.startswith("dog+step+0")
             logged_path = os.path.join(run_artifact_dir, file)
             if file.endswith(".png"):
                 loaded_image = np.asarray(Image.open(logged_path), dtype=np.uint8)
@@ -188,7 +188,7 @@ def test_log_image_with_steps():
             elif file.endswith(".json"):
                 with open(logged_path) as f:
                     metadata = json.load(f)
-                    assert metadata["filepath"].startswith("images/dog%step%0")
+                    assert metadata["filepath"].startswith("images/dog+step+0")
                     assert metadata["key"] == "dog"
                     assert metadata["step"] == 0
                     assert metadata["timestamp"] <= get_current_time_millis()
@@ -211,7 +211,7 @@ def test_log_image_with_timestamp():
         # .png file for the image, and .webp file for compressed image
         assert len(files) == 2
         for file in files:
-            assert file.startswith("dog%step%0")
+            assert file.startswith("dog+step+0")
             logged_path = os.path.join(run_artifact_dir, file)
             if file.endswith(".png"):
                 loaded_image = np.asarray(Image.open(logged_path), dtype=np.uint8)
@@ -219,7 +219,7 @@ def test_log_image_with_timestamp():
             elif file.endswith(".json"):
                 with open(logged_path) as f:
                     metadata = json.load(f)
-                    assert metadata["filepath"].startswith("images/dog%step%0")
+                    assert metadata["filepath"].startswith("images/dog+step+0")
                     assert metadata["key"] == "dog"
                     assert metadata["step"] == 0
                     assert metadata["timestamp"] == 100

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -389,7 +389,7 @@ def test_rest_get_artifact_api_log_image(artifacts_server):
     image = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
 
     with mlflow.start_run() as run:
-        mlflow.log_image(image, key="dog", step=100, timestamp=100, synchronous=True)
+        mlflow.log_image(image, key="dog", step=20, timestamp=100, synchronous=True)
 
     artifact_list_response = requests.get(
         url=f"{url}/ajax-api/2.0/mlflow/artifacts/list",
@@ -404,7 +404,7 @@ def test_rest_get_artifact_api_log_image(artifacts_server):
         )
         get_artifact_response.raise_for_status()
         assert (
-            "attachment; filename=dog+step+100+timestamp+100"
+            "attachment; filename=dog+step+20+timestamp+100"
             in get_artifact_response.headers["Content-Disposition"]
         )
         if path.endswith("png"):

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -404,7 +404,7 @@ def test_rest_get_artifact_api_log_image(artifacts_server):
         )
         get_artifact_response.raise_for_status()
         assert (
-            "attachment; filename=dog%step%100%timestamp%100"
+            "attachment; filename=dog+step+100+timestamp+100"
             in get_artifact_response.headers["Content-Disposition"]
         )
         if path.endswith("png"):

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -758,6 +758,7 @@ def test_negative_detection(uri):
         "path/",
         "path/to/file",
         "dog%step%100%timestamp%100",
+        "dog+step+100+timestamp+100",
     ],
 )
 def test_validate_path_is_safe_good(path):


### PR DESCRIPTION
### Related Issues/PRs

Closes #21085

### What changes are proposed in this pull request?

Replace `%` with `+` as the delimiter in image artifact filenames to prevent URL decoding from corrupting filenames. When step numbers like 20, 26, or 27 appear, patterns like `%20`, `%26`, `%27` get decoded by `urllib.parse.unquote()` in the path validation layer, turning them into space, `&`, `'`, etc.

The frontend (`ImageReducer.ts`) already supports both `+` and `%` delimiters, so existing artifacts with the old `%` format continue to work without any changes.


https://github.com/user-attachments/assets/dc0927e5-228f-4a65-b3bd-6289306ab3ac



### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Ran the reproduction script from the issue with steps 0–24 (including problematic step=20) against a local MLflow server. All images were correctly stored, listed, downloaded, and displayed in the UI.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where image artifact filenames were mangled when step numbers formed URL-encoding sequences (e.g., step=20 produced `%20` which was decoded to a space). The filename separator has been changed from `%` to `+`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)