### PR TITLE
Fix judge builder instruction textarea

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/HighlightedTextArea.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/HighlightedTextArea.tsx
@@ -144,6 +144,10 @@ export const HighlightedTextArea: React.FC<HighlightedTextAreaProps> = ({
         }}
       >
         {highlightedContent}
+        {/* Textareas render a trailing newline as a visible blank line (for the
+            cursor), but pre-wrap divs do not. Add a space so the backdrop
+            matches the textarea's content height. */}
+        {value?.endsWith('\n') && ' '}
       </div>
 
       {/* Transparent textarea on top for input */}


### PR DESCRIPTION
### Related Issues/PRs

Relates to experiment scorers HighlightedTextArea component

### What changes are proposed in this pull request?

Fixes a scroll desync bug in the `HighlightedTextArea` overlay pattern used in the LLM scorer instructions field. To repro, simply paste a lot of text in the box (enough to cause an overflow), then press enter at the end to create a newline. The two views should now be desynced and editing won't happen on the line you expect.

When the text ends in a newline, the `HighlightedTextArea` becomes shorter than the actual `textarea` used for editing. This seems to be some sort of general bug in the way `pre-wrap` divs handle trailing newlines.

As a workaround, add an explicit new element when the value ends in a newline to prevent this from happening

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Before:

https://github.com/user-attachments/assets/7a7386fd-6b56-4bf5-a786-cbe11d263975




After:



https://github.com/user-attachments/assets/bf6367e0-4436-402f-916b-3518e85e93f2



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix scroll desync in the LLM scorer instructions textarea where the highlighted backdrop would fall out of alignment with the cursor when pressing Enter at the end of overflowing content.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)