### PR TITLE
[WIP] Support "all" in trace overview charts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/ExperimentGenAIOverviewPage.tsx
@@ -27,6 +27,7 @@ import { TIME_UNIT_SECONDS, calculateDefaultTimeUnit, isTimeUnitValid } from './
 import { generateTimeBuckets } from './utils/chartUtils';
 import { OverviewChartProvider } from './OverviewChartContext';
 import { useOverviewTab, OverviewTab } from './hooks/useOverviewTab';
+import { useEarliestTraceTimestamp } from './hooks/useEarliestTraceTimestamp';
 
 const ExperimentGenAIOverviewPageImpl = () => {
   const { experimentId } = useParams();
@@ -47,19 +48,27 @@ const ExperimentGenAIOverviewPageImpl = () => {
     [monitoringConfig.dateNow, monitoringFilters],
   );
 
-  // Convert ISO strings to milliseconds for the API
-  const startTimeMs = startTime ? new Date(startTime).getTime() : undefined;
-  const endTimeMs = endTime ? new Date(endTime).getTime() : undefined;
+  // Convert ISO strings to milliseconds for the API.
+  // When "ALL" is selected, startTime is undefined — use 0 (epoch) so the
+  // backend returns data across all time while still accepting time_interval_seconds.
+  const isAllTime = monitoringFilters.startTimeLabel === 'ALL';
+  const startTimeMs = startTime ? new Date(startTime).getTime() : 0;
+  const endTimeMs = endTime ? new Date(endTime).getTime() : Date.now();
+
+  // For "ALL" mode, query the earliest trace timestamp so we can validate time
+  // units against the actual data span instead of epoch-to-now.
+  const earliestTraceTimestamp = useEarliestTraceTimestamp([experimentId], isAllTime);
+  const validationStartTimeMs = isAllTime ? (earliestTraceTimestamp ?? endTimeMs) : startTimeMs;
 
   // Calculate the default time unit for the current time range
-  const defaultTimeUnit = calculateDefaultTimeUnit(startTimeMs, endTimeMs);
+  const defaultTimeUnit = calculateDefaultTimeUnit(validationStartTimeMs, endTimeMs);
 
   // Auto-clear if selected time unit becomes invalid due to time range change
   useEffect(() => {
-    if (selectedTimeUnit && !isTimeUnitValid(startTimeMs, endTimeMs, selectedTimeUnit)) {
+    if (selectedTimeUnit && !isTimeUnitValid(validationStartTimeMs, endTimeMs, selectedTimeUnit)) {
       setSelectedTimeUnit(null);
     }
-  }, [startTimeMs, endTimeMs, selectedTimeUnit]);
+  }, [validationStartTimeMs, endTimeMs, selectedTimeUnit]);
 
   // Use selected if valid, otherwise fall back to default
   const effectiveTimeUnit = selectedTimeUnit ?? defaultTimeUnit;
@@ -67,10 +76,12 @@ const ExperimentGenAIOverviewPageImpl = () => {
   // Use the effective time unit for time interval
   const timeIntervalSeconds = TIME_UNIT_SECONDS[effectiveTimeUnit];
 
-  // Generate all time buckets once for all charts
+  // Generate all time buckets once for all charts.
+  // Skip pre-generation for "ALL" — the range is unbounded so we let charts
+  // derive buckets from the server response instead.
   const timeBuckets = useMemo(
-    () => generateTimeBuckets(startTimeMs, endTimeMs, timeIntervalSeconds),
-    [startTimeMs, endTimeMs, timeIntervalSeconds],
+    () => (isAllTime ? [] : generateTimeBuckets(startTimeMs, endTimeMs, timeIntervalSeconds)),
+    [isAllTime, startTimeMs, endTimeMs, timeIntervalSeconds],
   );
 
   return (
@@ -135,20 +146,13 @@ const ExperimentGenAIOverviewPageImpl = () => {
           <TimeUnitSelector
             value={effectiveTimeUnit}
             onChange={setSelectedTimeUnit}
-            startTimeMs={startTimeMs}
+            startTimeMs={validationStartTimeMs}
             endTimeMs={endTimeMs}
             allowClear={selectedTimeUnit !== null && selectedTimeUnit !== defaultTimeUnit}
             onClear={() => setSelectedTimeUnit(null)}
           />
 
-          {/*
-           * Time range selector - exclude 'ALL' since charts require start_time_ms and end_time_ms
-           * TODO: remove this once this is supported in backend
-           */}
-          <TracesV3DateSelector
-            excludeOptions={['ALL']}
-            refreshButtonComponentId="mlflow.experiment.overview.refresh-button"
-          />
+          <TracesV3DateSelector refreshButtonComponentId="mlflow.experiment.overview.refresh-button" />
         </div>
 
         <OverviewChartProvider

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useEarliestTraceTimestamp.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useEarliestTraceTimestamp.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import {
+  MetricViewType,
+  AggregationType,
+  TraceMetricKey,
+  TIME_BUCKET_DIMENSION_KEY,
+} from '@databricks/web-shared/model-trace-explorer';
+import { useTraceMetricsQuery } from './useTraceMetricsQuery';
+import { TIME_UNIT_SECONDS, TimeUnit } from '../utils/timeUtils';
+
+/**
+ * Lightweight hook that determines the earliest trace timestamp for an experiment.
+ * Queries trace count with yearly time buckets (very few results) and returns the
+ * first bucket's timestamp. Used to compute an effective time range for "ALL" mode
+ * so that time unit validation reflects the actual data span, not epoch-to-now.
+ */
+export function useEarliestTraceTimestamp(experimentIds: string[], enabled: boolean) {
+  const { data } = useTraceMetricsQuery({
+    experimentIds,
+    startTimeMs: 0,
+    endTimeMs: Date.now(),
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.TRACE_COUNT,
+    aggregations: [{ aggregation_type: AggregationType.COUNT }],
+    timeIntervalSeconds: TIME_UNIT_SECONDS[TimeUnit.Year],
+    enabled,
+  });
+
+  return useMemo(() => {
+    const dataPoints = data?.data_points ?? [];
+    if (dataPoints.length === 0) return undefined;
+
+    // Data points are ordered by time bucket ascending — first one is the earliest
+    const firstBucket = dataPoints[0]?.dimensions?.[TIME_BUCKET_DIMENSION_KEY];
+    if (!firstBucket) return undefined;
+
+    return new Date(firstBucket).getTime();
+  }, [data?.data_points]);
+}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useToolErrorRateChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useToolErrorRateChartData.ts
@@ -11,7 +11,7 @@ import {
   createSpanFilter,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from './useTraceMetricsQuery';
-import { formatTimestampForTraceMetrics } from '../utils/chartUtils';
+import { formatTimestampForTraceMetrics, getEffectiveTimeBuckets } from '../utils/chartUtils';
 import { useOverviewChartContext } from '../OverviewChartContext';
 
 export interface ToolErrorRateDataPoint {
@@ -102,14 +102,19 @@ export function useToolErrorRateChartData({
     return rateMap;
   }, [dataPoints]);
 
+  const effectiveBuckets = useMemo(
+    () => getEffectiveTimeBuckets(timeBuckets, errorRateByTimestamp),
+    [timeBuckets, errorRateByTimestamp],
+  );
+
   // Build chart data with all time buckets
   const chartData = useMemo(() => {
-    return timeBuckets.map((timestampMs) => ({
+    return effectiveBuckets.map((timestampMs) => ({
       name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
       errorRate: errorRateByTimestamp.get(timestampMs) || 0,
       timestampMs,
     }));
-  }, [timeBuckets, errorRateByTimestamp, timeIntervalSeconds]);
+  }, [effectiveBuckets, errorRateByTimestamp, timeIntervalSeconds]);
 
   // Check if we have actual data
   const hasData = dataPoints.length > 0;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useToolLatencyChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useToolLatencyChartData.ts
@@ -10,7 +10,7 @@ import {
   createSpanFilter,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from './useTraceMetricsQuery';
-import { formatTimestampForTraceMetrics } from '../utils/chartUtils';
+import { formatTimestampForTraceMetrics, getEffectiveTimeBuckets } from '../utils/chartUtils';
 import { useOverviewChartContext } from '../OverviewChartContext';
 
 export interface ToolLatencyDataPoint {
@@ -84,7 +84,8 @@ export function useToolLatencyChartData(): UseToolLatencyChartDataResult {
     const sortedToolNames = Array.from(toolSet).sort();
 
     // Build chart data with all time buckets filled
-    const chartDataResult = timeBuckets.map((timestampMs) => {
+    const effectiveBuckets = getEffectiveTimeBuckets(timeBuckets, dataByTimestamp);
+    const chartDataResult = effectiveBuckets.map((timestampMs) => {
       const toolLatencies = dataByTimestamp.get(timestampMs);
       const dataPoint: ToolLatencyDataPoint = {
         timestamp: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useToolUsageChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useToolUsageChartData.ts
@@ -10,7 +10,7 @@ import {
   createSpanFilter,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from './useTraceMetricsQuery';
-import { formatTimestampForTraceMetrics } from '../utils/chartUtils';
+import { formatTimestampForTraceMetrics, getEffectiveTimeBuckets } from '../utils/chartUtils';
 import { useOverviewChartContext } from '../OverviewChartContext';
 
 export interface ToolUsageDataPoint {
@@ -84,7 +84,8 @@ export function useToolUsageChartData(): UseToolUsageChartDataResult {
     const sortedToolNames = Array.from(toolSet).sort();
 
     // Build chart data with all time buckets filled
-    const chartDataResult = timeBuckets.map((timestampMs) => {
+    const effectiveBuckets = getEffectiveTimeBuckets(timeBuckets, dataByTimestamp);
+    const chartDataResult = effectiveBuckets.map((timestampMs) => {
       const toolCounts = dataByTimestamp.get(timestampMs);
       const dataPoint: ToolUsageDataPoint = {
         timestamp: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceAssessmentChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceAssessmentChartData.ts
@@ -8,7 +8,7 @@ import {
   createAssessmentFilter,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from './useTraceMetricsQuery';
-import { formatTimestampForTraceMetrics, useTimestampValueMap } from '../utils/chartUtils';
+import { formatTimestampForTraceMetrics, useTimestampValueMap, getEffectiveTimeBuckets } from '../utils/chartUtils';
 import {
   sortValuesAlphanumerically,
   shouldCreateHistogramBuckets,
@@ -98,14 +98,19 @@ export function useTraceAssessmentChartData(assessmentName: string): UseTraceAss
   );
   const valuesByTimestamp = useTimestampValueMap(timeSeriesDataPoints, valueExtractor);
 
+  const effectiveBuckets = useMemo(
+    () => getEffectiveTimeBuckets(timeBuckets, valuesByTimestamp),
+    [timeBuckets, valuesByTimestamp],
+  );
+
   // Prepare time series chart data - use null for missing data to show gaps in chart
   const timeSeriesChartData = useMemo(() => {
-    return timeBuckets.map((timestampMs) => ({
+    return effectiveBuckets.map((timestampMs) => ({
       name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
       value: valuesByTimestamp.get(timestampMs) ?? null,
       timestampMs,
     }));
-  }, [timeBuckets, valuesByTimestamp, timeIntervalSeconds]);
+  }, [effectiveBuckets, valuesByTimestamp, timeIntervalSeconds]);
 
   // Prepare distribution chart data - use actual values from API
   const distributionChartData = useMemo(() => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceCostOverTimeChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceCostOverTimeChartData.ts
@@ -7,7 +7,7 @@ import {
   TIME_BUCKET_DIMENSION_KEY,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from './useTraceMetricsQuery';
-import { formatTimestampForTraceMetrics } from '../utils/chartUtils';
+import { formatTimestampForTraceMetrics, getEffectiveTimeBuckets } from '../utils/chartUtils';
 import { useOverviewChartContext } from '../OverviewChartContext';
 import type { CostDimension } from './useTraceCostDimension';
 
@@ -91,9 +91,14 @@ export function useTraceCostOverTimeChartData(dimension: CostDimension = 'model'
     return map;
   }, [dataPoints, dimensionKey]);
 
+  const effectiveBuckets = useMemo(
+    () => getEffectiveTimeBuckets(timeBuckets, costByTimestampAndDimension),
+    [timeBuckets, costByTimestampAndDimension],
+  );
+
   // Prepare chart data - fill in all time buckets with 0 for missing data
   const chartData = useMemo(() => {
-    return timeBuckets.map((timestampMs) => {
+    return effectiveBuckets.map((timestampMs) => {
       const costs = costByTimestampAndDimension.get(timestampMs);
       const dataPoint: CostOverTimeDataPoint = {
         name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
@@ -105,7 +110,7 @@ export function useTraceCostOverTimeChartData(dimension: CostDimension = 'model'
 
       return dataPoint;
     });
-  }, [timeBuckets, costByTimestampAndDimension, dimensionValues, timeIntervalSeconds]);
+  }, [effectiveBuckets, costByTimestampAndDimension, dimensionValues, timeIntervalSeconds]);
 
   // Calculate total cost across all dimension values
   const totalCost = useMemo(() => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceErrorsChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceErrorsChartData.ts
@@ -8,7 +8,7 @@ import {
   createTraceFilter,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from './useTraceMetricsQuery';
-import { formatTimestampForTraceMetrics, useTimestampValueMap } from '../utils/chartUtils';
+import { formatTimestampForTraceMetrics, useTimestampValueMap, getEffectiveTimeBuckets } from '../utils/chartUtils';
 import { useOverviewChartContext } from '../OverviewChartContext';
 
 // Filter to get only error traces
@@ -108,9 +108,14 @@ export function useTraceErrorsChartData(): UseTraceErrorsChartDataResult {
   const errorCountByTimestamp = useTimestampValueMap(errorDataPoints, countExtractor);
   const totalCountByTimestamp = useTimestampValueMap(totalDataPoints, countExtractor);
 
+  const effectiveBuckets = useMemo(
+    () => getEffectiveTimeBuckets(timeBuckets, errorCountByTimestamp, totalCountByTimestamp),
+    [timeBuckets, errorCountByTimestamp, totalCountByTimestamp],
+  );
+
   // Prepare chart data - fill in all time buckets with 0 for missing data
   const chartData = useMemo(() => {
-    return timeBuckets.map((timestampMs) => {
+    return effectiveBuckets.map((timestampMs) => {
       const errorCount = errorCountByTimestamp.get(timestampMs) || 0;
       const totalCount = totalCountByTimestamp.get(timestampMs) || 0;
       const errorRate = totalCount > 0 ? (errorCount / totalCount) * 100 : 0;
@@ -122,7 +127,7 @@ export function useTraceErrorsChartData(): UseTraceErrorsChartDataResult {
         timestampMs,
       };
     });
-  }, [timeBuckets, errorCountByTimestamp, totalCountByTimestamp, timeIntervalSeconds]);
+  }, [effectiveBuckets, errorCountByTimestamp, totalCountByTimestamp, timeIntervalSeconds]);
 
   // Calculate average error rate across time buckets for the reference line
   const avgErrorRate = useMemo(() => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceLatencyChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceLatencyChartData.ts
@@ -9,7 +9,7 @@ import {
   getPercentileKey,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from './useTraceMetricsQuery';
-import { formatTimestampForTraceMetrics, useTimestampValueMap } from '../utils/chartUtils';
+import { formatTimestampForTraceMetrics, useTimestampValueMap, getEffectiveTimeBuckets } from '../utils/chartUtils';
 import { useOverviewChartContext } from '../OverviewChartContext';
 
 export interface LatencyChartDataPoint {
@@ -96,9 +96,14 @@ export function useTraceLatencyChartData(): UseTraceLatencyChartDataResult {
   );
   const latencyByTimestamp = useTimestampValueMap(latencyDataPoints, latencyExtractor);
 
+  const effectiveBuckets = useMemo(
+    () => getEffectiveTimeBuckets(timeBuckets, latencyByTimestamp),
+    [timeBuckets, latencyByTimestamp],
+  );
+
   // Prepare chart data - fill in all time buckets with 0 for missing data
   const chartData = useMemo(() => {
-    return timeBuckets.map((timestampMs) => {
+    return effectiveBuckets.map((timestampMs) => {
       const latency = latencyByTimestamp.get(timestampMs);
       return {
         name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
@@ -108,7 +113,7 @@ export function useTraceLatencyChartData(): UseTraceLatencyChartDataResult {
         timestampMs,
       };
     });
-  }, [timeBuckets, latencyByTimestamp, timeIntervalSeconds]);
+  }, [effectiveBuckets, latencyByTimestamp, timeIntervalSeconds]);
 
   return {
     chartData,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceRequestsChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceRequestsChartData.ts
@@ -2,7 +2,12 @@ import { useMemo, useCallback } from 'react';
 import { MetricViewType, AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from './useTraceMetricsQuery';
 import type { ChartZoomState } from '../utils/chartUtils';
-import { formatTimestampForTraceMetrics, useTimestampValueMap, useChartZoom } from '../utils/chartUtils';
+import {
+  formatTimestampForTraceMetrics,
+  useTimestampValueMap,
+  useChartZoom,
+  getEffectiveTimeBuckets,
+} from '../utils/chartUtils';
 import { useOverviewChartContext } from '../OverviewChartContext';
 
 export interface RequestsChartDataPoint {
@@ -63,9 +68,6 @@ export function useTraceRequestsChartData(): UseTraceRequestsChartDataResult {
     [traceCountDataPoints],
   );
 
-  // Calculate average requests per time bucket
-  const avgRequests = useMemo(() => totalRequests / timeBuckets.length, [totalRequests, timeBuckets.length]);
-
   // Create a map of counts by timestamp using shared utility
   const countExtractor = useCallback(
     (dp: { values?: Record<string, number> }) => dp.values?.[AggregationType.COUNT] || 0,
@@ -73,14 +75,23 @@ export function useTraceRequestsChartData(): UseTraceRequestsChartDataResult {
   );
   const countByTimestamp = useTimestampValueMap(traceCountDataPoints, countExtractor);
 
+  // Derive effective buckets: use pre-generated buckets or fall back to server data timestamps
+  const effectiveBuckets = useMemo(
+    () => getEffectiveTimeBuckets(timeBuckets, countByTimestamp),
+    [timeBuckets, countByTimestamp],
+  );
+
+  // Calculate average requests per time bucket
+  const avgRequests = useMemo(() => totalRequests / effectiveBuckets.length, [totalRequests, effectiveBuckets.length]);
+
   // Prepare chart data - fill in all time buckets with 0 for missing data
   const chartData = useMemo(() => {
-    return timeBuckets.map((timestampMs) => ({
+    return effectiveBuckets.map((timestampMs) => ({
       name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
       count: countByTimestamp.get(timestampMs) || 0,
       timestampMs,
     }));
-  }, [timeBuckets, countByTimestamp, timeIntervalSeconds]);
+  }, [effectiveBuckets, countByTimestamp, timeIntervalSeconds]);
 
   // Zoom functionality
   const zoom = useChartZoom(chartData, 'name');

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenStatsChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenStatsChartData.ts
@@ -9,7 +9,7 @@ import {
   getPercentileKey,
 } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from './useTraceMetricsQuery';
-import { formatTimestampForTraceMetrics, useTimestampValueMap } from '../utils/chartUtils';
+import { formatTimestampForTraceMetrics, useTimestampValueMap, getEffectiveTimeBuckets } from '../utils/chartUtils';
 import { useOverviewChartContext } from '../OverviewChartContext';
 
 export interface TokenStatsChartDataPoint {
@@ -96,9 +96,14 @@ export function useTraceTokenStatsChartData(): UseTraceTokenStatsChartDataResult
   );
   const tokenStatsByTimestamp = useTimestampValueMap(tokenStatsDataPoints, statsExtractor);
 
+  const effectiveBuckets = useMemo(
+    () => getEffectiveTimeBuckets(timeBuckets, tokenStatsByTimestamp),
+    [timeBuckets, tokenStatsByTimestamp],
+  );
+
   // Prepare chart data - fill in all time buckets with 0 for missing data
   const chartData = useMemo(() => {
-    return timeBuckets.map((timestampMs) => {
+    return effectiveBuckets.map((timestampMs) => {
       const stats = tokenStatsByTimestamp.get(timestampMs);
       return {
         name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
@@ -108,7 +113,7 @@ export function useTraceTokenStatsChartData(): UseTraceTokenStatsChartDataResult
         timestampMs,
       };
     });
-  }, [timeBuckets, tokenStatsByTimestamp, timeIntervalSeconds]);
+  }, [effectiveBuckets, tokenStatsByTimestamp, timeIntervalSeconds]);
 
   return {
     chartData,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenUsageChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenUsageChartData.ts
@@ -1,7 +1,7 @@
 import { useMemo, useCallback } from 'react';
 import { MetricViewType, AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
 import { useTraceMetricsQuery } from './useTraceMetricsQuery';
-import { formatTimestampForTraceMetrics, useTimestampValueMap } from '../utils/chartUtils';
+import { formatTimestampForTraceMetrics, useTimestampValueMap, getEffectiveTimeBuckets } from '../utils/chartUtils';
 import { useOverviewChartContext } from '../OverviewChartContext';
 
 export interface TokenUsageChartDataPoint {
@@ -111,15 +111,20 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
   const inputTokensMap = useTimestampValueMap(inputDataPoints, sumExtractor);
   const outputTokensMap = useTimestampValueMap(outputDataPoints, sumExtractor);
 
+  const effectiveBuckets = useMemo(
+    () => getEffectiveTimeBuckets(timeBuckets, inputTokensMap, outputTokensMap),
+    [timeBuckets, inputTokensMap, outputTokensMap],
+  );
+
   // Prepare chart data - fill in all time buckets with 0 for missing data
   const chartData = useMemo(() => {
-    return timeBuckets.map((timestampMs) => ({
+    return effectiveBuckets.map((timestampMs) => ({
       name: formatTimestampForTraceMetrics(timestampMs, timeIntervalSeconds),
       inputTokens: inputTokensMap.get(timestampMs) || 0,
       outputTokens: outputTokensMap.get(timestampMs) || 0,
       timestampMs,
     }));
-  }, [timeBuckets, inputTokensMap, outputTokensMap, timeIntervalSeconds]);
+  }, [effectiveBuckets, inputTokensMap, outputTokensMap, timeIntervalSeconds]);
 
   return {
     chartData,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/chartUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/chartUtils.ts
@@ -187,7 +187,7 @@ export function generateTimeBuckets(
   endTimeMs: number | undefined,
   timeIntervalSeconds: number,
 ): number[] {
-  if (!startTimeMs || !endTimeMs || timeIntervalSeconds <= 0) {
+  if (isNil(startTimeMs) || isNil(endTimeMs) || timeIntervalSeconds <= 0) {
     return [];
   }
 
@@ -202,6 +202,25 @@ export function generateTimeBuckets(
   }
 
   return buckets;
+}
+
+/**
+ * Returns pre-generated timeBuckets when available, otherwise derives sorted
+ * unique timestamps from the keys of the provided lookup maps. This allows
+ * charts to render server-returned data when no pre-generated buckets exist
+ * (e.g. when the "ALL" time range is selected).
+ */
+export function getEffectiveTimeBuckets(timeBuckets: number[], ...maps: Map<number, unknown>[]): number[] {
+  if (timeBuckets.length > 0) {
+    return timeBuckets;
+  }
+  const timestamps = new Set<number>();
+  for (const map of maps) {
+    for (const key of map.keys()) {
+      timestamps.add(key);
+    }
+  }
+  return Array.from(timestamps).sort((a, b) => a - b);
 }
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/timeUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/utils/timeUtils.ts
@@ -1,3 +1,5 @@
+import { isNil } from 'lodash';
+
 export enum TimeUnit {
   Second = 'second',
   Minute = 'minute',
@@ -28,7 +30,7 @@ export function calculateExpectedDataPoints(
   endTimeMs: number | undefined,
   timeUnit: TimeUnit,
 ): number {
-  if (!startTimeMs || !endTimeMs) {
+  if (isNil(startTimeMs) || isNil(endTimeMs)) {
     return 0;
   }
   const durationSeconds = (endTimeMs - startTimeMs) / 1000;
@@ -56,7 +58,7 @@ export function isTimeUnitValid(
  * - > 1 year: year level
  */
 export function calculateDefaultTimeUnit(startTimeMs?: number, endTimeMs?: number): TimeUnit {
-  if (!startTimeMs || !endTimeMs) {
+  if (isNil(startTimeMs) || isNil(endTimeMs)) {
     return TimeUnit.Day;
   }
 


### PR DESCRIPTION
Previously the "All" option was excluded from the date selector because the overview charts required start_time_ms and end_time_ms for time bucketing. This change re-enables it by:

- Passing start_time_ms=0 and end_time_ms=now to the backend for the "All" time range, which the backend handles correctly
- Skipping frontend time bucket pre-generation for "All" to avoid creating empty buckets from epoch to now
- Deriving chart buckets from server response data via a new getEffectiveTimeBuckets utility when pre-generated buckets are empty
- Adding useEarliestTraceTimestamp hook to query the actual data span so time unit validation reflects the real trace range, not epoch
- Fixing falsiness checks for startTimeMs=0 in timeUtils and chartUtils (using isNil instead of !value)

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
