### PR TITLE
Use correct `env` key for Claude Code settings environment variables

### DIFF
--- a/mlflow/claude_code/config.py
+++ b/mlflow/claude_code/config.py
@@ -15,7 +15,7 @@ from mlflow.environment_variables import (
 # Configuration field constants
 HOOK_FIELD_HOOKS = "hooks"
 HOOK_FIELD_COMMAND = "command"
-ENVIRONMENT_FIELD = "environment"
+ENVIRONMENT_FIELD = "env"
 
 # MLflow environment variable constants
 MLFLOW_HOOK_IDENTIFIER = "mlflow.claude_code.hooks"

--- a/tests/claude_code/test_config.py
+++ b/tests/claude_code/test_config.py
@@ -72,7 +72,7 @@ def test_get_env_var_from_os_environment_when_no_settings(tmp_path, monkeypatch)
 def test_get_env_var_settings_takes_precedence_over_os_env(tmp_path, monkeypatch):
     monkeypatch.setenv(MLFLOW_TRACING_ENABLED, "os_value")
 
-    config_data = {"environment": {MLFLOW_TRACING_ENABLED: "settings_value"}}
+    config_data = {"env": {MLFLOW_TRACING_ENABLED: "settings_value"}}
     claude_settings_path = tmp_path / ".claude" / "settings.json"
     claude_settings_path.parent.mkdir(parents=True, exist_ok=True)
     with open(claude_settings_path, "w") as f:
@@ -86,7 +86,7 @@ def test_get_env_var_settings_takes_precedence_over_os_env(tmp_path, monkeypatch
 def test_get_env_var_falls_back_to_os_env_when_not_in_settings(tmp_path, monkeypatch):
     monkeypatch.setenv(MLFLOW_TRACING_ENABLED, "os_value")
 
-    config_data = {"environment": {"OTHER_VAR": "other_value"}}
+    config_data = {"env": {"OTHER_VAR": "other_value"}}
     claude_settings_path = tmp_path / ".claude" / "settings.json"
     claude_settings_path.parent.mkdir(parents=True, exist_ok=True)
     with open(claude_settings_path, "w") as f:
@@ -115,7 +115,7 @@ def test_get_env_var_default_when_not_found(tmp_path, monkeypatch):
 
 def test_get_tracing_status_enabled(temp_settings_path):
     # Create settings with tracing enabled
-    config_data = {"environment": {MLFLOW_TRACING_ENABLED: "true"}}
+    config_data = {"env": {MLFLOW_TRACING_ENABLED: "true"}}
     with open(temp_settings_path, "w") as f:
         json.dump(config_data, f)
 
@@ -126,7 +126,7 @@ def test_get_tracing_status_enabled(temp_settings_path):
 
 def test_get_tracing_status_disabled(temp_settings_path):
     # Create settings with tracing disabled
-    config_data = {"environment": {MLFLOW_TRACING_ENABLED: "false"}}
+    config_data = {"env": {MLFLOW_TRACING_ENABLED: "false"}}
     with open(temp_settings_path, "w") as f:
         json.dump(config_data, f)
 
@@ -153,7 +153,7 @@ def test_setup_environment_config_new_file(temp_settings_path):
     # Verify configuration contents
     config = json.loads(temp_settings_path.read_text())
 
-    env_vars = config["environment"]
+    env_vars = config["env"]
     assert env_vars[MLFLOW_TRACING_ENABLED] == "true"
     assert env_vars["MLFLOW_TRACKING_URI"] == tracking_uri
     assert env_vars["MLFLOW_EXPERIMENT_ID"] == experiment_id
@@ -162,7 +162,7 @@ def test_setup_environment_config_new_file(temp_settings_path):
 def test_setup_environment_config_experiment_id_precedence(temp_settings_path):
     # Create existing config with different experiment ID
     existing_config = {
-        "environment": {
+        "env": {
             MLFLOW_TRACING_ENABLED: "true",
             "MLFLOW_EXPERIMENT_ID": "old_id",
             "MLFLOW_TRACKING_URI": "old_uri",
@@ -179,7 +179,7 @@ def test_setup_environment_config_experiment_id_precedence(temp_settings_path):
     # Verify configuration was updated
     config = json.loads(temp_settings_path.read_text())
 
-    env_vars = config["environment"]
+    env_vars = config["env"]
     assert env_vars[MLFLOW_TRACING_ENABLED] == "true"
     assert env_vars["MLFLOW_TRACKING_URI"] == new_tracking_uri
     assert env_vars["MLFLOW_EXPERIMENT_ID"] == new_experiment_id


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://databricks.atlassian.net/browse/ML-62983

### What changes are proposed in this pull request?

Claude Code's official settings key for environment variables is `env`, but MLflow was using `environment`. This caused issues when autologging was configured in `settings.local.json` (which doesn't have the workaround that reads the incorrect key).

Changed `ENVIRONMENT_FIELD` constant from `"environment"` to `"env"` in `config.py`. All downstream code (`hooks.py`, `cli.py`) uses this constant, so they pick up the change automatically.

### How is this PR tested?

- [x] Existing unit/integration tests

All 49 `tests/claude_code/` tests pass with the updated key.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)