### PR TITLE
Add session selection support with checkbox, actions, and row alignment

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -412,7 +412,10 @@ const TracesV3LogsImpl = React.memo(
         renderExportTracesToDatasetsModal={renderCustomExportTracesToDatasetsModal}
         DrawerComponent={AssistantAwareDrawer}
       >
-        <GenAITracesTableProvider experimentId={singleExperimentId} isGroupedBySession={forceGroupBySession || isGroupedBySession}>
+        <GenAITracesTableProvider
+          experimentId={singleExperimentId}
+          isGroupedBySession={forceGroupBySession || isGroupedBySession}
+        >
           <div
             css={{
               overflowY: 'hidden',

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -412,7 +412,7 @@ const TracesV3LogsImpl = React.memo(
         renderExportTracesToDatasetsModal={renderCustomExportTracesToDatasetsModal}
         DrawerComponent={AssistantAwareDrawer}
       >
-        <GenAITracesTableProvider experimentId={singleExperimentId} isGroupedBySession={isGroupedBySession}>
+        <GenAITracesTableProvider experimentId={singleExperimentId} isGroupedBySession={forceGroupBySession || isGroupedBySession}>
           <div
             css={{
               overflowY: 'hidden',

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2738,6 +2738,10 @@
     "defaultMessage": "Y-axis:",
     "description": "Label text for Y-axis in box plot comparison in MLflow"
   },
+  "Hk9B5H": {
+    "defaultMessage": "Delete sessions",
+    "description": "Delete sessions and all their traces action"
+  },
   "HlqAH9": {
     "defaultMessage": "Output type",
     "description": "Section header for judge output type selection"
@@ -6843,6 +6847,10 @@
     "defaultMessage": "Load model as a PyFuncModel.",
     "description": "Code comment which states how to load model using PyFuncModel"
   },
+  "kVgfHt": {
+    "defaultMessage": "Actions{count}",
+    "description": "Session actions dropdown button"
+  },
   "kW6/lu": {
     "defaultMessage": "Edit",
     "description": "Chat sessions actions dropdown group label for edit actions"
@@ -8178,6 +8186,10 @@
   "tUAhDM": {
     "defaultMessage": "Global guideline adherence",
     "description": "Evaluation results > known type of evaluation result assessment > global guideline adherence assessment. Used to indicate if the result adheres to the global guidelines in context of LLMs evaluation. Label displayed if user provided custom value, e.g. \"Global guideline adherence: moderate\""
+  },
+  "tUDgmf": {
+    "defaultMessage": "Select one or more sessions to perform actions.",
+    "description": "Tooltip shown when actions button is disabled due to no session selection"
   },
   "taI4Bv": {
     "defaultMessage": "to",

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.tsx
@@ -12,6 +12,7 @@ import type { RunEvaluationTracesDataEntry, TraceActions } from './types';
 import { shouldEnableTagGrouping } from './utils/FeatureUtils';
 import { applyTraceInfoV3ToEvalEntry, getRowIdFromTrace } from './utils/TraceUtils';
 import { shouldUseUnifiedModelTraceComparisonUI } from '../model-trace-explorer/FeatureUtils';
+import { SESSION_ID_METADATA_KEY } from '../model-trace-explorer/constants';
 import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
 
 interface GenAITracesTableActionsProps {
@@ -35,7 +36,7 @@ export const GenAITracesTableActions = (props: GenAITracesTableActionsProps) => 
     sqlWarehouseId,
   } = props;
 
-  const { table, selectedRowIds } = useContext(GenAITracesTableContext);
+  const { table, selectedRowIds, isGroupedBySession } = useContext(GenAITracesTableContext);
 
   const selectedTracesFromContext: RunEvaluationTracesDataEntry[] | undefined = useMemo(
     () =>
@@ -73,6 +74,7 @@ export const GenAITracesTableActions = (props: GenAITracesTableActionsProps) => 
       traceActions={traceActions}
       setRowSelection={setRowSelection ?? table?.setRowSelection}
       sqlWarehouseId={sqlWarehouseId}
+      isGroupedBySession={isGroupedBySession}
     />
   );
 };
@@ -83,10 +85,11 @@ interface TraceActionsDropdownProps {
   traceActions?: TraceActions;
   setRowSelection: React.Dispatch<React.SetStateAction<RowSelectionState>> | undefined;
   sqlWarehouseId?: string;
+  isGroupedBySession?: boolean;
 }
 
 const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
-  const { experimentId, selectedTraces, traceActions, setRowSelection, sqlWarehouseId } = props;
+  const { experimentId, selectedTraces, traceActions, setRowSelection, sqlWarehouseId, isGroupedBySession } = props;
   const intl = useIntl();
   const { theme } = useDesignSystemTheme();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -131,6 +134,20 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
     showAddToEvaluationDatasetModal?.(selectedTraces);
   };
 
+  const selectedSessionCount = useMemo(() => {
+    if (!isGroupedBySession) {
+      return 0;
+    }
+    const sessionIds = new Set<string>();
+    selectedTraces.forEach((trace) => {
+      const sessionId = trace.traceInfo?.trace_metadata?.[SESSION_ID_METADATA_KEY];
+      if (sessionId) {
+        sessionIds.add(sessionId);
+      }
+    });
+    return sessionIds.size;
+  }, [isGroupedBySession, selectedTraces]);
+
   const isEditTagsDisabled = selectedTraces.length > 1;
   const noTracesSelected = selectedTraces.length === 0;
   const noActionsAvailable = !hasExportAction && !hasEditTagsAction && !hasDeleteAction;
@@ -155,15 +172,25 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
       type="primary"
       endIcon={<ChevronDownIcon />}
     >
-      {intl.formatMessage(
-        {
-          defaultMessage: 'Actions{count}',
-          description: 'Trace actions dropdown button',
-        },
-        {
-          count: noTracesSelected ? '' : ` (${selectedTraces.length})`,
-        },
-      )}
+      {isGroupedBySession
+        ? intl.formatMessage(
+            {
+              defaultMessage: 'Actions{count}',
+              description: 'Session actions dropdown button',
+            },
+            {
+              count: selectedSessionCount === 0 ? '' : ` (${selectedSessionCount})`,
+            },
+          )
+        : intl.formatMessage(
+            {
+              defaultMessage: 'Actions{count}',
+              description: 'Trace actions dropdown button',
+            },
+            {
+              count: noTracesSelected ? '' : ` (${selectedTraces.length})`,
+            },
+          )}
     </Button>
   );
 
@@ -173,10 +200,17 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
         {noTracesSelected ? (
           <Tooltip
             componentId="mlflow.genai-traces-table.actions-disabled-tooltip"
-            content={intl.formatMessage({
-              defaultMessage: 'Select one or more traces to add to an evaluation or edit the traces.',
-              description: 'Tooltip shown when actions button is disabled due to no trace selection',
-            })}
+            content={
+              isGroupedBySession
+                ? intl.formatMessage({
+                    defaultMessage: 'Select one or more sessions to perform actions.',
+                    description: 'Tooltip shown when actions button is disabled due to no session selection',
+                  })
+                : intl.formatMessage({
+                    defaultMessage: 'Select one or more traces to add to an evaluation or edit the traces.',
+                    description: 'Tooltip shown when actions button is disabled due to no trace selection',
+                  })
+            }
           >
             <div>
               <DropdownMenu.Trigger disabled asChild>
@@ -188,78 +222,96 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
           <DropdownMenu.Trigger asChild>{ActionButton}</DropdownMenu.Trigger>
         )}
         <DropdownMenu.Content>
-          {isComparisonDrawerEnabled && (
-            <>
+          {isGroupedBySession ? (
+            hasDeleteAction && (
               <DropdownMenu.Item
-                componentId="mlflow.genai-traces-table.compare-traces"
-                onClick={handleOpenCompare}
-                disabled={!canCompare}
+                componentId="mlflow.genai-traces-table.delete-session"
+                onClick={handleDeleteTraces}
+                disabled={traceActions?.deleteTracesAction?.isDisabled}
+                disabledReason={traceActions?.deleteTracesAction?.disabledReason}
               >
-                {intl.formatMessage({ defaultMessage: 'Compare', description: 'Compare traces button' })}
+                {intl.formatMessage({
+                  defaultMessage: 'Delete sessions',
+                  description: 'Delete sessions and all their traces action',
+                })}
               </DropdownMenu.Item>
-              <DropdownMenu.Separator />
-            </>
-          )}
-          {hasExportAction && (
+            )
+          ) : (
             <>
-              <DropdownMenu.Group>
-                <DropdownMenu.Label css={groupLabelStyles}>
-                  {intl.formatMessage({
-                    defaultMessage: 'Use for evaluation',
-                    description: 'Trace actions dropdown group label',
-                  })}
-                </DropdownMenu.Label>
-                <DropdownMenu.Item
-                  componentId="mlflow.genai-traces-table.export-to-datasets"
-                  css={groupItemStyles}
-                  onClick={handleExportToDatasets}
-                >
-                  {intl.formatMessage({
-                    defaultMessage: 'Add to evaluation dataset',
-                    description: 'Add traces to evaluation dataset action',
-                  })}
-                </DropdownMenu.Item>
-              </DropdownMenu.Group>
-            </>
-          )}
-          {(hasEditTagsAction || hasDeleteAction) && (
-            <>
-              {hasExportAction && <DropdownMenu.Separator />}
-              <DropdownMenu.Group>
-                <DropdownMenu.Label css={groupLabelStyles}>
-                  {intl.formatMessage({
-                    defaultMessage: 'Edit',
-                    description: 'Trace actions dropdown group label',
-                  })}
-                </DropdownMenu.Label>
-                {hasEditTagsAction && (
+              {isComparisonDrawerEnabled && (
+                <>
                   <DropdownMenu.Item
-                    componentId="mlflow.genai-traces-table.edit-tags"
-                    css={groupItemStyles}
-                    onClick={handleEditTags}
-                    disabled={isEditTagsDisabled}
+                    componentId="mlflow.genai-traces-table.compare-traces"
+                    onClick={handleOpenCompare}
+                    disabled={!canCompare}
                   >
-                    {intl.formatMessage({
-                      defaultMessage: 'Edit tags',
-                      description: 'Edit tags action',
-                    })}
+                    {intl.formatMessage({ defaultMessage: 'Compare', description: 'Compare traces button' })}
                   </DropdownMenu.Item>
-                )}
-                {hasDeleteAction && (
-                  <DropdownMenu.Item
-                    componentId="mlflow.genai-traces-table.delete-traces"
-                    css={groupItemStyles}
-                    onClick={handleDeleteTraces}
-                    disabled={traceActions?.deleteTracesAction?.isDisabled}
-                    disabledReason={traceActions?.deleteTracesAction?.disabledReason}
-                  >
-                    {intl.formatMessage({
-                      defaultMessage: 'Delete traces',
-                      description: 'Delete traces action',
-                    })}
-                  </DropdownMenu.Item>
-                )}
-              </DropdownMenu.Group>
+                  <DropdownMenu.Separator />
+                </>
+              )}
+              {hasExportAction && (
+                <>
+                  <DropdownMenu.Group>
+                    <DropdownMenu.Label css={groupLabelStyles}>
+                      {intl.formatMessage({
+                        defaultMessage: 'Use for evaluation',
+                        description: 'Trace actions dropdown group label',
+                      })}
+                    </DropdownMenu.Label>
+                    <DropdownMenu.Item
+                      componentId="mlflow.genai-traces-table.export-to-datasets"
+                      css={groupItemStyles}
+                      onClick={handleExportToDatasets}
+                    >
+                      {intl.formatMessage({
+                        defaultMessage: 'Add to evaluation dataset',
+                        description: 'Add traces to evaluation dataset action',
+                      })}
+                    </DropdownMenu.Item>
+                  </DropdownMenu.Group>
+                </>
+              )}
+              {(hasEditTagsAction || hasDeleteAction) && (
+                <>
+                  {hasExportAction && <DropdownMenu.Separator />}
+                  <DropdownMenu.Group>
+                    <DropdownMenu.Label css={groupLabelStyles}>
+                      {intl.formatMessage({
+                        defaultMessage: 'Edit',
+                        description: 'Trace actions dropdown group label',
+                      })}
+                    </DropdownMenu.Label>
+                    {hasEditTagsAction && (
+                      <DropdownMenu.Item
+                        componentId="mlflow.genai-traces-table.edit-tags"
+                        css={groupItemStyles}
+                        onClick={handleEditTags}
+                        disabled={isEditTagsDisabled}
+                      >
+                        {intl.formatMessage({
+                          defaultMessage: 'Edit tags',
+                          description: 'Edit tags action',
+                        })}
+                      </DropdownMenu.Item>
+                    )}
+                    {hasDeleteAction && (
+                      <DropdownMenu.Item
+                        componentId="mlflow.genai-traces-table.delete-traces"
+                        css={groupItemStyles}
+                        onClick={handleDeleteTraces}
+                        disabled={traceActions?.deleteTracesAction?.isDisabled}
+                        disabledReason={traceActions?.deleteTracesAction?.disabledReason}
+                      >
+                        {intl.formatMessage({
+                          defaultMessage: 'Delete traces',
+                          description: 'Delete traces action',
+                        })}
+                      </DropdownMenu.Item>
+                    )}
+                  </DropdownMenu.Group>
+                </>
+              )}
             </>
           )}
         </DropdownMenu.Content>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.tsx
@@ -85,7 +85,7 @@ interface TraceActionsDropdownProps {
   traceActions?: TraceActions;
   setRowSelection: React.Dispatch<React.SetStateAction<RowSelectionState>> | undefined;
   sqlWarehouseId?: string;
-  isGroupedBySession?: boolean;
+  isGroupedBySession: boolean;
 }
 
 const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -299,6 +299,26 @@ export const GenAiTracesTableBody = React.memo(
       [table],
     );
 
+    const onToggleSessionSelection = useCallback(
+      (sessionId: string, traces: ModelTraceInfoV3[]) => {
+        const traceIds = traces.map((t) => t.trace_id);
+        const currentSelection = table.getState().rowSelection ?? {};
+        const allSelected = traceIds.every((id) => currentSelection[id]);
+        const updatedSelection: RowSelectionState = { ...currentSelection };
+
+        traceIds.forEach((id) => {
+          if (allSelected) {
+            delete updatedSelection[id];
+          } else {
+            updatedSelection[id] = true;
+          }
+        });
+
+        table.setRowSelection(updatedSelection);
+      },
+      [table],
+    );
+
     // Need to check if rowSelection is undefined, otherwise getIsAllRowsSelected throws an error
     const allRowSelected = rowSelection !== undefined && table.getIsAllRowsSelected();
     const someRowSelected = table.getIsSomeRowsSelected();
@@ -525,6 +545,7 @@ export const GenAiTracesTableBody = React.memo(
                 selectedColumns={sortedGroupedColumns}
                 expandedSessions={expandedSessions}
                 toggleSessionExpanded={toggleSessionExpanded}
+                onToggleSessionSelection={onToggleSessionSelection}
                 experimentId={experimentId}
                 getRunColor={getRunColor}
                 runUuid={runUuid}

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -335,8 +335,7 @@ export const GenAiTracesTableBody = React.memo(
             }
 
             table.setRowSelection(updatedSelection);
-            lastSelectedSessionIdRef.current =
-              Object.keys(updatedSelection).length === 0 ? null : sessionId;
+            lastSelectedSessionIdRef.current = Object.keys(updatedSelection).length === 0 ? null : sessionId;
             return;
           }
         }

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -114,6 +114,7 @@ export const GenAiTracesTableBody = React.memo(
     const { theme } = useDesignSystemTheme();
     const [collapsedHeader, setCollapsedHeader] = useState(false);
     const lastSelectedRowIdRef = useRef<string | null>(null);
+    const lastSelectedSessionIdRef = useRef<string | null>(null);
     // Track which sessions are expanded (collapsed by default)
     const [expandedSessions, setExpandedSessions] = useState<Set<string>>(new Set());
 
@@ -300,14 +301,50 @@ export const GenAiTracesTableBody = React.memo(
     );
 
     const onToggleSessionSelection = useCallback(
-      (sessionId: string, traces: ModelTraceInfoV3[]) => {
+      (sessionId: string, traces: ModelTraceInfoV3[], event: unknown) => {
         const traceIds = traces.map((t) => t.trace_id);
         const currentSelection = table.getState().rowSelection ?? {};
         const allSelected = traceIds.every((id) => currentSelection[id]);
-        const updatedSelection: RowSelectionState = { ...currentSelection };
+        const isDeselecting = allSelected;
 
+        const eventWithShiftKey = event as KeyboardEvent & MouseEvent;
+        const isShiftPressed = Boolean(eventWithShiftKey?.shiftKey);
+
+        if (isShiftPressed && lastSelectedSessionIdRef.current) {
+          // Find session headers in groupedRows for range selection
+          const sessionHeaders = groupedRows.filter(
+            (r): r is (typeof groupedRows)[number] & { type: 'sessionHeader' } => r.type === 'sessionHeader',
+          );
+          const anchorIndex = sessionHeaders.findIndex((h) => h.sessionId === lastSelectedSessionIdRef.current);
+          const currentIndex = sessionHeaders.findIndex((h) => h.sessionId === sessionId);
+
+          if (anchorIndex !== -1 && currentIndex !== -1) {
+            const [start, end] =
+              anchorIndex <= currentIndex ? [anchorIndex, currentIndex] : [currentIndex, anchorIndex];
+            const updatedSelection: RowSelectionState = { ...currentSelection };
+
+            for (let index = start; index <= end; index += 1) {
+              const header = sessionHeaders[index];
+              header.traces.forEach((t) => {
+                if (isDeselecting) {
+                  delete updatedSelection[t.trace_id];
+                } else {
+                  updatedSelection[t.trace_id] = true;
+                }
+              });
+            }
+
+            table.setRowSelection(updatedSelection);
+            lastSelectedSessionIdRef.current =
+              Object.keys(updatedSelection).length === 0 ? null : sessionId;
+            return;
+          }
+        }
+
+        // Default: toggle single session
+        const updatedSelection: RowSelectionState = { ...currentSelection };
         traceIds.forEach((id) => {
-          if (allSelected) {
+          if (isDeselecting) {
             delete updatedSelection[id];
           } else {
             updatedSelection[id] = true;
@@ -315,8 +352,12 @@ export const GenAiTracesTableBody = React.memo(
         });
 
         table.setRowSelection(updatedSelection);
+
+        // Update anchor: clear if nothing is selected after deselecting
+        const hasSelectionAfter = Object.keys(updatedSelection).length > 0;
+        lastSelectedSessionIdRef.current = hasSelectionAfter ? sessionId : null;
       },
-      [table],
+      [table, groupedRows],
     );
 
     // Need to check if rowSelection is undefined, otherwise getIsAllRowsSelected throws an error
@@ -338,11 +379,13 @@ export const GenAiTracesTableBody = React.memo(
     useEffect(() => {
       if (!enableRowSelection) {
         lastSelectedRowIdRef.current = null;
+        lastSelectedSessionIdRef.current = null;
         return;
       }
 
       if (!rowSelection || Object.keys(rowSelection).length === 0) {
         lastSelectedRowIdRef.current = null;
+        lastSelectedSessionIdRef.current = null;
       }
     }, [rowSelection, enableRowSelection]);
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -304,9 +304,9 @@ export const GenAiTracesTableBody = React.memo(
       (sessionId: string, traces: ModelTraceInfoV3[], event: unknown) => {
         const traceIds = traces.map((t) => t.trace_id);
         const currentSelection = table.getState().rowSelection ?? {};
-        const allSelected = traceIds.every((id) => currentSelection[id]);
-        const isDeselecting = allSelected;
+        const isDeselecting = traceIds.every((id) => currentSelection[id]);
 
+        // Support shift+click to select a range of sessions
         const eventWithShiftKey = event as KeyboardEvent & MouseEvent;
         const isShiftPressed = Boolean(eventWithShiftKey?.shiftKey);
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBodyRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBodyRows.tsx
@@ -88,6 +88,7 @@ export const GenAiTracesTableBodyRow = React.memo(
     // eslint-disable-next-line react/no-unused-prop-types
     selectedColumns, // Prop needed to force row re-rending when selectedColumns change
     rowSelectionChangeHandler,
+    noCheckbox,
   }: {
     row: Row<EvalTraceComparisonEntry>;
     exportableTrace?: boolean;
@@ -96,42 +97,55 @@ export const GenAiTracesTableBodyRow = React.memo(
     isSelected?: boolean;
     selectedColumns: TracesTableColumn[];
     rowSelectionChangeHandler?: (row: Row<EvalTraceComparisonEntry>, event: unknown) => void;
+    /** When true, renders a spacer instead of a checkbox in the select cell area */
+    noCheckbox?: boolean;
   }) => {
     const cells = row.getVisibleCells();
     const intl = useIntl();
+    const { theme } = useDesignSystemTheme();
     const rowSelectHandler = rowSelectionChangeHandler
       ? (event: unknown) => rowSelectionChangeHandler(row, event)
       : row.getToggleSelectedHandler();
     return (
       <>
         <TableRow>
-          <div css={{ display: 'flex', overflow: 'hidden', flexShrink: 0 }}>
-            {enableRowSelection && (
-              <Tooltip
-                componentId="mlflow.experiment-evaluation-monitoring.evals-logs-table-cell-tooltip"
-                content={
-                  isComparing
-                    ? intl.formatMessage({
-                        defaultMessage: 'You cannot select rows when comparing runs',
-                        description: 'Tooltip message for the select button when comparing runs',
-                      })
-                    : !exportableTrace
+          <div css={{ display: 'flex', overflow: 'hidden', flexShrink: 0, gap: noCheckbox ? theme.spacing.xs : 0 }}>
+            {enableRowSelection &&
+              (noCheckbox ? (
+                <>
+                  <TableRowSelectCell
+                    componentId="mlflow.experiment-evaluation-monitoring.evals-logs-table-cell.spacer"
+                    noCheckbox
+                  />
+                  {/* Spacer matching the chevron button width in the session header */}
+                  <div css={{ width: theme.general.heightSm, flexShrink: 0 }} />
+                </>
+              ) : (
+                <Tooltip
+                  componentId="mlflow.experiment-evaluation-monitoring.evals-logs-table-cell-tooltip"
+                  content={
+                    isComparing
                       ? intl.formatMessage({
-                          defaultMessage:
-                            'This trace is not exportable because it either contains an error or the response is not a ChatCompletionResponse.',
-                          description: 'Tooltip message for the export button when the trace is not exportable',
+                          defaultMessage: 'You cannot select rows when comparing runs',
+                          description: 'Tooltip message for the select button when comparing runs',
                         })
-                      : null
-                }
-              >
-                <TableRowSelectCell
-                  componentId="mlflow.experiment-evaluation-monitoring.evals-logs-table-cell"
-                  checked={isSelected && exportableTrace}
-                  onChange={rowSelectHandler}
-                  isDisabled={isComparing || !exportableTrace}
-                />
-              </Tooltip>
-            )}
+                      : !exportableTrace
+                        ? intl.formatMessage({
+                            defaultMessage:
+                              'This trace is not exportable because it either contains an error or the response is not a ChatCompletionResponse.',
+                            description: 'Tooltip message for the export button when the trace is not exportable',
+                          })
+                        : null
+                  }
+                >
+                  <TableRowSelectCell
+                    componentId="mlflow.experiment-evaluation-monitoring.evals-logs-table-cell"
+                    checked={isSelected && exportableTrace}
+                    onChange={rowSelectHandler}
+                    isDisabled={isComparing || !exportableTrace}
+                  />
+                </Tooltip>
+              ))}
           </div>
           {cells.map((cell) => (
             <GenAiTracesTableBodyRowCell cell={cell} key={cell.id} />

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBodyRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBodyRows.tsx
@@ -109,7 +109,9 @@ export const GenAiTracesTableBodyRow = React.memo(
     return (
       <>
         <TableRow>
-          <div css={{ display: 'flex', overflow: 'hidden', flexShrink: 0, gap: !displayCheckbox ? theme.spacing.xs : 0 }}>
+          <div
+            css={{ display: 'flex', overflow: 'hidden', flexShrink: 0, gap: !displayCheckbox ? theme.spacing.xs : 0 }}
+          >
             {enableRowSelection &&
               (!displayCheckbox ? (
                 <>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBodyRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBodyRows.tsx
@@ -88,7 +88,7 @@ export const GenAiTracesTableBodyRow = React.memo(
     // eslint-disable-next-line react/no-unused-prop-types
     selectedColumns, // Prop needed to force row re-rending when selectedColumns change
     rowSelectionChangeHandler,
-    noCheckbox,
+    displayCheckbox = true,
   }: {
     row: Row<EvalTraceComparisonEntry>;
     exportableTrace?: boolean;
@@ -97,8 +97,8 @@ export const GenAiTracesTableBodyRow = React.memo(
     isSelected?: boolean;
     selectedColumns: TracesTableColumn[];
     rowSelectionChangeHandler?: (row: Row<EvalTraceComparisonEntry>, event: unknown) => void;
-    /** When true, renders a spacer instead of a checkbox in the select cell area */
-    noCheckbox?: boolean;
+    /** When false, renders a spacer instead of a checkbox in the select cell area */
+    displayCheckbox?: boolean;
   }) => {
     const cells = row.getVisibleCells();
     const intl = useIntl();
@@ -109,9 +109,9 @@ export const GenAiTracesTableBodyRow = React.memo(
     return (
       <>
         <TableRow>
-          <div css={{ display: 'flex', overflow: 'hidden', flexShrink: 0, gap: noCheckbox ? theme.spacing.xs : 0 }}>
+          <div css={{ display: 'flex', overflow: 'hidden', flexShrink: 0, gap: !displayCheckbox ? theme.spacing.xs : 0 }}>
             {enableRowSelection &&
-              (noCheckbox ? (
+              (!displayCheckbox ? (
                 <>
                   <TableRowSelectCell
                     componentId="mlflow.experiment-evaluation-monitoring.evals-logs-table-cell.spacer"

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
@@ -2,7 +2,14 @@ import type { Row, RowSelectionState } from '@tanstack/react-table';
 import type { VirtualItem } from '@tanstack/react-virtual';
 import React, { useCallback, useMemo } from 'react';
 
-import { Button, ChevronDownIcon, ChevronRightIcon, TableRow } from '@databricks/design-system';
+import {
+  Button,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  TableRow,
+  TableRowSelectCell,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
 
 import { SessionHeaderCell } from './cellRenderers/SessionHeaderCellRenderers';
@@ -23,6 +30,7 @@ interface GenAiTracesTableSessionGroupedRowsProps {
   selectedColumns: TracesTableColumn[];
   expandedSessions: Set<string>;
   toggleSessionExpanded: (sessionId: string) => void;
+  onToggleSessionSelection?: (sessionId: string, traces: ModelTraceInfoV3[]) => void;
   experimentId?: string;
   getRunColor?: (runUuid: string) => string;
   runUuid?: string;
@@ -45,6 +53,10 @@ interface SessionHeaderRowProps {
   experimentId?: string;
   isExpanded: boolean;
   isComparing: boolean;
+  enableRowSelection?: boolean;
+  isSessionSelected?: boolean;
+  isSessionIndeterminate?: boolean;
+  onToggleSessionSelection?: (sessionId: string, traces: ModelTraceInfoV3[]) => void;
   toggleSessionExpanded: (sessionId: string) => void;
   getRunColor?: (runUuid: string) => string;
   runUuid?: string;
@@ -60,9 +72,11 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
   virtualItems,
   virtualizerTotalSize,
   virtualizerMeasureElement,
+  rowSelectionState,
   selectedColumns,
   expandedSessions,
   toggleSessionExpanded,
+  onToggleSessionSelection,
   experimentId,
   getRunColor,
   runUuid,
@@ -82,6 +96,21 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
     return map;
   }, [rows]);
 
+  const getSessionSelectionState = useCallback(
+    (traces: ModelTraceInfoV3[]) => {
+      if (!rowSelectionState || traces.length === 0) {
+        return { allSelected: false, someSelected: false };
+      }
+      const traceIds = traces.map((t) => t.trace_id);
+      const selectedCount = traceIds.filter((id) => rowSelectionState[id]).length;
+      return {
+        allSelected: selectedCount === traceIds.length,
+        someSelected: selectedCount > 0 && selectedCount < traceIds.length,
+      };
+    },
+    [rowSelectionState],
+  );
+
   return (
     <div
       style={{
@@ -99,6 +128,7 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
 
         // Render header using a custom renderer for session data
         if (groupedRow.type === 'sessionHeader') {
+          const { allSelected, someSelected } = getSessionSelectionState(groupedRow.traces);
           return (
             <div
               key={`session-header-${groupedRow.sessionId}-${virtualRow.index}`}
@@ -123,6 +153,10 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
                 experimentId={experimentId}
                 isExpanded={expandedSessions.has(groupedRow.sessionId)}
                 isComparing={isComparing}
+                enableRowSelection={enableRowSelection}
+                isSessionSelected={allSelected}
+                isSessionIndeterminate={someSelected}
+                onToggleSessionSelection={onToggleSessionSelection}
                 toggleSessionExpanded={toggleSessionExpanded}
                 searchQuery={searchQuery}
                 getRunColor={getRunColor}
@@ -150,6 +184,8 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
         }
 
         const exportableTrace = row.original.currentRunValue && !isComparing;
+        // For traces within a session, show a spacer instead of a checkbox to maintain alignment
+        const isSessionChild = !!groupedRow.sessionId;
 
         return (
           <div
@@ -167,10 +203,11 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
               row={row}
               exportableTrace={exportableTrace}
               enableRowSelection={enableRowSelection}
-              isSelected={enableRowSelection ? row.getIsSelected() : undefined}
+              isSelected={isSessionChild ? undefined : row.getIsSelected()}
+              noCheckbox={isSessionChild}
               isComparing={isComparing}
               selectedColumns={selectedColumns}
-              rowSelectionChangeHandler={rowSelectionChangeHandler}
+              rowSelectionChangeHandler={isSessionChild ? undefined : rowSelectionChangeHandler}
             />
           </div>
         );
@@ -191,6 +228,10 @@ const SessionHeaderRow = React.memo(function SessionHeaderRow({
   experimentId,
   isExpanded,
   isComparing,
+  enableRowSelection,
+  isSessionSelected,
+  isSessionIndeterminate,
+  onToggleSessionSelection,
   toggleSessionExpanded,
   getRunColor,
   runUuid,
@@ -202,9 +243,24 @@ const SessionHeaderRow = React.memo(function SessionHeaderRow({
     toggleSessionExpanded(sessionId);
   }, [toggleSessionExpanded, sessionId]);
 
+  const handleToggleSelection = useCallback(() => {
+    onToggleSessionSelection?.(sessionId, traces);
+  }, [onToggleSessionSelection, sessionId, traces]);
+
+  const { theme } = useDesignSystemTheme();
+
   return (
     <TableRow isHeader>
-      <div css={{ display: 'flex', alignItems: 'center' }}>
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+        {enableRowSelection && (
+          <TableRowSelectCell
+            componentId="mlflow.genai-traces-table.session-header.select-cell"
+            checked={isSessionSelected}
+            indeterminate={isSessionIndeterminate}
+            onChange={handleToggleSelection}
+            isDisabled={isComparing}
+          />
+        )}
         {/* Hide expand/collapse button when comparing - sessions are non-expandable in comparison mode */}
         {!isComparing && (
           <Button

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
@@ -30,7 +30,7 @@ interface GenAiTracesTableSessionGroupedRowsProps {
   selectedColumns: TracesTableColumn[];
   expandedSessions: Set<string>;
   toggleSessionExpanded: (sessionId: string) => void;
-  onToggleSessionSelection?: (sessionId: string, traces: ModelTraceInfoV3[]) => void;
+  onToggleSessionSelection?: (sessionId: string, traces: ModelTraceInfoV3[], event: unknown) => void;
   experimentId?: string;
   getRunColor?: (runUuid: string) => string;
   runUuid?: string;
@@ -56,7 +56,7 @@ interface SessionHeaderRowProps {
   enableRowSelection?: boolean;
   isSessionSelected?: boolean;
   isSessionIndeterminate?: boolean;
-  onToggleSessionSelection?: (sessionId: string, traces: ModelTraceInfoV3[]) => void;
+  onToggleSessionSelection?: (sessionId: string, traces: ModelTraceInfoV3[], event: unknown) => void;
   toggleSessionExpanded: (sessionId: string) => void;
   getRunColor?: (runUuid: string) => string;
   runUuid?: string;
@@ -243,9 +243,12 @@ const SessionHeaderRow = React.memo(function SessionHeaderRow({
     toggleSessionExpanded(sessionId);
   }, [toggleSessionExpanded, sessionId]);
 
-  const handleToggleSelection = useCallback(() => {
-    onToggleSessionSelection?.(sessionId, traces);
-  }, [onToggleSessionSelection, sessionId, traces]);
+  const handleToggleSelection = useCallback(
+    (event: unknown) => {
+      onToggleSessionSelection?.(sessionId, traces, event);
+    },
+    [onToggleSessionSelection, sessionId, traces],
+  );
 
   const { theme } = useDesignSystemTheme();
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableSessionGroupedRows.tsx
@@ -185,7 +185,7 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
 
         const exportableTrace = row.original.currentRunValue && !isComparing;
         // For traces within a session, show a spacer instead of a checkbox to maintain alignment
-        const isSessionChild = !!groupedRow.sessionId;
+        const isSessionTrace = !!groupedRow.sessionId;
 
         return (
           <div
@@ -203,11 +203,11 @@ export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTrace
               row={row}
               exportableTrace={exportableTrace}
               enableRowSelection={enableRowSelection}
-              isSelected={isSessionChild ? undefined : row.getIsSelected()}
-              noCheckbox={isSessionChild}
+              isSelected={isSessionTrace ? undefined : row.getIsSelected()}
+              displayCheckbox={!isSessionTrace}
               isComparing={isComparing}
               selectedColumns={selectedColumns}
-              rowSelectionChangeHandler={isSessionChild ? undefined : rowSelectionChangeHandler}
+              rowSelectionChangeHandler={isSessionTrace ? undefined : rowSelectionChangeHandler}
             />
           </div>
         );

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/SessionGroupingUtils.ts
@@ -16,7 +16,9 @@ export interface SessionHeaderRowData {
   persona?: string;
 }
 
-export type GroupedTraceTableRowData = { type: 'trace'; data: EvalTraceComparisonEntry } | SessionHeaderRowData;
+export type GroupedTraceTableRowData =
+  | { type: 'trace'; data: EvalTraceComparisonEntry; sessionId?: string }
+  | SessionHeaderRowData;
 
 export const SIMULATION_GOAL_KEY = 'mlflow.simulation.goal';
 export const SIMULATION_PERSONA_KEY = 'mlflow.simulation.persona';
@@ -257,6 +259,7 @@ export const groupTracesBySessionForTable = (
         result.push({
           type: 'trace',
           data: entry,
+          sessionId,
         });
 
         const traceId = entry.currentRunValue?.traceInfo?.trace_id;


### PR DESCRIPTION
### Related Issues/PRs

N/A (internal: ML-62965)

### What changes are proposed in this pull request?

This PR adds session-level selection support to the GenAI traces table when traces are grouped by session. Session header rows now include checkboxes that select or deselect all traces within that session, with an indeterminate state when only some traces are selected. The Actions dropdown adapts to session mode by showing only "Delete sessions" and displaying the count of selected sessions rather than individual traces. Child trace rows ("turns") within a session render a spacer instead of a checkbox so they align visually with session header content.


https://github.com/user-attachments/assets/3de0eeb0-983b-47f9-b7b2-ea37dcd8c7cb




### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Session-grouped traces table now supports selecting entire sessions via checkboxes on session header rows, with a dedicated "Delete sessions" action in the actions dropdown.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)