### PR TITLE
Fix Mistral autologging compatibility with mistralai >= 2.0

### DIFF
--- a/mlflow/mistral/__init__.py
+++ b/mlflow/mistral/__init__.py
@@ -24,7 +24,10 @@ def autolog(
         silent: If ``True``, suppress all event logs and warnings from MLflow during Mistral AI
             autologging. If ``False``, show all events and warnings.
     """
-    from mistralai.chat import Chat
+    try:
+        from mistralai.client.chat import Chat  # mistralai >= 2.0
+    except ImportError:
+        from mistralai.chat import Chat  # mistralai < 2.0
 
     safe_patch(
         FLAVOR_NAME,

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -373,10 +373,12 @@ def _check_and_log_warning_for_unsupported_package_versions(integration_name):
     ):
         min_var, _, pip_release = get_min_max_version_and_pip_release(integration_name)
         module = importlib.import_module(FLAVOR_TO_MODULE_NAME[integration_name])
+        installed_version = getattr(module, "__version__", None)
+        if installed_version is None:
+            installed_version = importlib.metadata.version(pip_release)
         _logger.warning(
             f"MLflow {integration_name} autologging is known to be compatible with "
-            f"{min_var} <= {pip_release}, but the installed version is "
-            f"{getattr(module, '__version__', importlib.metadata.version(pip_release))}. "
+            f"{min_var} <= {pip_release}, but the installed version is {installed_version}. "
             "If you encounter errors during autologging, try upgrading "
             f"/ downgrading {pip_release} to a compatible version, or try upgrading MLflow.",
         )

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -373,7 +373,9 @@ def _check_and_log_warning_for_unsupported_package_versions(integration_name):
     ):
         min_var, _, pip_release = get_min_max_version_and_pip_release(integration_name)
         module = importlib.import_module(FLAVOR_TO_MODULE_NAME[integration_name])
-        installed_version = getattr(module, "__version__", None) or importlib.metadata.version(pip_release)
+        installed_version = getattr(module, "__version__", None) or importlib.metadata.version(
+            pip_release
+        )
         _logger.warning(
             f"MLflow {integration_name} autologging is known to be compatible with "
             f"{min_var} <= {pip_release}, but the installed version is {installed_version}. "

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -373,9 +373,7 @@ def _check_and_log_warning_for_unsupported_package_versions(integration_name):
     ):
         min_var, _, pip_release = get_min_max_version_and_pip_release(integration_name)
         module = importlib.import_module(FLAVOR_TO_MODULE_NAME[integration_name])
-        installed_version = getattr(module, "__version__", None)
-        if installed_version is None:
-            installed_version = importlib.metadata.version(pip_release)
+        installed_version = getattr(module, "__version__", None) or importlib.metadata.version(pip_release)
         _logger.warning(
             f"MLflow {integration_name} autologging is known to be compatible with "
             f"{min_var} <= {pip_release}, but the installed version is {installed_version}. "

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -1,5 +1,6 @@
 import contextlib
 import importlib
+import importlib.metadata
 import inspect
 import logging
 import threading
@@ -375,7 +376,7 @@ def _check_and_log_warning_for_unsupported_package_versions(integration_name):
         _logger.warning(
             f"MLflow {integration_name} autologging is known to be compatible with "
             f"{min_var} <= {pip_release}, but the installed version is "
-            f"{module.__version__}. If you encounter errors during autologging, try upgrading "
+            f"{getattr(module, '__version__', importlib.metadata.version(pip_release))}. If you encounter errors during autologging, try upgrading "
             f"/ downgrading {pip_release} to a compatible version, or try upgrading MLflow.",
         )
 

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -376,7 +376,8 @@ def _check_and_log_warning_for_unsupported_package_versions(integration_name):
         _logger.warning(
             f"MLflow {integration_name} autologging is known to be compatible with "
             f"{min_var} <= {pip_release}, but the installed version is "
-            f"{getattr(module, '__version__', importlib.metadata.version(pip_release))}. If you encounter errors during autologging, try upgrading "
+            f"{getattr(module, '__version__', importlib.metadata.version(pip_release))}. "
+            "If you encounter errors during autologging, try upgrading "
             f"/ downgrading {pip_release} to a compatible version, or try upgrading MLflow.",
         )
 

--- a/tests/mistral/test_mistral_autolog.py
+++ b/tests/mistral/test_mistral_autolog.py
@@ -1,16 +1,33 @@
 from unittest.mock import patch
 
 import httpx
-import mistralai
 import pytest
-from mistralai.models import (
-    AssistantMessage,
-    ChatCompletionChoice,
-    ChatCompletionResponse,
-    FunctionCall,
-    ToolCall,
-    UsageInfo,
-)
+try:
+    from mistralai.client import Mistral  # mistralai >= 2.0
+    from mistralai.client.models import (
+        AssistantMessage,
+        ChatCompletionChoice,
+        ChatCompletionResponse,
+        FunctionCall,
+        ToolCall,
+        UsageInfo,
+    )
+
+    CHAT_DO_REQUEST_PATH = "mistralai.client.chat.Chat.do_request"
+    CHAT_DO_REQUEST_ASYNC_PATH = "mistralai.client.chat.Chat.do_request_async"
+except ImportError:
+    from mistralai import Mistral  # mistralai < 2.0
+    from mistralai.models import (
+        AssistantMessage,
+        ChatCompletionChoice,
+        ChatCompletionResponse,
+        FunctionCall,
+        ToolCall,
+        UsageInfo,
+    )
+
+    CHAT_DO_REQUEST_PATH = "mistralai.chat.Chat.do_request"
+    CHAT_DO_REQUEST_ASYNC_PATH = "mistralai.chat.Chat.do_request_async"
 from pydantic import BaseModel
 
 import mlflow.mistral
@@ -149,11 +166,11 @@ def _make_httpx_response(response: BaseModel, status_code: int = 200) -> httpx.R
 
 def test_chat_complete_autolog(mock_litellm_cost):
     with patch(
-        "mistralai.chat.Chat.do_request",
+        CHAT_DO_REQUEST_PATH,
         return_value=_make_httpx_response(DUMMY_CHAT_COMPLETION_RESPONSE),
     ):
         mlflow.mistral.autolog()
-        client = mistralai.Mistral(api_key="test_key")
+        client = Mistral(api_key="test_key")
         client.chat.complete(**DUMMY_CHAT_COMPLETION_REQUEST)
 
     traces = get_traces()
@@ -186,11 +203,11 @@ def test_chat_complete_autolog(mock_litellm_cost):
         }
 
     with patch(
-        "mistralai.chat.Chat.do_request",
+        CHAT_DO_REQUEST_PATH,
         return_value=_make_httpx_response(DUMMY_CHAT_COMPLETION_RESPONSE),
     ):
         mlflow.mistral.autolog(disable=True)
-        client = mistralai.Mistral(api_key="test_key")
+        client = Mistral(api_key="test_key")
         client.chat.complete(**DUMMY_CHAT_COMPLETION_REQUEST)
 
     # No new trace should be created
@@ -200,11 +217,11 @@ def test_chat_complete_autolog(mock_litellm_cost):
 
 def test_chat_complete_autolog_tool_calling():
     with patch(
-        "mistralai.chat.Chat.do_request",
+        CHAT_DO_REQUEST_PATH,
         return_value=_make_httpx_response(DUMMY_CHAT_COMPLETION_WITH_TOOLS_RESPONSE),
     ):
         mlflow.mistral.autolog()
-        client = mistralai.Mistral(api_key="test_key")
+        client = Mistral(api_key="test_key")
         client.chat.complete(**DUMMY_CHAT_COMPLETION_WITH_TOOLS_REQUEST)
 
     traces = get_traces()
@@ -270,11 +287,11 @@ def test_chat_complete_autolog_tool_calling():
 @pytest.mark.asyncio
 async def test_chat_complete_async_autolog():
     with patch(
-        "mistralai.chat.Chat.do_request_async",
+        CHAT_DO_REQUEST_ASYNC_PATH,
         return_value=_make_httpx_response(DUMMY_CHAT_COMPLETION_RESPONSE),
     ):
         mlflow.mistral.autolog()
-        client = mistralai.Mistral(api_key="test_key")
+        client = Mistral(api_key="test_key")
         await client.chat.complete_async(**DUMMY_CHAT_COMPLETION_REQUEST)
 
     traces = get_traces()

--- a/tests/mistral/test_mistral_autolog.py
+++ b/tests/mistral/test_mistral_autolog.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import httpx
 import pytest
+
 try:
     from mistralai.client import Mistral  # mistralai >= 2.0
     from mistralai.client.models import (


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
fix https://github.com/mlflow/dev/actions/runs/22578216207/job/65451158022#step:13:45

mistralai 2.0 introduces some changes that breaks MLflow's autologging integration. This PR fixes:

  1. Module path change: Chat moved from mistralai.chat to mistralai.client.chat in mistralai >= 2.0. The autolog setup now tries the new path first and falls back to the old one for older versions.
  2. Missing __version__ attribute: mistralai >= 2.0 no longer exposes __version__ on the top-level module. The version compatibility warning logic now falls back to importlib.metadata.version() when module.__version__ is unavailable.
 
### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
