### PR TITLE
Default usage_tracking to True for new gateway endpoints

### DIFF
--- a/mlflow/entities/gateway_endpoint.py
+++ b/mlflow/entities/gateway_endpoint.py
@@ -359,7 +359,7 @@ class GatewayEndpoint(_MlflowObject):
     routing_strategy: RoutingStrategy | None = None
     fallback_config: FallbackConfig | None = None
     experiment_id: str | None = None
-    usage_tracking: bool = False
+    usage_tracking: bool = True
     workspace: str | None = None
 
     def __post_init__(self):
@@ -404,7 +404,7 @@ class GatewayEndpoint(_MlflowObject):
         if proto.HasField("experiment_id"):
             experiment_id = proto.experiment_id or None
 
-        usage_tracking = proto.usage_tracking if proto.HasField("usage_tracking") else False
+        usage_tracking = proto.usage_tracking if proto.HasField("usage_tracking") else True
 
         return cls(
             endpoint_id=proto.endpoint_id,

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4682,7 +4682,7 @@ def _create_gateway_endpoint():
         request_message.experiment_id if request_message.HasField("experiment_id") else None
     )
     usage_tracking = (
-        request_message.usage_tracking if request_message.HasField("usage_tracking") else False
+        request_message.usage_tracking if request_message.HasField("usage_tracking") else True
     )
 
     endpoint = _get_tracking_store().create_gateway_endpoint(

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2400,7 +2400,7 @@ class SqlGatewayEndpoint(Base):
     ID of the MLflow experiment where traces for this endpoint are logged.
     Uses SET NULL on delete - if the experiment is deleted, this becomes NULL.
     """
-    usage_tracking = Column(Boolean, nullable=False, default=False)
+    usage_tracking = Column(Boolean, nullable=False, default=True)
     """
     Usage tracking: `Boolean`. Whether usage tracking is enabled for this endpoint.
     When true, traces will be logged for endpoint invocations.

--- a/mlflow/store/tracking/gateway/abstract_mixin.py
+++ b/mlflow/store/tracking/gateway/abstract_mixin.py
@@ -227,7 +227,7 @@ class GatewayStoreMixin:
         routing_strategy: RoutingStrategy | None = None,
         fallback_config: FallbackConfig | None = None,
         experiment_id: str | None = None,
-        usage_tracking: bool = False,
+        usage_tracking: bool = True,
     ) -> GatewayEndpoint:
         """
         Create a new endpoint with references to existing model definitions.

--- a/mlflow/store/tracking/gateway/rest_mixin.py
+++ b/mlflow/store/tracking/gateway/rest_mixin.py
@@ -226,7 +226,7 @@ class RestGatewayStoreMixin:
         routing_strategy: RoutingStrategy | None = None,
         fallback_config: FallbackConfig | None = None,
         experiment_id: str | None = None,
-        usage_tracking: bool = False,
+        usage_tracking: bool = True,
     ) -> GatewayEndpoint:
         """
         Create a new endpoint with associated model definitions.

--- a/mlflow/store/tracking/gateway/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/gateway/sqlalchemy_mixin.py
@@ -572,7 +572,7 @@ class SqlAlchemyGatewayStoreMixin:
         routing_strategy: RoutingStrategy | None = None,
         fallback_config: FallbackConfig | None = None,
         experiment_id: str | None = None,
-        usage_tracking: bool = False,
+        usage_tracking: bool = True,
     ) -> GatewayEndpoint:
         """
         Create a new endpoint with references to existing model definitions.

--- a/tests/store/tracking/test_gateway_sql_store.py
+++ b/tests/store/tracking/test_gateway_sql_store.py
@@ -578,6 +578,31 @@ def test_create_gateway_endpoint_auto_creates_experiment(store: SqlAlchemyStore)
     assert experiment.tags.get("mlflow.experiment.isGateway") == "true"
 
 
+def test_create_gateway_endpoint_usage_tracking_defaults_to_true(store: SqlAlchemyStore):
+    secret = store.create_gateway_secret(
+        secret_name="default-ut-key", secret_value={"api_key": "value"}
+    )
+    model_def = store.create_gateway_model_definition(
+        name="default-ut-model", secret_id=secret.secret_id, provider="openai", model_name="gpt-4"
+    )
+
+    # Create endpoint without specifying usage_tracking
+    endpoint = store.create_gateway_endpoint(
+        name="default-ut-endpoint",
+        model_configs=[
+            GatewayEndpointModelConfig(
+                model_definition_id=model_def.model_definition_id,
+                linkage_type=GatewayModelLinkageType.PRIMARY,
+                weight=1.0,
+            ),
+        ],
+    )
+
+    assert endpoint.usage_tracking is True
+    # An experiment should be auto-created since usage_tracking defaults to True
+    assert endpoint.experiment_id is not None
+
+
 def test_create_gateway_endpoint_empty_models_raises(store: SqlAlchemyStore):
     with pytest.raises(MlflowException, match="at least one") as exc:
         store.create_gateway_endpoint(name="empty-endpoint", model_configs=[])


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Changes the default value of `usage_tracking` from `False` to `True` when creating new gateway endpoints without explicitly specifying it. This ensures usage tracking is enabled by default for new endpoints.

**Changed files:**
- `mlflow/server/handlers.py` — `create_gateway_endpoint` handler default
- `mlflow/entities/gateway_endpoint.py` — entity dataclass default and `from_proto` fallback
- `mlflow/store/tracking/gateway/abstract_mixin.py` — abstract store method default
- `mlflow/store/tracking/gateway/sqlalchemy_mixin.py` — SQLAlchemy store method default
- `mlflow/store/tracking/gateway/rest_mixin.py` — REST store method default
- `mlflow/store/tracking/dbmodels/models.py` — DB model column default

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_create_gateway_endpoint_usage_tracking_defaults_to_true` to verify the new default behavior.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
