### PR TITLE
Fix broken image rendering in trace chat collapsed preview

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -14,7 +14,11 @@ import { FormattedMessage } from '@databricks/i18n';
 import { GenAIMarkdownRenderer } from '../../genai-markdown-renderer/GenAIMarkdownRenderer';
 
 import { ModelTraceExplorerChatMessageHeader } from './ModelTraceExplorerChatMessageHeader';
-import { CONTENT_TRUNCATION_LIMIT } from './ModelTraceExplorerChatRenderer.utils';
+import {
+  CONTENT_TRUNCATION_LIMIT,
+  getDisplayLength,
+  truncatePreservingImages,
+} from './ModelTraceExplorerChatRenderer.utils';
 import { ModelTraceExplorerToolCallMessage } from './ModelTraceExplorerToolCallMessage';
 import { CodeSnippetRenderMode, type ModelTraceChatMessage } from '../ModelTrace.types';
 import { ModelTraceExplorerCodeSnippetBody } from '../ModelTraceExplorerCodeSnippetBody';
@@ -152,9 +156,10 @@ export function ModelTraceExplorerChatMessage({
   const shouldDisplayCodeSnippet = isJson && (message.role === 'tool' || message.role === 'function');
   // if the content is JSON, truncation will be handled by the code
   // snippet. otherwise, we need to truncate the content manually.
-  const isExpandable = !shouldDisplayCodeSnippet && content.length > CONTENT_TRUNCATION_LIMIT;
+  const isExpandable = !shouldDisplayCodeSnippet && getDisplayLength(content) > CONTENT_TRUNCATION_LIMIT;
 
-  const displayedContent = isExpandable && !expanded ? `${content.slice(0, CONTENT_TRUNCATION_LIMIT)}...` : content;
+  const displayedContent =
+    isExpandable && !expanded ? truncatePreservingImages(content, CONTENT_TRUNCATION_LIMIT) : content;
 
   return (
     <div

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatRenderer.utils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatRenderer.utils.test.ts
@@ -3,6 +3,7 @@ import {
   getDisplayLength,
   truncatePreservingImages,
 } from './ModelTraceExplorerChatRenderer.utils';
+import { describe, it, expect } from '@jest/globals';
 
 describe('getDisplayLength', () => {
   it('returns the length of plain text', () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatRenderer.utils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatRenderer.utils.test.ts
@@ -1,0 +1,88 @@
+import {
+  CONTENT_TRUNCATION_LIMIT,
+  getDisplayLength,
+  truncatePreservingImages,
+} from './ModelTraceExplorerChatRenderer.utils';
+
+describe('getDisplayLength', () => {
+  it('returns the length of plain text', () => {
+    expect(getDisplayLength('hello world')).toBe(11);
+  });
+
+  it('excludes markdown images from the length', () => {
+    const content = 'hello ![](http://example.com/img.png) world';
+    expect(getDisplayLength(content)).toBe('hello  world'.length);
+  });
+
+  it('excludes data URI images from the length', () => {
+    const dataUri = 'data:image/png;base64,' + 'A'.repeat(1000);
+    const content = `hello ![](${dataUri}) world`;
+    expect(getDisplayLength(content)).toBe('hello  world'.length);
+  });
+
+  it('handles multiple images', () => {
+    const content = 'text ![](url1) middle ![](url2) end';
+    expect(getDisplayLength(content)).toBe('text  middle  end'.length);
+  });
+
+  it('handles content with no images', () => {
+    const content = 'a'.repeat(500);
+    expect(getDisplayLength(content)).toBe(500);
+  });
+});
+
+describe('truncatePreservingImages', () => {
+  it('does not truncate content shorter than the limit', () => {
+    const content = 'short text';
+    expect(truncatePreservingImages(content, CONTENT_TRUNCATION_LIMIT)).toBe('short text');
+  });
+
+  it('truncates plain text at the limit', () => {
+    const content = 'a'.repeat(500);
+    const result = truncatePreservingImages(content, CONTENT_TRUNCATION_LIMIT);
+    expect(result).toBe('a'.repeat(300) + '...');
+  });
+
+  it('preserves a data URI image when text content is short', () => {
+    const dataUri = 'data:image/png;base64,' + 'A'.repeat(1000);
+    const content = `Here is my image:\n\n![](${dataUri})`;
+    const result = truncatePreservingImages(content, CONTENT_TRUNCATION_LIMIT);
+    // Text portion is short, so the image should be fully preserved
+    expect(result).toBe(content);
+    expect(result).toContain(dataUri);
+  });
+
+  it('preserves images and truncates surrounding long text', () => {
+    const dataUri = 'data:image/png;base64,' + 'A'.repeat(500);
+    const longText = 'b'.repeat(400);
+    const content = `![](${dataUri})\n\n${longText}`;
+    const result = truncatePreservingImages(content, CONTENT_TRUNCATION_LIMIT);
+    // Image should be preserved, text truncated at limit
+    expect(result).toContain(dataUri);
+    expect(result.endsWith('...')).toBe(true);
+  });
+
+  it('truncates text before an image if text alone exceeds the limit', () => {
+    const longText = 'c'.repeat(400);
+    const content = `${longText} ![](http://example.com/img.png)`;
+    const result = truncatePreservingImages(content, CONTENT_TRUNCATION_LIMIT);
+    expect(result).toBe('c'.repeat(300) + '...');
+    expect(result).not.toContain('![](');
+  });
+
+  it('handles multiple images interspersed with text', () => {
+    const img1 = '![](data:image/png;base64,AAA)';
+    const img2 = '![](data:image/png;base64,BBB)';
+    const content = `hello ${img1} world ${img2} end`;
+    const result = truncatePreservingImages(content, CONTENT_TRUNCATION_LIMIT);
+    // Total text is short, so everything should be preserved
+    expect(result).toBe(content);
+  });
+
+  it('handles content that is only an image', () => {
+    const dataUri = 'data:image/png;base64,' + 'A'.repeat(2000);
+    const content = `![](${dataUri})`;
+    const result = truncatePreservingImages(content, CONTENT_TRUNCATION_LIMIT);
+    expect(result).toBe(content);
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatRenderer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatRenderer.utils.tsx
@@ -5,7 +5,19 @@ const MARKDOWN_IMAGE_REGEX = /!\[[^\]]*\]\([^)]+\)/g;
 
 // Returns content length excluding markdown image blocks.
 export const getDisplayLength = (content: string): number => {
-  return content.replace(MARKDOWN_IMAGE_REGEX, '').length;
+  let displayLength = 0;
+  let lastIndex = 0;
+
+  const regex = new RegExp(MARKDOWN_IMAGE_REGEX.source, 'g');
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(content)) !== null) {
+    displayLength += match.index - lastIndex;
+    lastIndex = match.index + match[0].length;
+  }
+
+  displayLength += content.length - lastIndex;
+  return displayLength;
 };
 
 // Truncates content without breaking markdown image syntax.
@@ -15,7 +27,7 @@ export const truncatePreservingImages = (content: string, limit: number): string
   let lastIndex = 0;
 
   const regex = new RegExp(MARKDOWN_IMAGE_REGEX.source, 'g');
-  let match;
+  let match: RegExpExecArray | null;
 
   while ((match = regex.exec(content)) !== null) {
     const textBefore = content.slice(lastIndex, match.index);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatRenderer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatRenderer.utils.tsx
@@ -1,1 +1,43 @@
 export const CONTENT_TRUNCATION_LIMIT = 300;
+
+// Matches markdown image syntax: ![alt text](url)
+const MARKDOWN_IMAGE_REGEX = /!\[[^\]]*\]\([^)]+\)/g;
+
+// Returns content length excluding markdown image blocks.
+export const getDisplayLength = (content: string): number => {
+  return content.replace(MARKDOWN_IMAGE_REGEX, '').length;
+};
+
+// Truncates content without breaking markdown image syntax.
+export const truncatePreservingImages = (content: string, limit: number): string => {
+  let result = '';
+  let displayLength = 0;
+  let lastIndex = 0;
+
+  const regex = new RegExp(MARKDOWN_IMAGE_REGEX.source, 'g');
+  let match;
+
+  while ((match = regex.exec(content)) !== null) {
+    const textBefore = content.slice(lastIndex, match.index);
+    const remainingLimit = limit - displayLength;
+
+    if (textBefore.length > remainingLimit) {
+      result += textBefore.slice(0, remainingLimit) + '...';
+      return result;
+    }
+
+    result += textBefore + match[0];
+    displayLength += textBefore.length;
+    lastIndex = match.index + match[0].length;
+  }
+
+  const remaining = content.slice(lastIndex);
+  const remainingLimit = limit - displayLength;
+  if (remaining.length > remainingLimit) {
+    result += remaining.slice(0, remainingLimit) + '...';
+  } else {
+    result += remaining;
+  }
+
+  return result;
+};


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

When a chat message contains an `image_url` content part with a data URI, the collapsed preview truncates the base64 string at 300 characters (`CONTENT_TRUNCATION_LIMIT`), breaking the markdown image syntax `![](data:...)`. The user sees raw broken markdown and base64 text instead of a rendered image.

This PR makes the truncation logic image-aware:
- `getDisplayLength()` calculates content length excluding markdown image blocks (since images render compactly)
- `truncatePreservingImages()` truncates only text portions while preserving complete `![](...)` blocks intact

Before (skip to 9~10 seconds)

https://github.com/user-attachments/assets/0f74edde-cb6a-4687-8af7-73b41dd9eca6

After (skip to 9~10 seconds)

https://github.com/user-attachments/assets/d6ae69c2-ac89-4151-9177-928e4abf1431

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed an issue where inline images (data URI) in trace chat messages appeared as broken markdown and raw base64 text in the collapsed preview. Images now render correctly without needing to expand the message.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)