### PR TITLE
Fix conversation simulator adding wrapper span that breaks custom scorers

### DIFF
--- a/mlflow/entities/evaluation_dataset.py
+++ b/mlflow/entities/evaluation_dataset.py
@@ -173,7 +173,10 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
 
             # Preserve session metadata from the original trace
             source_data = {"trace_id": trace.info.trace_id}
-            if session_id := trace.info.trace_metadata.get(TraceMetadataKey.TRACE_SESSION):
+            if session_id := (
+                trace.info.trace_metadata.get(TraceMetadataKey.TRACE_SESSION)
+                or trace.info.tags.get(TraceMetadataKey.TRACE_SESSION)
+            ):
                 source_data["session_id"] = session_id
 
             record_dict = {

--- a/mlflow/entities/session.py
+++ b/mlflow/entities/session.py
@@ -27,7 +27,9 @@ class Session:
     def id(self) -> str | None:
         if not self._traces:
             return None
-        return self._traces[0].info.request_metadata.get(TraceMetadataKey.TRACE_SESSION)
+        return self._traces[0].info.request_metadata.get(
+            TraceMetadataKey.TRACE_SESSION
+        ) or self._traces[0].info.tags.get(TraceMetadataKey.TRACE_SESSION)
 
     @property
     def traces(self) -> list[Trace]:

--- a/mlflow/genai/evaluation/session_utils.py
+++ b/mlflow/genai/evaluation/session_utils.py
@@ -59,10 +59,11 @@ def group_traces_by_session(
     for item in eval_items:
         session_id = None
 
-        # First, try to get session_id from the trace metadata if trace exists
+        # First, try to get session_id from the trace metadata or tags if trace exists
         if getattr(item, "trace", None):
-            trace_metadata = item.trace.info.trace_metadata
-            session_id = trace_metadata.get(TraceMetadataKey.TRACE_SESSION)
+            session_id = item.trace.info.trace_metadata.get(
+                TraceMetadataKey.TRACE_SESSION
+            ) or item.trace.info.tags.get(TraceMetadataKey.TRACE_SESSION)
 
         # If no session_id found in trace, check the source data (for dataset records)
         if not session_id and item.source is not None:

--- a/mlflow/genai/judges/tools/get_traces_in_session.py
+++ b/mlflow/genai/judges/tools/get_traces_in_session.py
@@ -84,7 +84,9 @@ class GetTracesInSession(JudgeTool):
         Raises:
             MlflowException: If session ID is not found or has invalid format
         """
-        session_id = trace.info.trace_metadata.get(TraceMetadataKey.TRACE_SESSION)
+        session_id = trace.info.trace_metadata.get(
+            TraceMetadataKey.TRACE_SESSION
+        ) or trace.info.tags.get(TraceMetadataKey.TRACE_SESSION)
 
         if not session_id:
             raise MlflowException(

--- a/mlflow/genai/scorers/adk/__init__.py
+++ b/mlflow/genai/scorers/adk/__init__.py
@@ -1,0 +1,510 @@
+"""
+ADK (Agent Development Kit) integration for MLflow.
+
+This module provides integration with Google ADK evaluation metrics, allowing
+them to be used with MLflow's scorer interface.
+
+Example usage:
+
+.. code-block:: python
+
+    from mlflow.genai.scorers.adk import ToolTrajectory, Hallucinations
+
+    result = mlflow.genai.evaluate(
+        data=eval_data,
+        scorers=[
+            ToolTrajectory(match_type="in_order"),
+            Hallucinations(model="gemini-2.5-flash"),
+        ],
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+from pydantic import PrivateAttr
+
+from mlflow.entities.assessment import Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.entities.trace import Trace
+from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
+from mlflow.genai.scorers.adk._mapping import map_adk_result_to_feedback, map_to_adk_invocations
+from mlflow.genai.scorers.adk._registry import (
+    ADK_NOT_INSTALLED_ERROR_MESSAGE,
+    get_adk_metric_name,
+    get_evaluator_class,
+    is_deterministic_metric,
+)
+from mlflow.genai.scorers.base import Scorer, ScorerKind
+from mlflow.utils.annotations import experimental
+
+_logger = logging.getLogger(__name__)
+
+
+@experimental(version="3.8.0")
+class AdkScorer(Scorer):
+    """Base scorer class for ADK evaluation metrics.
+
+    Wraps Google ADK evaluators for use with MLflow's scorer interface.
+
+    Args:
+        metric_name: Name of the ADK metric (e.g., "ToolTrajectory").
+            If not provided, uses the class-level metric_name attribute.
+        model: Model name for LLM-based evaluators (e.g., "gemini-2.5-flash").
+        **kwargs: Additional metric-specific parameters passed to the ADK
+            evaluator's criterion.
+    """
+
+    _evaluator: Any = PrivateAttr()
+
+    def __init__(
+        self,
+        metric_name: str | None = None,
+        model: str | None = None,
+        **kwargs: Any,
+    ):
+        if metric_name is None:
+            metric_name = getattr(self, "metric_name", None)
+            if metric_name is None:
+                raise MlflowException.invalid_parameter_value(
+                    "metric_name must be provided either as an argument or as a "
+                    "class attribute."
+                )
+
+        super().__init__(name=metric_name)
+
+        self._is_deterministic = is_deterministic_metric(metric_name)
+        adk_metric_name = get_adk_metric_name(metric_name)
+
+        if self._is_deterministic:
+            self._model_uri = None
+        else:
+            self._model_uri = model
+
+        self._evaluator = self._create_evaluator(
+            adk_metric_name, model, **kwargs
+        )
+
+    @staticmethod
+    def _create_evaluator(adk_metric_name: str, model: str | None, **kwargs):
+        """Create an ADK evaluator instance with the given configuration."""
+        try:
+            from google.adk.evaluation.eval_metrics import EvalMetric
+        except ImportError as e:
+            raise MlflowException.invalid_parameter_value(
+                ADK_NOT_INSTALLED_ERROR_MESSAGE
+            ) from e
+
+        evaluator_class = get_evaluator_class(adk_metric_name)
+        criterion = _build_criterion(adk_metric_name, model, **kwargs)
+
+        eval_metric = EvalMetric(
+            metric_name=adk_metric_name,
+            criterion=criterion,
+        )
+
+        return evaluator_class(eval_metric=eval_metric)
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.THIRD_PARTY
+
+    @property
+    def is_session_level_scorer(self) -> bool:
+        return False
+
+    def _raise_registration_not_supported(self, method_name: str):
+        raise MlflowException.invalid_parameter_value(
+            f"'{method_name}()' is not supported for third-party scorers like ADK. "
+            f"Third-party scorers cannot be registered, started, updated, or stopped. "
+            f"Use them directly in mlflow.genai.evaluate() instead."
+        )
+
+    def register(self, **kwargs):
+        self._raise_registration_not_supported("register")
+
+    def start(self, **kwargs):
+        self._raise_registration_not_supported("start")
+
+    def update(self, **kwargs):
+        self._raise_registration_not_supported("update")
+
+    def stop(self, **kwargs):
+        self._raise_registration_not_supported("stop")
+
+    def align(self, **kwargs):
+        raise MlflowException.invalid_parameter_value(
+            "'align()' is not supported for third-party scorers like ADK. "
+            "Alignment is only available for MLflow's built-in judges."
+        )
+
+    def __call__(
+        self,
+        *,
+        inputs: Any = None,
+        outputs: Any = None,
+        expectations: dict[str, Any] | None = None,
+        trace: Trace | None = None,
+        session: list[Trace] | None = None,
+    ) -> Feedback:
+        """Evaluate using the wrapped ADK evaluator.
+
+        Args:
+            inputs: The input to evaluate.
+            outputs: The output to evaluate.
+            expectations: Expected values for evaluation (expected_response,
+                expected_tool_calls, rubrics).
+            trace: MLflow trace for extracting tool call information.
+            session: Not used for ADK scorers (per-invocation evaluation).
+
+        Returns:
+            Feedback object with score, rationale, and ADK metadata.
+        """
+        if self._is_deterministic:
+            source_type = AssessmentSourceType.CODE
+            source_id = None
+        else:
+            source_type = AssessmentSourceType.LLM_JUDGE
+            source_id = self._model_uri
+
+        assessment_source = AssessmentSource(
+            source_type=source_type,
+            source_id=source_id,
+        )
+
+        try:
+            actual_invocation, expected_invocation = map_to_adk_invocations(
+                inputs=inputs,
+                outputs=outputs,
+                expectations=expectations,
+                trace=trace,
+            )
+
+            actual_list = [actual_invocation]
+            expected_list = [expected_invocation] if expected_invocation else None
+
+            eval_result = self._evaluator.evaluate_invocations(
+                actual_invocations=actual_list,
+                expected_invocations=expected_list,
+            )
+
+            return map_adk_result_to_feedback(
+                name=self.name,
+                eval_result=eval_result,
+                source=assessment_source,
+                is_deterministic=self._is_deterministic,
+            )
+        except Exception as e:
+            return Feedback(
+                name=self.name,
+                error=e,
+                source=assessment_source,
+            )
+
+
+@experimental(version="3.8.0")
+def get_scorer(
+    metric_name: str,
+    model: str | None = None,
+    **kwargs: Any,
+) -> AdkScorer:
+    """Get an ADK evaluation metric as an MLflow scorer.
+
+    Args:
+        metric_name: Name of the ADK metric. Available metrics:
+            - "ToolTrajectory": Tool call trajectory matching
+            - "FinalResponseMatch": Final response matching (LLM-based)
+            - "ResponseMatch": Response similarity (ROUGE-based)
+            - "RubricBasedResponseQuality": Rubric-based response quality
+            - "RubricBasedToolUseQuality": Rubric-based tool use quality
+            - "Hallucinations": Hallucination detection
+        model: Model name for LLM-based metrics (e.g., "gemini-2.5-flash").
+        **kwargs: Additional metric-specific parameters.
+
+    Returns:
+        AdkScorer instance that can be used with mlflow.genai.evaluate().
+
+    Examples:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers.adk import get_scorer
+
+        scorer = get_scorer("ToolTrajectory", match_type="in_order")
+        feedback = scorer(
+            inputs="Book a flight",
+            outputs="Flight booked",
+            expectations={"expected_tool_calls": ["search_flights", "book_flight"]},
+        )
+    """
+    return AdkScorer(
+        metric_name=metric_name,
+        model=model,
+        **kwargs,
+    )
+
+
+def _build_criterion(adk_metric_name: str, model: str | None, **kwargs):
+    """Build an ADK criterion for the given metric.
+
+    Creates the appropriate criterion subclass based on the metric type.
+    """
+    from google.adk.evaluation.eval_metrics import BaseCriterion
+
+    threshold = kwargs.pop("threshold", 0.5)
+
+    if adk_metric_name == "tool_trajectory_avg_score":
+        from google.adk.evaluation.eval_metrics import ToolTrajectoryCriterion
+
+        match_type = kwargs.pop("match_type", "exact")
+        return ToolTrajectoryCriterion(
+            threshold=threshold,
+            match_type=match_type,
+            **kwargs,
+        )
+
+    if adk_metric_name in (
+        "final_response_match_v2",
+        "rubric_based_final_response_quality_v1",
+        "rubric_based_tool_use_quality_v1",
+    ):
+        from google.adk.evaluation.eval_metrics import (
+            JudgeModelOptions,
+            RubricsBasedCriterion,
+        )
+
+        judge_opts = JudgeModelOptions()
+        if model:
+            judge_opts = JudgeModelOptions(judge_model=model)
+
+        rubrics = kwargs.pop("rubrics", [])
+
+        if adk_metric_name == "final_response_match_v2":
+            from google.adk.evaluation.eval_metrics import LlmAsAJudgeCriterion
+
+            return LlmAsAJudgeCriterion(
+                threshold=threshold,
+                judge_model_options=judge_opts,
+                **kwargs,
+            )
+
+        return RubricsBasedCriterion(
+            threshold=threshold,
+            judge_model_options=judge_opts,
+            rubrics=rubrics,
+            **kwargs,
+        )
+
+    if adk_metric_name == "hallucinations_v1":
+        from google.adk.evaluation.eval_metrics import (
+            HallucinationsCriterion,
+            JudgeModelOptions,
+        )
+
+        judge_opts = JudgeModelOptions()
+        if model:
+            judge_opts = JudgeModelOptions(judge_model=model)
+
+        evaluate_intermediate = kwargs.pop(
+            "evaluate_intermediate_nl_responses", False
+        )
+        return HallucinationsCriterion(
+            threshold=threshold,
+            judge_model_options=judge_opts,
+            evaluate_intermediate_nl_responses=evaluate_intermediate,
+            **kwargs,
+        )
+
+    if adk_metric_name == "response_match_score":
+        return BaseCriterion(threshold=threshold, **kwargs)
+
+    # Fallback: basic criterion
+    return BaseCriterion(threshold=threshold, **kwargs)
+
+
+# Named scorer subclasses for convenience
+
+
+@experimental(version="3.8.0")
+class ToolTrajectory(AdkScorer):
+    """Evaluates tool call trajectory accuracy.
+
+    Compares the sequence of tools called by the agent against expected
+    tool calls using one of three match types: EXACT, IN_ORDER, or ANY_ORDER.
+
+    Args:
+        match_type: Match strategy - "exact", "in_order", or "any_order".
+            Defaults to "exact".
+        threshold: Minimum score for passing (default: 0.5).
+        model: Not used for this deterministic metric.
+
+    Examples:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers.adk import ToolTrajectory
+
+        scorer = ToolTrajectory(match_type="in_order")
+        feedback = scorer(
+            inputs="Book a flight to NYC",
+            outputs="Flight booked",
+            expectations={
+                "expected_tool_calls": ["search_flights", "book_flight"],
+            },
+        )
+    """
+
+    metric_name: ClassVar[str] = "ToolTrajectory"
+
+
+@experimental(version="3.8.0")
+class FinalResponseMatch(AdkScorer):
+    """Evaluates if the agent's final response matches the expected response.
+
+    Uses an LLM judge to determine semantic equivalence between the agent's
+    response and the expected golden response.
+
+    Args:
+        model: LLM model for judging (e.g., "gemini-2.5-flash").
+        threshold: Minimum score for passing (default: 0.5).
+
+    Examples:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers.adk import FinalResponseMatch
+
+        scorer = FinalResponseMatch(model="gemini-2.5-flash")
+        feedback = scorer(
+            inputs="What is Python?",
+            outputs="Python is a programming language.",
+            expectations={"expected_response": "Python is a programming language."},
+        )
+    """
+
+    metric_name: ClassVar[str] = "FinalResponseMatch"
+
+
+@experimental(version="3.8.0")
+class ResponseMatch(AdkScorer):
+    """Evaluates response similarity using ROUGE-based matching.
+
+    A deterministic metric that computes text similarity between the
+    agent's response and the expected response without requiring an LLM.
+
+    Args:
+        threshold: Minimum score for passing (default: 0.5).
+
+    Examples:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers.adk import ResponseMatch
+
+        scorer = ResponseMatch(threshold=0.8)
+        feedback = scorer(
+            inputs="What is Python?",
+            outputs="Python is a programming language.",
+            expectations={"expected_response": "Python is a programming language."},
+        )
+    """
+
+    metric_name: ClassVar[str] = "ResponseMatch"
+
+
+@experimental(version="3.8.0")
+class RubricBasedResponseQuality(AdkScorer):
+    """Evaluates response quality using custom rubrics.
+
+    Uses an LLM judge to assess the agent's response against a set of
+    user-defined rubrics.
+
+    Args:
+        model: LLM model for judging (e.g., "gemini-2.5-flash").
+        rubrics: List of rubric strings or dicts for evaluation.
+        threshold: Minimum score for passing (default: 0.5).
+
+    Examples:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers.adk import RubricBasedResponseQuality
+
+        scorer = RubricBasedResponseQuality(
+            model="gemini-2.5-flash",
+            rubrics=["Response is helpful and accurate"],
+        )
+    """
+
+    metric_name: ClassVar[str] = "RubricBasedResponseQuality"
+
+
+@experimental(version="3.8.0")
+class RubricBasedToolUseQuality(AdkScorer):
+    """Evaluates tool use quality using custom rubrics.
+
+    Uses an LLM judge to assess the agent's tool usage against a set of
+    user-defined rubrics.
+
+    Args:
+        model: LLM model for judging (e.g., "gemini-2.5-flash").
+        rubrics: List of rubric strings or dicts for evaluation.
+        threshold: Minimum score for passing (default: 0.5).
+
+    Examples:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers.adk import RubricBasedToolUseQuality
+
+        scorer = RubricBasedToolUseQuality(
+            model="gemini-2.5-flash",
+            rubrics=["Agent uses the correct tools for the task"],
+        )
+    """
+
+    metric_name: ClassVar[str] = "RubricBasedToolUseQuality"
+
+
+@experimental(version="3.8.0")
+class Hallucinations(AdkScorer):
+    """Detects hallucinations in agent responses.
+
+    Uses an LLM judge to identify fabricated information in the agent's
+    response. Supports evaluating both final and intermediate responses.
+
+    Args:
+        model: LLM model for judging (e.g., "gemini-2.5-flash").
+        evaluate_intermediate_nl_responses: Whether to also evaluate
+            intermediate responses (default: False).
+        threshold: Minimum score for passing (default: 0.5).
+
+    Examples:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers.adk import Hallucinations
+
+        scorer = Hallucinations(model="gemini-2.5-flash")
+        feedback = scorer(
+            inputs="What is the capital of France?",
+            outputs="The capital of France is Paris.",
+        )
+    """
+
+    metric_name: ClassVar[str] = "Hallucinations"
+
+
+__all__ = [
+    "AdkScorer",
+    "get_scorer",
+    "ToolTrajectory",
+    "FinalResponseMatch",
+    "ResponseMatch",
+    "RubricBasedResponseQuality",
+    "RubricBasedToolUseQuality",
+    "Hallucinations",
+]

--- a/mlflow/genai/scorers/adk/_mapping.py
+++ b/mlflow/genai/scorers/adk/_mapping.py
@@ -1,0 +1,317 @@
+"""Converts between MLflow and ADK data models."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mlflow.entities.assessment import Feedback
+from mlflow.entities.assessment_source import AssessmentSource
+from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
+
+_logger = logging.getLogger(__name__)
+
+
+def _text_to_content(text: str):
+    """Convert a plain text string to a genai_types.Content object."""
+    from google.genai import types as genai_types
+
+    return genai_types.Content(parts=[genai_types.Part(text=text)])
+
+
+def _extract_text_from_inputs(inputs: Any) -> str:
+    """Extract text from MLflow inputs (dict, str, or other)."""
+    if inputs is None:
+        return ""
+    if isinstance(inputs, dict):
+        # Try common keys for the user query
+        for key in ("query", "question", "input", "prompt", "request"):
+            if key in inputs:
+                return str(inputs[key])
+        # Fall back to first string value
+        for v in inputs.values():
+            if isinstance(v, str):
+                return v
+        return str(inputs)
+    return str(inputs)
+
+
+def _extract_text_from_outputs(outputs: Any) -> str:
+    """Extract text from MLflow outputs (str or other)."""
+    if outputs is None:
+        return ""
+    if isinstance(outputs, dict):
+        for key in ("response", "output", "answer", "result"):
+            if key in outputs:
+                return str(outputs[key])
+        for v in outputs.values():
+            if isinstance(v, str):
+                return v
+        return str(outputs)
+    return str(outputs)
+
+
+def map_to_adk_invocations(
+    inputs: Any,
+    outputs: Any,
+    expectations: dict[str, Any] | None = None,
+    trace: Any | None = None,
+):
+    """Map MLflow scorer inputs to ADK Invocation objects.
+
+    Args:
+        inputs: MLflow inputs (dict or string).
+        outputs: MLflow outputs (string or dict).
+        expectations: Optional expected values.
+        trace: Optional MLflow trace.
+
+    Returns:
+        Tuple of (actual_invocation, expected_invocation_or_None).
+    """
+    from google.adk.evaluation.eval_case import IntermediateData, Invocation
+
+    # Build actual invocation
+    user_text = _extract_text_from_inputs(inputs)
+    response_text = _extract_text_from_outputs(outputs)
+
+    actual_invocation = Invocation(
+        user_content=_text_to_content(user_text),
+        final_response=_text_to_content(response_text) if response_text else None,
+        intermediate_data=_extract_intermediate_data_from_trace(trace),
+    )
+
+    # Build expected invocation from expectations
+    expected_invocation = None
+    if expectations:
+        expected_response = expectations.get("expected_response")
+        expected_tool_calls = expectations.get("expected_tool_calls")
+        rubrics = expectations.get("rubrics")
+
+        expected_intermediate_data = None
+        if expected_tool_calls:
+            expected_intermediate_data = _parse_expected_tool_calls(
+                expected_tool_calls
+            )
+
+        expected_final_response = None
+        if expected_response:
+            expected_final_response = _text_to_content(str(expected_response))
+
+        expected_rubrics = None
+        if rubrics:
+            expected_rubrics = _parse_rubrics(rubrics)
+
+        expected_invocation = Invocation(
+            user_content=_text_to_content(user_text),
+            final_response=expected_final_response,
+            intermediate_data=expected_intermediate_data,
+            rubrics=expected_rubrics,
+        )
+
+    return actual_invocation, expected_invocation
+
+
+def _extract_intermediate_data_from_trace(trace: Any):
+    """Extract tool calls and responses from an MLflow trace."""
+    if trace is None:
+        return None
+
+    from google.genai import types as genai_types
+
+    from google.adk.evaluation.eval_case import IntermediateData
+
+    tool_calls = []
+    tool_responses = []
+
+    try:
+        # Walk spans looking for tool/function spans
+        if hasattr(trace, "data") and hasattr(trace.data, "spans"):
+            for span in trace.data.spans:
+                if _is_tool_span(span):
+                    fc, fr = _span_to_function_call_and_response(span)
+                    if fc:
+                        tool_calls.append(fc)
+                    if fr:
+                        tool_responses.append(fr)
+    except Exception as e:
+        _logger.debug("Failed to extract tool data from trace: %s", e)
+
+    if tool_calls or tool_responses:
+        return IntermediateData(
+            tool_uses=tool_calls,
+            tool_responses=tool_responses,
+        )
+    return None
+
+
+def _is_tool_span(span) -> bool:
+    """Check if a trace span represents a tool call."""
+    span_type = getattr(span, "span_type", None)
+    if span_type and str(span_type).upper() in ("TOOL", "FUNCTION"):
+        return True
+    name = getattr(span, "name", "")
+    if name and any(
+        kw in name.lower() for kw in ("tool", "function_call", "function")
+    ):
+        return True
+    return False
+
+
+def _span_to_function_call_and_response(span):
+    """Convert a trace span to ADK FunctionCall and FunctionResponse."""
+    from google.genai import types as genai_types
+
+    fc = None
+    fr = None
+
+    name = getattr(span, "name", "unknown_tool")
+    inputs = getattr(span, "inputs", None)
+    outputs = getattr(span, "outputs", None)
+
+    args = {}
+    if isinstance(inputs, dict):
+        args = inputs
+    elif inputs is not None:
+        args = {"input": str(inputs)}
+
+    fc = genai_types.FunctionCall(name=name, args=args)
+
+    if outputs is not None:
+        response_data = {}
+        if isinstance(outputs, dict):
+            response_data = outputs
+        else:
+            response_data = {"result": str(outputs)}
+        fr = genai_types.FunctionResponse(name=name, response=response_data)
+
+    return fc, fr
+
+
+def _parse_expected_tool_calls(expected_tool_calls):
+    """Parse expected tool calls from expectations dict.
+
+    Supports:
+    - List of strings (tool names): [\"search\", \"book\"]
+    - List of dicts: [{\"name\": \"search\", \"args\": {...}}, ...]
+    """
+    from google.genai import types as genai_types
+
+    from google.adk.evaluation.eval_case import IntermediateData
+
+    function_calls = []
+    if isinstance(expected_tool_calls, list):
+        for tc in expected_tool_calls:
+            if isinstance(tc, str):
+                function_calls.append(
+                    genai_types.FunctionCall(name=tc, args={})
+                )
+            elif isinstance(tc, dict):
+                function_calls.append(
+                    genai_types.FunctionCall(
+                        name=tc.get("name", ""),
+                        args=tc.get("args", {}),
+                    )
+                )
+
+    return IntermediateData(tool_uses=function_calls)
+
+
+def _parse_rubrics(rubrics):
+    """Parse rubrics from expectations."""
+    from google.adk.evaluation.eval_rubrics import Rubric, RubricContent
+
+    parsed = []
+    if isinstance(rubrics, list):
+        for i, rubric in enumerate(rubrics):
+            if isinstance(rubric, str):
+                parsed.append(
+                    Rubric(
+                        rubric_id=f"rubric_{i}",
+                        rubric_content=RubricContent(text=rubric),
+                    )
+                )
+            elif isinstance(rubric, dict):
+                parsed.append(
+                    Rubric(
+                        rubric_id=rubric.get("id", f"rubric_{i}"),
+                        rubric_content=RubricContent(
+                            text=rubric.get("content", rubric.get("text", ""))
+                        ),
+                        description=rubric.get("description"),
+                    )
+                )
+    return parsed if parsed else None
+
+
+def map_adk_result_to_feedback(
+    name: str,
+    eval_result,
+    source: AssessmentSource,
+    is_deterministic: bool = False,
+) -> Feedback:
+    """Convert an ADK EvaluationResult to an MLflow Feedback object.
+
+    Args:
+        name: The metric/scorer name.
+        eval_result: ADK EvaluationResult.
+        source: AssessmentSource for the feedback.
+        is_deterministic: Whether the metric is deterministic.
+
+    Returns:
+        MLflow Feedback object.
+    """
+    from google.adk.evaluation.eval_metrics import EvalStatus
+
+    score = eval_result.overall_score
+    status = eval_result.overall_eval_status
+
+    # Build rationale from per-invocation results
+    rationale_parts = []
+    if eval_result.per_invocation_results:
+        for i, inv_result in enumerate(eval_result.per_invocation_results):
+            status_str = inv_result.eval_status.name if inv_result.eval_status else "UNKNOWN"
+            rationale_parts.append(
+                f"Invocation {i}: score={inv_result.score}, status={status_str}"
+            )
+            if inv_result.rubric_scores:
+                for rs in inv_result.rubric_scores:
+                    rationale_parts.append(
+                        f"  Rubric {rs.rubric_id}: score={rs.score}"
+                        + (f", rationale={rs.rationale}" if rs.rationale else "")
+                    )
+
+    rationale = "\n".join(rationale_parts) if rationale_parts else None
+
+    metadata = {
+        FRAMEWORK_METADATA_KEY: "adk",
+        "eval_status": status.name if status else "UNKNOWN",
+    }
+    if score is not None:
+        metadata["score"] = str(score)
+
+    # Use the score as the Feedback value (float)
+    # If score is None, fall back to pass/fail based on status
+    if score is not None:
+        value = score
+    elif status == EvalStatus.PASSED:
+        value = 1.0
+    elif status == EvalStatus.FAILED:
+        value = 0.0
+    else:
+        value = None
+
+    if value is not None:
+        return Feedback(
+            name=name,
+            value=value,
+            rationale=rationale,
+            source=source,
+            metadata=metadata,
+        )
+    else:
+        return Feedback(
+            name=name,
+            error="Evaluation did not produce a score",
+            source=source,
+            metadata=metadata,
+        )

--- a/mlflow/genai/scorers/adk/_registry.py
+++ b/mlflow/genai/scorers/adk/_registry.py
@@ -1,0 +1,89 @@
+"""Registry mapping metric names to ADK evaluator classes and metadata."""
+
+from __future__ import annotations
+
+from mlflow.exceptions import MlflowException
+
+ADK_NOT_INSTALLED_ERROR_MESSAGE = (
+    "google-adk is required to use ADK scorers. "
+    "Install it with: pip install google-adk"
+)
+
+# Registry format: metric_name -> (adk_metric_name, is_deterministic)
+_METRIC_REGISTRY = {
+    "ToolTrajectory": ("tool_trajectory_avg_score", True),
+    "FinalResponseMatch": ("final_response_match_v2", False),
+    "ResponseMatch": ("response_match_score", True),
+    "RubricBasedResponseQuality": ("rubric_based_final_response_quality_v1", False),
+    "RubricBasedToolUseQuality": ("rubric_based_tool_use_quality_v1", False),
+    "Hallucinations": ("hallucinations_v1", False),
+}
+
+# Map ADK metric names to evaluator class paths
+_EVALUATOR_CLASSES = {
+    "tool_trajectory_avg_score": (
+        "google.adk.evaluation.trajectory_evaluator",
+        "TrajectoryEvaluator",
+    ),
+    "final_response_match_v2": (
+        "google.adk.evaluation.final_response_match_v2",
+        "FinalResponseMatchV2Evaluator",
+    ),
+    "response_match_score": (
+        "google.adk.evaluation.response_evaluator",
+        "ResponseEvaluator",
+    ),
+    "rubric_based_final_response_quality_v1": (
+        "google.adk.evaluation.rubric_based_final_response_quality_v1",
+        "RubricBasedFinalResponseQualityV1Evaluator",
+    ),
+    "rubric_based_tool_use_quality_v1": (
+        "google.adk.evaluation.rubric_based_tool_use_quality_v1",
+        "RubricBasedToolUseV1Evaluator",
+    ),
+    "hallucinations_v1": (
+        "google.adk.evaluation.hallucinations_v1",
+        "HallucinationsV1Evaluator",
+    ),
+}
+
+
+def get_adk_metric_name(metric_name: str) -> str:
+    """Get the ADK metric name for a given scorer metric name."""
+    if metric_name in _METRIC_REGISTRY:
+        return _METRIC_REGISTRY[metric_name][0]
+    raise MlflowException.invalid_parameter_value(
+        f"Unknown ADK metric: '{metric_name}'. "
+        f"Available metrics: {', '.join(sorted(_METRIC_REGISTRY.keys()))}"
+    )
+
+
+def is_deterministic_metric(metric_name: str) -> bool:
+    """Check if a metric is deterministic (no LLM judge needed)."""
+    if metric_name in _METRIC_REGISTRY:
+        return _METRIC_REGISTRY[metric_name][1]
+    return False
+
+
+def get_evaluator_class(adk_metric_name: str):
+    """Dynamically import and return the ADK evaluator class."""
+    if adk_metric_name not in _EVALUATOR_CLASSES:
+        available = ", ".join(sorted(_EVALUATOR_CLASSES.keys()))
+        raise MlflowException.invalid_parameter_value(
+            f"No evaluator found for ADK metric '{adk_metric_name}'. "
+            f"Available: {available}"
+        )
+
+    module_path, class_name = _EVALUATOR_CLASSES[adk_metric_name]
+    try:
+        module = __import__(module_path, fromlist=[class_name])
+        return getattr(module, class_name)
+    except ImportError as e:
+        raise MlflowException.invalid_parameter_value(
+            ADK_NOT_INSTALLED_ERROR_MESSAGE
+        ) from e
+    except AttributeError:
+        raise MlflowException.invalid_parameter_value(
+            f"Could not find class '{class_name}' in module '{module_path}'. "
+            "Ensure you have a compatible version of google-adk installed."
+        )

--- a/mlflow/genai/scorers/job.py
+++ b/mlflow/genai/scorers/job.py
@@ -222,16 +222,18 @@ def _run_session_scorer(
 
     session_items = [EvalItem.from_trace(t) for t in traces]
 
-    # Get session_id from the first trace's metadata
+    # Get session_id from the first trace's metadata or tags
     first_session_item = get_first_trace_in_session(session_items)
-    trace_metadata = first_session_item.trace.info.trace_metadata or {}
-    session_id = trace_metadata.get(TraceMetadataKey.TRACE_SESSION)
+    trace_info = first_session_item.trace.info
+    session_id = (trace_info.trace_metadata or {}).get(
+        TraceMetadataKey.TRACE_SESSION
+    ) or (trace_info.tags or {}).get(TraceMetadataKey.TRACE_SESSION)
 
     if not session_id:
         raise MlflowException(
             "Session-level scorer requires traces with session metadata. "
-            f"Trace {first_session_item.trace.info.trace_id} is missing "
-            f"'{TraceMetadataKey.TRACE_SESSION}' in its metadata."
+            f"Trace {trace_info.trace_id} is missing "
+            f"'{TraceMetadataKey.TRACE_SESSION}' in its metadata or tags."
         )
 
     first_trace = first_session_item.trace
@@ -360,8 +362,9 @@ def _group_traces_by_session_id(
     trace_infos = tracking_store.batch_get_trace_infos(trace_ids)
 
     for trace_info in trace_infos:
-        trace_metadata = trace_info.trace_metadata or {}
-        if session_id := trace_metadata.get(TraceMetadataKey.TRACE_SESSION):
+        if session_id := (trace_info.trace_metadata or {}).get(
+            TraceMetadataKey.TRACE_SESSION
+        ) or (trace_info.tags or {}).get(TraceMetadataKey.TRACE_SESSION):
             if session_id not in session_groups:
                 session_groups[session_id] = []
             session_groups[session_id].append(trace_info.trace_id)

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -714,38 +714,6 @@ class ConversationSimulator:
         expectations: dict[str, Any] | None,
         turn: int,
     ) -> tuple[dict[str, Any], str | None]:
-        # NB: We trace the predict_fn call to add session and simulation metadata to the trace.
-        #     This adds a new root span to the trace, with the same inputs and outputs as the
-        #     predict_fn call. The goal/persona/turn metadata is used for trace comparison UI
-        #     since message content may differ between simulation runs.
-        @mlflow.trace(name=f"simulation_turn_{turn}", span_type="CHAIN")
-        def traced_predict(**kwargs):
-            metadata = {
-                TraceMetadataKey.TRACE_SESSION: trace_session_id,
-                "mlflow.simulation.goal": goal[:_MAX_METADATA_LENGTH],
-                "mlflow.simulation.persona": (persona or DEFAULT_PERSONA)[:_MAX_METADATA_LENGTH],
-                "mlflow.simulation.turn": str(turn),
-            }
-            if simulation_guidelines:
-                guidelines_str = (
-                    "\n".join(simulation_guidelines)
-                    if isinstance(simulation_guidelines, list)
-                    else simulation_guidelines
-                )
-                metadata["mlflow.simulation.simulation_guidelines"] = guidelines_str[
-                    :_MAX_METADATA_LENGTH
-                ]
-            mlflow.update_current_trace(metadata=metadata)
-            if span := mlflow.get_current_active_span():
-                span.set_attributes(
-                    {
-                        "mlflow.simulation.goal": goal,
-                        "mlflow.simulation.persona": persona or DEFAULT_PERSONA,
-                        "mlflow.simulation.context": context,
-                    }
-                )
-            return predict_fn(**kwargs)
-
         sig = inspect.signature(predict_fn)
         input_key = "messages" if "messages" in sig.parameters else "input"
         predict_kwargs = {
@@ -754,8 +722,43 @@ class ConversationSimulator:
             **context,
         }
 
-        response = traced_predict(**predict_kwargs)
+        prev_trace_id = mlflow.get_last_active_trace_id(thread_local=True)
+        response = predict_fn(**predict_kwargs)
         trace_id = mlflow.get_last_active_trace_id(thread_local=True)
+
+        # If predict_fn didn't create a new trace, create one so that
+        # evaluation still works for untraced predict functions.
+        if trace_id is None or trace_id == prev_trace_id:
+            with mlflow.start_span(
+                name=getattr(predict_fn, "__name__", "predict"),
+                span_type="CHAIN",
+            ) as span:
+                span.set_inputs({input_key: input_messages})
+                span.set_outputs(response)
+            trace_id = mlflow.get_last_active_trace_id(thread_local=True)
+
+        # Set simulation metadata as trace tags so that the predict_fn's own
+        # root span remains the trace's root span (no wrapper span).
+        if trace_id:
+            tags = {
+                TraceMetadataKey.TRACE_SESSION: trace_session_id,
+                "mlflow.simulation.goal": goal[:_MAX_METADATA_LENGTH],
+                "mlflow.simulation.persona": (persona or DEFAULT_PERSONA)[
+                    :_MAX_METADATA_LENGTH
+                ],
+                "mlflow.simulation.turn": str(turn),
+            }
+            if simulation_guidelines:
+                guidelines_str = (
+                    "\n".join(simulation_guidelines)
+                    if isinstance(simulation_guidelines, list)
+                    else simulation_guidelines
+                )
+                tags["mlflow.simulation.simulation_guidelines"] = guidelines_str[
+                    :_MAX_METADATA_LENGTH
+                ]
+            for key, value in tags.items():
+                mlflow.set_trace_tag(trace_id, key, value)
 
         # Log expectations to the first trace of the session
         if expectations and trace_id:

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -287,7 +287,9 @@ def validate_session(session: list[Trace]) -> None:
     """
     session_id_to_trace_ids: dict[str, list[str]] = {}
     for trace in session:
-        session_id = trace.info.trace_metadata.get(TraceMetadataKey.TRACE_SESSION)
+        session_id = trace.info.trace_metadata.get(
+            TraceMetadataKey.TRACE_SESSION
+        ) or trace.info.tags.get(TraceMetadataKey.TRACE_SESSION)
         if session_id is None:
             raise MlflowException(
                 f"All traces in 'session' must have a session_id. "

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3873,10 +3873,6 @@
     "defaultMessage": "Total",
     "description": "Label for total token usage"
   },
-  "QK9qFL": {
-    "defaultMessage": "Hide assessments",
-    "description": "Label for the button to hide the assessments pane"
-  },
   "QMCliz": {
     "defaultMessage": "Measure and compare LLM quality with built-in and custom scorers.",
     "description": "Feature card summary for evaluation"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3,10 +3,6 @@
     "defaultMessage": "Relevant",
     "description": "Evaluation results > retrieval relevancy assessment > positive value label. Displayed if evaluation result is considered as relevant to the query."
   },
-  "++Ydlz": {
-    "defaultMessage": "Assessments",
-    "description": "Label for the assessments pane"
-  },
   "+/Zrmm": {
     "defaultMessage": "Temperature",
     "description": "Label for temperature input"
@@ -22,6 +18,10 @@
   "+4+wQY": {
     "defaultMessage": "Store it securely and restrict access to server administrators only.",
     "description": "AI Gateway setup guide > Passphrase warning security note"
+  },
+  "+6tmRn": {
+    "defaultMessage": "Name",
+    "description": "Field label for assessment name in a creation form"
   },
   "+8+eEg": {
     "defaultMessage": "Follow these steps to enable the AI Gateway feature for managing AI provider credentials.",
@@ -58,10 +58,6 @@
   "+Njd07": {
     "defaultMessage": "No sessions found",
     "description": "Title for the empty sessions list in the select sessions modal"
-  },
-  "+SBxBK": {
-    "defaultMessage": "Assessment Type",
-    "description": "Field label for assessment type in a creation form"
   },
   "+WPAn1": {
     "defaultMessage": "Enter model name...",
@@ -322,10 +318,6 @@
   "08WP3h": {
     "defaultMessage": "Staging",
     "description": "Column title for staging phase version in the registered model page"
-  },
-  "0AOcOr": {
-    "defaultMessage": "Feedback",
-    "description": "Feedback select menu option for assessment type"
   },
   "0Bee6A": {
     "defaultMessage": "No retrieval logged",
@@ -1789,10 +1781,6 @@
   "AawxF/": {
     "defaultMessage": "Edit Endpoint Name",
     "description": "Title for edit endpoint name modal"
-  },
-  "AdlJNW": {
-    "defaultMessage": "Assessment Name",
-    "description": "Field label for assessment name in a creation form"
   },
   "AeRhuI": {
     "defaultMessage": "Conversational guidelines",
@@ -6187,10 +6175,6 @@
     "defaultMessage": "<strong>{length}</strong> matching {length, plural, =0 {runs} =1 {run} other {runs}}",
     "description": "Message for displaying how many runs match search criteria on experiment page"
   },
-  "gN67TK": {
-    "defaultMessage": "Enter an assessment name",
-    "description": "Placeholder for the assessment name typeahead"
-  },
   "gOUJ0f": {
     "defaultMessage": "No assessment for this evaluation",
     "description": "Text displayed when there is no assessment for a given evaluation"
@@ -7439,6 +7423,10 @@
     "defaultMessage": "Select at least one session to enable actions",
     "description": "Tooltip for disabled actions button when no sessions are selected"
   },
+  "ojLGIx": {
+    "defaultMessage": "Enter a feedback name",
+    "description": "Placeholder for the feedback name typeahead"
+  },
   "okQ1oB": {
     "defaultMessage": "Please input a new name for the new experiment.",
     "description": "Error message for name requirement in create experiment for MLflow"
@@ -8087,10 +8075,6 @@
     "defaultMessage": "Model {modelName} does not exist",
     "description": "Sub-message text for error message on overall model page"
   },
-  "tEaqGu": {
-    "defaultMessage": "Expectation",
-    "description": "Expectation select menu option for assessment type"
-  },
   "tGqJL4": {
     "defaultMessage": "Output",
     "description": "Label for the output tokens in the tooltip for the tokens cell."
@@ -8398,6 +8382,10 @@
   "vxY1CI": {
     "defaultMessage": "Status",
     "description": "Run page > Overview > Run status section label"
+  },
+  "w+Josc": {
+    "defaultMessage": "Enter an expectation name",
+    "description": "Placeholder for the expectation name typeahead"
   },
   "w/sljb": {
     "defaultMessage": "Sort descending",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -392,6 +392,12 @@ const getChatMessagesFromSpan = (
     }
   }
 
+  // When the output is a plain string and inputs parsed as chat messages,
+  // wrap the output as an assistant message so the chat UI can render.
+  if (messagesFromInputs.length > 0 && messagesFromOutputs.length === 0 && typeof outputs === 'string') {
+    return messagesFromInputs.concat([{ role: 'assistant', content: outputs }]);
+  }
+
   // when either input or output is not chat messages, we do not set the chat message fiels.
   if (messagesFromInputs.length === 0 || messagesFromOutputs.length === 0) {
     return undefined;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateButton.tsx
@@ -7,11 +7,13 @@ import { AssessmentCreateForm } from './AssessmentCreateForm';
 export const AssessmentCreateButton = ({
   title,
   assessmentName,
+  assessmentType,
   spanId,
   traceId,
 }: {
   title: React.ReactNode;
   assessmentName?: string;
+  assessmentType: 'feedback' | 'expectation';
   spanId?: string;
   traceId: string;
 }) => {
@@ -39,6 +41,7 @@ export const AssessmentCreateButton = ({
         <AssessmentCreateForm
           ref={ref}
           assessmentName={assessmentName}
+          assessmentType={assessmentType}
           spanId={spanId}
           traceId={traceId}
           setExpanded={setExpanded}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
@@ -46,6 +46,7 @@ describe('AssessmentCreateForm', () => {
   const mockSetExpanded = jest.fn();
   const defaultProps = {
     traceId: 'test-trace-id',
+    assessmentType: 'feedback' as const,
     setExpanded: mockSetExpanded,
   };
 
@@ -54,7 +55,7 @@ describe('AssessmentCreateForm', () => {
   });
 
   describe('handleChangeSchema - existing schemas', () => {
-    it('should update all fields when selecting an existing schema', async () => {
+    it('should update data type when selecting an existing schema', async () => {
       const user = userEvent.setup();
 
       // Mock existing assessments to populate schemas
@@ -65,29 +66,15 @@ describe('AssessmentCreateForm', () => {
 
       render(
         <TestWrapper assessments={existingAssessments}>
-          <AssessmentCreateForm {...defaultProps} />
+          <AssessmentCreateForm {...defaultProps} assessmentType="expectation" />
         </TestWrapper>,
       );
 
-      // Get the select buttons
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
       const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
-
-      expect(assessmentTypeSelect).toBeInTheDocument();
       expect(dataTypeSelect).toBeInTheDocument();
-
-      // Verify initial values
-      expect(assessmentTypeSelect).toHaveTextContent('Feedback');
       expect(dataTypeSelect).toHaveTextContent('Boolean');
 
-      // Change assessment type to expectation and data type to number
-      await user.click(assessmentTypeSelect);
-      const expectationOption = await screen.findByText('Expectation');
-      await user.click(expectationOption);
-      await waitFor(() => {
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
-      });
-
+      // Change data type to number
       await user.click(dataTypeSelect);
       await user.click(screen.getAllByText('Number')[0]);
       await waitFor(() => {
@@ -95,7 +82,7 @@ describe('AssessmentCreateForm', () => {
       });
 
       // Open the name typeahead
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter an expectation name');
       await user.click(nameInput);
 
       // Select an existing schema (expected_facts which is expectation/json)
@@ -104,17 +91,16 @@ describe('AssessmentCreateForm', () => {
       });
       await user.click(screen.getByText('expected_facts'));
 
-      // All fields should be updated to match the schema
+      // Data type should be updated to match the schema
       await waitFor(() => {
         expect(nameInput).toHaveValue('expected_facts');
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('JSON');
       });
     });
   });
 
   describe('handleChangeSchema - new assessment names', () => {
-    it('should preserve user-selected fields when typing a new assessment name', async () => {
+    it('should preserve user-selected data type when typing a new assessment name', async () => {
       const user = userEvent.setup();
 
       // Mock existing assessments to populate schemas
@@ -126,18 +112,9 @@ describe('AssessmentCreateForm', () => {
         </TestWrapper>,
       );
 
-      // Get the select buttons
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
       const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
-      // Change assessment type to expectation and data type to number
-      await user.click(assessmentTypeSelect);
-      const expectationOption = await screen.findByText('Expectation');
-      await user.click(expectationOption);
-      await waitFor(() => {
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
-      });
-
+      // Change data type to number
       await user.click(dataTypeSelect);
       await user.click(screen.getByText('Number'));
       await waitFor(() => {
@@ -145,7 +122,7 @@ describe('AssessmentCreateForm', () => {
       });
 
       // Type a new assessment name that doesn't exist in schemas
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter a feedback name');
       await user.type(nameInput, 'my_new_assessment');
 
       // Open the dropdown
@@ -159,15 +136,14 @@ describe('AssessmentCreateForm', () => {
       // Select the new name
       await user.click(screen.getByText('my_new_assessment'));
 
-      // Name should be updated, but assessment type and data type should be preserved
+      // Name should be updated, but data type should be preserved
       await waitFor(() => {
         expect(nameInput).toHaveValue('my_new_assessment');
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('Number');
       });
     });
 
-    it('should preserve user-selected fields when pressing Enter on a new name', async () => {
+    it('should preserve user-selected data type when pressing Enter on a new name', async () => {
       const user = userEvent.setup();
 
       const existingAssessments: Assessment[] = [MOCK_ASSESSMENT];
@@ -178,39 +154,31 @@ describe('AssessmentCreateForm', () => {
         </TestWrapper>,
       );
 
-      // Get the select buttons
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
       const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
-      // Change to non-default values
-      await user.click(assessmentTypeSelect);
-      const expectationOption = await screen.findByText('Expectation');
-      await user.click(expectationOption);
-
+      // Change to non-default value
       await user.click(dataTypeSelect);
       await user.click(screen.getAllByText('String')[0]);
 
       await waitFor(() => {
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('String');
       });
 
       // Type a new name and press Enter
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter a feedback name');
       await user.type(nameInput, 'another_new_name');
       await user.keyboard('{Enter}');
 
-      // Fields should be preserved
+      // Data type should be preserved
       await waitFor(() => {
         expect(nameInput).toHaveValue('another_new_name');
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('String');
       });
     });
   });
 
   describe('handleChangeSchema - clearing selection', () => {
-    it('should reset all fields when clearing the name', async () => {
+    it('should reset fields when clearing the name', async () => {
       const user = userEvent.setup();
 
       render(
@@ -219,25 +187,15 @@ describe('AssessmentCreateForm', () => {
         </TestWrapper>,
       );
 
-      // Get the select button
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
-
-      // Change some values
-      await user.click(assessmentTypeSelect);
-      const expectationOption = await screen.findByText('Expectation');
-      await user.click(expectationOption);
-
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter a feedback name');
       await user.type(nameInput, 'test_name');
 
       // Clear the input (simulating the clear button)
       await user.clear(nameInput);
 
-      // All fields should reset to defaults
+      // Fields should reset to defaults
       await waitFor(() => {
         expect(nameInput).toHaveValue('');
-        // Note: We can't easily test the internal state reset here
-        // as the selects may not visibly change until interaction
       });
     });
   });
@@ -252,31 +210,24 @@ describe('AssessmentCreateForm', () => {
         </TestWrapper>,
       );
 
-      // Get the select buttons
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
       const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
-      // Change to non-default values
-      await user.click(assessmentTypeSelect);
-      await user.click(screen.getByText('Expectation'));
-
+      // Change to non-default value
       await user.click(dataTypeSelect);
       await user.click(screen.getByText('Number'));
 
       await waitFor(() => {
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('Number');
       });
 
       // Type a name when there are no existing schemas
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter a feedback name');
       await user.type(nameInput, 'first_assessment');
       await user.keyboard('{Enter}');
 
-      // Fields should be preserved since this is a new name
+      // Data type should be preserved since this is a new name
       await waitFor(() => {
         expect(nameInput).toHaveValue('first_assessment');
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
         expect(dataTypeSelect).toHaveTextContent('Number');
       });
     });
@@ -292,20 +243,10 @@ describe('AssessmentCreateForm', () => {
         </TestWrapper>,
       );
 
-      // Get the select buttons
-      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
       const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
-      // Change values first
-      await user.click(assessmentTypeSelect);
-      await user.click(screen.getByText('Expectation'));
-
-      await waitFor(() => {
-        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
-      });
-
       // Type the exact name of an existing schema
-      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      const nameInput = screen.getByPlaceholderText('Enter a feedback name');
       await user.type(nameInput, 'Relevance');
       await user.click(nameInput);
 
@@ -315,10 +256,9 @@ describe('AssessmentCreateForm', () => {
       });
       await user.click(screen.getByTestId('assessment-name-typeahead-item-Relevance'));
 
-      // Since 'Relevance' is an existing schema (feedback/string), it should update all fields
+      // Since 'Relevance' is an existing schema (feedback/string), it should update data type
       await waitFor(() => {
         expect(nameInput).toHaveValue('Relevance');
-        expect(assessmentTypeSelect).toHaveTextContent('Feedback');
         expect(dataTypeSelect).toHaveTextContent('String');
       });
     });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
@@ -1,14 +1,7 @@
 import { isNil } from 'lodash';
 import { forwardRef, useCallback, useState } from 'react';
 
-import {
-  Button,
-  Input,
-  SimpleSelect,
-  SimpleSelectOption,
-  Typography,
-  useDesignSystemTheme,
-} from '@databricks/design-system';
+import { Button, Input, SimpleSelect, SimpleSelectOption, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { getUser } from '../../global-settings/getUser';
 
@@ -34,7 +27,7 @@ const ComponentMap: Record<AssessmentFormInputDataType, React.ComponentType<Asse
 
 type AssessmentCreateFormProps = {
   assessmentName?: string;
-  initialAssessmentType?: 'feedback' | 'expectation';
+  assessmentType: 'feedback' | 'expectation';
   spanId?: string;
   traceId: string;
   setExpanded: (expanded: boolean) => void;
@@ -45,7 +38,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
   (
     {
       assessmentName,
-      initialAssessmentType,
+      assessmentType,
       spanId,
       traceId,
       // used to close the form
@@ -58,9 +51,6 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
     const { schemas } = useAssessmentSchemas();
 
     const [name, setName] = useState('');
-    const [assessmentType, setAssessmentType] = useState<'feedback' | 'expectation'>(
-      initialAssessmentType ?? 'feedback',
-    );
     const [dataType, setDataType] = useState<AssessmentFormInputDataType>('boolean');
     const [value, setValue] = useState<string | boolean | number>(true);
     const [rationale, setRationale] = useState('');
@@ -143,7 +133,6 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
         // clear the form back to defaults
         if (!schema) {
           setName('');
-          setAssessmentType(initialAssessmentType ?? 'feedback');
           setDataType('boolean');
           setValue(true);
           setRationale('');
@@ -155,7 +144,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
         const isRealSchema = schemas.some((s) => s.name === schema.name);
 
         // Only update the name if it's a new assessment name (not in schemas)
-        // This preserves the user's selections for assessment type and data type
+        // This preserves the user's selections for data type
         if (!isRealSchema) {
           setName(schema.name);
           return;
@@ -163,7 +152,6 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
 
         // For existing schemas, update all fields
         setName(schema.name);
-        setAssessmentType(schema.assessmentType);
         setDataType(schema.dataType);
 
         // set the appropriate empty value for the data type
@@ -180,7 +168,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
             break;
         }
       },
-      [schemas, initialAssessmentType],
+      [schemas],
     );
 
     return (
@@ -197,37 +185,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
       >
         <Typography.Text size="sm" color="secondary">
           <FormattedMessage
-            defaultMessage="Assessment Type"
-            description="Field label for assessment type in a creation form"
-          />
-        </Typography.Text>
-        <SimpleSelect
-          id="shared.model-trace-explorer.assessment-type-select"
-          componentId="shared.model-trace-explorer.assessment-type-select"
-          label="Assessment Type"
-          value={assessmentType}
-          disabled={isLoading}
-          onChange={(e) => {
-            setAssessmentType(e.target.value as 'feedback' | 'expectation');
-            // JSON data is not available for feedback
-            if (e.target.value === 'feedback' && dataType === 'json') {
-              setDataType('string');
-            }
-          }}
-        >
-          <SimpleSelectOption value="feedback">
-            <FormattedMessage defaultMessage="Feedback" description="Feedback select menu option for assessment type" />
-          </SimpleSelectOption>
-          <SimpleSelectOption value="expectation">
-            <FormattedMessage
-              defaultMessage="Expectation"
-              description="Expectation select menu option for assessment type"
-            />
-          </SimpleSelectOption>
-        </SimpleSelect>
-        <Typography.Text css={{ marginTop: theme.spacing.xs }} size="sm" color="secondary">
-          <FormattedMessage
-            defaultMessage="Assessment Name"
+            defaultMessage="Name"
             description="Field label for assessment name in a creation form"
           />
         </Typography.Text>
@@ -240,6 +198,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
             handleChangeSchema={handleChangeSchema}
             nameError={nameError}
             setNameError={setNameError}
+            assessmentType={assessmentType}
           />
         )}
         <Typography.Text css={{ marginTop: theme.spacing.xs }} size="sm" color="secondary">

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateNameTypeahead.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateNameTypeahead.tsx
@@ -9,10 +9,21 @@ import {
   TypeaheadComboboxRoot,
   useComboboxState,
 } from '@databricks/design-system';
-import { useIntl } from '@databricks/i18n';
+import { defineMessages, useIntl } from '@databricks/i18n';
 
 import type { AssessmentSchema } from '../contexts/AssessmentSchemaContext';
 import { useAssessmentSchemas } from '../contexts/AssessmentSchemaContext';
+
+const placeholderMessages = defineMessages({
+  feedback: {
+    defaultMessage: 'Enter a feedback name',
+    description: 'Placeholder for the feedback name typeahead',
+  },
+  expectation: {
+    defaultMessage: 'Enter an expectation name',
+    description: 'Placeholder for the expectation name typeahead',
+  },
+});
 
 const getDefaultSchema = (name: string): AssessmentSchema => ({
   name,
@@ -26,12 +37,14 @@ export const AssessmentCreateNameTypeahead = ({
   nameError,
   setNameError,
   handleChangeSchema,
+  assessmentType,
 }: {
   name: string;
   setName: Dispatch<SetStateAction<string>>;
   nameError: React.ReactNode | null;
   setNameError: Dispatch<SetStateAction<React.ReactNode | null>>;
   handleChangeSchema: (schema: AssessmentSchema | null) => void;
+  assessmentType: 'feedback' | 'expectation';
 }) => {
   const { schemas } = useAssessmentSchemas();
   const intl = useIntl();
@@ -99,10 +112,7 @@ export const AssessmentCreateNameTypeahead = ({
     >
       <TypeaheadComboboxInput
         data-testid="assessment-name-typeahead-input"
-        placeholder={intl.formatMessage({
-          defaultMessage: 'Enter an assessment name',
-          description: 'Placeholder for the assessment name typeahead',
-        })}
+        placeholder={intl.formatMessage(placeholderMessages[assessmentType])}
         validationState={nameError ? 'error' : undefined}
         comboboxState={comboboxState}
         formOnChange={formOnChange}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentPaneToggle.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentPaneToggle.tsx
@@ -1,4 +1,4 @@
-import { useDesignSystemTheme, SidebarExpandIcon, Button, SidebarCollapseIcon } from '@databricks/design-system';
+import { Button, SidebarCollapseIcon } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
@@ -7,26 +7,23 @@ export const AssessmentPaneToggle = () => {
   const { assessmentsPaneExpanded, setAssessmentsPaneExpanded, assessmentsPaneEnabled } =
     useModelTraceExplorerViewState();
 
+  if (assessmentsPaneExpanded) {
+    return null;
+  }
+
   return (
     <Button
       disabled={!assessmentsPaneEnabled}
       type="primary"
       componentId="shared.model-trace-explorer.assessments-pane-toggle"
       size="small"
-      icon={assessmentsPaneExpanded ? <SidebarExpandIcon /> : <SidebarCollapseIcon />}
-      onClick={() => setAssessmentsPaneExpanded?.(!assessmentsPaneExpanded)}
+      icon={<SidebarCollapseIcon />}
+      onClick={() => setAssessmentsPaneExpanded?.(true)}
     >
-      {assessmentsPaneExpanded ? (
-        <FormattedMessage
-          defaultMessage="Hide assessments"
-          description="Label for the button to hide the assessments pane"
-        />
-      ) : (
-        <FormattedMessage
-          defaultMessage="Show assessments"
-          description="Label for the button to show the assessments pane"
-        />
-      )}
+      <FormattedMessage
+        defaultMessage="Show assessments"
+        description="Label for the button to show the assessments pane"
+      />
     </Button>
   );
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -71,11 +71,7 @@ export const AssessmentsPane = ({
       className={className}
     >
       <div css={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-        {assessmentsTitleOverride ? (
-          assessmentsTitleOverride()
-        ) : (
-          <FormattedMessage defaultMessage="Assessments" description="Label for the assessments pane" />
-        )}
+        {assessmentsTitleOverride ? assessmentsTitleOverride() : <span />}
         {setAssessmentsPaneExpanded && !disableCloseButton && (
           <Tooltip
             componentId="shared.model-trace-explorer.close-assessments-pane-tooltip"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneExpectationsSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneExpectationsSection.tsx
@@ -96,7 +96,7 @@ export const AssessmentsPaneExpectationsSection = ({
         <AssessmentCreateForm
           spanId={activeSpanId}
           traceId={traceId}
-          initialAssessmentType="expectation"
+          assessmentType="expectation"
           setExpanded={() => setCreateFormVisible(false)}
         />
       )}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -314,7 +314,7 @@ export const AssessmentsPaneFeedbackSection = ({
         <AssessmentCreateForm
           spanId={activeSpanId}
           traceId={traceId}
-          initialAssessmentType="feedback"
+          assessmentType="feedback"
           setExpanded={() => setCreateFormVisible(false)}
         />
       )}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackGroup.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackGroup.tsx
@@ -105,6 +105,7 @@ export const FeedbackGroup = ({
       {showCreateForm && (
         <AssessmentCreateForm
           assessmentName={name}
+          assessmentType="feedback"
           spanId={activeSpanId}
           traceId={traceId}
           setExpanded={setShowCreateForm}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.test.ts
@@ -23,6 +23,31 @@ describe('normalizeConversation (OTEL GenAI)', () => {
     ]);
   });
 
+  it('normalizes messages with non-standard role casing', () => {
+    const input = [
+      {
+        role: 'System',
+        parts: [{ type: 'text', content: 'You are a helpful assistant.' }],
+      },
+      {
+        role: 'User',
+        parts: [{ type: 'text', content: 'What is MLflow?' }],
+      },
+      {
+        role: 'Assistant',
+        parts: [{ type: 'text', content: 'MLflow is an open-source platform.' }],
+      },
+    ];
+
+    const result = normalizeConversation(input);
+
+    expect(result).toEqual([
+      expect.objectContaining({ role: 'system', content: 'You are a helpful assistant.' }),
+      expect.objectContaining({ role: 'user', content: 'What is MLflow?' }),
+      expect.objectContaining({ role: 'assistant', content: 'MLflow is an open-source platform.' }),
+    ]);
+  });
+
   it('normalizes tool call request and response', () => {
     const input = [
       {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.ts
@@ -28,7 +28,7 @@ type OtelToolCallResponsePart = OtelBasePart & {
 type OTelGenAIPart = OtelTextPart | OtelToolCallRequestPart | OtelToolCallResponsePart;
 
 type OtelGenAIMessage = {
-  role: 'system' | 'user' | 'assistant' | 'tool';
+  role: string;
   name?: string;
   parts: OTelGenAIPart[];
 };
@@ -58,7 +58,7 @@ const isSupportedOtelPart = (obj: unknown): obj is OTelGenAIPart => {
 export const isOtelGenAIChatMessage = (obj: unknown): obj is OtelGenAIMessage => {
   if (!isObject(obj)) return false;
   const role = get(obj, 'role');
-  if (!isString(role) || !['system', 'user', 'assistant', 'tool'].includes(role)) return false;
+  if (!isString(role)) return false;
   if (!has(obj, 'parts') || !isArray((obj as any).parts) || (obj as any).parts.length === 0) return false;
   return (obj as any).parts.every(isSupportedOtelPart);
 };
@@ -101,7 +101,7 @@ const normalizeToolCallResponsePart = (part: OtelToolCallResponsePart): ModelTra
 // Convert a single OTEL GenAI message into a single UI message.
 export const normalizeOtelGenAIChatMessage = (obj: OtelGenAIMessage): ModelTraceChatMessage | null => {
   if (!isOtelGenAIChatMessage(obj)) return null;
-  const role: ModelTraceChatMessage['role'] = obj.role as any;
+  const role: ModelTraceChatMessage['role'] = obj.role.toLowerCase() as any;
 
   const contentParts: ModelTraceContentParts[] = [];
   const toolCalls: ModelTraceToolCall[] = [];

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -1063,7 +1063,9 @@ def search_sessions(
         )
 
         for trace in traces:
-            session_id = trace.info.request_metadata.get(session_id_key)
+            session_id = trace.info.request_metadata.get(
+                session_id_key
+            ) or trace.info.tags.get(session_id_key)
             if session_id and session_id not in seen_session_ids:
                 seen_session_ids.add(session_id)
                 session_ids.append(session_id)

--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -423,12 +423,11 @@ def sanitize_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
             result = json.loads(value)
             if isinstance(result, str):
                 try:
-                    # If the original value is a string or dict, we store it as
-                    # a JSON-encoded string.  For other types, we store the original value directly.
-                    # For string type, this is to avoid interpreting "1" as an int accidentally.
-                    # For dictionary, we save the json-encoded-once string so that the UI can render
-                    # it correctly after loading.
-                    if isinstance(json.loads(result), (str, dict)):
+                    # If the value was double-encoded (e.g., via OTLP where from_otel_proto
+                    # calls dump_span_attribute_value on an already-serialized string), strip
+                    # one layer of encoding. The inner json.loads verifies the result is valid
+                    # JSON so we don't accidentally mangle non-JSON strings.
+                    if json.loads(result) is not None:
                         updated_attributes[key] = result
                         continue
                 except json.JSONDecodeError:

--- a/mlflow/tracing/processor/uc_table.py
+++ b/mlflow/tracing/processor/uc_table.py
@@ -81,6 +81,9 @@ class DatabricksUCTableSpanProcessor(BaseMlflowSpanProcessor):
                 (TraceMetadataKey.TRACE_USER, SpanAttributeKey.USER_ID),
                 (TraceMetadataKey.TRACE_SESSION, SpanAttributeKey.SESSION_ID),
             ):
-                if value := trace.info.trace_metadata.get(meta_key):
+                if value := (
+                    trace.info.trace_metadata.get(meta_key)
+                    or trace.info.tags.get(meta_key)
+                ):
                     with _bypass_attribute_guard(mlflow_span._span):
                         mlflow_span._span.set_attribute(attr_key, value)

--- a/tests/genai/scorers/adk/test_adk_scorer.py
+++ b/tests/genai/scorers/adk/test_adk_scorer.py
@@ -1,0 +1,459 @@
+"""Tests for ADK evaluation metrics as MLflow scorers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mlflow.entities.assessment import Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
+from mlflow.genai.scorers.adk._mapping import (
+    _extract_text_from_inputs,
+    _extract_text_from_outputs,
+    _parse_expected_tool_calls,
+    _text_to_content,
+    map_adk_result_to_feedback,
+    map_to_adk_invocations,
+)
+from mlflow.genai.scorers.adk._registry import (
+    _METRIC_REGISTRY,
+    get_adk_metric_name,
+    is_deterministic_metric,
+)
+from mlflow.genai.scorers.base import ScorerKind
+
+
+# --- Tests for _registry.py ---
+
+
+class TestRegistry:
+    def test_get_adk_metric_name(self):
+        assert get_adk_metric_name("ToolTrajectory") == "tool_trajectory_avg_score"
+        assert get_adk_metric_name("Hallucinations") == "hallucinations_v1"
+        assert get_adk_metric_name("ResponseMatch") == "response_match_score"
+
+    def test_get_adk_metric_name_unknown(self):
+        with pytest.raises(Exception, match="Unknown ADK metric"):
+            get_adk_metric_name("NonExistentMetric")
+
+    def test_is_deterministic_metric(self):
+        assert is_deterministic_metric("ToolTrajectory") is True
+        assert is_deterministic_metric("ResponseMatch") is True
+        assert is_deterministic_metric("Hallucinations") is False
+        assert is_deterministic_metric("FinalResponseMatch") is False
+
+    def test_registry_completeness(self):
+        expected_metrics = {
+            "ToolTrajectory",
+            "FinalResponseMatch",
+            "ResponseMatch",
+            "RubricBasedResponseQuality",
+            "RubricBasedToolUseQuality",
+            "Hallucinations",
+        }
+        assert set(_METRIC_REGISTRY.keys()) == expected_metrics
+
+
+# --- Tests for _mapping.py ---
+
+
+class TestTextToContent:
+    def test_basic_text(self):
+        content = _text_to_content("Hello world")
+        assert content.parts[0].text == "Hello world"
+
+    def test_empty_text(self):
+        content = _text_to_content("")
+        assert content.parts[0].text == ""
+
+
+class TestExtractTextFromInputs:
+    def test_dict_with_query(self):
+        assert _extract_text_from_inputs({"query": "test"}) == "test"
+
+    def test_dict_with_question(self):
+        assert _extract_text_from_inputs({"question": "test"}) == "test"
+
+    def test_dict_with_input(self):
+        assert _extract_text_from_inputs({"input": "test"}) == "test"
+
+    def test_string_input(self):
+        assert _extract_text_from_inputs("test string") == "test string"
+
+    def test_none_input(self):
+        assert _extract_text_from_inputs(None) == ""
+
+    def test_dict_fallback_to_first_string(self):
+        result = _extract_text_from_inputs({"custom_key": "value"})
+        assert result == "value"
+
+
+class TestExtractTextFromOutputs:
+    def test_string_output(self):
+        assert _extract_text_from_outputs("response text") == "response text"
+
+    def test_dict_with_response(self):
+        assert _extract_text_from_outputs({"response": "text"}) == "text"
+
+    def test_none_output(self):
+        assert _extract_text_from_outputs(None) == ""
+
+
+class TestParseExpectedToolCalls:
+    def test_list_of_strings(self):
+        result = _parse_expected_tool_calls(["search", "book"])
+        assert len(result.tool_uses) == 2
+        assert result.tool_uses[0].name == "search"
+        assert result.tool_uses[1].name == "book"
+
+    def test_list_of_dicts(self):
+        result = _parse_expected_tool_calls([
+            {"name": "search", "args": {"q": "flights"}},
+            {"name": "book", "args": {"id": "123"}},
+        ])
+        assert len(result.tool_uses) == 2
+        assert result.tool_uses[0].name == "search"
+        assert result.tool_uses[0].args == {"q": "flights"}
+
+
+class TestMapToAdkInvocations:
+    def test_basic_mapping(self):
+        actual, expected = map_to_adk_invocations(
+            inputs={"query": "What is Python?"},
+            outputs="Python is a language.",
+        )
+
+        assert actual.user_content.parts[0].text == "What is Python?"
+        assert actual.final_response.parts[0].text == "Python is a language."
+        assert expected is None
+
+    def test_with_expectations(self):
+        actual, expected = map_to_adk_invocations(
+            inputs={"query": "What is Python?"},
+            outputs="Python is a language.",
+            expectations={
+                "expected_response": "Python is a programming language.",
+                "expected_tool_calls": ["search"],
+            },
+        )
+
+        assert expected is not None
+        assert expected.final_response.parts[0].text == "Python is a programming language."
+        assert len(expected.intermediate_data.tool_uses) == 1
+        assert expected.intermediate_data.tool_uses[0].name == "search"
+
+    def test_string_inputs(self):
+        actual, _ = map_to_adk_invocations(
+            inputs="raw string input",
+            outputs="raw output",
+        )
+        assert actual.user_content.parts[0].text == "raw string input"
+
+    def test_none_outputs(self):
+        actual, _ = map_to_adk_invocations(
+            inputs="test",
+            outputs=None,
+        )
+        assert actual.final_response is None
+
+
+class TestMapAdkResultToFeedback:
+    def _make_eval_result(self, overall_score, status_name):
+        from google.adk.evaluation.eval_metrics import EvalStatus
+        from google.adk.evaluation.evaluator import EvaluationResult
+
+        status = getattr(EvalStatus, status_name)
+        return EvaluationResult(
+            overall_score=overall_score,
+            overall_eval_status=status,
+        )
+
+    def test_passed_result(self):
+        eval_result = self._make_eval_result(0.9, "PASSED")
+        source = AssessmentSource(source_type=AssessmentSourceType.CODE)
+
+        feedback = map_adk_result_to_feedback(
+            name="test_metric",
+            eval_result=eval_result,
+            source=source,
+        )
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.name == "test_metric"
+        assert feedback.value == 0.9
+        assert feedback.metadata[FRAMEWORK_METADATA_KEY] == "adk"
+        assert feedback.metadata["eval_status"] == "PASSED"
+
+    def test_failed_result(self):
+        eval_result = self._make_eval_result(0.3, "FAILED")
+        source = AssessmentSource(source_type=AssessmentSourceType.CODE)
+
+        feedback = map_adk_result_to_feedback(
+            name="test_metric",
+            eval_result=eval_result,
+            source=source,
+        )
+
+        assert feedback.value == 0.3
+
+    def test_not_evaluated_result(self):
+        eval_result = self._make_eval_result(None, "NOT_EVALUATED")
+        source = AssessmentSource(source_type=AssessmentSourceType.CODE)
+
+        feedback = map_adk_result_to_feedback(
+            name="test_metric",
+            eval_result=eval_result,
+            source=source,
+        )
+
+        assert feedback.error is not None
+
+
+# --- Tests for AdkScorer ---
+
+# Patch _create_evaluator at the class level since it's a static method
+# that creates real ADK objects internally. We mock it to return a mock
+# evaluator directly.
+_PATCH_CREATE_EVALUATOR = "mlflow.genai.scorers.adk.AdkScorer._create_evaluator"
+
+
+class TestAdkScorer:
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_scorer_kind(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import AdkScorer
+
+        scorer = AdkScorer(metric_name="ToolTrajectory")
+        assert scorer.kind == ScorerKind.THIRD_PARTY
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_is_not_session_level(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import AdkScorer
+
+        scorer = AdkScorer(metric_name="ToolTrajectory")
+        assert scorer.is_session_level_scorer is False
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_register_not_supported(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import AdkScorer
+
+        scorer = AdkScorer(metric_name="ToolTrajectory")
+        with pytest.raises(Exception, match="not supported"):
+            scorer.register()
+        with pytest.raises(Exception, match="not supported"):
+            scorer.start()
+        with pytest.raises(Exception, match="not supported"):
+            scorer.stop()
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_call_with_successful_evaluation(self, mock_create):
+        from google.adk.evaluation.eval_case import Invocation
+        from google.adk.evaluation.eval_metrics import EvalStatus
+        from google.adk.evaluation.evaluator import EvaluationResult, PerInvocationResult
+        from google.genai import types as genai_types
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_invocations.return_value = EvaluationResult(
+            overall_score=1.0,
+            overall_eval_status=EvalStatus.PASSED,
+            per_invocation_results=[
+                PerInvocationResult(
+                    actual_invocation=Invocation(
+                        user_content=genai_types.Content(
+                            parts=[genai_types.Part(text="test")]
+                        ),
+                    ),
+                    score=1.0,
+                    eval_status=EvalStatus.PASSED,
+                )
+            ],
+        )
+        mock_create.return_value = mock_evaluator
+
+        from mlflow.genai.scorers.adk import AdkScorer
+
+        scorer = AdkScorer(metric_name="ToolTrajectory")
+        feedback = scorer(
+            inputs={"query": "test"},
+            outputs="test output",
+            expectations={"expected_tool_calls": ["tool1"]},
+        )
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.value == 1.0
+        assert feedback.metadata[FRAMEWORK_METADATA_KEY] == "adk"
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_call_handles_evaluator_error(self, mock_create):
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_invocations.side_effect = RuntimeError(
+            "Evaluator failed"
+        )
+        mock_create.return_value = mock_evaluator
+
+        from mlflow.genai.scorers.adk import AdkScorer
+
+        scorer = AdkScorer(metric_name="ToolTrajectory")
+        feedback = scorer(
+            inputs={"query": "test"},
+            outputs="test output",
+        )
+
+        assert isinstance(feedback, Feedback)
+        assert feedback.error is not None
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_deterministic_scorer_source_type(self, mock_create):
+        from google.adk.evaluation.eval_case import Invocation
+        from google.adk.evaluation.eval_metrics import EvalStatus
+        from google.adk.evaluation.evaluator import EvaluationResult, PerInvocationResult
+        from google.genai import types as genai_types
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_invocations.return_value = EvaluationResult(
+            overall_score=1.0,
+            overall_eval_status=EvalStatus.PASSED,
+            per_invocation_results=[
+                PerInvocationResult(
+                    actual_invocation=Invocation(
+                        user_content=genai_types.Content(
+                            parts=[genai_types.Part(text="test")]
+                        ),
+                    ),
+                    score=1.0,
+                    eval_status=EvalStatus.PASSED,
+                )
+            ],
+        )
+        mock_create.return_value = mock_evaluator
+
+        from mlflow.genai.scorers.adk import AdkScorer
+
+        # ToolTrajectory is deterministic
+        scorer = AdkScorer(metric_name="ToolTrajectory")
+        feedback = scorer(inputs="test", outputs="output")
+
+        assert feedback.source.source_type == AssessmentSourceType.CODE
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_non_deterministic_scorer_source_type(self, mock_create):
+        from google.adk.evaluation.eval_case import Invocation
+        from google.adk.evaluation.eval_metrics import EvalStatus
+        from google.adk.evaluation.evaluator import EvaluationResult, PerInvocationResult
+        from google.genai import types as genai_types
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_invocations.return_value = EvaluationResult(
+            overall_score=0.8,
+            overall_eval_status=EvalStatus.PASSED,
+            per_invocation_results=[
+                PerInvocationResult(
+                    actual_invocation=Invocation(
+                        user_content=genai_types.Content(
+                            parts=[genai_types.Part(text="test")]
+                        ),
+                    ),
+                    score=0.8,
+                    eval_status=EvalStatus.PASSED,
+                )
+            ],
+        )
+        mock_create.return_value = mock_evaluator
+
+        from mlflow.genai.scorers.adk import AdkScorer
+
+        # Hallucinations is non-deterministic
+        scorer = AdkScorer(metric_name="Hallucinations", model="gemini-2.5-flash")
+        feedback = scorer(inputs="test", outputs="output")
+
+        assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
+        assert feedback.source.source_id == "gemini-2.5-flash"
+
+
+# --- Tests for named scorer subclasses ---
+
+
+class TestNamedScorers:
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_tool_trajectory_class(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import ToolTrajectory
+
+        scorer = ToolTrajectory(match_type="in_order")
+        assert scorer.name == "ToolTrajectory"
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_hallucinations_class(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import Hallucinations
+
+        scorer = Hallucinations(model="gemini-2.5-flash")
+        assert scorer.name == "Hallucinations"
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_response_match_class(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import ResponseMatch
+
+        scorer = ResponseMatch()
+        assert scorer.name == "ResponseMatch"
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_final_response_match_class(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import FinalResponseMatch
+
+        scorer = FinalResponseMatch(model="gemini-2.5-flash")
+        assert scorer.name == "FinalResponseMatch"
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_rubric_based_response_quality_class(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import RubricBasedResponseQuality
+
+        scorer = RubricBasedResponseQuality(model="gemini-2.5-flash")
+        assert scorer.name == "RubricBasedResponseQuality"
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_rubric_based_tool_use_quality_class(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import RubricBasedToolUseQuality
+
+        scorer = RubricBasedToolUseQuality(model="gemini-2.5-flash")
+        assert scorer.name == "RubricBasedToolUseQuality"
+
+
+# --- Tests for get_scorer factory ---
+
+
+class TestGetScorer:
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_get_scorer_basic(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import get_scorer
+
+        scorer = get_scorer("ToolTrajectory", match_type="exact")
+        assert scorer.name == "ToolTrajectory"
+
+    @patch(_PATCH_CREATE_EVALUATOR)
+    def test_get_scorer_with_model(self, mock_create):
+        mock_create.return_value = MagicMock()
+
+        from mlflow.genai.scorers.adk import get_scorer
+
+        scorer = get_scorer("Hallucinations", model="gemini-2.5-flash")
+        assert scorer.name == "Hallucinations"

--- a/tests/genai/simulators/conftest.py
+++ b/tests/genai/simulators/conftest.py
@@ -11,24 +11,26 @@ def mock_trace():
 @pytest.fixture
 def simulation_mocks(mock_trace):
     """Fixture providing common mocks for conversation simulation tests."""
+    # Use a counter to return unique trace IDs for each call
+    trace_id_counter = {"count": 0}
+
+    def unique_trace_id(*args, **kwargs):
+        trace_id_counter["count"] += 1
+        return f"trace_{trace_id_counter['count']}"
+
     with (
         patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke,
-        patch("mlflow.trace") as mock_trace_decorator,
-        patch("mlflow.get_last_active_trace_id") as mock_get_trace_id,
-        patch("mlflow.update_current_trace") as mock_update_trace,
+        patch("mlflow.get_last_active_trace_id", side_effect=unique_trace_id) as mock_get_trace_id,
+        patch("mlflow.set_trace_tag") as mock_set_trace_tag,
         patch(
             "mlflow.tracing.client.TracingClient",
             return_value=Mock(get_trace=lambda _: mock_trace),
         ),
     ):
-        mock_get_trace_id.return_value = "trace_123"
-        mock_trace_decorator.return_value = lambda fn: fn
-
         yield {
             "invoke": mock_invoke,
-            "trace_decorator": mock_trace_decorator,
             "get_trace_id": mock_get_trace_id,
-            "update_trace": mock_update_trace,
+            "set_trace_tag": mock_set_trace_tag,
             "trace": mock_trace,
         }
 

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -120,7 +120,7 @@ def test_conversation_simulator_basic_simulation(
     assert len(all_traces[0]) == 2  # 2 traces
     assert all(t is simulation_mocks["trace"] for t in all_traces[0])
     assert simulation_mocks["invoke"].call_count == 4  # 2 turns * 2 calls each
-    assert simulation_mocks["update_trace"].call_count == 2
+    assert simulation_mocks["set_trace_tag"].call_count > 0
 
 
 def test_conversation_simulator_max_turns_stopping(
@@ -543,7 +543,7 @@ def test_user_agent_class_receives_context(simple_test_case, mock_predict_fn, si
     assert captured_contexts[1].is_first_turn is False
 
 
-def test_conversation_simulator_sets_span_attributes(mock_predict_fn_with_context):
+def test_conversation_simulator_sets_simulation_tags(mock_predict_fn_with_context):
     long_goal = "A" * 500
     long_persona = "B" * 500
     context = {"user_id": "U001", "session_id": "S001"}
@@ -567,17 +567,13 @@ def test_conversation_simulator_sets_span_attributes(mock_predict_fn_with_contex
         assert len(first_test_case_traces) == 2
 
         for trace in first_test_case_traces:
-            root_span = trace.data.spans[0]
-            metadata = trace.info.request_metadata
+            tags = trace.info.tags
 
-            assert root_span.attributes["mlflow.simulation.goal"] == long_goal
-            assert root_span.attributes["mlflow.simulation.persona"] == long_persona
-            assert root_span.attributes["mlflow.simulation.context"] == context
-            assert metadata["mlflow.simulation.goal"] == long_goal[:_MAX_METADATA_LENGTH]
-            assert metadata["mlflow.simulation.persona"] == long_persona[:_MAX_METADATA_LENGTH]
+            assert tags["mlflow.simulation.goal"] == long_goal[:_MAX_METADATA_LENGTH]
+            assert tags["mlflow.simulation.persona"] == long_persona[:_MAX_METADATA_LENGTH]
 
 
-def test_conversation_simulator_uses_default_persona_and_empty_context(mock_predict_fn):
+def test_conversation_simulator_uses_default_persona(mock_predict_fn):
     with patch("mlflow.genai.simulators.simulator.invoke_model_without_tracing") as mock_invoke:
         mock_invoke.side_effect = [
             "Test message",
@@ -592,11 +588,10 @@ def test_conversation_simulator_uses_default_persona_and_empty_context(mock_pred
         all_traces = simulator.simulate(mock_predict_fn)
 
         trace = all_traces[0][0]
-        root_span = trace.data.spans[0]
+        tags = trace.info.tags
 
-        assert root_span.attributes["mlflow.simulation.goal"] == "Test goal"
-        assert root_span.attributes["mlflow.simulation.persona"] == DEFAULT_PERSONA
-        assert root_span.attributes["mlflow.simulation.context"] == {}
+        assert tags["mlflow.simulation.goal"] == "Test goal"
+        assert tags["mlflow.simulation.persona"] == DEFAULT_PERSONA
 
 
 def test_conversation_simulator_logs_expectations_to_first_trace(mock_predict_fn):
@@ -926,11 +921,11 @@ def test_conversation_simulator_with_simulation_guidelines(mock_predict_fn):
         prompt = generate_call.kwargs["messages"][0].content
         assert "Ask clarifying questions before proceeding" in prompt
 
-        # Verify simulation_guidelines are in trace metadata
+        # Verify simulation_guidelines are in trace tags
         trace = all_traces[0][0]
-        metadata = trace.info.request_metadata
-        assert "mlflow.simulation.simulation_guidelines" in metadata
+        tags = trace.info.tags
+        assert "mlflow.simulation.simulation_guidelines" in tags
         assert (
-            metadata["mlflow.simulation.simulation_guidelines"]
+            tags["mlflow.simulation.simulation_guidelines"]
             == "Ask clarifying questions before proceeding"
         )

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -361,6 +361,11 @@ def test_translate_inputs_outputs_edge_cases(
             {"key": json.dumps([1, 2, 3])},
             {"key": "[1, 2, 3]"},
         ),
+        # Double-encoded list (e.g., gen_ai.input.messages via OTLP)
+        (
+            {"key": json.dumps(json.dumps([{"role": "user", "content": "hello"}]))},
+            {"key": json.dumps([{"role": "user", "content": "hello"}])},
+        ),
     ],
 )
 def test_sanitize_attributes(attributes: dict[str, Any], expected_attributes: dict[str, Any]):


### PR DESCRIPTION
### Related Issues/PRs

Resolve https://databricks.atlassian.net/browse/ML-62496

### What changes are proposed in this pull request?

The conversation simulator wraps each `predict_fn` call with `@mlflow.trace(name=f"simulation_turn_{turn}")`, creating a wrapper root span. When scorers extract inputs/outputs from the trace's root span, they get the simulator wrapper's data (which includes extra kwargs like `mlflow_session_id`, context) instead of the user's actual function data.

This PR:
- **Removes the wrapper span entirely** — `predict_fn` is now called directly
- If `predict_fn` doesn't create its own trace, one is created via `mlflow.start_span()` so evaluation still works for untraced functions
- **Stores simulation metadata as trace tags** (instead of span attributes/request metadata), since tags can be set after trace finalization via `mlflow.set_trace_tag()`
- **Updates all session ID lookups** to check both `trace_metadata` and `tags` for backward compatibility (9 files)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

All 56 simulator tests pass, plus 21 session utils tests, 86 judge/trace utils tests, and 50 evaluation utils tests.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed conversation simulator adding a `simulation_turn_x` wrapper span around each predict_fn call, which caused custom scorers to extract wrong inputs/outputs from traces.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)