### PR TITLE
Fix Chat tab not rendering for non-OpenAI model names in OpenAI autolog spans

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -37,17 +37,6 @@ const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) =
 
   return (
     <g>
-      {/* Model name in donut center */}
-      <text
-        x={cx}
-        y={cy}
-        textAnchor="middle"
-        fill={theme.colors.textPrimary}
-        fontSize={theme.typography.fontSizeSm}
-        fontWeight={500}
-      >
-        {name}
-      </text>
       {/* Main pie sector */}
       <Sector
         cx={cx}
@@ -72,10 +61,21 @@ const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) =
       <path d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`} stroke={fill} fill="none" />
       {/* Dot at line end */}
       <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
-      {/* Cost label */}
+      {/* Model name label */}
       <text
         x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
         y={ey}
+        textAnchor={textAnchor}
+        fill={theme.colors.textPrimary}
+        fontSize={theme.typography.fontSizeSm}
+        fontWeight={500}
+      >
+        {name}
+      </text>
+      {/* Cost label */}
+      <text
+        x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
+        y={ey + theme.spacing.md}
         textAnchor={textAnchor}
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}
@@ -85,7 +85,7 @@ const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) =
       {/* Percentage label */}
       <text
         x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey + theme.spacing.md}
+        y={ey + theme.spacing.md * 2}
         textAnchor={textAnchor}
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -75,7 +75,7 @@ const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) =
       {/* Cost label */}
       <text
         x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey + theme.spacing.md}
+        y={ey + theme.spacing.lg}
         textAnchor={textAnchor}
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}
@@ -85,7 +85,7 @@ const createActiveShapeRenderer = (theme: DesignSystemThemeInterface['theme']) =
       {/* Percentage label */}
       <text
         x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey + theme.spacing.md * 2}
+        y={ey + theme.spacing.lg * 2}
         textAnchor={textAnchor}
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useDesignSystemTheme, PieChartIcon, type DesignSystemThemeInterface } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
-import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Sector } from 'recharts';
+import { PieChart, Pie, ResponsiveContainer, Legend, Sector, Tooltip } from 'recharts';
 import { formatCostUSD } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceCostBreakdownChartData } from '../hooks/useTraceCostBreakdownChartData';
 import { useTraceCostDimension } from '../hooks/useTraceCostDimension';
@@ -94,36 +94,32 @@ export const TraceCostBreakdownChart: React.FC = () => {
   const { dimension, setDimension } = useTraceCostDimension();
   const { chartData, totalCost, isLoading, error, hasData } = useTraceCostBreakdownChartData(dimension);
   const { getChartColor } = useChartColors();
-  const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
   const { getOpacity, handleLegendMouseEnter, handleLegendMouseLeave } = useLegendHighlight();
+
+  const coloredChartData = useMemo(
+    () =>
+      chartData.map((entry, index) => ({
+        ...entry,
+        fill: getChartColor(index),
+        fillOpacity: getOpacity(entry.name),
+      })),
+    [chartData, getChartColor, getOpacity],
+  );
 
   const activeShapeRenderer = useMemo(
     () => (props: unknown) => renderActiveShape(props as ActiveShapeProps, theme),
     [theme],
   );
 
-  const onPieEnter = useCallback((_: unknown, index: number) => {
-    setActiveIndex(index);
-  }, []);
-
-  const onPieLeave = useCallback(() => {
-    setActiveIndex(undefined);
-  }, []);
-
   const onLegendMouseEnter = useCallback(
     (data: { value: string | undefined }) => {
       handleLegendMouseEnter(data);
-      const index = chartData.findIndex((entry) => entry.name === data.value);
-      if (index !== -1) {
-        setActiveIndex(index);
-      }
     },
-    [handleLegendMouseEnter, chartData],
+    [handleLegendMouseEnter],
   );
 
   const onLegendMouseLeave = useCallback(() => {
     handleLegendMouseLeave();
-    setActiveIndex(undefined);
   }, [handleLegendMouseLeave]);
 
   const legendFormatter = useCallback(
@@ -179,7 +175,7 @@ export const TraceCostBreakdownChart: React.FC = () => {
           <ResponsiveContainer width="100%" height="100%">
             <PieChart style={{ overflow: 'visible' }}>
               <Pie
-                data={chartData}
+                data={coloredChartData}
                 cx="50%"
                 cy="50%"
                 innerRadius={PIE_INNER_RADIUS}
@@ -188,14 +184,8 @@ export const TraceCostBreakdownChart: React.FC = () => {
                 dataKey="value"
                 nameKey="name"
                 activeShape={activeShapeRenderer}
-                activeIndex={activeIndex}
-                onMouseEnter={onPieEnter}
-                onMouseLeave={onPieLeave}
-              >
-                {chartData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={getChartColor(index)} fillOpacity={getOpacity(entry.name)} />
-                ))}
-              </Pie>
+              />
+              <Tooltip content={() => null} cursor={false} />
               <Legend
                 layout="vertical"
                 align="right"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -33,6 +33,11 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill, name, value, percentage } = props;
   const { sx, sy, mx, my, ex, ey, textAnchor, cos } = calculatePieActiveShapeGeometry(props, theme);
 
+  // Clamp label Y so it stays within the chart area (top and bottom)
+  const maxLabelY = cy * 2 - theme.spacing.md * 2;
+  const labelY = Math.max(theme.spacing.md, Math.min(maxLabelY, ey));
+  const labelX = ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs;
+
   return (
     <g>
       {/* Main pie sector */}
@@ -56,13 +61,13 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
         fill={fill}
       />
       {/* Connecting line: radial segment -> horizontal segment */}
-      <path d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`} stroke={fill} fill="none" />
+      <path d={`M${sx},${sy}L${mx},${my}L${ex},${labelY}`} stroke={fill} fill="none" />
       {/* Dot at line end */}
-      <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
+      <circle cx={ex} cy={labelY} r={2} fill={fill} stroke="none" />
       {/* Model name label */}
       <text
-        x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey}
+        x={labelX}
+        y={labelY}
         textAnchor={textAnchor}
         fill={theme.colors.textPrimary}
         fontSize={theme.typography.fontSizeSm}
@@ -70,25 +75,15 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
       >
         {name}
       </text>
-      {/* Cost label */}
+      {/* Cost and percentage label */}
       <text
-        x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey + theme.spacing.lg}
+        x={labelX}
+        y={labelY + theme.spacing.md}
         textAnchor={textAnchor}
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}
       >
-        {formatCostUSD(value)}
-      </text>
-      {/* Percentage label */}
-      <text
-        x={ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs}
-        y={ey + theme.spacing.lg * 2}
-        textAnchor={textAnchor}
-        fill={theme.colors.textSecondary}
-        fontSize={theme.typography.fontSizeSm}
-      >
-        {percentage.toFixed(2)}%
+        {formatCostUSD(value)}, {percentage.toFixed(2)}%
       </text>
     </g>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useDesignSystemTheme, PieChartIcon, type DesignSystemThemeInterface } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
-import { PieChart, Pie, ResponsiveContainer, Legend, Sector, Tooltip } from 'recharts';
+import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Sector } from 'recharts';
 import { formatCostUSD } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceCostBreakdownChartData } from '../hooks/useTraceCostBreakdownChartData';
 import { useTraceCostDimension } from '../hooks/useTraceCostDimension';
@@ -94,67 +94,33 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
   );
 };
 
-interface ShapeProps extends ActiveShapeProps {
-  isActive: boolean;
-  index: number;
-  fillOpacity?: number;
-}
-
-/**
- * Creates a shape renderer that shows active styling for:
- * - Pie slice hover (via Tooltip's isActive)
- * - Legend hover (via legendActiveIndex)
- */
-const createShapeRenderer =
-  (theme: DesignSystemThemeInterface['theme'], legendActiveIndex: number | undefined) =>
-  (props: ShapeProps): React.ReactElement => {
-    const isActive = props.isActive || legendActiveIndex === props.index;
-
-    if (isActive) {
-      return renderActiveShape(props, theme);
-    }
-
-    return (
-      <Sector
-        cx={props.cx}
-        cy={props.cy}
-        innerRadius={props.innerRadius}
-        outerRadius={props.outerRadius}
-        startAngle={props.startAngle}
-        endAngle={props.endAngle}
-        fill={props.fill}
-        fillOpacity={props.fillOpacity}
-      />
-    );
-  };
-
 export const TraceCostBreakdownChart: React.FC = () => {
   const { theme } = useDesignSystemTheme();
   const { dimension, setDimension } = useTraceCostDimension();
   const { chartData, totalCost, isLoading, error, hasData } = useTraceCostBreakdownChartData(dimension);
   const { getChartColor } = useChartColors();
+  const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
   const { getOpacity, handleLegendMouseEnter, handleLegendMouseLeave } = useLegendHighlight();
-  const [legendActiveIndex, setLegendActiveIndex] = useState<number | undefined>(undefined);
 
-  const shapeRenderer = useMemo(() => createShapeRenderer(theme, legendActiveIndex), [theme, legendActiveIndex]);
-
-  // Add fill colors and opacity directly to data
-  const coloredChartData = useMemo(
-    () =>
-      chartData.map((entry, index) => ({
-        ...entry,
-        fill: getChartColor(index),
-        fillOpacity: getOpacity(entry.name),
-      })),
-    [chartData, getChartColor, getOpacity],
+  const activeShapeRenderer = useMemo(
+    () => (props: unknown) => renderActiveShape(props as ActiveShapeProps, theme),
+    [theme],
   );
+
+  const onPieEnter = useCallback((_: unknown, index: number) => {
+    setActiveIndex(index);
+  }, []);
+
+  const onPieLeave = useCallback(() => {
+    setActiveIndex(undefined);
+  }, []);
 
   const onLegendMouseEnter = useCallback(
     (data: { value: string | undefined }) => {
       handleLegendMouseEnter(data);
       const index = chartData.findIndex((entry) => entry.name === data.value);
       if (index !== -1) {
-        setLegendActiveIndex(index);
+        setActiveIndex(index);
       }
     },
     [handleLegendMouseEnter, chartData],
@@ -162,7 +128,7 @@ export const TraceCostBreakdownChart: React.FC = () => {
 
   const onLegendMouseLeave = useCallback(() => {
     handleLegendMouseLeave();
-    setLegendActiveIndex(undefined);
+    setActiveIndex(undefined);
   }, [handleLegendMouseLeave]);
 
   const legendFormatter = useCallback(
@@ -218,7 +184,7 @@ export const TraceCostBreakdownChart: React.FC = () => {
           <ResponsiveContainer width="100%" height="100%">
             <PieChart style={{ overflow: 'visible' }}>
               <Pie
-                data={coloredChartData}
+                data={chartData}
                 cx="50%"
                 cy="50%"
                 innerRadius={PIE_INNER_RADIUS}
@@ -226,10 +192,15 @@ export const TraceCostBreakdownChart: React.FC = () => {
                 paddingAngle={PIE_PADDING_ANGLE}
                 dataKey="value"
                 nameKey="name"
-                shape={shapeRenderer}
-              />
-              {/* Tooltip enables internal active state tracking for pie hover (recharts 3.x) */}
-              <Tooltip content={() => null} cursor={false} />
+                activeShape={activeShapeRenderer}
+                activeIndex={activeIndex}
+                onMouseEnter={onPieEnter}
+                onMouseLeave={onPieLeave}
+              >
+                {chartData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={getChartColor(index)} fillOpacity={getOpacity(entry.name)} />
+                ))}
+              </Pie>
               <Legend
                 layout="vertical"
                 align="right"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -28,7 +28,7 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill, name, value, percentage } = props;
 
   // Label is always centered above the pie — no overflow issues regardless of slice position
-  const labelY = cy - outerRadius - theme.spacing.lg;
+  const labelY = cy - PIE_PADDING_ANGLE - outerRadius - theme.spacing.lg;
 
   return (
     <g>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useDesignSystemTheme, PieChartIcon, type DesignSystemThemeInterface } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { PieChart, Pie, ResponsiveContainer, Legend, Sector, Tooltip } from 'recharts';
@@ -89,13 +89,51 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
   );
 };
 
+interface ShapeProps extends ActiveShapeProps {
+  isActive: boolean;
+  index: number;
+  fillOpacity?: number;
+}
+
+/**
+ * Creates a shape renderer that shows active styling for:
+ * - Pie slice hover (via Tooltip's isActive)
+ * - Legend hover (via legendActiveIndex)
+ */
+const createShapeRenderer =
+  (theme: DesignSystemThemeInterface['theme'], legendActiveIndex: number | undefined) =>
+  (props: ShapeProps): React.ReactElement => {
+    const isActive = props.isActive || legendActiveIndex === props.index;
+
+    if (isActive) {
+      return renderActiveShape(props, theme);
+    }
+
+    return (
+      <Sector
+        cx={props.cx}
+        cy={props.cy}
+        innerRadius={props.innerRadius}
+        outerRadius={props.outerRadius}
+        startAngle={props.startAngle}
+        endAngle={props.endAngle}
+        fill={props.fill}
+        fillOpacity={props.fillOpacity}
+      />
+    );
+  };
+
 export const TraceCostBreakdownChart: React.FC = () => {
   const { theme } = useDesignSystemTheme();
   const { dimension, setDimension } = useTraceCostDimension();
   const { chartData, totalCost, isLoading, error, hasData } = useTraceCostBreakdownChartData(dimension);
   const { getChartColor } = useChartColors();
   const { getOpacity, handleLegendMouseEnter, handleLegendMouseLeave } = useLegendHighlight();
+  const [legendActiveIndex, setLegendActiveIndex] = useState<number | undefined>(undefined);
 
+  const shapeRenderer = useMemo(() => createShapeRenderer(theme, legendActiveIndex), [theme, legendActiveIndex]);
+
+  // Add fill colors and opacity directly to data
   const coloredChartData = useMemo(
     () =>
       chartData.map((entry, index) => ({
@@ -106,20 +144,20 @@ export const TraceCostBreakdownChart: React.FC = () => {
     [chartData, getChartColor, getOpacity],
   );
 
-  const activeShapeRenderer = useMemo(
-    () => (props: unknown) => renderActiveShape(props as ActiveShapeProps, theme),
-    [theme],
-  );
-
   const onLegendMouseEnter = useCallback(
     (data: { value: string | undefined }) => {
       handleLegendMouseEnter(data);
+      const index = chartData.findIndex((entry) => entry.name === data.value);
+      if (index !== -1) {
+        setLegendActiveIndex(index);
+      }
     },
-    [handleLegendMouseEnter],
+    [handleLegendMouseEnter, chartData],
   );
 
   const onLegendMouseLeave = useCallback(() => {
     handleLegendMouseLeave();
+    setLegendActiveIndex(undefined);
   }, [handleLegendMouseLeave]);
 
   const legendFormatter = useCallback(
@@ -183,8 +221,9 @@ export const TraceCostBreakdownChart: React.FC = () => {
                 paddingAngle={PIE_PADDING_ANGLE}
                 dataKey="value"
                 nameKey="name"
-                activeShape={activeShapeRenderer}
+                shape={shapeRenderer}
               />
+              {/* Tooltip enables internal active state tracking for pie hover (recharts 3.x) */}
               <Tooltip content={() => null} cursor={false} />
               <Legend
                 layout="vertical"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceCostBreakdownChart.tsx
@@ -14,12 +14,7 @@ import {
   OverviewChartContainer,
   DEFAULT_CHART_CONTENT_HEIGHT,
 } from './OverviewChartComponents';
-import {
-  useChartColors,
-  useLegendHighlight,
-  calculatePieActiveShapeGeometry,
-  type ActiveShapeProps,
-} from '../utils/chartUtils';
+import { useChartColors, useLegendHighlight, type ActiveShapeProps } from '../utils/chartUtils';
 
 // Pie chart sizing constants
 const PIE_INNER_RADIUS = 50;
@@ -31,12 +26,9 @@ const PIE_PADDING_ANGLE = 2;
  */
 const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInterface['theme']) => {
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill, name, value, percentage } = props;
-  const { sx, sy, mx, my, ex, ey, textAnchor, cos } = calculatePieActiveShapeGeometry(props, theme);
 
-  // Clamp label Y so it stays within the chart area (top and bottom)
-  const maxLabelY = cy * 2 - theme.spacing.md * 2;
-  const labelY = Math.max(theme.spacing.md, Math.min(maxLabelY, ey));
-  const labelX = ex + (cos >= 0 ? 1 : -1) * theme.spacing.xs;
+  // Label is always centered above the pie — no overflow issues regardless of slice position
+  const labelY = cy - outerRadius - theme.spacing.lg;
 
   return (
     <g>
@@ -60,26 +52,22 @@ const renderActiveShape = (props: ActiveShapeProps, theme: DesignSystemThemeInte
         outerRadius={outerRadius + theme.spacing.sm}
         fill={fill}
       />
-      {/* Connecting line: radial segment -> horizontal segment */}
-      <path d={`M${sx},${sy}L${mx},${my}L${ex},${labelY}`} stroke={fill} fill="none" />
-      {/* Dot at line end */}
-      <circle cx={ex} cy={labelY} r={2} fill={fill} stroke="none" />
-      {/* Model name label */}
+      {/* Model name */}
       <text
-        x={labelX}
+        x={cx}
         y={labelY}
-        textAnchor={textAnchor}
+        textAnchor="middle"
         fill={theme.colors.textPrimary}
         fontSize={theme.typography.fontSizeSm}
         fontWeight={500}
       >
         {name}
       </text>
-      {/* Cost and percentage label */}
+      {/* Cost and percentage */}
       <text
-        x={labelX}
+        x={cx}
         y={labelY + theme.spacing.md}
-        textAnchor={textAnchor}
+        textAnchor="middle"
         fill={theme.colors.textSecondary}
         fontSize={theme.typography.fontSizeSm}
       >
@@ -215,7 +203,7 @@ export const TraceCostBreakdownChart: React.FC = () => {
               <Pie
                 data={coloredChartData}
                 cx="50%"
-                cy="50%"
+                cy="60%"
                 innerRadius={PIE_INNER_RADIUS}
                 outerRadius={PIE_OUTER_RADIUS}
                 paddingAngle={PIE_PADDING_ANGLE}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/chartUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/chartUtils.ts
@@ -61,16 +61,16 @@ export function calculatePieActiveShapeGeometry(
   const sin = Math.sin(-RADIAN * midAngle);
   const cos = Math.cos(-RADIAN * midAngle);
 
-  // Line start point (just outside the pie slice)
-  const sx = cx + (outerRadius + theme.spacing.sm) * cos;
-  const sy = cy + (outerRadius + theme.spacing.sm) * sin;
+  // Line start point (just outside the outer highlight arc)
+  const sx = cx + (outerRadius + theme.spacing.md) * cos;
+  const sy = cy + (outerRadius + theme.spacing.md) * sin;
 
   // Line bend point (further out, creates an elbow in the line)
-  const mx = cx + (outerRadius + theme.spacing.md) * cos;
-  const my = cy + (outerRadius + theme.spacing.md) * sin;
+  const mx = cx + (outerRadius + theme.spacing.lg) * cos;
+  const my = cy + (outerRadius + theme.spacing.lg) * sin;
 
   // Line end point (horizontal offset from bend, direction based on left/right side)
-  const ex = mx + (cos >= 0 ? 1 : -1) * theme.spacing.md;
+  const ex = mx + (cos >= 0 ? 1 : -1) * theme.spacing.lg;
   const ey = my;
   const textAnchor = cos >= 0 ? 'start' : 'end';
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -1006,7 +1006,7 @@ export const isModelTraceChoices = (obj: any): obj is ModelTraceChatResponse['ch
   return (
     Array.isArray(obj) &&
     obj.length > 0 &&
-    obj.every((choice: any) => has(choice, 'message') && isModelTraceChatMessage(choice.message))
+    obj.every((choice: any) => has(choice, 'message') && isRawModelTraceChatMessage(choice.message))
   );
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.test.ts
@@ -406,6 +406,30 @@ describe('normalizeConversation', () => {
     ]);
   });
 
+  it('handles an OpenAI-compatible chat output with array content (e.g. non-OpenAI model via gateway)', () => {
+    const outputWithArrayContent = {
+      id: 'chatcmpl-abc123',
+      choices: [
+        {
+          finish_reason: 'stop',
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello from Anthropic model!' }],
+          },
+        },
+      ],
+      model: 'anthropic-claude-sonnet-4',
+      object: 'chat.completion',
+    };
+    expect(normalizeConversation(outputWithArrayContent, 'openai')).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Hello from Anthropic model!',
+      }),
+    ]);
+  });
+
   it('handles an OpenAI responses formats', () => {
     expect(normalizeConversation(MOCK_OPENAI_RESPONSES_INPUT, 'openai')).toEqual([
       expect.objectContaining({

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
@@ -38,20 +38,14 @@ export const normalizeOpenAIChatInput = (obj: any): ModelTraceChatMessage[] | nu
 // normalize the OpenAI chat response format (object with 'choices' key)
 export const normalizeOpenAIChatResponse = (obj: any): ModelTraceChatMessage[] | null => {
   if (isModelTraceChoices(obj)) {
-    return obj.map((choice) => ({
-      ...choice.message,
-      tool_calls: choice.message.tool_calls?.map(prettyPrintToolCall),
-    }));
+    return compact(obj.map((choice) => prettyPrintChatMessage(choice.message)));
   }
 
   if (!isModelTraceChatResponse(obj)) {
     return null;
   }
 
-  return obj.choices.map((choice) => ({
-    ...choice.message,
-    tool_calls: choice.message.tool_calls?.map(prettyPrintToolCall),
-  }));
+  return compact(obj.choices.map((choice) => prettyPrintChatMessage(choice.message)));
 };
 
 const isOpenAIResponsesInputMessage = (obj: unknown): obj is OpenAIResponsesInputMessage => {


### PR DESCRIPTION
### Related Issues/PRs

Closes #21217

### What changes are proposed in this pull request?

When using `mlflow.openai.autolog()` with an OpenAI-compatible gateway routing non-OpenAI models (e.g. `anthropic-claude-sonnet-4`), the response message content arrives as an array of content parts (`[{"type": "text", "text": "..."}]`) instead of a plain string. 

`isModelTraceChoices` was calling `isModelTraceChatMessage` which only accepted `string | null` content, causing validation to fail and the **Chat tab** to not render.

**Fix:**
- Use `isRawModelTraceChatMessage` in `isModelTraceChoices` — it already validates both string and array content via `isContentType`
- Use `prettyPrintChatMessage` in `normalizeOpenAIChatResponse` to normalize array content parts to strings (via `formatChatContent`), consistent with how inputs are handled

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added a test case to `openai.test.ts` that verifies an OpenAI-compatible chat output with array content (e.g. from an Anthropic model via gateway) is correctly parsed and the content is normalized to a string.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

**Bug fixes:**

Fix the Chat tab not rendering in the trace UI when using `mlflow.openai.autolog()` with non-OpenAI model names routed through an OpenAI-compatible gateway (e.g. MLflow AI Gateway). The Chat tab now renders correctly regardless of the model name, as long as the span has valid chat completion inputs/outputs.