### PR TITLE
Improve DSPy trace chat view readability

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.test.ts
@@ -63,6 +63,17 @@ describe('normalizeConversation', () => {
     expect(conv?.[0].content).not.toContain('[[ ## completed ## ]]');
     expect(conv?.[0].content).toContain('  \n');
   });
+
+  it('should render JSON output as a formatted code block', () => {
+    const jsonOutput = ['{ "summary": "MLflow is great." }'];
+    const conv = normalizeConversation(jsonOutput, 'dspy');
+    expect(conv).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        content: '```json\n{\n  "summary": "MLflow is great."\n}\n```',
+      }),
+    ]);
+  });
 });
 
 describe('formatDspySections', () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 
 import { normalizeConversation } from '../ModelTraceExplorer.utils';
+import { formatDspySections } from './dspy';
 
 const MOCK_DSPY_INPUT = {
   messages: [
@@ -32,9 +33,19 @@ describe('normalizeConversation', () => {
       }),
       expect.objectContaining({
         role: 'user',
-        content: expect.stringContaining('[[ ## passage ## ]]'),
+        content: expect.stringContaining('#### Passage'),
       }),
     ]);
+    // Standalone markers should be converted to headings (first one has no rule above)
+    expect(conv?.[0].content).toContain('#### Passage');
+    expect(conv?.[0].content).toContain('#### Reasoning');
+    expect(conv?.[0].content).toContain('#### Summary');
+    // The completed marker should be removed
+    expect(conv?.[0].content).not.toContain('[[ ## completed ## ]]');
+    // Inline references inside backticks should be preserved
+    expect(conv?.[1].content).toContain('`[[ ## reasoning ## ]]`');
+    expect(conv?.[1].content).toContain('`[[ ## summary ## ]]`');
+    expect(conv?.[1].content).toContain('`[[ ## completed ## ]]`');
     // Ensure single newlines are converted to hard breaks for markdown rendering
     expect(conv?.[0].content).toContain('  \n');
   });
@@ -43,10 +54,58 @@ describe('normalizeConversation', () => {
     const conv = normalizeConversation(MOCK_DSPY_OUTPUT, 'dspy');
     expect(conv).toEqual([
       expect.objectContaining({
-        content: expect.stringContaining('[[ ## reasoning ## ]]'),
+        content: expect.stringContaining('#### Reasoning'),
         role: 'assistant',
       }),
     ]);
+    expect(conv?.[0].content).toContain('#### Summary');
+    // completed marker should be removed
+    expect(conv?.[0].content).not.toContain('[[ ## completed ## ]]');
     expect(conv?.[0].content).toContain('  \n');
+  });
+});
+
+describe('formatDspySections', () => {
+  it('should convert standalone markers to markdown headings', () => {
+    const input = '[[ ## reasoning ## ]]\nSome reasoning text';
+    expect(formatDspySections(input)).toBe('#### Reasoning\nSome reasoning text');
+  });
+
+  it('should handle markers with leading/trailing whitespace on the line', () => {
+    const input = '  [[ ## passage ## ]]  \nSome text';
+    expect(formatDspySections(input)).toBe('#### Passage\nSome text');
+  });
+
+  it('should remove the completed marker entirely', () => {
+    const input = 'Some text\n\n[[ ## completed ## ]]';
+    expect(formatDspySections(input)).toBe('Some text\n\n');
+  });
+
+  it('should leave inline references unchanged', () => {
+    const input = 'Start with `[[ ## reasoning ## ]]` then `[[ ## summary ## ]]`.';
+    expect(formatDspySections(input)).toBe(input);
+  });
+
+  it('should title-case snake_case variable names', () => {
+    const input = '[[ ## tool_name_0 ## ]]';
+    expect(formatDspySections(input)).toBe('#### Tool Name 0');
+  });
+
+  it('should handle multiple sections', () => {
+    const input = '[[ ## reasoning ## ]]\nThinking...\n\n[[ ## summary ## ]]\nDone.\n\n[[ ## completed ## ]]';
+    const result = formatDspySections(input);
+    expect(result).toContain('#### Reasoning');
+    expect(result).toContain('#### Summary');
+    expect(result).not.toContain('[[ ## completed ## ]]');
+    expect(result).not.toContain('#### Completed');
+  });
+
+  it('should return text unchanged when there are no markers', () => {
+    const input = 'Just regular text with no markers.';
+    expect(formatDspySections(input)).toBe(input);
+  });
+
+  it('should return empty string unchanged', () => {
+    expect(formatDspySections('')).toBe('');
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
@@ -5,25 +5,19 @@ import { prettyPrintChatMessage } from '../ModelTraceExplorer.utils';
 
 // Convert a snake_case or space-separated variable name into Title Case.
 // e.g. "tool_name_0" → "Tool Name 0"
-const titleCase = (name: string) =>
-  name
-    .replace(/_/g, ' ')
-    .replace(/\b[a-z]/g, (ch) => ch.toUpperCase());
+const titleCase = (name: string) => name.replace(/_/g, ' ').replace(/\b[a-z]/g, (ch) => ch.toUpperCase());
 
 // Convert standalone `[[ ## name ## ]]` markers into markdown headings.
 // - Markers that sit on their own line become `#### Title Cased Name`
 // - The `[[ ## completed ## ]]` terminator is removed entirely
 // - Inline references (e.g. inside backticks mid-sentence) are left unchanged
 export const formatDspySections = (text: string): string =>
-  text.replace(
-    /^[ \t]*\[\[\s*##\s*(.*?)\s*##\s*\]\][ \t]*$/gm,
-    (_match, name: string) => {
-      if (name.toLowerCase() === 'completed') {
-        return '';
-      }
-      return `#### ${titleCase(name.trim())}`;
-    },
-  );
+  text.replace(/^[ \t]*\[\[\s*##\s*(.*?)\s*##\s*\]\][ \t]*$/gm, (_match, name: string) => {
+    if (name.toLowerCase() === 'completed') {
+      return '';
+    }
+    return `#### ${titleCase(name.trim())}`;
+  });
 
 export const normalizeDspyChatInput = (obj: unknown): ModelTraceChatMessage[] | null => {
   // Handle DSPy format with messages array
@@ -33,9 +27,7 @@ export const normalizeDspyChatInput = (obj: unknown): ModelTraceChatMessage[] | 
       .map((msg: any) =>
         prettyPrintChatMessage({
           type: 'message',
-          content: isString(msg.content)
-            ? toMarkdownWithHardBreaks(formatDspySections(msg.content))
-            : msg.content,
+          content: isString(msg.content) ? toMarkdownWithHardBreaks(formatDspySections(msg.content)) : msg.content,
           role: msg.role,
         }),
       )

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
@@ -3,6 +3,28 @@ import { has, isArray, isString } from 'lodash';
 import type { ModelTraceChatMessage } from '../ModelTrace.types';
 import { prettyPrintChatMessage } from '../ModelTraceExplorer.utils';
 
+// Convert a snake_case or space-separated variable name into Title Case.
+// e.g. "tool_name_0" → "Tool Name 0"
+const titleCase = (name: string) =>
+  name
+    .replace(/_/g, ' ')
+    .replace(/\b[a-z]/g, (ch) => ch.toUpperCase());
+
+// Convert standalone `[[ ## name ## ]]` markers into markdown headings.
+// - Markers that sit on their own line become `#### Title Cased Name`
+// - The `[[ ## completed ## ]]` terminator is removed entirely
+// - Inline references (e.g. inside backticks mid-sentence) are left unchanged
+export const formatDspySections = (text: string): string =>
+  text.replace(
+    /^[ \t]*\[\[\s*##\s*(.*?)\s*##\s*\]\][ \t]*$/gm,
+    (_match, name: string) => {
+      if (name.toLowerCase() === 'completed') {
+        return '';
+      }
+      return `#### ${titleCase(name.trim())}`;
+    },
+  );
+
 export const normalizeDspyChatInput = (obj: unknown): ModelTraceChatMessage[] | null => {
   // Handle DSPy format with messages array
   if (has(obj, 'messages') && isArray((obj as any).messages)) {
@@ -11,7 +33,9 @@ export const normalizeDspyChatInput = (obj: unknown): ModelTraceChatMessage[] | 
       .map((msg: any) =>
         prettyPrintChatMessage({
           type: 'message',
-          content: isString(msg.content) ? toMarkdownWithHardBreaks(msg.content) : msg.content,
+          content: isString(msg.content)
+            ? toMarkdownWithHardBreaks(formatDspySections(msg.content))
+            : msg.content,
           role: msg.role,
         }),
       )
@@ -25,7 +49,7 @@ export const normalizeDspyChatOutput = (obj: unknown): ModelTraceChatMessage[] |
   // Handle DSPy format with array output
   if (isArray(obj) && obj.length > 0 && obj.every(isString)) {
     // Join all output strings into one assistant message
-    const content = toMarkdownWithHardBreaks(obj.join('\n'));
+    const content = toMarkdownWithHardBreaks(formatDspySections(obj.join('\n')));
     const message = prettyPrintChatMessage({ type: 'message', content, role: 'assistant' });
     return message && [message];
   }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
@@ -48,8 +48,21 @@ export const normalizeDspyChatInput = (obj: unknown): ModelTraceChatMessage[] | 
 export const normalizeDspyChatOutput = (obj: unknown): ModelTraceChatMessage[] | null => {
   // Handle DSPy format with array output
   if (isArray(obj) && obj.length > 0 && obj.every(isString)) {
-    // Join all output strings into one assistant message
-    const content = toMarkdownWithHardBreaks(formatDspySections(obj.join('\n')));
+    const joined = obj.join('\n');
+
+    // If the output is valid JSON, render it as a formatted code block
+    let content: string;
+    try {
+      const parsed = JSON.parse(joined);
+      if (typeof parsed === 'object' && parsed !== null) {
+        content = '```json\n' + JSON.stringify(parsed, null, 2) + '\n```';
+      } else {
+        content = toMarkdownWithHardBreaks(formatDspySections(joined));
+      }
+    } catch {
+      content = toMarkdownWithHardBreaks(formatDspySections(joined));
+    }
+
     const message = prettyPrintChatMessage({ type: 'message', content, role: 'assistant' });
     return message && [message];
   }


### PR DESCRIPTION
### Related Issues/PRs

#xxx

### What changes are proposed in this pull request?

DSPy traces embed multiple variables (reasoning, summary, tool_name, etc.) into a single message using `[[ ## variable_name ## ]]` separators, which previously rendered as one long, hard-to-read text block in the chat view. This PR parses those markers and renders them as visually distinct markdown headings (`#### Title Cased Name`), removes the `[[ ## completed ## ]]` terminator, and preserves inline references (e.g. inside backticks) unchanged. A `titleCase` helper converts snake_case names like `tool_name_0` into `Tool Name 0`. Eight new unit tests cover the `formatDspySections` function, and existing tests are updated to assert the new heading format.

**Before**

<img width="1040" height="694" alt="Screenshot 2026-03-03 at 14 44 01" src="https://github.com/user-attachments/assets/dae5e4d2-7621-4185-a71a-2f39b6cf7186" />

**After**

 
<img width="1129" height="681" alt="Screenshot 2026-03-03 at 14 45 13" src="https://github.com/user-attachments/assets/bbb1e392-eabf-47f4-878c-0c21bbc8814c" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

DSPy trace section markers (`[[ ## name ## ]]`) in the chat view are now rendered as formatted markdown headings, improving readability of multi-section DSPy trace outputs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)