### PR TITLE
Fix Claude Code autologging import collision with local mlflow folders

### DIFF
--- a/mlflow/claude_code/hooks.py
+++ b/mlflow/claude_code/hooks.py
@@ -46,7 +46,8 @@ def upsert_hook(config: dict[str, Any], hook_type: str, handler_name: str) -> No
 
     python_cmd = "uv run python" if "UV" in os.environ else "python"
     hook_command = (
-        f'{python_cmd} -c "from mlflow.claude_code.hooks import {handler_name}; {handler_name}()"'
+        f"{python_cmd} -I -c \"import sys; sys.path = [p for p in sys.path if p not in ('', '.')]; "
+        f'from mlflow.claude_code.hooks import {handler_name}; {handler_name}()"'
     )
 
     mlflow_hook = {"type": "command", HOOK_FIELD_COMMAND: hook_command}

--- a/mlflow/claude_code/hooks.py
+++ b/mlflow/claude_code/hooks.py
@@ -46,8 +46,8 @@ def upsert_hook(config: dict[str, Any], hook_type: str, handler_name: str) -> No
 
     python_cmd = "uv run python" if "UV" in os.environ else "python"
     hook_command = (
-        f"{python_cmd} -I -c \"import sys; sys.path = [p for p in sys.path if p not in ('', '.')]; "
-        f'from mlflow.claude_code.hooks import {handler_name}; {handler_name}()"'
+        f"{python_cmd} -I -c "
+        f'"from mlflow.claude_code.hooks import {handler_name}; {handler_name}()"'
     )
 
     mlflow_hook = {"type": "command", HOOK_FIELD_COMMAND: hook_command}

--- a/tests/claude_code/test_cli.py
+++ b/tests/claude_code/test_cli.py
@@ -69,8 +69,7 @@ def test_claude_setup_with_uv_env_var(runner, monkeypatch):
         hook_command = _get_hook_command_from_settings()
         assert hook_command == (
             "uv run python -I -c "
-            "\"import sys; sys.path = [p for p in sys.path if p not in ('', '.')]; "
-            'from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
+            '"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
         )
 
 
@@ -84,15 +83,14 @@ def test_claude_setup_without_uv_env_var(runner, monkeypatch):
         hook_command = _get_hook_command_from_settings()
         assert hook_command == (
             "python -I -c "
-            "\"import sys; sys.path = [p for p in sys.path if p not in ('', '.')]; "
-            'from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
+            '"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
         )
 
 
-def test_upsert_hook_strips_cwd_from_sys_path():
+def test_upsert_hook_uses_isolated_mode():
     config = {HOOK_FIELD_HOOKS: {}}
     upsert_hook(config, "Stop", "stop_hook_handler")
 
     hook_command = config[HOOK_FIELD_HOOKS]["Stop"][0][HOOK_FIELD_HOOKS][0][HOOK_FIELD_COMMAND]
-    assert "sys.path = [p for p in sys.path if p not in ('', '.')]" in hook_command
+    assert " -I -c " in hook_command
     assert "from mlflow.claude_code.hooks import stop_hook_handler" in hook_command

--- a/tests/claude_code/test_cli.py
+++ b/tests/claude_code/test_cli.py
@@ -5,6 +5,8 @@ import pytest
 from click.testing import CliRunner
 
 from mlflow.claude_code.cli import commands
+from mlflow.claude_code.config import HOOK_FIELD_COMMAND, HOOK_FIELD_HOOKS
+from mlflow.claude_code.hooks import upsert_hook
 
 
 @pytest.fixture
@@ -66,8 +68,9 @@ def test_claude_setup_with_uv_env_var(runner, monkeypatch):
 
         hook_command = _get_hook_command_from_settings()
         assert hook_command == (
-            "uv run python -c "
-            '"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
+            "uv run python -I -c "
+            "\"import sys; sys.path = [p for p in sys.path if p not in ('', '.')]; "
+            'from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
         )
 
 
@@ -80,6 +83,16 @@ def test_claude_setup_without_uv_env_var(runner, monkeypatch):
 
         hook_command = _get_hook_command_from_settings()
         assert hook_command == (
-            "python -c "
-            '"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
+            "python -I -c "
+            "\"import sys; sys.path = [p for p in sys.path if p not in ('', '.')]; "
+            'from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
         )
+
+
+def test_upsert_hook_strips_cwd_from_sys_path():
+    config = {HOOK_FIELD_HOOKS: {}}
+    upsert_hook(config, "Stop", "stop_hook_handler")
+
+    hook_command = config[HOOK_FIELD_HOOKS]["Stop"][0][HOOK_FIELD_HOOKS][0][HOOK_FIELD_COMMAND]
+    assert "sys.path = [p for p in sys.path if p not in ('', '.')]" in hook_command
+    assert "from mlflow.claude_code.hooks import stop_hook_handler" in hook_command


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://databricks.atlassian.net/browse/ML-62984

### What changes are proposed in this pull request?

The Claude Code autologging hook command (`python -c "from mlflow.claude_code.hooks import ..."`) fails in repositories that contain a local `mlflow/` folder (e.g., the universe repo). Python's module resolution prioritizes local directories over installed packages, causing the import to resolve against the local folder instead of the installed `mlflow` package.

This PR adds the `-I` (isolated mode) flag to the `python` command in the hook. `-I` implies `-P`, which prevents Python from prepending the current working directory to `sys.path`, ensuring the installed `mlflow` package is always used regardless of local directory structure.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added `test_upsert_hook_uses_isolated_mode` to verify the generated hook command includes the `-I` flag. Updated existing UV env var tests to expect `-I` in the command.

#### Manual test

```bash
# 1. Create a directory with a local mlflow/ folder (simulates repos like universe)
mkdir -p /tmp/test-ml-62984/mlflow
touch /tmp/test-ml-62984/mlflow/__init__.py

# 2. BUG: without -I, the import fails (resolves to local folder)
cd /tmp/test-ml-62984
python -c "from mlflow.claude_code.hooks import stop_hook_handler"
# => ModuleNotFoundError: No module named 'mlflow.claude_code'

# 3. FIX: with -I, the import succeeds (uses installed package)
cd /tmp/test-ml-62984
python -I -c "from mlflow.claude_code.hooks import stop_hook_handler"
# => Exit 0 (success)

# Clean up
rm -rf /tmp/test-ml-62984
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed Claude Code autologging failing in repositories that contain a local `mlflow/` folder by running the hook command in Python's isolated mode (`-I`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)