### PR TITLE
[FIX] Experiment tags are cut off in Experiments table when exceeding column width

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import userEvent from '@testing-library/user-event';
+import { ExperimentListTableTagsCell } from './ExperimentListTableTagsCell';
+import type { ExperimentEntity } from '../types';
+
+// Mock KeyValueTag component
+jest.mock('../../common/components/KeyValueTag', () => ({
+  KeyValueTag: ({ tag }: { tag: { key: string; value?: string } }) => (
+    <span data-testid="key-value-tag">{`${tag.key}: ${tag.value || ''}`}</span>
+  ),
+}));
+
+// Mock isUserFacingTag to pass through all tags
+jest.mock('../../common/utils/TagUtils', () => ({
+  isUserFacingTag: () => true,
+}));
+
+const createMockTableMeta = (onEditTags = jest.fn()) => ({
+  onEditTags,
+});
+
+const createMockRow = (tags: Array<{ key: string; value?: string }> = []) => ({
+  original: {
+    experimentId: '1',
+    name: 'Test Experiment',
+    tags,
+  } as ExperimentEntity,
+});
+
+const createMockCellContext = (tags: Array<{ key: string; value?: string }> = [], onEditTags = jest.fn()) => ({
+  row: createMockRow(tags),
+  table: {
+    options: {
+      meta: createMockTableMeta(onEditTags),
+    },
+  },
+});
+
+describe('ExperimentListTableTagsCell', () => {
+  let onEditTags: ReturnType<typeof jest.fn>;
+
+  beforeEach(() => {
+    onEditTags = jest.fn();
+  });
+
+  it('renders tags correctly when there are 3 or fewer tags', () => {
+    const tags = [
+      { key: 'tag1', value: 'value1' },
+      { key: 'tag2', value: 'value2' },
+      { key: 'tag3', value: 'value3' },
+    ];
+
+    renderWithDesignSystem(<ExperimentListTableTagsCell {...createMockCellContext(tags, onEditTags)} />);
+
+    const renderedTags = screen.getAllByTestId('key-value-tag');
+    expect(renderedTags).toHaveLength(3);
+    expect(screen.queryByText(/\+.*more/)).not.toBeInTheDocument();
+  });
+
+  it('shows "+N more" button when there are more than 3 tags', () => {
+    const tags = [
+      { key: 'tag1', value: 'value1' },
+      { key: 'tag2', value: 'value2' },
+      { key: 'tag3', value: 'value3' },
+      { key: 'tag4', value: 'value4' },
+      { key: 'tag5', value: 'value5' },
+    ];
+
+    renderWithDesignSystem(<ExperimentListTableTagsCell {...createMockCellContext(tags, onEditTags)} />);
+
+    // Should only show 3 tags initially
+    const renderedTags = screen.getAllByTestId('key-value-tag');
+    expect(renderedTags).toHaveLength(3);
+
+    // Should show "+2 more" button
+    expect(screen.getByText('+2 more')).toBeInTheDocument();
+  });
+
+  it('expands to show all tags when "+N more" is clicked', async () => {
+    const tags = [
+      { key: 'tag1', value: 'value1' },
+      { key: 'tag2', value: 'value2' },
+      { key: 'tag3', value: 'value3' },
+      { key: 'tag4', value: 'value4' },
+      { key: 'tag5', value: 'value5' },
+    ];
+
+    renderWithDesignSystem(<ExperimentListTableTagsCell {...createMockCellContext(tags, onEditTags)} />);
+
+    // Click "+2 more" button
+    await userEvent.click(screen.getByText('+2 more'));
+
+    // Should now show all 5 tags
+    const renderedTags = screen.getAllByTestId('key-value-tag');
+    expect(renderedTags).toHaveLength(5);
+
+    // Should show "Show less" button
+    expect(screen.getByText('Show less')).toBeInTheDocument();
+  });
+
+  it('collapses tags when "Show less" is clicked', async () => {
+    const tags = [
+      { key: 'tag1', value: 'value1' },
+      { key: 'tag2', value: 'value2' },
+      { key: 'tag3', value: 'value3' },
+      { key: 'tag4', value: 'value4' },
+    ];
+
+    renderWithDesignSystem(<ExperimentListTableTagsCell {...createMockCellContext(tags, onEditTags)} />);
+
+    // Expand
+    await userEvent.click(screen.getByText('+1 more'));
+    expect(screen.getAllByTestId('key-value-tag')).toHaveLength(4);
+
+    // Collapse
+    await userEvent.click(screen.getByText('Show less'));
+    expect(screen.getAllByTestId('key-value-tag')).toHaveLength(3);
+    expect(screen.getByText('+1 more')).toBeInTheDocument();
+  });
+
+  it('shows "Add tags" button when there are no tags', () => {
+    renderWithDesignSystem(<ExperimentListTableTagsCell {...createMockCellContext([], onEditTags)} />);
+
+    expect(screen.getByText('Add tags')).toBeInTheDocument();
+    expect(screen.queryByTestId('key-value-tag')).not.toBeInTheDocument();
+  });
+
+  it('calls onEditTags when edit button is clicked', async () => {
+    const tags = [{ key: 'tag1', value: 'value1' }];
+    const mockOnEditTags = jest.fn();
+
+    renderWithDesignSystem(<ExperimentListTableTagsCell {...createMockCellContext(tags, mockOnEditTags)} />);
+
+    const editButton = screen.getByRole('button', { name: 'Edit tags' });
+    await userEvent.click(editButton);
+
+    expect(mockOnEditTags).toHaveBeenCalledWith(createMockRow(tags).original);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.tsx
@@ -1,9 +1,12 @@
-import { Button, PencilIcon } from '@databricks/design-system';
+import { Button, ChevronDoubleDownIcon, ChevronDoubleUpIcon, PencilIcon, Tooltip } from '@databricks/design-system';
 import 'react-virtualized/styles.css';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useState } from 'react';
 import { KeyValueTag } from '../../common/components/KeyValueTag';
 import { isUserFacingTag } from '../../common/utils/TagUtils';
 import type { ExperimentTableColumnDef, ExperimentTableMetadata } from './ExperimentListTable';
+
+const MAX_VISIBLE_TAGS = 3;
 
 export const ExperimentListTableTagsCell: ExperimentTableColumnDef['cell'] = ({
   row: { original },
@@ -12,18 +15,69 @@ export const ExperimentListTableTagsCell: ExperimentTableColumnDef['cell'] = ({
   },
 }) => {
   const intl = useIntl();
+  const [showMore, setShowMore] = useState(false);
 
   const { onEditTags } = meta as ExperimentTableMetadata;
 
   const visibleTagList = original?.tags?.filter((tag) => isUserFacingTag(tag.key)) || [];
   const containsTags = visibleTagList.length > 0;
+  const hasMoreTags = visibleTagList.length > MAX_VISIBLE_TAGS;
+
+  const tagsToDisplay = showMore ? visibleTagList : visibleTagList.slice(0, MAX_VISIBLE_TAGS);
+  const remainingTagsCount = visibleTagList.length - MAX_VISIBLE_TAGS;
+
+  // Render tags for overflow tooltip
+  const overflowTagsTooltipContent = hasMoreTags && !showMore
+    ? visibleTagList.slice(MAX_VISIBLE_TAGS).map((tag) => `${tag.key}: ${tag.value || ''}`).join('\n')
+    : null;
 
   return (
-    <div css={{ display: 'flex' }}>
-      <div css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'flex' }}>
-        {visibleTagList?.map((tag) => (
+    <div css={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+      <div css={{ display: 'flex', flexWrap: 'wrap', gap: 4, alignItems: 'center' }}>
+        {tagsToDisplay?.map((tag) => (
           <KeyValueTag key={tag.key} tag={tag} />
         ))}
+        {hasMoreTags && !showMore && (
+          <Tooltip
+            componentId="mlflow.experiment.list.tags.overflow_tooltip"
+            content={overflowTagsTooltipContent}
+            title={
+              <FormattedMessage
+                defaultMessage="Additional tags"
+                description="Tooltip title for overflow tags in experiments table"
+              />
+            }
+          >
+            <Button
+              componentId="mlflow.experiment.list.tags.show_more"
+              size="small"
+              onClick={() => setShowMore(true)}
+              type="tertiary"
+              css={{ flexShrink: 0 }}
+            >
+              <FormattedMessage
+                defaultMessage="+{count} more"
+                description="Show more tags button in experiments table"
+                values={{ count: remainingTagsCount }}
+              />
+            </Button>
+          </Tooltip>
+        )}
+        {showMore && hasMoreTags && (
+          <Button
+            componentId="mlflow.experiment.list.tags.show_less"
+            size="small"
+            onClick={() => setShowMore(false)}
+            icon={<ChevronDoubleUpIcon />}
+            type="tertiary"
+            css={{ flexShrink: 0 }}
+          >
+            <FormattedMessage
+              defaultMessage="Show less"
+              description="Show less tags button in experiments table"
+            />
+          </Button>
+        )}
       </div>
       <Button
         componentId="mlflow.experiment.list.tag.add"


### PR DESCRIPTION
## Summary
Fixes #20867

This PR addresses the issue where experiment tags are visually cut off when they exceed the column width in the Experiments table.

## Changes
- Modified `ExperimentListTableTagsCell.tsx` to limit visible tags to 3 initially
- Added a "+N more" button when there are additional tags (with a tooltip showing the overflow tags)
- Added a "Show less" button to collapse expanded tags back to the default 3
- Changed the layout from `overflow: hidden, nowrap` to `flexWrap: wrap` to allow tags to wrap properly

## Testing
- Added comprehensive unit tests covering:
  - Rendering 3 or fewer tags (no overflow button)
  - Showing "+N more" button when tags exceed 3
  - Expanding to show all tags when button is clicked
  - Collapsing back to 3 tags
  - "Add tags" button when no tags exist
  - Edit tags functionality

## Screenshots
**Before:** Tags would be cut off with horizontal scrollbar, making them unreadable.

**After:** 
- First 3 tags are shown
- "+N more" button with tooltip shows remaining tags
- Click to expand shows all tags
- "Show less" button collapses back

This follows the same pattern used in `ModelListTagsCell` for consistency with the rest of the codebase.