### PR TITLE
Add IS NULL/IS NOT NULL support for trace tags in search_traces

### DIFF
--- a/docs/docs/genai/tracing/search-traces.mdx
+++ b/docs/docs/genai/tracing/search-traces.mdx
@@ -63,7 +63,7 @@ The `search_traces` API uses a SQL-like Domain Specific Language (DSL) for query
 | **String Fields**    | `trace.client_request_id`, `trace.name`                              | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | trace.name LIKE "%Generate%"       |
 | **Linked Prompts**   | `prompt`                                                             | `=` (format: `"name/version"`)                                | prompt = "qa-system-prompt/4"      |
 | **Span Name/Type**   | `span.name`, `span.type`                                             | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | span.type RLIKE "^LLM"             |
-| **Tags**             | `tag.<key>`                                                          | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | tag.key = "value"                  |
+| **Tags**             | `tag.<key>`                                                          | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | tag.key = "value"                  |
 | **Metadata**         | `metadata.<key>`                                                     | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | metadata.user_id LIKE "user%"      |
 | **Feedback**         | `feedback.<name>`                                                    | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | feedback.rating = "excellent"      |
 | **Expectations**     | `expectation.<name>`                                                 | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | expectation.result = "pass"        |
@@ -172,6 +172,17 @@ mlflow.search_traces(filter_string="tag.environment ILIKE '%prod%'")
 
 # Regular expression matching with RLIKE
 mlflow.search_traces(filter_string="tag.version RLIKE '^v[0-9]+\\.[0-9]+'")
+
+# Find traces where a tag key exists
+mlflow.search_traces(filter_string="tag.model_name IS NOT NULL")
+
+# Find traces where a tag key is missing
+mlflow.search_traces(filter_string="tag.environment IS NULL")
+
+# Combine null checks with other filters
+mlflow.search_traces(
+    filter_string="tag.environment IS NOT NULL AND tag.model_name = 'gpt-4'"
+)
 ```
 
 #### Filter by Metadata

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -6275,6 +6275,16 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
                     )
                     span_filters.append(association_subquery)
                     continue
+                if comparator in ("IS NULL", "IS NOT NULL"):
+                    tag_exists_subquery = session.query(SqlTraceTag.request_id).filter(
+                        SqlTraceTag.request_id == SqlTraceInfo.request_id,
+                        SqlTraceTag.key == key_name,
+                    )
+                    if comparator == "IS NULL":
+                        attribute_filters.append(~tag_exists_subquery.exists())
+                    else:
+                        attribute_filters.append(tag_exists_subquery.exists())
+                    continue
                 entity = SqlTraceTag
             elif SearchTraceUtils.is_request_metadata(key_type, comparator):
                 # Handle IS NULL / IS NOT NULL for metadata

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1711,7 +1711,7 @@ class SearchTraceUtils(SearchUtils):
         "end_time",
     }
 
-    VALID_TAG_COMPARATORS = {"!=", "=", "LIKE", "ILIKE", "RLIKE"}
+    VALID_TAG_COMPARATORS = {"!=", "=", "LIKE", "ILIKE", "RLIKE", "IS NULL", "IS NOT NULL"}
     VALID_STRING_ATTRIBUTE_COMPARATORS = {"!=", "=", "IN", "NOT IN", "LIKE", "ILIKE", "RLIKE"}
     VALID_SPAN_ATTRIBUTE_COMPARATORS = {"!=", "=", "IN", "NOT IN", "LIKE", "ILIKE", "RLIKE"}
     VALID_METADATA_COMPARATORS = {"!=", "=", "LIKE", "ILIKE", "RLIKE", "IS NULL", "IS NOT NULL"}

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1795,8 +1795,16 @@ class SearchTraceUtils(SearchUtils):
         comparator = sed.get("comparator").upper()
 
         if cls.is_tag(type_, comparator):
+            if comparator == "IS NULL":
+                return key not in trace.tags
+            elif comparator == "IS NOT NULL":
+                return key in trace.tags
             lhs = trace.tags.get(key)
         elif cls.is_request_metadata(type_, comparator):
+            if comparator == "IS NULL":
+                return key not in trace.request_metadata
+            elif comparator == "IS NOT NULL":
+                return key in trace.request_metadata
             lhs = trace.request_metadata.get(key)
         elif cls.is_attribute(type_, key, comparator):
             lhs = getattr(trace, key)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -6737,6 +6737,58 @@ def test_search_traces_with_metadata_is_not_null_filter(store: SqlAlchemyStore):
     assert trace_ids == {trace1_id}
 
 
+def test_search_traces_with_tag_is_null_filter(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_tag_is_null")
+
+    trace1_id = "trace1"
+    trace2_id = "trace2"
+    trace3_id = "trace3"
+
+    _create_trace(store, trace1_id, exp_id, tags={"env": "production", "region": "us"})
+    _create_trace(store, trace2_id, exp_id, tags={"env": "staging"})
+    _create_trace(store, trace3_id, exp_id, tags={})
+
+    traces, _ = store.search_traces([exp_id], filter_string="tag.region IS NULL")
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace2_id, trace3_id}
+
+    traces, _ = store.search_traces([exp_id], filter_string="tag.env IS NULL")
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace3_id}
+
+    traces, _ = store.search_traces(
+        [exp_id], filter_string='tag.region IS NULL AND tag.env = "staging"'
+    )
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace2_id}
+
+
+def test_search_traces_with_tag_is_not_null_filter(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_tag_is_not_null")
+
+    trace1_id = "trace1"
+    trace2_id = "trace2"
+    trace3_id = "trace3"
+
+    _create_trace(store, trace1_id, exp_id, tags={"env": "production", "region": "us"})
+    _create_trace(store, trace2_id, exp_id, tags={"env": "staging"})
+    _create_trace(store, trace3_id, exp_id, tags={})
+
+    traces, _ = store.search_traces([exp_id], filter_string="tag.region IS NOT NULL")
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace1_id}
+
+    traces, _ = store.search_traces([exp_id], filter_string="tag.env IS NOT NULL")
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace1_id, trace2_id}
+
+    traces, _ = store.search_traces(
+        [exp_id], filter_string='tag.region IS NOT NULL AND tag.env = "production"'
+    )
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace1_id}
+
+
 @pytest.mark.skipif(IS_MSSQL, reason="RLIKE is not supported for MSSQL database dialect.")
 def test_search_traces_with_metadata_rlike_filters(store: SqlAlchemyStore):
     exp_id = store.create_experiment("test_metadata_rlike")

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -17,10 +17,13 @@ from mlflow.entities import (
     RunInputs,
     RunStatus,
     RunTag,
+    TraceState,
+    trace_location,
 )
+from mlflow.entities.trace_info import TraceInfo
 from mlflow.exceptions import MlflowException
 from mlflow.utils.mlflow_tags import MLFLOW_DATASET_CONTEXT
-from mlflow.utils.search_utils import SearchUtils
+from mlflow.utils.search_utils import SearchTraceUtils, SearchUtils
 
 
 @pytest.mark.parametrize(
@@ -692,3 +695,58 @@ def test_like_pattern_with_plus_character(tmp_path):
 
     exps = mlflow.search_experiments(filter_string='name LIKE "jamie-foo C+%"')
     assert len(exps) == 1
+
+
+def test_search_trace_utils_filter_tag_is_null():
+    loc = trace_location.TraceLocation.from_experiment_id("0")
+    trace1 = TraceInfo(
+        trace_id="t1", trace_location=loc, request_time=0,
+        state=TraceState.OK, tags={"env": "prod", "region": "us"},
+    )
+    trace2 = TraceInfo(
+        trace_id="t2", trace_location=loc, request_time=0,
+        state=TraceState.OK, tags={"env": "staging"},
+    )
+    trace3 = TraceInfo(
+        trace_id="t3", trace_location=loc, request_time=0,
+        state=TraceState.OK, tags={},
+    )
+    traces = [trace1, trace2, trace3]
+
+    result = SearchTraceUtils.filter(traces, "tag.region IS NULL")
+    assert {t.trace_id for t in result} == {"t2", "t3"}
+
+    result = SearchTraceUtils.filter(traces, "tag.region IS NOT NULL")
+    assert {t.trace_id for t in result} == {"t1"}
+
+    result = SearchTraceUtils.filter(traces, "tag.env IS NULL")
+    assert {t.trace_id for t in result} == {"t3"}
+
+    result = SearchTraceUtils.filter(traces, "tag.env IS NOT NULL")
+    assert {t.trace_id for t in result} == {"t1", "t2"}
+
+    result = SearchTraceUtils.filter(traces, 'tag.region IS NULL AND tag.env = "staging"')
+    assert {t.trace_id for t in result} == {"t2"}
+
+
+def test_search_trace_utils_filter_metadata_is_null():
+    loc = trace_location.TraceLocation.from_experiment_id("0")
+    trace1 = TraceInfo(
+        trace_id="t1", trace_location=loc, request_time=0,
+        state=TraceState.OK, trace_metadata={"user": "alice", "session": "s1"},
+    )
+    trace2 = TraceInfo(
+        trace_id="t2", trace_location=loc, request_time=0,
+        state=TraceState.OK, trace_metadata={"user": "bob"},
+    )
+    trace3 = TraceInfo(
+        trace_id="t3", trace_location=loc, request_time=0,
+        state=TraceState.OK, trace_metadata={},
+    )
+    traces = [trace1, trace2, trace3]
+
+    result = SearchTraceUtils.filter(traces, "metadata.session IS NULL")
+    assert {t.trace_id for t in result} == {"t2", "t3"}
+
+    result = SearchTraceUtils.filter(traces, "metadata.session IS NOT NULL")
+    assert {t.trace_id for t in result} == {"t1"}

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -700,16 +700,25 @@ def test_like_pattern_with_plus_character(tmp_path):
 def test_search_trace_utils_filter_tag_is_null():
     loc = trace_location.TraceLocation.from_experiment_id("0")
     trace1 = TraceInfo(
-        trace_id="t1", trace_location=loc, request_time=0,
-        state=TraceState.OK, tags={"env": "prod", "region": "us"},
+        trace_id="t1",
+        trace_location=loc,
+        request_time=0,
+        state=TraceState.OK,
+        tags={"env": "prod", "region": "us"},
     )
     trace2 = TraceInfo(
-        trace_id="t2", trace_location=loc, request_time=0,
-        state=TraceState.OK, tags={"env": "staging"},
+        trace_id="t2",
+        trace_location=loc,
+        request_time=0,
+        state=TraceState.OK,
+        tags={"env": "staging"},
     )
     trace3 = TraceInfo(
-        trace_id="t3", trace_location=loc, request_time=0,
-        state=TraceState.OK, tags={},
+        trace_id="t3",
+        trace_location=loc,
+        request_time=0,
+        state=TraceState.OK,
+        tags={},
     )
     traces = [trace1, trace2, trace3]
 
@@ -732,16 +741,25 @@ def test_search_trace_utils_filter_tag_is_null():
 def test_search_trace_utils_filter_metadata_is_null():
     loc = trace_location.TraceLocation.from_experiment_id("0")
     trace1 = TraceInfo(
-        trace_id="t1", trace_location=loc, request_time=0,
-        state=TraceState.OK, trace_metadata={"user": "alice", "session": "s1"},
+        trace_id="t1",
+        trace_location=loc,
+        request_time=0,
+        state=TraceState.OK,
+        trace_metadata={"user": "alice", "session": "s1"},
     )
     trace2 = TraceInfo(
-        trace_id="t2", trace_location=loc, request_time=0,
-        state=TraceState.OK, trace_metadata={"user": "bob"},
+        trace_id="t2",
+        trace_location=loc,
+        request_time=0,
+        state=TraceState.OK,
+        trace_metadata={"user": "bob"},
     )
     trace3 = TraceInfo(
-        trace_id="t3", trace_location=loc, request_time=0,
-        state=TraceState.OK, trace_metadata={},
+        trace_id="t3",
+        trace_location=loc,
+        request_time=0,
+        state=TraceState.OK,
+        trace_metadata={},
     )
     traces = [trace1, trace2, trace3]
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add `IS NULL` and `IS NOT NULL` operator support for trace tags in the `search_traces` API. Previously, these operators were supported for metadata and assessments but not for tags. This enables queries like:

- `tag.model_name IS NOT NULL` — find traces where a tag key exists
- `tag.environment IS NULL` — find traces where a tag key is missing

Changes:
- Added `IS NULL` and `IS NOT NULL` to `SearchTraceUtils.VALID_TAG_COMPARATORS`
- Added existence-subquery handling for trace tags in `_get_filter_clauses_for_search_traces()`, following the same pattern used for metadata and assessments
- Updated the search-traces documentation to reflect the new operators

### How is this PR tested?

- [x] New unit/integration tests

Added `test_search_traces_with_tag_is_null_filter` and `test_search_traces_with_tag_is_not_null_filter` in `tests/store/tracking/test_sqlalchemy_store.py`, covering:
- Basic IS NULL / IS NOT NULL filtering
- Combined filters (e.g., `tag.region IS NULL AND tag.env = "staging"`)

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

Updated `docs/docs/genai/tracing/search-traces.mdx`:
- Added IS NULL/IS NOT NULL to the Tags row in the comparator table
- Added usage examples in the "Filter by Tags" section

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add `IS NULL` and `IS NOT NULL` operator support for trace tags in `search_traces`, enabling filtering for traces where a specific tag key exists or is missing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)