### PR TITLE
Fix Traces view in Prompts tab not being scrollable

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
@@ -275,7 +275,7 @@ const PromptsDetailsPage = ({ experimentId }: { experimentId?: string } = {}) =>
           />
         </div>
         {showPreviewPane && (
-          <div css={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <div css={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
             <div css={{ borderLeft: `1px solid ${theme.colors.border}`, flex: 1, overflow: 'hidden', display: 'flex' }}>
               {mode === PromptVersionsTableMode.PREVIEW && (
                 <PromptContentPreview

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptFilteredTracesView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptFilteredTracesView.tsx
@@ -56,6 +56,8 @@ const PromptFilteredTracesViewImpl = ({
         flexDirection: 'column',
         gap: theme.spacing.sm,
         height: '100%',
+        flex: 1,
+        minWidth: 0,
         overflowY: 'hidden',
       }}
     >


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Fixes the Traces view in the Prompts details page not being scrollable. The right pane flex container was using the default `minWidth: auto`, which prevented it from shrinking below the traces table's natural width (~1440px). This caused the content to overflow and be clipped by the parent's `overflow: hidden` instead of being properly scrollable.

**Changes:**
- Add `minWidth: 0` to the right pane container in `PromptsDetailsPage.tsx` to allow the flex item to shrink
- Add `flex: 1` and `minWidth: 0` to `PromptFilteredTracesView.tsx` to properly fill and constrain the available space

https://github.com/user-attachments/assets/4b551d4a-2f21-472e-a2c7-7e2846482437


### How is this PR tested?

- [x] Manual tests

Verified in the browser that the traces table is now properly constrained within the right pane and supports horizontal scrolling.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix Traces view in Prompts tab not being scrollable due to incorrect flex layout constraints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)