### PR TITLE
Refine input/output sorting heuristic in trace session view

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { rankByKeyImportance, PREFERRED_INPUT_KEYS, PREFERRED_OUTPUT_KEYS } from './SingleChatTurnMessages';
+
+const rankInputByImportance = rankByKeyImportance(PREFERRED_INPUT_KEYS);
+const rankOutputByImportance = rankByKeyImportance(PREFERRED_OUTPUT_KEYS);
+
+const keys = (items: { key: string }[]) => items.map((item) => item.key);
+const toItems = (...itemKeys: string[]) => itemKeys.map((key) => ({ key, value: 'v' }));
+
+describe('rankByKeyImportance', () => {
+  describe('rankInputByImportance', () => {
+    it('should prioritize "messages" above other keys', () => {
+      const items = toItems('config', 'messages', 'temperature');
+      expect(keys(items.sort(rankInputByImportance))).toEqual(['messages', 'config', 'temperature']);
+    });
+
+    it('should prioritize "input" above non-preferred keys', () => {
+      const items = toItems('temperature', 'input', 'config');
+      expect(keys(items.sort(rankInputByImportance))).toEqual(['input', 'temperature', 'config']);
+    });
+
+    it('should prioritize "inputs" above non-preferred keys', () => {
+      const items = toItems('config', 'inputs');
+      expect(keys(items.sort(rankInputByImportance))).toEqual(['inputs', 'config']);
+    });
+
+    it('should rank preferred keys in priority order: messages > input > inputs', () => {
+      const items = toItems('inputs', 'input', 'messages');
+      expect(keys(items.sort(rankInputByImportance))).toEqual(['messages', 'input', 'inputs']);
+    });
+
+    it('should be case-insensitive', () => {
+      const items = toItems('config', 'Messages', 'INPUT');
+      expect(keys(items.sort(rankInputByImportance))).toEqual(['Messages', 'INPUT', 'config']);
+    });
+
+    it('should preserve original order for non-preferred keys', () => {
+      const items = toItems('alpha', 'beta', 'gamma');
+      expect(keys(items.sort(rankInputByImportance))).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('should handle a single preferred key among many non-preferred', () => {
+      const items = toItems('a', 'b', 'messages', 'c', 'd');
+      expect(keys(items.sort(rankInputByImportance))).toEqual(['messages', 'a', 'b', 'c', 'd']);
+    });
+
+    it('should handle an empty list', () => {
+      expect(toItems().sort(rankInputByImportance)).toEqual([]);
+    });
+
+    it('should handle a single item', () => {
+      expect(keys(toItems('messages').sort(rankInputByImportance))).toEqual(['messages']);
+    });
+  });
+
+  describe('rankOutputByImportance', () => {
+    it('should prioritize "response" above other keys', () => {
+      const items = toItems('metadata', 'response', 'usage');
+      expect(keys(items.sort(rankOutputByImportance))).toEqual(['response', 'metadata', 'usage']);
+    });
+
+    it('should prioritize "output" above non-preferred keys', () => {
+      const items = toItems('usage', 'output');
+      expect(keys(items.sort(rankOutputByImportance))).toEqual(['output', 'usage']);
+    });
+
+    it('should prioritize "outputs" above non-preferred keys', () => {
+      const items = toItems('metadata', 'outputs', 'usage');
+      expect(keys(items.sort(rankOutputByImportance))).toEqual(['outputs', 'metadata', 'usage']);
+    });
+
+    it('should prioritize "generations" above non-preferred keys', () => {
+      const items = toItems('metadata', 'generations');
+      expect(keys(items.sort(rankOutputByImportance))).toEqual(['generations', 'metadata']);
+    });
+
+    it('should rank preferred keys in priority order: response > output > outputs > generations', () => {
+      const items = toItems('generations', 'outputs', 'output', 'response');
+      expect(keys(items.sort(rankOutputByImportance))).toEqual([
+        'response',
+        'output',
+        'outputs',
+        'generations',
+      ]);
+    });
+
+    it('should be case-insensitive', () => {
+      const items = toItems('usage', 'Response', 'GENERATIONS');
+      expect(keys(items.sort(rankOutputByImportance))).toEqual(['Response', 'GENERATIONS', 'usage']);
+    });
+  });
+
+  describe('custom preferred keys', () => {
+    it('should work with arbitrary preferred key lists', () => {
+      const rankByCustom = rankByKeyImportance(['z', 'a']);
+      const items = toItems('b', 'a', 'z', 'c');
+      expect(keys(items.sort(rankByCustom))).toEqual(['z', 'a', 'b', 'c']);
+    });
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.test.ts
@@ -77,12 +77,7 @@ describe('rankByKeyImportance', () => {
 
     it('should rank preferred keys in priority order: response > output > outputs > generations', () => {
       const items = toItems('generations', 'outputs', 'output', 'response');
-      expect(keys(items.sort(rankOutputByImportance))).toEqual([
-        'response',
-        'output',
-        'outputs',
-        'generations',
-      ]);
+      expect(keys(items.sort(rankOutputByImportance))).toEqual(['response', 'output', 'outputs', 'generations']);
     });
 
     it('should be case-insensitive', () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
@@ -8,6 +8,26 @@ import { parseModelTraceToTree, createListFromObject } from '../ModelTraceExplor
 import { ModelTraceExplorerChatMessage } from '../right-pane/ModelTraceExplorerChatMessage';
 import { ModelTraceExplorerSummarySection } from '../summary-view/ModelTraceExplorerSummarySection';
 
+export const PREFERRED_INPUT_KEYS = ['messages', 'input', 'inputs'];
+export const PREFERRED_OUTPUT_KEYS = ['response', 'output', 'outputs', 'generations'];
+
+export const rankByKeyImportance = (preferredKeys: string[]) => {
+  return (a: { key: string }, b: { key: string }): number => {
+    const aIndex = preferredKeys.indexOf(a.key.toLowerCase());
+    const bIndex = preferredKeys.indexOf(b.key.toLowerCase());
+    // Both are preferred: sort by preference order
+    if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
+    // Only one is preferred: it comes first
+    if (aIndex !== -1) return -1;
+    if (bIndex !== -1) return 1;
+    // Neither is preferred: preserve original order
+    return 0;
+  };
+};
+
+const rankInputByImportance = rankByKeyImportance(PREFERRED_INPUT_KEYS);
+const rankOutputByImportance = rankByKeyImportance(PREFERRED_OUTPUT_KEYS);
+
 export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
   const { theme } = useDesignSystemTheme();
 
@@ -41,13 +61,12 @@ export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
     );
   }
 
-  // reverse to show the first param before the cutoff
   const inputList = createListFromObject(rootSpan.inputs)
     .filter((item) => item.value !== 'null')
-    .reverse();
+    .sort(rankInputByImportance);
   const outputList = createListFromObject(rootSpan.outputs)
     .filter((item) => item.value !== 'null')
-    .reverse();
+    .sort(rankOutputByImportance);
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
@@ -61,12 +61,16 @@ export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
     );
   }
 
+  // Sort by importance then reverse — the component expands upwards,
+  // so the last item in the array is the one visible above the fold.
   const inputList = createListFromObject(rootSpan.inputs)
     .filter((item) => item.value !== 'null')
-    .sort(rankInputByImportance);
+    .sort(rankInputByImportance)
+    .reverse();
   const outputList = createListFromObject(rootSpan.outputs)
     .filter((item) => item.value !== 'null')
-    .sort(rankOutputByImportance);
+    .sort(rankOutputByImportance)
+    .reverse();
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Replaces the naive `.reverse()` heuristic for sorting inputs/outputs in the single chat turn session view with importance-based sorting. Previously, the list was simply reversed under the assumption that the first parameter was most important. Now, items are sorted by key name relevance:

- **Inputs**: Keys `messages`, `input`, `inputs` are prioritized (in that order)
- **Outputs**: Keys `response`, `output`, `outputs`, `generations` are prioritized (in that order)

This ensures the most meaningful data is displayed "above the fold" when `maxVisibleItems={1}` limits visibility.

Implementation uses a `rankByKeyImportance` factory that creates a comparator from a list of preferred keys, with case-insensitive matching.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

new unit tests

Before, claude response was hidden under "See more":


https://github.com/user-attachments/assets/06f3ed3d-01dc-4aa1-ae27-f7c6cae29af5



After, messages are displayed first:



https://github.com/user-attachments/assets/60bcb56f-6e69-4b3c-8165-b9428b5f4324



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)