### PR TITLE
Fix Shift+Enter not creating newlines in assistant chat input

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -1,0 +1,103 @@
+import { describe, test, expect, jest, beforeEach, beforeAll } from '@jest/globals';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithIntl } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { AssistantChatPanel } from './AssistantChatPanel';
+
+beforeAll(() => {
+  // scrollIntoView is not available in JSDOM
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+const mockSendMessage = jest.fn();
+const mockCancelSession = jest.fn();
+
+jest.mock('./AssistantContext', () => ({
+  useAssistant: () => ({
+    isPanelOpen: true,
+    sessionId: 'test-session',
+    messages: [],
+    isStreaming: false,
+    error: null,
+    currentStatus: null,
+    activeTools: [],
+    setupComplete: true,
+    isLoadingConfig: false,
+    isLocalServer: true,
+    openPanel: jest.fn(),
+    closePanel: jest.fn(),
+    sendMessage: mockSendMessage,
+    regenerateLastMessage: jest.fn(),
+    reset: jest.fn(),
+    cancelSession: mockCancelSession,
+    refreshConfig: jest.fn(),
+    completeSetup: jest.fn(),
+  }),
+}));
+
+jest.mock('./AssistantPageContext', () => ({
+  useAssistantPageContext: () => ({ experimentId: '123' }),
+}));
+
+jest.mock('../common/utils/RoutingUtils', () => ({
+  useAssistantPrompts: () => ['Prompt 1', 'Prompt 2'],
+}));
+
+const renderChatPanel = () => {
+  return renderWithIntl(
+    <DesignSystemProvider>
+      <AssistantChatPanel />
+    </DesignSystemProvider>,
+  );
+};
+
+describe('AssistantChatPanel', () => {
+  beforeEach(() => {
+    mockSendMessage.mockClear();
+    mockCancelSession.mockClear();
+  });
+
+  test('renders a textarea for chat input', () => {
+    renderChatPanel();
+    const textarea = screen.getByPlaceholderText('Ask a question...');
+    expect(textarea.tagName).toBe('TEXTAREA');
+  });
+
+  test('Shift+Enter inserts a newline instead of sending', async () => {
+    const user = userEvent.setup();
+    renderChatPanel();
+    const textarea = screen.getByPlaceholderText('Ask a question...');
+
+    await user.click(textarea);
+    await user.type(textarea, 'line one');
+    await user.keyboard('{Shift>}{Enter}{/Shift}');
+    await user.type(textarea, 'line two');
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue('line one\nline two');
+  });
+
+  test('Enter sends the message without Shift held', async () => {
+    const user = userEvent.setup();
+    renderChatPanel();
+    const textarea = screen.getByPlaceholderText('Ask a question...');
+
+    await user.click(textarea);
+    await user.type(textarea, 'hello');
+    await user.keyboard('{Enter}');
+
+    expect(mockSendMessage).toHaveBeenCalledWith('hello');
+  });
+
+  test('Enter does not send when input is empty', async () => {
+    const user = userEvent.setup();
+    renderChatPanel();
+    const textarea = screen.getByPlaceholderText('Ask a question...');
+
+    await user.click(textarea);
+    await user.keyboard('{Enter}');
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -267,16 +267,30 @@ const ChatPanelContent = () => {
 
   const [inputValue, setInputValue] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Auto-scroll to bottom when messages change
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  const resizeTextarea = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+  }, []);
+
   const handleSend = useCallback(() => {
     if (inputValue.trim() && !isStreaming) {
       sendMessage(inputValue.trim());
       setInputValue('');
+      // Reset textarea height after sending
+      const textarea = textareaRef.current;
+      if (textarea) {
+        textarea.style.height = 'auto';
+      }
     }
   }, [inputValue, isStreaming, sendMessage]);
 
@@ -355,12 +369,17 @@ const ChatPanelContent = () => {
             backgroundColor: theme.colors.backgroundPrimary,
           }}
         >
-          <div css={{ display: 'flex', alignItems: 'center' }}>
-            <input
+          <div css={{ display: 'flex', alignItems: 'flex-end' }}>
+            <textarea
+              ref={textareaRef}
               placeholder="Ask a question..."
               value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
+              onChange={(e) => {
+                setInputValue(e.target.value);
+                resizeTextarea();
+              }}
               onKeyDown={handleKeyDown}
+              rows={1}
               css={{
                 flex: 1,
                 border: 'none',
@@ -369,6 +388,12 @@ const ChatPanelContent = () => {
                 fontSize: theme.typography.fontSizeBase,
                 color: theme.colors.textPrimary,
                 padding: theme.spacing.xs,
+                resize: 'none',
+                overflow: 'hidden',
+                fontFamily: 'inherit',
+                lineHeight: 'inherit',
+                maxHeight: 150,
+                overflowY: 'auto',
                 '&::placeholder': {
                   color: theme.colors.textPlaceholder,
                 },

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -262,8 +262,6 @@ const ChatPanelContent = () => {
   const { theme } = useDesignSystemTheme();
   const { messages, isStreaming, error, activeTools, sendMessage, regenerateLastMessage, cancelSession } =
     useAssistant();
-  const pageContext = useAssistantPageContext();
-  const hasExperimentContext = Boolean(pageContext['experimentId']);
 
   const [inputValue, setInputValue] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -274,23 +272,19 @@ const ChatPanelContent = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const resizeTextarea = useCallback(() => {
+  // Auto-resize textarea to fit content
+  useEffect(() => {
     const textarea = textareaRef.current;
     if (textarea) {
       textarea.style.height = 'auto';
       textarea.style.height = `${textarea.scrollHeight}px`;
     }
-  }, []);
+  }, [inputValue]);
 
   const handleSend = useCallback(() => {
     if (inputValue.trim() && !isStreaming) {
       sendMessage(inputValue.trim());
       setInputValue('');
-      // Reset textarea height after sending
-      const textarea = textareaRef.current;
-      if (textarea) {
-        textarea.style.height = 'auto';
-      }
     }
   }, [inputValue, isStreaming, sendMessage]);
 
@@ -374,10 +368,7 @@ const ChatPanelContent = () => {
               ref={textareaRef}
               placeholder="Ask a question..."
               value={inputValue}
-              onChange={(e) => {
-                setInputValue(e.target.value);
-                resizeTextarea();
-              }}
+              onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
               rows={1}
               css={{
@@ -389,11 +380,11 @@ const ChatPanelContent = () => {
                 color: theme.colors.textPrimary,
                 padding: theme.spacing.xs,
                 resize: 'none',
-                overflow: 'hidden',
+                overflowX: 'hidden',
+                overflowY: 'auto',
                 fontFamily: 'inherit',
                 lineHeight: 'inherit',
                 maxHeight: 150,
-                overflowY: 'auto',
                 '&::placeholder': {
                   color: theme.colors.textPlaceholder,
                 },


### PR DESCRIPTION
### Related Issues/PRs

Closes https://databricks.atlassian.net/browse/ML-63024

### What changes are proposed in this pull request?

The assistant chat input was using an `<input>` element, which is inherently single-line and cannot contain newlines. Even though the `handleKeyDown` handler correctly skipped sending on Shift+Enter, the element itself doesn't support multi-line text. This PR changes the input to a `<textarea>` with auto-resize behavior:

- Replaced `<input>` with `<textarea>` that starts as a single row and auto-grows as the user types
- Added `maxHeight: 150` cap with scroll overflow so the textarea doesn't take over the panel
- Reset textarea height after sending a message
- Aligned the send button to the bottom of the container so it stays anchored as the textarea grows

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Added `AssistantChatPanel.test.tsx` with 4 tests:
- Verifies the input renders as a `<textarea>`
- Verifies Shift+Enter inserts a newline without sending
- Verifies Enter sends the message
- Verifies Enter on empty input doesn't send

https://github.com/user-attachments/assets/55998889-9199-49d0-ae38-0838236a92b1



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed Shift+Enter in the MLflow Assistant chat window to correctly insert newlines instead of doing nothing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)