### PR TITLE
Fix truncated model names in Cost Breakdown donut chart

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -37,17 +37,6 @@ const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) =
 
   return (
     <g>
-      {/* Model name in donut center */}
-      <text
-        x={cx}
-        y={cy}
-        textAnchor="middle"
-        fill={theme.colors.textPrimary}
-        fontSize={theme.typography.fontSizeSm}
-        fontWeight={500}
-      >
-        {name}
-      </text>
       {/* Main pie sector */}
       <Sector
         cx={cx}
@@ -72,10 +61,21 @@ const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) =
       <path d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`} stroke={fill} fill="none" />
       {/* Dot at line end */}
       <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
-      {/* Cost label */}
+      {/* Model name label */}
       <text
         x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
         y={ey}
+        textAnchor={textAnchor}
+        fill={theme.colors.textPrimary}
+        fontSize={theme.typography.fontSizeSm}
+        fontWeight={500}
+      >
+        {name}
+      </text>
+      {/* Cost label */}
+      <text
+        x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
+        y={ey + theme.spacing.md}
         textAnchor={textAnchor}
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}
@@ -85,7 +85,7 @@ const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) =
       {/* Percentage label */}
       <text
         x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey + theme.spacing.md}
+        y={ey + theme.spacing.md * 2}
         textAnchor={textAnchor}
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -75,7 +75,7 @@ const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) =
       {/* Cost label */}
       <text
         x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey + theme.spacing.md}
+        y={ey + theme.spacing.lg}
         textAnchor={textAnchor}
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}
@@ -85,7 +85,7 @@ const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) =
       {/* Percentage label */}
       <text
         x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey + theme.spacing.md * 2}
+        y={ey + theme.spacing.lg * 2}
         textAnchor={textAnchor}
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useDesignSystemTheme, PieChartIcon, type DesignSystemThemeInterface } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
-import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Sector } from 'recharts';
+import { PieChart, Pie, ResponsiveContainer, Legend, Sector, Tooltip } from 'recharts';
 import { formatCostUSD } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceCostBreakdownChartData } from '../hooks/useTraceCostBreakdownChartData';
 import { useTraceCostDimension } from '../hooks/useTraceCostDimension';
@@ -94,36 +94,32 @@ export const TraceCostBreakdownChart: React.FC = () => {
   const { dimension, setDimension } = useTraceCostDimension();
   const { chartData, totalCost, isLoading, error, hasData } = useTraceCostBreakdownChartData(dimension);
   const { getChartColor } = useChartColors();
-  const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
   const { getOpacity, handleLegendMouseEnter, handleLegendMouseLeave } = useLegendHighlight();
+
+  const coloredChartData = useMemo(
+    () =>
+      chartData.map((entry, index) => ({
+        ...entry,
+        fill: getChartColor(index),
+        fillOpacity: getOpacity(entry.name),
+      })),
+    [chartData, getChartColor, getOpacity],
+  );
 
   const activeShapeRenderer = useMemo(
     () => (props: unknown) => renderActiveShape(props as ActiveShapeProps, theme),
     [theme],
   );
 
-  const onPieEnter = useCallback((_: unknown, index: number) => {
-    setActiveIndex(index);
-  }, []);
-
-  const onPieLeave = useCallback(() => {
-    setActiveIndex(undefined);
-  }, []);
-
   const onLegendMouseEnter = useCallback(
     (data: { value: string | undefined }) => {
       handleLegendMouseEnter(data);
-      const index = chartData.findIndex((entry) => entry.name === data.value);
-      if (index !== -1) {
-        setActiveIndex(index);
-      }
     },
-    [handleLegendMouseEnter, chartData],
+    [handleLegendMouseEnter],
   );
 
   const onLegendMouseLeave = useCallback(() => {
     handleLegendMouseLeave();
-    setActiveIndex(undefined);
   }, [handleLegendMouseLeave]);
 
   const legendFormatter = useCallback(
@@ -179,7 +175,7 @@ export const TraceCostBreakdownChart: React.FC = () => {
           <ResponsiveContainer width="100%" height="100%">
             <PieChart style={{ overflow: 'visible' }}>
               <Pie
-                data={chartData}
+                data={coloredChartData}
                 cx="50%"
                 cy="50%"
                 innerRadius={PIE_INNER_RADIUS}
@@ -188,14 +184,8 @@ export const TraceCostBreakdownChart: React.FC = () => {
                 dataKey="value"
                 nameKey="name"
                 activeShape={activeShapeRenderer}
-                activeIndex={activeIndex}
-                onMouseEnter={onPieEnter}
-                onMouseLeave={onPieLeave}
-              >
-                {chartData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={getChartColor(index)} fillOpacity={getOpacity(entry.name)} />
-                ))}
-              </Pie>
+              />
+              <Tooltip content={() => null} cursor={false} />
               <Legend
                 layout="vertical"
                 align="right"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -33,6 +33,11 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill, name, value, percentage } = props;
   const { sx, sy, mx, my, ex, ey, textAnchor, cos } = calculatePieActiveShapeGeometry(props, theme);
 
+  // Clamp label Y so it stays within the chart area (top and bottom)
+  const maxLabelY = cy * 2 - theme.spacing.md * 2;
+  const labelY = Math.max(theme.spacing.md, Math.min(maxLabelY, ey));
+  const labelX = ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs;
+
   return (
     <g>
       {/* Main pie sector */}
@@ -56,13 +61,13 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
         fill={fill}
       />
       {/* Connecting line: radial segment -> horizontal segment */}
-      <path d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`} stroke={fill} fill="none" />
+      <path d={`M${sx},${sy}L${mx},${my}L${ex},${labelY}`} stroke={fill} fill="none" />
       {/* Dot at line end */}
-      <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
+      <circle cx={ex} cy={labelY} r={2} fill={fill} stroke="none" />
       {/* Model name label */}
       <text
-        x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey}
+        x={labelX}
+        y={labelY}
         textAnchor={textAnchor}
         fill={theme.colors.textPrimary}
         fontSize={theme.typography.fontSizeSm}
@@ -70,25 +75,15 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
       >
         {name}
       </text>
-      {/* Cost label */}
+      {/* Cost and percentage label */}
       <text
-        x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey + theme.spacing.lg}
+        x={labelX}
+        y={labelY + theme.spacing.md}
         textAnchor={textAnchor}
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}
       >
-        {formatCostUSD(value)}
-      </text>
-      {/* Percentage label */}
-      <text
-        x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey + theme.spacing.lg * 2}
-        textAnchor={textAnchor}
-        fill={theme.colors.textSecondary}
-        fontSize={theme.typography.fontSizeSm}
-      >
-        {percentage.toFixed(2)}%
+        {formatCostUSD(value)}, {percentage.toFixed(2)}%
       </text>
     </g>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useDesignSystemTheme, PieChartIcon, type DesignSystemThemeInterface } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
-import { PieChart, Pie, ResponsiveContainer, Legend, Sector, Tooltip } from 'recharts';
+import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Sector } from 'recharts';
 import { formatCostUSD } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceCostBreakdownChartData } from '../hooks/useTraceCostBreakdownChartData';
 import { useTraceCostDimension } from '../hooks/useTraceCostDimension';
@@ -94,67 +94,33 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
   );
 };
 
-interface ShapeProps extends ActiveShapeProps {
-  isActive: boolean;
-  index: number;
-  fillOpacity?: number;
-}
-
-/**
- * Creates a shape renderer that shows active styling for:
- * - Pie slice hover (via Tooltip's isActive)
- * - Legend hover (via legendActiveIndex)
- */
-const createShapeRenderer =
-  (theme: DesignSystemThemeInterface['theme'], legendActiveIndex: number | undefined) =>
-  (props: ShapeProps): React.ReactElement => {
-    const isActive = props.isActive || legendActiveIndex === props.index;
-
-    if (isActive) {
-      return renderActiveShape(props, theme);
-    }
-
-    return (
-      <Sector
-        cx={props.cx}
-        cy={props.cy}
-        innerRadius={props.innerRadius}
-        outerRadius={props.outerRadius}
-        startAngle={props.startAngle}
-        endAngle={props.endAngle}
-        fill={props.fill}
-        fillOpacity={props.fillOpacity}
-      />
-    );
-  };
-
 export const TraceCostBreakdownChart: React.FC = () => {
   const { theme } = useDesignSystemTheme();
   const { dimension, setDimension } = useTraceCostDimension();
   const { chartData, totalCost, isLoading, error, hasData } = useTraceCostBreakdownChartData(dimension);
   const { getChartColor } = useChartColors();
+  const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
   const { getOpacity, handleLegendMouseEnter, handleLegendMouseLeave } = useLegendHighlight();
-  const [legendActiveIndex, setLegendActiveIndex] = useState<number | undefined>(undefined);
 
-  const shapeRenderer = useMemo(() => createShapeRenderer(theme, legendActiveIndex), [theme, legendActiveIndex]);
-
-  // Add fill colors and opacity directly to data
-  const coloredChartData = useMemo(
-    () =>
-      chartData.map((entry, index) => ({
-        ...entry,
-        fill: getChartColor(index),
-        fillOpacity: getOpacity(entry.name),
-      })),
-    [chartData, getChartColor, getOpacity],
+  const activeShapeRenderer = useMemo(
+    () => (props: unknown) => renderActiveShape(props as ActiveShapeProps, theme),
+    [theme],
   );
+
+  const onPieEnter = useCallback((_: unknown, index: number) => {
+    setActiveIndex(index);
+  }, []);
+
+  const onPieLeave = useCallback(() => {
+    setActiveIndex(undefined);
+  }, []);
 
   const onLegendMouseEnter = useCallback(
     (data: { value: string | undefined }) => {
       handleLegendMouseEnter(data);
       const index = chartData.findIndex((entry) => entry.name === data.value);
       if (index !== -1) {
-        setLegendActiveIndex(index);
+        setActiveIndex(index);
       }
     },
     [handleLegendMouseEnter, chartData],
@@ -162,7 +128,7 @@ export const TraceCostBreakdownChart: React.FC = () => {
 
   const onLegendMouseLeave = useCallback(() => {
     handleLegendMouseLeave();
-    setLegendActiveIndex(undefined);
+    setActiveIndex(undefined);
   }, [handleLegendMouseLeave]);
 
   const legendFormatter = useCallback(
@@ -218,7 +184,7 @@ export const TraceCostBreakdownChart: React.FC = () => {
           <ResponsiveContainer width="100%" height="100%">
             <PieChart style={{ overflow: 'visible' }}>
               <Pie
-                data={coloredChartData}
+                data={chartData}
                 cx="50%"
                 cy="50%"
                 innerRadius={PIE_INNER_RADIUS}
@@ -226,10 +192,15 @@ export const TraceCostBreakdownChart: React.FC = () => {
                 paddingAngle={PIE_PADDING_ANGLE}
                 dataKey="value"
                 nameKey="name"
-                shape={shapeRenderer}
-              />
-              {/* Tooltip enables internal active state tracking for pie hover (recharts 3.x) */}
-              <Tooltip content={() => null} cursor={false} />
+                activeShape={activeShapeRenderer}
+                activeIndex={activeIndex}
+                onMouseEnter={onPieEnter}
+                onMouseLeave={onPieLeave}
+              >
+                {chartData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={getChartColor(index)} fillOpacity={getOpacity(entry.name)} />
+                ))}
+              </Pie>
               <Legend
                 layout="vertical"
                 align="right"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -28,7 +28,7 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill, name, value, percentage } = props;
 
   // Label is always centered above the pie — no overflow issues regardless of slice position
-  const labelY = cy - outerRadius - theme.spacing.lg;
+  const labelY = cy - PIE_PADDING_ANGLE - outerRadius - theme.spacing.lg;
 
   return (
     <g>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useDesignSystemTheme, PieChartIcon, type DesignSystemThemeInterface } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { PieChart, Pie, ResponsiveContainer, Legend, Sector, Tooltip } from 'recharts';
@@ -89,13 +89,51 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
   );
 };
 
+interface ShapeProps extends ActiveShapeProps {
+  isActive: boolean;
+  index: number;
+  fillOpacity?: number;
+}
+
+/**
+ * Creates a shape renderer that shows active styling for:
+ * - Pie slice hover (via Tooltip's isActive)
+ * - Legend hover (via legendActiveIndex)
+ */
+const createShapeRenderer =
+  (theme: DesignSystemThemeInterface['theme'], legendActiveIndex: number | undefined) =>
+  (props: ShapeProps): React.ReactElement => {
+    const isActive = props.isActive || legendActiveIndex === props.index;
+
+    if (isActive) {
+      return renderActiveShape(props, theme);
+    }
+
+    return (
+      <Sector
+        cx={props.cx}
+        cy={props.cy}
+        innerRadius={props.innerRadius}
+        outerRadius={props.outerRadius}
+        startAngle={props.startAngle}
+        endAngle={props.endAngle}
+        fill={props.fill}
+        fillOpacity={props.fillOpacity}
+      />
+    );
+  };
+
 export const TraceCostBreakdownChart: React.FC = () => {
   const { theme } = useDesignSystemTheme();
   const { dimension, setDimension } = useTraceCostDimension();
   const { chartData, totalCost, isLoading, error, hasData } = useTraceCostBreakdownChartData(dimension);
   const { getChartColor } = useChartColors();
   const { getOpacity, handleLegendMouseEnter, handleLegendMouseLeave } = useLegendHighlight();
+  const [legendActiveIndex, setLegendActiveIndex] = useState<number | undefined>(undefined);
 
+  const shapeRenderer = useMemo(() => createShapeRenderer(theme, legendActiveIndex), [theme, legendActiveIndex]);
+
+  // Add fill colors and opacity directly to data
   const coloredChartData = useMemo(
     () =>
       chartData.map((entry, index) => ({
@@ -106,20 +144,20 @@ export const TraceCostBreakdownChart: React.FC = () => {
     [chartData, getChartColor, getOpacity],
   );
 
-  const activeShapeRenderer = useMemo(
-    () => (props: unknown) => renderActiveShape(props as ActiveShapeProps, theme),
-    [theme],
-  );
-
   const onLegendMouseEnter = useCallback(
     (data: { value: string | undefined }) => {
       handleLegendMouseEnter(data);
+      const index = chartData.findIndex((entry) => entry.name === data.value);
+      if (index !== -1) {
+        setLegendActiveIndex(index);
+      }
     },
-    [handleLegendMouseEnter],
+    [handleLegendMouseEnter, chartData],
   );
 
   const onLegendMouseLeave = useCallback(() => {
     handleLegendMouseLeave();
+    setLegendActiveIndex(undefined);
   }, [handleLegendMouseLeave]);
 
   const legendFormatter = useCallback(
@@ -183,8 +221,9 @@ export const TraceCostBreakdownChart: React.FC = () => {
                 paddingAngle={PIE_PADDING_ANGLE}
                 dataKey="value"
                 nameKey="name"
-                activeShape={activeShapeRenderer}
+                shape={shapeRenderer}
               />
+              {/* Tooltip enables internal active state tracking for pie hover (recharts 3.x) */}
               <Tooltip content={() => null} cursor={false} />
               <Legend
                 layout="vertical"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -28,7 +28,7 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill, name, value, percentage } = props;
 
   // Label is always centered above the pie — no overflow issues regardless of slice position
-  const labelY = cy - PIE_PADDING_ANGLE - outerRadius - theme.spacing.lg;
+  const labelY = cy - outerRadius - theme.spacing.lg - 4;
 
   return (
     <g>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -14,12 +14,7 @@ import {
   OverviewChartContainer,
   DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
-import {
-  useChartColors,
-  useLegendHighlight,
-  calculatePieActiveShapeGeometry,
-  type ActiveShapeProps,
-} from '../utils/chartUtils';
+import { useChartColors, useLegendHighlight, type ActiveShapeProps } from '../utils/chartUtils';
 
 // Pie chart sizing constants
 const PIE_INNER_RADIUS = 50;
@@ -31,12 +26,9 @@ const PIE_PADDING_ANGLE = 2;
  */
 const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInterface['theme']) => {
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill, name, value, percentage } = props;
-  const { sx, sy, mx, my, ex, ey, textAnchor, cos } = calculatePieActiveShapeGeometry(props, theme);
 
-  // Clamp label Y so it stays within the chart area (top and bottom)
-  const maxLabelY = cy * 2 - theme.spacing.md * 2;
-  const labelY = Math.max(theme.spacing.md, Math.min(maxLabelY, ey));
-  const labelX = ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs;
+  // Label is always centered above the pie — no overflow issues regardless of slice position
+  const labelY = cy - outerRadius - theme.spacing.lg;
 
   return (
     <g>
@@ -60,26 +52,22 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
         outerRadius={outerRadius + theme.spacing.sm}
         fill={fill}
       />
-      {/* Connecting line: radial segment -> horizontal segment */}
-      <path d={`M${sx},${sy}L${mx},${my}L${ex},${labelY}`} stroke={fill} fill="none" />
-      {/* Dot at line end */}
-      <circle cx={ex} cy={labelY} r={2} fill={fill} stroke="none" />
-      {/* Model name label */}
+      {/* Model name */}
       <text
-        x={labelX}
+        x={cx}
         y={labelY}
-        textAnchor={textAnchor}
+        textAnchor="middle"
         fill={theme.colors.textPrimary}
         fontSize={theme.typography.fontSizeSm}
         fontWeight={500}
       >
         {name}
       </text>
-      {/* Cost and percentage label */}
+      {/* Cost and percentage */}
       <text
-        x={labelX}
+        x={cx}
         y={labelY + theme.spacing.md}
-        textAnchor={textAnchor}
+        textAnchor="middle"
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}
       >
@@ -215,7 +203,7 @@ export const TraceCostBreakdownChart: React.FC = () => {
               <Pie
                 data={coloredChartData}
                 cx="50%"
-                cy="50%"
+                cy="60%"
                 innerRadius={PIE_INNER_RADIUS}
                 outerRadius={PIE_OUTER_RADIUS}
                 paddingAngle={PIE_PADDING_ANGLE}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/chartUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/chartUtils.ts
@@ -61,16 +61,16 @@ export function calculatePieActiveShapeGeometry(
   const sin = Math.sin(-RADIAN * midAngle);
   const cos = Math.cos(-RADIAN * midAngle);
 
-  // Line start point (just outside the pie slice)
-  const sx = cx + (outerRadius + theme.spacing.sm) * cos;
-  const sy = cy + (outerRadius + theme.spacing.sm) * sin;
+  // Line start point (just outside the outer highlight arc)
+  const sx = cx + (outerRadius + theme.spacing.md) * cos;
+  const sy = cy + (outerRadius + theme.spacing.md) * sin;
 
   // Line bend point (further out, creates an elbow in the line)
-  const mx = cx + (outerRadius + theme.spacing.md) * cos;
-  const my = cy + (outerRadius + theme.spacing.md) * sin;
+  const mx = cx + (outerRadius + theme.spacing.lg) * cos;
+  const my = cy + (outerRadius + theme.spacing.lg) * sin;
 
   // Line end point (horizontal offset from bend, direction based on left/right side)
-  const ex = mx + (cos >= 0 ? 1 : -1) * theme.spacing.md;
+  const ex = mx + (cos >= 0 ? 1 : -1) * theme.spacing.lg;
   const ey = my;
   const textAnchor = cos >= 0 ? 'start' : 'end';
 


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

In the Cost Breakdown donut chart on the Usage tab, long model names (e.g. "gpt-5.2-2025-12-11") were truncated when rendered inside the small donut center area, making them difficult to read.

This PR moves the model name label from the donut center to the top of the chart. The external labels now show two stacked lines: model name (bold), cost & percentage.

before
<img width="1024" height="319" alt="image" src="https://github.com/user-attachments/assets/7ead81ec-a82f-4550-a241-125fbb8e8619" />


after
<img width="709" height="325" alt="image" src="https://github.com/user-attachments/assets/3679f856-fc3c-443c-a675-a992bb9ec8b7" />


### How is this PR tested?

- [x] Manual tests

Verified visually that long model names are now fully visible in the external label area.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed truncated model names in the Cost Breakdown donut chart by moving labels to the external label area.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)