### PR TITLE
Make assessment pills clickable in session view to open trace viewer with assessment expanded

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatConversation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatConversation.tsx
@@ -26,6 +26,7 @@ export const ExperimentSingleChatConversation = ({
   setSelectedTrace,
   chatRefs,
   getAssessmentTitle,
+  onAssessmentClick,
 }: {
   traces: ModelTrace[];
   selectedTurnIndex: number | null;
@@ -33,6 +34,7 @@ export const ExperimentSingleChatConversation = ({
   setSelectedTrace?: (trace: ModelTrace) => void;
   chatRefs?: MutableRefObject<{ [traceId: string]: HTMLDivElement }>;
   getAssessmentTitle: (assessmentName: string) => string;
+  onAssessmentClick?: (trace: ModelTrace, assessmentId: string) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
 
@@ -116,6 +118,9 @@ export const ExperimentSingleChatConversation = ({
                   trace={trace}
                   getAssessmentTitle={getAssessmentTitle}
                   onAddAssessmentsClick={setSelectedTrace ? () => setSelectedTrace(trace) : undefined}
+                  onAssessmentClick={
+                    onAssessmentClick ? (assessmentId) => onAssessmentClick(trace, assessmentId) : undefined
+                  }
                 />
               </>
             )}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -80,6 +80,7 @@ const ExperimentSingleChatSessionPageImpl = () => {
   const location = useLocation();
   const [selectedTurnIndex, setSelectedTurnIndex] = useState<number | null>(null);
   const [selectedTrace, setSelectedTrace] = useState<ModelTrace | null>(null);
+  const [highlightedAssessmentId, setHighlightedAssessmentId] = useState<string | null>(null);
   const chatRefs = useRef<{ [traceId: string]: HTMLDivElement }>({});
 
   invariant(experimentId, 'Experiment ID must be defined');
@@ -185,6 +186,14 @@ const ExperimentSingleChatSessionPageImpl = () => {
               setSelectedTrace={setSelectedTrace}
               chatRefs={chatRefs}
               getAssessmentTitle={getAssessmentTitle}
+              onAssessmentClick={(trace, assessmentId) => {
+                setHighlightedAssessmentId(assessmentId);
+                setSelectedTrace(trace);
+                const index = (traces ?? []).findIndex((t) => getModelTraceId(t) === getModelTraceId(trace));
+                if (index >= 0) {
+                  setSelectedTurnIndex(index);
+                }
+              }}
             />
             {shouldEnableAssessmentsInSessions() && (
               <ExperimentSingleChatSessionScoreResults
@@ -203,12 +212,16 @@ const ExperimentSingleChatSessionPageImpl = () => {
         )}
         {selectedTrace !== null && selectedTurnIndex !== null && (
           <ModelTraceExplorerDrawer
-            handleClose={() => setSelectedTrace(null)}
+            handleClose={() => {
+              setSelectedTrace(null);
+              setHighlightedAssessmentId(null);
+            }}
             selectPreviousEval={() => {
               if (selectedTurnIndex > 0 && traces) {
                 const prevIndex = selectedTurnIndex - 1;
                 setSelectedTurnIndex(prevIndex);
                 setSelectedTrace(traces[prevIndex]);
+                setHighlightedAssessmentId(null);
               }
             }}
             selectNextEval={() => {
@@ -216,6 +229,7 @@ const ExperimentSingleChatSessionPageImpl = () => {
                 const nextIndex = selectedTurnIndex + 1;
                 setSelectedTurnIndex(nextIndex);
                 setSelectedTrace(traces[nextIndex]);
+                setHighlightedAssessmentId(null);
               }
             }}
             isPreviousAvailable={selectedTurnIndex > 0}
@@ -238,10 +252,18 @@ const ExperimentSingleChatSessionPageImpl = () => {
             >
               {isEvaluatingTracesInDetailsViewEnabled() ? (
                 <JudgeContextProviderForTrace>
-                  <ModelTraceExplorer modelTrace={selectedTrace} collapseAssessmentPane="force-open" />
+                  <ModelTraceExplorer
+                    modelTrace={selectedTrace}
+                    collapseAssessmentPane="force-open"
+                    initialHighlightedAssessmentId={highlightedAssessmentId ?? undefined}
+                  />
                 </JudgeContextProviderForTrace>
               ) : (
-                <ModelTraceExplorer modelTrace={selectedTrace} collapseAssessmentPane="force-open" />
+                <ModelTraceExplorer
+                  modelTrace={selectedTrace}
+                  collapseAssessmentPane="force-open"
+                  initialHighlightedAssessmentId={highlightedAssessmentId ?? undefined}
+                />
               )}
             </div>
           </ModelTraceExplorerDrawer>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.tsx
@@ -26,6 +26,7 @@ export const ModelTraceExplorerImpl = ({
   onSelectSpan,
   collapseAssessmentPane,
   showLoadingState,
+  initialHighlightedAssessmentId,
 }: {
   modelTrace: ModelTrace;
   className?: string;
@@ -38,6 +39,7 @@ export const ModelTraceExplorerImpl = ({
    */
   collapseAssessmentPane?: boolean | 'force-open';
   showLoadingState?: boolean;
+  initialHighlightedAssessmentId?: string;
 }) => {
   const [modelTrace, setModelTrace] = useState(initialModelTrace);
   const [forceDisplay, setForceDisplay] = useState(false);
@@ -92,6 +94,7 @@ export const ModelTraceExplorerImpl = ({
         assessmentsPaneEnabled={assessmentsPaneEnabled}
         initialAssessmentsPaneCollapsed={collapseAssessmentPane}
         isTraceInitialLoading={isTraceInitialLoading}
+        initialHighlightedAssessmentId={initialHighlightedAssessmentId}
       >
         {showLoadingState ? (
           <ModelTraceExplorerSkeleton />

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerViewStateContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerViewStateContext.tsx
@@ -90,6 +90,7 @@ export const ModelTraceExplorerViewStateProvider = ({
   isTraceInitialLoading = false,
   children,
   readOnly = false,
+  initialHighlightedAssessmentId,
 }: {
   modelTrace: ModelTrace;
   initialActiveView?: 'summary' | 'detail';
@@ -99,6 +100,7 @@ export const ModelTraceExplorerViewStateProvider = ({
   initialAssessmentsPaneCollapsed?: boolean | 'force-open';
   isTraceInitialLoading?: boolean;
   readOnly?: boolean;
+  initialHighlightedAssessmentId?: string;
 }) => {
   const topLevelNodes = useMemo(() => parseModelTraceToTreeWithMultipleRoots(modelTrace), [modelTrace]);
   const rootNode = topLevelNodes.length === 1 ? topLevelNodes[0] : null;
@@ -163,7 +165,7 @@ export const ModelTraceExplorerViewStateProvider = ({
     [preferences],
   );
 
-  const pendingHighlightRef = useRef<string | null>(null);
+  const pendingHighlightRef = useRef<string | null>(initialHighlightedAssessmentId ?? null);
   const highlightListenersRef = useRef<Map<string, Set<() => void>>>(new Map());
 
   const subscribeToHighlightEvent = useCallback((assessmentId: string, callback: () => void) => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnAssessments.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnAssessments.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import { DesignSystemProvider } from '@databricks/design-system';
 import { IntlProvider } from '@databricks/i18n';
@@ -247,5 +247,26 @@ describe('SingleChatTurnAssessments', () => {
 
     // Should not show any "+ N" indicator
     expect(screen.queryByText(/\+ \d+/)).not.toBeInTheDocument();
+  });
+
+  it('should call onAssessmentClick with assessment ID when pill is clicked', () => {
+    const mockOnAssessmentClick = jest.fn();
+    const trace = createMockTrace([
+      createMockAssessment('assess-1', 'Relevance'),
+      createMockAssessment('assess-2', 'Correctness'),
+    ]);
+
+    render(
+      <TestWrapper>
+        <SingleChatTurnAssessments
+          trace={trace}
+          getAssessmentTitle={mockGetAssessmentTitle}
+          onAssessmentClick={mockOnAssessmentClick}
+        />
+      </TestWrapper>,
+    );
+
+    fireEvent.click(screen.getByText('Relevance:', { exact: false }));
+    expect(mockOnAssessmentClick).toHaveBeenCalledWith('assess-1');
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnAssessments.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnAssessments.tsx
@@ -18,10 +18,12 @@ export const SingleChatTurnAssessments = ({
   trace,
   getAssessmentTitle,
   onAddAssessmentsClick,
+  onAssessmentClick,
 }: {
   trace: ModelTrace;
   getAssessmentTitle: (assessmentName: string) => string;
   onAddAssessmentsClick?: () => void;
+  onAssessmentClick?: (assessmentId: string) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
   const info = isV3ModelTraceInfo(trace.info) ? trace.info : null;
@@ -87,18 +89,34 @@ export const SingleChatTurnAssessments = ({
           }
           const title = getAssessmentTitle(assessment.assessment_name);
           const value = getAssessmentValue(assessment)?.toString() ?? '';
-          return (
-            <div key={assessment.assessment_id}>
-              {/* Both expectations and feedback assessments are formatted with title and value in the same box */}
-              <AssessmentDisplayValue
-                prefix={<>{title}: </>}
-                jsonValue={value}
-                css={{ maxWidth: 150 }}
-                skipIcons={isExpectationAssessment(assessment)}
-                overrideColor={isExpectationAssessment(assessment) ? 'default' : undefined}
-              />
-            </div>
+          const pill = (
+            <AssessmentDisplayValue
+              prefix={<>{title}: </>}
+              jsonValue={value}
+              css={{ maxWidth: 150 }}
+              skipIcons={isExpectationAssessment(assessment)}
+              overrideColor={isExpectationAssessment(assessment) ? 'default' : undefined}
+            />
           );
+          if (onAssessmentClick) {
+            return (
+              <button
+                key={assessment.assessment_id}
+                type="button"
+                onClick={() => onAssessmentClick(assessment.assessment_id)}
+                css={{
+                  all: 'unset',
+                  cursor: 'pointer',
+                  // Without this, the pill shows an arrow cursor because the
+                  // design system Tag component sets cursor: default.
+                  '& *': { cursor: 'inherit' },
+                }}
+              >
+                {pill}
+              </button>
+            );
+          }
+          return <div key={assessment.assessment_id}>{pill}</div>;
         })}
       </Overflow>
     </div>


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

### What changes are proposed in this pull request?

Make assessment pills clickable in session view to open trace viewer with assessment expanded

https://github.com/user-attachments/assets/e443a1ae-d16c-4294-a0ee-c1e650bca69e


### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Clicking trace feedback from the session page now correctly opens the trace viewer with the feedback expanded

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
