### PR TITLE
Add session_id and user kwargs to configure_trace and update_current_trace

### DIFF
--- a/docs/docs/genai/tracing/prod-tracing.mdx
+++ b/docs/docs/genai/tracing/prod-tracing.mdx
@@ -206,12 +206,10 @@ def handle_chat(request: Request, chat_request: ChatRequest):
 
     # Update the current trace with all context and environment metadata
     mlflow.update_current_trace(
+        session_id=session_id,
+        user=user_id,
         client_request_id=client_request_id,
-        tags={
-            # Session context - groups traces from multi-turn conversations
-            "mlflow.trace.session": session_id,
-            # User context - associates traces with specific users
-            "mlflow.trace.user": user_id,
+        metadata={
             # Environment metadata - tracks deployment context
             "environment": "production",
             "app_version": os.getenv("APP_VERSION", "1.0.0"),
@@ -300,19 +298,19 @@ mlflow.set_experiment("production-genai-app")
 
 # Query traces by user
 user_traces = mlflow.search_traces(
-    filter_string="tags.`mlflow.trace.user` = 'user-jane-doe-12345'",
+    filter_string="metadata.`mlflow.trace.user` = 'user-jane-doe-12345'",
     max_results=100,
 )
 
 # Query traces by session
 session_traces = mlflow.search_traces(
-    filter_string="tags.`mlflow.trace.session` = 'session-def-456'",
+    filter_string="metadata.`mlflow.trace.session` = 'session-def-456'",
     max_results=100,
 )
 
 # Query traces by environment
 production_traces = mlflow.search_traces(
-    filter_string="tags.environment = 'production'",
+    filter_string="metadata.environment = 'production'",
     max_results=100,
 )
 ```

--- a/docs/docs/genai/tracing/track-environments-context/index.mdx
+++ b/docs/docs/genai/tracing/track-environments-context/index.mdx
@@ -93,12 +93,10 @@ def handle_chat(request: Request, chat_request: ChatRequest):
     # Update the current trace with all context and environment metadata
     # The @mlflow.trace decorator ensures an active trace is available
     mlflow.update_current_trace(
+        session_id=session_id,
+        user=user_id,
         client_request_id=client_request_id,
         metadata={
-            # Reserved session metadata - groups traces from multi-turn conversations
-            "mlflow.trace.session": session_id,
-            # Reserved user metadata - associates traces with specific users
-            "mlflow.trace.user": user_id,
             # Override automatically populated environment metadata
             "mlflow.source.type": os.getenv(
                 "APP_ENVIRONMENT", "development"

--- a/docs/docs/genai/tracing/track-users-sessions/index.mdx
+++ b/docs/docs/genai/tracing/track-users-sessions/index.mdx
@@ -14,16 +14,11 @@ Many real-world AI applications use session to maintain multi-turn user interact
 
 ## Store User and Session IDs in Metadata
 
-MLflow provides two standard metadata fields for session and user tracking:
-
-- `mlflow.trace.user` - Associates traces with specific users
-- `mlflow.trace.session` - Groups traces belonging to multi-turn conversations
-
-When you use these standard metadata fields, MLflow automatically enables filtering and grouping in the UI. Unlike tags, metadata cannot be updated once the trace is logged, making it ideal for immutable identifiers like user and session IDs.
+MLflow provides dedicated `session_id` and `user` parameters in both <APILink fn="mlflow.update_current_trace" /> and <APILink fn="mlflow.configure_trace" /> for session and user tracking. These are stored as standard metadata fields (`mlflow.trace.session` and `mlflow.trace.user`), which automatically enables filtering and grouping in the UI. Unlike tags, metadata cannot be updated once the trace is logged, making it ideal for immutable identifiers like user and session IDs.
 
 ## Basic Usage
 
-To record user and session information in your application, use the <APILink fn="mlflow.update_current_trace" /> API and pass the user and session IDs in the metadata.
+To record user and session information in your application, use the <APILink fn="mlflow.update_current_trace" /> API and pass the user and session IDs directly.
 
 <Tabs>
   <TabItem value="python" label="Python" default>
@@ -39,10 +34,8 @@ To record user and session information in your application, use the <APILink fn=
 
         # Add user and session context to the current trace
         mlflow.update_current_trace(
-            metadata={
-                "mlflow.trace.user": user_id,  # Links trace to specific user
-                "mlflow.trace.session": session_id,  # Groups trace with conversation
-            }
+            session_id=session_id,
+            user=user_id,
         )
 
         # Your chat logic here
@@ -102,10 +95,8 @@ To record user and session information in your application, use the <APILink fn=
     def process_chat(message: str, user_id: str, session_id: str):
         # Update trace with user and session context
         mlflow.update_current_trace(
-            metadata={
-                "mlflow.trace.session": session_id,
-                "mlflow.trace.user": user_id,
-            }
+            session_id=session_id,
+            user=user_id,
         )
 
         # Process chat message using OpenAI API

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -176,6 +176,7 @@ from mlflow.tracing.assessment import (
 )
 from mlflow.tracing.fluent import (
     add_trace,
+    configure_trace,
     delete_trace_tag,
     get_active_trace_id,
     get_current_active_span,
@@ -211,6 +212,7 @@ __all__ = [
     "active_run",
     # Tracing APIs
     "add_trace",
+    "configure_trace",
     "delete_trace_tag",
     "flush_trace_async_logging",
     "get_active_trace_id",

--- a/mlflow/tracing/context.py
+++ b/mlflow/tracing/context.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class _ConfiguredTraceInfo:
+    """Metadata and tags declared via ``mlflow.configure_trace()`` that should be
+    injected into every trace created within the current scope."""
+
+    metadata: dict[str, str] = field(default_factory=dict)
+    tags: dict[str, str] = field(default_factory=dict)
+
+
+_CONFIGURE_TRACE_INFO: ContextVar[_ConfiguredTraceInfo | None] = ContextVar(
+    "mlflow_configure_trace_info", default=None
+)
+
+
+def get_configured_trace_metadata() -> dict[str, str] | None:
+    info = _CONFIGURE_TRACE_INFO.get()
+    return info.metadata or None if info else None
+
+
+def get_configured_trace_tags() -> dict[str, str] | None:
+    info = _CONFIGURE_TRACE_INFO.get()
+    return info.tags or None if info else None

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -1237,6 +1237,8 @@ def _set_last_active_trace_id(trace_id: str):
 def update_current_trace(
     tags: dict[str, str] | None = None,
     metadata: dict[str, str] | None = None,
+    session_id: str | None = None,
+    user: str | None = None,
     client_request_id: str | None = None,
     request_preview: str | None = None,
     response_preview: str | None = None,
@@ -1252,6 +1254,10 @@ def update_current_trace(
         metadata: A dictionary of metadata to update the trace with. Metadata cannot be updated
             once the trace is logged. It is suitable for recording immutable values like the
             git hash of the application version that produced the trace.
+        session_id: Session ID to associate with the trace. Stored as metadata under the
+            ``mlflow.trace.session`` key.
+        user: User identifier to associate with the trace. Stored as metadata under the
+            ``mlflow.trace.user`` key.
         client_request_id: Client supplied request ID to associate with the trace. This is
             useful for linking the trace back to a specific request in your application or
             external system. If None, the client request ID is not updated.
@@ -1289,16 +1295,14 @@ def update_current_trace(
             with mlflow.start_span("span"):
                 mlflow.update_current_trace(tags={"fruit": "apple"}, client_request_id="req-12345")
 
-        Updating source information of the trace. These keys are reserved ones and MLflow populate
-        them from environment information by default. You can override them if needed. Please refer
-        to the MLflow Tracing documentation for the full list of reserved metadata keys.
+        Updating user, session, and source information of the trace:
 
         .. code-block:: python
 
             mlflow.update_current_trace(
+                session_id="session-4f855da00427",
+                user="user-id-cc156f29bcfb",
                 metadata={
-                    "mlflow.trace.session": "session-4f855da00427",
-                    "mlflow.trace.user": "user-id-cc156f29bcfb",
                     "mlflow.source.name": "inference.py",
                     "mlflow.source.git.commit": "1234567890",
                     "mlflow.source.git.repoURL": "https://github.com/mlflow/mlflow",
@@ -1361,6 +1365,10 @@ def update_current_trace(
     tags = tags or {}
     metadata = metadata or {}
 
+    if session_id is not None:
+        metadata[TraceMetadataKey.TRACE_SESSION] = session_id
+    if user is not None:
+        metadata[TraceMetadataKey.TRACE_USER] = user
     if model_id:
         metadata[TraceMetadataKey.MODEL_ID] = model_id
 
@@ -1435,6 +1443,8 @@ def set_trace_tag(trace_id: str, key: str, value: str):
 
 @contextlib.contextmanager
 def configure_trace(
+    session_id: str | None = None,
+    user: str | None = None,
     metadata: dict[str, str] | None = None,
     tags: dict[str, str] | None = None,
 ) -> Generator[None, None, None]:
@@ -1443,8 +1453,8 @@ def configure_trace(
     within its scope, without creating a wrapper span.
 
     This is useful when you need to attach system-level information (e.g. session
-    IDs) to traces produced by code you don't control (such as a user-provided
-    ``predict_fn``).
+    IDs, user IDs) to traces produced by code you don't control (such as a
+    user-provided ``predict_fn``).
 
     Nesting is supported — inner values are merged on top of outer values, with
     inner values winning on key conflicts.
@@ -1453,24 +1463,42 @@ def configure_trace(
 
         import mlflow
 
+        with mlflow.configure_trace(session_id="session-123", user="user@example.com"):
+            # Any trace created inside this block will carry the session ID and user.
+            my_traced_function()
+
+        # You can also pass arbitrary metadata and tags:
         with mlflow.configure_trace(
-            metadata={"mlflow.trace.session": "session-123"},
-            tags={"mlflow.simulation.goal": "Learn about MLflow"},
+            session_id="session-123",
+            metadata={"mlflow.source.name": "inference.py"},
+            tags={"env": "staging"},
         ):
-            # Any trace created inside this block will carry the metadata and tags.
             my_traced_function()
 
     Args:
+        session_id: Session ID to associate with the trace. Stored as metadata
+            under the ``mlflow.trace.session`` key.
+        user: User identifier to associate with the trace. Stored as metadata
+            under the ``mlflow.trace.user`` key.
         metadata: Key-value pairs to inject into the trace's ``request_metadata``
             (immutable after trace creation).
         tags: Key-value pairs to inject into the trace's ``tags``.
     """
     from mlflow.tracing.context import _CONFIGURE_TRACE_INFO, _ConfiguredTraceInfo
 
+    # Build metadata dict from dedicated kwargs + generic metadata
+    effective_metadata = {}
+    if session_id is not None:
+        effective_metadata[TraceMetadataKey.TRACE_SESSION] = session_id
+    if user is not None:
+        effective_metadata[TraceMetadataKey.TRACE_USER] = user
+    if metadata:
+        effective_metadata.update(metadata)
+
     current = _CONFIGURE_TRACE_INFO.get()
 
     # Merge with any outer configure_trace scope
-    merged_metadata = {**(current.metadata if current else {}), **(metadata or {})}
+    merged_metadata = {**(current.metadata if current else {}), **effective_metadata}
     merged_tags = {**(current.tags if current else {}), **(tags or {})}
 
     token = _CONFIGURE_TRACE_INFO.set(

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -1433,6 +1433,55 @@ def set_trace_tag(trace_id: str, key: str, value: str):
     TracingClient().set_trace_tag(trace_id, key, value)
 
 
+@contextlib.contextmanager
+def configure_trace(
+    metadata: dict[str, str] | None = None,
+    tags: dict[str, str] | None = None,
+) -> Generator[None, None, None]:
+    """
+    A context manager that injects metadata and/or tags into any trace created
+    within its scope, without creating a wrapper span.
+
+    This is useful when you need to attach system-level information (e.g. session
+    IDs) to traces produced by code you don't control (such as a user-provided
+    ``predict_fn``).
+
+    Nesting is supported — inner values are merged on top of outer values, with
+    inner values winning on key conflicts.
+
+    .. code-block:: python
+
+        import mlflow
+
+        with mlflow.configure_trace(
+            metadata={"mlflow.trace.session": "session-123"},
+            tags={"mlflow.simulation.goal": "Learn about MLflow"},
+        ):
+            # Any trace created inside this block will carry the metadata and tags.
+            my_traced_function()
+
+    Args:
+        metadata: Key-value pairs to inject into the trace's ``request_metadata``
+            (immutable after trace creation).
+        tags: Key-value pairs to inject into the trace's ``tags``.
+    """
+    from mlflow.tracing.context import _CONFIGURE_TRACE_INFO, _ConfiguredTraceInfo
+
+    current = _CONFIGURE_TRACE_INFO.get()
+
+    # Merge with any outer configure_trace scope
+    merged_metadata = {**(current.metadata if current else {}), **(metadata or {})}
+    merged_tags = {**(current.tags if current else {}), **(tags or {})}
+
+    token = _CONFIGURE_TRACE_INFO.set(
+        _ConfiguredTraceInfo(metadata=merged_metadata, tags=merged_tags)
+    )
+    try:
+        yield
+    finally:
+        _CONFIGURE_TRACE_INFO.reset(token)
+
+
 @deprecated_parameter("request_id", "trace_id", version="3.0.0")
 def delete_trace_tag(trace_id: str, key: str) -> None:
     """

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -140,6 +140,12 @@ class BaseMlflowSpanProcessor(OtelMetricsMixin, SimpleSpanProcessor):
         elif model_id := maybe_get_logged_model_id():
             metadata[TraceMetadataKey.MODEL_ID] = model_id
 
+        # Append metadata from configure_trace() scope (caller-declared, wins on conflict)
+        from mlflow.tracing.context import get_configured_trace_metadata
+
+        if ctx_metadata := get_configured_trace_metadata():
+            metadata.update(ctx_metadata)
+
         return metadata
 
     def _get_basic_trace_tags(self, span: OTelReadableSpan) -> dict[str, Any]:
@@ -151,6 +157,14 @@ class BaseMlflowSpanProcessor(OtelMetricsMixin, SimpleSpanProcessor):
             tags.update({TraceTagKey.EVAL_REQUEST_ID: request_id})
         if dependencies_schema := maybe_get_dependencies_schemas():
             tags.update(dependencies_schema)
+
+        # Append tags from configure_trace() scope before trace name
+        # (trace name tag always wins because it comes last)
+        from mlflow.tracing.context import get_configured_trace_tags
+
+        if ctx_tags := get_configured_trace_tags():
+            tags.update(ctx_tags)
+
         tags.update({TraceTagKey.TRACE_NAME: span.name})
         return tags
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -2905,3 +2905,65 @@ def test_configure_trace_tags_only():
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert trace.info.tags["t"] == "v"
+
+
+def test_configure_trace_session_id_and_user():
+    @mlflow.trace
+    def my_func():
+        return "hello"
+
+    with mlflow.configure_trace(session_id="sess-123", user="user@example.com"):
+        my_func()
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace.info.trace_metadata["mlflow.trace.session"] == "sess-123"
+    assert trace.info.trace_metadata["mlflow.trace.user"] == "user@example.com"
+
+
+def test_configure_trace_session_id_with_metadata():
+    @mlflow.trace
+    def my_func():
+        return "hello"
+
+    with mlflow.configure_trace(
+        session_id="sess-456",
+        user="alice",
+        metadata={"custom_key": "custom_value"},
+    ):
+        my_func()
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace.info.trace_metadata["mlflow.trace.session"] == "sess-456"
+    assert trace.info.trace_metadata["mlflow.trace.user"] == "alice"
+    assert trace.info.trace_metadata["custom_key"] == "custom_value"
+
+
+def test_update_current_trace_with_session_id_and_user():
+    @mlflow.trace
+    def my_func():
+        mlflow.update_current_trace(session_id="sess-789", user="bob")
+        return "hello"
+
+    my_func()
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace.info.trace_metadata["mlflow.trace.session"] == "sess-789"
+    assert trace.info.trace_metadata["mlflow.trace.user"] == "bob"
+
+
+def test_update_current_trace_session_id_with_metadata():
+    @mlflow.trace
+    def my_func():
+        mlflow.update_current_trace(
+            session_id="sess-abc",
+            user="carol",
+            metadata={"env": "staging"},
+        )
+        return "hello"
+
+    my_func()
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace.info.trace_metadata["mlflow.trace.session"] == "sess-abc"
+    assert trace.info.trace_metadata["mlflow.trace.user"] == "carol"
+    assert trace.info.trace_metadata["env"] == "staging"

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -2811,3 +2811,97 @@ assert len(trace_ids) == 5
             "MLFLOW_TRACE_SAMPLING_RATIO": "0.0",
         },
     )
+
+
+def test_configure_trace_injects_metadata_and_tags():
+    @mlflow.trace
+    def my_func():
+        return "hello"
+
+    with mlflow.configure_trace(
+        metadata={"custom_key": "custom_value"},
+        tags={"my_tag": "tag_value"},
+    ):
+        my_func()
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace.info.request_metadata["custom_key"] == "custom_value"
+    assert trace.info.tags["my_tag"] == "tag_value"
+
+
+def test_configure_trace_no_wrapper_span():
+    @mlflow.trace
+    def my_func():
+        return "hello"
+
+    with mlflow.configure_trace(metadata={"k": "v"}):
+        my_func()
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    # Only the one span from @mlflow.trace, no wrapper
+    assert len(trace.data.spans) == 1
+    assert trace.data.spans[0].name == "my_func"
+
+
+def test_configure_trace_nesting_merges():
+    @mlflow.trace
+    def my_func():
+        return "hello"
+
+    with mlflow.configure_trace(
+        metadata={"outer_key": "outer_val", "shared": "outer"},
+        tags={"outer_tag": "ot"},
+    ):
+        with mlflow.configure_trace(
+            metadata={"inner_key": "inner_val", "shared": "inner"},
+            tags={"inner_tag": "it"},
+        ):
+            my_func()
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    # Both outer and inner metadata present
+    assert trace.info.request_metadata["outer_key"] == "outer_val"
+    assert trace.info.request_metadata["inner_key"] == "inner_val"
+    # Inner wins on conflict
+    assert trace.info.request_metadata["shared"] == "inner"
+    # Both tags present
+    assert trace.info.tags["outer_tag"] == "ot"
+    assert trace.info.tags["inner_tag"] == "it"
+
+
+def test_configure_trace_resets_after_exit():
+    @mlflow.trace
+    def my_func():
+        return "hello"
+
+    with mlflow.configure_trace(metadata={"session": "s1"}):
+        pass
+
+    # Trace created outside the block should NOT have the metadata
+    my_func()
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert "session" not in trace.info.request_metadata
+
+
+def test_configure_trace_metadata_only():
+    @mlflow.trace
+    def my_func():
+        return "hello"
+
+    with mlflow.configure_trace(metadata={"k": "v"}):
+        my_func()
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace.info.request_metadata["k"] == "v"
+
+
+def test_configure_trace_tags_only():
+    @mlflow.trace
+    def my_func():
+        return "hello"
+
+    with mlflow.configure_trace(tags={"t": "v"}):
+        my_func()
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace.info.tags["t"] == "v"


### PR DESCRIPTION
## Summary
- Adds dedicated `session_id` and `user` kwargs to both `mlflow.configure_trace()` and `mlflow.update_current_trace()` as convenience parameters that map to the standard `mlflow.trace.session` and `mlflow.trace.user` metadata keys
- Updates documentation (track-users-sessions, track-environments-context, prod-tracing) to use the new kwargs instead of raw metadata strings
- Fixes `tags.` → `metadata.` in prod-tracing search query examples

**Stack**: PR 2 of 3 — depends on #21308

## Test plan
- [x] New tests: `test_configure_trace_session_id_and_user`, `test_configure_trace_session_id_with_metadata`, `test_update_current_trace_with_session_id_and_user`, `test_update_current_trace_session_id_with_metadata`
- [x] Existing configure_trace tests still pass (10 total)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>