### PR TITLE
Fix pydantic-ai autologging compatibility with pydantic-ai >= 1.63.0

### DIFF
--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -64,6 +64,21 @@ def _patch_method(cls, method_name):
         safe_patch(FLAVOR_NAME, cls, method_name, patched_class_call)
 
 
+def _tool_manager_uses_execute_tool_call() -> bool:
+    """Return True if ToolManager has execute_tool_call (pydantic-ai >= 1.63.0).
+
+    In pydantic-ai >= 1.63.0, _agent_graph._call_tool() calls
+    tool_manager.execute_tool_call() directly rather than handle_call(), so we
+    must patch execute_tool_call to capture the TOOL span.
+    """
+    try:
+        from pydantic_ai._tool_manager import ToolManager
+
+        return hasattr(ToolManager, "execute_tool_call")
+    except ImportError:
+        return False
+
+
 @autologging_integration(FLAVOR_NAME)
 def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False):
     """
@@ -92,7 +107,12 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
             "request",
             "request_stream",
         ],
-        "pydantic_ai._tool_manager.ToolManager": ["handle_call"],
+        # In pydantic-ai >= 1.63.0, _agent_graph calls execute_tool_call directly,
+        # bypassing handle_call. Patch execute_tool_call when available; fall back to
+        # handle_call for older versions where execute_tool_call doesn't exist.
+        "pydantic_ai._tool_manager.ToolManager": ["execute_tool_call"]
+        if _tool_manager_uses_execute_tool_call()
+        else ["handle_call"],
         "pydantic_ai.mcp.MCPServer": ["call_tool", "list_tools"],
     }
 

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -449,10 +449,12 @@ def _parse_usage(result: Any) -> dict[str, int] | None:
 
         # input_tokens/output_tokens are the current field names; request_tokens/
         # response_tokens are deprecated aliases kept for backward compatibility.
-        input_tokens = getattr(usage, "input_tokens", None) or getattr(usage, "request_tokens", 0)
-        output_tokens = getattr(usage, "output_tokens", None) or getattr(
-            usage, "response_tokens", 0
-        )
+        input_tokens = getattr(usage, "input_tokens", None)
+        if input_tokens is None:
+            input_tokens = getattr(usage, "request_tokens", 0)
+        output_tokens = getattr(usage, "output_tokens", None)
+        if output_tokens is None:
+            output_tokens = getattr(usage, "response_tokens", 0)
         total_tokens = getattr(usage, "total_tokens", input_tokens + output_tokens)
         return {
             TokenUsageKey.INPUT_TOKENS: input_tokens,

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -449,9 +449,7 @@ def _parse_usage(result: Any) -> dict[str, int] | None:
 
         # input_tokens/output_tokens are the current field names; request_tokens/
         # response_tokens are deprecated aliases kept for backward compatibility.
-        input_tokens = getattr(usage, "input_tokens", None) or getattr(
-            usage, "request_tokens", 0
-        )
+        input_tokens = getattr(usage, "input_tokens", None) or getattr(usage, "request_tokens", 0)
         output_tokens = getattr(usage, "output_tokens", None) or getattr(
             usage, "response_tokens", 0
         )

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -455,7 +455,9 @@ def _parse_usage(result: Any) -> dict[str, int] | None:
         output_tokens = getattr(usage, "output_tokens", None)
         if output_tokens is None:
             output_tokens = getattr(usage, "response_tokens", 0)
-        total_tokens = getattr(usage, "total_tokens", input_tokens + output_tokens)
+        total_tokens = getattr(usage, "total_tokens")
+        if total_tokens is None:
+            total_tokens = input_tokens + output_tokens
         return {
             TokenUsageKey.INPUT_TOKENS: input_tokens,
             TokenUsageKey.OUTPUT_TOKENS: output_tokens,

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -447,10 +447,19 @@ def _parse_usage(result: Any) -> dict[str, int] | None:
         if usage is None:
             return None
 
+        # input_tokens/output_tokens are the current field names; request_tokens/
+        # response_tokens are deprecated aliases kept for backward compatibility.
+        input_tokens = getattr(usage, "input_tokens", None) or getattr(
+            usage, "request_tokens", 0
+        )
+        output_tokens = getattr(usage, "output_tokens", None) or getattr(
+            usage, "response_tokens", 0
+        )
+        total_tokens = getattr(usage, "total_tokens", input_tokens + output_tokens)
         return {
-            TokenUsageKey.INPUT_TOKENS: usage.request_tokens,
-            TokenUsageKey.OUTPUT_TOKENS: usage.response_tokens,
-            TokenUsageKey.TOTAL_TOKENS: usage.total_tokens,
+            TokenUsageKey.INPUT_TOKENS: input_tokens,
+            TokenUsageKey.OUTPUT_TOKENS: output_tokens,
+            TokenUsageKey.TOTAL_TOKENS: total_tokens,
         }
     except Exception as e:
         _logger.debug(f"Failed to parse token usage from output: {e}")

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -26,6 +26,14 @@ IS_USAGE_DEPRECATED = PYDANTIC_AI_VERSION >= Version("0.7.3")
 HAS_RUN_STREAM_SYNC = hasattr(Agent, "run_stream_sync")
 # Streaming tests require pydantic-ai >= 1.0.0 due to API changes
 HAS_STABLE_STREAMING_API = PYDANTIC_AI_VERSION >= Version("1.0.0")
+# In pydantic-ai >= 1.63.0, _agent_graph calls execute_tool_call directly instead of handle_call
+from pydantic_ai._tool_manager import ToolManager as _ToolManager
+
+TOOL_MANAGER_SPAN_NAME = (
+    "ToolManager.execute_tool_call"
+    if hasattr(_ToolManager, "execute_tool_call")
+    else "ToolManager.handle_call"
+)
 
 
 def _make_dummy_response_without_tool():
@@ -425,7 +433,7 @@ async def test_agent_run_stream_with_tool(agent_with_tool):
     assert spans[1].parent_id == spans[0].span_id
 
     assert spans[2].span_type == SpanType.TOOL
-    assert spans[2].name == "ToolManager.handle_call"
+    assert spans[2].name == TOOL_MANAGER_SPAN_NAME
     assert spans[2].parent_id == spans[0].span_id
 
     assert spans[3].name == "InstrumentedModel.request_stream"
@@ -475,7 +483,7 @@ def test_agent_run_stream_sync_with_tool(agent_with_tool):
     assert spans[1].parent_id == spans[0].span_id
 
     assert spans[2].span_type == SpanType.TOOL
-    assert spans[2].name == "ToolManager.handle_call"
+    assert spans[2].name == TOOL_MANAGER_SPAN_NAME
     assert spans[2].parent_id == spans[0].span_id
 
     assert spans[3].name == "InstrumentedModel.request_stream"

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -26,14 +26,18 @@ IS_USAGE_DEPRECATED = PYDANTIC_AI_VERSION >= Version("0.7.3")
 HAS_RUN_STREAM_SYNC = hasattr(Agent, "run_stream_sync")
 # Streaming tests require pydantic-ai >= 1.0.0 due to API changes
 HAS_STABLE_STREAMING_API = PYDANTIC_AI_VERSION >= Version("1.0.0")
-# In pydantic-ai >= 1.63.0, _agent_graph calls execute_tool_call directly instead of handle_call
-from pydantic_ai._tool_manager import ToolManager as _ToolManager
+# In pydantic-ai >= 1.63.0, _agent_graph calls execute_tool_call directly instead of handle_call.
+# _tool_manager module doesn't exist in older versions (e.g. 0.2.x).
+try:
+    from pydantic_ai._tool_manager import ToolManager as _ToolManager
 
-TOOL_MANAGER_SPAN_NAME = (
-    "ToolManager.execute_tool_call"
-    if hasattr(_ToolManager, "execute_tool_call")
-    else "ToolManager.handle_call"
-)
+    TOOL_MANAGER_SPAN_NAME = (
+        "ToolManager.execute_tool_call"
+        if hasattr(_ToolManager, "execute_tool_call")
+        else "ToolManager.handle_call"
+    )
+except ImportError:
+    TOOL_MANAGER_SPAN_NAME = "ToolManager.handle_call"
 
 
 def _make_dummy_response_without_tool():


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
fix https://github.com/mlflow/dev/actions/runs/22578216207/job/65451155026#step:13:378

pydantic-ai 1.63.0 introduced two changes that broke MLflow's autologging integration:

  1. ToolManager API change: _agent_graph now calls ToolManager.execute_tool_call() directly instead of handle_call(). This caused TOOL spans to be silently dropped. The fix detects which method is available at runtime and patches the correct one (execute_tool_call for >= 1.63.0, handle_call for older versions).
  2. Usage field rename: Token usage fields were renamed from request_tokens/response_tokens to input_tokens/output_tokens. The fix uses getattr with fallbacks to support both old and new field names.
 
### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
