### PR TITLE
Allow multiple judge selection in Run judge on trace modal

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
@@ -11,7 +11,7 @@ import {
   Input,
   Modal,
   PlusIcon,
-  Radio,
+  Checkbox,
   SearchIcon,
   TableSkeleton,
   Typography,
@@ -135,15 +135,30 @@ const RunJudgeModalImpl = ({
   }, [templateOptions, searchValue]);
 
   const [error, setError] = useState<Error | undefined>(undefined);
-  const [selectedJudge, setSelectedJudge] = useState<LLMScorer | LLM_TEMPLATE | undefined>(undefined);
+  const [selectedJudges, setSelectedJudges] = useState<(LLMScorer | LLM_TEMPLATE)[]>([]);
+
+  const hasSelectedTemplates = selectedJudges.some((j) => !isObject(j));
+
+  const toggleJudge = (judge: LLMScorer | LLM_TEMPLATE) => {
+    setSelectedJudges((prev) => {
+      const isSelected = prev.some((j) =>
+        isObject(judge) && isObject(j) ? (j as LLMScorer).name === (judge as LLMScorer).name : j === judge,
+      );
+      return isSelected
+        ? prev.filter((j) =>
+            isObject(judge) && isObject(j) ? (j as LLMScorer).name !== (judge as LLMScorer).name : j !== judge,
+          )
+        : [...prev, judge];
+    });
+  };
 
   const handleModalConfirm = async () => {
-    if (!selectedJudge) {
+    if (selectedJudges.length === 0) {
       return;
     }
     setError(undefined);
     try {
-      evaluateTraces(selectedJudge, [itemId], currentEndpointName);
+      selectedJudges.forEach((judge) => evaluateTraces(judge, [itemId], currentEndpointName));
       onClose();
     } catch (error) {
       setError(error as Error);
@@ -176,11 +191,20 @@ const RunJudgeModalImpl = ({
           defaultMessage: 'Cancel',
           description: 'Button text for canceling a judge run',
         })}
-        okText={intl.formatMessage({
-          defaultMessage: 'Run judge',
-          description: 'Button text for running a judge',
-        })}
-        okButtonProps={{ disabled: !selectedJudge || (!currentEndpointName && judgeSelectionMode === 'template') }}
+        okText={
+          selectedJudges.length > 1
+            ? intl.formatMessage({
+                defaultMessage: 'Run judges',
+                description: 'Button text for running multiple judges',
+              })
+            : intl.formatMessage({
+                defaultMessage: 'Run judge',
+                description: 'Button text for running a judge',
+              })
+        }
+        okButtonProps={{
+          disabled: selectedJudges.length === 0 || (hasSelectedTemplates && !currentEndpointName),
+        }}
         onOk={handleModalConfirm}
       >
         <div css={{ display: 'flex', gap: theme.spacing.sm, marginBottom: theme.spacing.sm }}>
@@ -260,8 +284,10 @@ const RunJudgeModalImpl = ({
                   <ScorerOption
                     scorer={scorer}
                     key={scorer.name}
-                    onClick={() => setSelectedJudge(scorer)}
-                    selected={isObject(selectedJudge) && selectedJudge?.name === scorer.name}
+                    onClick={() => toggleJudge(scorer)}
+                    selected={selectedJudges.some(
+                      (j) => isObject(j) && (j as LLMScorer).name === scorer.name,
+                    )}
                   />
                 ))
               )}
@@ -271,15 +297,15 @@ const RunJudgeModalImpl = ({
           {judgeSelectionMode === 'template' &&
             displayedTemplates?.map((template) => (
               <TemplateOption
-                selected={selectedJudge === template.value}
+                selected={selectedJudges.includes(template.value)}
                 template={template}
                 key={template.value}
-                onClick={() => setSelectedJudge(template.value)}
+                onClick={() => toggleJudge(template.value)}
                 scope={scope}
               />
             ))}
         </div>
-        {judgeSelectionMode === 'template' && (
+        {hasSelectedTemplates && (
           <div
             css={{
               display: 'flex',
@@ -329,19 +355,19 @@ const ScorerOption = ({
   const { theme } = useDesignSystemTheme();
   return (
     <div
-      role="radio"
+      role="checkbox"
       aria-checked={selected}
       css={{ cursor: 'pointer', height: 48, flexShrink: 0 }}
       onClick={() => onClick(scorer)}
     >
-      <Radio componentId="mlflow.experiment-scorers.traces-view-judge-llm" checked={selected}>
+      <Checkbox componentId="mlflow.experiment-scorers.traces-view-judge-llm" isChecked={selected}>
         <div css={{ display: 'flex', flexDirection: 'column', marginLeft: theme.spacing.xs }}>
           <Typography.Text css={{ flex: 1 }}>{scorer.name}</Typography.Text>
           <Typography.Hint>
             <FormattedMessage defaultMessage="Custom judge" description="Label indicating a custom judge scorer" />
           </Typography.Hint>
         </div>
-      </Radio>
+      </Checkbox>
     </div>
   );
 };
@@ -364,12 +390,12 @@ const TemplateOption = ({
   const { theme } = useDesignSystemTheme();
   return (
     <div
-      role="radio"
+      role="checkbox"
       aria-checked={selected}
       css={{ cursor: 'pointer', height: 48, flexShrink: 0 }}
       onClick={() => onClick(template.value)}
     >
-      <Radio componentId="mlflow.experiment-scorers.traces-view-judge-template" checked={selected}>
+      <Checkbox componentId="mlflow.experiment-scorers.traces-view-judge-template" isChecked={selected}>
         <div css={{ display: 'flex', flexDirection: 'column', marginLeft: theme.spacing.xs }}>
           <Typography.Text css={{ flex: 1 }}>{template.label}</Typography.Text>
           <Typography.Hint>
@@ -386,7 +412,7 @@ const TemplateOption = ({
             )}
           </Typography.Hint>
         </div>
-      </Radio>
+      </Checkbox>
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
@@ -30,7 +30,7 @@ import {
   getEndpointNameFromGatewayModel,
 } from '../../../../gateway/utils/gatewayUtils';
 import { TEMPLATE_INSTRUCTIONS_MAP } from '../prompts';
-import { isEmpty, isObject } from 'lodash';
+import { isEmpty } from 'lodash';
 
 interface UseRunScorerInTracesViewConfigurationReturnType extends ModelTraceExplorerRunJudgeConfig {
   RunJudgeModalElement: React.ReactNode;
@@ -135,30 +135,34 @@ const RunJudgeModalImpl = ({
   }, [templateOptions, searchValue]);
 
   const [error, setError] = useState<Error | undefined>(undefined);
-  const [selectedJudges, setSelectedJudges] = useState<(LLMScorer | LLM_TEMPLATE)[]>([]);
+  const [selectedScorers, setSelectedScorers] = useState<LLMScorer[]>([]);
+  const [selectedTemplates, setSelectedTemplates] = useState<LLM_TEMPLATE[]>([]);
 
-  const hasSelectedTemplates = selectedJudges.some((j) => !isObject(j));
+  const selectedJudgeCount = selectedScorers.length + selectedTemplates.length;
+  const hasSelectedTemplates = selectedTemplates.length > 0;
 
-  const toggleJudge = (judge: LLMScorer | LLM_TEMPLATE) => {
-    setSelectedJudges((prev) => {
-      const isSelected = prev.some((j) =>
-        isObject(judge) && isObject(j) ? (j as LLMScorer).name === (judge as LLMScorer).name : j === judge,
-      );
-      return isSelected
-        ? prev.filter((j) =>
-            isObject(judge) && isObject(j) ? (j as LLMScorer).name !== (judge as LLMScorer).name : j !== judge,
-          )
-        : [...prev, judge];
+  const toggleScorer = (scorer: LLMScorer) => {
+    setSelectedScorers((prev) => {
+      const isSelected = prev.some((s) => s.name === scorer.name);
+      return isSelected ? prev.filter((s) => s.name !== scorer.name) : [...prev, scorer];
+    });
+  };
+
+  const toggleTemplate = (template: LLM_TEMPLATE) => {
+    setSelectedTemplates((prev) => {
+      const isSelected = prev.includes(template);
+      return isSelected ? prev.filter((t) => t !== template) : [...prev, template];
     });
   };
 
   const handleModalConfirm = async () => {
-    if (selectedJudges.length === 0) {
+    if (selectedJudgeCount === 0) {
       return;
     }
     setError(undefined);
     try {
-      selectedJudges.forEach((judge) => evaluateTraces(judge, [itemId], currentEndpointName));
+      selectedScorers.forEach((scorer) => evaluateTraces(scorer, [itemId], currentEndpointName));
+      selectedTemplates.forEach((template) => evaluateTraces(template, [itemId], currentEndpointName));
       onClose();
     } catch (error) {
       setError(error as Error);
@@ -192,7 +196,7 @@ const RunJudgeModalImpl = ({
           description: 'Button text for canceling a judge run',
         })}
         okText={
-          selectedJudges.length > 1
+          selectedJudgeCount > 1
             ? intl.formatMessage({
                 defaultMessage: 'Run judges',
                 description: 'Button text for running multiple judges',
@@ -203,7 +207,7 @@ const RunJudgeModalImpl = ({
               })
         }
         okButtonProps={{
-          disabled: selectedJudges.length === 0 || (hasSelectedTemplates && !currentEndpointName),
+          disabled: selectedJudgeCount === 0 || (hasSelectedTemplates && !currentEndpointName),
         }}
         onOk={handleModalConfirm}
       >
@@ -284,8 +288,8 @@ const RunJudgeModalImpl = ({
                   <ScorerOption
                     scorer={scorer}
                     key={scorer.name}
-                    onClick={() => toggleJudge(scorer)}
-                    selected={selectedJudges.some((j) => isObject(j) && (j as LLMScorer).name === scorer.name)}
+                    onClick={() => toggleScorer(scorer)}
+                    selected={selectedScorers.some((s) => s.name === scorer.name)}
                   />
                 ))
               )}
@@ -295,10 +299,10 @@ const RunJudgeModalImpl = ({
           {judgeSelectionMode === 'template' &&
             displayedTemplates?.map((template) => (
               <TemplateOption
-                selected={selectedJudges.includes(template.value)}
+                selected={selectedTemplates.includes(template.value)}
                 template={template}
                 key={template.value}
-                onClick={() => toggleJudge(template.value)}
+                onClick={() => toggleTemplate(template.value)}
                 scope={scope}
               />
             ))}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration.tsx
@@ -285,9 +285,7 @@ const RunJudgeModalImpl = ({
                     scorer={scorer}
                     key={scorer.name}
                     onClick={() => toggleJudge(scorer)}
-                    selected={selectedJudges.some(
-                      (j) => isObject(j) && (j as LLMScorer).name === scorer.name,
-                    )}
+                    selected={selectedJudges.some((j) => isObject(j) && (j as LLMScorer).name === scorer.name)}
                   />
                 ))
               )}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2078,6 +2078,10 @@
     "defaultMessage": "No usage data available",
     "description": "Empty state title"
   },
+  "COIi12": {
+    "defaultMessage": "Run judges",
+    "description": "Button text for running multiple judges"
+  },
   "CPO2ro": {
     "defaultMessage": "GenAI apps & agents",
     "description": "A short label for custom experiments automatically identified as being focused on generative AI app and agent development"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #ML-62978

### What changes are proposed in this pull request?

Change the "Run judge on trace" modal from single-select (radio buttons) to multi-select (checkboxes), allowing users to select and run multiple judges on a trace in one action.



https://github.com/user-attachments/assets/60cd46ff-8265-4fc1-abfd-15b958f43d49


### How is this PR tested?

- [x] Manual tests

Verified in dev server:
- Checkboxes appear instead of radio buttons
- Multiple judges can be selected across both Custom and Pre-built tabs
- Selections persist when switching tabs
- "Run judges" (plural) shows when >1 selected
- Endpoint selector appears when any template is selected
- All selected judges run in parallel on confirm

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Allow selecting and running multiple judges at once in the "Run judge on trace" modal, instead of having to repeat the workflow for each judge.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)