### PR TITLE
Fill timing gaps in Claude Code traces with LLM spans

### DIFF
--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -272,10 +272,13 @@ def _get_next_timestamp_ns(transcript: list[dict[str, Any]], current_idx: int) -
     return None
 
 
-def _extract_content_and_tools(content: list[dict[str, Any]]) -> tuple[str, list[dict[str, Any]]]:
-    """Extract text content and tool uses from assistant response content."""
+def _extract_content_and_tools(
+    content: list[dict[str, Any]],
+) -> tuple[str, list[dict[str, Any]], str]:
+    """Extract text content, tool uses, and thinking text from assistant response content."""
     text_content = ""
     tool_uses = []
+    thinking_text = ""
 
     if isinstance(content, list):
         for part in content:
@@ -284,8 +287,10 @@ def _extract_content_and_tools(content: list[dict[str, Any]]) -> tuple[str, list
                     text_content += part.get(CONTENT_TYPE_TEXT, "")
                 elif part.get(MESSAGE_FIELD_TYPE) == CONTENT_TYPE_TOOL_USE:
                     tool_uses.append(part)
+                elif part.get(MESSAGE_FIELD_TYPE) == "thinking":
+                    thinking_text += part.get("thinking", "")
 
-    return text_content, tool_uses
+    return text_content, tool_uses, thinking_text
 
 
 def _find_tool_results(transcript: list[dict[str, Any]], start_idx: int) -> dict[str, Any]:
@@ -402,10 +407,31 @@ def _set_token_usage_attribute(span, usage: dict[str, Any]) -> None:
     span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
 
 
+def _create_inference_span(
+    parent_span, start_ns: int, end_ns: int, thinking_text: str = ""
+) -> None:
+    """Create an LLM span covering the inferred inference time before a tool call."""
+    span = mlflow.start_span_no_context(
+        name="llm",
+        parent_span=parent_span,
+        span_type=SpanType.LLM,
+        start_time_ns=start_ns,
+    )
+    if thinking_text:
+        span.set_outputs({"thinking": thinking_text})
+    span.end(end_time_ns=end_ns)
+
+
 def _create_llm_and_tool_spans(
     parent_span, transcript: list[dict[str, Any]], start_idx: int
 ) -> None:
     """Create LLM and tool spans for assistant responses with proper timing."""
+    # Track the end of the last span to fill gaps with thinking spans.
+    # Starts at the parent span's start time (user message timestamp).
+    last_span_end_ns = parent_span.start_time_ns
+    # Accumulate thinking text from thinking-only entries to attach to the next thinking span.
+    pending_thinking_text = ""
+
     for i in range(start_idx, len(transcript)):
         entry = transcript[i]
         if entry.get(MESSAGE_FIELD_TYPE) != MESSAGE_TYPE_ASSISTANT:
@@ -424,18 +450,39 @@ def _create_llm_and_tool_spans(
         usage = msg.get("usage", {})
 
         # First check if we have meaningful content to create a span for
-        text_content, tool_uses = _extract_content_and_tools(content)
+        text_content, tool_uses, thinking_text = _extract_content_and_tools(content)
+
+        # Skip entries that don't produce spans (e.g. thinking-only blocks),
+        # but accumulate thinking text for the next thinking span.
+        if not (text_content and text_content.strip()) and not tool_uses:
+            if thinking_text:
+                pending_thinking_text += thinking_text
+            continue
+
+        # Fill any gap before this entry
+        has_gap = last_span_end_ns and timestamp_ns and timestamp_ns > last_span_end_ns
 
         # Only create LLM span if there's text content (no tools)
         llm_span = None
         if text_content and text_content.strip() and not tool_uses:
+            # Extend the LLM span backwards to cover any gap (inference time)
+            span_start_ns = last_span_end_ns if has_gap else timestamp_ns
+            if pending_thinking_text:
+                output_content = [
+                    {"type": "thinking", "thinking": pending_thinking_text},
+                    *content,
+                ]
+                pending_thinking_text = ""
+            else:
+                output_content = content
+
             messages = _get_input_messages(transcript, i)
 
             llm_span = mlflow.start_span_no_context(
                 name="llm",
                 parent_span=parent_span,
                 span_type=SpanType.LLM,
-                start_time_ns=timestamp_ns,
+                start_time_ns=span_start_ns,
                 inputs={
                     "model": msg.get("model", "unknown"),
                     "messages": messages,
@@ -454,10 +501,15 @@ def _create_llm_and_tool_spans(
                 {
                     "type": "message",
                     "role": "assistant",
-                    "content": content,
+                    "content": output_content,
                 }
             )
             llm_span.end(end_time_ns=timestamp_ns + duration_ns)
+            last_span_end_ns = timestamp_ns + duration_ns
+        elif has_gap:
+            # Gap before a tool span — create a thinking span (no thinking text to merge)
+            _create_inference_span(parent_span, last_span_end_ns, timestamp_ns)
+            pending_thinking_text = ""
 
         # Create tool spans with proportional timing and actual results
         if tool_uses:
@@ -483,6 +535,8 @@ def _create_llm_and_tool_spans(
 
                 tool_span.set_outputs({"result": tool_result})
                 tool_span.end(end_time_ns=tool_start_ns + tool_duration_ns)
+
+            last_span_end_ns = timestamp_ns + duration_ns
 
 
 def _finalize_trace(

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -250,6 +250,7 @@ def test_process_transcript_creates_spans(mock_transcript_file):
     llm_spans = [s for s in spans if s.span_type == SpanType.LLM]
     tool_spans = [s for s in spans if s.span_type == SpanType.TOOL]
 
+    # 2 LLM spans (gaps absorbed into LLM spans) + 1 tool span
     assert len(llm_spans) == 2
     assert len(tool_spans) == 1
 
@@ -261,18 +262,85 @@ def test_process_transcript_creates_spans(mock_transcript_file):
     for llm_span in llm_spans:
         assert llm_span.get_attribute(SpanAttributeKey.MESSAGE_FORMAT) == "anthropic"
 
-    # Verify LLM span outputs are in Anthropic response format
-    first_llm = llm_spans[0]
-    outputs = first_llm.outputs
+    # Verify the first LLM span has Anthropic format output
+    text_llm = llm_spans[0]
+    outputs = text_llm.outputs
     assert outputs["type"] == "message"
     assert outputs["role"] == "assistant"
     assert isinstance(outputs["content"], list)
 
     # Verify LLM span inputs contain messages in Anthropic format
-    inputs = first_llm.inputs
+    inputs = text_llm.inputs
     assert "messages" in inputs
     messages = inputs["messages"]
     assert any(m["role"] == "user" for m in messages)
+
+
+def test_process_transcript_llm_span_absorbs_gap(mock_transcript_file):
+    trace = process_transcript(mock_transcript_file, "test-session-123")
+
+    assert trace is not None
+
+    spans = list(trace.search_spans())
+    llm_spans = [s for s in spans if s.name == "llm"]
+
+    # First LLM span absorbs the gap (starts at root span start, not at assistant timestamp)
+    root_span = trace.data.spans[0]
+    assert llm_spans[0].start_time_ns == root_span.start_time_ns
+
+
+DUMMY_TRANSCRIPT_WITH_THINKING = [
+    {
+        "type": "user",
+        "message": {"role": "user", "content": "What is 2 + 2?"},
+        "timestamp": "2025-01-15T10:00:00.000Z",
+        "sessionId": "test-session-123",
+    },
+    {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "The user wants to add 2 and 2."}],
+        },
+        "timestamp": "2025-01-15T10:00:01.000Z",
+    },
+    {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "The answer is 4."}],
+        },
+        "timestamp": "2025-01-15T10:00:01.100Z",
+    },
+]
+
+
+def test_process_transcript_merges_thinking_into_llm_span(tmp_path):
+    transcript_path = tmp_path / "transcript.jsonl"
+    with open(transcript_path, "w") as f:
+        for entry in DUMMY_TRANSCRIPT_WITH_THINKING:
+            f.write(json.dumps(entry) + "\n")
+
+    trace = process_transcript(str(transcript_path), "test-session-123")
+    assert trace is not None
+
+    spans = list(trace.search_spans())
+    llm_spans = [s for s in spans if s.name == "llm"]
+
+    # Single LLM span with thinking merged in
+    assert len(llm_spans) == 1
+
+    llm_span = llm_spans[0]
+    # LLM span starts at the root span start (covers the thinking gap)
+    root_span = trace.data.spans[0]
+    assert llm_span.start_time_ns == root_span.start_time_ns
+
+    # Output includes both thinking and text content
+    output_content = llm_span.outputs["content"]
+    assert output_content[0]["type"] == "thinking"
+    assert output_content[0]["thinking"] == "The user wants to add 2 and 2."
+    assert output_content[1]["type"] == "text"
+    assert output_content[1]["text"] == "The answer is 4."
 
 
 def test_process_transcript_returns_none_for_nonexistent_file():
@@ -323,7 +391,6 @@ def test_process_transcript_tracks_token_usage(mock_transcript_file_with_usage):
 
     assert trace is not None
 
-    # Find the LLM span
     spans = list(trace.search_spans())
     llm_spans = [s for s in spans if s.span_type == SpanType.LLM]
 
@@ -800,6 +867,7 @@ def test_process_transcript_includes_steer_messages(tmp_path):
 
     spans = list(trace.search_spans())
     llm_spans = [s for s in spans if s.span_type == SpanType.LLM]
+    # 2 LLM spans: each absorbs the gap before it
     assert len(llm_spans) == 2
 
     # The second LLM span should include the steer message in its inputs


### PR DESCRIPTION
### Related Issues/PRs

Relates to Claude Code tracing improvements

### What changes are proposed in this pull request?

When processing Claude Code transcripts into MLflow traces, timing gaps between user messages and assistant responses (LLM inference time) left dead zones in the trace visualization. This PR fills those gaps by:

- Extending LLM spans backwards to absorb inference time before text responses
- Merging extended thinking blocks into the following LLM span's output content
- Creating separate LLM spans for inference gaps before tool-only responses

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)