### PR TITLE
Add IS NULL/IS NOT NULL operators for trace tags in search UI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/filters/TableFilterItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/filters/TableFilterItem.tsx
@@ -99,6 +99,10 @@ const getAvailableOperators = (column: string, key?: string): FilterOperator[] =
     return [FilterOperator.EQUALS, FilterOperator.IS_NULL, FilterOperator.IS_NOT_NULL];
   }
 
+  if (column === TracesTableColumnGroup.TAG) {
+    return [FilterOperator.EQUALS, FilterOperator.IS_NULL, FilterOperator.IS_NOT_NULL];
+  }
+
   return [FilterOperator.EQUALS];
 };
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.test.tsx
@@ -1789,4 +1789,71 @@ describe('createMlflowSearchFilter', () => {
     expect(filterString).toContain("attributes.status = 'OK'");
     expect(filterString).toContain(' AND ');
   });
+
+  test('creates correct filter string for tag IS NULL', () => {
+    const networkFilters = [
+      {
+        column: TracesTableColumnGroup.TAG,
+        operator: FilterOperator.IS_NULL,
+        key: 'environment',
+        value: undefined,
+      },
+    ];
+
+    const filterString = createMlflowSearchFilter(undefined, undefined, networkFilters);
+
+    expect(filterString).toBe('tags.environment IS NULL');
+  });
+
+  test('creates correct filter string for tag IS NOT NULL', () => {
+    const networkFilters = [
+      {
+        column: TracesTableColumnGroup.TAG,
+        operator: FilterOperator.IS_NOT_NULL,
+        key: 'model_name',
+        value: undefined,
+      },
+    ];
+
+    const filterString = createMlflowSearchFilter(undefined, undefined, networkFilters);
+
+    expect(filterString).toBe('tags.model_name IS NOT NULL');
+  });
+
+  test('creates correct filter string for tag IS NULL with special characters in key', () => {
+    const networkFilters = [
+      {
+        column: TracesTableColumnGroup.TAG,
+        operator: FilterOperator.IS_NULL,
+        key: 'my.tag',
+        value: undefined,
+      },
+    ];
+
+    const filterString = createMlflowSearchFilter(undefined, undefined, networkFilters);
+
+    expect(filterString).toBe('tags.`my.tag` IS NULL');
+  });
+
+  test('combines tag IS NULL/IS NOT NULL filters with other filters', () => {
+    const networkFilters = [
+      {
+        column: TracesTableColumnGroup.TAG,
+        operator: FilterOperator.IS_NOT_NULL,
+        key: 'environment',
+        value: undefined,
+      },
+      {
+        column: STATE_COLUMN_ID,
+        operator: FilterOperator.EQUALS,
+        value: 'OK',
+      },
+    ];
+
+    const filterString = createMlflowSearchFilter(undefined, undefined, networkFilters);
+
+    expect(filterString).toContain('tags.environment IS NOT NULL');
+    expect(filterString).toContain("attributes.status = 'OK'");
+    expect(filterString).toContain(' AND ');
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.tsx
@@ -664,7 +664,14 @@ export const createMlflowSearchFilter = (
               networkFilter.key.includes('.') || networkFilter.key.includes(' ')
                 ? `${tagField}.\`${networkFilter.key}\``
                 : `${tagField}.${networkFilter.key}`;
-            filter.push(`${fieldName} ${networkFilter.operator} '${networkFilter.value}'`);
+            if (
+              networkFilter.operator === FilterOperator.IS_NULL ||
+              networkFilter.operator === FilterOperator.IS_NOT_NULL
+            ) {
+              filter.push(`${fieldName} ${networkFilter.operator}`);
+            } else {
+              filter.push(`${fieldName} ${networkFilter.operator} '${networkFilter.value}'`);
+            }
           }
           break;
         case EXECUTION_DURATION_COLUMN_ID:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21277

### What changes are proposed in this pull request?

Expose `IS NULL` and `IS NOT NULL` operators in the trace search filter dropdown for tags, enabling users to filter traces by tag existence directly in the UI. The backend support was added in #21277.

<img width="636" height="297" alt="image" src="https://github.com/user-attachments/assets/929eba54-0c81-4006-93c6-a347159e7272" />

### How is this PR tested?

- [x] New unit/integration tests

Added tests in `useMlflowTraces.test.tsx`:
- Tag IS NULL filter string generation
- Tag IS NOT NULL filter string generation
- Tag IS NULL with special characters in key (backtick escaping)
- Combined tag IS NULL/IS NOT NULL with other filters

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

Documentation was updated in #21277.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add `IS NULL` and `IS NOT NULL` operators for trace tags in the search UI, allowing users to filter traces by whether a specific tag key exists or is missing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)