### PR TITLE
Make retrieved document source URLs clickable in span details view

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/key-value-tag/KeyValueTag.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/key-value-tag/KeyValueTag.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import { DesignSystemProvider } from '@databricks/design-system';
+
+import { KeyValueTag, getKeyAndValueComplexTruncation } from './KeyValueTag';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <DesignSystemProvider>{children}</DesignSystemProvider>
+);
+
+describe('KeyValueTag', () => {
+  it('renders key and value as plain text for non-URL values', () => {
+    render(<KeyValueTag itemKey="page" itemValue="5" />, { wrapper: Wrapper });
+    expect(screen.getByText('page')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders a clickable link for http URL values', () => {
+    render(<KeyValueTag itemKey="source" itemValue='"http://example.com/doc.pdf"' />, { wrapper: Wrapper });
+    expect(screen.getByText('source')).toBeInTheDocument();
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'http://example.com/doc.pdf');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders a clickable link for https URL values', () => {
+    render(<KeyValueTag itemKey="source" itemValue='"https://example.com/doc.pdf"' />, { wrapper: Wrapper });
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://example.com/doc.pdf');
+  });
+
+  it('renders a clickable link for URL values without surrounding quotes', () => {
+    render(<KeyValueTag itemKey="source" itemValue="https://example.com/doc.pdf" />, { wrapper: Wrapper });
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://example.com/doc.pdf');
+  });
+
+  it('does not render a link for non-URL string values', () => {
+    render(<KeyValueTag itemKey="format" itemValue='"pdf"' />, { wrapper: Wrapper });
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('"pdf"')).toBeInTheDocument();
+  });
+});
+
+describe('getKeyAndValueComplexTruncation', () => {
+  it('does not truncate when total length is within limit', () => {
+    expect(getKeyAndValueComplexTruncation('key', 'val', 18)).toEqual({
+      shouldTruncateKey: false,
+      shouldTruncateValue: false,
+    });
+  });
+
+  it('truncates the longer string when shorter is within half limit', () => {
+    expect(getKeyAndValueComplexTruncation('k', 'a-very-long-value-string', 18)).toEqual({
+      shouldTruncateKey: false,
+      shouldTruncateValue: true,
+    });
+  });
+
+  it('truncates both when shorter string exceeds half the limit', () => {
+    expect(getKeyAndValueComplexTruncation('a-long-key-name', 'a-long-value-name', 18)).toEqual({
+      shouldTruncateKey: true,
+      shouldTruncateValue: true,
+    });
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/key-value-tag/KeyValueTag.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/key-value-tag/KeyValueTag.tsx
@@ -1,9 +1,16 @@
 import type { Interpolation, Theme } from '@emotion/react';
 
-import { Tag, Tooltip, Typography } from '@databricks/design-system';
+import { Tag, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
 
 // max characters for key + value before truncation
 const MAX_CHARS_LENGTH = 18;
+
+const URL_REGEX = /^"?(https?:\/\/[^\s"]+)"?$/;
+
+function extractUrl(value: string): string | null {
+  const match = value.match(URL_REGEX);
+  return match ? match[1] : null;
+}
 
 const getTruncatedStyles = (shouldTruncate: boolean): Interpolation<Theme> =>
   shouldTruncate
@@ -31,6 +38,8 @@ export const KeyValueTag = ({
   className?: string;
 }) => {
   const { shouldTruncateKey, shouldTruncateValue } = getKeyAndValueComplexTruncation(itemKey, itemValue, charLimit);
+  const { theme } = useDesignSystemTheme();
+  const url = extractUrl(itemValue);
 
   return (
     <Tooltip componentId="shared.model-trace-explorer.key-value-tag.hover-tooltip" content={`${itemKey}: ${itemValue}`}>
@@ -40,9 +49,21 @@ export const KeyValueTag = ({
             {itemKey}
           </Typography.Text>
           :&nbsp;
-          <Typography.Text css={getTruncatedStyles(shouldTruncateValue)} size="sm">
-            {itemValue}
-          </Typography.Text>
+          {url ? (
+            <Typography.Link
+              componentId="shared.model-trace-explorer.key-value-tag.link"
+              href={url}
+              openInNewTab
+              css={[getTruncatedStyles(shouldTruncateValue), { fontSize: theme.typography.fontSizeSm }]}
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            >
+              {url}
+            </Typography.Link>
+          ) : (
+            <Typography.Text css={getTruncatedStyles(shouldTruncateValue)} size="sm">
+              {itemValue}
+            </Typography.Text>
+          )}
         </span>
       </Tag>
     </Tooltip>
@@ -55,15 +76,17 @@ export function getKeyAndValueComplexTruncation(
   charLimit: number,
 ): { shouldTruncateKey: boolean; shouldTruncateValue: boolean } {
   const fullLength = key.length + value.length;
-  const isKeyLonger = key.length > value.length;
-  const shorterLength = isKeyLonger ? value.length : key.length;
 
   // No need to truncate if tag is short enough
   if (fullLength <= charLimit) return { shouldTruncateKey: false, shouldTruncateValue: false };
-  // If the shorter string is too long, truncate both key and value.
-  if (shorterLength > charLimit / 2) return { shouldTruncateKey: true, shouldTruncateValue: true };
 
-  // Otherwise truncate the longer string
+  // If the shorter string exceeds half the limit, truncate both
+  if (Math.min(key.length, value.length) > charLimit / 2) {
+    return { shouldTruncateKey: true, shouldTruncateValue: true };
+  }
+
+  // Otherwise truncate only the longer string
+  const isKeyLonger = key.length > value.length;
   return {
     shouldTruncateKey: isKeyLonger,
     shouldTruncateValue: !isKeyLonger,


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://databricks.atlassian.net/browse/ML-63000

### What changes are proposed in this pull request?

The `KeyValueTag` component in the trace explorer now detects URL values in document metadata and renders them as clickable `Typography.Link` elements instead of plain text. This fixes the issue where retrieved document source links (e.g., `source: "https://..."`) were displayed as non-interactive strings in the span details view.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="780" height="731" alt="image" src="https://github.com/user-attachments/assets/fa8f46e7-070c-44ea-87c6-dffed182ac12" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

URL values in retrieved document metadata tags are now rendered as clickable links in the trace span details view.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)