### PR TITLE
Fix Chat UI not rendering for Google ADK traces

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -1115,6 +1115,8 @@ export const normalizeConversation = (input: any, messageFormat?: string): Model
       default:
         const chatMessages = normalizeOpenAIFormats(input);
         if (chatMessages) return chatMessages;
+        const geminiFallbackMessages = normalizeGeminiChatInput(input) ?? normalizeGeminiChatOutput(input);
+        if (geminiFallbackMessages) return geminiFallbackMessages;
         break;
     }
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.test.ts
@@ -82,6 +82,56 @@ const MOCK_GEMINI_OUTPUT = {
   parsed: null,
 };
 
+// ADK input with function_call and function_response parts
+const MOCK_ADK_INPUT = {
+  model: 'gemini-3-flash-preview',
+  config: { system_instruction: 'You are a helpful assistant.' },
+  contents: [
+    { role: 'user', parts: [{ text: 'Hi, I want to learn about Google ADK' }] },
+    {
+      role: 'model',
+      parts: [{ function_call: { name: 'doc_search', args: { query: 'Google ADK overview' } } }],
+    },
+    {
+      role: 'user',
+      parts: [
+        {
+          function_response: {
+            name: 'doc_search',
+            response: { result: 'Google ADK is a framework for building AI agents.' },
+          },
+        },
+      ],
+    },
+    { role: 'model', parts: [{ text: 'The Google ADK is a framework for building AI agents.' }] },
+  ],
+};
+
+// ADK output with direct content (no candidates wrapper)
+const MOCK_ADK_OUTPUT = {
+  model_version: 'gemini-3-flash-preview',
+  content: {
+    role: 'model',
+    parts: [{ text: 'The Google ADK is a framework for building AI agents.' }],
+  },
+  finish_reason: 'STOP',
+  usage_metadata: {
+    prompt_token_count: 100,
+    candidates_token_count: 20,
+    total_token_count: 120,
+  },
+};
+
+// ADK output with function_call in direct content
+const MOCK_ADK_OUTPUT_WITH_FUNCTION_CALL = {
+  model_version: 'gemini-3-flash-preview',
+  content: {
+    role: 'model',
+    parts: [{ function_call: { name: 'doc_search', args: { query: 'Google ADK overview' } } }],
+  },
+  finish_reason: 'STOP',
+};
+
 const MOCK_GEMINI_OUTPUT_WITH_THINKING = {
   candidates: [
     {
@@ -132,5 +182,94 @@ describe('normalizeConversation', () => {
         reasoning: expect.stringMatching(/let me think about how many r's/i),
       }),
     ]);
+  });
+
+  it('should handle ADK input with function_call and function_response parts', () => {
+    const result = normalizeConversation(MOCK_ADK_INPUT, 'gemini');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(4);
+
+    // First message: user text
+    expect(result![0]).toMatchObject({
+      role: 'user',
+      content: expect.stringMatching(/I want to learn about Google ADK/i),
+    });
+
+    // Second message: model function_call → assistant with tool_calls
+    expect(result![1]).toMatchObject({
+      role: 'assistant',
+      tool_calls: [
+        {
+          id: 'doc_search',
+          function: {
+            name: 'doc_search',
+            arguments: JSON.stringify({ query: 'Google ADK overview' }, null, 2),
+          },
+        },
+      ],
+    });
+
+    // Third message: user function_response → tool message
+    expect(result![2]).toMatchObject({
+      role: 'tool',
+      name: 'doc_search',
+      content: expect.stringMatching(/Google ADK is a framework/i),
+    });
+
+    // Fourth message: model text response
+    expect(result![3]).toMatchObject({
+      role: 'assistant',
+      content: expect.stringMatching(/Google ADK is a framework/i),
+    });
+  });
+
+  it('should handle ADK output with direct content (no candidates wrapper)', () => {
+    const result = normalizeConversation(MOCK_ADK_OUTPUT, 'gemini');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]).toMatchObject({
+      role: 'assistant',
+      content: expect.stringMatching(/Google ADK is a framework/i),
+    });
+  });
+
+  it('should handle ADK output with function_call in direct content', () => {
+    const result = normalizeConversation(MOCK_ADK_OUTPUT_WITH_FUNCTION_CALL, 'gemini');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]).toMatchObject({
+      role: 'assistant',
+      tool_calls: [
+        {
+          id: 'doc_search',
+          function: {
+            name: 'doc_search',
+            arguments: JSON.stringify({ query: 'Google ADK overview' }, null, 2),
+          },
+        },
+      ],
+    });
+  });
+
+  it('should handle ADK data without messageFormat via default fallback', () => {
+    // When no messageFormat is set (as in ADK traces), the default case should
+    // fall back to Gemini normalizers after OpenAI fails
+    const result = normalizeConversation(MOCK_ADK_INPUT, undefined);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(4);
+    expect(result![0]).toMatchObject({ role: 'user' });
+    expect(result![1]).toMatchObject({ role: 'assistant', tool_calls: expect.any(Array) });
+    expect(result![2]).toMatchObject({ role: 'tool' });
+    expect(result![3]).toMatchObject({ role: 'assistant' });
+  });
+
+  it('should handle ADK output without messageFormat via default fallback', () => {
+    const result = normalizeConversation(MOCK_ADK_OUTPUT, undefined);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]).toMatchObject({
+      role: 'assistant',
+      content: expect.stringMatching(/Google ADK is a framework/i),
+    });
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
@@ -1,6 +1,6 @@
 import { compact, has, isArray, isObject, isString } from 'lodash';
 
-import type { ModelTraceChatMessage } from '../ModelTrace.types';
+import type { ModelTraceChatMessage, ModelTraceToolCall } from '../ModelTrace.types';
 import { prettyPrintChatMessage } from '../ModelTraceExplorer.utils';
 
 export type GeminiChatInput = {
@@ -47,59 +47,44 @@ type GeminiContent = {
   parts: GeminiContentPart[];
 };
 
-// Gemini parts can have a `thought` boolean flag indicating thinking content
-// When thought=true, the text contains the model's thinking/reasoning
-// When thought is null/undefined, the text contains the regular response
-type GeminiContentPart = {
+type GeminiTextPart = {
   text: string;
   thought?: boolean | null;
 };
-// | { inlineData: GeminiBlob }
-// | { functionCall: GeminiFunctionCall }
-// | { functionResponse: GeminiFunctionResponse }
-// | { fileData: GeminiFileData }
-// | { executableCode: GeminiExecutableCode }
-// | { codeExecutionResult: GeminiCodeExecutionResult };
 
-// type GeminiBlob = {
-//   mimeType: string;
-//   data: string;
-// };
+type GeminiFunctionCallPart = {
+  function_call: {
+    name: string;
+    args: Record<string, unknown>;
+  };
+};
 
-// type GeminiFunctionCall = {
-//   id: string;
-//   name: string;
-//   args: Record<string, string>;
-// };
+type GeminiFunctionResponsePart = {
+  function_response: {
+    name: string;
+    response: Record<string, unknown>;
+  };
+};
 
-// type GeminiFunctionResponse = {
-//   id: string;
-//   name: string;
-//   response: Record<string, string>;
-//   willContinue: boolean;
-//   scheduling: 'SCHEDULING_UNSPECIFIED' | 'SILENT' | 'WHEN_IDLE' | 'INTERRUPT';
-// };
+type GeminiContentPart = GeminiTextPart | GeminiFunctionCallPart | GeminiFunctionResponsePart;
 
-// type GeminiFileData = {
-//   mimeType: string;
-//   fileUri: string;
-// };
-
-// type GeminiExecutableCode = {
-//   language: 'LANGUAGE_UNSPECIFIED' | 'PYTHON';
-//   code: string;
-// };
-
-// type GeminiCodeExecutionResult = {
-//   outcome: 'OUTCOME_UNSPECIFIED' | 'OUTCOME_OK' | 'OUTCOME_FAILED' | 'OUTCOME_DEADLINE_EXCEEDED';
-//   output: string;
-// };
-
-const isGeminiContentPart = (obj: unknown): obj is GeminiContentPart => {
+const isGeminiTextPart = (obj: unknown): obj is GeminiTextPart => {
   return isObject(obj) && 'text' in obj && isString(obj.text);
 };
 
-const isThinkingPart = (part: GeminiContentPart): boolean => {
+const isGeminiFunctionCallPart = (obj: unknown): obj is GeminiFunctionCallPart => {
+  return isObject(obj) && 'function_call' in obj && isObject((obj as any).function_call);
+};
+
+const isGeminiFunctionResponsePart = (obj: unknown): obj is GeminiFunctionResponsePart => {
+  return isObject(obj) && 'function_response' in obj && isObject((obj as any).function_response);
+};
+
+const isGeminiContentPart = (obj: unknown): obj is GeminiContentPart => {
+  return isGeminiTextPart(obj) || isGeminiFunctionCallPart(obj) || isGeminiFunctionResponsePart(obj);
+};
+
+const isThinkingPart = (part: GeminiTextPart): boolean => {
   return part.thought === true;
 };
 
@@ -124,22 +109,88 @@ const processGeminiContentParts = (
 ): {
   textParts: { type: 'text'; text: string }[];
   thinking: string | null;
+  toolCalls: ModelTraceToolCall[];
+  functionResponses: { name: string; response: Record<string, unknown> }[];
 } => {
   const textParts: { type: 'text'; text: string }[] = [];
   const thinkingParts: string[] = [];
+  const toolCalls: ModelTraceToolCall[] = [];
+  const functionResponses: { name: string; response: Record<string, unknown> }[] = [];
 
   for (const part of parts) {
-    if (isThinkingPart(part)) {
-      // Thinking parts have thought=true and the thinking content in text
-      thinkingParts.push(part.text);
-    } else {
-      // Regular text parts have thought=null/undefined
-      textParts.push({ type: 'text', text: part.text });
+    if (isGeminiFunctionCallPart(part)) {
+      toolCalls.push({
+        id: part.function_call.name,
+        function: {
+          name: part.function_call.name,
+          arguments: JSON.stringify(part.function_call.args),
+        },
+      });
+    } else if (isGeminiFunctionResponsePart(part)) {
+      functionResponses.push({
+        name: part.function_response.name,
+        response: part.function_response.response,
+      });
+    } else if (isGeminiTextPart(part)) {
+      if (isThinkingPart(part)) {
+        thinkingParts.push(part.text);
+      } else {
+        textParts.push({ type: 'text', text: part.text });
+      }
     }
   }
 
   const thinking = thinkingParts.length > 0 ? thinkingParts.join('\n\n') : null;
-  return { textParts, thinking };
+  return { textParts, thinking, toolCalls, functionResponses };
+};
+
+const normalizeGeminiContentToMessages = (content: GeminiContent): ModelTraceChatMessage[] => {
+  const role = content.role === 'model' ? 'assistant' : content.role;
+  const { textParts, thinking, toolCalls, functionResponses } = processGeminiContentParts(content.parts);
+
+  const messages: ModelTraceChatMessage[] = [];
+
+  // Emit function_response parts as individual tool messages
+  for (const fr of functionResponses) {
+    const toolMsg = prettyPrintChatMessage({
+      type: 'message',
+      role: 'tool',
+      name: fr.name,
+      content: JSON.stringify(fr.response),
+    });
+    if (toolMsg) {
+      messages.push(toolMsg);
+    }
+  }
+
+  // Emit the main message (text and/or tool_calls)
+  if (textParts.length > 0 || toolCalls.length > 0) {
+    const message = prettyPrintChatMessage({
+      type: 'message',
+      content: textParts.length > 0 ? textParts : undefined,
+      role,
+      tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+    });
+    if (message) {
+      if (thinking) {
+        messages.push({ ...message, reasoning: thinking });
+      } else {
+        messages.push(message);
+      }
+    }
+  } else if (thinking) {
+    // Only thinking, no text or tool_calls
+    const message = prettyPrintChatMessage({
+      type: 'message',
+      content: undefined,
+      role,
+    });
+    if (message) {
+      messages.push({ ...message, reasoning: thinking });
+    }
+  }
+
+  return messages;
 };
 
 export const normalizeGeminiChatInput = (obj: unknown): ModelTraceChatMessage[] | null => {
@@ -154,21 +205,8 @@ export const normalizeGeminiChatInput = (obj: unknown): ModelTraceChatMessage[] 
     }
 
     if (isArray(obj.contents) && obj.contents.every(isGeminiContent)) {
-      return compact(
-        obj.contents.map((item) => {
-          const role = item.role === 'model' ? 'assistant' : item.role;
-          const { textParts, thinking } = processGeminiContentParts(item.parts);
-          const message = prettyPrintChatMessage({
-            type: 'message',
-            content: textParts.length > 0 ? textParts : undefined,
-            role,
-          });
-          if (message && thinking) {
-            return { ...message, reasoning: thinking };
-          }
-          return message;
-        }),
-      );
+      const messages = obj.contents.flatMap(normalizeGeminiContentToMessages);
+      return messages.length > 0 ? messages : null;
     }
   }
 
@@ -181,23 +219,14 @@ export const normalizeGeminiChatOutput = (obj: unknown): ModelTraceChatMessage[]
   }
 
   if ('candidates' in obj && isArray(obj.candidates) && obj.candidates.every(isGeminiCandidate)) {
-    return compact(
-      obj.candidates
-        .flatMap((item) => item.content)
-        .map((item) => {
-          const role = item.role === 'model' ? 'assistant' : item.role;
-          const { textParts, thinking } = processGeminiContentParts(item.parts);
-          const message = prettyPrintChatMessage({
-            type: 'message',
-            content: textParts.length > 0 ? textParts : undefined,
-            role,
-          });
-          if (message && thinking) {
-            return { ...message, reasoning: thinking };
-          }
-          return message;
-        }),
-    );
+    const messages = obj.candidates.flatMap((item) => normalizeGeminiContentToMessages(item.content));
+    return messages.length > 0 ? messages : null;
+  }
+
+  // ADK output format: { content: GeminiContent } without candidates wrapper
+  if ('content' in obj && isGeminiContent(obj.content)) {
+    const messages = normalizeGeminiContentToMessages(obj.content);
+    return messages.length > 0 ? messages : null;
   }
 
   return null;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/gemini.ts
@@ -148,20 +148,19 @@ const normalizeGeminiContentToMessages = (content: GeminiContent): ModelTraceCha
   const role = content.role === 'model' ? 'assistant' : content.role;
   const { textParts, thinking, toolCalls, functionResponses } = processGeminiContentParts(content.parts);
 
-  const messages: ModelTraceChatMessage[] = [];
-
   // Emit function_response parts as individual tool messages
-  for (const fr of functionResponses) {
-    const toolMsg = prettyPrintChatMessage({
-      type: 'message',
-      role: 'tool',
-      name: fr.name,
-      content: JSON.stringify(fr.response),
-    });
-    if (toolMsg) {
-      messages.push(toolMsg);
-    }
-  }
+  const toolMessages = compact(
+    functionResponses.map((fr) =>
+      prettyPrintChatMessage({
+        type: 'message',
+        role: 'tool',
+        name: fr.name,
+        content: JSON.stringify(fr.response),
+      }),
+    ),
+  );
+
+  const messages: ModelTraceChatMessage[] = [...toolMessages];
 
   // Emit the main message (text and/or tool_calls)
   if (textParts.length > 0 || toolCalls.length > 0) {


### PR DESCRIPTION
### Related Issues/PRs

<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Google ADK traces store chat data in Gemini API format within `mlflow.spanInputs`/`mlflow.spanOutputs` on `call_llm` spans. The Chat UI failed to render because:

1. **No `mlflow.message.format`** is set on ADK spans, so `normalizeConversation()` falls to the `default` case which only tries OpenAI format
2. **`isGeminiContentPart` was text-only** — it rejected `function_call`/`function_response` parts that ADK uses for tool interactions
3. **ADK output format differs** — uses `{ content: { role, parts } }` directly instead of `{ candidates: [{ content: {...} }] }`

This PR fixes all three issues:

- **Extend Gemini normalizer types** to support `function_call` and `function_response` content parts as a union type alongside text parts
- **Update `processGeminiContentParts`** to convert `function_call` parts → `ModelTraceToolCall[]` and `function_response` parts → tool messages
- **Add `normalizeGeminiContentToMessages`** shared helper that maps a single `GeminiContent` → `ModelTraceChatMessage[]`
- **Support ADK output format** — detect `{ content: GeminiContent }` without the `candidates` wrapper in `normalizeGeminiChatOutput`
- **Add Gemini fallback** in the `default` case of `normalizeConversation()` so ADK traces without `mlflow.message.format` are still rendered


<img width="1440" height="900" alt="adk-call-llm-1" src="https://github.com/user-attachments/assets/4d3cdf9d-7569-4509-959b-8b67e41ce83d" />
<img width="1440" height="900" alt="adk-call-llm-2" src="https://github.com/user-attachments/assets/6271a7d6-a370-4e92-971f-dfce20c8bf44" />
<img width="1440" height="900" alt="adk-call-llm-3" src="https://github.com/user-attachments/assets/6683839c-a8f8-48cf-9f59-b650c12795ac" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

5 new test cases added:
- ADK input with `function_call`/`function_response` parts → tool_calls + tool messages
- ADK output with direct `content` (no candidates wrapper)
- ADK output with `function_call` in direct content
- Default fallback for ADK input (no messageFormat)
- Default fallback for ADK output (no messageFormat)

All 114 chat-utils tests pass (14 test suites).

**Manual verification**: Screenshots of the Chat UI rendering for each `call_llm` span in an ADK trace will be attached as a follow-up comment.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix Chat UI not rendering for Google ADK traces by extending the Gemini chat normalizer to support `function_call`/`function_response` content parts and the ADK-specific output format, and adding a Gemini fallback in the default message format case.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)