### PR TITLE
Remove redundant "Hide assessments" toggle button

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3889,10 +3889,6 @@
     "defaultMessage": "Total",
     "description": "Label for total token usage"
   },
-  "QK9qFL": {
-    "defaultMessage": "Hide assessments",
-    "description": "Label for the button to hide the assessments pane"
-  },
   "QMCliz": {
     "defaultMessage": "Measure and compare LLM quality with built-in and custom scorers.",
     "description": "Feature card summary for evaluation"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentPaneToggle.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentPaneToggle.tsx
@@ -1,4 +1,4 @@
-import { useDesignSystemTheme, SidebarExpandIcon, Button, SidebarCollapseIcon } from '@databricks/design-system';
+import { Button, SidebarCollapseIcon } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
@@ -7,26 +7,23 @@ export const AssessmentPaneToggle = () => {
   const { assessmentsPaneExpanded, setAssessmentsPaneExpanded, assessmentsPaneEnabled } =
     useModelTraceExplorerViewState();
 
+  if (assessmentsPaneExpanded) {
+    return null;
+  }
+
   return (
     <Button
       disabled={!assessmentsPaneEnabled}
       type="primary"
       componentId="shared.model-trace-explorer.assessments-pane-toggle"
       size="small"
-      icon={assessmentsPaneExpanded ? <SidebarExpandIcon /> : <SidebarCollapseIcon />}
-      onClick={() => setAssessmentsPaneExpanded?.(!assessmentsPaneExpanded)}
+      icon={<SidebarCollapseIcon />}
+      onClick={() => setAssessmentsPaneExpanded?.(true)}
     >
-      {assessmentsPaneExpanded ? (
-        <FormattedMessage
-          defaultMessage="Hide assessments"
-          description="Label for the button to hide the assessments pane"
-        />
-      ) : (
-        <FormattedMessage
-          defaultMessage="Show assessments"
-          description="Label for the button to show the assessments pane"
-        />
-      )}
+      <FormattedMessage
+        defaultMessage="Show assessments"
+        description="Label for the button to show the assessments pane"
+      />
     </Button>
   );
 };


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21281

### What changes are proposed in this pull request?

Split from #21281 per [review feedback](https://github.com/mlflow/mlflow/pull/21281#discussion_r2876297325).

The "Hide assessments" toggle button now returns `null` when the pane is expanded, since the close (x) button inside the pane already handles hiding. The "Show assessments" button still appears when the pane is collapsed.

Please see the linked PR and UI preview for the visual difference.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Removed the redundant "Hide assessments" toggle button — the close (x) button inside the pane already provides this functionality.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)