### PR TITLE
Add cached tokens display to Token Usage chart

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
@@ -31,6 +31,13 @@ const createCachedTokensDataPoint = (timeBucket: string, sum: number) => ({
   values: { [AggregationType.SUM]: sum },
 });
 
+// Helper to create a cache creation tokens data point
+const createCacheCreationTokensDataPoint = (timeBucket: string, sum: number) => ({
+  metric_name: TraceMetricKey.CACHE_CREATION_INPUT_TOKENS,
+  dimensions: { time_bucket: timeBucket },
+  values: { [AggregationType.SUM]: sum },
+});
+
 // Helper to create a total tokens data point (no time bucket)
 const createTotalTokensDataPoint = (sum: number) => ({
   metric_name: TraceMetricKey.TOTAL_TOKENS,
@@ -92,6 +99,7 @@ describe('TraceTokenUsageChart', () => {
     outputDataPoints: any[],
     totalDataPoints: any[],
     cachedDataPoints: any[] = [],
+    cacheCreationDataPoints: any[] = [],
   ) => {
     server.use(
       rest.post(getAjaxUrl('ajax-api/3.0/mlflow/traces/metrics'), async (req, res, ctx) => {
@@ -105,6 +113,8 @@ describe('TraceTokenUsageChart', () => {
           return res(ctx.json({ data_points: totalDataPoints }));
         } else if (metricName === TraceMetricKey.CACHE_READ_INPUT_TOKENS) {
           return res(ctx.json({ data_points: cachedDataPoints }));
+        } else if (metricName === TraceMetricKey.CACHE_CREATION_INPUT_TOKENS) {
+          return res(ctx.json({ data_points: cacheCreationDataPoints }));
         }
         return res(ctx.json({ data_points: [] }));
       }),
@@ -269,6 +279,49 @@ describe('TraceTokenUsageChart', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('line-Cached Tokens')).toBeInTheDocument();
+      });
+    });
+
+    it('should display cache write tokens in subtitle when present', async () => {
+      const mockCacheCreationDataPoints = [
+        createCacheCreationTokensDataPoint('2025-12-22T10:00:00Z', 5000),
+        createCacheCreationTokensDataPoint('2025-12-22T11:00:00Z', 8000),
+      ];
+
+      setupTraceMetricsHandler(
+        mockInputDataPoints,
+        mockOutputDataPoints,
+        mockTotalDataPoints,
+        [],
+        mockCacheCreationDataPoints,
+      );
+
+      renderComponent();
+
+      // Cache creation: 5000 + 8000 = 13000 => 13.00K cache write
+      await waitFor(() => {
+        expect(screen.getByText(/13\.00K cache write/)).toBeInTheDocument();
+      });
+    });
+
+    it('should render cache write tokens line when data is present', async () => {
+      const mockCacheCreationDataPoints = [
+        createCacheCreationTokensDataPoint('2025-12-22T10:00:00Z', 5000),
+        createCacheCreationTokensDataPoint('2025-12-22T11:00:00Z', 8000),
+      ];
+
+      setupTraceMetricsHandler(
+        mockInputDataPoints,
+        mockOutputDataPoints,
+        mockTotalDataPoints,
+        [],
+        mockCacheCreationDataPoints,
+      );
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('line-Cache Write Tokens')).toBeInTheDocument();
       });
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
@@ -24,8 +24,8 @@ const createOutputTokensDataPoint = (timeBucket: string, sum: number) => ({
   values: { [AggregationType.SUM]: sum },
 });
 
-// Helper to create a cached (cache read) tokens data point
-const createCachedTokensDataPoint = (timeBucket: string, sum: number) => ({
+// Helper to create a cache read tokens data point
+const createCacheReadTokensDataPoint = (timeBucket: string, sum: number) => ({
   metric_name: TraceMetricKey.CACHE_READ_INPUT_TOKENS,
   dimensions: { time_bucket: timeBucket },
   values: { [AggregationType.SUM]: sum },
@@ -98,7 +98,7 @@ describe('TraceTokenUsageChart', () => {
     inputDataPoints: any[],
     outputDataPoints: any[],
     totalDataPoints: any[],
-    cachedDataPoints: any[] = [],
+    cacheReadDataPoints: any[] = [],
     cacheCreationDataPoints: any[] = [],
   ) => {
     server.use(
@@ -112,7 +112,7 @@ describe('TraceTokenUsageChart', () => {
         } else if (metricName === TraceMetricKey.TOTAL_TOKENS) {
           return res(ctx.json({ data_points: totalDataPoints }));
         } else if (metricName === TraceMetricKey.CACHE_READ_INPUT_TOKENS) {
-          return res(ctx.json({ data_points: cachedDataPoints }));
+          return res(ctx.json({ data_points: cacheReadDataPoints }));
         } else if (metricName === TraceMetricKey.CACHE_CREATION_INPUT_TOKENS) {
           return res(ctx.json({ data_points: cacheCreationDataPoints }));
         }
@@ -252,12 +252,12 @@ describe('TraceTokenUsageChart', () => {
     });
 
     it('should display cache read tokens in subtitle when present', async () => {
-      const mockCachedDataPoints = [
-        createCachedTokensDataPoint('2025-12-22T10:00:00Z', 10000),
-        createCachedTokensDataPoint('2025-12-22T11:00:00Z', 15000),
+      const mockCacheReadDataPoints = [
+        createCacheReadTokensDataPoint('2025-12-22T10:00:00Z', 10000),
+        createCacheReadTokensDataPoint('2025-12-22T11:00:00Z', 15000),
       ];
 
-      setupTraceMetricsHandler(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints, mockCachedDataPoints);
+      setupTraceMetricsHandler(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints, mockCacheReadDataPoints);
 
       renderComponent();
 
@@ -268,12 +268,12 @@ describe('TraceTokenUsageChart', () => {
     });
 
     it('should render cache read tokens line when data is present', async () => {
-      const mockCachedDataPoints = [
-        createCachedTokensDataPoint('2025-12-22T10:00:00Z', 10000),
-        createCachedTokensDataPoint('2025-12-22T11:00:00Z', 15000),
+      const mockCacheReadDataPoints = [
+        createCacheReadTokensDataPoint('2025-12-22T10:00:00Z', 10000),
+        createCacheReadTokensDataPoint('2025-12-22T11:00:00Z', 15000),
       ];
 
-      setupTraceMetricsHandler(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints, mockCachedDataPoints);
+      setupTraceMetricsHandler(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints, mockCacheReadDataPoints);
 
       renderComponent();
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
@@ -24,6 +24,13 @@ const createOutputTokensDataPoint = (timeBucket: string, sum: number) => ({
   values: { [AggregationType.SUM]: sum },
 });
 
+// Helper to create a cached (cache read) tokens data point
+const createCachedTokensDataPoint = (timeBucket: string, sum: number) => ({
+  metric_name: TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+  dimensions: { time_bucket: timeBucket },
+  values: { [AggregationType.SUM]: sum },
+});
+
 // Helper to create a total tokens data point (no time bucket)
 const createTotalTokensDataPoint = (sum: number) => ({
   metric_name: TraceMetricKey.TOTAL_TOKENS,
@@ -80,7 +87,12 @@ describe('TraceTokenUsageChart', () => {
   };
 
   // Helper to setup MSW handler for trace metrics endpoint with routing based on metric_name
-  const setupTraceMetricsHandler = (inputDataPoints: any[], outputDataPoints: any[], totalDataPoints: any[]) => {
+  const setupTraceMetricsHandler = (
+    inputDataPoints: any[],
+    outputDataPoints: any[],
+    totalDataPoints: any[],
+    cachedDataPoints: any[] = [],
+  ) => {
     server.use(
       rest.post(getAjaxUrl('ajax-api/3.0/mlflow/traces/metrics'), async (req, res, ctx) => {
         const body = await req.json();
@@ -91,6 +103,8 @@ describe('TraceTokenUsageChart', () => {
           return res(ctx.json({ data_points: outputDataPoints }));
         } else if (metricName === TraceMetricKey.TOTAL_TOKENS) {
           return res(ctx.json({ data_points: totalDataPoints }));
+        } else if (metricName === TraceMetricKey.CACHE_READ_INPUT_TOKENS) {
+          return res(ctx.json({ data_points: cachedDataPoints }));
         }
         return res(ctx.json({ data_points: [] }));
       }),
@@ -224,6 +238,37 @@ describe('TraceTokenUsageChart', () => {
       await waitFor(() => {
         expect(screen.getByText(/125\.00K input/)).toBeInTheDocument();
         expect(screen.getByText(/50\.00K output/)).toBeInTheDocument();
+      });
+    });
+
+    it('should display cached tokens in subtitle when present', async () => {
+      const mockCachedDataPoints = [
+        createCachedTokensDataPoint('2025-12-22T10:00:00Z', 10000),
+        createCachedTokensDataPoint('2025-12-22T11:00:00Z', 15000),
+      ];
+
+      setupTraceMetricsHandler(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints, mockCachedDataPoints);
+
+      renderComponent();
+
+      // Cached: 10000 + 15000 = 25000 => 25.00K cached
+      await waitFor(() => {
+        expect(screen.getByText(/25\.00K cached/)).toBeInTheDocument();
+      });
+    });
+
+    it('should render cached tokens line when data is present', async () => {
+      const mockCachedDataPoints = [
+        createCachedTokensDataPoint('2025-12-22T10:00:00Z', 10000),
+        createCachedTokensDataPoint('2025-12-22T11:00:00Z', 15000),
+      ];
+
+      setupTraceMetricsHandler(mockInputDataPoints, mockOutputDataPoints, mockTotalDataPoints, mockCachedDataPoints);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('line-Cached Tokens')).toBeInTheDocument();
       });
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
@@ -278,7 +278,7 @@ describe('TraceTokenUsageChart', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByTestId('line-Cache Read')).toBeInTheDocument();
+        expect(screen.getByTestId('line-(Cache Read)')).toBeInTheDocument();
       });
     });
 
@@ -321,7 +321,7 @@ describe('TraceTokenUsageChart', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByTestId('line-Cache Write')).toBeInTheDocument();
+        expect(screen.getByTestId('line-(Cache Write)')).toBeInTheDocument();
       });
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
@@ -199,11 +199,11 @@ describe('TraceTokenUsageChart', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+        expect(screen.getByTestId('composed-chart')).toBeInTheDocument();
       });
 
       // Verify the area chart has all time buckets (3 buckets for 2-hour range with 1hr interval)
-      expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+      expect(screen.getByTestId('composed-chart')).toHaveAttribute('data-count', '3');
     });
 
     it('should display both input and output token areas', async () => {
@@ -251,7 +251,7 @@ describe('TraceTokenUsageChart', () => {
       });
     });
 
-    it('should display cached tokens in subtitle when present', async () => {
+    it('should display cache read tokens in subtitle when present', async () => {
       const mockCachedDataPoints = [
         createCachedTokensDataPoint('2025-12-22T10:00:00Z', 10000),
         createCachedTokensDataPoint('2025-12-22T11:00:00Z', 15000),
@@ -261,13 +261,13 @@ describe('TraceTokenUsageChart', () => {
 
       renderComponent();
 
-      // Cached: 10000 + 15000 = 25000 => 25.00K cached
+      // Cached: 10000 + 15000 = 25000 => 25.00K cache read
       await waitFor(() => {
-        expect(screen.getByText(/25\.00K cached/)).toBeInTheDocument();
+        expect(screen.getByText(/25\.00K cache read/)).toBeInTheDocument();
       });
     });
 
-    it('should render cached tokens line when data is present', async () => {
+    it('should render cache read tokens line when data is present', async () => {
       const mockCachedDataPoints = [
         createCachedTokensDataPoint('2025-12-22T10:00:00Z', 10000),
         createCachedTokensDataPoint('2025-12-22T11:00:00Z', 15000),
@@ -278,11 +278,11 @@ describe('TraceTokenUsageChart', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByTestId('line-Cached Tokens')).toBeInTheDocument();
+        expect(screen.getByTestId('line-Cache Read Input Tokens')).toBeInTheDocument();
       });
     });
 
-    it('should display cache write tokens in subtitle when present', async () => {
+    it('should display cache creation tokens in subtitle when present', async () => {
       const mockCacheCreationDataPoints = [
         createCacheCreationTokensDataPoint('2025-12-22T10:00:00Z', 5000),
         createCacheCreationTokensDataPoint('2025-12-22T11:00:00Z', 8000),
@@ -304,7 +304,7 @@ describe('TraceTokenUsageChart', () => {
       });
     });
 
-    it('should render cache write tokens line when data is present', async () => {
+    it('should render cache creation tokens line when data is present', async () => {
       const mockCacheCreationDataPoints = [
         createCacheCreationTokensDataPoint('2025-12-22T10:00:00Z', 5000),
         createCacheCreationTokensDataPoint('2025-12-22T11:00:00Z', 8000),
@@ -321,7 +321,7 @@ describe('TraceTokenUsageChart', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByTestId('line-Cache Write Tokens')).toBeInTheDocument();
+        expect(screen.getByTestId('line-Cache Creation Input Tokens')).toBeInTheDocument();
       });
     });
 
@@ -484,7 +484,7 @@ describe('TraceTokenUsageChart', () => {
 
       // Should still render with all 3 time buckets
       await waitFor(() => {
-        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+        expect(screen.getByTestId('composed-chart')).toHaveAttribute('data-count', '3');
       });
     });
 
@@ -499,7 +499,7 @@ describe('TraceTokenUsageChart', () => {
 
       // Should still render the chart with all time buckets
       await waitFor(() => {
-        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+        expect(screen.getByTestId('composed-chart')).toHaveAttribute('data-count', '3');
       });
 
       // Should display 0 when total tokens is not available
@@ -529,7 +529,7 @@ describe('TraceTokenUsageChart', () => {
 
       // Should still render the chart with all generated time buckets (all with 0 values)
       await waitFor(() => {
-        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+        expect(screen.getByTestId('composed-chart')).toHaveAttribute('data-count', '3');
       });
     });
 
@@ -544,7 +544,7 @@ describe('TraceTokenUsageChart', () => {
 
       // Should render chart with all 3 time buckets (missing ones filled with 0)
       await waitFor(() => {
-        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+        expect(screen.getByTestId('composed-chart')).toHaveAttribute('data-count', '3');
       });
     });
 
@@ -564,7 +564,7 @@ describe('TraceTokenUsageChart', () => {
 
       // Should render chart with all 3 time buckets
       await waitFor(() => {
-        expect(screen.getByTestId('area-chart')).toHaveAttribute('data-count', '3');
+        expect(screen.getByTestId('composed-chart')).toHaveAttribute('data-count', '3');
       });
     });
   });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
@@ -278,7 +278,7 @@ describe('TraceTokenUsageChart', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByTestId('line-Cache Read Input Tokens')).toBeInTheDocument();
+        expect(screen.getByTestId('line-Cache Read')).toBeInTheDocument();
       });
     });
 
@@ -321,7 +321,7 @@ describe('TraceTokenUsageChart', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByTestId('line-Cache Creation Input Tokens')).toBeInTheDocument();
+        expect(screen.getByTestId('line-Cache Write')).toBeInTheDocument();
       });
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useDesignSystemTheme, LightningIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
-import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { AreaChart, Area, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import { useTraceTokenUsageChartData } from '../hooks/useTraceTokenUsageChartData';
 import {
   OverviewChartLoadingState,
@@ -27,7 +27,7 @@ export const TraceTokenUsageChart: React.FC = () => {
   const { experimentIds, timeIntervalSeconds } = useOverviewChartContext();
 
   // Fetch and process token usage chart data
-  const { chartData, totalTokens, totalInputTokens, totalOutputTokens, isLoading, error, hasData } =
+  const { chartData, totalTokens, totalInputTokens, totalOutputTokens, totalCachedTokens, isLoading, error, hasData } =
     useTraceTokenUsageChartData();
 
   const tooltipFormatter = useCallback(
@@ -39,6 +39,7 @@ export const TraceTokenUsageChart: React.FC = () => {
   const areaColors = {
     inputTokens: theme.colors.blue400,
     outputTokens: theme.colors.green400,
+    cachedTokens: theme.colors.yellow500,
   };
 
   if (isLoading) {
@@ -55,7 +56,11 @@ export const TraceTokenUsageChart: React.FC = () => {
         icon={<LightningIcon />}
         title={<FormattedMessage defaultMessage="Token Usage" description="Title for the token usage chart" />}
         value={formatCount(totalTokens)}
-        subtitle={`(${formatCount(totalInputTokens)} input, ${formatCount(totalOutputTokens)} output)`}
+        subtitle={
+          totalCachedTokens > 0
+            ? `(${formatCount(totalInputTokens)} input, ${formatCount(totalOutputTokens)} output, ${formatCount(totalCachedTokens)} cached)`
+            : `(${formatCount(totalInputTokens)} input, ${formatCount(totalOutputTokens)} output)`
+        }
       />
 
       {/* Chart */}
@@ -101,6 +106,16 @@ export const TraceTokenUsageChart: React.FC = () => {
                 strokeWidth={2}
                 dot={getLineDotStyle(areaColors.outputTokens)}
                 name="Output Tokens"
+              />
+              <Line
+                type="monotone"
+                dataKey="cachedTokens"
+                stroke={areaColors.cachedTokens}
+                strokeWidth={2}
+                strokeDasharray="5 3"
+                strokeOpacity={getOpacity('Cached Tokens')}
+                dot={getLineDotStyle(areaColors.cachedTokens)}
+                name="Cached Tokens"
               />
               <Legend
                 verticalAlign="bottom"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useDesignSystemTheme, LightningIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
-import { AreaChart, Area, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { ComposedChart, Area, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import { useTraceTokenUsageChartData } from '../hooks/useTraceTokenUsageChartData';
 import {
   OverviewChartLoadingState,
@@ -68,7 +68,7 @@ export const TraceTokenUsageChart: React.FC = () => {
         value={formatCount(totalTokens)}
         subtitle={(() => {
           const parts = [`${formatCount(totalInputTokens)} input`, `${formatCount(totalOutputTokens)} output`];
-          if (totalCachedTokens > 0) parts.push(`${formatCount(totalCachedTokens)} cached`);
+          if (totalCachedTokens > 0) parts.push(`${formatCount(totalCachedTokens)} cache read`);
           if (totalCacheCreationTokens > 0) parts.push(`${formatCount(totalCacheCreationTokens)} cache write`);
           return `(${parts.join(', ')})`;
         })()}
@@ -78,7 +78,7 @@ export const TraceTokenUsageChart: React.FC = () => {
       <div css={{ height: DEFAULT_CHART_CONTENT_HEIGHT, marginTop: theme.spacing.sm }}>
         {hasData ? (
           <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={chartData} margin={{ top: 10, right: 30, left: 10, bottom: 0 }}>
+            <ComposedChart data={chartData} margin={{ top: 10, right: 30, left: 10, bottom: 0 }}>
               <XAxis dataKey="name" {...xAxisProps} />
               <YAxis {...yAxisProps} />
               <Tooltip
@@ -124,9 +124,9 @@ export const TraceTokenUsageChart: React.FC = () => {
                 stroke={areaColors.cachedTokens}
                 strokeWidth={2}
                 strokeDasharray="5 3"
-                strokeOpacity={getOpacity('Cached Tokens')}
+                strokeOpacity={getOpacity('Cache Read Input Tokens')}
                 dot={getLineDotStyle(areaColors.cachedTokens)}
-                name="Cached Tokens"
+                name="Cache Read Input Tokens"
               />
               <Line
                 type="monotone"
@@ -134,9 +134,9 @@ export const TraceTokenUsageChart: React.FC = () => {
                 stroke={areaColors.cacheCreationTokens}
                 strokeWidth={2}
                 strokeDasharray="5 3"
-                strokeOpacity={getOpacity('Cache Write Tokens')}
+                strokeOpacity={getOpacity('Cache Creation Input Tokens')}
                 dot={getLineDotStyle(areaColors.cacheCreationTokens)}
-                name="Cache Write Tokens"
+                name="Cache Creation Input Tokens"
               />
               <Legend
                 verticalAlign="bottom"
@@ -145,7 +145,7 @@ export const TraceTokenUsageChart: React.FC = () => {
                 onMouseLeave={handleLegendMouseLeave}
                 {...scrollableLegendProps}
               />
-            </AreaChart>
+            </ComposedChart>
           </ResponsiveContainer>
         ) : (
           <OverviewChartEmptyState />

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -106,6 +106,26 @@ export const TraceTokenUsageChart: React.FC = () => {
                 dot={getLineDotStyle(areaColors.inputTokens)}
                 name="Input Tokens"
               />
+              <Line
+                type="monotone"
+                dataKey="cacheReadTokens"
+                stroke={areaColors.cacheReadTokens}
+                strokeWidth={2}
+                strokeDasharray="5 3"
+                strokeOpacity={getOpacity('(Cache Read)')}
+                dot={getLineDotStyle(areaColors.cacheReadTokens)}
+                name="(Cache Read)"
+              />
+              <Line
+                type="monotone"
+                dataKey="cacheCreationTokens"
+                stroke={areaColors.cacheCreationTokens}
+                strokeWidth={2}
+                strokeDasharray="5 3"
+                strokeOpacity={getOpacity('(Cache Write)')}
+                dot={getLineDotStyle(areaColors.cacheCreationTokens)}
+                name="(Cache Write)"
+              />
               <Area
                 type="monotone"
                 dataKey="outputTokens"
@@ -117,26 +137,6 @@ export const TraceTokenUsageChart: React.FC = () => {
                 strokeWidth={2}
                 dot={getLineDotStyle(areaColors.outputTokens)}
                 name="Output Tokens"
-              />
-              <Line
-                type="monotone"
-                dataKey="cacheReadTokens"
-                stroke={areaColors.cacheReadTokens}
-                strokeWidth={2}
-                strokeDasharray="5 3"
-                strokeOpacity={getOpacity('Cache Read')}
-                dot={getLineDotStyle(areaColors.cacheReadTokens)}
-                name="Cache Read"
-              />
-              <Line
-                type="monotone"
-                dataKey="cacheCreationTokens"
-                stroke={areaColors.cacheCreationTokens}
-                strokeWidth={2}
-                strokeDasharray="5 3"
-                strokeOpacity={getOpacity('Cache Write')}
-                dot={getLineDotStyle(areaColors.cacheCreationTokens)}
-                name="Cache Write"
               />
               <Legend
                 verticalAlign="bottom"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -27,8 +27,17 @@ export const TraceTokenUsageChart: React.FC = () => {
   const { experimentIds, timeIntervalSeconds } = useOverviewChartContext();
 
   // Fetch and process token usage chart data
-  const { chartData, totalTokens, totalInputTokens, totalOutputTokens, totalCachedTokens, isLoading, error, hasData } =
-    useTraceTokenUsageChartData();
+  const {
+    chartData,
+    totalTokens,
+    totalInputTokens,
+    totalOutputTokens,
+    totalCachedTokens,
+    totalCacheCreationTokens,
+    isLoading,
+    error,
+    hasData,
+  } = useTraceTokenUsageChartData();
 
   const tooltipFormatter = useCallback(
     (value: number, name: string) => [formatCount(value), name] as [string, string],
@@ -40,6 +49,7 @@ export const TraceTokenUsageChart: React.FC = () => {
     inputTokens: theme.colors.blue400,
     outputTokens: theme.colors.green400,
     cachedTokens: theme.colors.yellow500,
+    cacheCreationTokens: theme.colors.purple,
   };
 
   if (isLoading) {
@@ -56,11 +66,12 @@ export const TraceTokenUsageChart: React.FC = () => {
         icon={<LightningIcon />}
         title={<FormattedMessage defaultMessage="Token Usage" description="Title for the token usage chart" />}
         value={formatCount(totalTokens)}
-        subtitle={
-          totalCachedTokens > 0
-            ? `(${formatCount(totalInputTokens)} input, ${formatCount(totalOutputTokens)} output, ${formatCount(totalCachedTokens)} cached)`
-            : `(${formatCount(totalInputTokens)} input, ${formatCount(totalOutputTokens)} output)`
-        }
+        subtitle={(() => {
+          const parts = [`${formatCount(totalInputTokens)} input`, `${formatCount(totalOutputTokens)} output`];
+          if (totalCachedTokens > 0) parts.push(`${formatCount(totalCachedTokens)} cached`);
+          if (totalCacheCreationTokens > 0) parts.push(`${formatCount(totalCacheCreationTokens)} cache write`);
+          return `(${parts.join(', ')})`;
+        })()}
       />
 
       {/* Chart */}
@@ -116,6 +127,16 @@ export const TraceTokenUsageChart: React.FC = () => {
                 strokeOpacity={getOpacity('Cached Tokens')}
                 dot={getLineDotStyle(areaColors.cachedTokens)}
                 name="Cached Tokens"
+              />
+              <Line
+                type="monotone"
+                dataKey="cacheCreationTokens"
+                stroke={areaColors.cacheCreationTokens}
+                strokeWidth={2}
+                strokeDasharray="5 3"
+                strokeOpacity={getOpacity('Cache Write Tokens')}
+                dot={getLineDotStyle(areaColors.cacheCreationTokens)}
+                name="Cache Write Tokens"
               />
               <Legend
                 verticalAlign="bottom"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -124,9 +124,9 @@ export const TraceTokenUsageChart: React.FC = () => {
                 stroke={areaColors.cachedTokens}
                 strokeWidth={2}
                 strokeDasharray="5 3"
-                strokeOpacity={getOpacity('Cache Read Input Tokens')}
+                strokeOpacity={getOpacity('Cache Read')}
                 dot={getLineDotStyle(areaColors.cachedTokens)}
-                name="Cache Read Input Tokens"
+                name="Cache Read"
               />
               <Line
                 type="monotone"
@@ -134,9 +134,9 @@ export const TraceTokenUsageChart: React.FC = () => {
                 stroke={areaColors.cacheCreationTokens}
                 strokeWidth={2}
                 strokeDasharray="5 3"
-                strokeOpacity={getOpacity('Cache Creation Input Tokens')}
+                strokeOpacity={getOpacity('Cache Write')}
                 dot={getLineDotStyle(areaColors.cacheCreationTokens)}
-                name="Cache Creation Input Tokens"
+                name="Cache Write"
               />
               <Legend
                 verticalAlign="bottom"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.tsx
@@ -32,7 +32,7 @@ export const TraceTokenUsageChart: React.FC = () => {
     totalTokens,
     totalInputTokens,
     totalOutputTokens,
-    totalCachedTokens,
+    totalCacheReadTokens,
     totalCacheCreationTokens,
     isLoading,
     error,
@@ -48,7 +48,7 @@ export const TraceTokenUsageChart: React.FC = () => {
   const areaColors = {
     inputTokens: theme.colors.blue400,
     outputTokens: theme.colors.green400,
-    cachedTokens: theme.colors.yellow500,
+    cacheReadTokens: theme.colors.yellow500,
     cacheCreationTokens: theme.colors.purple,
   };
 
@@ -68,7 +68,7 @@ export const TraceTokenUsageChart: React.FC = () => {
         value={formatCount(totalTokens)}
         subtitle={(() => {
           const parts = [`${formatCount(totalInputTokens)} input`, `${formatCount(totalOutputTokens)} output`];
-          if (totalCachedTokens > 0) parts.push(`${formatCount(totalCachedTokens)} cache read`);
+          if (totalCacheReadTokens > 0) parts.push(`${formatCount(totalCacheReadTokens)} cache read`);
           if (totalCacheCreationTokens > 0) parts.push(`${formatCount(totalCacheCreationTokens)} cache write`);
           return `(${parts.join(', ')})`;
         })()}
@@ -120,12 +120,12 @@ export const TraceTokenUsageChart: React.FC = () => {
               />
               <Line
                 type="monotone"
-                dataKey="cachedTokens"
-                stroke={areaColors.cachedTokens}
+                dataKey="cacheReadTokens"
+                stroke={areaColors.cacheReadTokens}
                 strokeWidth={2}
                 strokeDasharray="5 3"
                 strokeOpacity={getOpacity('Cache Read')}
-                dot={getLineDotStyle(areaColors.cachedTokens)}
+                dot={getLineDotStyle(areaColors.cacheReadTokens)}
                 name="Cache Read"
               />
               <Line

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenUsageChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenUsageChartData.ts
@@ -8,6 +8,7 @@ export interface TokenUsageChartDataPoint {
   name: string;
   inputTokens: number;
   outputTokens: number;
+  cachedTokens: number;
   timestampMs: number;
 }
 
@@ -20,6 +21,8 @@ export interface UseTraceTokenUsageChartDataResult {
   totalInputTokens: number;
   /** Total output tokens in the time range */
   totalOutputTokens: number;
+  /** Total cached (cache read) tokens in the time range */
+  totalCachedTokens: number;
   /** Whether data is currently being fetched */
   isLoading: boolean;
   /** Error if data fetching failed */
@@ -70,6 +73,22 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
     filters,
   });
 
+  // Fetch cached (cache read) tokens over time
+  const {
+    data: cachedTokensData,
+    isLoading: isLoadingCached,
+    error: cachedError,
+  } = useTraceMetricsQuery({
+    experimentIds,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+    aggregations: [{ aggregation_type: AggregationType.SUM }],
+    timeIntervalSeconds,
+    filters,
+  });
+
   // Fetch total tokens (without time bucketing) for the header
   const {
     data: totalTokensData,
@@ -87,8 +106,9 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
 
   const inputDataPoints = useMemo(() => inputTokensData?.data_points || [], [inputTokensData?.data_points]);
   const outputDataPoints = useMemo(() => outputTokensData?.data_points || [], [outputTokensData?.data_points]);
-  const isLoading = isLoadingInput || isLoadingOutput || isLoadingTotal;
-  const error = inputError || outputError || totalError;
+  const cachedDataPoints = useMemo(() => cachedTokensData?.data_points || [], [cachedTokensData?.data_points]);
+  const isLoading = isLoadingInput || isLoadingOutput || isLoadingCached || isLoadingTotal;
+  const error = inputError || outputError || cachedError || totalError;
 
   // Extract total tokens from the response
   const totalTokens = totalTokensData?.data_points?.[0]?.values?.[AggregationType.SUM] || 0;
@@ -102,6 +122,10 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
     () => outputDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0),
     [outputDataPoints],
   );
+  const totalCachedTokens = useMemo(
+    () => cachedDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0),
+    [cachedDataPoints],
+  );
 
   // Create maps of tokens by timestamp using shared utility
   const sumExtractor = useCallback(
@@ -110,6 +134,7 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
   );
   const inputTokensMap = useTimestampValueMap(inputDataPoints, sumExtractor);
   const outputTokensMap = useTimestampValueMap(outputDataPoints, sumExtractor);
+  const cachedTokensMap = useTimestampValueMap(cachedDataPoints, sumExtractor);
 
   // Prepare chart data - fill in all time buckets with 0 for missing data
   const chartData = useMemo(() => {
@@ -117,15 +142,17 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
       name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
       inputTokens: inputTokensMap.get(timestampMs) || 0,
       outputTokens: outputTokensMap.get(timestampMs) || 0,
+      cachedTokens: cachedTokensMap.get(timestampMs) || 0,
       timestampMs,
     }));
-  }, [timeBuckets, inputTokensMap, outputTokensMap, timeIntervalSeconds]);
+  }, [timeBuckets, inputTokensMap, outputTokensMap, cachedTokensMap, timeIntervalSeconds]);
 
   return {
     chartData,
     totalTokens,
     totalInputTokens,
     totalOutputTokens,
+    totalCachedTokens,
     isLoading,
     error,
     hasData: inputDataPoints.length > 0 || outputDataPoints.length > 0,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenUsageChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenUsageChartData.ts
@@ -9,6 +9,7 @@ export interface TokenUsageChartDataPoint {
   inputTokens: number;
   outputTokens: number;
   cachedTokens: number;
+  cacheCreationTokens: number;
   timestampMs: number;
 }
 
@@ -23,6 +24,8 @@ export interface UseTraceTokenUsageChartDataResult {
   totalOutputTokens: number;
   /** Total cached (cache read) tokens in the time range */
   totalCachedTokens: number;
+  /** Total cache creation tokens in the time range */
+  totalCacheCreationTokens: number;
   /** Whether data is currently being fetched */
   isLoading: boolean;
   /** Error if data fetching failed */
@@ -89,6 +92,22 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
     filters,
   });
 
+  // Fetch cache creation tokens over time
+  const {
+    data: cacheCreationTokensData,
+    isLoading: isLoadingCacheCreation,
+    error: cacheCreationError,
+  } = useTraceMetricsQuery({
+    experimentIds,
+    startTimeMs,
+    endTimeMs,
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.CACHE_CREATION_INPUT_TOKENS,
+    aggregations: [{ aggregation_type: AggregationType.SUM }],
+    timeIntervalSeconds,
+    filters,
+  });
+
   // Fetch total tokens (without time bucketing) for the header
   const {
     data: totalTokensData,
@@ -107,8 +126,12 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
   const inputDataPoints = useMemo(() => inputTokensData?.data_points || [], [inputTokensData?.data_points]);
   const outputDataPoints = useMemo(() => outputTokensData?.data_points || [], [outputTokensData?.data_points]);
   const cachedDataPoints = useMemo(() => cachedTokensData?.data_points || [], [cachedTokensData?.data_points]);
-  const isLoading = isLoadingInput || isLoadingOutput || isLoadingCached || isLoadingTotal;
-  const error = inputError || outputError || cachedError || totalError;
+  const cacheCreationDataPoints = useMemo(
+    () => cacheCreationTokensData?.data_points || [],
+    [cacheCreationTokensData?.data_points],
+  );
+  const isLoading = isLoadingInput || isLoadingOutput || isLoadingCached || isLoadingCacheCreation || isLoadingTotal;
+  const error = inputError || outputError || cachedError || cacheCreationError || totalError;
 
   // Extract total tokens from the response
   const totalTokens = totalTokensData?.data_points?.[0]?.values?.[AggregationType.SUM] || 0;
@@ -126,6 +149,10 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
     () => cachedDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0),
     [cachedDataPoints],
   );
+  const totalCacheCreationTokens = useMemo(
+    () => cacheCreationDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0),
+    [cacheCreationDataPoints],
+  );
 
   // Create maps of tokens by timestamp using shared utility
   const sumExtractor = useCallback(
@@ -135,6 +162,7 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
   const inputTokensMap = useTimestampValueMap(inputDataPoints, sumExtractor);
   const outputTokensMap = useTimestampValueMap(outputDataPoints, sumExtractor);
   const cachedTokensMap = useTimestampValueMap(cachedDataPoints, sumExtractor);
+  const cacheCreationTokensMap = useTimestampValueMap(cacheCreationDataPoints, sumExtractor);
 
   // Prepare chart data - fill in all time buckets with 0 for missing data
   const chartData = useMemo(() => {
@@ -143,9 +171,10 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
       inputTokens: inputTokensMap.get(timestampMs) || 0,
       outputTokens: outputTokensMap.get(timestampMs) || 0,
       cachedTokens: cachedTokensMap.get(timestampMs) || 0,
+      cacheCreationTokens: cacheCreationTokensMap.get(timestampMs) || 0,
       timestampMs,
     }));
-  }, [timeBuckets, inputTokensMap, outputTokensMap, cachedTokensMap, timeIntervalSeconds]);
+  }, [timeBuckets, inputTokensMap, outputTokensMap, cachedTokensMap, cacheCreationTokensMap, timeIntervalSeconds]);
 
   return {
     chartData,
@@ -153,6 +182,7 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
     totalInputTokens,
     totalOutputTokens,
     totalCachedTokens,
+    totalCacheCreationTokens,
     isLoading,
     error,
     hasData: inputDataPoints.length > 0 || outputDataPoints.length > 0,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenUsageChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenUsageChartData.ts
@@ -8,7 +8,7 @@ export interface TokenUsageChartDataPoint {
   name: string;
   inputTokens: number;
   outputTokens: number;
-  cachedTokens: number;
+  cacheReadTokens: number;
   cacheCreationTokens: number;
   timestampMs: number;
 }
@@ -22,8 +22,8 @@ export interface UseTraceTokenUsageChartDataResult {
   totalInputTokens: number;
   /** Total output tokens in the time range */
   totalOutputTokens: number;
-  /** Total cached (cache read) tokens in the time range */
-  totalCachedTokens: number;
+  /** Total cache read tokens in the time range */
+  totalCacheReadTokens: number;
   /** Total cache creation tokens in the time range */
   totalCacheCreationTokens: number;
   /** Whether data is currently being fetched */
@@ -76,11 +76,11 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
     filters,
   });
 
-  // Fetch cached (cache read) tokens over time
+  // Fetch cache read tokens over time
   const {
-    data: cachedTokensData,
-    isLoading: isLoadingCached,
-    error: cachedError,
+    data: cacheReadTokensData,
+    isLoading: isLoadingCacheRead,
+    error: cacheReadError,
   } = useTraceMetricsQuery({
     experimentIds,
     startTimeMs,
@@ -125,13 +125,13 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
 
   const inputDataPoints = useMemo(() => inputTokensData?.data_points || [], [inputTokensData?.data_points]);
   const outputDataPoints = useMemo(() => outputTokensData?.data_points || [], [outputTokensData?.data_points]);
-  const cachedDataPoints = useMemo(() => cachedTokensData?.data_points || [], [cachedTokensData?.data_points]);
+  const cacheReadDataPoints = useMemo(() => cacheReadTokensData?.data_points || [], [cacheReadTokensData?.data_points]);
   const cacheCreationDataPoints = useMemo(
     () => cacheCreationTokensData?.data_points || [],
     [cacheCreationTokensData?.data_points],
   );
-  const isLoading = isLoadingInput || isLoadingOutput || isLoadingCached || isLoadingCacheCreation || isLoadingTotal;
-  const error = inputError || outputError || cachedError || cacheCreationError || totalError;
+  const isLoading = isLoadingInput || isLoadingOutput || isLoadingCacheRead || isLoadingCacheCreation || isLoadingTotal;
+  const error = inputError || outputError || cacheReadError || cacheCreationError || totalError;
 
   // Extract total tokens from the response
   const totalTokens = totalTokensData?.data_points?.[0]?.values?.[AggregationType.SUM] || 0;
@@ -145,9 +145,9 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
     () => outputDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0),
     [outputDataPoints],
   );
-  const totalCachedTokens = useMemo(
-    () => cachedDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0),
-    [cachedDataPoints],
+  const totalCacheReadTokens = useMemo(
+    () => cacheReadDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0),
+    [cacheReadDataPoints],
   );
   const totalCacheCreationTokens = useMemo(
     () => cacheCreationDataPoints.reduce((sum, dp) => sum + (dp.values?.[AggregationType.SUM] || 0), 0),
@@ -161,7 +161,7 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
   );
   const inputTokensMap = useTimestampValueMap(inputDataPoints, sumExtractor);
   const outputTokensMap = useTimestampValueMap(outputDataPoints, sumExtractor);
-  const cachedTokensMap = useTimestampValueMap(cachedDataPoints, sumExtractor);
+  const cacheReadTokensMap = useTimestampValueMap(cacheReadDataPoints, sumExtractor);
   const cacheCreationTokensMap = useTimestampValueMap(cacheCreationDataPoints, sumExtractor);
 
   // Prepare chart data - fill in all time buckets with 0 for missing data
@@ -170,18 +170,18 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
       name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
       inputTokens: inputTokensMap.get(timestampMs) || 0,
       outputTokens: outputTokensMap.get(timestampMs) || 0,
-      cachedTokens: cachedTokensMap.get(timestampMs) || 0,
+      cacheReadTokens: cacheReadTokensMap.get(timestampMs) || 0,
       cacheCreationTokens: cacheCreationTokensMap.get(timestampMs) || 0,
       timestampMs,
     }));
-  }, [timeBuckets, inputTokensMap, outputTokensMap, cachedTokensMap, cacheCreationTokensMap, timeIntervalSeconds]);
+  }, [timeBuckets, inputTokensMap, outputTokensMap, cacheReadTokensMap, cacheCreationTokensMap, timeIntervalSeconds]);
 
   return {
     chartData,
     totalTokens,
     totalInputTokens,
     totalOutputTokens,
-    totalCachedTokens,
+    totalCacheReadTokens,
     totalCacheCreationTokens,
     isLoading,
     error,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/TraceMetrics.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/TraceMetrics.types.ts
@@ -12,6 +12,8 @@ export enum TraceMetricKey {
   INPUT_TOKENS = 'input_tokens',
   OUTPUT_TOKENS = 'output_tokens',
   TOTAL_TOKENS = 'total_tokens',
+  CACHE_READ_INPUT_TOKENS = 'cache_read_input_tokens',
+  CACHE_CREATION_INPUT_TOKENS = 'cache_creation_input_tokens',
 }
 
 /**

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -75,6 +75,14 @@ TRACES_METRICS_CONFIGS: dict[TraceMetricKey, TraceMetricsConfig] = {
         aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
         dimensions={TraceMetricDimensionKey.TRACE_NAME},
     ),
+    TraceMetricKey.CACHE_READ_INPUT_TOKENS: TraceMetricsConfig(
+        aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
+        dimensions={TraceMetricDimensionKey.TRACE_NAME},
+    ),
+    TraceMetricKey.CACHE_CREATION_INPUT_TOKENS: TraceMetricsConfig(
+        aggregation_types={AggregationType.SUM, AggregationType.AVG, AggregationType.PERCENTILE},
+        dimensions={TraceMetricDimensionKey.TRACE_NAME},
+    ),
 }
 
 # SpanMetricKey -> TraceMetricsConfig mapping for spans

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -208,10 +208,18 @@ class TraceMetricKey:
     INPUT_TOKENS = "input_tokens"
     OUTPUT_TOKENS = "output_tokens"
     TOTAL_TOKENS = "total_tokens"
+    CACHE_READ_INPUT_TOKENS = "cache_read_input_tokens"
+    CACHE_CREATION_INPUT_TOKENS = "cache_creation_input_tokens"
 
     @classmethod
     def token_usage_keys(cls) -> list[str]:
-        return [cls.INPUT_TOKENS, cls.OUTPUT_TOKENS, cls.TOTAL_TOKENS]
+        return [
+            cls.INPUT_TOKENS,
+            cls.OUTPUT_TOKENS,
+            cls.TOTAL_TOKENS,
+            cls.CACHE_READ_INPUT_TOKENS,
+            cls.CACHE_CREATION_INPUT_TOKENS,
+        ]
 
 
 class TraceMetricDimensionKey:

--- a/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
@@ -978,6 +978,110 @@ def test_query_trace_metrics_total_tokens_without_token_usage(store: SqlAlchemyS
     assert len(result) == 0
 
 
+@pytest.fixture
+def traces_with_cached_token_usage_setup(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_traces_with_cached_token_usage")
+    traces_data = [
+        # (trace_id, name, input, output, total, cache_read, cache_creation)
+        ("trace1", "workflow_a", 100, 50, 150, 30, 10),
+        ("trace2", "workflow_a", 200, 100, 300, 60, 20),
+        ("trace3", "workflow_a", 150, 75, 225, 0, 0),
+        ("trace4", "workflow_b", 300, 150, 450, 100, 50),
+        ("trace5", "workflow_b", 250, 125, 375, 80, 40),
+    ]
+
+    for trace_id, name, input_t, output_t, total_t, cache_read, cache_creation in traces_data:
+        token_usage = {
+            TraceMetricKey.INPUT_TOKENS: input_t,
+            TraceMetricKey.OUTPUT_TOKENS: output_t,
+            TraceMetricKey.TOTAL_TOKENS: total_t,
+            TraceMetricKey.CACHE_READ_INPUT_TOKENS: cache_read,
+            TraceMetricKey.CACHE_CREATION_INPUT_TOKENS: cache_creation,
+        }
+        trace_info = TraceInfo(
+            trace_id=trace_id,
+            trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+            request_time=get_current_time_millis(),
+            execution_duration=100,
+            state=TraceStatus.OK,
+            tags={TraceTagKey.TRACE_NAME: name},
+            trace_metadata={TraceMetadataKey.TOKEN_USAGE: json.dumps(token_usage)},
+        )
+        store.start_trace(trace_info)
+    return exp_id, store
+
+
+def test_query_trace_metrics_cache_read_input_tokens_sum(traces_with_cached_token_usage_setup):
+    exp_id, store = traces_with_cached_token_usage_setup
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.TRACES,
+        metric_name=TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
+        dimensions=[TraceMetricDimensionKey.TRACE_NAME],
+    )
+
+    assert len(result) == 2
+    assert asdict(result[0]) == {
+        "metric_name": TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+        "dimensions": {TraceMetricDimensionKey.TRACE_NAME: "workflow_a"},
+        "values": {"SUM": 90},
+    }
+    assert asdict(result[1]) == {
+        "metric_name": TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+        "dimensions": {TraceMetricDimensionKey.TRACE_NAME: "workflow_b"},
+        "values": {"SUM": 180},
+    }
+
+
+def test_query_trace_metrics_cache_creation_input_tokens_sum(traces_with_cached_token_usage_setup):
+    exp_id, store = traces_with_cached_token_usage_setup
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.TRACES,
+        metric_name=TraceMetricKey.CACHE_CREATION_INPUT_TOKENS,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
+        dimensions=[TraceMetricDimensionKey.TRACE_NAME],
+    )
+
+    assert len(result) == 2
+    assert asdict(result[0]) == {
+        "metric_name": TraceMetricKey.CACHE_CREATION_INPUT_TOKENS,
+        "dimensions": {TraceMetricDimensionKey.TRACE_NAME: "workflow_a"},
+        "values": {"SUM": 30},
+    }
+    assert asdict(result[1]) == {
+        "metric_name": TraceMetricKey.CACHE_CREATION_INPUT_TOKENS,
+        "dimensions": {TraceMetricDimensionKey.TRACE_NAME: "workflow_b"},
+        "values": {"SUM": 90},
+    }
+
+
+def test_query_trace_metrics_cache_read_input_tokens_no_dimensions(
+    traces_with_cached_token_usage_setup,
+):
+    exp_id, store = traces_with_cached_token_usage_setup
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.TRACES,
+        metric_name=TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+        aggregations=[
+            MetricAggregation(aggregation_type=AggregationType.SUM),
+            MetricAggregation(aggregation_type=AggregationType.AVG),
+        ],
+    )
+
+    assert len(result) == 1
+    assert asdict(result[0]) == {
+        "metric_name": TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+        "dimensions": {},
+        "values": {"SUM": 270, "AVG": 54.0},
+    }
+
+
 def test_query_span_metrics_count_no_dimensions(store: SqlAlchemyStore):
     exp_id = store.create_experiment("test_span_count_no_dimensions")
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Expose `cache_read_input_tokens` and `cache_creation_input_tokens` through the trace metrics API and display cached tokens as a dashed line overlay on the Token Usage chart in the experiment overview page.

<img width="469" height="317" alt="image" src="https://github.com/user-attachments/assets/6f886ea2-e6ba-4507-be80-ebac9422e508" />

**Backend:**
- Add `CACHE_READ_INPUT_TOKENS` and `CACHE_CREATION_INPUT_TOKENS` to `TraceMetricKey` and `token_usage_keys()`
- Add corresponding entries in `TRACES_METRICS_CONFIGS` with SUM/AVG/PERCENTILE aggregations

**Frontend:**
- Add enum values to `TraceMetricKey` TypeScript enum
- Fetch cached token data via `useTraceMetricsQuery` in `useTraceTokenUsageChartData` hook
- Render cached tokens as a dashed yellow line overlay on the stacked area chart
- Show cached token count in the subtitle when present (e.g., "125K input, 50K output, 25K cached")

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests:
- Backend: 3 tests for `cache_read_input_tokens` and `cache_creation_input_tokens` metric queries (SUM with dimensions, SUM without dimensions)
- Frontend: 2 tests for cached tokens subtitle display and cached tokens line rendering

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Display cached token usage (cache read and cache creation input tokens) as a dashed line overlay on the Token Usage chart in the experiment overview page.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)