### PR TITLE
Fix Chat tab not rendering for non-OpenAI model names in OpenAI autolog spans

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -1006,7 +1006,7 @@ export const isModelTraceChoices = (obj: any): obj is ModelTraceChatResponse['ch
   return (
     Array.isArray(obj) &&
     obj.length > 0 &&
-    obj.every((choice: any) => has(choice, 'message') && isModelTraceChatMessage(choice.message))
+    obj.every((choice: any) => has(choice, 'message') && isRawModelTraceChatMessage(choice.message))
   );
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.test.ts
@@ -406,6 +406,30 @@ describe('normalizeConversation', () => {
     ]);
   });
 
+  it('handles an OpenAI-compatible chat output with array content (e.g. non-OpenAI model via gateway)', () => {
+    const outputWithArrayContent = {
+      id: 'chatcmpl-abc123',
+      choices: [
+        {
+          finish_reason: 'stop',
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello from Anthropic model!' }],
+          },
+        },
+      ],
+      model: 'anthropic-claude-sonnet-4',
+      object: 'chat.completion',
+    };
+    expect(normalizeConversation(outputWithArrayContent, 'openai')).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Hello from Anthropic model!',
+      }),
+    ]);
+  });
+
   it('handles an OpenAI responses formats', () => {
     expect(normalizeConversation(MOCK_OPENAI_RESPONSES_INPUT, 'openai')).toEqual([
       expect.objectContaining({

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
@@ -38,20 +38,14 @@ export const normalizeOpenAIChatInput = (obj: any): ModelTraceChatMessage[] | nu
 // normalize the OpenAI chat response format (object with 'choices' key)
 export const normalizeOpenAIChatResponse = (obj: any): ModelTraceChatMessage[] | null => {
   if (isModelTraceChoices(obj)) {
-    return obj.map((choice) => ({
-      ...choice.message,
-      tool_calls: choice.message.tool_calls?.map(prettyPrintToolCall),
-    }));
+    return compact(obj.map((choice) => prettyPrintChatMessage(choice.message)));
   }
 
   if (!isModelTraceChatResponse(obj)) {
     return null;
   }
 
-  return obj.choices.map((choice) => ({
-    ...choice.message,
-    tool_calls: choice.message.tool_calls?.map(prettyPrintToolCall),
-  }));
+  return compact(obj.choices.map((choice) => prettyPrintChatMessage(choice.message)));
 };
 
 const isOpenAIResponsesInputMessage = (obj: unknown): obj is OpenAIResponsesInputMessage => {


### PR DESCRIPTION
### Related Issues/PRs

Closes #21217

### What changes are proposed in this pull request?

When using `mlflow.openai.autolog()` with an OpenAI-compatible gateway routing non-OpenAI models (e.g. `anthropic-claude-sonnet-4`), the response message content arrives as an array of content parts (`[{"type": "text", "text": "..."}]`) instead of a plain string.

`isModelTraceChoices` was calling `isModelTraceChatMessage` which only accepted `string | null` content, causing validation to fail and the **Chat tab** to not render.

- Use `isRawModelTraceChatMessage` in `isModelTraceChoices` — it already validates both string and array content via `isContentType`
- Use `prettyPrintChatMessage` in `normalizeOpenAIChatResponse` to normalize array content parts to strings (via `formatChatContent`), consistent with how inputs are handled

<img width="1554" height="505" alt="image" src="https://github.com/user-attachments/assets/96e78209-dd82-4e0d-83c9-7252d52c174a" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix the Chat tab not rendering in the trace UI when using `mlflow.openai.autolog()` with non-OpenAI model names routed through an OpenAI-compatible gateway (e.g. MLflow AI Gateway).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)