### PR TITLE
Fix CrewAI autologging compatibility with crewai >= 1.10

### DIFF
--- a/mlflow/crewai/__init__.py
+++ b/mlflow/crewai/__init__.py
@@ -44,7 +44,9 @@ def autolog(
     CREWAI_VERSION = Version(crewai.__version__)
 
     # _create_long_term_memory was replaced by _save_to_memory in crewai 1.10.0
-    _memory_method = "_save_to_memory" if CREWAI_VERSION >= Version("1.10.0") else "_create_long_term_memory"
+    _memory_method = (
+        "_save_to_memory" if CREWAI_VERSION >= Version("1.10.0") else "_create_long_term_memory"
+    )
     class_method_map = {
         "crewai.Crew": ["kickoff", "kickoff_for_each", "train"],
         "crewai.Agent": ["execute_task"],

--- a/mlflow/crewai/__init__.py
+++ b/mlflow/crewai/__init__.py
@@ -43,6 +43,8 @@ def autolog(
 
     CREWAI_VERSION = Version(crewai.__version__)
 
+    # _create_long_term_memory was replaced by _save_to_memory in crewai 1.10.0
+    _memory_method = "_save_to_memory" if CREWAI_VERSION >= Version("1.10.0") else "_create_long_term_memory"
     class_method_map = {
         "crewai.Crew": ["kickoff", "kickoff_for_each", "train"],
         "crewai.Agent": ["execute_task"],
@@ -50,23 +52,25 @@ def autolog(
         "crewai.LLM": ["call"],
         "crewai.Flow": ["kickoff"],
         "crewai.agents.agent_builder.base_agent_executor_mixin.CrewAgentExecutorMixin": [
-            "_create_long_term_memory"
+            _memory_method
         ],
     }
     standalone_method_map = {}
 
     if CREWAI_VERSION >= Version("0.83.0"):
         # knowledge and memory are not available before 0.83.0
-        class_method_map.update(
-            {
-                "crewai.memory.ShortTermMemory": ["save", "search"],
-                "crewai.memory.LongTermMemory": ["save", "search"],
-                "crewai.memory.EntityMemory": ["save", "search"],
-                "crewai.Knowledge": ["query"],
-            }
-        )
-        if CREWAI_VERSION < Version("0.157.0"):
-            class_method_map.update({"crewai.memory.UserMemory": ["save", "search"]})
+        # ShortTermMemory/LongTermMemory/EntityMemory were replaced by unified MemoryScope in 1.10.0
+        if CREWAI_VERSION < Version("1.10.0"):
+            class_method_map.update(
+                {
+                    "crewai.memory.ShortTermMemory": ["save", "search"],
+                    "crewai.memory.LongTermMemory": ["save", "search"],
+                    "crewai.memory.EntityMemory": ["save", "search"],
+                }
+            )
+            if CREWAI_VERSION < Version("0.157.0"):
+                class_method_map.update({"crewai.memory.UserMemory": ["save", "search"]})
+        class_method_map.update({"crewai.Knowledge": ["query"]})
 
     # Modern Tool calling support for CrewAI >= 0.114.0
     if CREWAI_VERSION >= Version("0.114.0"):

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -851,7 +851,7 @@ crewai:
       pip install git+https://github.com/crewAIInc/crewAI#subdirectory=lib/crewai
   autologging:
     minimum: "0.105.0"
-    maximum: "1.9.3"
+    maximum: "1.10.3"
     unsupported: ["==0.114.0"]
     requirements:
     run: pytest tests/crewai

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -123,7 +123,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.105.0",
-            "maximum": "1.9.3"
+            "maximum": "1.10.3"
         }
     },
     "agno": {

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -23,6 +23,12 @@ _LLM_ANSWER = "What about Tokyo?"
 
 _CREWAI_VERSION = Version(crewai.__version__)
 _IS_CREWAI_V1_OR_LATER = _CREWAI_VERSION.major >= 1
+# _create_long_term_memory was replaced by _save_to_memory in crewai 1.10.0
+_MEMORY_SPAN_NAME = (
+    "CrewAgentExecutor._save_to_memory"
+    if _CREWAI_VERSION >= Version("1.10.0")
+    else "CrewAgentExecutor._create_long_term_memory"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -333,7 +339,7 @@ def test_kickoff_enable_disable_autolog(simple_agent_1, task_1, autolog, mock_li
 
     # Create Long Term Memory
     span_4 = traces[0].data.spans[4]
-    assert span_4.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_4.name == _MEMORY_SPAN_NAME
     assert span_4.span_type == SpanType.MEMORY
     assert span_4.parent_id is span_2.span_id
     assert span_4.inputs == {
@@ -493,7 +499,7 @@ def test_kickoff_tool_calling(tool_agent_1, task_1_with_tool, autolog, mock_lite
         }
     # Create Long Term Memory
     span_6 = traces[0].data.spans[6]
-    assert span_6.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_6.name == _MEMORY_SPAN_NAME
     assert span_6.span_type == SpanType.MEMORY
     assert span_6.parent_id is span_2.span_id
 
@@ -558,7 +564,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
 
     # Create Long Term Memory
     span_4 = traces[0].data.spans[4]
-    assert span_4.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_4.name == _MEMORY_SPAN_NAME
     assert span_4.span_type == SpanType.MEMORY
     assert span_4.parent_id is span_2.span_id
     assert span_4.inputs == {
@@ -600,7 +606,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     assert span_7.model_name == "openai/gpt-4o-mini"
     # Create Long Term Memory
     span_8 = traces[0].data.spans[8]
-    assert span_8.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_8.name == _MEMORY_SPAN_NAME
     assert span_8.span_type == SpanType.MEMORY
     assert span_8.parent_id is span_6.span_id
     assert span_8.inputs == {
@@ -620,8 +626,12 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
 
 
 @pytest.mark.skipif(
-    Version(crewai.__version__) < Version("0.83.0"),
-    reason=("Memory feature in the current style is not available before 0.83.0"),
+    Version(crewai.__version__) < Version("0.83.0")
+    or Version(crewai.__version__) >= Version("1.10.0"),
+    reason=(
+        "Memory feature in the current style is not available before 0.83.0. "
+        "The memory API was redesigned in 1.10.0 and this test needs to be updated."
+    ),
 )
 def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
     crew = Crew(
@@ -731,7 +741,7 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
 
     # Create Long Term Memory
     span_8 = traces[0].data.spans[8]
-    assert span_8.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_8.name == _MEMORY_SPAN_NAME
     assert span_8.span_type == SpanType.MEMORY
     assert span_8.parent_id is span_2.span_id
     assert span_8.inputs == {
@@ -816,7 +826,7 @@ def test_knowledge(simple_agent_1, task_1, monkeypatch, autolog):
 
     # Create Long Term Memory
     span_5 = traces[0].data.spans[5]
-    assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_5.name == _MEMORY_SPAN_NAME
     assert span_5.span_type == SpanType.MEMORY
     assert span_5.parent_id is span_2.span_id
     assert span_5.inputs == {
@@ -896,7 +906,7 @@ def test_kickoff_for_each(simple_agent_1, task_1, autolog):
     assert span_4.model_name == "openai/gpt-4o-mini"
     # Create Long Term Memory
     span_5 = traces[0].data.spans[5]
-    assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_5.name == _MEMORY_SPAN_NAME
     assert span_5.span_type == SpanType.MEMORY
     assert span_5.parent_id is span_3.span_id
     assert span_5.inputs == {
@@ -976,7 +986,7 @@ def test_flow(simple_agent_1, task_1, autolog):
     assert span_4.model_name == "openai/gpt-4o-mini"
     # Create Long Term Memory
     span_5 = traces[0].data.spans[5]
-    assert span_5.name == "CrewAgentExecutor._create_long_term_memory"
+    assert span_5.name == _MEMORY_SPAN_NAME
     assert span_5.span_type == SpanType.MEMORY
     assert span_5.parent_id is span_3.span_id
     assert span_5.inputs == {


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
fix https://github.com/mlflow/dev/actions/runs/22578216207/job/65451158000#step:13:1147

crewai 1.10.0 restructured its memory API, breaking MLflow's autologging integration. This PR addresses three changes:

  1. Method rename: CrewAgentExecutorMixin._create_long_term_memory was replaced by _save_to_memory in crewai >= 1.10.0. The patched method is now selected dynamically based on the installed version.
  2. Memory class removal: ShortTermMemory, LongTermMemory, and EntityMemory were replaced by a unified MemoryScope in crewai >=1.10.0. These classes are now only patched for versions < 1.10.0.
  3. Supported version bump: The maximum tested version in ml-package-versions.yml and ml_package_versions.py is updated from 1.9.3 to 1.10.3.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
