### PR TITLE
[ML-62948] Fix dataset link not clickable for external source type

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetLink.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetLink.test.tsx
@@ -1,0 +1,80 @@
+import { describe, test, expect } from '@jest/globals';
+import { renderWithIntl, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { ExperimentViewDatasetLink } from './ExperimentViewDatasetLink';
+import { DatasetSourceTypes } from '../../../../types';
+import type { RunDatasetWithTags } from '../../../../types';
+import { DesignSystemProvider } from '@databricks/design-system';
+
+const createDatasetWithTags = (sourceType: string, source: string): RunDatasetWithTags =>
+  ({
+    dataset: {
+      name: 'test-dataset',
+      digest: 'abc123',
+      sourceType,
+      source,
+    },
+    tags: [],
+  }) as any;
+
+const testRunTags = {} as Record<string, { key: string; value: string }>;
+
+const renderComponent = (datasetWithTags: RunDatasetWithTags) => {
+  return renderWithIntl(
+    <DesignSystemProvider>
+      <ExperimentViewDatasetLink datasetWithTags={datasetWithTags} runTags={testRunTags} />
+    </DesignSystemProvider>,
+  );
+};
+
+describe('ExperimentViewDatasetLink', () => {
+  test('renders clickable link for HTTP source type', () => {
+    const dataset = createDatasetWithTags(DatasetSourceTypes.HTTP, JSON.stringify({ url: 'https://example.com/data' }));
+    renderComponent(dataset);
+
+    const link = screen.getByRole('link', { name: /Open dataset/i });
+    expect(link).toHaveAttribute('href', 'https://example.com/data');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  test('renders clickable link for EXTERNAL source type with url', () => {
+    const dataset = createDatasetWithTags(
+      DatasetSourceTypes.EXTERNAL,
+      JSON.stringify({ url: 'https://external.example.com/dataset' }),
+    );
+    renderComponent(dataset);
+
+    const link = screen.getByRole('link', { name: /Open dataset/i });
+    expect(link).toHaveAttribute('href', 'https://external.example.com/dataset');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  test('renders nothing for EXTERNAL source type without url', () => {
+    const dataset = createDatasetWithTags(DatasetSourceTypes.EXTERNAL, JSON.stringify({ other: 'value' }));
+    const { container } = renderComponent(dataset);
+    expect(container.innerHTML).toBe('');
+  });
+
+  test('renders clickable link for HUGGING_FACE source type', () => {
+    const dataset = createDatasetWithTags(
+      DatasetSourceTypes.HUGGING_FACE,
+      JSON.stringify({ path: 'org/dataset-name' }),
+    );
+    renderComponent(dataset);
+
+    const link = screen.getByRole('link', { name: /Open dataset/i });
+    expect(link).toHaveAttribute('href', 'https://huggingface.co/datasets/org/dataset-name');
+  });
+
+  test('renders copy button for S3 source type', () => {
+    const dataset = createDatasetWithTags(DatasetSourceTypes.S3, JSON.stringify({ uri: 's3://bucket/path' }));
+    renderComponent(dataset);
+
+    expect(screen.getByText(/Copy S3 URI to clipboard/i)).toBeInTheDocument();
+  });
+
+  test('renders nothing for unknown source type', () => {
+    const dataset = createDatasetWithTags('unknown', JSON.stringify({ url: 'https://example.com' }));
+    const { container } = renderComponent(dataset);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetLink.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetLink.tsx
@@ -1,7 +1,6 @@
-import { Button, CopyIcon, NewWindowIcon, Typography } from '@databricks/design-system';
+import { Button, CopyIcon, NewWindowIcon } from '@databricks/design-system';
 import type { RunDatasetWithTags } from '../../../../types';
 import { DatasetSourceTypes } from '../../../../types';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { getDatasetSourceUrl } from '../../../../utils/DatasetUtils';
 import { CopyButton } from '../../../../../shared/building_blocks/CopyButton';
@@ -13,7 +12,11 @@ export interface DatasetLinkProps {
 
 export const ExperimentViewDatasetLink = ({ datasetWithTags, runTags }: DatasetLinkProps) => {
   const { dataset } = datasetWithTags;
-  if (dataset.sourceType === DatasetSourceTypes.HTTP || dataset.sourceType === DatasetSourceTypes.HUGGING_FACE) {
+  if (
+    dataset.sourceType === DatasetSourceTypes.HTTP ||
+    dataset.sourceType === DatasetSourceTypes.HUGGING_FACE ||
+    dataset.sourceType === DatasetSourceTypes.EXTERNAL
+  ) {
     const url = getDatasetSourceUrl(datasetWithTags);
     if (url) {
       return (
@@ -48,19 +51,6 @@ export const ExperimentViewDatasetLink = ({ datasetWithTags, runTags }: DatasetL
         </CopyButton>
       );
     }
-  }
-  if (dataset.sourceType === DatasetSourceTypes.EXTERNAL) {
-    return (
-      <Button
-        componentId="codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_3"
-        icon={<NewWindowIcon />}
-      >
-        <FormattedMessage
-          defaultMessage="Go to external location"
-          description="Text for the external location link in the experiment run dataset drawer"
-        />
-      </Button>
-    );
   }
   return null;
 };

--- a/mlflow/server/js/src/experiment-tracking/utils/DatasetUtils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/DatasetUtils.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from '@jest/globals';
+import { getDatasetSourceUrl } from './DatasetUtils';
+import { DatasetSourceTypes } from '../types';
+import type { RunDatasetWithTags } from '../types';
+
+const createDatasetWithTags = (sourceType: string, source: string): RunDatasetWithTags =>
+  ({
+    dataset: {
+      name: 'test-dataset',
+      digest: 'abc123',
+      sourceType,
+      source,
+    },
+    tags: [],
+  }) as any;
+
+describe('getDatasetSourceUrl', () => {
+  test('returns url for HTTP source type', () => {
+    const dataset = createDatasetWithTags(DatasetSourceTypes.HTTP, JSON.stringify({ url: 'https://example.com/data' }));
+    expect(getDatasetSourceUrl(dataset)).toBe('https://example.com/data');
+  });
+
+  test('returns url for EXTERNAL source type', () => {
+    const dataset = createDatasetWithTags(
+      DatasetSourceTypes.EXTERNAL,
+      JSON.stringify({ url: 'https://external.example.com/dataset' }),
+    );
+    expect(getDatasetSourceUrl(dataset)).toBe('https://external.example.com/dataset');
+  });
+
+  test('returns uri for S3 source type', () => {
+    const dataset = createDatasetWithTags(DatasetSourceTypes.S3, JSON.stringify({ uri: 's3://bucket/path' }));
+    expect(getDatasetSourceUrl(dataset)).toBe('s3://bucket/path');
+  });
+
+  test('returns constructed URL for HUGGING_FACE source type', () => {
+    const dataset = createDatasetWithTags(
+      DatasetSourceTypes.HUGGING_FACE,
+      JSON.stringify({ path: 'org/dataset-name' }),
+    );
+    expect(getDatasetSourceUrl(dataset)).toBe('https://huggingface.co/datasets/org/dataset-name');
+  });
+
+  test('returns null for unknown source type', () => {
+    const dataset = createDatasetWithTags('unknown', JSON.stringify({ url: 'https://example.com' }));
+    expect(getDatasetSourceUrl(dataset)).toBeNull();
+  });
+
+  test('returns null when source JSON is invalid', () => {
+    const dataset = createDatasetWithTags(DatasetSourceTypes.HTTP, 'not-json');
+    expect(getDatasetSourceUrl(dataset)).toBeNull();
+  });
+
+  test('returns null for EXTERNAL source with no url field', () => {
+    const dataset = createDatasetWithTags(DatasetSourceTypes.EXTERNAL, JSON.stringify({ other: 'value' }));
+    expect(getDatasetSourceUrl(dataset)).toBeUndefined();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/utils/DatasetUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/DatasetUtils.ts
@@ -7,7 +7,7 @@ export const getDatasetSourceUrl = (datasetWithTags: RunDatasetWithTags) => {
   const { dataset } = datasetWithTags;
   const sourceType = dataset.sourceType;
   try {
-    if (sourceType === DatasetSourceTypes.HTTP) {
+    if (sourceType === DatasetSourceTypes.HTTP || sourceType === DatasetSourceTypes.EXTERNAL) {
       const { url } = JSON.parse(dataset.source);
       return url;
     }


### PR DESCRIPTION
### Related Issues/PRs
Relates to https://databricks.atlassian.net/browse/ML-62948

### What changes are proposed in this pull request?
The EXTERNAL dataset source type rendered a non-functional button in the dataset details drawer. Fixed by adding EXTERNAL to the URL extraction logic and consolidating with HTTP/HuggingFace link rendering.

### How is this PR tested?
- [x] New unit/integration tests

### Does this PR require documentation update?
- [x] No.

### Does this PR require updating the MLflow Skills repository?
- [x] No.

### Release Notes
#### Is this a user-facing change?
- [x] Yes. Fixed dataset link in details drawer not clickable for external source type.

#### What component(s), interfaces, languages, and integrations does this PR affect?
- [x] area/uiux

#### How should the PR be classified in the release notes?
- [x] rn/bug-fix

#### Should this PR be included in the next patch release?
- [x] Yes
- [ ] No