### PR TITLE
Widen assessment error stack trace modal

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerCodeSnippet.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerCodeSnippet.tsx
@@ -43,6 +43,7 @@ export function ModelTraceExplorerCodeSnippet({
   activeMatch = null,
   containsActiveMatch = false,
   initialRenderMode,
+  initialExpanded,
 }: {
   title: string;
   tokens?: number;
@@ -54,6 +55,7 @@ export function ModelTraceExplorerCodeSnippet({
   // current active match (either in the key or value)
   containsActiveMatch?: boolean;
   initialRenderMode?: CodeSnippetRenderMode;
+  initialExpanded?: boolean;
 }) {
   const parsedData = useMemo(() => JSON.parse(data), [data]);
   const dataIsString = isString(parsedData);
@@ -162,6 +164,7 @@ export function ModelTraceExplorerCodeSnippet({
           activeMatch={activeMatch}
           containsActiveMatch={containsActiveMatch}
           renderMode={renderMode}
+          initialExpanded={initialExpanded}
         />
       </div>
     </div>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackErrorItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackErrorItem.tsx
@@ -52,6 +52,7 @@ export const FeedbackErrorItem = ({ error }: { error: AssessmentError }) => {
             data={JSON.stringify(error.stack_trace)}
             title=""
             initialRenderMode={CodeSnippetRenderMode.TEXT}
+            initialExpanded
           />
         </Modal>
       )}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackErrorItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackErrorItem.tsx
@@ -44,6 +44,7 @@ export const FeedbackErrorItem = ({ error }: { error: AssessmentError }) => {
           }
           visible={isModalVisible}
           componentId="shared.model-trace-explorer.feedback-error-stack-trace-modal"
+          size="wide"
           footer={null}
           onCancel={() => setIsModalVisible(false)}
         >


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Sets the assessment error stack trace modal to `size="wide"` so that long stack traces are easier to read without excessive horizontal scrolling. Also sets the code snippet to expanded so the user doesn't have to click one more time.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified that the stack trace modal now renders wider when clicking "View stack trace" on an assessment error in the trace explorer.

Before:

https://github.com/user-attachments/assets/3ee1262e-53aa-40f0-8fa8-935e5f47e96e

After:


https://github.com/user-attachments/assets/5ba31891-eaa2-4815-8f92-1df695fb0b2f




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Widened the assessment error stack trace modal in the trace explorer for improved readability.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)