### PR TITLE
Add Gemini CLI tracing integration

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/gemini_cli.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/gemini_cli.mdx
@@ -1,0 +1,173 @@
+---
+sidebar_label: Gemini CLI
+---
+
+import { Users, BookOpen, Scale } from "lucide-react";
+
+import ImageBox from "@site/src/components/ImageBox";
+import TilesGrid from "@site/src/components/TilesGrid";
+import TileCard from "@site/src/components/TileCard";
+
+# Tracing Gemini CLI
+
+[MLflow Tracing](/genai/tracing) provides automatic tracing for [Gemini CLI](https://github.com/google-gemini/gemini-cli), Google's open-source terminal-based AI coding agent powered by Gemini models.
+
+After setting up auto tracing, MLflow will automatically capture traces of your Gemini CLI conversations and log them to the active MLflow experiment. The trace automatically captures information such as:
+
+- User prompts and assistant responses
+- Tool usage (file operations, shell commands, code edits, etc.)
+- Conversation timing and duration
+- Tool execution results
+- Token usage (input, output, and total tokens)
+- Session metadata including working directory and user
+
+## Setup
+
+Gemini CLI tracing is configured using the `mlflow autolog gemini-cli` CLI command, which sets up [Gemini CLI hooks](https://geminicli.com/docs/hooks/) to automatically capture conversation traces.
+
+### Requirements
+
+- MLflow >= 3.5 (`pip install 'mlflow[genai]>=3.5'`)
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed and configured
+
+### Basic Setup
+
+```bash
+# Set up tracing in current directory
+mlflow autolog gemini-cli
+
+# Set up tracing in specific directory
+mlflow autolog gemini-cli ~/my-project
+
+# Check tracing status
+mlflow autolog gemini-cli --status
+
+# Disable tracing
+mlflow autolog gemini-cli --disable
+```
+
+### Configuration Examples
+
+```bash
+# Set up with custom tracking URI
+mlflow autolog gemini-cli -u file://./custom-mlruns
+mlflow autolog gemini-cli -u sqlite:///mlflow.db
+
+# Set up with Databricks backend and a specific experiment ID
+mlflow autolog gemini-cli -u databricks -e 123456789
+
+# Set up with specific experiment
+mlflow autolog gemini-cli -n "My AI Project"
+```
+
+### Environment Variables
+
+After running the setup command, set the following environment variables in your shell:
+
+```bash
+# Required: Enable MLflow tracing for Gemini CLI
+export MLFLOW_GEMINI_CLI_TRACING_ENABLED=true
+
+# Optional: MLflow tracking server URI
+export MLFLOW_TRACKING_URI=http://localhost:5000
+
+# Optional: Experiment ID or name
+export MLFLOW_EXPERIMENT_ID=123456
+```
+
+### How It Works
+
+1. **Setup Phase**: The `mlflow autolog gemini-cli` command configures Gemini CLI hooks in a `.gemini/settings.json` file in your project directory
+2. **Automatic Tracing**: When you use the `gemini` command in the configured directory, the `SessionEnd` hook automatically processes the conversation transcript and creates an MLflow trace
+3. **View Results**: Use the MLflow UI to explore your traces
+
+### Basic Example
+
+```bash
+# Set up tracing in your project
+mlflow autolog gemini-cli ~/my-project
+
+# Set environment variables
+export MLFLOW_GEMINI_CLI_TRACING_ENABLED=true
+
+# Navigate to project directory
+cd ~/my-project
+
+# Use Gemini CLI normally - tracing happens automatically
+gemini "help me refactor this Python function to be more efficient"
+
+# View traces in MLflow UI
+mlflow server
+```
+
+## Tracking Token Usage and Cost
+
+MLflow automatically tracks token usage for Gemini CLI conversations. The token usage for each LLM call will be logged in each Trace/Span and the aggregated cost and time trend are displayed in the built-in dashboard. See the [Token Usage and Cost Tracking](/genai/tracing/token-usage-cost) documentation for details on accessing this information programmatically.
+
+## Troubleshooting
+
+### Check CLI Status
+
+```bash
+mlflow autolog gemini-cli --status
+```
+
+This shows:
+
+- Whether tracing is enabled
+- Current tracking URI
+- Configured experiment
+
+### Common Issues
+
+**Tracing not working:**
+
+- Ensure `MLFLOW_GEMINI_CLI_TRACING_ENABLED=true` is set in your shell environment
+- Check that `.gemini/settings.json` exists in your project directory
+- Verify the `SessionEnd` hook is present in the settings file
+- Review logs in `.gemini/mlflow/gemini_tracing.log`
+
+**Missing traces:**
+
+- Verify the tracking URI is accessible
+- Check that the MLflow server is running
+- Review logs in `.gemini/mlflow/gemini_tracing.log`
+
+### Disable Tracing
+
+To stop automatic tracing:
+
+```bash
+mlflow autolog gemini-cli --disable
+```
+
+This removes the hooks from `.gemini/settings.json` but preserves existing traces.
+
+## Next Steps
+
+<TilesGrid>
+  <TileCard
+    icon={Scale}
+    iconSize={48}
+    title="Evaluate the Agent"
+    description="Learn how to evaluate the agent's performance with LLM judges."
+    href="/genai/eval-monitor/running-evaluation/agents"
+    linkText="Evaluate agents →"
+  />
+  <TileCard
+    icon={BookOpen}
+    iconSize={48}
+    title="Manage Prompts"
+    description="Learn how to manage prompts with MLflow's prompt registry."
+    href="/genai/prompt-registry"
+    linkText="Manage prompts →"
+  />
+  <TileCard
+    icon={Users}
+    iconSize={48}
+    title="Automatic Agent Optimization"
+    description="Automatically optimize the agent end-to-end with state-of-the-art algorithms."
+    href="/genai/prompt-registry/optimize-prompts"
+    linkText="Optimize prompts →"
+  />
+</TilesGrid>

--- a/docs/sidebarsGenAI.ts
+++ b/docs/sidebarsGenAI.ts
@@ -418,6 +418,11 @@ const sidebarsGenAI: SidebarsConfig = {
                 },
                 {
                   type: 'doc',
+                  id: 'tracing/integrations/listing/gemini_cli',
+                  label: 'Gemini CLI',
+                },
+                {
+                  type: 'doc',
                   id: 'tracing/integrations/listing/instructor',
                   label: 'Instructor',
                 },

--- a/docs/src/components/TracingIntegrations/index.tsx
+++ b/docs/src/components/TracingIntegrations/index.tsx
@@ -406,6 +406,13 @@ const TRACING_INTEGRATIONS: TracingIntegration[] = [
     category: 'Tools',
   },
   {
+    id: 'gemini_cli',
+    name: 'Gemini CLI',
+    logoPath: '/images/logos/google-gemini-logo.svg',
+    link: '/genai/tracing/integrations/listing/gemini_cli',
+    category: 'Tools',
+  },
+  {
     id: 'langfuse',
     name: 'Langfuse',
     logoPath: '/images/logos/langfuse-logo.png',

--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -1317,6 +1317,14 @@ try:
 except ImportError:
     pass
 
+# Add Gemini CLI integration commands (as subcommand of autolog group)
+try:
+    import mlflow.gemini_cli.cli
+
+    mlflow.claude_code.cli.commands.add_command(mlflow.gemini_cli.cli.gemini_cli)
+except (ImportError, NameError):
+    pass
+
 # Add Assistant CLI commands
 try:
     import mlflow.assistant.cli

--- a/mlflow/gemini_cli/__init__.py
+++ b/mlflow/gemini_cli/__init__.py
@@ -1,0 +1,22 @@
+"""Gemini CLI integration for MLflow.
+
+This module provides automatic tracing of Gemini CLI conversations to MLflow.
+
+Usage:
+    mlflow autolog gemini-cli [directory] [options]
+
+After setup, use the regular 'gemini' command and traces will be automatically captured.
+
+Example:
+
+.. code-block:: bash
+
+    # Set up tracing in current directory
+    mlflow autolog gemini-cli
+
+    # Use Gemini CLI normally
+    gemini "help me refactor this function"
+
+    # View traces
+    mlflow server
+"""

--- a/mlflow/gemini_cli/cli.py
+++ b/mlflow/gemini_cli/cli.py
@@ -1,0 +1,167 @@
+"""MLflow CLI commands for Gemini CLI integration."""
+
+from pathlib import Path
+
+import click
+
+from mlflow.gemini_cli.config import get_tracing_status, setup_environment_config
+from mlflow.gemini_cli.hooks import disable_tracing_hooks, setup_hooks_config
+
+
+@click.command("gemini-cli")
+@click.argument("directory", default=".", type=click.Path(file_okay=False, dir_okay=True))
+@click.option(
+    "--tracking-uri", "-u", help="MLflow tracking URI (e.g., 'databricks' or 'file://mlruns')"
+)
+@click.option("--experiment-id", "-e", help="MLflow experiment ID")
+@click.option("--experiment-name", "-n", help="MLflow experiment name")
+@click.option("--disable", is_flag=True, help="Disable Gemini CLI tracing in the specified directory")
+@click.option("--status", is_flag=True, help="Show current tracing status")
+def gemini_cli(
+    directory: str,
+    tracking_uri: str | None,
+    experiment_id: str | None,
+    experiment_name: str | None,
+    disable: bool,
+    status: bool,
+) -> None:
+    """Set up Gemini CLI tracing in a directory.
+
+    This command configures Gemini CLI hooks to automatically trace conversations
+    to MLflow. After setup, use the regular 'gemini' command and traces will be
+    automatically created.
+
+    DIRECTORY: Directory to set up tracing in (default: current directory)
+
+    Examples:
+
+      # Set up tracing in current directory with local storage
+      mlflow autolog gemini-cli
+
+      # Set up tracing in a specific project directory
+      mlflow autolog gemini-cli ~/my-project
+
+      # Set up tracing with Databricks
+      mlflow autolog gemini-cli -u databricks -e 123456789
+
+      # Set up tracing with custom tracking URI
+      mlflow autolog gemini-cli -u file://./custom-mlruns
+
+      # Disable tracing in current directory
+      mlflow autolog gemini-cli --disable
+    """
+    target_dir = Path(directory).resolve()
+    gemini_dir = target_dir / ".gemini"
+    settings_file = gemini_dir / "settings.json"
+
+    if status:
+        _show_status(target_dir, settings_file)
+        return
+
+    if disable:
+        _handle_disable(settings_file)
+        return
+
+    click.echo(f"Configuring Gemini CLI tracing in: {target_dir}")
+
+    # Create .gemini directory and set up hooks
+    gemini_dir.mkdir(parents=True, exist_ok=True)
+    setup_hooks_config(settings_file)
+    click.echo("Gemini CLI hooks configured")
+
+    # Build environment variables for user reference
+    env_vars = setup_environment_config(tracking_uri, experiment_id, experiment_name)
+
+    # Show final status
+    _show_setup_status(target_dir, tracking_uri, experiment_id, experiment_name, env_vars)
+
+
+def _handle_disable(settings_file: Path) -> None:
+    """Handle disable command."""
+    if disable_tracing_hooks(settings_file):
+        click.echo("Gemini CLI tracing disabled")
+    else:
+        click.echo("No Gemini CLI configuration found - tracing was not enabled")
+
+
+def _show_status(target_dir: Path, settings_file: Path) -> None:
+    """Show current tracing status."""
+    click.echo(f"Gemini CLI tracing status in: {target_dir}")
+
+    tracing_status = get_tracing_status(settings_file)
+
+    if not tracing_status.enabled:
+        click.echo("Gemini CLI tracing is not enabled")
+        if tracing_status.reason:
+            click.echo(f"   Reason: {tracing_status.reason}")
+        return
+
+    click.echo("Gemini CLI tracing is ENABLED")
+    if tracing_status.tracking_uri:
+        click.echo(f"Tracking URI: {tracing_status.tracking_uri}")
+
+    if tracing_status.experiment_id:
+        click.echo(f"Experiment ID: {tracing_status.experiment_id}")
+    elif tracing_status.experiment_name:
+        click.echo(f"Experiment Name: {tracing_status.experiment_name}")
+    else:
+        click.echo("Experiment: Default (experiment 0)")
+
+
+def _show_setup_status(
+    target_dir: Path,
+    tracking_uri: str | None,
+    experiment_id: str | None,
+    experiment_name: str | None,
+    env_vars: dict[str, str],
+) -> None:
+    """Show setup completion status."""
+    current_dir = Path.cwd().resolve()
+
+    click.echo("\n" + "=" * 50)
+    click.echo("Gemini CLI Tracing Setup Complete!")
+    click.echo("=" * 50)
+
+    click.echo(f"Directory: {target_dir}")
+
+    # Show tracking configuration
+    if tracking_uri:
+        click.echo(f"Tracking URI: {tracking_uri}")
+
+    if experiment_id:
+        click.echo(f"Experiment ID: {experiment_id}")
+    elif experiment_name:
+        click.echo(f"Experiment Name: {experiment_name}")
+    else:
+        click.echo("Experiment: Default (experiment 0)")
+
+    # Show required environment variables
+    click.echo("\n" + "=" * 30)
+    click.echo("Required Environment Variables:")
+    click.echo("=" * 30)
+    click.echo("Set these in your shell before running Gemini CLI:")
+    for var_name, var_value in env_vars.items():
+        click.echo(f"  export {var_name}={var_value}")
+
+    # Show next steps
+    click.echo("\n" + "=" * 30)
+    click.echo("Next Steps:")
+    click.echo("=" * 30)
+
+    # Only show cd if it's a different directory
+    if target_dir != current_dir:
+        click.echo(f"cd {target_dir}")
+
+    click.echo("gemini 'your prompt here'")
+
+    if tracking_uri and tracking_uri.startswith("file://"):
+        click.echo(f"\nView your traces:")
+        click.echo(f"   mlflow server --backend-store-uri {tracking_uri}")
+    elif not tracking_uri:
+        click.echo(f"\nView your traces:")
+        click.echo("   mlflow server")
+    elif tracking_uri == "databricks":
+        click.echo("\nView your traces in your Databricks workspace")
+
+    click.echo("\nTo disable tracing later:")
+    click.echo("   mlflow autolog gemini-cli --disable")

--- a/mlflow/gemini_cli/config.py
+++ b/mlflow/gemini_cli/config.py
@@ -1,0 +1,148 @@
+"""Configuration management for Gemini CLI integration with MLflow."""
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mlflow.environment_variables import (
+    MLFLOW_EXPERIMENT_ID,
+    MLFLOW_EXPERIMENT_NAME,
+    MLFLOW_TRACKING_URI,
+)
+
+# Configuration field constants
+HOOK_FIELD_HOOKS = "hooks"
+HOOK_FIELD_COMMAND = "command"
+
+# MLflow environment variable constants
+MLFLOW_HOOK_IDENTIFIER = "mlflow.gemini_cli.hooks"
+MLFLOW_TRACING_ENABLED = "MLFLOW_GEMINI_CLI_TRACING_ENABLED"
+
+
+@dataclass
+class TracingStatus:
+    """Dataclass for tracing status information."""
+
+    enabled: bool
+    tracking_uri: str | None = None
+    experiment_id: str | None = None
+    experiment_name: str | None = None
+    reason: str | None = None
+
+
+def load_gemini_config(settings_path: Path) -> dict[str, Any]:
+    """Load existing Gemini CLI configuration from settings file.
+
+    Args:
+        settings_path: Path to Gemini settings.json file
+
+    Returns:
+        Configuration dictionary, empty dict if file doesn't exist or is invalid
+    """
+    if settings_path.exists():
+        try:
+            with open(settings_path, encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            return {}
+    return {}
+
+
+def save_gemini_config(settings_path: Path, config: dict[str, Any]) -> None:
+    """Save Gemini CLI configuration to settings file.
+
+    Args:
+        settings_path: Path to Gemini settings.json file
+        config: Configuration dictionary to save
+    """
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(settings_path, "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2)
+
+
+def get_tracing_status(settings_path: Path) -> TracingStatus:
+    """Get current tracing status from Gemini CLI settings.
+
+    Args:
+        settings_path: Path to Gemini settings file
+
+    Returns:
+        TracingStatus with tracing status information
+    """
+    if not settings_path.exists():
+        return TracingStatus(enabled=False, reason="No configuration found")
+
+    config = load_gemini_config(settings_path)
+    hooks = config.get(HOOK_FIELD_HOOKS, {})
+    session_end_hooks = hooks.get("SessionEnd", [])
+
+    # Check if any MLflow hook is configured
+    enabled = False
+    for hook_group in session_end_hooks:
+        if HOOK_FIELD_HOOKS in hook_group:
+            for hook in hook_group[HOOK_FIELD_HOOKS]:
+                if MLFLOW_HOOK_IDENTIFIER in hook.get(HOOK_FIELD_COMMAND, ""):
+                    enabled = True
+                    break
+
+    # Get environment variables from OS environment (Gemini CLI uses env vars directly)
+    tracking_uri = os.environ.get(MLFLOW_TRACKING_URI.name)
+    experiment_id = os.environ.get(MLFLOW_EXPERIMENT_ID.name)
+    experiment_name = os.environ.get(MLFLOW_EXPERIMENT_NAME.name)
+
+    return TracingStatus(
+        enabled=enabled,
+        tracking_uri=tracking_uri,
+        experiment_id=experiment_id,
+        experiment_name=experiment_name,
+    )
+
+
+def get_env_var(var_name: str, default: str = "") -> str:
+    """Get environment variable value.
+
+    Args:
+        var_name: Environment variable name
+        default: Default value if not found
+
+    Returns:
+        Environment variable value
+    """
+    value = os.environ.get(var_name)
+    if value is not None:
+        return value
+    return default
+
+
+def setup_environment_config(
+    tracking_uri: str | None = None,
+    experiment_id: str | None = None,
+    experiment_name: str | None = None,
+) -> dict[str, str]:
+    """Build a dictionary of MLflow environment variables for user reference.
+
+    Gemini CLI hooks receive environment variables from the shell, so we
+    return the variables the user should set, rather than writing them
+    into the settings file.
+
+    Args:
+        tracking_uri: MLflow tracking URI
+        experiment_id: MLflow experiment ID (takes precedence over name)
+        experiment_name: MLflow experiment name
+
+    Returns:
+        Dictionary of environment variable name to value
+    """
+    env_vars: dict[str, str] = {}
+    env_vars[MLFLOW_TRACING_ENABLED] = "true"
+
+    if tracking_uri:
+        env_vars[MLFLOW_TRACKING_URI.name] = tracking_uri
+    if experiment_id:
+        env_vars[MLFLOW_EXPERIMENT_ID.name] = experiment_id
+    elif experiment_name:
+        env_vars[MLFLOW_EXPERIMENT_NAME.name] = experiment_name
+
+    return env_vars

--- a/mlflow/gemini_cli/hooks.py
+++ b/mlflow/gemini_cli/hooks.py
@@ -1,0 +1,206 @@
+"""Hook management for Gemini CLI integration with MLflow."""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from mlflow.gemini_cli.config import (
+    HOOK_FIELD_COMMAND,
+    HOOK_FIELD_HOOKS,
+    MLFLOW_HOOK_IDENTIFIER,
+    load_gemini_config,
+    save_gemini_config,
+)
+from mlflow.gemini_cli.tracing import (
+    GEMINI_TRACING_LEVEL,
+    get_hook_response,
+    get_logger,
+    is_tracing_enabled,
+    process_transcript,
+    read_hook_input,
+    setup_mlflow,
+)
+
+# ============================================================================
+# HOOK CONFIGURATION UTILITIES
+# ============================================================================
+
+
+def upsert_hook(config: dict[str, Any], hook_type: str, handler_name: str) -> None:
+    """Insert or update a single MLflow hook in the configuration.
+
+    Args:
+        config: The hooks configuration dictionary to modify
+        hook_type: The hook type (e.g., 'SessionEnd')
+        handler_name: The handler function name (e.g., 'session_end_hook_handler')
+    """
+    if hook_type not in config[HOOK_FIELD_HOOKS]:
+        config[HOOK_FIELD_HOOKS][hook_type] = []
+
+    hook_command = (
+        f'python -c "from mlflow.gemini_cli.hooks import {handler_name}; {handler_name}()"'
+    )
+
+    mlflow_hook = {
+        "type": "command",
+        "name": "mlflow-tracing",
+        HOOK_FIELD_COMMAND: hook_command,
+        "description": "MLflow tracing hook for Gemini CLI",
+    }
+
+    # Check if MLflow hook already exists and update it
+    hook_exists = False
+    for hook_group in config[HOOK_FIELD_HOOKS][hook_type]:
+        if HOOK_FIELD_HOOKS in hook_group:
+            for hook in hook_group[HOOK_FIELD_HOOKS]:
+                if MLFLOW_HOOK_IDENTIFIER in hook.get(HOOK_FIELD_COMMAND, ""):
+                    hook.update(mlflow_hook)
+                    hook_exists = True
+                    break
+
+    # Add new hook if it doesn't exist
+    if not hook_exists:
+        config[HOOK_FIELD_HOOKS][hook_type].append({HOOK_FIELD_HOOKS: [mlflow_hook]})
+
+
+def setup_hooks_config(settings_path: Path) -> None:
+    """Set up Gemini CLI hooks for MLflow tracing.
+
+    Creates or updates SessionEnd hook that calls MLflow tracing handler.
+    Updates existing MLflow hooks if found, otherwise adds new ones.
+
+    Args:
+        settings_path: Path to Gemini settings.json file
+    """
+    config = load_gemini_config(settings_path)
+
+    if HOOK_FIELD_HOOKS not in config:
+        config[HOOK_FIELD_HOOKS] = {}
+
+    upsert_hook(config, "SessionEnd", "session_end_hook_handler")
+
+    save_gemini_config(settings_path, config)
+
+
+# ============================================================================
+# HOOK REMOVAL AND CLEANUP
+# ============================================================================
+
+
+def disable_tracing_hooks(settings_path: Path) -> bool:
+    """Remove MLflow hooks from Gemini CLI settings.
+
+    Args:
+        settings_path: Path to Gemini settings file
+
+    Returns:
+        True if hooks were removed, False if no configuration was found
+    """
+    if not settings_path.exists():
+        return False
+
+    config = load_gemini_config(settings_path)
+    hooks_removed = False
+
+    # Remove MLflow hooks from SessionEnd
+    if "SessionEnd" in config.get(HOOK_FIELD_HOOKS, {}):
+        hook_groups = config[HOOK_FIELD_HOOKS]["SessionEnd"]
+        filtered_groups = []
+
+        for group in hook_groups:
+            if HOOK_FIELD_HOOKS in group:
+                filtered_hooks = [
+                    hook
+                    for hook in group[HOOK_FIELD_HOOKS]
+                    if MLFLOW_HOOK_IDENTIFIER not in hook.get(HOOK_FIELD_COMMAND, "")
+                ]
+
+                if filtered_hooks:
+                    filtered_groups.append({HOOK_FIELD_HOOKS: filtered_hooks})
+                else:
+                    hooks_removed = True
+            else:
+                filtered_groups.append(group)
+
+        if filtered_groups:
+            config[HOOK_FIELD_HOOKS]["SessionEnd"] = filtered_groups
+        else:
+            del config[HOOK_FIELD_HOOKS]["SessionEnd"]
+            hooks_removed = True
+
+    # Clean up empty hooks section
+    if HOOK_FIELD_HOOKS in config and not config[HOOK_FIELD_HOOKS]:
+        del config[HOOK_FIELD_HOOKS]
+
+    # Save updated config or remove file if empty
+    if config:
+        save_gemini_config(settings_path, config)
+    else:
+        settings_path.unlink()
+
+    return hooks_removed
+
+
+# ============================================================================
+# GEMINI CLI HOOK HANDLERS
+# ============================================================================
+
+
+def _process_session_end_hook(
+    session_id: str | None, transcript_path: str | None
+) -> dict[str, Any]:
+    """Common logic for processing session end hooks.
+
+    Args:
+        session_id: Session identifier
+        transcript_path: Path to transcript file
+
+    Returns:
+        Hook response dictionary
+    """
+    get_logger().log(
+        GEMINI_TRACING_LEVEL,
+        "SessionEnd hook: session=%s, transcript=%s",
+        session_id,
+        transcript_path,
+    )
+
+    # Process the transcript and create MLflow trace
+    trace = process_transcript(transcript_path, session_id)
+
+    if trace is not None:
+        return get_hook_response()
+    return get_hook_response(
+        error=(
+            "Failed to process transcript, please check .gemini/mlflow/gemini_tracing.log"
+            " for more details"
+        ),
+    )
+
+
+def session_end_hook_handler() -> None:
+    """CLI hook handler for session end - processes transcript and creates trace.
+
+    This handler is called by Gemini CLI via the SessionEnd hook.
+    It reads hook input from stdin, processes the transcript, and creates an MLflow trace.
+    """
+    if not is_tracing_enabled():
+        response = get_hook_response()
+        print(json.dumps(response))  # noqa: T201
+        return
+
+    try:
+        hook_data = read_hook_input()
+        session_id = hook_data.get("session_id")
+        transcript_path = hook_data.get("transcript_path")
+
+        setup_mlflow()
+        response = _process_session_end_hook(session_id, transcript_path)
+        print(json.dumps(response))  # noqa: T201
+
+    except Exception as e:
+        get_logger().error("Error in SessionEnd hook: %s", e, exc_info=True)
+        response = get_hook_response(error=str(e))
+        print(json.dumps(response))  # noqa: T201
+        sys.exit(1)

--- a/mlflow/gemini_cli/tracing.py
+++ b/mlflow/gemini_cli/tracing.py
@@ -1,0 +1,634 @@
+"""MLflow tracing integration for Gemini CLI interactions."""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import mlflow
+from mlflow.entities import SpanType
+from mlflow.environment_variables import (
+    MLFLOW_EXPERIMENT_ID,
+    MLFLOW_EXPERIMENT_NAME,
+    MLFLOW_TRACKING_URI,
+)
+from mlflow.gemini_cli.config import MLFLOW_TRACING_ENABLED, get_env_var
+from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey, TraceMetadataKey
+from mlflow.tracing.provider import _get_trace_exporter
+from mlflow.tracing.trace_manager import InMemoryTraceManager
+
+# ============================================================================
+# CONSTANTS
+# ============================================================================
+
+NANOSECONDS_PER_MS = 1e6
+NANOSECONDS_PER_S = 1e9
+MAX_PREVIEW_LENGTH = 1000
+
+# Gemini CLI message types
+MESSAGE_TYPE_USER = "user"
+MESSAGE_TYPE_GEMINI = "gemini"
+MESSAGE_TYPE_SESSION_METADATA = "session_metadata"
+MESSAGE_TYPE_MESSAGE_UPDATE = "message_update"
+
+# Content field names
+FIELD_TYPE = "type"
+FIELD_CONTENT = "content"
+FIELD_ID = "id"
+FIELD_TIMESTAMP = "timestamp"
+FIELD_TOKENS = "tokens"
+FIELD_TOOL_CALL = "functionCall"
+FIELD_TOOL_RESPONSE = "functionResponse"
+
+# Custom logging level for Gemini CLI tracing
+GEMINI_TRACING_LEVEL = logging.WARNING - 5
+
+
+# ============================================================================
+# LOGGING AND SETUP
+# ============================================================================
+
+
+def setup_logging() -> logging.Logger:
+    """Set up logging directory and return configured logger.
+
+    Creates .gemini/mlflow directory structure and configures file-based logging.
+    """
+    log_dir = Path(os.getcwd()) / ".gemini" / "mlflow"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    logger = logging.getLogger(__name__)
+    logger.handlers.clear()
+
+    log_file = log_dir / "gemini_tracing.log"
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(file_handler)
+    logging.addLevelName(GEMINI_TRACING_LEVEL, "GEMINI_TRACING")
+    logger.setLevel(GEMINI_TRACING_LEVEL)
+    logger.propagate = False
+
+    return logger
+
+
+_MODULE_LOGGER: logging.Logger | None = None
+
+
+def get_logger() -> logging.Logger:
+    """Get the configured module logger."""
+    global _MODULE_LOGGER
+
+    if _MODULE_LOGGER is None:
+        _MODULE_LOGGER = setup_logging()
+    return _MODULE_LOGGER
+
+
+def setup_mlflow() -> None:
+    """Configure MLflow tracking URI and experiment."""
+    if not is_tracing_enabled():
+        return
+
+    tracking_uri = get_env_var(MLFLOW_TRACKING_URI.name)
+    if tracking_uri:
+        mlflow.set_tracking_uri(tracking_uri)
+
+    experiment_id = get_env_var(MLFLOW_EXPERIMENT_ID.name)
+    experiment_name = get_env_var(MLFLOW_EXPERIMENT_NAME.name)
+
+    try:
+        if experiment_id:
+            mlflow.set_experiment(experiment_id=experiment_id)
+        elif experiment_name:
+            mlflow.set_experiment(experiment_name)
+    except Exception as e:
+        get_logger().warning("Failed to set experiment: %s", e)
+
+
+def is_tracing_enabled() -> bool:
+    """Check if MLflow Gemini CLI tracing is enabled via environment variable."""
+    return get_env_var(MLFLOW_TRACING_ENABLED).lower() in ("true", "1", "yes")
+
+
+# ============================================================================
+# INPUT/OUTPUT UTILITIES
+# ============================================================================
+
+
+def read_hook_input() -> dict[str, Any]:
+    """Read JSON input from stdin for Gemini CLI hook processing."""
+    try:
+        input_data = sys.stdin.read()
+        return json.loads(input_data)
+    except json.JSONDecodeError as e:
+        raise json.JSONDecodeError(f"Failed to parse hook input: {e}", input_data, 0) from e
+
+
+def read_transcript(transcript_path: str) -> list[dict[str, Any]]:
+    """Read and parse a Gemini CLI conversation transcript from JSONL file.
+
+    Args:
+        transcript_path: Path to the transcript JSONL file
+
+    Returns:
+        List of parsed JSON entries from the transcript
+    """
+    with open(transcript_path, encoding="utf-8") as f:
+        lines = f.readlines()
+        return [json.loads(line) for line in lines if line.strip()]
+
+
+def get_hook_response(error: str | None = None, **kwargs) -> dict[str, Any]:
+    """Build hook response dictionary for Gemini CLI hook protocol.
+
+    Args:
+        error: Error message if hook failed, None if successful
+        kwargs: Additional fields to include in response
+
+    Returns:
+        Hook response dictionary compatible with Gemini CLI hook protocol
+    """
+    if error is not None:
+        return {"continue": False, "stopReason": error, **kwargs}
+    return {"continue": True, **kwargs}
+
+
+# ============================================================================
+# TIMESTAMP AND CONTENT PARSING UTILITIES
+# ============================================================================
+
+
+def parse_timestamp_to_ns(timestamp: str | int | float | None) -> int | None:
+    """Convert various timestamp formats to nanoseconds since Unix epoch.
+
+    Args:
+        timestamp: Can be ISO string, Unix timestamp (seconds/ms), or nanoseconds
+
+    Returns:
+        Nanoseconds since Unix epoch, or None if parsing fails
+    """
+    if not timestamp:
+        return None
+
+    if isinstance(timestamp, str):
+        try:
+            import dateutil.parser
+
+            dt = dateutil.parser.parse(timestamp)
+            return int(dt.timestamp() * NANOSECONDS_PER_S)
+        except Exception:
+            get_logger().warning("Could not parse timestamp: %s", timestamp)
+            return None
+    if isinstance(timestamp, (int, float)):
+        if timestamp < 1e10:
+            return int(timestamp * NANOSECONDS_PER_S)
+        if timestamp < 1e13:
+            return int(timestamp * NANOSECONDS_PER_MS)
+        return int(timestamp)
+
+    return None
+
+
+def extract_text_content(content: str | list[dict[str, Any]] | Any) -> str:
+    """Extract text content from Gemini message content.
+
+    Gemini CLI messages have content as a list of parts, each with a "text" field.
+
+    Args:
+        content: Either a string or list of content parts from Gemini API
+
+    Returns:
+        Extracted text content, empty string if none found
+    """
+    if isinstance(content, list):
+        text_parts = [
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and "text" in part
+        ]
+        return "\n".join(text_parts)
+    if isinstance(content, str):
+        return content
+    return str(content) if content else ""
+
+
+def find_last_user_message_index(transcript: list[dict[str, Any]]) -> int | None:
+    """Find the index of the last user message in the transcript.
+
+    Args:
+        transcript: List of conversation entries from Gemini CLI transcript
+
+    Returns:
+        Index of last user message, or None if not found
+    """
+    for i in range(len(transcript) - 1, -1, -1):
+        entry = transcript[i]
+        if entry.get(FIELD_TYPE) == MESSAGE_TYPE_USER:
+            content = entry.get(FIELD_CONTENT, [])
+            text = extract_text_content(content)
+            if text and text.strip():
+                return i
+    return None
+
+
+# ============================================================================
+# TRANSCRIPT PROCESSING HELPERS
+# ============================================================================
+
+
+def _get_next_timestamp_ns(transcript: list[dict[str, Any]], current_idx: int) -> int | None:
+    """Get the timestamp of the next entry for duration calculation."""
+    for i in range(current_idx + 1, len(transcript)):
+        if timestamp := transcript[i].get(FIELD_TIMESTAMP):
+            return parse_timestamp_to_ns(timestamp)
+    return None
+
+
+def _extract_content_and_tools(
+    content: list[dict[str, Any]],
+) -> tuple[str, list[dict[str, Any]]]:
+    """Extract text content and tool calls from Gemini response content.
+
+    Args:
+        content: List of content parts from Gemini response
+
+    Returns:
+        Tuple of (text_content, tool_calls)
+    """
+    text_content = ""
+    tool_calls = []
+
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict):
+                if "text" in part:
+                    text_content += part.get("text", "")
+                elif FIELD_TOOL_CALL in part:
+                    tool_calls.append(part[FIELD_TOOL_CALL])
+
+    return text_content, tool_calls
+
+
+def _find_tool_results(
+    transcript: list[dict[str, Any]], start_idx: int
+) -> dict[str, Any]:
+    """Find tool results following the current Gemini response.
+
+    Returns a mapping from function name to tool result content.
+    """
+    tool_results: dict[str, Any] = {}
+
+    for i in range(start_idx + 1, len(transcript)):
+        entry = transcript[i]
+        if entry.get(FIELD_TYPE) == MESSAGE_TYPE_GEMINI:
+            break
+
+        content = entry.get(FIELD_CONTENT, [])
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and FIELD_TOOL_RESPONSE in part:
+                    func_response = part[FIELD_TOOL_RESPONSE]
+                    func_name = func_response.get("name", "")
+                    func_result = func_response.get("response", {})
+                    if func_name:
+                        tool_results[func_name] = func_result
+
+    return tool_results
+
+
+def _get_token_usage(transcript: list[dict[str, Any]], msg_id: str) -> dict[str, Any]:
+    """Get token usage for a specific message from message_update entries.
+
+    Args:
+        transcript: Full transcript
+        msg_id: Message ID to find usage for
+
+    Returns:
+        Token usage dictionary with input_tokens, output_tokens, total_tokens
+    """
+    for entry in transcript:
+        if (
+            entry.get(FIELD_TYPE) == MESSAGE_TYPE_MESSAGE_UPDATE
+            and entry.get(FIELD_ID) == msg_id
+            and FIELD_TOKENS in entry
+        ):
+            tokens = entry[FIELD_TOKENS]
+            input_tokens = tokens.get("input", 0)
+            output_tokens = tokens.get("output", 0)
+            return {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": input_tokens + output_tokens,
+            }
+    return {}
+
+
+def _set_token_usage_attribute(span, usage: dict[str, Any]) -> None:
+    """Set token usage on a span using the standardized CHAT_USAGE attribute.
+
+    Args:
+        span: The MLflow span to set token usage on
+        usage: Dictionary containing token usage info
+    """
+    if not usage:
+        return
+
+    input_tokens = usage.get("input_tokens", 0)
+    output_tokens = usage.get("output_tokens", 0)
+
+    usage_dict = {
+        TokenUsageKey.INPUT_TOKENS: input_tokens,
+        TokenUsageKey.OUTPUT_TOKENS: output_tokens,
+        TokenUsageKey.TOTAL_TOKENS: input_tokens + output_tokens,
+    }
+
+    span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
+
+
+def _create_llm_and_tool_spans(
+    parent_span, transcript: list[dict[str, Any]], start_idx: int
+) -> None:
+    """Create LLM and tool spans for Gemini responses with proper timing."""
+    for i in range(start_idx, len(transcript)):
+        entry = transcript[i]
+        if entry.get(FIELD_TYPE) != MESSAGE_TYPE_GEMINI:
+            continue
+
+        timestamp_ns = parse_timestamp_to_ns(entry.get(FIELD_TIMESTAMP))
+        msg_id = entry.get(FIELD_ID, "")
+
+        # Calculate duration based on next timestamp or use default
+        if next_timestamp_ns := _get_next_timestamp_ns(transcript, i):
+            duration_ns = next_timestamp_ns - timestamp_ns if timestamp_ns else int(
+                1000 * NANOSECONDS_PER_MS
+            )
+        else:
+            duration_ns = int(1000 * NANOSECONDS_PER_MS)  # 1 second default
+
+        content = entry.get(FIELD_CONTENT, [])
+        text_content, tool_calls = _extract_content_and_tools(content)
+
+        # Get token usage from message_update entries
+        usage = _get_token_usage(transcript, msg_id)
+
+        # Create LLM span if there's text content (no tool calls)
+        if text_content and text_content.strip() and not tool_calls:
+            llm_span = mlflow.start_span_no_context(
+                name="llm",
+                parent_span=parent_span,
+                span_type=SpanType.LLM,
+                start_time_ns=timestamp_ns,
+                inputs={
+                    "model": entry.get("model", "gemini"),
+                    "messages": [{"role": "assistant", "content": text_content}],
+                },
+                attributes={
+                    "model": entry.get("model", "gemini"),
+                },
+            )
+
+            _set_token_usage_attribute(llm_span, usage)
+
+            llm_span.set_outputs(
+                {
+                    "role": "assistant",
+                    "content": text_content,
+                }
+            )
+            if timestamp_ns:
+                llm_span.end(end_time_ns=timestamp_ns + duration_ns)
+            else:
+                llm_span.end()
+
+        # Create tool spans
+        if tool_calls:
+            tool_results = _find_tool_results(transcript, i)
+            tool_duration_ns = duration_ns // max(len(tool_calls), 1)
+
+            for idx, tool_call in enumerate(tool_calls):
+                tool_name = tool_call.get("name", "unknown")
+                tool_args = tool_call.get("args", {})
+                tool_result = tool_results.get(tool_name, "No result found")
+
+                tool_start_ns = (
+                    timestamp_ns + (idx * tool_duration_ns) if timestamp_ns else None
+                )
+
+                tool_span = mlflow.start_span_no_context(
+                    name=f"tool_{tool_name}",
+                    parent_span=parent_span,
+                    span_type=SpanType.TOOL,
+                    start_time_ns=tool_start_ns,
+                    inputs=tool_args,
+                    attributes={
+                        "tool_name": tool_name,
+                    },
+                )
+
+                tool_span.set_outputs({"result": tool_result})
+                if tool_start_ns:
+                    tool_span.end(end_time_ns=tool_start_ns + tool_duration_ns)
+                else:
+                    tool_span.end()
+
+
+def _finalize_trace(
+    parent_span,
+    user_prompt: str,
+    final_response: str | None,
+    session_id: str | None,
+    end_time_ns: int | None = None,
+    total_usage: dict[str, Any] | None = None,
+) -> mlflow.entities.Trace:
+    """Finalize the trace with metadata and end it."""
+    try:
+        with InMemoryTraceManager.get_instance().get_trace(parent_span.trace_id) as in_memory_trace:
+            if user_prompt:
+                in_memory_trace.info.request_preview = user_prompt[:MAX_PREVIEW_LENGTH]
+            if final_response:
+                in_memory_trace.info.response_preview = final_response[:MAX_PREVIEW_LENGTH]
+
+            metadata = {
+                TraceMetadataKey.TRACE_USER: os.environ.get("USER", ""),
+                "mlflow.trace.working_directory": os.getcwd(),
+            }
+            if session_id:
+                metadata[TraceMetadataKey.TRACE_SESSION] = session_id
+
+            if total_usage:
+                metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(
+                    {
+                        TokenUsageKey.INPUT_TOKENS: total_usage.get("input_tokens", 0),
+                        TokenUsageKey.OUTPUT_TOKENS: total_usage.get("output_tokens", 0),
+                        TokenUsageKey.TOTAL_TOKENS: total_usage.get("total_tokens", 0),
+                    }
+                )
+
+            in_memory_trace.info.trace_metadata = {
+                **in_memory_trace.info.trace_metadata,
+                **metadata,
+            }
+    except Exception as e:
+        get_logger().warning("Failed to update trace metadata and previews: %s", e)
+
+    outputs = {"status": "completed"}
+    if final_response:
+        outputs["response"] = final_response
+    parent_span.set_outputs(outputs)
+    parent_span.end(end_time_ns=end_time_ns)
+    _flush_trace_async_logging()
+    get_logger().log(GEMINI_TRACING_LEVEL, "Created MLflow trace: %s", parent_span.trace_id)
+    return mlflow.get_trace(parent_span.trace_id)
+
+
+def _flush_trace_async_logging() -> None:
+    """Flush any pending async trace logging."""
+    try:
+        if hasattr(_get_trace_exporter(), "_async_queue"):
+            mlflow.flush_trace_async_logging()
+    except Exception as e:
+        get_logger().debug("Failed to flush trace async logging: %s", e)
+
+
+def find_final_gemini_response(transcript: list[dict[str, Any]], start_idx: int) -> str | None:
+    """Find the final text response from Gemini for trace preview.
+
+    Args:
+        transcript: List of conversation entries
+        start_idx: Index to start searching from
+
+    Returns:
+        Final Gemini response text or None
+    """
+    final_response = None
+
+    for i in range(start_idx, len(transcript)):
+        entry = transcript[i]
+        if entry.get(FIELD_TYPE) != MESSAGE_TYPE_GEMINI:
+            continue
+
+        content = entry.get(FIELD_CONTENT, [])
+        text = extract_text_content(content)
+        if text and text.strip():
+            final_response = text
+
+    return final_response
+
+
+def _aggregate_token_usage(transcript: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate token usage from all message_update entries in the transcript.
+
+    Args:
+        transcript: Full transcript
+
+    Returns:
+        Aggregated token usage dictionary
+    """
+    total_input = 0
+    total_output = 0
+
+    for entry in transcript:
+        if entry.get(FIELD_TYPE) == MESSAGE_TYPE_MESSAGE_UPDATE and FIELD_TOKENS in entry:
+            tokens = entry[FIELD_TOKENS]
+            total_input += tokens.get("input", 0)
+            total_output += tokens.get("output", 0)
+
+    if total_input > 0 or total_output > 0:
+        return {
+            "input_tokens": total_input,
+            "output_tokens": total_output,
+            "total_tokens": total_input + total_output,
+        }
+    return {}
+
+
+# ============================================================================
+# MAIN TRANSCRIPT PROCESSING
+# ============================================================================
+
+
+def process_transcript(
+    transcript_path: str, session_id: str | None = None
+) -> mlflow.entities.Trace | None:
+    """Process a Gemini CLI conversation transcript and create an MLflow trace with spans.
+
+    Args:
+        transcript_path: Path to the Gemini CLI transcript JSONL file
+        session_id: Optional session identifier
+
+    Returns:
+        MLflow trace object if successful, None if processing fails
+    """
+    try:
+        transcript = read_transcript(transcript_path)
+        if not transcript:
+            get_logger().warning("Empty transcript, skipping")
+            return None
+
+        last_user_idx = find_last_user_message_index(transcript)
+        if last_user_idx is None:
+            get_logger().warning("No user message found in transcript")
+            return None
+
+        last_user_entry = transcript[last_user_idx]
+        last_user_prompt = last_user_entry.get(FIELD_CONTENT, "")
+
+        if not session_id:
+            # Try to get session ID from session_metadata entry
+            for entry in transcript:
+                if entry.get(FIELD_TYPE) == MESSAGE_TYPE_SESSION_METADATA:
+                    session_id = entry.get("sessionId")
+                    break
+            if not session_id:
+                session_id = f"gemini-{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+        get_logger().log(
+            GEMINI_TRACING_LEVEL, "Creating MLflow trace for session: %s", session_id
+        )
+
+        conv_start_ns = parse_timestamp_to_ns(last_user_entry.get(FIELD_TIMESTAMP))
+
+        parent_span = mlflow.start_span_no_context(
+            name="gemini_cli_conversation",
+            inputs={"prompt": extract_text_content(last_user_prompt)},
+            start_time_ns=conv_start_ns,
+            span_type=SpanType.AGENT,
+        )
+
+        # Create spans for all Gemini responses and tool uses
+        _create_llm_and_tool_spans(parent_span, transcript, last_user_idx + 1)
+
+        # Aggregate token usage across all messages
+        total_usage = _aggregate_token_usage(transcript)
+        if total_usage:
+            _set_token_usage_attribute(parent_span, total_usage)
+
+        # Update trace with preview content and end timing
+        final_response = find_final_gemini_response(transcript, last_user_idx + 1)
+        user_prompt_text = extract_text_content(last_user_prompt)
+
+        # Calculate end time
+        last_entry = transcript[-1] if transcript else last_user_entry
+        conv_end_ns = parse_timestamp_to_ns(last_entry.get(FIELD_TIMESTAMP))
+        if not conv_end_ns or (conv_start_ns and conv_end_ns <= conv_start_ns):
+            if conv_start_ns:
+                conv_end_ns = conv_start_ns + int(10 * NANOSECONDS_PER_S)
+            else:
+                conv_end_ns = None
+
+        return _finalize_trace(
+            parent_span,
+            user_prompt_text,
+            final_response,
+            session_id,
+            conv_end_ns,
+            total_usage,
+        )
+
+    except Exception as e:
+        get_logger().error("Error processing transcript: %s", e, exc_info=True)
+        return None

--- a/mlflow/gemini_cli/tracing.py
+++ b/mlflow/gemini_cli/tracing.py
@@ -129,17 +129,51 @@ def read_hook_input() -> dict[str, Any]:
 
 
 def read_transcript(transcript_path: str) -> list[dict[str, Any]]:
-    """Read and parse a Gemini CLI conversation transcript from JSONL file.
+    """Read and parse a Gemini CLI conversation transcript.
+
+    The Gemini CLI can produce two transcript formats:
+    - JSONL: one JSON object per line (the expected format)
+    - Single JSON object: {"messages": [...]} with one message per line
 
     Args:
-        transcript_path: Path to the transcript JSONL file
+        transcript_path: Path to the transcript file
 
     Returns:
         List of parsed JSON entries from the transcript
     """
     with open(transcript_path, encoding="utf-8") as f:
-        lines = f.readlines()
-        return [json.loads(line) for line in lines if line.strip()]
+        raw = f.read()
+
+    # Try standard JSONL parsing first (one JSON object per line)
+    lines = raw.splitlines()
+    if lines:
+        first_line = lines[0].strip()
+        try:
+            parsed_first = json.loads(first_line)
+            # If first line is a complete JSON object with "messages" key
+            # (not a JSONL entry), handle the single-JSON-object format
+            if isinstance(parsed_first, dict) and "messages" in parsed_first:
+                return parsed_first["messages"]
+            # Otherwise, treat as JSONL: parse each non-empty line
+            return [json.loads(line) for line in lines if line.strip()]
+        except json.JSONDecodeError:
+            pass
+
+    # Fallback: try parsing the raw content as a Python dict literal
+    # (Gemini CLI may write transcripts with single-quoted keys/strings)
+    try:
+        import ast
+        parsed = ast.literal_eval(raw)
+        if isinstance(parsed, dict) and "messages" in parsed:
+            return parsed["messages"]
+    except (ValueError, SyntaxError):
+        pass
+
+    raise json.JSONDecodeError(
+        f"Failed to parse transcript file: not valid JSONL or JSON object with 'messages'",
+        raw,
+        0,
+    )
 
 
 def get_hook_response(error: str | None = None, **kwargs) -> dict[str, Any]:

--- a/tests/gemini_cli/test_cli.py
+++ b/tests/gemini_cli/test_cli.py
@@ -1,0 +1,56 @@
+import pytest
+from click.testing import CliRunner
+
+from mlflow.gemini_cli.cli import gemini_cli
+
+
+@pytest.fixture
+def runner():
+    """Provide a CLI runner for tests."""
+    return CliRunner()
+
+
+def test_gemini_cli_help_command(runner):
+    result = runner.invoke(gemini_cli, ["--help"])
+    assert result.exit_code == 0
+    assert "Set up Gemini CLI tracing" in result.output
+    assert "--tracking-uri" in result.output
+    assert "--experiment-id" in result.output
+    assert "--disable" in result.output
+    assert "--status" in result.output
+
+
+def test_gemini_cli_status_with_no_config(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(gemini_cli, ["--status"])
+        assert result.exit_code == 0
+        assert "Gemini CLI tracing is not enabled" in result.output
+
+
+def test_gemini_cli_disable_with_no_config(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(gemini_cli, ["--disable"])
+        assert result.exit_code == 0
+        assert "No Gemini CLI configuration found" in result.output
+
+
+def test_gemini_cli_setup_creates_config(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(gemini_cli, ["."])
+        assert result.exit_code == 0
+        assert "Gemini CLI hooks configured" in result.output
+        assert "Gemini CLI Tracing Setup Complete!" in result.output
+
+
+def test_gemini_cli_setup_with_tracking_uri(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(gemini_cli, [".", "-u", "http://localhost:5000"])
+        assert result.exit_code == 0
+        assert "http://localhost:5000" in result.output
+
+
+def test_gemini_cli_setup_with_experiment_id(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(gemini_cli, [".", "-e", "123456"])
+        assert result.exit_code == 0
+        assert "123456" in result.output

--- a/tests/gemini_cli/test_config.py
+++ b/tests/gemini_cli/test_config.py
@@ -1,0 +1,137 @@
+import json
+
+import pytest
+
+from mlflow.gemini_cli.config import (
+    MLFLOW_TRACING_ENABLED,
+    get_env_var,
+    get_tracing_status,
+    load_gemini_config,
+    save_gemini_config,
+    setup_environment_config,
+)
+
+
+@pytest.fixture
+def temp_settings_path(tmp_path):
+    """Provide a temporary settings.json path for tests."""
+    return tmp_path / "settings.json"
+
+
+def test_load_gemini_config_valid_json(temp_settings_path):
+    config_data = {"hooks": {"SessionEnd": []}}
+    with open(temp_settings_path, "w") as f:
+        json.dump(config_data, f)
+
+    result = load_gemini_config(temp_settings_path)
+    assert result == config_data
+
+
+def test_load_gemini_config_missing_file(tmp_path):
+    non_existent_path = tmp_path / "non_existent.json"
+    result = load_gemini_config(non_existent_path)
+    assert result == {}
+
+
+def test_load_gemini_config_invalid_json(temp_settings_path):
+    with open(temp_settings_path, "w") as f:
+        f.write("invalid json content")
+
+    result = load_gemini_config(temp_settings_path)
+    assert result == {}
+
+
+def test_save_gemini_config_creates_file(temp_settings_path):
+    config_data = {"test": "value"}
+    save_gemini_config(temp_settings_path, config_data)
+
+    assert temp_settings_path.exists()
+    saved_data = json.loads(temp_settings_path.read_text())
+    assert saved_data == config_data
+
+
+def test_save_gemini_config_creates_directory(tmp_path):
+    nested_path = tmp_path / "nested" / "dir" / "settings.json"
+    config_data = {"test": "value"}
+
+    save_gemini_config(nested_path, config_data)
+
+    assert nested_path.exists()
+    saved_data = json.loads(nested_path.read_text())
+    assert saved_data == config_data
+
+
+def test_get_env_var_from_os_environment(monkeypatch):
+    monkeypatch.setenv(MLFLOW_TRACING_ENABLED, "test_os_value")
+    result = get_env_var(MLFLOW_TRACING_ENABLED, "default")
+    assert result == "test_os_value"
+
+
+def test_get_env_var_default_when_not_found(monkeypatch):
+    monkeypatch.delenv(MLFLOW_TRACING_ENABLED, raising=False)
+    result = get_env_var(MLFLOW_TRACING_ENABLED, "default_value")
+    assert result == "default_value"
+
+
+def test_get_tracing_status_enabled(temp_settings_path):
+    config_data = {
+        "hooks": {
+            "SessionEnd": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": 'python -c "from mlflow.gemini_cli.hooks import session_end_hook_handler; session_end_hook_handler()"',
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+    with open(temp_settings_path, "w") as f:
+        json.dump(config_data, f)
+
+    status = get_tracing_status(temp_settings_path)
+    assert status.enabled is True
+
+
+def test_get_tracing_status_no_hooks(temp_settings_path):
+    config_data = {"hooks": {}}
+    with open(temp_settings_path, "w") as f:
+        json.dump(config_data, f)
+
+    status = get_tracing_status(temp_settings_path)
+    assert status.enabled is False
+
+
+def test_get_tracing_status_no_config(tmp_path):
+    non_existent_path = tmp_path / "missing.json"
+    status = get_tracing_status(non_existent_path)
+    assert status.enabled is False
+    assert status.reason == "No configuration found"
+
+
+def test_setup_environment_config_with_tracking_uri():
+    env_vars = setup_environment_config(tracking_uri="http://localhost:5000")
+    assert env_vars[MLFLOW_TRACING_ENABLED] == "true"
+    assert env_vars["MLFLOW_TRACKING_URI"] == "http://localhost:5000"
+
+
+def test_setup_environment_config_with_experiment_id():
+    env_vars = setup_environment_config(experiment_id="123")
+    assert env_vars["MLFLOW_EXPERIMENT_ID"] == "123"
+    assert "MLFLOW_EXPERIMENT_NAME" not in env_vars
+
+
+def test_setup_environment_config_with_experiment_name():
+    env_vars = setup_environment_config(experiment_name="my-experiment")
+    assert env_vars["MLFLOW_EXPERIMENT_NAME"] == "my-experiment"
+    assert "MLFLOW_EXPERIMENT_ID" not in env_vars
+
+
+def test_setup_environment_config_experiment_id_precedence():
+    env_vars = setup_environment_config(
+        experiment_id="123", experiment_name="my-experiment"
+    )
+    assert env_vars["MLFLOW_EXPERIMENT_ID"] == "123"
+    assert "MLFLOW_EXPERIMENT_NAME" not in env_vars

--- a/tests/gemini_cli/test_hooks.py
+++ b/tests/gemini_cli/test_hooks.py
@@ -1,0 +1,130 @@
+import json
+
+import pytest
+
+from mlflow.gemini_cli.config import HOOK_FIELD_HOOKS, MLFLOW_HOOK_IDENTIFIER
+from mlflow.gemini_cli.hooks import disable_tracing_hooks, setup_hooks_config, upsert_hook
+
+
+@pytest.fixture
+def temp_settings_path(tmp_path):
+    """Provide a temporary settings.json path for tests."""
+    return tmp_path / "settings.json"
+
+
+def test_setup_hooks_config_creates_new_file(temp_settings_path):
+    setup_hooks_config(temp_settings_path)
+
+    assert temp_settings_path.exists()
+    config = json.loads(temp_settings_path.read_text())
+    assert HOOK_FIELD_HOOKS in config
+    assert "SessionEnd" in config[HOOK_FIELD_HOOKS]
+
+    # Verify the hook command contains the MLflow identifier
+    session_end_hooks = config[HOOK_FIELD_HOOKS]["SessionEnd"]
+    assert len(session_end_hooks) == 1
+    hooks_list = session_end_hooks[0][HOOK_FIELD_HOOKS]
+    assert len(hooks_list) == 1
+    assert MLFLOW_HOOK_IDENTIFIER in hooks_list[0]["command"]
+
+
+def test_setup_hooks_config_preserves_existing_hooks(temp_settings_path):
+    # Create existing config with other hooks
+    existing_config = {
+        HOOK_FIELD_HOOKS: {
+            "BeforeTool": [{"hooks": [{"type": "command", "command": "echo test"}]}],
+        }
+    }
+    with open(temp_settings_path, "w") as f:
+        json.dump(existing_config, f)
+
+    setup_hooks_config(temp_settings_path)
+
+    config = json.loads(temp_settings_path.read_text())
+    assert "BeforeTool" in config[HOOK_FIELD_HOOKS]
+    assert "SessionEnd" in config[HOOK_FIELD_HOOKS]
+
+
+def test_setup_hooks_config_updates_existing_mlflow_hook(temp_settings_path):
+    # Create config with existing MLflow hook
+    existing_config = {
+        HOOK_FIELD_HOOKS: {
+            "SessionEnd": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": 'python -c "from mlflow.gemini_cli.hooks import old_handler; old_handler()"',
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+    with open(temp_settings_path, "w") as f:
+        json.dump(existing_config, f)
+
+    setup_hooks_config(temp_settings_path)
+
+    config = json.loads(temp_settings_path.read_text())
+    session_end_hooks = config[HOOK_FIELD_HOOKS]["SessionEnd"]
+    assert len(session_end_hooks) == 1
+    hooks_list = session_end_hooks[0][HOOK_FIELD_HOOKS]
+    assert len(hooks_list) == 1
+    assert "session_end_hook_handler" in hooks_list[0]["command"]
+
+
+def test_disable_tracing_hooks_removes_mlflow_hooks(temp_settings_path):
+    setup_hooks_config(temp_settings_path)
+
+    result = disable_tracing_hooks(temp_settings_path)
+    assert result is True
+
+    config = json.loads(temp_settings_path.read_text())
+    # The hooks section should be cleaned up
+    assert HOOK_FIELD_HOOKS not in config or "SessionEnd" not in config.get(HOOK_FIELD_HOOKS, {})
+
+
+def test_disable_tracing_hooks_no_config(tmp_path):
+    non_existent = tmp_path / "missing.json"
+    result = disable_tracing_hooks(non_existent)
+    assert result is False
+
+
+def test_disable_tracing_hooks_preserves_other_hooks(temp_settings_path):
+    # Create config with both MLflow and other hooks
+    config = {
+        HOOK_FIELD_HOOKS: {
+            "SessionEnd": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": 'python -c "from mlflow.gemini_cli.hooks import session_end_hook_handler; session_end_hook_handler()"',
+                        }
+                    ]
+                }
+            ],
+            "BeforeTool": [
+                {"hooks": [{"type": "command", "command": "echo other"}]}
+            ],
+        }
+    }
+    with open(temp_settings_path, "w") as f:
+        json.dump(config, f)
+
+    result = disable_tracing_hooks(temp_settings_path)
+    assert result is True
+
+    config = json.loads(temp_settings_path.read_text())
+    assert "BeforeTool" in config[HOOK_FIELD_HOOKS]
+
+
+def test_upsert_hook_adds_new_hook():
+    config = {HOOK_FIELD_HOOKS: {}}
+    upsert_hook(config, "SessionEnd", "session_end_hook_handler")
+
+    assert "SessionEnd" in config[HOOK_FIELD_HOOKS]
+    hooks_list = config[HOOK_FIELD_HOOKS]["SessionEnd"]
+    assert len(hooks_list) == 1
+    assert MLFLOW_HOOK_IDENTIFIER in hooks_list[0][HOOK_FIELD_HOOKS][0]["command"]

--- a/tests/gemini_cli/test_tracing.py
+++ b/tests/gemini_cli/test_tracing.py
@@ -1,0 +1,284 @@
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mlflow.gemini_cli.tracing import (
+    _aggregate_token_usage,
+    _extract_content_and_tools,
+    extract_text_content,
+    find_final_gemini_response,
+    find_last_user_message_index,
+    get_hook_response,
+    is_tracing_enabled,
+    parse_timestamp_to_ns,
+    process_transcript,
+    read_transcript,
+)
+
+
+def test_extract_text_content_from_list():
+    content = [{"text": "Hello"}, {"text": " world"}]
+    assert extract_text_content(content) == "Hello\n world"
+
+
+def test_extract_text_content_from_string():
+    assert extract_text_content("Hello world") == "Hello world"
+
+
+def test_extract_text_content_empty():
+    assert extract_text_content([]) == ""
+    assert extract_text_content("") == ""
+
+
+def test_extract_text_content_with_tool_calls():
+    content = [
+        {"text": "Let me check that"},
+        {"functionCall": {"name": "read_file", "args": {"path": "test.py"}}},
+    ]
+    assert extract_text_content(content) == "Let me check that"
+
+
+def test_parse_timestamp_to_ns_iso_string():
+    result = parse_timestamp_to_ns("2024-01-15T10:30:00Z")
+    assert result is not None
+    assert isinstance(result, int)
+    assert result > 0
+
+
+def test_parse_timestamp_to_ns_unix_seconds():
+    result = parse_timestamp_to_ns(1705312200)
+    assert result is not None
+    assert result == int(1705312200 * 1e9)
+
+
+def test_parse_timestamp_to_ns_unix_ms():
+    result = parse_timestamp_to_ns(1705312200000)
+    assert result is not None
+    assert result == int(1705312200000 * 1e6)
+
+
+def test_parse_timestamp_to_ns_none():
+    assert parse_timestamp_to_ns(None) is None
+    assert parse_timestamp_to_ns("") is None
+
+
+def test_find_last_user_message_index():
+    transcript = [
+        {"type": "session_metadata", "sessionId": "test"},
+        {"type": "user", "content": [{"text": "Hello"}]},
+        {"type": "gemini", "content": [{"text": "Hi there!"}]},
+        {"type": "user", "content": [{"text": "How are you?"}]},
+        {"type": "gemini", "content": [{"text": "I'm good!"}]},
+    ]
+    assert find_last_user_message_index(transcript) == 3
+
+
+def test_find_last_user_message_index_no_user():
+    transcript = [
+        {"type": "session_metadata", "sessionId": "test"},
+        {"type": "gemini", "content": [{"text": "Hi!"}]},
+    ]
+    assert find_last_user_message_index(transcript) is None
+
+
+def test_find_last_user_message_index_empty_content():
+    transcript = [
+        {"type": "user", "content": []},
+        {"type": "user", "content": [{"text": "Real message"}]},
+    ]
+    assert find_last_user_message_index(transcript) == 1
+
+
+def test_extract_content_and_tools_text_only():
+    content = [{"text": "Hello"}]
+    text, tools = _extract_content_and_tools(content)
+    assert text == "Hello"
+    assert tools == []
+
+
+def test_extract_content_and_tools_with_function_call():
+    content = [
+        {"functionCall": {"name": "read_file", "args": {"path": "test.py"}}},
+    ]
+    text, tools = _extract_content_and_tools(content)
+    assert text == ""
+    assert len(tools) == 1
+    assert tools[0]["name"] == "read_file"
+
+
+def test_extract_content_and_tools_mixed():
+    content = [
+        {"text": "Let me check"},
+        {"functionCall": {"name": "run_command", "args": {"cmd": "ls"}}},
+    ]
+    text, tools = _extract_content_and_tools(content)
+    assert text == "Let me check"
+    assert len(tools) == 1
+
+
+def test_aggregate_token_usage():
+    transcript = [
+        {"type": "user", "content": [{"text": "Hello"}]},
+        {"type": "gemini", "id": "msg1", "content": [{"text": "Hi"}]},
+        {"type": "message_update", "id": "msg1", "tokens": {"input": 10, "output": 5}},
+        {"type": "user", "content": [{"text": "More"}]},
+        {"type": "gemini", "id": "msg2", "content": [{"text": "Sure"}]},
+        {"type": "message_update", "id": "msg2", "tokens": {"input": 15, "output": 8}},
+    ]
+    usage = _aggregate_token_usage(transcript)
+    assert usage["input_tokens"] == 25
+    assert usage["output_tokens"] == 13
+    assert usage["total_tokens"] == 38
+
+
+def test_aggregate_token_usage_no_updates():
+    transcript = [
+        {"type": "user", "content": [{"text": "Hello"}]},
+        {"type": "gemini", "content": [{"text": "Hi"}]},
+    ]
+    usage = _aggregate_token_usage(transcript)
+    assert usage == {}
+
+
+def test_find_final_gemini_response():
+    transcript = [
+        {"type": "user", "content": [{"text": "Hello"}]},
+        {"type": "gemini", "content": [{"text": "First response"}]},
+        {"type": "gemini", "content": [{"text": "Final response"}]},
+    ]
+    result = find_final_gemini_response(transcript, 1)
+    assert result == "Final response"
+
+
+def test_find_final_gemini_response_none():
+    transcript = [
+        {"type": "user", "content": [{"text": "Hello"}]},
+    ]
+    result = find_final_gemini_response(transcript, 1)
+    assert result is None
+
+
+def test_get_hook_response_success():
+    response = get_hook_response()
+    assert response == {"continue": True}
+
+
+def test_get_hook_response_error():
+    response = get_hook_response(error="Something failed")
+    assert response == {"continue": False, "stopReason": "Something failed"}
+
+
+def test_is_tracing_enabled_true(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GEMINI_CLI_TRACING_ENABLED", "true")
+    assert is_tracing_enabled() is True
+
+
+def test_is_tracing_enabled_false(monkeypatch):
+    monkeypatch.delenv("MLFLOW_GEMINI_CLI_TRACING_ENABLED", raising=False)
+    assert is_tracing_enabled() is False
+
+
+def test_read_transcript(tmp_path):
+    transcript_file = tmp_path / "transcript.jsonl"
+    entries = [
+        {"type": "session_metadata", "sessionId": "test-session"},
+        {"type": "user", "content": [{"text": "Hello"}]},
+        {"type": "gemini", "content": [{"text": "Hi there!"}]},
+    ]
+    with open(transcript_file, "w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+    result = read_transcript(str(transcript_file))
+    assert len(result) == 3
+    assert result[0]["type"] == "session_metadata"
+    assert result[1]["type"] == "user"
+    assert result[2]["type"] == "gemini"
+
+
+def test_process_transcript_creates_trace(tmp_path):
+    transcript_file = tmp_path / "transcript.jsonl"
+    entries = [
+        {"type": "session_metadata", "sessionId": "test-session", "startTime": "2024-01-15T10:00:00Z"},
+        {"type": "user", "id": "msg1", "content": [{"text": "What is 2+2?"}], "timestamp": "2024-01-15T10:00:01Z"},
+        {"type": "gemini", "id": "msg2", "content": [{"text": "2+2 equals 4."}], "timestamp": "2024-01-15T10:00:02Z"},
+        {"type": "message_update", "id": "msg2", "tokens": {"input": 10, "output": 5}},
+    ]
+    with open(transcript_file, "w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+    trace = process_transcript(str(transcript_file), "test-session")
+    assert trace is not None
+
+
+def test_process_transcript_empty_file(tmp_path):
+    transcript_file = tmp_path / "empty.jsonl"
+    transcript_file.touch()
+
+    trace = process_transcript(str(transcript_file))
+    assert trace is None
+
+
+def test_process_transcript_no_user_message(tmp_path):
+    transcript_file = tmp_path / "no_user.jsonl"
+    entries = [
+        {"type": "session_metadata", "sessionId": "test"},
+        {"type": "gemini", "content": [{"text": "Hi"}]},
+    ]
+    with open(transcript_file, "w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+    trace = process_transcript(str(transcript_file))
+    assert trace is None
+
+
+def test_process_transcript_with_tool_calls(tmp_path):
+    transcript_file = tmp_path / "tools.jsonl"
+    entries = [
+        {"type": "session_metadata", "sessionId": "tool-session"},
+        {
+            "type": "user",
+            "id": "msg1",
+            "content": [{"text": "Read test.py"}],
+            "timestamp": "2024-01-15T10:00:00Z",
+        },
+        {
+            "type": "gemini",
+            "id": "msg2",
+            "content": [
+                {"functionCall": {"name": "read_file", "args": {"path": "test.py"}}},
+            ],
+            "timestamp": "2024-01-15T10:00:01Z",
+        },
+        {
+            "type": "user",
+            "id": "msg3",
+            "content": [
+                {
+                    "functionResponse": {
+                        "name": "read_file",
+                        "response": {"content": "print('hello')"},
+                    }
+                }
+            ],
+            "timestamp": "2024-01-15T10:00:02Z",
+        },
+        {
+            "type": "gemini",
+            "id": "msg4",
+            "content": [{"text": "The file contains a simple print statement."}],
+            "timestamp": "2024-01-15T10:00:03Z",
+        },
+        {"type": "message_update", "id": "msg2", "tokens": {"input": 10, "output": 5}},
+        {"type": "message_update", "id": "msg4", "tokens": {"input": 20, "output": 15}},
+    ]
+    with open(transcript_file, "w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+    trace = process_transcript(str(transcript_file), "tool-session")
+    assert trace is not None

--- a/tests/gemini_cli/test_tracing.py
+++ b/tests/gemini_cli/test_tracing.py
@@ -198,6 +198,26 @@ def test_read_transcript(tmp_path):
     assert result[2]["type"] == "gemini"
 
 
+def test_read_transcript_single_json_object(tmp_path):
+    """Test reading transcript written as a single JSON object with 'messages' key."""
+    transcript_file = tmp_path / "transcript.json"
+    payload = {
+        "messages": [
+            {"type": "session_metadata", "sessionId": "test-session"},
+            {"type": "user", "content": [{"text": "Hello"}]},
+            {"type": "gemini", "content": [{"text": "Hi there!"}]},
+        ]
+    }
+    with open(transcript_file, "w") as f:
+        json.dump(payload, f)
+
+    result = read_transcript(str(transcript_file))
+    assert len(result) == 3
+    assert result[0]["type"] == "session_metadata"
+    assert result[1]["type"] == "user"
+    assert result[2]["type"] == "gemini"
+
+
 def test_process_transcript_creates_trace(tmp_path):
     transcript_file = tmp_path / "transcript.jsonl"
     entries = [


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

Towards #20307

### What changes are proposed in this pull request?

Add tracing support for [Gemini CLI](https://github.com/google-gemini/gemini-cli), Google's open-source terminal-based AI coding agent. This follows the same pattern as the existing Claude Code integration, using Gemini CLI's [hooks system](https://geminicli.com/docs/hooks/) (specifically the `SessionEnd` hook) to automatically capture conversation traces.

**Changes:**

- **`mlflow/gemini_cli/` module**: New Python module with:
  - `config.py` — Configuration management (load/save `.gemini/settings.json`, tracing status)
  - `hooks.py` — Hook setup/removal and `SessionEnd` hook handler
  - `tracing.py` — Transcript processing, span creation (LLM + tool spans), token usage tracking
  - `cli.py` — `mlflow autolog gemini-cli` CLI command
- **`mlflow/cli/__init__.py`** — Register `gemini-cli` as subcommand of the `autolog` group
- **Documentation** — `gemini_cli.mdx` integration guide with setup instructions and troubleshooting
- **Sidebar & Integrations** — Add Gemini CLI to the tracing integrations listing under "Tools"
- **Tests** — Comprehensive tests for config, hooks, tracing, and CLI modules

### How is this PR tested?

- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add tracing support for Gemini CLI conversations via the `mlflow autolog gemini-cli` command. Automatically captures user prompts, assistant responses, tool usage, and token usage from Gemini CLI sessions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)