### PR TITLE
Fix long error messages overflowing in assessment error alerts

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackErrorItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackErrorItem.tsx
@@ -18,7 +18,7 @@ export const FeedbackErrorItem = ({ error }: { error: AssessmentError }) => {
         message={error.error_code}
         componentId="shared.model-trace-explorer.feedback-error-item"
         description={
-          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, overflowWrap: 'anywhere' }}>
             <span>{error.error_message}</span>
             {error.stack_trace && (
               <Typography.Link


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add `overflow-wrap: anywhere` to the error description container in `FeedbackErrorItem` so that long unbroken strings (e.g. URLs, encoded values) wrap correctly within the flex-layout `Alert` instead of overflowing.

`overflow-wrap: anywhere` is used instead of `break-word` because in a flex context, `break-word` doesn't reduce the element's min-content intrinsic size — so the flex item never shrinks enough for the break to take effect.

### How is this PR tested?

- [x] Manual tests

Verified in the browser that long error messages now wrap correctly within the alert container.

Before:

<img width="1496" height="928" alt="Screenshot 2026-03-03 at 1 49 30 PM" src="https://github.com/user-attachments/assets/4ff36dca-a8e4-4516-87a6-a5226b3458f7" />

After

<img width="1496" height="932" alt="Screenshot 2026-03-03 at 1 48 24 PM" src="https://github.com/user-attachments/assets/7b4208c7-f123-4e3f-94cc-75a8fcf676ac" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)