### PR TITLE
Improve dataset records empty state and add-record modals

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/AddManuallyModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/AddManuallyModal.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useState } from 'react';
+import { Alert, FormUI, Input, Modal, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useUpsertDatasetRecordsMutation } from '../hooks/useUpsertDatasetRecordsMutation';
+import { useQueryClient } from '@databricks/web-shared/query-client';
+import { GET_DATASET_RECORDS_QUERY_KEY } from '../constants';
+
+export const AddManuallyModal = ({
+  visible,
+  onCancel,
+  datasetId,
+}: {
+  visible: boolean;
+  onCancel: () => void;
+  datasetId: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const queryClient = useQueryClient();
+
+  const [inputsValue, setInputsValue] = useState('');
+  const [expectationsValue, setExpectationsValue] = useState('');
+  const [inputsError, setInputsError] = useState('');
+  const [expectationsError, setExpectationsError] = useState('');
+  const [apiError, setApiError] = useState('');
+
+  const { upsertDatasetRecordsMutation, isLoading } = useUpsertDatasetRecordsMutation({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [GET_DATASET_RECORDS_QUERY_KEY, datasetId] });
+      handleClose();
+    },
+    onError: (err: any) => {
+      setApiError(err?.message || 'Failed to add record');
+    },
+  });
+
+  const handleClose = useCallback(() => {
+    setInputsValue('');
+    setExpectationsValue('');
+    setInputsError('');
+    setExpectationsError('');
+    setApiError('');
+    onCancel();
+  }, [onCancel]);
+
+  const validateJson = (value: string, fieldName: string): Record<string, unknown> | null => {
+    if (!value.trim()) return null;
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return null;
+      }
+      return parsed;
+    } catch {
+      return null;
+    }
+  };
+
+  const handleSubmit = useCallback(() => {
+    let hasError = false;
+
+    if (!inputsValue.trim()) {
+      setInputsError(
+        intl.formatMessage({
+          defaultMessage: 'Inputs field is required',
+          description: 'Error when inputs field is empty in add manually modal',
+        }),
+      );
+      hasError = true;
+    } else {
+      const parsedInputs = validateJson(inputsValue, 'inputs');
+      if (!parsedInputs) {
+        setInputsError(
+          intl.formatMessage({
+            defaultMessage: 'Inputs must be a valid JSON object',
+            description: 'Error when inputs field has invalid JSON',
+          }),
+        );
+        hasError = true;
+      }
+    }
+
+    if (expectationsValue.trim()) {
+      const parsedExpectations = validateJson(expectationsValue, 'expectations');
+      if (!parsedExpectations) {
+        setExpectationsError(
+          intl.formatMessage({
+            defaultMessage: 'Expectations must be a valid JSON object',
+            description: 'Error when expectations field has invalid JSON',
+          }),
+        );
+        hasError = true;
+      }
+    }
+
+    if (hasError) return;
+
+    const record: { inputs: Record<string, unknown>; expectations?: Record<string, unknown> } = {
+      inputs: JSON.parse(inputsValue.trim()),
+    };
+    if (expectationsValue.trim()) {
+      record.expectations = JSON.parse(expectationsValue.trim());
+    }
+
+    upsertDatasetRecordsMutation({
+      datasetId,
+      records: JSON.stringify([record]),
+    });
+  }, [inputsValue, expectationsValue, datasetId, upsertDatasetRecordsMutation, intl]);
+
+  return (
+    <Modal
+      componentId="mlflow.add-manually-modal"
+      visible={visible}
+      onCancel={handleClose}
+      title={
+        <FormattedMessage
+          defaultMessage="Add record manually"
+          description="Add manually modal title for dataset records"
+        />
+      }
+      okText={intl.formatMessage({
+        defaultMessage: 'Add',
+        description: 'Add manually modal action button',
+      })}
+      cancelText={intl.formatMessage({
+        defaultMessage: 'Cancel',
+        description: 'Add manually modal cancel button',
+      })}
+      onOk={handleSubmit}
+      okButtonProps={{ loading: isLoading }}
+      zIndex={theme.options.zIndexBase + 20}
+    >
+      {apiError && (
+        <Alert
+          componentId="mlflow.add-manually-modal.error"
+          type="error"
+          message={apiError}
+          closable
+          onClose={() => setApiError('')}
+          css={{ marginBottom: theme.spacing.sm }}
+        />
+      )}
+
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+        <div>
+          <FormUI.Label htmlFor="inputs-textarea">
+            <FormattedMessage
+              defaultMessage="Inputs"
+              description="Label for the inputs JSON field in add manually modal"
+            />
+            <span css={{ color: theme.colors.textValidationDanger }}> *</span>
+          </FormUI.Label>
+          <FormUI.Hint>
+            <FormattedMessage defaultMessage="Enter a JSON object" description="Hint text for the inputs JSON field" />
+          </FormUI.Hint>
+          <Input.TextArea
+            componentId="mlflow.add-manually-modal.inputs"
+            id="inputs-textarea"
+            value={inputsValue}
+            onChange={(e) => {
+              setInputsValue(e.target.value);
+              setInputsError('');
+            }}
+            rows={5}
+            css={{ fontFamily: 'monospace' }}
+            placeholder='{"question": "What is MLflow?"}'
+          />
+          {inputsError && <FormUI.Message type="error" message={inputsError} />}
+        </div>
+
+        <div>
+          <FormUI.Label htmlFor="expectations-textarea">
+            <FormattedMessage
+              defaultMessage="Expectations (optional)"
+              description="Label for the expectations JSON field in add manually modal"
+            />
+          </FormUI.Label>
+          <FormUI.Hint>
+            <FormattedMessage
+              defaultMessage="Enter a JSON object"
+              description="Hint text for the expectations JSON field"
+            />
+          </FormUI.Hint>
+          <Input.TextArea
+            componentId="mlflow.add-manually-modal.expectations"
+            id="expectations-textarea"
+            value={expectationsValue}
+            onChange={(e) => {
+              setExpectationsValue(e.target.value);
+              setExpectationsError('');
+            }}
+            rows={5}
+            css={{ fontFamily: 'monospace' }}
+            placeholder='{"expected_response": "..."}'
+          />
+          {expectationsError && <FormUI.Message type="error" message={expectationsError} />}
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/AddViaCodeModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/AddViaCodeModal.tsx
@@ -1,0 +1,94 @@
+import { CopyIcon, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { CodeSnippet } from '@databricks/web-shared/snippet';
+import { CopyButton } from '@mlflow/mlflow/src/shared/building_blocks/CopyButton';
+
+function getCodeSnippet(datasetName: string): string {
+  return `from mlflow.genai.datasets import get_dataset
+
+dataset = get_dataset(name="${datasetName}")
+dataset.merge_records([
+    {
+        "inputs": {"question": "What is MLflow?"},
+        "expectations": {"expected_response": "An ML platform"},
+    }
+])`;
+}
+
+export const AddViaCodeModal = ({
+  visible,
+  onCancel,
+  datasetName,
+}: {
+  visible: boolean;
+  onCancel: () => void;
+  datasetName: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const code = getCodeSnippet(datasetName);
+
+  return (
+    <Modal
+      componentId="mlflow.add-via-code-modal"
+      visible={visible}
+      onCancel={onCancel}
+      title={
+        <FormattedMessage
+          defaultMessage="Add records via code"
+          description="Add via code modal title for dataset records"
+        />
+      }
+      footer={null}
+      zIndex={theme.options.zIndexBase + 20}
+    >
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+        <Typography.Text color="secondary">
+          <FormattedMessage
+            defaultMessage="Use the MLflow Python SDK to add records to your dataset programmatically."
+            description="Description text in the add via code modal"
+          />
+        </Typography.Text>
+
+        <div css={{ position: 'relative' }}>
+          <CopyButton
+            componentId="mlflow.add-via-code-modal.copy"
+            css={{
+              zIndex: 1,
+              position: 'absolute',
+              top: theme.spacing.xs,
+              right: theme.spacing.xs,
+            }}
+            showLabel={false}
+            copyText={code}
+            icon={<CopyIcon />}
+          />
+          <CodeSnippet showLineNumbers language="python" theme={theme.isDarkMode ? 'duotoneDark' : 'light'}>
+            {code}
+          </CodeSnippet>
+        </div>
+
+        <Typography.Text color="secondary" size="sm">
+          <FormattedMessage
+            defaultMessage="For more information, visit the {docsLink}."
+            description="Documentation link text in the add via code modal"
+            values={{
+              docsLink: (
+                <Typography.Link
+                  componentId="mlflow.add-via-code-modal.docs-link"
+                  href="https://mlflow.org/docs/latest/genai/datasets/sdk-guide/#adding-records-to-a-dataset"
+                  openInNewTab
+                >
+                  <FormattedMessage
+                    defaultMessage="MLflow Datasets documentation"
+                    description="Link text for datasets documentation"
+                  />
+                </Typography.Link>
+              ),
+            }}
+          />
+        </Typography.Text>
+      </div>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsEmptyState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsEmptyState.tsx
@@ -1,5 +1,13 @@
 import { useState } from 'react';
-import { Button, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import {
+  BracketsCurlyIcon,
+  CodeIcon,
+  ListBorderIcon,
+  Tag,
+  Typography,
+  UploadIcon,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { Link, useParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
@@ -9,44 +17,72 @@ import { AddViaCodeModal } from './AddViaCodeModal';
 const ActionCard = ({
   title,
   description,
+  icon,
   onClick,
+  disabled,
 }: {
   title: React.ReactNode;
   description: React.ReactNode;
+  icon: React.ReactNode;
   onClick?: () => void;
+  disabled?: boolean;
 }) => {
   const { theme } = useDesignSystemTheme();
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          onClick?.();
-        }
-      }}
+      role={disabled ? undefined : 'button'}
+      tabIndex={disabled ? undefined : 0}
+      onClick={disabled ? undefined : onClick}
+      onKeyDown={
+        disabled
+          ? undefined
+          : (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                onClick?.();
+              }
+            }
+      }
       css={{
         display: 'flex',
-        flexDirection: 'column',
-        gap: theme.spacing.xs,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: theme.spacing.md,
         padding: theme.spacing.md,
         border: `1px solid ${theme.colors.border}`,
         borderRadius: theme.borders.borderRadiusMd,
-        cursor: 'pointer',
-        flex: 1,
-        minWidth: 180,
-        '&:hover': {
-          borderColor: theme.colors.actionDefaultBorderHover,
-          backgroundColor: theme.colors.actionDefaultBackgroundHover,
-        },
+        cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.5 : 1,
+        ...(!disabled && {
+          '&:hover': {
+            borderColor: theme.colors.actionDefaultBorderHover,
+            backgroundColor: theme.colors.actionDefaultBackgroundHover,
+          },
+        }),
       }}
     >
-      <Typography.Text bold>{title}</Typography.Text>
-      <Typography.Text color="secondary" size="sm">
-        {description}
-      </Typography.Text>
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: theme.colors.actionTertiaryTextDefault,
+          backgroundColor: theme.colors.actionTertiaryBackgroundHover,
+          borderRadius: theme.borders.borderRadiusMd,
+          width: 32,
+          height: 32,
+          minWidth: 32,
+          fontSize: 16,
+        }}
+      >
+        {icon}
+      </div>
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, alignItems: 'flex-start', textAlign: 'left' }}>
+        <Typography.Text bold>{title}</Typography.Text>
+        <Typography.Text color="secondary" size="sm">
+          {description}
+        </Typography.Text>
+      </div>
     </div>
   );
 };
@@ -92,13 +128,14 @@ export const ExperimentEvaluationDatasetRecordsEmptyState = ({
       <div
         css={{
           display: 'flex',
+          flexDirection: 'column',
           gap: theme.spacing.md,
-          flexWrap: 'wrap',
-          justifyContent: 'center',
-          maxWidth: 700,
+          maxWidth: 500,
+          width: '100%',
         }}
       >
         <ActionCard
+          icon={<BracketsCurlyIcon />}
           title={
             <FormattedMessage
               defaultMessage="Add Manually"
@@ -114,6 +151,7 @@ export const ExperimentEvaluationDatasetRecordsEmptyState = ({
           onClick={() => setAddManuallyVisible(true)}
         />
         <ActionCard
+          icon={<CodeIcon />}
           title={
             <FormattedMessage
               defaultMessage="Add via Code"
@@ -129,8 +167,9 @@ export const ExperimentEvaluationDatasetRecordsEmptyState = ({
           onClick={() => setAddViaCodeVisible(true)}
         />
         {tracesRoute && (
-          <Link to={tracesRoute} css={{ flex: 1, minWidth: 180, textDecoration: 'none' }}>
+          <Link to={tracesRoute} css={{ textDecoration: 'none' }}>
             <ActionCard
+              icon={<ListBorderIcon />}
               title={
                 <FormattedMessage
                   defaultMessage="Select Traces"
@@ -146,6 +185,30 @@ export const ExperimentEvaluationDatasetRecordsEmptyState = ({
             />
           </Link>
         )}
+        <ActionCard
+          icon={<UploadIcon />}
+          disabled
+          title={
+            <>
+              <FormattedMessage
+                defaultMessage="Upload CSV"
+                description="Action card title for uploading a CSV file to a dataset"
+              />{' '}
+              <Tag componentId="mlflow.dataset.upload-csv-coming-soon">
+                <FormattedMessage
+                  defaultMessage="Coming soon"
+                  description="Tag label indicating the upload CSV feature is not yet available"
+                />
+              </Tag>
+            </>
+          }
+          description={
+            <FormattedMessage
+              defaultMessage="Import dataset items from a CSV file"
+              description="Action card description for uploading a CSV file to a dataset"
+            />
+          }
+        />
       </div>
       <AddManuallyModal
         visible={addManuallyVisible}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsEmptyState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsEmptyState.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react';
+import { Button, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { Link, useParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
+import { AddManuallyModal } from './AddManuallyModal';
+import { AddViaCodeModal } from './AddViaCodeModal';
+
+const ActionCard = ({
+  title,
+  description,
+  onClick,
+}: {
+  title: React.ReactNode;
+  description: React.ReactNode;
+  onClick?: () => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          onClick?.();
+        }
+      }}
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing.xs,
+        padding: theme.spacing.md,
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        cursor: 'pointer',
+        flex: 1,
+        minWidth: 180,
+        '&:hover': {
+          borderColor: theme.colors.actionDefaultBorderHover,
+          backgroundColor: theme.colors.actionDefaultBackgroundHover,
+        },
+      }}
+    >
+      <Typography.Text bold>{title}</Typography.Text>
+      <Typography.Text color="secondary" size="sm">
+        {description}
+      </Typography.Text>
+    </div>
+  );
+};
+
+export const ExperimentEvaluationDatasetRecordsEmptyState = ({
+  datasetId,
+  datasetName,
+}: {
+  datasetId: string;
+  datasetName: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const { experimentId } = useParams();
+  const [addManuallyVisible, setAddManuallyVisible] = useState(false);
+  const [addViaCodeVisible, setAddViaCodeVisible] = useState(false);
+
+  const tracesRoute = experimentId ? Routes.getExperimentPageTracesTabRoute(experimentId) : undefined;
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: theme.spacing.lg,
+        gap: theme.spacing.sm,
+        textAlign: 'center',
+      }}
+    >
+      <Typography.Title level={4} color="secondary">
+        <FormattedMessage
+          defaultMessage="Add items to your dataset"
+          description="Title for the empty state when an evaluation dataset has no records"
+        />
+      </Typography.Title>
+      <Typography.Paragraph color="secondary" css={{ maxWidth: 460, marginBottom: theme.spacing.sm }}>
+        <FormattedMessage
+          defaultMessage="Datasets are collections of specific edge cases and underrepresented patterns used to evaluate your application."
+          description="Description for the empty state when an evaluation dataset has no records"
+        />
+      </Typography.Paragraph>
+      <div
+        css={{
+          display: 'flex',
+          gap: theme.spacing.md,
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          maxWidth: 700,
+        }}
+      >
+        <ActionCard
+          title={
+            <FormattedMessage
+              defaultMessage="Add Manually"
+              description="Action card title for manually adding a record to a dataset"
+            />
+          }
+          description={
+            <FormattedMessage
+              defaultMessage="Manually input a single item"
+              description="Action card description for manually adding a record to a dataset"
+            />
+          }
+          onClick={() => setAddManuallyVisible(true)}
+        />
+        <ActionCard
+          title={
+            <FormattedMessage
+              defaultMessage="Add via Code"
+              description="Action card title for adding records via Python SDK"
+            />
+          }
+          description={
+            <FormattedMessage
+              defaultMessage="Use the MLflow Python SDK"
+              description="Action card description for adding records via Python SDK"
+            />
+          }
+          onClick={() => setAddViaCodeVisible(true)}
+        />
+        {tracesRoute && (
+          <Link to={tracesRoute} css={{ flex: 1, minWidth: 180, textDecoration: 'none' }}>
+            <ActionCard
+              title={
+                <FormattedMessage
+                  defaultMessage="Select Traces"
+                  description="Action card title for selecting traces to add to a dataset"
+                />
+              }
+              description={
+                <FormattedMessage
+                  defaultMessage='Select traces in the Traces tab, then use the "Actions" button to add them to a dataset'
+                  description="Action card description for selecting traces to add to a dataset via actions button"
+                />
+              }
+            />
+          </Link>
+        )}
+      </div>
+      <AddManuallyModal
+        visible={addManuallyVisible}
+        onCancel={() => setAddManuallyVisible(false)}
+        datasetId={datasetId}
+      />
+      <AddViaCodeModal
+        visible={addViaCodeVisible}
+        onCancel={() => setAddViaCodeVisible(false)}
+        datasetName={datasetName}
+      />
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsTable.tsx
@@ -8,6 +8,7 @@ import { Table } from '@databricks/design-system';
 import { useIntl } from 'react-intl';
 import { JsonCell } from './ExperimentEvaluationDatasetJsonCell';
 import { ExperimentEvaluationDatasetRecordsToolbar } from './ExperimentEvaluationDatasetRecordsToolbar';
+import { ExperimentEvaluationDatasetRecordsEmptyState } from './ExperimentEvaluationDatasetRecordsEmptyState';
 import type { EvaluationDataset, EvaluationDatasetRecord } from '../types';
 import { useInfiniteScrollFetch } from '../hooks/useInfiniteScrollFetch';
 
@@ -145,12 +146,19 @@ export const ExperimentEvaluationDatasetRecordsTable = ({ dataset }: { dataset: 
         css={{ flex: 1 }}
         empty={
           !isLoading && table.getRowModel().rows.length === 0 ? (
-            <Empty
-              description={intl.formatMessage({
-                defaultMessage: 'No records found',
-                description: 'Empty state for the evaluation dataset records table',
-              })}
-            />
+            searchFilter.trim() ? (
+              <Empty
+                description={intl.formatMessage({
+                  defaultMessage: 'No records found',
+                  description: 'Empty state for the evaluation dataset records table when search yields no results',
+                })}
+              />
+            ) : (
+              <ExperimentEvaluationDatasetRecordsEmptyState
+                datasetId={datasetId ?? ''}
+                datasetName={dataset.name ?? ''}
+              />
+            )
           ) : undefined
         }
         scrollable

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -559,6 +559,10 @@
     "defaultMessage": "added {when} by {user}",
     "description": "Evaluation review > assessments > detailed history > added history entry"
   },
+  "20pGXz": {
+    "defaultMessage": "Add",
+    "description": "Add manually modal action button"
+  },
   "25EUlg": {
     "defaultMessage": "The code snippets below demonstrate how to load the logged model.",
     "description": "Subtext heading explaining the below section of the model artifact view on how users can load the registered logged model"
@@ -642,6 +646,10 @@
   "2Us2jl": {
     "defaultMessage": "X axis",
     "description": "Label for X axis in Contour chart configurator in compare runs chart config modal"
+  },
+  "2XgfPm": {
+    "defaultMessage": "No records found",
+    "description": "Empty state for the evaluation dataset records table when search yields no results"
   },
   "2YEXRM": {
     "defaultMessage": "Edit",
@@ -1298,6 +1306,10 @@
     "defaultMessage": "MLflow API documentation",
     "description": "Link to the MLflow API documentation for the Trace object"
   },
+  "7RkH9i": {
+    "defaultMessage": "Add record manually",
+    "description": "Add manually modal title for dataset records"
+  },
   "7S/ozs": {
     "defaultMessage": "Context sufficient",
     "description": "Evaluation results > context sufficiency assessment > positive value label. Displayed if retrieved context is sufficient to generate the expected response."
@@ -1550,6 +1562,10 @@
     "defaultMessage": "The guidelines LLM judge determines whether the response adheres to the guidelines provided. All responses must adhere to guidelines.",
     "description": "Evaluation results > known type of evaluation result assessment > guidelines judge."
   },
+  "9ADmh+": {
+    "defaultMessage": "Manually input a single item",
+    "description": "Action card description for manually adding a record to a dataset"
+  },
   "9AfxK7": {
     "defaultMessage": "Goal",
     "description": "Column label for simulation goal"
@@ -1621,6 +1637,10 @@
   "9ZHB3D": {
     "defaultMessage": "MLflow runs:",
     "description": "A label for the associated MLflow runs in the prompt details page"
+  },
+  "9ZPBhY": {
+    "defaultMessage": "Select traces in the Traces tab, then use the \"Actions\" button to add them to a dataset",
+    "description": "Action card description for selecting traces to add to a dataset via actions button"
   },
   "9ZzOhu": {
     "defaultMessage": "API Keys",
@@ -2630,6 +2650,10 @@
     "defaultMessage": "null",
     "description": "Null value in the evaluations table."
   },
+  "H3cwTr": {
+    "defaultMessage": "Add Manually",
+    "description": "Action card title for manually adding a record to a dataset"
+  },
   "H7JwOl": {
     "defaultMessage": "Delete version",
     "description": "A label for a button to delete prompt version on the prompt details page"
@@ -3438,6 +3462,10 @@
     "defaultMessage": "Create custom code judge",
     "description": "Title for new custom code judge modal"
   },
+  "N63SVe": {
+    "defaultMessage": "Add records via code",
+    "description": "Add via code modal title for dataset records"
+  },
   "N79Rdb": {
     "defaultMessage": "{count, plural, =1 {1 month} other {# months}} ago",
     "description": "Time duration in months"
@@ -3717,6 +3745,10 @@
   "P31kXd": {
     "defaultMessage": "Cost breakdown",
     "description": "Header for span cost breakdown"
+  },
+  "P6UGCb": {
+    "defaultMessage": "For more information, visit the {docsLink}.",
+    "description": "Documentation link text in the add via code modal"
   },
   "PAUNgq": {
     "defaultMessage": "Cost Breakdown",
@@ -4273,6 +4305,10 @@
     "defaultMessage": "Line Smoothness",
     "description": "Label for the smoothness slider for the graph plot for metrics"
   },
+  "T693b6": {
+    "defaultMessage": "Cancel",
+    "description": "Add manually modal cancel button"
+  },
   "T6s9Mi": {
     "defaultMessage": "Delete API Key",
     "description": "Gateway > API key details drawer > Delete API key button"
@@ -4364,10 +4400,6 @@
     "defaultMessage": "Cancel",
     "description": "Cancel button label within a modal for adding/editing a new runs comparison chart"
   },
-  "TnD/vL": {
-    "defaultMessage": "No records found",
-    "description": "Empty state for the evaluation dataset records table"
-  },
   "Tpj2su": {
     "defaultMessage": "Attributes",
     "description": "Label for the attributes column group in the logged model column selector"
@@ -4407,6 +4439,10 @@
   "U4s/77": {
     "defaultMessage": "Show more",
     "description": "Button to expand alert description"
+  },
+  "U7XxqM": {
+    "defaultMessage": "Use the MLflow Python SDK to add records to your dataset programmatically.",
+    "description": "Description text in the add via code modal"
   },
   "U82iv6": {
     "defaultMessage": "Registered Models",
@@ -4639,6 +4675,14 @@
   "VcNdOq": {
     "defaultMessage": "No description",
     "description": "Run page > Overview > Description section > Empty value placeholder"
+  },
+  "Vdgp7Z": {
+    "defaultMessage": "Expectations (optional)",
+    "description": "Label for the expectations JSON field in add manually modal"
+  },
+  "Vei/8N": {
+    "defaultMessage": "Inputs field is required",
+    "description": "Error when inputs field is empty in add manually modal"
   },
   "VfGJFc": {
     "defaultMessage": "Deleted traces cannot be restored. Are you sure you want to proceed?",
@@ -5002,6 +5046,10 @@
   "YEN2Ll": {
     "defaultMessage": "Used by ({count})",
     "description": "Gateway > Endpoint bindings drawer > Title"
+  },
+  "YErJq2": {
+    "defaultMessage": "MLflow Datasets documentation",
+    "description": "Link text for datasets documentation"
   },
   "YG2DsC": {
     "defaultMessage": "Collapse section",
@@ -5599,6 +5647,10 @@
     "defaultMessage": "Select a cell to display preview",
     "description": "Experiment page > table view > preview sidebar > nothing selected"
   },
+  "cAPh1z": {
+    "defaultMessage": "Expectations must be a valid JSON object",
+    "description": "Error when expectations field has invalid JSON"
+  },
   "cAujuc": {
     "defaultMessage": "Endpoints using this key ({count})",
     "description": "Gateway > Delete API key modal > Endpoints list header"
@@ -5690,6 +5742,10 @@
   "cYlLx9": {
     "defaultMessage": "Usage",
     "description": "Sidebar link for gateway usage"
+  },
+  "cfvU7K": {
+    "defaultMessage": "Enter a JSON object",
+    "description": "Hint text for the expectations JSON field"
   },
   "ckfi1K": {
     "defaultMessage": "Refresh evaluation runs",
@@ -5850,6 +5906,10 @@
   "dqfOjO": {
     "defaultMessage": "You cannot select rows when comparing runs",
     "description": "Tooltip message for the select button when comparing runs"
+  },
+  "drVq/D": {
+    "defaultMessage": "Add via Code",
+    "description": "Action card title for adding records via Python SDK"
   },
   "dt3hj5": {
     "defaultMessage": "Add tags",
@@ -6415,6 +6475,10 @@
     "defaultMessage": "+∞",
     "description": "Label displaying positive infinity symbol displayed on a plot UI element"
   },
+  "hcSOfj": {
+    "defaultMessage": "Datasets are collections of specific edge cases and underrepresented patterns used to evaluate your application.",
+    "description": "Description for the empty state when an evaluation dataset has no records"
+  },
   "hg+bcy": {
     "defaultMessage": "Enable telemetry",
     "description": "Enable telemetry settings title"
@@ -6838,6 +6902,10 @@
   "kTkJkb": {
     "defaultMessage": "Parallel coordinates chart does not support aggregated string values. Use other parameters or disable run grouping to continue.",
     "description": "Experiment page > compare runs > parallel coordinates chart configuration modal > unsupported string values warning"
+  },
+  "kU0qfS": {
+    "defaultMessage": "Inputs",
+    "description": "Label for the inputs JSON field in add manually modal"
   },
   "kV2Dw/": {
     "defaultMessage": "Load model as a PyFuncModel.",
@@ -7723,6 +7791,10 @@
     "defaultMessage": "Register model",
     "description": "Register model modal title to register the model for deployment"
   },
+  "qTaLBB": {
+    "defaultMessage": "Inputs must be a valid JSON object",
+    "description": "Error when inputs field has invalid JSON"
+  },
   "qTjYVU": {
     "defaultMessage": "Hide run",
     "description": "A tooltip for the visibility icon button in the runs table next to the visible run"
@@ -8227,6 +8299,10 @@
     "defaultMessage": "Native MLflow API for model invocations. Supports seamless model switching and advanced routing.",
     "description": "MLflow invocations API description"
   },
+  "tvhwjn": {
+    "defaultMessage": "Select Traces",
+    "description": "Action card title for selecting traces to add to a dataset"
+  },
   "tx3aAM": {
     "defaultMessage": "Add tag",
     "description": "Key-value tag editor modal > Add tag button"
@@ -8242,6 +8318,10 @@
   "u13xKF": {
     "defaultMessage": "Custom judge",
     "description": "LLM judge option for creating a custom judge"
+  },
+  "u7MR0C": {
+    "defaultMessage": "Use the MLflow Python SDK",
+    "description": "Action card description for adding records via Python SDK"
   },
   "uABFy0": {
     "defaultMessage": "AI Gateway",
@@ -8667,6 +8747,10 @@
     "defaultMessage": "Recent Experiments",
     "description": "Home page experiments preview title"
   },
+  "xNlzTr": {
+    "defaultMessage": "Add items to your dataset",
+    "description": "Title for the empty state when an evaluation dataset has no records"
+  },
   "xPkIEE": {
     "defaultMessage": "Active",
     "description": "Tab text to view active versions under details tab\n                                on the model view page"
@@ -8898,6 +8982,10 @@
   "z/CjX4": {
     "defaultMessage": "View stack trace",
     "description": "Link to view the stack trace for an assessment error"
+  },
+  "z13NbD": {
+    "defaultMessage": "Enter a JSON object",
+    "description": "Hint text for the inputs JSON field"
   },
   "z2Gyuw": {
     "defaultMessage": "MLflow Model",


### PR DESCRIPTION

### What changes are proposed in this pull request?

Currently, the onboarding flow for dataset UI is incomplete. After user creates a new dataset, there is no action shown to users to add new records from UI.

<img width="909" height="364" alt="Screenshot 2026-03-03 at 17 12 06" src="https://github.com/user-attachments/assets/c2d51957-126b-4ebd-8043-c09eda95c683" />

This PR updates the empty state for dataset records view with cards for adding records manually, via code, and selecting traces. Everything is already supported by backend so no new REST API is required.


https://github.com/user-attachments/assets/15cd6b7c-248f-4648-b262-b7190d16d80f


### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved dataset records empty state with actionable cards and polished add-record modals.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)