### PR TITLE
Clean up assessment pane: remove type dropdown and redundant toggle

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3873,10 +3873,6 @@
     "defaultMessage": "Total",
     "description": "Label for total token usage"
   },
-  "QK9qFL": {
-    "defaultMessage": "Hide assessments",
-    "description": "Label for the button to hide the assessments pane"
-  },
   "QMCliz": {
     "defaultMessage": "Measure and compare LLM quality with built-in and custom scorers.",
     "description": "Feature card summary for evaluation"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3,10 +3,6 @@
     "defaultMessage": "Relevant",
     "description": "Evaluation results > retrieval relevancy assessment > positive value label. Displayed if evaluation result is considered as relevant to the query."
   },
-  "++Ydlz": {
-    "defaultMessage": "Assessments",
-    "description": "Label for the assessments pane"
-  },
   "+/Zrmm": {
     "defaultMessage": "Temperature",
     "description": "Label for temperature input"
@@ -22,6 +18,10 @@
   "+4+wQY": {
     "defaultMessage": "Store it securely and restrict access to server administrators only.",
     "description": "AI Gateway setup guide > Passphrase warning security note"
+  },
+  "+6tmRn": {
+    "defaultMessage": "Name",
+    "description": "Field label for assessment name in a creation form"
   },
   "+8+eEg": {
     "defaultMessage": "Follow these steps to enable the AI Gateway feature for managing AI provider credentials.",
@@ -58,10 +58,6 @@
   "+Njd07": {
     "defaultMessage": "No sessions found",
     "description": "Title for the empty sessions list in the select sessions modal"
-  },
-  "+SBxBK": {
-    "defaultMessage": "Assessment Type",
-    "description": "Field label for assessment type in a creation form"
   },
   "+WPAn1": {
     "defaultMessage": "Enter model name...",
@@ -322,10 +318,6 @@
   "08WP3h": {
     "defaultMessage": "Staging",
     "description": "Column title for staging phase version in the registered model page"
-  },
-  "0AOcOr": {
-    "defaultMessage": "Feedback",
-    "description": "Feedback select menu option for assessment type"
   },
   "0Bee6A": {
     "defaultMessage": "No retrieval logged",
@@ -1789,10 +1781,6 @@
   "AawxF/": {
     "defaultMessage": "Edit Endpoint Name",
     "description": "Title for edit endpoint name modal"
-  },
-  "AdlJNW": {
-    "defaultMessage": "Assessment Name",
-    "description": "Field label for assessment name in a creation form"
   },
   "AeRhuI": {
     "defaultMessage": "Conversational guidelines",
@@ -6187,10 +6175,6 @@
     "defaultMessage": "<strong>{length}</strong> matching {length, plural, =0 {runs} =1 {run} other {runs}}",
     "description": "Message for displaying how many runs match search criteria on experiment page"
   },
-  "gN67TK": {
-    "defaultMessage": "Enter an assessment name",
-    "description": "Placeholder for the assessment name typeahead"
-  },
   "gOUJ0f": {
     "defaultMessage": "No assessment for this evaluation",
     "description": "Text displayed when there is no assessment for a given evaluation"
@@ -7439,6 +7423,10 @@
     "defaultMessage": "Select at least one session to enable actions",
     "description": "Tooltip for disabled actions button when no sessions are selected"
   },
+  "ojLGIx": {
+    "defaultMessage": "Enter a feedback name",
+    "description": "Placeholder for the feedback name typeahead"
+  },
   "okQ1oB": {
     "defaultMessage": "Please input a new name for the new experiment.",
     "description": "Error message for name requirement in create experiment for MLflow"
@@ -8087,10 +8075,6 @@
     "defaultMessage": "Model {modelName} does not exist",
     "description": "Sub-message text for error message on overall model page"
   },
-  "tEaqGu": {
-    "defaultMessage": "Expectation",
-    "description": "Expectation select menu option for assessment type"
-  },
   "tGqJL4": {
     "defaultMessage": "Output",
     "description": "Label for the output tokens in the tooltip for the tokens cell."
@@ -8398,6 +8382,10 @@
   "vxY1CI": {
     "defaultMessage": "Status",
     "description": "Run page > Overview > Run status section label"
+  },
+  "w+Josc": {
+    "defaultMessage": "Enter an expectation name",
+    "description": "Placeholder for the expectation name typeahead"
   },
   "w/sljb": {
     "defaultMessage": "Sort descending",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateButton.tsx
@@ -7,11 +7,13 @@ import { AssessmentCreateForm } from './AssessmentCreateForm';
 export const AssessmentCreateButton = ({
   title,
   assessmentName,
+  assessmentType,
   spanId,
   traceId,
 }: {
   title: React.ReactNode;
   assessmentName?: string;
+  assessmentType: 'feedback' | 'expectation';
   spanId?: string;
   traceId: string;
 }) => {
@@ -39,6 +41,7 @@ export const AssessmentCreateButton = ({
         <AssessmentCreateForm
           ref={ref}
           assessmentName={assessmentName}
+          assessmentType={assessmentType}
           spanId={spanId}
           traceId={traceId}
           setExpanded={setExpanded}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
@@ -46,6 +46,7 @@ describe('AssessmentCreateForm', () => {
   const mockSetExpanded = jest.fn();
   const defaultProps = {
     traceId: 'test-trace-id',
+    assessmentType: 'feedback' as const,
     setExpanded: mockSetExpanded,
   };
 
@@ -54,7 +55,7 @@ describe('AssessmentCreateForm', () => {
   });
 
   describe('handleChangeSchema - existing schemas', () => {
-    it('should update all fields when selecting an existing schema', async () => {
+    it('should update data type when selecting an existing schema', async () => {
       const user = userEvent.setup();
 
       // Mock existing assessments to populate schemas
@@ -65,29 +66,15 @@ describe('AssessmentCreateForm', () => {
 
       render(
         <TestWrapper assessments={existingAssessments}>
-          <AssessmentCreateForm {...defaultProps} />
+          <AssessmentCreateForm {...defaultProps} assessmentType="expectation" />
         </TestWrapper>,
       );
 
-      // Get the select buttons
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
       const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
-
-      expect(assessmentTypeSelect).toBeInTheDocument();
       expect(dataTypeSelect).toBeInTheDocument();
-
-      // Verify initial values
-      expect(assessmentTypeSelect).toHaveTextContent('Feedback');
       expect(dataTypeSelect).toHaveTextContent('Boolean');
 
-      // Change assessment type to expectation and data type to number
-      await user.click(assessmentTypeSelect);
-      const expectationOption = await screen.findByText('Expectation');
-      await user.click(expectationOption);
-      await waitFor(() => {
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
-      });
-
+      // Change data type to number
       await user.click(dataTypeSelect);
       await user.click(screen.getAllByText('Number')[0]);
       await waitFor(() => {
@@ -95,7 +82,7 @@ describe('AssessmentCreateForm', () => {
       });
 
       // Open the name typeahead
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter an expectation name');
       await user.click(nameInput);
 
       // Select an existing schema (expected_facts which is expectation/json)
@@ -104,17 +91,16 @@ describe('AssessmentCreateForm', () => {
       });
       await user.click(screen.getByText('expected_facts'));
 
-      // All fields should be updated to match the schema
+      // Data type should be updated to match the schema
       await waitFor(() => {
         expect(nameInput).toHaveValue('expected_facts');
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('JSON');
       });
     });
   });
 
   describe('handleChangeSchema - new assessment names', () => {
-    it('should preserve user-selected fields when typing a new assessment name', async () => {
+    it('should preserve user-selected data type when typing a new assessment name', async () => {
       const user = userEvent.setup();
 
       // Mock existing assessments to populate schemas
@@ -126,18 +112,9 @@ describe('AssessmentCreateForm', () => {
         </TestWrapper>,
       );
 
-      // Get the select buttons
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
       const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
-      // Change assessment type to expectation and data type to number
-      await user.click(assessmentTypeSelect);
-      const expectationOption = await screen.findByText('Expectation');
-      await user.click(expectationOption);
-      await waitFor(() => {
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
-      });
-
+      // Change data type to number
       await user.click(dataTypeSelect);
       await user.click(screen.getByText('Number'));
       await waitFor(() => {
@@ -145,7 +122,7 @@ describe('AssessmentCreateForm', () => {
       });
 
       // Type a new assessment name that doesn't exist in schemas
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter a feedback name');
       await user.type(nameInput, 'my_new_assessment');
 
       // Open the dropdown
@@ -159,15 +136,14 @@ describe('AssessmentCreateForm', () => {
       // Select the new name
       await user.click(screen.getByText('my_new_assessment'));
 
-      // Name should be updated, but assessment type and data type should be preserved
+      // Name should be updated, but data type should be preserved
       await waitFor(() => {
         expect(nameInput).toHaveValue('my_new_assessment');
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('Number');
       });
     });
 
-    it('should preserve user-selected fields when pressing Enter on a new name', async () => {
+    it('should preserve user-selected data type when pressing Enter on a new name', async () => {
       const user = userEvent.setup();
 
       const existingAssessments: Assessment[] = [MOCK_ASSESSMENT];
@@ -178,39 +154,31 @@ describe('AssessmentCreateForm', () => {
         </TestWrapper>,
       );
 
-      // Get the select buttons
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
       const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
-      // Change to non-default values
-      await user.click(assessmentTypeSelect);
-      const expectationOption = await screen.findByText('Expectation');
-      await user.click(expectationOption);
-
+      // Change to non-default value
       await user.click(dataTypeSelect);
       await user.click(screen.getAllByText('String')[0]);
 
       await waitFor(() => {
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('String');
       });
 
       // Type a new name and press Enter
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter a feedback name');
       await user.type(nameInput, 'another_new_name');
       await user.keyboard('{Enter}');
 
-      // Fields should be preserved
+      // Data type should be preserved
       await waitFor(() => {
         expect(nameInput).toHaveValue('another_new_name');
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('String');
       });
     });
   });
 
   describe('handleChangeSchema - clearing selection', () => {
-    it('should reset all fields when clearing the name', async () => {
+    it('should reset fields when clearing the name', async () => {
       const user = userEvent.setup();
 
       render(
@@ -219,25 +187,15 @@ describe('AssessmentCreateForm', () => {
         </TestWrapper>,
       );
 
-      // Get the select button
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
-
-      // Change some values
-      await user.click(assessmentTypeSelect);
-      const expectationOption = await screen.findByText('Expectation');
-      await user.click(expectationOption);
-
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter a feedback name');
       await user.type(nameInput, 'test_name');
 
       // Clear the input (simulating the clear button)
       await user.clear(nameInput);
 
-      // All fields should reset to defaults
+      // Fields should reset to defaults
       await waitFor(() => {
         expect(nameInput).toHaveValue('');
-        // Note: We can't easily test the internal state reset here
-        // as the selects may not visibly change until interaction
       });
     });
   });
@@ -252,31 +210,24 @@ describe('AssessmentCreateForm', () => {
         </TestWrapper>,
       );
 
-      // Get the select buttons
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
       const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
-      // Change to non-default values
-      await user.click(assessmentTypeSelect);
-      await user.click(screen.getByText('Expectation'));
-
+      // Change to non-default value
       await user.click(dataTypeSelect);
       await user.click(screen.getByText('Number'));
 
       await waitFor(() => {
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('Number');
       });
 
       // Type a name when there are no existing schemas
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter a feedback name');
       await user.type(nameInput, 'first_assessment');
       await user.keyboard('{Enter}');
 
-      // Fields should be preserved since this is a new name
+      // Data type should be preserved since this is a new name
       await waitFor(() => {
         expect(nameInput).toHaveValue('first_assessment');
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('Number');
       });
     });
@@ -292,20 +243,10 @@ describe('AssessmentCreateForm', () => {
         </TestWrapper>,
       );
 
-      // Get the select buttons
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
       const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
-      // Change values first
-      await user.click(assessmentTypeSelect);
-      await user.click(screen.getByText('Expectation'));
-
-      await waitFor(() => {
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
-      });
-
       // Type the exact name of an existing schema
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter a feedback name');
       await user.type(nameInput, 'Relevance');
       await user.click(nameInput);
 
@@ -315,10 +256,9 @@ describe('AssessmentCreateForm', () => {
       });
       await user.click(screen.getByTestId('assessment-name-typeahead-item-Relevance'));
 
-      // Since 'Relevance' is an existing schema (feedback/string), it should update all fields
+      // Since 'Relevance' is an existing schema (feedback/string), it should update data type
       await waitFor(() => {
         expect(nameInput).toHaveValue('Relevance');
-        expect(assessmentTypeSelect).toHaveTextContent('Feedback');
         expect(dataTypeSelect).toHaveTextContent('String');
       });
     });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
@@ -1,14 +1,7 @@
 import { isNil } from 'lodash';
 import { forwardRef, useCallback, useState } from 'react';
 
-import {
-  Button,
-  Input,
-  SimpleSelect,
-  SimpleSelectOption,
-  Typography,
-  useDesignSystemTheme,
-} from '@databricks/design-system';
+import { Button, Input, SimpleSelect, SimpleSelectOption, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { getUser } from '../../global-settings/getUser';
 
@@ -34,7 +27,7 @@ const ComponentMap: Record<AssessmentFormInputDataType, React.ComponentType<Asse
 
 type AssessmentCreateFormProps = {
   assessmentName?: string;
-  initialAssessmentType?: 'feedback' | 'expectation';
+  assessmentType: 'feedback' | 'expectation';
   spanId?: string;
   traceId: string;
   setExpanded: (expanded: boolean) => void;
@@ -45,7 +38,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
   (
     {
       assessmentName,
-      initialAssessmentType,
+      assessmentType,
       spanId,
       traceId,
       // used to close the form
@@ -58,9 +51,6 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
     const { schemas } = useAssessmentSchemas();
 
     const [name, setName] = useState('');
-    const [assessmentType, setAssessmentType] = useState<'feedback' | 'expectation'>(
-      initialAssessmentType ?? 'feedback',
-    );
     const [dataType, setDataType] = useState<AssessmentFormInputDataType>('boolean');
     const [value, setValue] = useState<string | boolean | number>(true);
     const [rationale, setRationale] = useState('');
@@ -143,7 +133,6 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
         // clear the form back to defaults
         if (!schema) {
           setName('');
-          setAssessmentType(initialAssessmentType ?? 'feedback');
           setDataType('boolean');
           setValue(true);
           setRationale('');
@@ -155,7 +144,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
         const isRealSchema = schemas.some((s) => s.name === schema.name);
 
         // Only update the name if it's a new assessment name (not in schemas)
-        // This preserves the user's selections for assessment type and data type
+        // This preserves the user's selections for data type
         if (!isRealSchema) {
           setName(schema.name);
           return;
@@ -163,7 +152,6 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
 
         // For existing schemas, update all fields
         setName(schema.name);
-        setAssessmentType(schema.assessmentType);
         setDataType(schema.dataType);
 
         // set the appropriate empty value for the data type
@@ -180,7 +168,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
             break;
         }
       },
-      [schemas, initialAssessmentType],
+      [schemas],
     );
 
     return (
@@ -197,37 +185,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
       >
         <Typography.Text size="sm" color="secondary">
           <FormattedMessage
-            defaultMessage="Assessment Type"
-            description="Field label for assessment type in a creation form"
-          />
-        </Typography.Text>
-        <SimpleSelect
-          id="shared.model-trace-explorer.assessment-type-select"
-          componentId="shared.model-trace-explorer.assessment-type-select"
-          label="Assessment Type"
-          value={assessmentType}
-          disabled={isLoading}
-          onChange={(e) => {
-            setAssessmentType(e.target.value as 'feedback' | 'expectation');
-            // JSON data is not available for feedback
-            if (e.target.value === 'feedback' && dataType === 'json') {
-              setDataType('string');
-            }
-          }}
-        >
-          <SimpleSelectOption value="feedback">
-            <FormattedMessage defaultMessage="Feedback" description="Feedback select menu option for assessment type" />
-          </SimpleSelectOption>
-          <SimpleSelectOption value="expectation">
-            <FormattedMessage
-              defaultMessage="Expectation"
-              description="Expectation select menu option for assessment type"
-            />
-          </SimpleSelectOption>
-        </SimpleSelect>
-        <Typography.Text css={{ marginTop: theme.spacing.xs }} size="sm" color="secondary">
-          <FormattedMessage
-            defaultMessage="Assessment Name"
+            defaultMessage="Name"
             description="Field label for assessment name in a creation form"
           />
         </Typography.Text>
@@ -240,6 +198,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
             handleChangeSchema={handleChangeSchema}
             nameError={nameError}
             setNameError={setNameError}
+            assessmentType={assessmentType}
           />
         )}
         <Typography.Text css={{ marginTop: theme.spacing.xs }} size="sm" color="secondary">

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateNameTypeahead.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateNameTypeahead.tsx
@@ -9,10 +9,21 @@ import {
   TypeaheadComboboxRoot,
   useComboboxState,
 } from '@databricks/design-system';
-import { useIntl } from '@databricks/i18n';
+import { defineMessages, useIntl } from '@databricks/i18n';
 
 import type { AssessmentSchema } from '../contexts/AssessmentSchemaContext';
 import { useAssessmentSchemas } from '../contexts/AssessmentSchemaContext';
+
+const placeholderMessages = defineMessages({
+  feedback: {
+    defaultMessage: 'Enter a feedback name',
+    description: 'Placeholder for the feedback name typeahead',
+  },
+  expectation: {
+    defaultMessage: 'Enter an expectation name',
+    description: 'Placeholder for the expectation name typeahead',
+  },
+});
 
 const getDefaultSchema = (name: string): AssessmentSchema => ({
   name,
@@ -26,12 +37,14 @@ export const AssessmentCreateNameTypeahead = ({
   nameError,
   setNameError,
   handleChangeSchema,
+  assessmentType,
 }: {
   name: string;
   setName: Dispatch<SetStateAction<string>>;
   nameError: React.ReactNode | null;
   setNameError: Dispatch<SetStateAction<React.ReactNode | null>>;
   handleChangeSchema: (schema: AssessmentSchema | null) => void;
+  assessmentType: 'feedback' | 'expectation';
 }) => {
   const { schemas } = useAssessmentSchemas();
   const intl = useIntl();
@@ -99,10 +112,7 @@ export const AssessmentCreateNameTypeahead = ({
     >
       <TypeaheadComboboxInput
         data-testid="assessment-name-typeahead-input"
-        placeholder={intl.formatMessage({
-          defaultMessage: 'Enter an assessment name',
-          description: 'Placeholder for the assessment name typeahead',
-        })}
+        placeholder={intl.formatMessage(placeholderMessages[assessmentType])}
         validationState={nameError ? 'error' : undefined}
         comboboxState={comboboxState}
         formOnChange={formOnChange}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentPaneToggle.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentPaneToggle.tsx
@@ -1,4 +1,4 @@
-import { useDesignSystemTheme, SidebarExpandIcon, Button, SidebarCollapseIcon } from '@databricks/design-system';
+import { Button, SidebarCollapseIcon } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
@@ -7,26 +7,23 @@ export const AssessmentPaneToggle = () => {
   const { assessmentsPaneExpanded, setAssessmentsPaneExpanded, assessmentsPaneEnabled } =
     useModelTraceExplorerViewState();
 
+  if (assessmentsPaneExpanded) {
+    return null;
+  }
+
   return (
     <Button
       disabled={!assessmentsPaneEnabled}
       type="primary"
       componentId="shared.model-trace-explorer.assessments-pane-toggle"
       size="small"
-      icon={assessmentsPaneExpanded ? <SidebarExpandIcon /> : <SidebarCollapseIcon />}
-      onClick={() => setAssessmentsPaneExpanded?.(!assessmentsPaneExpanded)}
+      icon={<SidebarCollapseIcon />}
+      onClick={() => setAssessmentsPaneExpanded?.(true)}
     >
-      {assessmentsPaneExpanded ? (
-        <FormattedMessage
-          defaultMessage="Hide assessments"
-          description="Label for the button to hide the assessments pane"
-        />
-      ) : (
-        <FormattedMessage
-          defaultMessage="Show assessments"
-          description="Label for the button to show the assessments pane"
-        />
-      )}
+      <FormattedMessage
+        defaultMessage="Show assessments"
+        description="Label for the button to show the assessments pane"
+      />
     </Button>
   );
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -71,11 +71,7 @@ export const AssessmentsPane = ({
       className={className}
     >
       <div css={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-        {assessmentsTitleOverride ? (
-          assessmentsTitleOverride()
-        ) : (
-          <FormattedMessage defaultMessage="Assessments" description="Label for the assessments pane" />
-        )}
+        {assessmentsTitleOverride ? assessmentsTitleOverride() : <span />}
         {setAssessmentsPaneExpanded && !disableCloseButton && (
           <Tooltip
             componentId="shared.model-trace-explorer.close-assessments-pane-tooltip"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneExpectationsSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneExpectationsSection.tsx
@@ -96,7 +96,7 @@ export const AssessmentsPaneExpectationsSection = ({
         <AssessmentCreateForm
           spanId={activeSpanId}
           traceId={traceId}
-          initialAssessmentType="expectation"
+          assessmentType="expectation"
           setExpanded={() => setCreateFormVisible(false)}
         />
       )}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -314,7 +314,7 @@ export const AssessmentsPaneFeedbackSection = ({
         <AssessmentCreateForm
           spanId={activeSpanId}
           traceId={traceId}
-          initialAssessmentType="feedback"
+          assessmentType="feedback"
           setExpanded={() => setCreateFormVisible(false)}
         />
       )}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackGroup.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackGroup.tsx
@@ -105,6 +105,7 @@ export const FeedbackGroup = ({
       {showCreateForm && (
         <AssessmentCreateForm
           assessmentName={name}
+          assessmentType="feedback"
           spanId={activeSpanId}
           traceId={traceId}
           setExpanded={setShowCreateForm}


### PR DESCRIPTION
### Related Issues/PRs

Resolve ML-62939
Resolve ML-62964

### What changes are proposed in this pull request?

Two minor assessment pane UX improvements:

1. **Remove redundant "Hide assessments" toggle** (ML-62939): The toggle button now returns `null` when the pane is expanded, since the close (x) button inside the pane already handles hiding. The "Show assessments" button still appears when the pane is collapsed.

2. **Remove assessment type dropdown and align terminology** (ML-62964): The "Assessment Type" dropdown in the creation form is removed — the type is now determined by which section (Feedback or Expectations) the form is opened from. Updated terminology:
   - "Assessment Name" → "Name"
   - Placeholder: "Enter a feedback name" / "Enter an expectation name" (context-aware)
   - Removed "Assessments" title from pane header (section headers already provide context)

**Before**:
<img width="440" height="404" alt="Screenshot 2026-03-03 at 13 55 45" src="https://github.com/user-attachments/assets/818b542d-e643-4a09-952f-8a8fe230e8d2" />


**After**:
<img width="480" height="418" alt="Screenshot 2026-03-03 at 13 55 32" src="https://github.com/user-attachments/assets/40661ab8-9dea-4652-b608-3ee7441e72a9" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Updated 6 existing tests in `AssessmentCreateForm.test.tsx` to reflect the removed dropdown and updated placeholders. All tests pass. Verified manually in the dev server.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Cleaned up the assessment pane UI: removed redundant "Hide assessments" toggle (close button suffices), removed the assessment type dropdown from the creation form (type is now inferred from context), and aligned terminology with the Feedback/Expectations split.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)