### PR TITLE
Set MODEL_PROVIDER across autologging integrations for cost breakdown

### DIFF
--- a/mlflow/ag2/ag2_logger.py
+++ b/mlflow/ag2/ag2_logger.py
@@ -15,7 +15,7 @@ from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatus, SpanStatusCode
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.fluent import start_span_no_context
-from mlflow.tracing.utils import capture_function_input_args
+from mlflow.tracing.utils import capture_function_input_args, extract_provider_from_model_string
 from mlflow.utils.autologging_utils import autologging_is_disabled
 from mlflow.utils.autologging_utils.safety import safe_patch
 
@@ -279,6 +279,9 @@ class MlflowAg2Logger(BaseLogger):
         )
         if model := request.get("model"):
             span.set_attribute(SpanAttributeKey.MODEL, model)
+            if isinstance(model, str):
+                if provider := extract_provider_from_model_string(model):
+                    span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
         if usage := self._parse_usage(response):
             span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage)
 

--- a/mlflow/ag2/ag2_logger.py
+++ b/mlflow/ag2/ag2_logger.py
@@ -15,7 +15,7 @@ from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatus, SpanStatusCode
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.fluent import start_span_no_context
-from mlflow.tracing.utils import capture_function_input_args, extract_provider_from_model_string
+from mlflow.tracing.utils import capture_function_input_args
 from mlflow.utils.autologging_utils import autologging_is_disabled
 from mlflow.utils.autologging_utils.safety import safe_patch
 
@@ -280,8 +280,9 @@ class MlflowAg2Logger(BaseLogger):
         if model := request.get("model"):
             span.set_attribute(SpanAttributeKey.MODEL, model)
             if isinstance(model, str):
-                if provider := extract_provider_from_model_string(model):
-                    span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
+                match model.split("/", 1):
+                    case [provider, _]:
+                        span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
         if usage := self._parse_usage(response):
             span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage)
 

--- a/mlflow/autogen/__init__.py
+++ b/mlflow/autogen/__init__.py
@@ -9,7 +9,7 @@ from mlflow.entities import SpanType
 from mlflow.telemetry.events import AutologgingEvent
 from mlflow.telemetry.track import _record_event
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
-from mlflow.tracing.utils import construct_full_inputs, extract_provider_from_model_string
+from mlflow.tracing.utils import construct_full_inputs
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     get_autologging_config,
@@ -71,8 +71,9 @@ def autolog(
                 if model := getattr(self, "model", None):
                     if isinstance(model, str):
                         span.set_attribute(SpanAttributeKey.MODEL, model)
-                        if provider := extract_provider_from_model_string(model):
-                            span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
+                        match model.split("/", 1):
+                            case [provider, _]:
+                                span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
 
                 if tools := inputs.get("tools"):
                     log_tools(span, tools)

--- a/mlflow/autogen/__init__.py
+++ b/mlflow/autogen/__init__.py
@@ -9,7 +9,7 @@ from mlflow.entities import SpanType
 from mlflow.telemetry.events import AutologgingEvent
 from mlflow.telemetry.track import _record_event
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
-from mlflow.tracing.utils import construct_full_inputs
+from mlflow.tracing.utils import construct_full_inputs, extract_provider_from_model_string
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     get_autologging_config,
@@ -71,6 +71,8 @@ def autolog(
                 if model := getattr(self, "model", None):
                     if isinstance(model, str):
                         span.set_attribute(SpanAttributeKey.MODEL, model)
+                        if provider := extract_provider_from_model_string(model):
+                            span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
 
                 if tools := inputs.get("tools"):
                     log_tools(span, tools)

--- a/mlflow/bedrock/_autolog.py
+++ b/mlflow/bedrock/_autolog.py
@@ -14,7 +14,7 @@ from mlflow.bedrock.utils import parse_complete_token_usage_from_response, skip_
 from mlflow.entities import LiveSpan, SpanType
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.fluent import start_span_no_context
-from mlflow.tracing.utils import set_span_chat_tools
+from mlflow.tracing.utils import extract_provider_from_model_string, set_span_chat_tools
 from mlflow.utils.autologging_utils import safe_patch
 
 _BEDROCK_RUNTIME_SERVICE_NAME = "bedrock-runtime"
@@ -196,6 +196,8 @@ def _patched_converse_stream(original, self, *args, **kwargs):
 
     if model_id := kwargs.get("modelId"):
         attributes[SpanAttributeKey.MODEL] = model_id
+        if provider := extract_provider_from_model_string(model_id, separator="."):
+            attributes[SpanAttributeKey.MODEL_PROVIDER] = provider
 
     span = start_span_no_context(
         name=f"{_BEDROCK_SPAN_PREFIX}{original.__name__}",
@@ -231,3 +233,5 @@ def _extract_and_set_model_name(span: LiveSpan, kwargs: dict[str, Any]):
     """Extract model name from kwargs and set it on the span."""
     if model_id := kwargs.get("modelId"):
         span.set_attribute(SpanAttributeKey.MODEL, model_id)
+        if provider := extract_provider_from_model_string(model_id, separator="."):
+            span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)

--- a/mlflow/bedrock/_autolog.py
+++ b/mlflow/bedrock/_autolog.py
@@ -14,7 +14,7 @@ from mlflow.bedrock.utils import parse_complete_token_usage_from_response, skip_
 from mlflow.entities import LiveSpan, SpanType
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.fluent import start_span_no_context
-from mlflow.tracing.utils import extract_provider_from_model_string, set_span_chat_tools
+from mlflow.tracing.utils import set_span_chat_tools
 from mlflow.utils.autologging_utils import safe_patch
 
 _BEDROCK_RUNTIME_SERVICE_NAME = "bedrock-runtime"
@@ -196,8 +196,9 @@ def _patched_converse_stream(original, self, *args, **kwargs):
 
     if model_id := kwargs.get("modelId"):
         attributes[SpanAttributeKey.MODEL] = model_id
-        if provider := extract_provider_from_model_string(model_id, separator="."):
-            attributes[SpanAttributeKey.MODEL_PROVIDER] = provider
+        match model_id.split(".", 1):
+            case [provider, _]:
+                attributes[SpanAttributeKey.MODEL_PROVIDER] = provider
 
     span = start_span_no_context(
         name=f"{_BEDROCK_SPAN_PREFIX}{original.__name__}",
@@ -233,5 +234,6 @@ def _extract_and_set_model_name(span: LiveSpan, kwargs: dict[str, Any]):
     """Extract model name from kwargs and set it on the span."""
     if model_id := kwargs.get("modelId"):
         span.set_attribute(SpanAttributeKey.MODEL, model_id)
-        if provider := extract_provider_from_model_string(model_id, separator="."):
-            span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
+        match model_id.split(".", 1):
+            case [provider, _]:
+                span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -11,7 +11,7 @@ import mlflow
 from mlflow.entities import SpanType
 from mlflow.entities.span import LiveSpan
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
-from mlflow.tracing.utils import TraceJSONEncoder
+from mlflow.tracing.utils import TraceJSONEncoder, extract_provider_from_model_string
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 
 _logger = logging.getLogger(__name__)
@@ -316,6 +316,9 @@ def _set_span_attributes(span: LiveSpan, instance):
             # Set model name explicitly using the MODEL attribute key
             if model := getattr(instance, "model", None):
                 span.set_attribute(SpanAttributeKey.MODEL, model)
+                if isinstance(model, str):
+                    if provider := extract_provider_from_model_string(model):
+                        span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
 
         elif isinstance(instance, Flow):
             for key, value in instance.__dict__.items():

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -11,7 +11,7 @@ import mlflow
 from mlflow.entities import SpanType
 from mlflow.entities.span import LiveSpan
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
-from mlflow.tracing.utils import TraceJSONEncoder, extract_provider_from_model_string
+from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 
 _logger = logging.getLogger(__name__)
@@ -317,8 +317,9 @@ def _set_span_attributes(span: LiveSpan, instance):
             if model := getattr(instance, "model", None):
                 span.set_attribute(SpanAttributeKey.MODEL, model)
                 if isinstance(model, str):
-                    if provider := extract_provider_from_model_string(model):
-                        span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
+                    match model.split("/", 1):
+                        case [provider, _]:
+                            span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
 
         elif isinstance(instance, Flow):
             for key, value in instance.__dict__.items():

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -22,7 +22,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
-from mlflow.tracing.utils import extract_provider_from_model_string, maybe_set_prediction_context
+from mlflow.tracing.utils import maybe_set_prediction_context
 from mlflow.tracing.utils.token import SpanWithToken
 from mlflow.utils import _get_fully_qualified_class_name
 from mlflow.utils.autologging_utils import (
@@ -167,8 +167,9 @@ class MlflowCallback(BaseCallback):
             SpanAttributeKey.MESSAGE_FORMAT: "dspy",
             SpanAttributeKey.MODEL: instance.model,
         }
-        if provider := extract_provider_from_model_string(instance.model):
-            attributes[SpanAttributeKey.MODEL_PROVIDER] = provider
+        match instance.model.split("/", 1):
+            case [provider, _]:
+                attributes[SpanAttributeKey.MODEL_PROVIDER] = provider
 
         inputs = self._unpack_kwargs(inputs)
 

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -22,7 +22,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
-from mlflow.tracing.utils import maybe_set_prediction_context
+from mlflow.tracing.utils import extract_provider_from_model_string, maybe_set_prediction_context
 from mlflow.tracing.utils.token import SpanWithToken
 from mlflow.utils import _get_fully_qualified_class_name
 from mlflow.utils.autologging_utils import (
@@ -167,6 +167,8 @@ class MlflowCallback(BaseCallback):
             SpanAttributeKey.MESSAGE_FORMAT: "dspy",
             SpanAttributeKey.MODEL: instance.model,
         }
+        if provider := extract_provider_from_model_string(instance.model):
+            attributes[SpanAttributeKey.MODEL_PROVIDER] = provider
 
         inputs = self._unpack_kwargs(inputs)
 

--- a/mlflow/gemini/autolog.py
+++ b/mlflow/gemini/autolog.py
@@ -119,6 +119,7 @@ class TracingSession:
             # Chat instances store model in _model attribute
             if model := (self.inputs.get("model") or getattr(self.instance, "_model", None)):
                 self.span.set_attribute(SpanAttributeKey.MODEL, model)
+                self.span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, "gemini")
         except Exception as e:
             _logger.debug(f"Failed to extract model for span {self.span.name}: {e}", exc_info=True)
 

--- a/mlflow/groq/_groq_autolog.py
+++ b/mlflow/groq/_groq_autolog.py
@@ -39,6 +39,7 @@ def patched_call(original, self, *args, **kwargs):
             # Extract model name from kwargs
             if model := kwargs.get("model"):
                 span.set_attribute(SpanAttributeKey.MODEL, model)
+                span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, "groq")
 
             if tools := kwargs.get("tools"):
                 try:

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -348,8 +348,13 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         self._extract_and_set_model_name(span, kwargs)
 
     def _extract_and_set_model_name(self, span: LiveSpan, kwargs: dict[str, Any]):
-        if model := kwargs.get("invocation_params", {}).get("model"):
+        invocation_params = kwargs.get("invocation_params", {})
+        if model := invocation_params.get("model"):
             span.set_attribute(SpanAttributeKey.MODEL, model)
+        if _type := invocation_params.get("_type"):
+            # LangChain's _type field follows the pattern "<provider>" or "<provider>-chat"
+            provider = _type.removesuffix("-chat")
+            span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
 
     def _extract_tool_definitions(self, kwargs: dict[str, Any]) -> list[ChatTool]:
         raw_tools = kwargs.get("invocation_params", {}).get("tools", [])

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -28,7 +28,6 @@ from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import (
-    extract_provider_from_model_string,
     maybe_set_prediction_context,
     set_span_chat_tools,
 )

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -28,6 +28,7 @@ from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import (
+    extract_provider_from_model_string,
     maybe_set_prediction_context,
     set_span_chat_tools,
 )

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -39,7 +39,7 @@ from mlflow.entities.span_status import SpanStatusCode
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
-from mlflow.tracing.utils import extract_provider_from_model_string, set_span_chat_tools
+from mlflow.tracing.utils import set_span_chat_tools
 
 _logger = logging.getLogger(__name__)
 
@@ -484,8 +484,9 @@ class MlflowEventHandler(BaseEventHandler, extra="allow"):
         if model_dict and (model := model_dict.get("model")):
             span.set_attribute(SpanAttributeKey.MODEL, model)
             if isinstance(model, str):
-                if provider := extract_provider_from_model_string(model):
-                    span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
+                match model.split("/", 1):
+                    case [provider, _]:
+                        span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
 
     def _extract_token_usage(self, response: ChatResponse | CompletionResponse) -> dict[str, int]:
         if raw := response.raw:

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -39,7 +39,7 @@ from mlflow.entities.span_status import SpanStatusCode
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
-from mlflow.tracing.utils import set_span_chat_tools
+from mlflow.tracing.utils import extract_provider_from_model_string, set_span_chat_tools
 
 _logger = logging.getLogger(__name__)
 
@@ -339,6 +339,9 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
             attr[SpanAttributeKey.MODEL] = metadata.model_name
             if params_str := metadata.model_dump_json(exclude_unset=True):
                 attr["invocation_params"] = json.loads(params_str)
+        # LlamaIndex LLM class names map directly to providers
+        # e.g., OpenAI, Anthropic, Gemini, Bedrock, etc.
+        attr[SpanAttributeKey.MODEL_PROVIDER] = instance.__class__.__name__.lower()
         return attr
 
     @_get_instance_attributes.register
@@ -346,6 +349,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         return {
             "model_name": instance.model_name,
             SpanAttributeKey.MODEL: instance.model_name,
+            SpanAttributeKey.MODEL_PROVIDER: instance.__class__.__name__.lower(),
             "embed_batch_size": instance.embed_batch_size,
         }
 
@@ -479,6 +483,9 @@ class MlflowEventHandler(BaseEventHandler, extra="allow"):
     def _extract_and_set_model_name(self, span: LiveSpan, model_dict: dict[str, Any] | None):
         if model_dict and (model := model_dict.get("model")):
             span.set_attribute(SpanAttributeKey.MODEL, model)
+            if isinstance(model, str):
+                if provider := extract_provider_from_model_string(model):
+                    span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
 
     def _extract_token_usage(self, response: ChatResponse | CompletionResponse) -> dict[str, int]:
         if raw := response.raw:

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -10,6 +10,7 @@ from mlflow.entities import SpanType
 from mlflow.entities.span import LiveSpan
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.provider import with_active_span
+from mlflow.tracing.utils import extract_provider_from_model_string
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 
 _logger = logging.getLogger(__name__)
@@ -102,6 +103,10 @@ def _set_span_attributes(span: LiveSpan, instance):
             span.set_attributes({k: v for k, v in model_attrs.items() if v is not None})
             if model_name := getattr(instance, "model_name", None):
                 span.set_attribute(SpanAttributeKey.MODEL, model_name)
+                # Pydantic AI model_name uses "provider:model" format
+                # e.g., "openai:gpt-4o", "anthropic:claude-3-5-haiku"
+                if provider := extract_provider_from_model_string(model_name, separator=":"):
+                    span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
     except Exception as e:
         _logger.warning("Failed saving InstrumentedModel attributes: %s", e)
 

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -10,7 +10,6 @@ from mlflow.entities import SpanType
 from mlflow.entities.span import LiveSpan
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.provider import with_active_span
-from mlflow.tracing.utils import extract_provider_from_model_string
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 
 _logger = logging.getLogger(__name__)
@@ -105,8 +104,9 @@ def _set_span_attributes(span: LiveSpan, instance):
                 span.set_attribute(SpanAttributeKey.MODEL, model_name)
                 # Pydantic AI model_name uses "provider:model" format
                 # e.g., "openai:gpt-4o", "anthropic:claude-3-5-haiku"
-                if provider := extract_provider_from_model_string(model_name, separator=":"):
-                    span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
+                match model_name.split(":", 1):
+                    case [provider, _]:
+                        span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
     except Exception as e:
         _logger.warning("Failed saving InstrumentedModel attributes: %s", e)
 

--- a/mlflow/semantic_kernel/tracing_utils.py
+++ b/mlflow/semantic_kernel/tracing_utils.py
@@ -159,6 +159,8 @@ def set_token_usage(mlflow_span: LiveSpan) -> None:
 
 
 def set_model(mlflow_span: LiveSpan) -> None:
-    """Set model name attribute on the MLflow span."""
+    """Set model name and provider attributes on the MLflow span."""
     if model := mlflow_span.get_attribute(model_gen_ai_attributes.MODEL):
         mlflow_span.set_attribute(SpanAttributeKey.MODEL, model)
+    if provider := mlflow_span.get_attribute(model_gen_ai_attributes.SYSTEM):
+        mlflow_span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)

--- a/mlflow/strands/autolog.py
+++ b/mlflow/strands/autolog.py
@@ -76,6 +76,8 @@ class StrandsSpanProcessor(SimpleSpanProcessor):
                 _set_inputs_outputs(mlflow_span, span)
                 if model := span.attributes.get("gen_ai.request.model"):
                     mlflow_span.set_attribute(SpanAttributeKey.MODEL, model)
+                if provider := span.attributes.get("gen_ai.system"):
+                    mlflow_span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
                 _set_token_usage(mlflow_span, span)
             tracer = _get_tracer(__name__)
             tracer.span_processor.on_end(span)

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -803,26 +803,6 @@ def set_span_model_attribute(span: LiveSpan, inputs: dict[str, Any]) -> None:
         _logger.debug(f"Failed to set model for {span}. Error: {e}")
 
 
-def extract_provider_from_model_string(model: str, separator: str = "/") -> str | None:
-    """Extract the LLM provider name from a model string.
-
-    Many frameworks encode the provider in the model name using a separator:
-      - litellm format: "openai/gpt-4" (separator="/")
-      - Bedrock format: "anthropic.claude-3-haiku" (separator=".")
-      - LangChain _type: "openai-chat" (separator="-chat" suffix)
-
-    Args:
-        model: The model string that may contain a provider prefix.
-        separator: The separator between provider and model name.
-
-    Returns:
-        The provider name, or None if no separator is found.
-    """
-    if separator in model:
-        return model.split(separator)[0]
-    return None
-
-
 def should_compute_cost_client_side() -> bool:
     """Whether LLM cost should be computed on the client side.
 

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -803,6 +803,26 @@ def set_span_model_attribute(span: LiveSpan, inputs: dict[str, Any]) -> None:
         _logger.debug(f"Failed to set model for {span}. Error: {e}")
 
 
+def extract_provider_from_model_string(model: str, separator: str = "/") -> str | None:
+    """Extract the LLM provider name from a model string.
+
+    Many frameworks encode the provider in the model name using a separator:
+      - litellm format: "openai/gpt-4" (separator="/")
+      - Bedrock format: "anthropic.claude-3-haiku" (separator=".")
+      - LangChain _type: "openai-chat" (separator="-chat" suffix)
+
+    Args:
+        model: The model string that may contain a provider prefix.
+        separator: The separator between provider and model name.
+
+    Returns:
+        The provider name, or None if no separator is found.
+    """
+    if separator in model:
+        return model.split(separator)[0]
+    return None
+
+
 def should_compute_cost_client_side() -> bool:
     """Whether LLM cost should be computed on the client side.
 

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -706,6 +706,57 @@ async def test_tracer_with_manual_traces_async():
     assert spans[2].parent_id == spans[1].span_id
 
 
+@pytest.mark.parametrize(
+    ("_type", "expected_provider"),
+    [
+        ("openai-chat", "openai"),
+        ("anthropic-chat", "anthropic"),
+        ("bedrock-chat", "bedrock"),
+        ("openai", "openai"),
+    ],
+)
+def test_chat_model_extracts_model_provider(_type, expected_provider):
+    callback = MlflowLangchainTracer()
+    run_id = str(uuid.uuid4())
+    callback.on_chat_model_start(
+        {},
+        [[HumanMessage("test")]],
+        run_id=run_id,
+        name="test_chat_model",
+        invocation_params={"model": "gpt-4", "_type": _type},
+    )
+    callback.on_llm_end(
+        LLMResult(generations=[[{"text": "response"}]]),
+        run_id=run_id,
+    )
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    span = trace.data.spans[0]
+    assert span.get_attribute(SpanAttributeKey.MODEL) == "gpt-4"
+    assert span.get_attribute(SpanAttributeKey.MODEL_PROVIDER) == expected_provider
+
+
+def test_chat_model_no_provider_when_type_missing():
+    callback = MlflowLangchainTracer()
+    run_id = str(uuid.uuid4())
+    callback.on_chat_model_start(
+        {},
+        [[HumanMessage("test")]],
+        run_id=run_id,
+        name="test_chat_model",
+        invocation_params={"model": "gpt-4"},
+    )
+    callback.on_llm_end(
+        LLMResult(generations=[[{"text": "response"}]]),
+        run_id=run_id,
+    )
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    span = trace.data.spans[0]
+    assert span.get_attribute(SpanAttributeKey.MODEL) == "gpt-4"
+    assert span.get_attribute(SpanAttributeKey.MODEL_PROVIDER) is None
+
+
 @pytest.mark.parametrize("run_tracer_inline", [True, False])
 def test_tracer_run_inline_parameter(run_tracer_inline):
     tracer = MlflowLangchainTracer(run_inline=run_tracer_inline)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #ML-62941

### What changes are proposed in this pull request?

The cost breakdown chart in the Overview tab supports grouping by model provider, but the provider view shows "no cost logged" for most autologging integrations because `SpanAttributeKey.MODEL_PROVIDER` is never set on spans.

This PR fixes the issue by extracting and setting the LLM provider in all autologging integrations where it can be reliably determined:

- **LangChain**: Extract provider from `invocation_params["_type"]` (e.g., `"openai-chat"` → `"openai"`)
- **Gemini/Groq**: Hardcode the provider since they are direct LLM providers
- **Bedrock**: Parse from `modelId` format `"anthropic.claude-3-haiku"` using `"."` separator
- **DSPy/CrewAI**: Parse from litellm format `"openai/gpt-4"` using `"/"` separator
- **Strands/Semantic Kernel**: Read from OTel `gen_ai.system` attribute

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New parametrized tests added for LangChain provider extraction. Manually verified with a LangGraph agent that the provider is correctly set on spans.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Set `MODEL_PROVIDER` span attribute across autologging integrations (LangChain, Gemini, Groq, Bedrock, DSPy, CrewAI, Strands, Semantic Kernel) to populate the cost breakdown by provider view in the Overview tab.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)