### PR TITLE
Capture Claude Code version in trace metadata

### DIFF
--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -615,13 +615,6 @@ def process_transcript(
             MESSAGE_FIELD_CONTENT, ""
         )
 
-        # Extract Claude Code version from transcript entries (CLI-only).
-        # The first entry is often a queue-operation without a version field,
-        # so scan until we find one.
-        claude_code_version = next(
-            (entry.get("version") for entry in transcript if "version" in entry), None
-        )
-
         if not session_id:
             session_id = f"claude-{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
@@ -648,6 +641,11 @@ def process_transcript(
         conv_end_ns = parse_timestamp_to_ns(last_entry.get(MESSAGE_FIELD_TIMESTAMP))
         if not conv_end_ns or conv_end_ns <= conv_start_ns:
             conv_end_ns = conv_start_ns + int(10 * NANOSECONDS_PER_S)
+
+        # Extract Claude Code version from transcript entries (CLI-only)
+        claude_code_version = next(
+            (ver for entry in transcript if (ver := entry.get("version"))), None
+        )
 
         return _finalize_trace(
             parent_span,

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -48,6 +48,7 @@ MESSAGE_FIELD_TOOL_USE_RESULT = "toolUseResult"
 MESSAGE_FIELD_COMMAND_NAME = "commandName"
 MESSAGE_TYPE_QUEUE_OPERATION = "queue-operation"
 QUEUE_OPERATION_ENQUEUE = "enqueue"
+METADATA_KEY_CLAUDE_CODE_VERSION = "claude_code_version"
 
 # Custom logging level for Claude tracing
 CLAUDE_TRACING_LEVEL = logging.WARNING - 5
@@ -509,7 +510,7 @@ def _finalize_trace(
             if session_id:
                 metadata[TraceMetadataKey.TRACE_SESSION] = session_id
             if claude_code_version:
-                metadata["claude_code_version"] = claude_code_version
+                metadata[METADATA_KEY_CLAUDE_CODE_VERSION] = claude_code_version
 
             # Set token usage directly on trace metadata so it survives
             # even if span-level aggregation doesn't pick it up

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -48,7 +48,7 @@ MESSAGE_FIELD_TOOL_USE_RESULT = "toolUseResult"
 MESSAGE_FIELD_COMMAND_NAME = "commandName"
 MESSAGE_TYPE_QUEUE_OPERATION = "queue-operation"
 QUEUE_OPERATION_ENQUEUE = "enqueue"
-METADATA_KEY_CLAUDE_CODE_VERSION = "claude_code_version"
+METADATA_KEY_CLAUDE_CODE_VERSION = "mlflow.claude_code_version"
 
 # Custom logging level for Claude tracing
 CLAUDE_TRACING_LEVEL = logging.WARNING - 5

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -615,8 +615,12 @@ def process_transcript(
             MESSAGE_FIELD_CONTENT, ""
         )
 
-        # Extract Claude Code version from the first JSONL entry (CLI-only)
-        claude_code_version = transcript[0].get("version")
+        # Extract Claude Code version from transcript entries (CLI-only).
+        # The first entry is often a queue-operation without a version field,
+        # so scan until we find one.
+        claude_code_version = next(
+            (entry.get("version") for entry in transcript if "version" in entry), None
+        )
 
         if not session_id:
             session_id = f"claude-{datetime.now().strftime('%Y%m%d_%H%M%S')}"

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -492,6 +492,7 @@ def _finalize_trace(
     session_id: str | None,
     end_time_ns: int | None = None,
     usage: dict[str, Any] | None = None,
+    claude_code_version: str | None = None,
 ) -> mlflow.entities.Trace:
     try:
         # Set trace previews and metadata for UI display
@@ -507,6 +508,8 @@ def _finalize_trace(
             }
             if session_id:
                 metadata[TraceMetadataKey.TRACE_SESSION] = session_id
+            if claude_code_version:
+                metadata["claude_code_version"] = claude_code_version
 
             # Set token usage directly on trace metadata so it survives
             # even if span-level aggregation doesn't pick it up
@@ -611,6 +614,9 @@ def process_transcript(
             MESSAGE_FIELD_CONTENT, ""
         )
 
+        # Extract Claude Code version from the first JSONL entry (CLI-only)
+        claude_code_version = transcript[0].get("version")
+
         if not session_id:
             session_id = f"claude-{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
@@ -644,6 +650,7 @@ def process_transcript(
             final_response,
             session_id,
             conv_end_ns,
+            claude_code_version=claude_code_version,
         )
 
     except Exception as e:

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -17,6 +17,7 @@ import mlflow
 import mlflow.claude_code.tracing as tracing_module
 from mlflow.claude_code.tracing import (
     CLAUDE_TRACING_LEVEL,
+    METADATA_KEY_CLAUDE_CODE_VERSION,
     find_last_user_message_index,
     get_hook_response,
     parse_timestamp_to_ns,
@@ -782,14 +783,14 @@ def test_process_transcript_captures_claude_code_version(tmp_path):
     trace = process_transcript(str(transcript_path), "test-version-session")
 
     assert trace is not None
-    assert trace.info.trace_metadata.get("claude_code_version") == "1.0.16"
+    assert trace.info.trace_metadata.get(METADATA_KEY_CLAUDE_CODE_VERSION) == "1.0.16"
 
 
 def test_process_transcript_no_version_field(mock_transcript_file):
     trace = process_transcript(mock_transcript_file, "test-session-no-version")
 
     assert trace is not None
-    assert "claude_code_version" not in trace.info.trace_metadata
+    assert METADATA_KEY_CLAUDE_CODE_VERSION not in trace.info.trace_metadata
 
 
 def test_process_transcript_includes_steer_messages(tmp_path):

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -759,17 +759,20 @@ def test_find_last_user_message_skips_consecutive_skill_injections():
 def test_process_transcript_captures_claude_code_version(tmp_path):
     transcript = [
         {
-            "type": "system",
-            "version": "1.0.16",
+            "type": "queue-operation",
+            "operation": "dequeue",
             "timestamp": "2025-01-15T09:59:59.000Z",
+            "sessionId": "test-version-session",
         },
         {
             "type": "user",
+            "version": "2.1.34",
             "message": {"role": "user", "content": "Hello!"},
             "timestamp": "2025-01-15T10:00:00.000Z",
         },
         {
             "type": "assistant",
+            "version": "2.1.34",
             "message": {
                 "role": "assistant",
                 "content": [{"type": "text", "text": "Hi there!"}],
@@ -783,7 +786,7 @@ def test_process_transcript_captures_claude_code_version(tmp_path):
     trace = process_transcript(str(transcript_path), "test-version-session")
 
     assert trace is not None
-    assert trace.info.trace_metadata.get(METADATA_KEY_CLAUDE_CODE_VERSION) == "1.0.16"
+    assert trace.info.trace_metadata.get(METADATA_KEY_CLAUDE_CODE_VERSION) == "2.1.34"
 
 
 def test_process_transcript_no_version_field(mock_transcript_file):

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -755,6 +755,43 @@ def test_find_last_user_message_skips_consecutive_skill_injections():
     assert transcript[idx]["message"]["content"] == "Do the thing."
 
 
+def test_process_transcript_captures_claude_code_version(tmp_path):
+    transcript = [
+        {
+            "type": "system",
+            "version": "1.0.16",
+            "timestamp": "2025-01-15T09:59:59.000Z",
+        },
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "Hello!"},
+            "timestamp": "2025-01-15T10:00:00.000Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hi there!"}],
+            },
+            "timestamp": "2025-01-15T10:00:01.000Z",
+        },
+    ]
+
+    transcript_path = tmp_path / "version_transcript.jsonl"
+    transcript_path.write_text("\n".join(json.dumps(entry) for entry in transcript) + "\n")
+    trace = process_transcript(str(transcript_path), "test-version-session")
+
+    assert trace is not None
+    assert trace.info.trace_metadata.get("claude_code_version") == "1.0.16"
+
+
+def test_process_transcript_no_version_field(mock_transcript_file):
+    trace = process_transcript(mock_transcript_file, "test-session-no-version")
+
+    assert trace is not None
+    assert "claude_code_version" not in trace.info.trace_metadata
+
+
 def test_process_transcript_includes_steer_messages(tmp_path):
     transcript = [
         {


### PR DESCRIPTION
### Related Issues/PRs

Relates to ML-63014

### What changes are proposed in this pull request?

Extract the `version` field from the first JSONL entry in CLI transcripts and store it as `claude_code_version` in trace metadata. This enables correlating trace behavior with specific Claude Code releases for debugging regressions and understanding version-specific issues.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1642" height="794" alt="image" src="https://github.com/user-attachments/assets/9a81d775-f701-486d-9c45-a923ea3b6eb8" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)