### PR TITLE
Add git stack stacked PR workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,34 @@ gh run view <run-id>
 gh run watch
 ```
 
+### Stacked PRs with git stack
+
+Use `git stack` to manage stacked (dependent) pull requests:
+
+```bash
+# Create a branch for the first PR
+git stack create first-change
+# Make changes, then commit
+git add . && git commit -s -m "First change"
+git stack push   # Creates the PR
+
+# Create a dependent second PR
+git stack create second-change
+# Make changes, then commit
+git add . && git commit -s -m "Second change"
+git stack push   # Creates the second PR
+
+# Address review comments on the first PR
+git switch stack/first-change
+# Make changes, then commit
+git add . && git commit -s -m "Address review comments"
+git stack sync   # Rebases dependent branches onto the updated first branch
+# If merge conflicts: resolve, then: git rebase --continue && git stack sync --continue --from stack/first-change
+git stack push   # Updates both PRs
+```
+
+Key commands: `git stack create <name>`, `git stack push`, `git stack sync`, `git stack commit` (commit + sync in one step).
+
 ## Pre-commit Hooks
 
 The repository uses pre-commit for code quality. Install hooks with:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds a concise "Stacked PRs with git stack" section to CLAUDE.md under the Checking CI Status section, documenting the stacked PR workflow used in this repo.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Documentation-only change (CLAUDE.md).

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)