### PR TITLE
Add admin-only authorization to webhook CRUD operations

### DIFF
--- a/docs/api_reference/source/rest-api.rst
+++ b/docs/api_reference/source/rest-api.rst
@@ -4335,9 +4335,7 @@ Create Webhook
 | ``2.0/mlflow/webhooks`` | ``POST``    |
 +-------------------------+-------------+
 
-.. note::
 
-    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 
@@ -4400,9 +4398,7 @@ List Webhooks
 | ``2.0/mlflow/webhooks`` | ``GET``     |
 +-------------------------+-------------+
 
-.. note::
 
-    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 
@@ -4459,9 +4455,7 @@ Get Webhook
 | ``2.0/mlflow/webhooks/{webhook_id}`` | ``GET``     |
 +--------------------------------------+-------------+
 
-.. note::
 
-    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 
@@ -4514,9 +4508,7 @@ Update Webhook
 | ``2.0/mlflow/webhooks/{webhook_id}`` | ``PATCH``   |
 +--------------------------------------+-------------+
 
-.. note::
 
-    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 
@@ -4581,9 +4573,7 @@ Delete Webhook
 | ``2.0/mlflow/webhooks/{webhook_id}`` | ``DELETE``  |
 +--------------------------------------+-------------+
 
-.. note::
 
-    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 
@@ -4620,9 +4610,7 @@ Test Webhook
 | ``2.0/mlflow/webhooks/{webhook_id}/test`` | ``POST``    |
 +-------------------------------------------+-------------+
 
-.. note::
 
-    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 

--- a/docs/api_reference/source/rest-api.rst
+++ b/docs/api_reference/source/rest-api.rst
@@ -4335,7 +4335,9 @@ Create Webhook
 | ``2.0/mlflow/webhooks`` | ``POST``    |
 +-------------------------+-------------+
 
+.. note::
 
+    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 
@@ -4398,7 +4400,9 @@ List Webhooks
 | ``2.0/mlflow/webhooks`` | ``GET``     |
 +-------------------------+-------------+
 
+.. note::
 
+    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 
@@ -4455,7 +4459,9 @@ Get Webhook
 | ``2.0/mlflow/webhooks/{webhook_id}`` | ``GET``     |
 +--------------------------------------+-------------+
 
+.. note::
 
+    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 
@@ -4508,7 +4514,9 @@ Update Webhook
 | ``2.0/mlflow/webhooks/{webhook_id}`` | ``PATCH``   |
 +--------------------------------------+-------------+
 
+.. note::
 
+    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 
@@ -4573,7 +4581,9 @@ Delete Webhook
 | ``2.0/mlflow/webhooks/{webhook_id}`` | ``DELETE``  |
 +--------------------------------------+-------------+
 
+.. note::
 
+    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 
@@ -4610,7 +4620,9 @@ Test Webhook
 | ``2.0/mlflow/webhooks/{webhook_id}/test`` | ``POST``    |
 +-------------------------------------------+-------------+
 
+.. note::
 
+    When :ref:`MLflow Authentication <auth>` is enabled, this endpoint requires admin privileges.
 
 
 

--- a/docs/docs/classic-ml/webhooks/index.mdx
+++ b/docs/docs/classic-ml/webhooks/index.mdx
@@ -21,6 +21,14 @@ MLflow webhooks enable real-time notifications when specific events occur in the
 - **Multiple event types** including model/prompt creation, versioning, and tagging
 - **Built-in testing** to verify webhook connectivity
 
+:::note Authorization
+
+When [MLflow Authentication](/self-hosting/security/basic-http-auth) is enabled, all webhook
+operations (create, list, get, update, delete, and test) require **admin privileges**. Non-admin
+users will receive a `403 Forbidden` response when attempting to access webhook endpoints.
+
+:::
+
 ## Supported Events
 
 MLflow webhooks support the following Model Registry and Prompt Registry events:

--- a/docs/docs/self-hosting/security/basic-http-auth.mdx
+++ b/docs/docs/self-hosting/security/basic-http-auth.mdx
@@ -1134,6 +1134,42 @@ MLflow Authentication provides API endpoints to manage users and permissions.
       <td>`DELETE`</td>
       <td>can_manage</td>
     </tr>
+    <tr>
+      <td>Create Webhook</td>
+      <td>`2.0/mlflow/webhooks`</td>
+      <td>`POST`</td>
+      <td>Only admin</td>
+    </tr>
+    <tr>
+      <td>List Webhooks</td>
+      <td>`2.0/mlflow/webhooks`</td>
+      <td>`GET`</td>
+      <td>Only admin</td>
+    </tr>
+    <tr>
+      <td>Get Webhook</td>
+      <td>`2.0/mlflow/webhooks/&lt;webhook_id&gt;`</td>
+      <td>`GET`</td>
+      <td>Only admin</td>
+    </tr>
+    <tr>
+      <td>Update Webhook</td>
+      <td>`2.0/mlflow/webhooks/&lt;webhook_id&gt;`</td>
+      <td>`PATCH`</td>
+      <td>Only admin</td>
+    </tr>
+    <tr>
+      <td>Delete Webhook</td>
+      <td>`2.0/mlflow/webhooks/&lt;webhook_id&gt;`</td>
+      <td>`DELETE`</td>
+      <td>Only admin</td>
+    </tr>
+    <tr>
+      <td>Test Webhook</td>
+      <td>`2.0/mlflow/webhooks/&lt;webhook_id&gt;/test`</td>
+      <td>`POST`</td>
+      <td>Only admin</td>
+    </tr>
   </tbody>
 </table>
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -150,6 +150,15 @@ from mlflow.protos.service_pb2 import (
 from mlflow.protos.service_pb2 import (
     ListGatewaySecretInfos as ListGatewaySecretInfos,
 )
+from mlflow.protos.webhooks_pb2 import (
+    CreateWebhook,
+    DeleteWebhook,
+    GetWebhook,
+    ListWebhooks,
+    TestWebhook,
+    UpdateWebhook,
+    WebhookService,
+)
 from mlflow.server import app
 from mlflow.server.auth.config import DEFAULT_AUTHORIZATION_FUNCTION, read_auth_config
 from mlflow.server.auth.entities import User
@@ -221,6 +230,7 @@ from mlflow.server.handlers import (
     _get_tracking_store,
     catch_mlflow_exception,
     get_endpoints,
+    get_service_endpoints,
 )
 from mlflow.server.jobs import get_job
 from mlflow.server.workspace_helpers import _get_workspace_store
@@ -1643,6 +1653,29 @@ LOGGED_MODEL_BEFORE_REQUEST_VALIDATORS = {
     for method in methods
 }
 
+WEBHOOK_BEFORE_REQUEST_HANDLERS = {
+    CreateWebhook: sender_is_admin,
+    GetWebhook: sender_is_admin,
+    ListWebhooks: sender_is_admin,
+    UpdateWebhook: sender_is_admin,
+    DeleteWebhook: sender_is_admin,
+    TestWebhook: sender_is_admin,
+}
+
+
+def get_webhook_before_request_handler(request_class):
+    return WEBHOOK_BEFORE_REQUEST_HANDLERS.get(request_class)
+
+
+WEBHOOK_BEFORE_REQUEST_VALIDATORS = {
+    # Paths for webhooks contain path parameters (e.g. /mlflow/webhooks/<webhook_id>)
+    (_re_compile_path(http_path), method): handler
+    for http_path, handler, methods in get_service_endpoints(
+        WebhookService, get_webhook_before_request_handler
+    )
+    for method in methods
+}
+
 _AJAX_API_PATH_PREFIX = "/ajax-api/2.0"
 
 
@@ -1719,6 +1752,18 @@ def _find_validator(req: Request) -> Callable[[], bool] | None:
             (
                 v
                 for (pat, method), v in LOGGED_MODEL_BEFORE_REQUEST_VALIDATORS.items()
+                if pat.fullmatch(req.path) and method == req.method
+            ),
+            None,
+        )
+
+    if "/mlflow/webhooks" in req.path:
+        # Webhook routes contain path parameters (e.g., /mlflow/webhooks/<webhook_id>)
+        # so we need regex matching
+        return next(
+            (
+                v
+                for (pat, method), v in WEBHOOK_BEFORE_REQUEST_VALIDATORS.items()
                 if pat.fullmatch(req.path) and method == req.method
             ),
             None,

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -2781,6 +2781,13 @@ def test_webhook_admin_only_permissions(client, monkeypatch):
     response.raise_for_status()
     webhook_id = response.json()["webhook"]["webhook_id"]
 
+    # Admin: list webhooks should succeed
+    response = requests.get(
+        url=client.tracking_uri + "/api/2.0/mlflow/webhooks",
+        auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
+    )
+    response.raise_for_status()
+
     # Non-admin: get webhook should be forbidden
     with User(user1, password1, monkeypatch):
         response = requests.get(
@@ -2788,6 +2795,13 @@ def test_webhook_admin_only_permissions(client, monkeypatch):
             auth=(user1, password1),
         )
         assert response.status_code == 403
+
+    # Admin: get webhook should succeed
+    response = requests.get(
+        url=client.tracking_uri + f"/api/2.0/mlflow/webhooks/{webhook_id}",
+        auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
+    )
+    response.raise_for_status()
 
     # Non-admin: update webhook should be forbidden
     with User(user1, password1, monkeypatch):
@@ -2798,6 +2812,14 @@ def test_webhook_admin_only_permissions(client, monkeypatch):
         )
         assert response.status_code == 403
 
+    # Admin: update webhook should succeed
+    response = requests.patch(
+        url=client.tracking_uri + f"/api/2.0/mlflow/webhooks/{webhook_id}",
+        json={"name": "updated-name"},
+        auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
+    )
+    response.raise_for_status()
+
     # Non-admin: test webhook should be forbidden
     with User(user1, password1, monkeypatch):
         response = requests.post(
@@ -2806,6 +2828,14 @@ def test_webhook_admin_only_permissions(client, monkeypatch):
             auth=(user1, password1),
         )
         assert response.status_code == 403
+
+    # Admin: test webhook should succeed
+    response = requests.post(
+        url=client.tracking_uri + f"/api/2.0/mlflow/webhooks/{webhook_id}/test",
+        json={},
+        auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
+    )
+    response.raise_for_status()
 
     # Non-admin: delete webhook should be forbidden
     with User(user1, password1, monkeypatch):

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import jwt
 import pytest
 import requests
+from cryptography.fernet import Fernet
 
 import mlflow
 from mlflow import MlflowClient
@@ -2741,7 +2742,7 @@ def test_list_users(client):
 
 @pytest.mark.parametrize(
     "client",
-    [{"MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY": "X4vHi-vCRxqZZ4-CETv_97GCg2mC3WAp9kOz_01tygg="}],
+    [{"MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY": Fernet.generate_key().decode("utf-8")}],
     indirect=True,
 )
 def test_webhook_admin_only_permissions(client, monkeypatch):

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -2737,3 +2737,87 @@ def test_list_users(client):
     data = response.json()
     assert "users" in data
     assert len(data["users"]) >= 3
+
+
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY": "X4vHi-vCRxqZZ4-CETv_97GCg2mC3WAp9kOz_01tygg="}],
+    indirect=True,
+)
+def test_webhook_admin_only_permissions(client, monkeypatch):
+    user1, password1 = create_user(client.tracking_uri)
+
+    # Non-admin: create webhook should be forbidden
+    with User(user1, password1, monkeypatch):
+        response = requests.post(
+            url=client.tracking_uri + "/api/2.0/mlflow/webhooks",
+            json={
+                "name": "test-webhook",
+                "url": "https://example.com/webhook",
+                "events": [{"entity": "MODEL_VERSION", "action": "CREATED"}],
+            },
+            auth=(user1, password1),
+        )
+        assert response.status_code == 403
+
+    # Non-admin: list webhooks should be forbidden
+    with User(user1, password1, monkeypatch):
+        response = requests.get(
+            url=client.tracking_uri + "/api/2.0/mlflow/webhooks",
+            auth=(user1, password1),
+        )
+        assert response.status_code == 403
+
+    # Admin: create webhook should succeed
+    response = requests.post(
+        url=client.tracking_uri + "/api/2.0/mlflow/webhooks",
+        json={
+            "name": "admin-webhook",
+            "url": "https://example.com/webhook",
+            "events": [{"entity": "MODEL_VERSION", "action": "CREATED"}],
+        },
+        auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
+    )
+    response.raise_for_status()
+    webhook_id = response.json()["webhook"]["webhook_id"]
+
+    # Non-admin: get webhook should be forbidden
+    with User(user1, password1, monkeypatch):
+        response = requests.get(
+            url=client.tracking_uri + f"/api/2.0/mlflow/webhooks/{webhook_id}",
+            auth=(user1, password1),
+        )
+        assert response.status_code == 403
+
+    # Non-admin: update webhook should be forbidden
+    with User(user1, password1, monkeypatch):
+        response = requests.patch(
+            url=client.tracking_uri + f"/api/2.0/mlflow/webhooks/{webhook_id}",
+            json={"name": "updated-name"},
+            auth=(user1, password1),
+        )
+        assert response.status_code == 403
+
+    # Non-admin: test webhook should be forbidden
+    with User(user1, password1, monkeypatch):
+        response = requests.post(
+            url=client.tracking_uri + f"/api/2.0/mlflow/webhooks/{webhook_id}/test",
+            json={},
+            auth=(user1, password1),
+        )
+        assert response.status_code == 403
+
+    # Non-admin: delete webhook should be forbidden
+    with User(user1, password1, monkeypatch):
+        response = requests.delete(
+            url=client.tracking_uri + f"/api/2.0/mlflow/webhooks/{webhook_id}",
+            auth=(user1, password1),
+        )
+        assert response.status_code == 403
+
+    # Admin: delete webhook should succeed
+    response = requests.delete(
+        url=client.tracking_uri + f"/api/2.0/mlflow/webhooks/{webhook_id}",
+        auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
+    )
+    response.raise_for_status()


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When MLflow Authentication is enabled, webhook endpoints currently have no authorization validators — any authenticated user can create, read, update, delete, and test webhooks. This PR restricts all webhook CRUD operations to admin-only access:

- Adds `WEBHOOK_BEFORE_REQUEST_HANDLERS` mapping all 6 webhook protobuf request classes to `sender_is_admin`
- Uses regex-based path matching via `WEBHOOK_BEFORE_REQUEST_VALIDATORS` for parameterized webhook URLs (e.g., `/mlflow/webhooks/<webhook_id>`), following the same pattern as logged-model authorization
- Adds webhook path check in `_find_validator()` to route webhook requests through the regex-based validators
- Updates webhook docs, auth permissions table, and REST API reference docs

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New `test_webhook_admin_only_permissions` test verifies:
- Non-admin users get 403 on all 6 webhook endpoints (create, list, get, update, test, delete)
- Admin users can successfully create and delete webhooks

All 12 existing webhook tests continue to pass (they don't use auth).

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [x] Instructions

Updated:
- `docs/docs/classic-ml/webhooks/index.mdx` — authorization note
- `docs/docs/self-hosting/security/basic-http-auth.mdx` — webhook rows in permissions table
- `docs/api_reference/source/rest-api.rst` — admin-only note on each webhook endpoint

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

When MLflow Authentication is enabled, all webhook operations (create, list, get, update, delete, test) now require admin privileges. Non-admin users will receive a 403 Forbidden response.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)