### PR TITLE
[ML-63097] Fix broken LLM judge documentation links

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/LLMScorerFormRenderer.tsx
@@ -383,7 +383,7 @@ const InstructionsSection: React.FC<InstructionsSectionProps> = ({ mode, control
               learnMore: (
                 <Typography.Link
                   componentId="mlflow.experiment-scorers.instructions-learn-more-link"
-                  href="https://mlflow.org/docs/latest/genai/eval-monitor/scorers/llm-judge/make-judge/"
+                  href="https://mlflow.org/docs/latest/genai/eval-monitor/scorers/"
                   openInNewTab
                 >
                   <FormattedMessage defaultMessage="Learn more" description="Learn more link text" />
@@ -461,7 +461,7 @@ const GuidelinesSection: React.FC<GuidelinesSectionProps> = ({ mode, control }) 
   };
 
   const getLlmJudgeDocUrl = () => {
-    return 'https://mlflow.org/docs/latest/genai/eval-monitor/scorers/llm-judge/';
+    return 'https://mlflow.org/docs/latest/genai/eval-monitor/scorers/';
   };
 
   const isSessionLevel = evaluationScope === ScorerEvaluationScope.SESSIONS;

--- a/mlflow/server/js/src/home/news-items.tsx
+++ b/mlflow/server/js/src/home/news-items.tsx
@@ -37,7 +37,7 @@ export const homeNewsItems: HomeNewsItemDefinition[] = [
     id: 'agents-as-a-judge',
     title: <FormattedMessage defaultMessage="Agents-as-a-judge" description="Home page news card title three" />,
     description: 'Leverage agents as a judge to perform deep trace analysis and improve your evaluation accuracy.',
-    link: 'https://mlflow.org/docs/latest/genai/eval-monitor/scorers/llm-judge/agentic-overview/index.html',
+    link: 'https://mlflow.org/docs/latest/genai/eval-monitor/scorers/',
     componentId: 'mlflow.home.news.agents_as_a_judge',
     thumbnail: {
       gradient: {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.tsx
@@ -88,7 +88,7 @@ export const DEFAULT_ASSESSMENTS_SORT_ORDER: string[] = [
 
 export const getJudgeMetricsLink = (asessmentDocLink?: AssessmentLearnMoreLink) => {
   // return OSS docs link
-  return 'https://mlflow.org/docs/latest/genai/eval-monitor/scorers/llm-judge/';
+  return 'https://mlflow.org/docs/latest/genai/eval-monitor/scorers/';
 };
 
 export interface AssessmentLearnMoreLink {


### PR DESCRIPTION
### Related Issues/PRs

Closes https://databricks.atlassian.net/browse/ML-63097

### What changes are proposed in this pull request?

Update all broken LLM judge documentation URLs (`/scorers/llm-judge/...`) that return 404 errors to point to the valid scorers page (`/scorers/`).

### How is this PR tested?

- [x] Manual tests

Verified the updated URL (https://mlflow.org/docs/latest/genai/eval-monitor/scorers/) loads correctly and the info button, learn more links, and news card all navigate to the right page.


<img width="1168" height="533" alt="image" src="https://github.com/user-attachments/assets/ae59aed7-858d-44b1-ab04-5323557f0b7f" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed broken documentation links for LLM judge scorers that were returning 404 errors.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)