### PR TITLE
Fix refresh button on evaluation runs page to also refresh traces and assessments

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.test.tsx
@@ -10,9 +10,15 @@ import { MockedReduxStoreProvider } from '../../../common/utils/TestUtils';
 import { IntlProvider } from 'react-intl';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { invalidateMlflowSearchTracesCache } from '@databricks/web-shared/genai-traces-table';
 
 jest.mock('../../hooks/useExperimentQuery', () => ({
   useGetExperimentQuery: jest.fn(() => ({})),
+}));
+
+jest.mock('@databricks/web-shared/genai-traces-table', () => ({
+  ...jest.requireActual('@databricks/web-shared/genai-traces-table'),
+  invalidateMlflowSearchTracesCache: jest.fn(),
 }));
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
@@ -133,5 +139,16 @@ describe('ExperimentEvaluationRunsPage', () => {
       expect(screen.getByText('Test Run 50')).toBeInTheDocument();
       expect(screen.getByText('Test Run 99')).toBeInTheDocument();
     });
+  });
+
+  test('should invalidate traces cache when refresh button is clicked', async () => {
+    await waitFor(() => {
+      expect(screen.getByText('Test Run 0')).toBeInTheDocument();
+    });
+
+    const refreshButton = screen.getByRole('button', { name: 'Refresh evaluation runs' });
+    fireEvent.click(refreshButton);
+
+    expect(invalidateMlflowSearchTracesCache).toHaveBeenCalled();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.test.tsx
@@ -17,7 +17,7 @@ jest.mock('../../hooks/useExperimentQuery', () => ({
 }));
 
 jest.mock('@databricks/web-shared/genai-traces-table', () => ({
-  ...jest.requireActual('@databricks/web-shared/genai-traces-table'),
+  ...(jest.requireActual('@databricks/web-shared/genai-traces-table') as Record<string, unknown>),
   invalidateMlflowSearchTracesCache: jest.fn(),
 }));
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -20,6 +20,8 @@ import {
   EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
   EvalRunsTableKeyedColumnPrefix,
 } from './ExperimentEvaluationRunsTable.constants';
+import { invalidateMlflowSearchTracesCache } from '@databricks/web-shared/genai-traces-table';
+import { useQueryClient } from '@databricks/web-shared/query-client';
 import { FormattedMessage } from 'react-intl';
 import { useSelectedRunUuid } from '../../components/evaluations/hooks/useSelectedRunUuid';
 import { useCompareToRunUuid } from '../../components/evaluations/hooks/useCompareToRunUuid';
@@ -61,6 +63,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
     EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
   );
 
+  const queryClient = useQueryClient();
   const enableImprovedComparison = shouldEnableImprovedEvalRunsComparison();
 
   // When flag is enabled, default to grouping by dataset
@@ -97,6 +100,11 @@ const ExperimentEvaluationRunsPageImpl = () => {
     enabled: true,
     filter: searchFilter,
   });
+
+  const refetchAll = useCallback(() => {
+    refetch();
+    invalidateMlflowSearchTracesCache({ queryClient });
+  }, [refetch, queryClient]);
 
   const runUuids = useMemo(() => runs?.map((run) => run.info.runUuid) ?? [], [runs]);
 
@@ -302,7 +310,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
   const renderTableControls = () => (
     <ExperimentEvaluationRunsTableControls
       runs={runs ?? []}
-      refetchRuns={refetch}
+      refetchRuns={refetchAll}
       isFetching={isFetching || isLoading}
       searchRunsError={error}
       searchFilter={searchFilter}


### PR DESCRIPTION
### Related Issues/PRs

Closes https://databricks.atlassian.net/browse/ML-62431

### What changes are proposed in this pull request?

The refresh button on the evaluation runs page only refreshed the run list (left panel), leaving traces and assessments in the right panel stale. Users had to do a full browser reload to see updated evaluation progress.

This PR adds `invalidateMlflowSearchTracesCache()` alongside the existing `refetch()` call so that clicking the refresh button also refreshes traces and assessments for the currently viewed run.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a test that verifies `invalidateMlflowSearchTracesCache` is called when the refresh button is clicked.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the refresh button on the evaluation runs page to also refresh traces and assessments, not just the run list.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)