### PR TITLE
Improve quality chart readability and styling in overview tab

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.test.tsx
@@ -369,7 +369,7 @@ describe('TraceAssessmentChart', () => {
         expect(barChart).toBeInTheDocument();
         // Should show individual values, not bucketed
         expect(barChart).toHaveAttribute('data-count', '5');
-        expect(barChart).toHaveAttribute('data-labels', '1,2,3,4,5');
+        expect(barChart).toHaveAttribute('data-labels', '5,4,3,2,1');
       });
     });
 
@@ -427,7 +427,7 @@ describe('TraceAssessmentChart', () => {
         expect(barChart).toBeInTheDocument();
         // Should show individual values
         expect(barChart).toHaveAttribute('data-count', '2');
-        expect(barChart).toHaveAttribute('data-labels', 'false,true');
+        expect(barChart).toHaveAttribute('data-labels', 'true,false');
       });
     });
 
@@ -447,7 +447,7 @@ describe('TraceAssessmentChart', () => {
         expect(barChart).toBeInTheDocument();
         // Should show individual values sorted alphabetically
         expect(barChart).toHaveAttribute('data-count', '3');
-        expect(barChart).toHaveAttribute('data-labels', 'error,fail,pass');
+        expect(barChart).toHaveAttribute('data-labels', 'pass,fail,error');
       });
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { CheckCircleIcon, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -12,6 +12,8 @@ import {
   ResponsiveContainer,
   ReferenceLine,
   Legend,
+  // eslint-disable-next-line import/no-deprecated
+  Cell,
 } from 'recharts';
 import { useTraceAssessmentChartData } from '../hooks/useTraceAssessmentChartData';
 import {
@@ -72,6 +74,20 @@ export const TraceAssessmentChart: React.FC<TraceAssessmentChartProps> = ({ asse
 
   // Use provided color or default to green
   const chartLineColor = lineColor || theme.colors.green500;
+
+  // Map assessment value names to Tag background colors with increased opacity for chart visibility.
+  // Base colors from design system Tag backgrounds (tagBackgroundLime/tagBackgroundCoral) with 5x opacity.
+  const barColorLime = 'rgba(2, 179, 2, 0.40)';
+  const barColorCoral = 'rgba(240, 0, 64, 0.50)';
+  const getBarColor = useCallback(
+    (name: string) => {
+      const lower = name.toLowerCase();
+      if (lower === 'yes' || lower === 'true') return barColorLime;
+      if (lower === 'no' || lower === 'false') return barColorCoral;
+      return chartLineColor;
+    },
+    [chartLineColor],
+  );
 
   const distributionTooltipFormatter = useCallback((value: number) => [value, 'count'] as [number, string], []);
 
@@ -134,6 +150,8 @@ export const TraceAssessmentChart: React.FC<TraceAssessmentChartProps> = ({ asse
   const { timeSeriesChartData, distributionChartData, isLoading, error, hasData } =
     useTraceAssessmentChartData(assessmentName);
 
+  const reversedDistributionData = useMemo(() => [...distributionChartData].reverse(), [distributionChartData]);
+
   if (isLoading) {
     return <OverviewChartLoadingState />;
   }
@@ -175,15 +193,31 @@ export const TraceAssessmentChart: React.FC<TraceAssessmentChartProps> = ({ asse
             />
           }
         >
-          <BarChart data={distributionChartData} layout="vertical" margin={{ top: 10, right: 10, left: 10, bottom: 0 }}>
+          <BarChart
+            data={reversedDistributionData}
+            layout="vertical"
+            barCategoryGap="28%"
+            margin={{ top: 10, right: 10, left: 10, bottom: 0 }}
+          >
             <XAxis type="number" allowDecimals={false} {...xAxisProps} />
-            <YAxis type="category" dataKey="name" {...yAxisProps} width={60} />
+            <YAxis
+              type="category"
+              dataKey="name"
+              {...yAxisProps}
+              tick={{ ...yAxisProps.tick, fontSize: 14 }}
+              width={80}
+            />
             <Tooltip
               content={distributionTooltipContent}
               cursor={{ fill: theme.colors.actionTertiaryBackgroundHover }}
             />
             <Legend {...scrollableLegendProps} />
-            <Bar dataKey="count" fill={chartLineColor} radius={[0, 4, 4, 0]} />
+            <Bar dataKey="count" fill={chartLineColor} radius={[0, 4, 4, 0]}>
+              {reversedDistributionData.map((entry) => (
+                // eslint-disable-next-line import/no-deprecated
+                <Cell key={entry.name} fill={getBarColor(entry.name)} />
+              ))}
+            </Bar>
           </BarChart>
         </ChartPanel>
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceAssessmentChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceAssessmentChartData.ts
@@ -145,7 +145,7 @@ export function useTraceAssessmentChartData(assessmentName: string): UseTraceAss
     // For non-bucketed values (sparse integers, strings, booleans), use as-is
     const sortedValues = sortValuesAlphanumerically(allValues);
     return sortedValues.map((value) => ({
-      name: value,
+      name: value.replace(/^"|"$/g, ''),
       count: valueCounts[value] || 0,
     }));
   }, [distributionDataPoints]);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Improves the quality graph in the experiment overview tab:

- **Larger Y-axis labels**: Font size increased from 10 → 14 and width from 60 → 80px for better readability
- **Strip double quotes**: Assessment value names no longer show surrounding `"` quotes (e.g., `"yes"` → `yes`)
- **Reversed sort order**: Higher/positive values (yes, true) appear at the top, lower/negative values (no, false) at the bottom
- **Per-bar coloring**: Bars are colored to match assessment Tag backgrounds — lime for yes/true, coral for no/false, default chart color for other values
- **Thinner bars**: Bar thickness reduced to ~80% of original via `barCategoryGap`


**Before**
<img width="853" height="252" alt="Screenshot 2026-03-03 at 19 30 35" src="https://github.com/user-attachments/assets/7b054ef3-f89c-40b8-bda3-163b93e33747" />

**After**
<img width="853" height="253" alt="Screenshot 2026-03-03 at 19 30 06" src="https://github.com/user-attachments/assets/71e1e7ab-449e-4da1-ab62-4ae07e9a0701" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests (updated test expectations for reversed label order)
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved readability of quality assessment charts in the experiment overview tab — larger labels, per-value bar coloring matching assessment tags, and better sort order.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)