### PR TITLE
Fix UI flickering in trace review modal during background refetches

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
@@ -240,7 +240,6 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
               {/* prettier-ignore */}
               <ModelTraceExplorerModalBody
                 traceData={currentTraceQueryResult.data}
-                showLoadingState={shouldUseModelTraceExplorerDrawerUI() && (currentTraceQueryResult.isLoading)}
               />
             </div>
           ) : (
@@ -307,7 +306,6 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
         selectNextEval={selectNextEval}
         selectPreviousEval={selectPreviousEval}
         renderModalTitle={renderModalTitle}
-        isLoading={currentTraceQueryResult.isLoading}
       >
         {content}
         {renderExportTracesToDatasetsModal?.({
@@ -329,7 +327,6 @@ const ModalWrapper = ({
   renderModalTitle,
   handleClose,
   children,
-  isLoading,
 }: {
   children: React.ReactNode;
   selectPreviousEval: () => void;
@@ -338,7 +335,6 @@ const ModalWrapper = ({
   isNextAvailable: boolean;
   renderModalTitle: () => React.ReactNode;
   handleClose: () => void;
-  isLoading?: boolean;
 }) => {
   const { theme, classNamePrefix } = useDesignSystemTheme();
   const useRadixModal = false;
@@ -442,10 +438,8 @@ const ModalWrapper = ({
 // prettier-ignore
 const ModelTraceExplorerModalBody = ({
   traceData,
-  showLoadingState,
 }: {
   traceData: ModelTrace;
-  showLoadingState: boolean;
 }) => {
   return (
     <ModelTraceExplorer

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
@@ -218,7 +218,7 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
         {/* Only show skeleton for the first fetch to avoid flickering when polling new spans */}
         {!shouldUseModelTraceExplorerDrawerUI() &&
           !currentTraceQueryResult.data &&
-          currentTraceQueryResult.isFetching && (
+          currentTraceQueryResult.isLoading && (
             <GenericSkeleton
               label="Loading trace..."
               style={{
@@ -240,12 +240,12 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
               {/* prettier-ignore */}
               <ModelTraceExplorerModalBody
                 traceData={currentTraceQueryResult.data}
-                showLoadingState={shouldUseModelTraceExplorerDrawerUI() && (currentTraceQueryResult.isFetching)}
+                showLoadingState={shouldUseModelTraceExplorerDrawerUI() && (currentTraceQueryResult.isLoading)}
               />
             </div>
           ) : (
             evaluation?.currentRunValue &&
-            (shouldUseModelTraceExplorerDrawerUI() && currentTraceQueryResult.isFetching ? (
+            (shouldUseModelTraceExplorerDrawerUI() && currentTraceQueryResult.isLoading ? (
               <div css={{ marginLeft: -theme.spacing.lg, marginRight: -theme.spacing.lg }}>
                 <ModelTraceExplorerSkeleton />
               </div>
@@ -289,7 +289,7 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
           selectNextEval={selectNextEval}
           selectPreviousEval={selectPreviousEval}
           renderModalTitle={renderModalTitle}
-          isLoading={currentTraceQueryResult.isFetching}
+          isLoading={currentTraceQueryResult.isLoading}
           experimentId={experimentId}
           traceInfo={currentTraceInfo}
         >
@@ -307,7 +307,7 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
         selectNextEval={selectNextEval}
         selectPreviousEval={selectPreviousEval}
         renderModalTitle={renderModalTitle}
-        isLoading={currentTraceQueryResult.isFetching}
+        isLoading={currentTraceQueryResult.isLoading}
       >
         {content}
         {renderExportTracesToDatasetsModal?.({


### PR DESCRIPTION
### Related Issues/PRs

Relates to trace review modal UX improvements

### What changes are proposed in this pull request?

Replace `currentTraceQueryResult.isFetching` with `currentTraceQueryResult.isLoading` in `GenAiEvaluationTracesReviewModal` to prevent UI flickering during background refetches.

In React Query, `isFetching` is `true` whenever any request is in flight (including background refetches/polling), while `isLoading` is only `true` when there is no cached data yet (the initial load). Using `isFetching` caused skeleton/loading states to flash during background refetches, resulting in a poor user experience. This change ensures skeletons only appear on the initial load.

All 5 occurrences in the file were updated:
- GenericSkeleton overlay (line 221)
- `showLoadingState` prop for `ModelTraceExplorerModalBody` (line 243)
- `ModelTraceExplorerSkeleton` rendering (line 248)
- `isLoading` prop passed to `ModelTraceExplorerDrawer` (line 292)
- `isLoading` prop passed to `ModalWrapper` (line 310)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified that the trace review modal no longer flickers when traces are being polled/refetched in the background.

Before:


https://github.com/user-attachments/assets/8891f10f-ce74-4f61-8d8f-462650cd1535



After:

https://github.com/user-attachments/assets/09e48f91-7d63-440a-8254-d6e29b232081




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix UI flickering in the trace review modal that occurred during background refetches by using `isLoading` instead of `isFetching` for skeleton state checks.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)