### PR TITLE
Update PR template patch release section wording

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -83,9 +83,9 @@ Note that GitHub prefixes anchor names in markdown with "user-content-".
 <summary>What is a minor/patch release?</summary>
 
 - Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
-  Minor bug fixes, doc updates and new features usually go into minor releases.
+  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
 - Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
-  Critical bug fixes and doc updates usually go into patch releases.
+  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.
 
 </details>
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -91,5 +91,5 @@ Note that GitHub prefixes anchor names in markdown with "user-content-".
 
 <!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->
 
-- [ ] Yes (this PR is critical and needs to be in the next patch release)
-- [ ] No (this PR can wait for the next minor release)
+- [ ] This PR is critical and needs to be in the next patch release
+- [ ] This PR can wait for the next minor release

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -77,21 +77,19 @@ Note that GitHub prefixes anchor names in markdown with "user-content-".
 - [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
 - [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
 
-#### Should this PR be included in the next patch release?
-
-`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.
+#### Is this PR a critical bugfix or security fix that should go into the next patch release?
 
 <details>
 <summary>What is a minor/patch release?</summary>
 
 - Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
-  Bug fixes, doc updates and new features usually go into minor releases.
+  Minor bug fixes, doc updates and new features usually go into minor releases.
 - Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
-  Bug fixes and doc updates usually go into patch releases.
+  Critical bug fixes and doc updates usually go into patch releases.
 
 </details>
 
 <!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->
 
-- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
-- [ ] No (this PR will be included in the next minor release)
+- [ ] Yes (this PR is critical and needs to be in the next patch release)
+- [ ] No (this PR can wait for the next minor release)

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -65,26 +65,26 @@ module.exports = async ({ context, github, core }) => {
     return;
   }
 
-  const yesRegex = /- \[( |x)\] yes \(this PR will be/gi;
+  // TODO: remove the or clause once all open PRs have switched to the new template
+  const yesRegex = /- \[( |x)\] yes \(this PR (will be|is critical)/gi;
   const yesMatches = [...body.matchAll(yesRegex)];
   const yesMatch = yesMatches.length > 0 ? yesMatches[yesMatches.length - 1] : null;
   const yes = yesMatch ? yesMatch[1].toLowerCase() === "x" : false;
-  const noRegex = /- \[( |x)\] no \(this PR will be/gi;
+  // TODO: remove the or clause once all open PRs have switched to the new template
+  const noRegex = /- \[( |x)\] no \(this PR (will be|can wait)/gi;
   const noMatches = [...body.matchAll(noRegex)];
   const noMatch = noMatches.length > 0 ? noMatches[noMatches.length - 1] : null;
   const no = noMatch ? noMatch[1].toLowerCase() === "x" : false;
 
   if (yes && no) {
     core.setFailed(
-      "Both yes and no are selected. Please select only one in the `Should this PR be included in the next patch release?` section."
+      "Both yes and no are selected. Please select only one in the patch release section."
     );
     return;
   }
 
   if (!yes && !no) {
-    core.setFailed(
-      "Please fill in the `Should this PR be included in the next patch release?` section."
-    );
+    core.setFailed("Please fill in the patch release section.");
     return;
   }
 

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -66,12 +66,12 @@ module.exports = async ({ context, github, core }) => {
   }
 
   // TODO: remove the "yes/no" alternatives once all open PRs have switched to the new template
-  const yesRegex = /- \[( |x)\] (yes \()?this PR is critical/gi;
+  const yesRegex = /- \[( |x)\] (yes \()?this PR (will be|is critical)/gi;
   const yesMatches = [...body.matchAll(yesRegex)];
   const yesMatch = yesMatches.length > 0 ? yesMatches[yesMatches.length - 1] : null;
   const yes = yesMatch ? yesMatch[1].toLowerCase() === "x" : false;
   // TODO: remove the "yes/no" alternatives once all open PRs have switched to the new template
-  const noRegex = /- \[( |x)\] (no \()?this PR can wait/gi;
+  const noRegex = /- \[( |x)\] (no \()?this PR (will be|can wait)/gi;
   const noMatches = [...body.matchAll(noRegex)];
   const noMatch = noMatches.length > 0 ? noMatches[noMatches.length - 1] : null;
   const no = noMatch ? noMatch[1].toLowerCase() === "x" : false;

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -65,13 +65,13 @@ module.exports = async ({ context, github, core }) => {
     return;
   }
 
-  // TODO: remove the or clause once all open PRs have switched to the new template
-  const yesRegex = /- \[( |x)\] yes \(this PR (will be|is critical)/gi;
+  // TODO: remove the "yes/no" alternatives once all open PRs have switched to the new template
+  const yesRegex = /- \[( |x)\] (yes \()?this PR is critical/gi;
   const yesMatches = [...body.matchAll(yesRegex)];
   const yesMatch = yesMatches.length > 0 ? yesMatches[yesMatches.length - 1] : null;
   const yes = yesMatch ? yesMatch[1].toLowerCase() === "x" : false;
-  // TODO: remove the or clause once all open PRs have switched to the new template
-  const noRegex = /- \[( |x)\] no \(this PR (will be|can wait)/gi;
+  // TODO: remove the "yes/no" alternatives once all open PRs have switched to the new template
+  const noRegex = /- \[( |x)\] (no \()?this PR can wait/gi;
   const noMatches = [...body.matchAll(noRegex)];
   const noMatch = noMatches.length > 0 ? noMatches[noMatches.length - 1] : null;
   const no = noMatch ? noMatch[1].toLowerCase() === "x" : false;


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

- Rewords the patch release section in the PR template to clarify that only **critical bugfixes and security fixes** should be selected for patch releases (previously the wording suggested all bug fixes and doc updates should be included)
- Updates the `patch.js` workflow regex to match the new checkbox text, with backward compatibility for existing open PRs that still use the old template wording

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The regex changes were verified to match both old and new checkbox text patterns.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Critical bug fixes and doc updates usually go into patch releases.

</details>

- [ ] Yes (this PR is critical and needs to be in the next patch release)
- [x] No (this PR can wait for the next minor release)