### PR TITLE
Fix span type not translated for OTel spans when MLflow SDK is active

### DIFF
--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -23,7 +23,11 @@ from mlflow.tracing.otel.translation.spring_ai import SpringAiTranslator
 from mlflow.tracing.otel.translation.traceloop import TraceloopTranslator
 from mlflow.tracing.otel.translation.vercel_ai import VercelAITranslator
 from mlflow.tracing.otel.translation.voltagent import VoltAgentTranslator
-from mlflow.tracing.utils import calculate_cost_by_model_and_token_usage, dump_span_attribute_value
+from mlflow.tracing.utils import (
+    calculate_cost_by_model_and_token_usage,
+    dump_span_attribute_value,
+    try_json_loads,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -71,10 +75,7 @@ def translate_span_when_storing(span: Span) -> dict[str, Any]:
     # Override UNKNOWN (the LiveSpan default) with the translator-determined type.
     if mlflow_type := translate_span_type_from_otel(attributes):
         current_raw = attributes.get(SpanAttributeKey.SPAN_TYPE)
-        try:
-            current_type = json.loads(current_raw) if current_raw else None
-        except (json.JSONDecodeError, TypeError):
-            current_type = None
+        current_type = try_json_loads(current_raw) if current_raw else None
         if current_type in (None, SpanType.UNKNOWN):
             attributes[SpanAttributeKey.SPAN_TYPE] = dump_span_attribute_value(mlflow_type)
 
@@ -344,13 +345,10 @@ def translate_loaded_span(span_dict: dict[str, Any]) -> dict[str, Any]:
     attributes = span_dict.get("attributes", {})
 
     try:
-        current_raw = attributes.get(SpanAttributeKey.SPAN_TYPE)
-        current_type = None
-        if current_raw:
-            try:
-                current_type = json.loads(current_raw)
-            except (json.JSONDecodeError, TypeError):
-                current_type = current_raw
+        if current_raw := attributes.get(SpanAttributeKey.SPAN_TYPE):
+            current_type = try_json_loads(current_raw)
+        else:
+            current_type = None
         if current_type in (None, SpanType.UNKNOWN):
             if mlflow_type := translate_span_type_from_otel(attributes):
                 attributes[SpanAttributeKey.SPAN_TYPE] = dump_span_attribute_value(mlflow_type)

--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -344,9 +344,15 @@ def translate_loaded_span(span_dict: dict[str, Any]) -> dict[str, Any]:
     attributes = span_dict.get("attributes", {})
 
     try:
-        if SpanAttributeKey.SPAN_TYPE not in attributes:
+        current_raw = attributes.get(SpanAttributeKey.SPAN_TYPE)
+        current_type = None
+        if current_raw:
+            try:
+                current_type = json.loads(current_raw)
+            except (json.JSONDecodeError, TypeError):
+                current_type = current_raw
+        if current_type in (None, SpanType.UNKNOWN):
             if mlflow_type := translate_span_type_from_otel(attributes):
-                # Serialize to match how MLflow stores attributes
                 attributes[SpanAttributeKey.SPAN_TYPE] = dump_span_attribute_value(mlflow_type)
     except Exception:
         _logger.debug("Failed to translate span type", exc_info=True)

--- a/mlflow/tracing/processor/otel_metrics_mixin.py
+++ b/mlflow/tracing/processor/otel_metrics_mixin.py
@@ -5,7 +5,6 @@ This mixin allows different span processor implementations to share common metri
 while maintaining their own inheritance hierarchies (BatchSpanProcessor, SimpleSpanProcessor).
 """
 
-import json
 import logging
 from typing import Any
 
@@ -17,7 +16,7 @@ from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 from mlflow.entities.span import SpanType
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.trace_manager import InMemoryTraceManager
-from mlflow.tracing.utils import get_experiment_id_for_trace
+from mlflow.tracing.utils import get_experiment_id_for_trace, try_json_loads
 from mlflow.tracing.utils.otlp import _get_otlp_metrics_endpoint, _get_otlp_metrics_protocol
 
 _logger = logging.getLogger(__name__)
@@ -91,12 +90,10 @@ class OtelMetricsMixin:
         if self._duration_histogram is None:
             return
 
-        span_type = span.attributes.get(SpanAttributeKey.SPAN_TYPE, SpanType.UNKNOWN)
-        try:
-            # Span attributes are JSON encoded by default; decode them for metric label readability
-            span_type = json.loads(span_type)
-        except (json.JSONDecodeError, TypeError):
-            pass
+        # Span attributes are JSON encoded by default; decode them for metric label readability
+        span_type = try_json_loads(
+            span.attributes.get(SpanAttributeKey.SPAN_TYPE, SpanType.UNKNOWN)
+        )
 
         attributes = {
             "root": span.parent is None,

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -128,6 +128,14 @@ def dump_span_attribute_value(value: Any) -> str:
     return json.dumps(value, cls=TraceJSONEncoder, ensure_ascii=False)
 
 
+def try_json_loads(value: Any) -> Any:
+    """Try to parse a value as JSON, returning the original value on failure."""
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+
+
 @lru_cache(maxsize=1)
 def encode_span_id(span_id: int) -> str:
     """

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -111,6 +111,7 @@ def test_translate_loaded_span_sets_span_type(attr_key, attr_value, expected_typ
 @pytest.mark.parametrize(
     ("span_dict", "should_have_span_type", "expected_type"),
     [
+        # Existing non-UNKNOWN span type should NOT be overridden
         (
             {
                 "attributes": {
@@ -120,6 +121,27 @@ def test_translate_loaded_span_sets_span_type(attr_key, attr_value, expected_typ
             },
             True,
             SpanType.TOOL,
+        ),
+        # UNKNOWN span type SHOULD be overridden by OTel attributes
+        (
+            {
+                "attributes": {
+                    SpanAttributeKey.SPAN_TYPE: json.dumps(SpanType.UNKNOWN),
+                    "openinference.span.kind": "LLM",
+                }
+            },
+            True,
+            SpanType.LLM,
+        ),
+        # None/missing span type SHOULD be set from OTel attributes
+        (
+            {
+                "attributes": {
+                    "openinference.span.kind": "AGENT",
+                }
+            },
+            True,
+            SpanType.AGENT,
         ),
         ({"attributes": {"some.other.attribute": "value"}}, False, None),
         ({}, False, None),


### PR DESCRIPTION
### Related Issues/PRs

#xxx

### What changes are proposed in this pull request?

When using frameworks like Google ADK with `MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false`, the MLflow span processor injects `mlflow.spanType = "null"` onto OTel spans during `on_start()`. The `translate_loaded_span()` function only checked for key presence (`not in`), so it skipped translation when the key existed — even with a null value. This caused span types (e.g., LLM, TOOL) to not be displayed in the trace UI.

This aligns `translate_loaded_span` with the existing `translate_span_when_storing` logic, which correctly checks the actual value (`None` or `UNKNOWN`) before deciding whether to translate.


**Before**

<img width="1043" height="571" alt="Screenshot 2026-03-03 at 16 45 41" src="https://github.com/user-attachments/assets/9f1317ce-2546-4936-8b87-ed22c8b746f3" />

**After**

<img width="1050" height="525" alt="Screenshot 2026-03-03 at 16 44 24" src="https://github.com/user-attachments/assets/8d626d8e-2a1a-4fe8-babf-54df0799c252" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified with a Google ADK agent using `MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false` — span types now display correctly in the trace UI.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed span type translation not working for OTel-based frameworks (e.g., Google ADK) when combined with the MLflow SDK (`MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false`). Span types like LLM and TOOL now display correctly in the trace UI.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)