### PR TITLE
Add Databricks Docs link to docs navbar

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -151,6 +151,10 @@ const config: Config = {
           position: 'right',
         },
         {
+          type: 'custom-databricksDocsLink',
+          position: 'right',
+        },
+        {
           href: 'https://github.com/mlflow/mlflow',
           label: 'GitHub',
           position: 'right',

--- a/docs/src/components/NavbarItems/DatabricksDocsLink.tsx
+++ b/docs/src/components/NavbarItems/DatabricksDocsLink.tsx
@@ -1,0 +1,29 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import { useLocation } from '@docusaurus/router';
+
+const DATABRICKS_DOCS_BASE = 'https://docs.databricks.com/aws/en/mlflow';
+const DATABRICKS_DOCS_GENAI = 'https://docs.databricks.com/aws/en/mlflow3/genai/';
+
+interface DatabricksDocsLinkProps {
+  mobile?: boolean;
+  [key: string]: any;
+}
+
+export default function DatabricksDocsLink({ mobile, ...props }: DatabricksDocsLinkProps): JSX.Element {
+  const location = useLocation();
+  const genaiPath = useBaseUrl('/genai');
+
+  const href = location.pathname.startsWith(genaiPath) ? DATABRICKS_DOCS_GENAI : DATABRICKS_DOCS_BASE;
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="navbar__item navbar__link databricks-docs-link"
+      {...props}
+    >
+      Databricks
+    </a>
+  );
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -426,6 +426,12 @@ html[data-genai-theme='true'] {
   opacity: 0.5;
 }
 
+.databricks-docs-link {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
 .github-link {
   display: flex;
   align-items: center;

--- a/docs/src/theme/NavbarItem/ComponentTypes.tsx
+++ b/docs/src/theme/NavbarItem/ComponentTypes.tsx
@@ -1,9 +1,11 @@
 import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import DatabricksDocsLink from '@site/src/components/NavbarItems/DatabricksDocsLink';
 import DocsDropdown from '@site/src/components/NavbarItems/DocsDropdown';
 import VersionSelector from '@site/src/components/NavbarItems/VersionSelector';
 
 export default {
   ...ComponentTypes,
+  'custom-databricksDocsLink': DatabricksDocsLink,
   'custom-docsDropdown': DocsDropdown,
   'custom-versionSelector': VersionSelector,
 };


### PR DESCRIPTION
### Related Issues/PRs

Relates to #ML-62952

### What changes are proposed in this pull request?

Adds a "Databricks Docs" link to the MLflow documentation site navbar, positioned next to the GitHub link. This gives users a convenient way to navigate to Databricks MLflow documentation without relying solely on the landing page selector.

**Changes:**
- Added a "Databricks Docs" navbar item in `docusaurus.config.ts` linking to `https://docs.databricks.com/aws/en/mlflow/`
- Added corresponding CSS class in `custom.css` for consistent styling with the existing GitHub link

### How is this PR tested?

- [x] Manual tests

Verified the Docusaurus config is valid and the navbar item follows established patterns (same structure as the existing GitHub link).

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added a "Databricks Docs" link to the MLflow documentation site navbar for easier access to Databricks MLflow documentation.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)