### PR TITLE
Improve quality chart readability: larger labels and sentiment-based bar colors

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.tsx
@@ -6,6 +6,8 @@ import {
   Line,
   BarChart,
   Bar,
+  // eslint-disable-next-line import/no-deprecated -- Cell is deprecated in recharts v3 but no alternative exists for per-bar coloring
+  Cell,
   XAxis,
   YAxis,
   Tooltip,
@@ -34,6 +36,25 @@ import { getLineDotStyle } from '../utils/chartUtils';
 import { useOverviewChartContext } from '../OverviewChartContext';
 import { useMonitoringFilters } from '../../../hooks/useMonitoringFilters';
 import { useNavigate } from '../../../../common/utils/RoutingUtils';
+
+const POSITIVE_VALUES = new Set(['yes', 'true', '1']);
+const NEGATIVE_VALUES = new Set(['no', 'false', '0']);
+
+/**
+ * Returns a sentiment-based color for an assessment value bar.
+ * Green for positive values (yes/true/1), red for negative values (no/false/0),
+ * or the default chart color for other values.
+ */
+function getAssessmentBarColor(
+  name: string,
+  theme: ReturnType<typeof useDesignSystemTheme>['theme'],
+  defaultColor: string,
+): string {
+  const normalized = name.toLowerCase().trim();
+  if (POSITIVE_VALUES.has(normalized)) return theme.colors.green500;
+  if (NEGATIVE_VALUES.has(normalized)) return theme.colors.red500;
+  return defaultColor;
+}
 
 /** Local component for chart panel with label */
 const ChartPanel: React.FC<{ label: React.ReactNode; children: React.ReactElement }> = ({ label, children }) => {
@@ -177,13 +198,23 @@ export const TraceAssessmentChart: React.FC<TraceAssessmentChartProps> = ({ asse
         >
           <BarChart data={distributionChartData} layout="vertical" margin={{ top: 10, right: 10, left: 10, bottom: 0 }}>
             <XAxis type="number" allowDecimals={false} {...xAxisProps} />
-            <YAxis type="category" dataKey="name" {...yAxisProps} width={60} />
+            <YAxis
+              type="category"
+              dataKey="name"
+              {...yAxisProps}
+              tick={{ ...yAxisProps.tick, fontSize: 12 }}
+              width={80}
+            />
             <Tooltip
               content={distributionTooltipContent}
               cursor={{ fill: theme.colors.actionTertiaryBackgroundHover }}
             />
             <Legend {...scrollableLegendProps} />
-            <Bar dataKey="count" fill={chartLineColor} radius={[0, 4, 4, 0]} />
+            <Bar dataKey="count" fill={chartLineColor} radius={[0, 4, 4, 0]}>
+              {distributionChartData.map((entry) => (
+                <Cell key={entry.name} fill={getAssessmentBarColor(entry.name, theme, chartLineColor)} />
+              ))}
+            </Bar>
           </BarChart>
         </ChartPanel>
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceAssessmentChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceAssessmentChartData.ts
@@ -145,7 +145,7 @@ export function useTraceAssessmentChartData(assessmentName: string): UseTraceAss
     // For non-bucketed values (sparse integers, strings, booleans), use as-is
     const sortedValues = sortValuesAlphanumerically(allValues);
     return sortedValues.map((value) => ({
-      name: value,
+      name: value.replace(/^"|"$/g, ''),
       count: valueCounts[value] || 0,
     }));
   }, [distributionDataPoints]);


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://databricks.atlassian.net/browse/ML-62998

### What changes are proposed in this pull request?

The value labels on the quality graph (assessment distribution bar chart) in the Overview tab are too small to read comfortably. This PR:

1. **Increases Y-axis label font size** from 10px to 12px for better readability of assessment value names
2. **Increases Y-axis width** from 60px to 80px to accommodate the larger text
3. **Adds sentiment-based bar coloring**: green for positive values (yes/true/1), red for negative values (no/false/0), matching the assessment batch colors used in trace view. Non-boolean values retain the default chart color.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

All 25 existing tests in `TraceAssessmentChart.test.tsx` pass without changes.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved readability of quality chart labels in the Overview tab and added sentiment-based bar coloring (green for positive, red for negative assessment values).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)