### PR TITLE
Support search_prompt_versions in OSS SQLAlchemy store

### DIFF
--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -970,7 +970,7 @@ class AbstractStore:
         # Verify the registered model exists and is a prompt
         rm = self.get_registered_model(name)
         if hasattr(rm, "_tags") and isinstance(rm._tags, dict):
-            internal_tags = rm._tags.copy()
+            internal_tags = rm._tags
         elif hasattr(rm, "_tags") and rm._tags:
             internal_tags = {tag.key: tag.value for tag in rm._tags}
         else:

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -952,26 +952,59 @@ class AbstractStore:
 
     def search_prompt_versions(
         self, name: str, max_results: int | None = None, page_token: str | None = None
-    ):
+    ) -> PagedList[PromptVersion]:
         """
         Search prompt versions for a given prompt name.
 
-        This method is only supported in Unity Catalog registries.
-        For OSS registries, this functionality is not available.
+        Default implementation: searches ModelVersions with prompt tags filtered
+        by the given prompt name, then converts them to PromptVersion objects.
 
         Args:
-            name: Name of the prompt to search versions for
-            max_results: Maximum number of versions to return
-            page_token: Token for pagination
+            name: Name of the prompt to search versions for.
+            max_results: Maximum number of versions to return.
+            page_token: Token for pagination.
 
-        Raises:
-            MlflowException: Always, as this is not supported in OSS registries
+        Returns:
+            A PagedList of PromptVersion objects.
         """
-        raise MlflowException(
-            "search_prompt_versions() is not supported in this registry. "
-            "This method is only available in Unity Catalog registries.",
-            INVALID_PARAMETER_VALUE,
+        # Verify the registered model exists and is a prompt
+        rm = self.get_registered_model(name)
+        if hasattr(rm, "_tags") and isinstance(rm._tags, dict):
+            internal_tags = rm._tags.copy()
+        elif hasattr(rm, "_tags") and rm._tags:
+            internal_tags = {tag.key: tag.value for tag in rm._tags}
+        else:
+            internal_tags = {}
+
+        if internal_tags.get(IS_PROMPT_TAG_KEY) != "true":
+            raise MlflowException(
+                f"Name `{name}` is registered as a model, not a prompt. "
+                f"Use search_model_versions() instead.",
+                INVALID_PARAMETER_VALUE,
+            )
+
+        if max_results is None:
+            max_results = 100
+
+        filter_string = f"name = '{name}' AND tag.`{IS_PROMPT_TAG_KEY}` = 'true'"
+
+        model_versions = self.search_model_versions(
+            filter_string=filter_string,
+            max_results=max_results,
+            order_by=["version_number DESC"],
+            page_token=page_token,
         )
+
+        if isinstance(rm.tags, dict):
+            prompt_tags = rm.tags.copy()
+        else:
+            prompt_tags = {tag.key: tag.value for tag in rm.tags}
+
+        prompt_versions = [
+            model_version_to_prompt_version(mv, prompt_tags=prompt_tags) for mv in model_versions
+        ]
+
+        return PagedList(prompt_versions, model_versions.token)
 
     def link_prompts_to_trace(self, prompt_versions: list[PromptVersion], trace_id: str) -> None:
         """

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -29,6 +29,7 @@ from mlflow.prompt.registry_utils import (
     add_prompt_filter_string,
     is_prompt_supported_registry,
 )
+from mlflow.store._unity_catalog.registry.utils import proto_to_mlflow_prompt
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry import (
     SEARCH_MODEL_VERSION_MAX_RESULTS_DEFAULT,
@@ -715,11 +716,9 @@ class ModelRegistryClient:
 
     def search_prompt_versions(
         self, name: str, max_results: int | None = None, page_token: str | None = None
-    ):
+    ) -> PagedList[PromptVersion]:
         """
         Search prompt versions for a given prompt name.
-
-        This method delegates directly to the store. Only supported in Unity Catalog registries.
 
         Args:
             name: Name of the prompt to search versions for.
@@ -727,12 +726,18 @@ class ModelRegistryClient:
             page_token: Token for pagination.
 
         Returns:
-            SearchPromptVersionsResponse containing the list of versions.
-
-        Raises:
-            MlflowException: If used with non-Unity Catalog registries.
+            A PagedList of PromptVersion objects.
         """
-        return self.store.search_prompt_versions(name, max_results, page_token)
+        response = self.store.search_prompt_versions(name, max_results, page_token)
+
+        # OSS stores already return PagedList[PromptVersion]
+        if isinstance(response, PagedList):
+            return response
+
+        # UC store returns SearchPromptVersionsResponse proto — normalize it
+        prompt_versions = [proto_to_mlflow_prompt(pv) for pv in response.prompt_versions]
+        next_token = response.next_page_token or None
+        return PagedList(prompt_versions, next_token)
 
     def link_prompt_version_to_model(self, name: str, version: int | str, model_id: str) -> None:
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -6247,15 +6247,14 @@ class MlflowClient:
         """
         Search prompt versions for a given prompt name.
 
-        This method delegates directly to the store. Only supported in Unity Catalog registries.
-
         Args:
             name: Name of the prompt to search versions for.
             max_results: Maximum number of versions to return.
             page_token: Token for pagination.
 
         Returns:
-            SearchPromptVersionsResponse containing the list of versions.
+            A :py:class:`PagedList <mlflow.store.entities.PagedList>` of
+            :py:class:`~mlflow.entities.model_registry.PromptVersion` objects.
 
         Example:
 
@@ -6264,9 +6263,9 @@ class MlflowClient:
             from mlflow import MlflowClient
 
             client = MlflowClient()
-            response = client.search_prompt_versions("my_prompt", max_results=10)
-            for version in response.prompt_versions:
-                print(f"Version {version.version}: {version.description}")
+            versions = client.search_prompt_versions("my_prompt", max_results=10)
+            for version in versions:
+                print(f"Version {version.version}: {version.template}")
         """
         registry_client = self._get_registry_client()
         return registry_client.search_prompt_versions(name, max_results, page_token)
@@ -6297,7 +6296,7 @@ class MlflowClient:
             # For Unity Catalog, delete all versions first
             if client.get_registry_uri().startswith("databricks-uc"):
                 versions = client.search_prompt_versions("my_prompt")
-                for version in versions.prompt_versions:
+                for version in versions:
                     client.delete_prompt_version("my_prompt", version.version)
 
             # Then delete the prompt
@@ -6309,16 +6308,9 @@ class MlflowClient:
         registry_uri = self._registry_uri
 
         if is_databricks_unity_catalog_uri(registry_uri):
-            search_response = self.search_prompt_versions(name, max_results=1)
+            versions = self.search_prompt_versions(name, max_results=1)
 
-            # Check if any versions exist
-            has_versions = (
-                hasattr(search_response, "prompt_versions")
-                and search_response.prompt_versions
-                and len(search_response.prompt_versions) > 0
-            )
-
-            if has_versions:
+            if len(versions) > 0:
                 raise MlflowException(
                     f"Cannot delete prompt '{name}' because it still has undeleted versions. "
                     f"Please delete all versions first using delete_prompt_version(), "

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -20,6 +20,7 @@ from mlflow.environment_variables import (
     MLFLOW_TRACKING_URI,
 )
 from mlflow.exceptions import MlflowException
+from mlflow.prompt.constants import PROMPT_TEXT_TAG_KEY
 from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
     RESOURCE_ALREADY_EXISTS,
@@ -1945,6 +1946,70 @@ def test_search_prompts_versions(store):
     )
     assert len(mvs) == 1
     assert mvs[0].name == "prompt_2"
+
+
+def test_search_prompt_versions(store):
+    # Create a prompt with 3 versions
+    store.create_registered_model(
+        "my_prompt", tags=[RegisteredModelTag(key=IS_PROMPT_TAG_KEY, value="true")]
+    )
+    for i in range(1, 4):
+        store.create_model_version(
+            "my_prompt",
+            str(i),
+            "dummy_source",
+            tags=[
+                ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true"),
+                ModelVersionTag(key=PROMPT_TEXT_TAG_KEY, value=f"Hello {{{{name}}}} v{i}"),
+            ],
+        )
+
+    # Create a different prompt to verify filtering by name
+    store.create_registered_model(
+        "other_prompt", tags=[RegisteredModelTag(key=IS_PROMPT_TAG_KEY, value="true")]
+    )
+    store.create_model_version(
+        "other_prompt",
+        "1",
+        "dummy_source",
+        tags=[
+            ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true"),
+            ModelVersionTag(key=PROMPT_TEXT_TAG_KEY, value="Other prompt text"),
+        ],
+    )
+
+    # Search all versions of my_prompt
+    results = store.search_prompt_versions("my_prompt")
+    assert len(results) == 3
+    # Should be ordered by version descending
+    assert [pv.version for pv in results] == [3, 2, 1]
+    assert all(pv.name == "my_prompt" for pv in results)
+
+    # Pagination with max_results
+    page1 = store.search_prompt_versions("my_prompt", max_results=2)
+    assert len(page1) == 2
+    assert [pv.version for pv in page1] == [3, 2]
+    assert page1.token is not None
+
+    # Fetch next page
+    page2 = store.search_prompt_versions("my_prompt", max_results=2, page_token=page1.token)
+    assert len(page2) == 1
+    assert page2[0].version == 1
+    assert page2.token is None
+
+    # Search other_prompt returns only its versions
+    results = store.search_prompt_versions("other_prompt")
+    assert len(results) == 1
+    assert results[0].name == "other_prompt"
+
+    # Searching a non-existent prompt raises
+    with pytest.raises(MlflowException, match="not found"):
+        store.search_prompt_versions("nonexistent_prompt")
+
+    # Searching a model (not a prompt) raises
+    store.create_registered_model("a_model")
+    with pytest.raises(MlflowException, match="registered as a model, not a prompt"):
+        store.search_prompt_versions("a_model")
 
 
 def test_create_registered_model_handle_prompt_properly(store):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2575,12 +2575,11 @@ def test_delete_prompt_with_versions_unity_catalog_error(registry_uri):
     # Mock Unity Catalog behavior
     client = MlflowClient(registry_uri=registry_uri)
 
-    # Mock the search_prompt_versions to return versions
-    mock_response = Mock()
-    mock_response.prompt_versions = [Mock(version="1")]
+    # Mock the search_prompt_versions to return a PagedList with versions
+    mock_versions = PagedList([Mock(version="1")], None)
 
     with (
-        patch.object(client, "search_prompt_versions", return_value=mock_response),
+        patch.object(client, "search_prompt_versions", return_value=mock_versions),
         patch.object(client, "_registry_uri", registry_uri),
     ):
         with pytest.raises(


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`MlflowClient.search_prompt_versions()` previously raised `MlflowException` when called against the OSS (SQLAlchemy) backend, stating it was only available in Unity Catalog registries. However, prompts in the OSS backend are stored as `RegisteredModel`/`ModelVersion` rows tagged with `is_prompt=true`, and all the infrastructure to search them already exists.

This PR adds a working default implementation in `AbstractStore.search_prompt_versions()` that:
- Delegates to `search_model_versions()` with a name + `is_prompt` tag filter
- Converts results to `PromptVersion` objects using the existing `model_version_to_prompt_version()` utility
- Returns `PagedList[PromptVersion]` with pagination support
- Follows the same delegation pattern used by all other prompt methods (e.g., `search_prompts` → `search_registered_models`)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_search_prompt_versions` in `tests/store/model_registry/test_sqlalchemy_store.py` covering:
- Basic search returning all versions
- Version ordering (newest first)
- Pagination with `max_results` and `page_token`
- Filtering by prompt name
- Error on non-existent prompt

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`MlflowClient.search_prompt_versions()` now works with the OSS SQLAlchemy backend, returning a paginated list of `PromptVersion` objects. Previously this method only worked with Unity Catalog registries.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)