### PR TITLE
Fix session assessments panel terminology

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
@@ -8,7 +8,7 @@ import {
   AssessmentsPane,
   ModelTraceExplorerRunJudgesContextProvider,
 } from '@databricks/web-shared/model-trace-explorer';
-import { first, last } from 'lodash';
+import { first } from 'lodash';
 import { useEffect, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { ResizableBox } from 'react-resizable';
@@ -18,10 +18,6 @@ import { ScorerEvaluationScope } from '../../experiment-scorers/constants';
 
 const initialWidth = 300;
 const maxWidth = 600;
-
-const getAssessmentsPaneComponent = () => {
-  return AssessmentsPane;
-};
 
 export const ExperimentSingleChatSessionScoreResults = ({
   traces,
@@ -47,8 +43,6 @@ export const ExperimentSingleChatSessionScoreResults = ({
     [firstTraceInfoInSession],
   );
 
-  const AssessmentsPaneComponent = getAssessmentsPaneComponent();
-
   const traceUpdateContext = useModelTraceExplorerUpdateTraceContext();
 
   if (!firstTraceInfoInSession) {
@@ -56,7 +50,7 @@ export const ExperimentSingleChatSessionScoreResults = ({
   }
 
   const assessmentPaneElement = (
-    <AssessmentsPaneComponent
+    <AssessmentsPane
       assessments={sessionAssessments}
       traceId={firstTraceInfoInSession.trace_id}
       css={{
@@ -134,9 +128,9 @@ export const ExperimentSingleChatSessionScoreResults = ({
 const AssessmentsTitleOverride = (count?: number) => (
   <Typography.Title level={3} withoutMargins css={{ flexShrink: 0 }}>
     <FormattedMessage
-      defaultMessage="Session scorers{count, plural, =0 {} other { (#)}}"
+      defaultMessage="Session assessments{count, plural, =0 {} other { (#)}}"
       values={{ count: count ?? 0 }}
-      description="Section title in a side panel that displays session-level scorers"
+      description="Section title in a side panel that displays session-level assessments"
     />
   </Typography.Title>
 );

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -846,6 +846,10 @@
     "defaultMessage": "Aliases allow you to assign a mutable, named reference to a particular prompt version.",
     "description": "Description for the edit aliases modal on the registered prompt details page"
   },
+  "4H11jY": {
+    "defaultMessage": "Add a custom expectation to this trace.",
+    "description": "Hint message prompting user to add a new expectation to a trace"
+  },
   "4HKr3y": {
     "defaultMessage": "Attributes",
     "description": "Header for attribute columns in the evaluation runs table column configuration"
@@ -953,10 +957,6 @@
   "5GCYzy": {
     "defaultMessage": "Experiment Runs - Databricks",
     "description": "Title on a page used to manage MLflow experiments runs"
-  },
-  "5IeFBG": {
-    "defaultMessage": "Session scorers{count, plural, =0 {} other { (#)}}",
-    "description": "Section title in a side panel that displays session-level scorers"
   },
   "5Mzn2b": {
     "defaultMessage": "Creator",
@@ -3338,10 +3338,6 @@
     "defaultMessage": "Calls",
     "description": "Column header for call count"
   },
-  "MNLhKO": {
-    "defaultMessage": "Add custom feedback to this trace.",
-    "description": "Hint message prompting user to add new feedback"
-  },
   "MQ4Voz": {
     "defaultMessage": "{count, plural, one {Input} other {Inputs}}",
     "description": "Evaluation review > input section > title"
@@ -3820,6 +3816,10 @@
   "PuXTcZ": {
     "defaultMessage": "Welcome to MLflow",
     "description": "Workspace landing page title"
+  },
+  "PvgihY": {
+    "defaultMessage": "Session assessments{count, plural, =0 {} other { (#)}}",
+    "description": "Section title in a side panel that displays session-level assessments"
   },
   "PwQiIn": {
     "defaultMessage": "Actions{count}",
@@ -5115,6 +5115,10 @@
     "defaultMessage": "Confirm",
     "description": "A label for the confirmation button in the modal displayed when the experiment type could not be inferred"
   },
+  "Yy18iD": {
+    "defaultMessage": "Add a custom expectation to this session.",
+    "description": "Hint message prompting user to add a new expectation to a session"
+  },
   "Z+tEhr": {
     "defaultMessage": "Compare selected runs",
     "description": "Tooltip for the compare button when enabled"
@@ -5806,10 +5810,6 @@
   "dTLq6E": {
     "defaultMessage": "expand {title}",
     "description": "Common component > collapsible section > alternative label when collapsed"
-  },
-  "dTjHiD": {
-    "defaultMessage": "Add a custom expectation to this trace.",
-    "description": "Hint message prompting user to add a new expectation"
   },
   "dUY9eq": {
     "defaultMessage": "Edit description",
@@ -7867,6 +7867,10 @@
     "defaultMessage": "Relevant",
     "description": "Evaluation results > relevancy assessment > positive value label. Displayed if evaluation result is considered as irrelevant to the query."
   },
+  "rPEyUh": {
+    "defaultMessage": "Add custom feedback to this trace.",
+    "description": "Hint message prompting user to add new feedback to a trace"
+  },
   "rPbiUM": {
     "defaultMessage": "Labeling sessions",
     "description": "Label for the labeling sessions tab in the MLflow experiment navbar"
@@ -8878,6 +8882,10 @@
   "yrsFOP": {
     "defaultMessage": "Datasets",
     "description": "Title for the datasets section on the run details page"
+  },
+  "yv5FMp": {
+    "defaultMessage": "Add custom feedback to this session.",
+    "description": "Hint message prompting user to add new feedback to a session"
   },
   "yyjAgE": {
     "defaultMessage": "Output for the trace",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -108,7 +108,12 @@ export const AssessmentsPane = ({
         sessionId={sessionId}
       />
       <Spacer size="sm" shrinks={false} />
-      <AssessmentsPaneExpectationsSection expectations={expectations} activeSpanId={activeSpanId} traceId={traceId} />
+      <AssessmentsPaneExpectationsSection
+        expectations={expectations}
+        activeSpanId={activeSpanId}
+        traceId={traceId}
+        sessionId={sessionId}
+      />
     </div>
   );
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneExpectationsSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneExpectationsSection.tsx
@@ -16,10 +16,12 @@ export const AssessmentsPaneExpectationsSection = ({
   expectations,
   activeSpanId,
   traceId,
+  sessionId,
 }: {
   expectations: ExpectationAssessment[];
   activeSpanId?: string;
   traceId: string;
+  sessionId?: string;
 }) => {
   const sortedExpectations = useMemo(
     () => expectations.toSorted((left, right) => left.assessment_name.localeCompare(right.assessment_name)),
@@ -52,15 +54,11 @@ export const AssessmentsPaneExpectationsSection = ({
         {!isEmpty(sortedExpectations) && <AddExpectationButton onClick={() => setCreateFormVisible(true)} />}
       </div>
       {sortedExpectations.length > 0 ? (
-        <>
-          <div
-            css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm, marginBottom: theme.spacing.sm }}
-          >
-            {sortedExpectations.map((expectation) => (
-              <ExpectationItem expectation={expectation} key={expectation.assessment_id} />
-            ))}
-          </div>
-        </>
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm, marginBottom: theme.spacing.sm }}>
+          {sortedExpectations.map((expectation) => (
+            <ExpectationItem expectation={expectation} key={expectation.assessment_id} />
+          ))}
+        </div>
       ) : (
         !createFormVisible && (
           <div
@@ -72,10 +70,17 @@ export const AssessmentsPaneExpectationsSection = ({
             }}
           >
             <Typography.Hint>
-              <FormattedMessage
-                defaultMessage="Add a custom expectation to this trace."
-                description="Hint message prompting user to add a new expectation"
-              />{' '}
+              {sessionId ? (
+                <FormattedMessage
+                  defaultMessage="Add a custom expectation to this session."
+                  description="Hint message prompting user to add a new expectation to a session"
+                />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="Add a custom expectation to this trace."
+                  description="Hint message prompting user to add a new expectation to a trace"
+                />
+              )}{' '}
               <Typography.Link
                 componentId="shared.model-trace-explorer.expectation-learn-more-link"
                 openInNewTab

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -292,10 +292,17 @@ export const AssessmentsPaneFeedbackSection = ({
           }}
         >
           <Typography.Hint>
-            <FormattedMessage
-              defaultMessage="Add custom feedback to this trace."
-              description="Hint message prompting user to add new feedback"
-            />{' '}
+            {sessionId ? (
+              <FormattedMessage
+                defaultMessage="Add custom feedback to this session."
+                description="Hint message prompting user to add new feedback to a session"
+              />
+            ) : (
+              <FormattedMessage
+                defaultMessage="Add custom feedback to this trace."
+                description="Hint message prompting user to add new feedback to a trace"
+              />
+            )}{' '}
             <Typography.Link
               componentId="shared.model-trace-explorer.feedback-learn-more-link"
               openInNewTab


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://databricks.atlassian.net/browse/ML-62960

### What changes are proposed in this pull request?

- Rename "Session scorers" → "Session assessments" to align with terminology used elsewhere in the UI
- Change "Add custom feedback to this trace" → "...to this session" when viewing session-level assessments
- Change "Add a custom expectation to this trace" → "...to this session" when viewing session-level assessments

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified via liteswap that session assessments panel shows correct "session" terminology.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)