### PR TITLE
Fix Create Judge button remaining disabled when selecting judges without expanding Auto evaluation

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/EvaluateTracesSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/EvaluateTracesSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   useDesignSystemTheme,
   Typography,
@@ -59,16 +59,6 @@ const EvaluateTracesSection: React.FC<EvaluateTracesSectionProps> = ({ control, 
     [llmTemplate, instructions],
   );
   const isNonGatewayModel = useMemo(() => getModelProvider(model) === ModelProvider.OTHER, [model]);
-
-  // Set sampleRate based on whether automatic evaluation is allowed
-  useEffect(() => {
-    if (!setValue) return;
-    if (hasExpectations || isNonGatewayModel) {
-      setValue('sampleRate', 0);
-    } else {
-      setValue('sampleRate', 100);
-    }
-  }, [hasExpectations, isNonGatewayModel, setValue]);
 
   const isAutomaticEvaluationEnabled = sampleRate > 0;
   const isSessionLevelScorer = evaluationScope === ScorerEvaluationScope.SESSIONS;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
@@ -24,8 +24,16 @@ import { useTemplateOptions, validateInstructions } from './llmScorerUtils';
 import { isScorerModelSelectionEnabled } from '../../../common/utils/FeatureUtils';
 import { type SCORER_TYPE, ScorerEvaluationScope } from './constants';
 import { COMPONENT_ID_PREFIX, type ScorerFormMode, SCORER_FORM_MODE } from './constants';
-import { LLM_TEMPLATE, isGuidelinesTemplate, type JudgeOutputTypeKind, type JudgePrimitiveOutputType } from './types';
+import {
+  LLM_TEMPLATE,
+  isGuidelinesTemplate,
+  isExpectationsTemplate,
+  type JudgeOutputTypeKind,
+  type JudgePrimitiveOutputType,
+} from './types';
 import { TEMPLATE_INSTRUCTIONS_MAP, EDITABLE_TEMPLATES } from './prompts';
+import { hasTemplateVariable } from './utils/templateUtils';
+import { ModelProvider, getModelProvider } from '../../../gateway/utils/gatewayUtils';
 import EvaluateTracesSection from './EvaluateTracesSection';
 import { ModelSectionRenderer } from './ModelSectionRenderer';
 import OutputTypeSection from './OutputTypeSection';
@@ -70,7 +78,7 @@ interface LLMTemplateSectionProps {
 
 const LLMTemplateSection: React.FC<LLMTemplateSectionProps> = ({ mode, control, setValue, currentTemplate }) => {
   const { theme } = useDesignSystemTheme();
-  const { watch } = useFormContext<LLMScorerFormData>();
+  const { watch, unregister } = useFormContext<LLMScorerFormData>();
   const scope = watch('evaluationScope');
   const intl = useIntl();
   const { templateOptions, displayMap } = useTemplateOptions(scope);
@@ -80,10 +88,16 @@ const LLMTemplateSection: React.FC<LLMTemplateSectionProps> = ({ mode, control, 
   };
 
   const handleTemplateChange = (newTemplate: string) => {
-    const instructions = TEMPLATE_INSTRUCTIONS_MAP[newTemplate] || '';
     const isInstructionsJudge = EDITABLE_TEMPLATES.has(newTemplate);
     setValue('isInstructionsJudge', isInstructionsJudge);
-    setValue('instructions', instructions, { shouldValidate: isInstructionsJudge });
+    if (isInstructionsJudge) {
+      const instructions = TEMPLATE_INSTRUCTIONS_MAP[newTemplate] || '';
+      setValue('instructions', instructions, { shouldValidate: true });
+    } else {
+      // For non-instructions templates, unregister the instructions field
+      // to remove its validation rule.
+      unregister('instructions');
+    }
   };
 
   const isReadOnly = mode !== SCORER_FORM_MODE.CREATE;
@@ -544,7 +558,25 @@ const LLMScorerFormRenderer: React.FC<LLMScorerFormRendererProps> = ({
 }) => {
   const { theme } = useDesignSystemTheme();
   const selectedTemplate = useWatch({ control, name: 'llmTemplate' });
+  const instructions = useWatch({ control, name: 'instructions' });
+  const model = useWatch({ control, name: 'model' });
+  const disableMonitoring = useWatch({ control, name: 'disableMonitoring' });
   const accordionRef = useRef<ScorerFormAccordionHandle>(null);
+
+  // Set sampleRate based on whether automatic evaluation is allowed.
+  // This runs regardless of accordion state, ensuring sampleRate is correct
+  // even if the Automatic evaluation section is never expanded.
+  useEffect(() => {
+    if (disableMonitoring) return;
+    const hasExpectations =
+      isExpectationsTemplate(selectedTemplate) || hasTemplateVariable(instructions, 'expectations');
+    const isNonGatewayModel = getModelProvider(model) === ModelProvider.OTHER;
+    if (hasExpectations || isNonGatewayModel) {
+      setValue('sampleRate', 0);
+    } else {
+      setValue('sampleRate', 100);
+    }
+  }, [selectedTemplate, instructions, model, disableMonitoring, setValue]);
 
   // Check if General section is complete and progress to Evaluation Criteria
   const checkAndProgressGeneral = useCallback(


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Fix the issue that `Create Judge` button is grey when I select judges like `Correctness` without expanding the `Auto evaluation` section.
Before:

https://github.com/user-attachments/assets/c1a71f1d-8a8f-47d7-a73b-47bf33c7e1d3

After:

https://github.com/user-attachments/assets/6a114082-9d84-4dea-b79c-f54fc02e3392



<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
