### PR TITLE
[ML-62973] Clean up custom code scorer example in empty state

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/CustomCodeScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/CustomCodeScorerFormRenderer.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useDesignSystemTheme, Typography, CopyIcon } from '@databricks/design-system';
-import { FormattedMessage, useIntl } from '@databricks/i18n';
+import { FormattedMessage } from '@databricks/i18n';
 import { CodeSnippet } from '@databricks/web-shared/snippet';
 import { CopyButton } from '@mlflow/mlflow/src/shared/building_blocks/CopyButton';
 import { useWatch, type Control } from 'react-hook-form';
 import type { SCORER_TYPE } from './constants';
-import { COMPONENT_ID_PREFIX, type ScorerFormMode, SCORER_FORM_MODE } from './constants';
+import { type ScorerFormMode, SCORER_FORM_MODE } from './constants';
 import EvaluateTracesSection from './EvaluateTracesSection';
 
 const getDocLink = () => {
@@ -58,7 +58,6 @@ interface CustomCodeScorerFormRendererProps {
 
 const CustomCodeScorerFormRenderer: React.FC<CustomCodeScorerFormRendererProps> = ({ control, mode }) => {
   const { theme } = useDesignSystemTheme();
-  const intl = useIntl();
 
   const code = useWatch({ control, name: 'code' });
 
@@ -73,28 +72,22 @@ const CustomCodeScorerFormRenderer: React.FC<CustomCodeScorerFormRendererProps> 
   };
 
   if (mode === SCORER_FORM_MODE.CREATE) {
-    const step1Code = `pip install --upgrade "mlflow>=3.1.0"`;
-
-    const step2Code = `from mlflow.genai.scorers import scorer, ScorerSamplingConfig
-from typing import Optional, Any
+    const step1Code = `from mlflow.genai.scorers import scorer
 from mlflow.entities import Feedback
-import mlflow.entities
 
 @scorer
-def my_custom_scorer(
-  inputs: Optional[dict[str, Any]],  # The agent's raw input, parsed from the Trace or dataset, as a Python dict
-  outputs: Optional[Any],  # The agent's raw output, parsed from the Trace or dataset
-  expectations: Optional[dict[str, Any]],  # The expectations passed to evaluate(data=...), as a Python dict
-  trace: Optional[mlflow.entities.Trace]  # The app's resulting Trace containing spans and other metadata
-) -> int | float | bool | str | Feedback | list[Feedback]:
-    """
-    Custom scorer template - implement your scoring logic here.
-    Return a score as int, float, bool, str, or Feedback object(s).
-    """
-    # TODO: Implement your custom scoring logic
-    return 1.0`;
+def my_custom_judge(
+  inputs,  # The agent's raw input, parsed from the Trace or dataset
+  outputs,  # The agent's raw output, parsed from the Trace or dataset
+) -> Feedback:
+    """Check if the output is non-empty and return a Feedback object."""
+    is_non_empty = outputs is not None and len(str(outputs).strip()) > 0
+    return Feedback(
+        value=is_non_empty,
+        rationale="Output is non-empty" if is_non_empty else "Output is empty",
+    )`;
 
-    const step3Code = `import mlflow
+    const step2Code = `import mlflow
 
 eval_dataset = [
     {
@@ -105,15 +98,15 @@ eval_dataset = [
 
 mlflow.genai.evaluate(
     data=eval_dataset,
-    scorers=[my_custom_scorer],
+    scorers=[my_custom_judge],
 )`;
 
     return (
       <div css={{ display: 'flex', flexDirection: 'column' }}>
         <Typography.Text>
           <FormattedMessage
-            defaultMessage="Follow these steps to create a custom judge using your own code. {link}"
-            description="Brief instructions for custom judge functions"
+            defaultMessage="Follow these steps to create a custom code judge using your own code. {link}"
+            description="Brief instructions for custom code judge creation"
             values={{
               link: (
                 <Typography.Link
@@ -127,41 +120,24 @@ mlflow.genai.evaluate(
             }}
           />
         </Typography.Text>
-        {/* Step 1: Install MLflow */}
+        {/* Step 1: Define your judge */}
         <div>
           <Typography.Title level={4} css={{ marginTop: theme.spacing.sm }}>
             <FormattedMessage
-              defaultMessage="Step 1: Install MLflow"
-              description="Step 1 title for custom judge creation"
+              defaultMessage="Step 1: Define your judge function"
+              description="Step 1 title for custom code judge creation"
             />
           </Typography.Title>
           <Typography.Text css={{ display: 'block', marginBottom: theme.spacing.md, maxWidth: 800 }}>
             <FormattedMessage
-              defaultMessage="Install or upgrade MLflow to ensure you have the latest judge functionality."
-              description="Step 1 description for installing MLflow"
-            />
-          </Typography.Text>
-          <CodeBlockWithCopy
-            // Dummy comment to ensure copybara won't fail with formatting issues
-            code={step1Code}
-            language="bash"
-            theme={theme}
-          />
-        </div>
-        {/* Step 2: Define your scorer */}
-        <div>
-          <Typography.Title level={4} css={{ marginTop: theme.spacing.sm }}>
-            <FormattedMessage
-              defaultMessage="Step 2: Define your judge function"
-              description="Step 2 title for custom judge creation"
-            />
-          </Typography.Title>
-          <Typography.Text css={{ display: 'block', marginBottom: theme.spacing.md, maxWidth: 800 }}>
-            <FormattedMessage
-              defaultMessage="Create a custom judge function using the {decorator} decorator. Implement your scoring logic in the function body. {link}"
-              description="Step 2 description for defining judge function"
+              defaultMessage="Create a custom judge function using the {decorator} decorator. All parameters ({inputs}, {outputs}, {expectations}, {trace}) are optional — include only the ones your logic needs. {link}"
+              description="Step 1 description for defining judge function"
               values={{
                 decorator: <Typography.Text code>@scorer</Typography.Text>,
+                inputs: <Typography.Text code>inputs</Typography.Text>,
+                outputs: <Typography.Text code>outputs</Typography.Text>,
+                expectations: <Typography.Text code>expectations</Typography.Text>,
+                trace: <Typography.Text code>trace</Typography.Text>,
                 link: (
                   <Typography.Link
                     componentId="codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_209"
@@ -176,23 +152,23 @@ mlflow.genai.evaluate(
           </Typography.Text>
           <CodeBlockWithCopy
             // Dummy comment to ensure copybara won't fail with formatting issues
-            code={step2Code}
+            code={step1Code}
             language="python"
             theme={theme}
           />
         </div>
-        {/* Step 3: Run the scorer */}
+        {/* Step 2: Run the judge */}
         <div>
           <Typography.Title level={4} css={{ marginTop: theme.spacing.sm }}>
             <FormattedMessage
-              defaultMessage="Step 3: Run the judge"
-              description="Step 3 title for custom judge creation"
+              defaultMessage="Step 2: Run the judge"
+              description="Step 2 title for custom code judge creation"
             />
           </Typography.Title>
           <Typography.Text css={{ display: 'block', marginBottom: theme.spacing.md, maxWidth: 800 }}>
             <FormattedMessage
               defaultMessage="Pass the function directly to {evaluate}, just like other predefined or LLM-based judges."
-              description="Step 3 description for running the judge"
+              description="Step 2 description for running the judge"
               values={{
                 evaluate: <Typography.Text code>mlflow.genai.evaluate</Typography.Text>,
               }}
@@ -200,7 +176,7 @@ mlflow.genai.evaluate(
           </Typography.Text>
           <CodeBlockWithCopy
             // Dummy comment to ensure copybara won't fail with formatting issues
-            code={step3Code}
+            code={step2Code}
             language="python"
             theme={theme}
           />

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -51,10 +51,6 @@
     "defaultMessage": "Source Run",
     "description": "Label name for source run metadata in model version page"
   },
-  "+NSi44": {
-    "defaultMessage": "Step 1: Install MLflow",
-    "description": "Step 1 title for custom judge creation"
-  },
   "+Njd07": {
     "defaultMessage": "No sessions found",
     "description": "Title for the empty sessions list in the select sessions modal"
@@ -715,6 +711,10 @@
     "defaultMessage": "Add new tag",
     "description": "Experiment tracking > experiment page > runs > add new tag button"
   },
+  "35bW7o": {
+    "defaultMessage": "Step 2: Run the judge",
+    "description": "Step 2 title for custom code judge creation"
+  },
   "36g3aR": {
     "defaultMessage": "Edit",
     "description": "Text for the edit button next to the description section title on\n             the model view page"
@@ -1290,6 +1290,10 @@
     "defaultMessage": "Tags",
     "description": "Column title text for model version tags in model version table"
   },
+  "7O0x9Q": {
+    "defaultMessage": "Create a custom judge function using the {decorator} decorator. All parameters ({inputs}, {outputs}, {expectations}, {trace}) are optional — include only the ones your logic needs. {link}",
+    "description": "Step 1 description for defining judge function"
+  },
   "7PCvDy": {
     "defaultMessage": "OK",
     "description": "Confirmation button text on the model version stage transition request/approval modal"
@@ -1757,10 +1761,6 @@
   "AGWpnl": {
     "defaultMessage": "Add tags",
     "description": "Tag assignment modal > Title of the add tags modal"
-  },
-  "AHRvpU": {
-    "defaultMessage": "Pass the function directly to {evaluate}, just like other predefined or LLM-based judges.",
-    "description": "Step 3 description for running the judge"
   },
   "AHaom4": {
     "defaultMessage": "No assessments available",
@@ -2949,10 +2949,6 @@
   "JYVQuV": {
     "defaultMessage": "Run ID",
     "description": "Run page > Overview > Run ID section label"
-  },
-  "JZuU8B": {
-    "defaultMessage": "Step 2: Define your judge function",
-    "description": "Step 2 title for custom judge creation"
   },
   "JaanQY": {
     "defaultMessage": "Tools",
@@ -5059,10 +5055,6 @@
     "defaultMessage": "Auto-refresh",
     "description": "String for the auto-refresh button that refreshes the runs list automatically"
   },
-  "Yb0kNG": {
-    "defaultMessage": "Install or upgrade MLflow to ensure you have the latest judge functionality.",
-    "description": "Step 1 description for installing MLflow"
-  },
   "Yd5ANL": {
     "defaultMessage": "PASS",
     "description": "Header label for pass/fail assessment type for the pass rate"
@@ -5102,6 +5094,10 @@
   "YrYgo5": {
     "defaultMessage": "Select an endpoint to view logs",
     "description": "No endpoint selected message for logs tab"
+  },
+  "YrlNKi": {
+    "defaultMessage": "Follow these steps to create a custom code judge using your own code. {link}",
+    "description": "Brief instructions for custom code judge creation"
   },
   "YuYnxd": {
     "defaultMessage": "Delete",
@@ -6375,10 +6371,6 @@
     "defaultMessage": "View full dashboard",
     "description": "Link to view full usage dashboard"
   },
-  "hR2Zvd": {
-    "defaultMessage": "Create a custom judge function using the {decorator} decorator. Implement your scoring logic in the function body. {link}",
-    "description": "Step 2 description for defining judge function"
-  },
   "hT5ZGW": {
     "defaultMessage": "Remove message",
     "description": "Button to remove a chat message row"
@@ -6827,10 +6819,6 @@
     "defaultMessage": "Search runs using a simplified version of the SQL {whereBold} clause.",
     "description": "Tooltip string to explain how to search runs from the experiments table"
   },
-  "kJJqpX": {
-    "defaultMessage": "Follow these steps to create a custom judge using your own code. {link}",
-    "description": "Brief instructions for custom judge functions"
-  },
   "kNTkr+": {
     "defaultMessage": "Discard",
     "description": "Experiment page > artifact compare view > prompt lab artifact synchronization > submit button label"
@@ -7146,6 +7134,10 @@
   "mZtok7": {
     "defaultMessage": "Linked prompts",
     "description": "Label for the linked prompts view tab in the model trace explorer"
+  },
+  "mba0x8": {
+    "defaultMessage": "Step 1: Define your judge function",
+    "description": "Step 1 title for custom code judge creation"
   },
   "md81Lo": {
     "defaultMessage": "Error",
@@ -8271,6 +8263,10 @@
     "defaultMessage": "Not grounded",
     "description": "Evaluation results > retrieval grounded assessment > negative value label. Displayed if evaluation result is considered as not grounded."
   },
+  "uW5+ph": {
+    "defaultMessage": "Pass the function directly to {evaluate}, just like other predefined or LLM-based judges.",
+    "description": "Step 2 description for running the judge"
+  },
   "uX2XCM": {
     "defaultMessage": "Edit Model Configuration",
     "description": "Title for the edit model config modal"
@@ -8934,10 +8930,6 @@
   "zC/uKl": {
     "defaultMessage": "Auto-refresh",
     "description": "Run page > Charts tab > Auto-refresh toggle button"
-  },
-  "zDEFn7": {
-    "defaultMessage": "Step 3: Run the judge",
-    "description": "Step 3 title for custom judge creation"
   },
   "zE5aGj": {
     "defaultMessage": "Guidelines",


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://databricks.atlassian.net/browse/ML-62973

### What changes are proposed in this pull request?

Cleans up the custom code judge example shown in the empty state UI:

- Remove redundant "Install MLflow" step (users are already in the MLflow UI)
- Remove unused `ScorerSamplingConfig` import and mixed/redundant imports
- Replace skeleton template (`return 1.0` with TODO) with a working example that checks output non-emptiness and returns a `Feedback` object
- Use "judge" terminology consistently in user-facing text
- Add guidance that scorer function parameters (`inputs`, `outputs`, `expectations`, `trace`) are all optional

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified lint, prettier, type-check, and i18n checks all pass.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)