### PR TITLE
Fall back to agentic judge mode when trace inputs/outputs are missing

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -518,12 +518,63 @@ class InstructionsJudge(Judge):
             if self._TEMPLATE_VARIABLE_EXPECTATIONS in self.template_variables:
                 expectations = resolve_expectations_from_session(expectations, session)
 
-        self._check_required_parameters(inputs, outputs, expectations, trace, conversation)
+        # Detect if we need to fall back to agentic (trace-based) mode.
+        # This handles OTel-based traces (e.g. Google ADK, LangChain JS, Vercel AI SDK)
+        # where root spans don't have explicit inputs/outputs.
+        is_fallback_to_trace_mode = False
+        if trace is not None and self._TEMPLATE_VARIABLE_TRACE not in self.template_variables:
+            missing_inputs = (
+                self._TEMPLATE_VARIABLE_INPUTS in self.template_variables and inputs is None
+            )
+            missing_outputs = (
+                self._TEMPLATE_VARIABLE_OUTPUTS in self.template_variables and outputs is None
+            )
+            if missing_inputs or missing_outputs:
+                is_fallback_to_trace_mode = True
+                _logger.info(
+                    "Could not extract %s from the trace root span. "
+                    "Falling back to trace-based judge mode.",
+                    " and ".join(
+                        field
+                        for field, missing in [
+                            ("inputs", missing_inputs),
+                            ("outputs", missing_outputs),
+                        ]
+                        if missing
+                    ),
+                )
+
+        if not is_fallback_to_trace_mode:
+            self._check_required_parameters(inputs, outputs, expectations, trace, conversation)
+        else:
+            # In fallback mode, inputs/outputs will be discovered by the agentic judge
+            # via tools. But we still need to validate other required parameters.
+            missing_params = []
+            if (
+                self._TEMPLATE_VARIABLE_EXPECTATIONS in self.template_variables
+                and expectations is None
+            ):
+                missing_params.append("expectations")
+            if (
+                self._TEMPLATE_VARIABLE_CONVERSATION in self.template_variables
+                and conversation is None
+            ):
+                missing_params.append("session")
+            if missing_params:
+                missing_str = "', '".join(missing_params)
+                raise MlflowException(
+                    f"Must specify '{missing_str}' - required by template variables "
+                    "in instructions.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+
         self._warn_unused_parameters(
             original_inputs, original_outputs, original_expectations, conversation
         )
 
-        is_trace_based = self._TEMPLATE_VARIABLE_TRACE in self.template_variables
+        is_trace_based = (
+            self._TEMPLATE_VARIABLE_TRACE in self.template_variables or is_fallback_to_trace_mode
+        )
 
         system_content = self._build_system_message(is_trace_based)
         user_content = self._build_user_message(inputs, outputs, expectations, conversation)

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -531,17 +531,15 @@ class InstructionsJudge(Judge):
             )
             if missing_inputs or missing_outputs:
                 is_fallback_to_trace_mode = True
+                missing_fields = []
+                if missing_inputs:
+                    missing_fields.append("inputs")
+                if missing_outputs:
+                    missing_fields.append("outputs")
                 _logger.info(
                     "Could not extract %s from the trace root span. "
                     "Falling back to trace-based judge mode.",
-                    " and ".join(
-                        field
-                        for field, missing in [
-                            ("inputs", missing_inputs),
-                            ("outputs", missing_outputs),
-                        ]
-                        if missing
-                    ),
+                    " and ".join(missing_fields),
                 )
 
         if not is_fallback_to_trace_mode:
@@ -555,10 +553,7 @@ class InstructionsJudge(Judge):
                 and expectations is None
             ):
                 missing_params.append("expectations")
-            if (
-                self._TEMPLATE_VARIABLE_CONVERSATION in self.template_variables
-                and session is None
-            ):
+            if self._TEMPLATE_VARIABLE_CONVERSATION in self.template_variables and session is None:
                 missing_params.append("session")
             if missing_params:
                 missing_str = "', '".join(missing_params)
@@ -575,6 +570,13 @@ class InstructionsJudge(Judge):
         is_trace_based = (
             self._TEMPLATE_VARIABLE_TRACE in self.template_variables or is_fallback_to_trace_mode
         )
+
+        if is_fallback_to_trace_mode:
+            _logger.debug("Using trace-based (agentic) judge mode via fallback.")
+        elif is_trace_based:
+            _logger.debug("Using trace-based (agentic) judge mode.")
+        else:
+            _logger.debug("Using standard (non-agentic) judge mode.")
 
         system_content = self._build_system_message(is_trace_based)
         user_content = self._build_user_message(inputs, outputs, expectations, conversation)

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -545,7 +545,7 @@ class InstructionsJudge(Judge):
                 )
 
         if not is_fallback_to_trace_mode:
-            self._check_required_parameters(inputs, outputs, expectations, trace, conversation)
+            self._check_required_parameters(inputs, outputs, expectations, trace, session or None)
         else:
             # In fallback mode, inputs/outputs will be discovered by the agentic judge
             # via tools. But we still need to validate other required parameters.
@@ -557,7 +557,7 @@ class InstructionsJudge(Judge):
                 missing_params.append("expectations")
             if (
                 self._TEMPLATE_VARIABLE_CONVERSATION in self.template_variables
-                and conversation is None
+                and session is None
             ):
                 missing_params.append("session")
             if missing_params:

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -1821,17 +1821,19 @@ def test_unused_parameters_warning(
     with patch("mlflow.genai.judges.instructions_judge._logger") as mock_logger:
         judge(**provided_params)
 
+        # Filter debug calls to find the "unused parameters" warning,
+        # ignoring the mode-selection debug log.
+        unused_param_calls = [
+            call
+            for call in mock_logger.debug.call_args_list
+            if "parameters were provided but are not used" in str(call)
+        ]
+
         if "{{ trace }}" in instructions:
-            assert not mock_logger.debug.called
+            assert len(unused_param_calls) == 0
         else:
-            assert mock_logger.debug.called
-
-            debug_call_args = mock_logger.debug.call_args
-            assert debug_call_args is not None
-
-            warning_msg = debug_call_args[0][0]
-
-            assert "parameters were provided but are not used" in warning_msg
+            assert len(unused_param_calls) == 1
+            warning_msg = unused_param_calls[0][0][0]
             assert expected_warning in warning_msg
 
 
@@ -2739,10 +2741,12 @@ def test_warning_shown_for_explicitly_provided_unused_fields(mock_invoke_judge_m
     with mock.patch("mlflow.genai.judges.instructions_judge._logger.debug") as mock_debug:
         judge(inputs="What is AI?", outputs="This output is not used by the template")
 
-        mock_debug.assert_called_once()
-        debug_message = mock_debug.call_args[0][0]
+        unused_param_calls = [
+            call for call in mock_debug.call_args_list if "not used by this judge" in str(call)
+        ]
+        assert len(unused_param_calls) == 1
+        debug_message = unused_param_calls[0][0][0]
         assert "outputs" in debug_message
-        assert "not used by this judge" in debug_message
 
 
 def test_no_warning_for_trace_based_judge_with_extra_fields(mock_invoke_judge_model):
@@ -3628,10 +3632,14 @@ def test_conversation_unused_parameter_warning(mock_invoke_judge_model):
     with patch("mlflow.genai.judges.instructions_judge._logger") as mock_logger:
         judge(outputs={"answer": "Test"}, session=[trace1])
 
-        mock_logger.debug.assert_called_once()
-        warning_msg = mock_logger.debug.call_args[0][0]
+        unused_param_calls = [
+            call
+            for call in mock_logger.debug.call_args_list
+            if "not used by this judge" in str(call)
+        ]
+        assert len(unused_param_calls) == 1
+        warning_msg = unused_param_calls[0][0][0]
         assert "conversation" in warning_msg or "session" in warning_msg
-        assert "not used by this judge" in warning_msg
 
 
 def test_conversation_no_warning_when_used(mock_invoke_judge_model):

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -2137,6 +2137,159 @@ def test_field_based_template_extracts_missing_fields_from_trace(
     assert "Trace output" in user_message
 
 
+def _create_otel_trace_without_root_inputs_outputs(
+    root_inputs=None, root_outputs=None, child_inputs=None, child_outputs=None
+):
+    """Create a trace simulating OTel-based traces where root span lacks inputs/outputs."""
+    root_attributes = {
+        "mlflow.spanType": json.dumps(SpanType.CHAIN),
+    }
+    if root_inputs is not None:
+        root_attributes["mlflow.spanInputs"] = json.dumps(root_inputs)
+    if root_outputs is not None:
+        root_attributes["mlflow.spanOutputs"] = json.dumps(root_outputs)
+
+    root_span = Span(
+        OTelReadableSpan(
+            name="root_span",
+            context=build_otel_context(trace_id=999999, span_id=1),
+            parent=None,
+            start_time=100000000,
+            end_time=200000000,
+            attributes=root_attributes,
+        )
+    )
+
+    child_span = Span(
+        OTelReadableSpan(
+            name="llm_call",
+            context=build_otel_context(trace_id=999999, span_id=2),
+            parent=build_otel_context(trace_id=999999, span_id=1),
+            start_time=110000000,
+            end_time=190000000,
+            attributes={
+                "mlflow.spanType": json.dumps(SpanType.LLM),
+                "mlflow.spanInputs": json.dumps(child_inputs or {"prompt": "What is MLflow?"}),
+                "mlflow.spanOutputs": json.dumps(
+                    child_outputs or {"text": "MLflow is an ML platform."}
+                ),
+            },
+        )
+    )
+
+    trace_info = TraceInfo(
+        trace_id="otel-trace-no-root-io",
+        trace_location=TraceLocation.from_experiment_id("0"),
+        request_time=1234567890,
+        execution_duration=1000,
+        state=TraceState.OK,
+        trace_metadata={"mlflow.trace_schema.version": "2"},
+        tags={
+            "mlflow.traceName": "otel_trace",
+            "mlflow.source.name": "test",
+            "mlflow.source.type": "LOCAL",
+        },
+    )
+    return Trace(info=trace_info, data=TraceData(spans=[root_span, child_span]))
+
+
+def test_fallback_to_agentic_mode_when_trace_missing_inputs_outputs(mock_invoke_judge_model):
+    """When a trace has no root span inputs/outputs, fall back to agentic judge mode."""
+    judge = make_judge(
+        name="test_judge",
+        instructions="Evaluate if {{ inputs }} matches {{ outputs }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace = _create_otel_trace_without_root_inputs_outputs()
+
+    # Should NOT raise "Must specify 'inputs', 'outputs'" error
+    result = judge(trace=trace)
+    assert isinstance(result, Feedback)
+
+    # Verify agentic mode was used (trace passed to invoke_judge_model)
+    captured = mock_invoke_judge_model.captured_args
+    assert captured["trace"] is trace
+    assert "analyze a trace" in captured["prompt"][0].content.lower()
+
+
+def test_fallback_with_partial_data(mock_invoke_judge_model):
+    """When trace has inputs but not outputs at root, fallback triggers and includes inputs."""
+    judge = make_judge(
+        name="test_judge",
+        instructions="Evaluate if {{ inputs }} matches {{ outputs }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace = _create_otel_trace_without_root_inputs_outputs(
+        root_inputs={"question": "What is MLflow?"},
+        root_outputs=None,
+    )
+
+    result = judge(trace=trace)
+    assert isinstance(result, Feedback)
+
+    # Verify agentic mode was used
+    captured = mock_invoke_judge_model.captured_args
+    assert captured["trace"] is trace
+
+    # Verify the resolved inputs are included in the user message
+    user_message = captured["prompt"][1].content
+    assert "What is MLflow?" in user_message
+
+
+def test_no_fallback_when_no_trace():
+    """Without a trace, the original error is raised (no regression)."""
+    judge = make_judge(
+        name="test_judge",
+        instructions="Evaluate if {{ inputs }} matches {{ outputs }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    with pytest.raises(MlflowException, match="Must specify 'inputs', 'outputs'"):
+        judge()
+
+
+def test_no_fallback_when_trace_has_root_data(mock_invoke_judge_model):
+    """When trace has root span data, normal (non-agentic) mode is used."""
+    judge = make_judge(
+        name="test_judge",
+        instructions="Evaluate if {{ inputs }} matches {{ outputs }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace = _create_otel_trace_without_root_inputs_outputs(
+        root_inputs={"question": "What is MLflow?"},
+        root_outputs={"answer": "MLflow is great"},
+    )
+
+    result = judge(trace=trace)
+    assert isinstance(result, Feedback)
+
+    # Verify normal mode was used (trace NOT passed to invoke_judge_model)
+    captured = mock_invoke_judge_model.captured_args
+    assert captured["trace"] is None
+
+
+def test_fallback_still_validates_expectations():
+    """In fallback mode, missing expectations still raises an error."""
+    judge = make_judge(
+        name="test_judge",
+        instructions="Check if {{ inputs }} meets {{ expectations }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace = _create_otel_trace_without_root_inputs_outputs()
+
+    with pytest.raises(MlflowException, match="Must specify 'expectations'"):
+        judge(trace=trace)
+
+
 def test_trace_based_template_with_additional_inputs(mock_invoke_judge_model):
     judge = make_judge(
         name="test_judge",

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -2194,7 +2194,6 @@ def _create_otel_trace_without_root_inputs_outputs(
 
 
 def test_fallback_to_agentic_mode_when_trace_missing_inputs_outputs(mock_invoke_judge_model):
-    """When a trace has no root span inputs/outputs, fall back to agentic judge mode."""
     judge = make_judge(
         name="test_judge",
         instructions="Evaluate if {{ inputs }} matches {{ outputs }}",
@@ -2215,7 +2214,6 @@ def test_fallback_to_agentic_mode_when_trace_missing_inputs_outputs(mock_invoke_
 
 
 def test_fallback_with_partial_data(mock_invoke_judge_model):
-    """When trace has inputs but not outputs at root, fallback triggers and includes inputs."""
     judge = make_judge(
         name="test_judge",
         instructions="Evaluate if {{ inputs }} matches {{ outputs }}",
@@ -2241,7 +2239,6 @@ def test_fallback_with_partial_data(mock_invoke_judge_model):
 
 
 def test_no_fallback_when_no_trace():
-    """Without a trace, the original error is raised (no regression)."""
     judge = make_judge(
         name="test_judge",
         instructions="Evaluate if {{ inputs }} matches {{ outputs }}",
@@ -2254,7 +2251,6 @@ def test_no_fallback_when_no_trace():
 
 
 def test_no_fallback_when_trace_has_root_data(mock_invoke_judge_model):
-    """When trace has root span data, normal (non-agentic) mode is used."""
     judge = make_judge(
         name="test_judge",
         instructions="Evaluate if {{ inputs }} matches {{ outputs }}",
@@ -2276,7 +2272,6 @@ def test_no_fallback_when_trace_has_root_data(mock_invoke_judge_model):
 
 
 def test_fallback_still_validates_expectations():
-    """In fallback mode, missing expectations still raises an error."""
     judge = make_judge(
         name="test_judge",
         instructions="Check if {{ inputs }} meets {{ expectations }}",


### PR DESCRIPTION
### Related Issues/PRs

<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Custom LLM judges created from the UI fail with `SCORER_ERROR: Must specify 'inputs', 'outputs' - required by template variables in instructions` when run against OTel-based traces (Google ADK, LangChain JS, Vercel AI SDK, etc.) that don't have explicit inputs/outputs at the root span.

This PR adds fallback logic in `InstructionsJudge.__call__`: when a trace is available but `inputs`/`outputs` can't be extracted from the root span, instead of raising an error, the judge switches to trace-based (agentic) mode. This gives the LLM access to trace analysis tools (`GetRootSpan`, `ListSpans`, `GetSpan`, etc.) to discover inputs/outputs from child spans.

Key behavior:
- Only triggers when a trace is present AND root span extraction returned `None` for required fields
- Still validates non-input/output parameters (expectations, session) in fallback mode
- When partial data is available (e.g., inputs resolved but outputs didn't), includes it in the prompt
- No change when traces have proper root span data or when `{{ trace }}` is already in the template

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Custom LLM judges now gracefully handle OTel-based traces (Google ADK, LangChain JS, Vercel AI SDK, etc.) that lack inputs/outputs at the root span. Instead of failing with a `SCORER_ERROR`, the judge falls back to agentic mode and uses tools to analyze the trace structure.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)