### PR TITLE
Fix stale prompt cache after prompt deletion

### DIFF
--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -414,6 +414,13 @@ class PromptCache:
         with self._lock:
             self._cache.pop(key, None)
 
+    def delete_all(self, prompt_name: str) -> None:
+        """Delete all cached entries for a prompt name."""
+        with self._lock:
+            keys_to_delete = [key for key in self._cache if key.name == prompt_name]
+            for key in keys_to_delete:
+                self._cache.pop(key, None)
+
     def clear(self) -> None:
         """Clear all cached prompts."""
         with self._lock:

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -417,7 +417,8 @@ class PromptCache:
     def delete_all(self, prompt_name: str) -> None:
         """Delete all cached entries for a prompt name."""
         with self._lock:
-            for key in (key for key in tuple(self._cache) if key.name == prompt_name):
+            keys_to_delete = [key for key in self._cache if key.name == prompt_name]
+            for key in keys_to_delete:
                 self._cache.pop(key, None)
 
     def clear(self) -> None:

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -417,8 +417,7 @@ class PromptCache:
     def delete_all(self, prompt_name: str) -> None:
         """Delete all cached entries for a prompt name."""
         with self._lock:
-            keys_to_delete = [key for key in self._cache if key.name == prompt_name]
-            for key in keys_to_delete:
+            for key in (key for key in tuple(self._cache) if key.name == prompt_name):
                 self._cache.pop(key, None)
 
     def clear(self) -> None:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -6158,7 +6158,11 @@ class MlflowClient:
             client.delete_prompt_version("my_prompt", "1")
         """
         registry_client = self._get_registry_client()
-        return registry_client.delete_prompt_version(name, version)
+        registry_client.delete_prompt_version(name, version)
+
+        # Invalidate all cache entries for this prompt name since aliases and
+        # "latest" may also resolve to the deleted version.
+        PromptCache.get_instance().delete_all(name)
 
     @require_prompt_registry
     @translate_prompt_exception
@@ -6331,7 +6335,9 @@ class MlflowClient:
         # the background thread holds a session open while we try to delete.
         with _prompt_experiment_link_lock:
             # For non-Unity Catalog registries, or if version check passes, delete the prompt
-            return registry_client.delete_prompt(name)
+            registry_client.delete_prompt(name)
+            PromptCache.get_instance().delete_all(name)
+            return
 
     @experimental(version="3.4.0")
     @_disable_in_databricks()

--- a/tests/genai/utils/test_prompt_cache.py
+++ b/tests/genai/utils/test_prompt_cache.py
@@ -74,6 +74,26 @@ def test_delete_prompt_by_alias():
     assert cache.get(key2) == "value2"  # staging still cached
 
 
+def test_delete_all_prompt_entries():
+    cache = PromptCache.get_instance()
+    key1 = PromptCacheKey.from_parts("my-prompt", version=1)
+    key2 = PromptCacheKey.from_parts("my-prompt", version=2)
+    key3 = PromptCacheKey.from_parts("my-prompt", alias="latest")
+    key4 = PromptCacheKey.from_parts("other-prompt", version=1)
+
+    cache.set(key1, "value1")
+    cache.set(key2, "value2")
+    cache.set(key3, "value3")
+    cache.set(key4, "value4")
+
+    cache.delete_all("my-prompt")
+
+    assert cache.get(key1) is None
+    assert cache.get(key2) is None
+    assert cache.get(key3) is None
+    assert cache.get(key4) == "value4"
+
+
 def test_clear():
     cache = PromptCache.get_instance()
     key1 = PromptCacheKey.from_parts("prompt1", version=1)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -77,6 +77,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_USER,
 )
 from mlflow.utils.os import is_windows
+from mlflow.prompt.registry_utils import PromptCache
 
 from tests.tracing.conftest import async_logging_enabled  # noqa: F401
 from tests.tracing.helper import create_test_trace_info, get_traces
@@ -683,6 +684,13 @@ def disable_prompt_cache():
     yield
     MLFLOW_ALIAS_PROMPT_CACHE_TTL_SECONDS.unset()
     MLFLOW_VERSION_PROMPT_CACHE_TTL_SECONDS.unset()
+
+
+@pytest.fixture
+def reset_prompt_cache():
+    PromptCache._reset_instance()
+    yield
+    PromptCache._reset_instance()
 
 
 @pytest.fixture(params=["file", "sqlalchemy"])
@@ -2477,6 +2485,59 @@ def test_delete_prompt_version_no_auto_cleanup(tracking_uri):
         client.get_prompt_version("test_prompt", 1)
 
 
+def test_delete_prompt_version_invalidates_cached_load_prompt(tracking_uri, reset_prompt_cache):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    client.register_prompt(name="test_prompt", template="Version 1")
+    loaded = client.load_prompt("test_prompt", version=1)
+    assert loaded.template == "Version 1"
+
+    client.delete_prompt_version("test_prompt", "1")
+
+    with pytest.raises(MlflowException, match=r"Prompt.*name=test_prompt.*version=1.*not found"):
+        client.get_prompt_version("test_prompt", 1)
+
+    with pytest.raises(MlflowException, match=r"Prompt.*name=test_prompt.*version=1.*not found"):
+        client.load_prompt("test_prompt", version=1)
+
+
+def test_delete_prompt_version_invalidates_latest_cache(tracking_uri, reset_prompt_cache):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    client.register_prompt(name="test_prompt", template="Version 1")
+    client.register_prompt(name="test_prompt", template="Version 2")
+
+    latest_prompt = client.load_prompt("prompts:/test_prompt@latest")
+    assert latest_prompt.version == 2
+    assert latest_prompt.template == "Version 2"
+
+    client.delete_prompt_version("test_prompt", "2")
+
+    latest_prompt_after_delete = client.load_prompt("prompts:/test_prompt@latest")
+    assert latest_prompt_after_delete.version == 1
+    assert latest_prompt_after_delete.template == "Version 1"
+
+
+def test_delete_prompt_version_invalidates_alias_cache(tracking_uri, reset_prompt_cache):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    client.register_prompt(name="test_prompt", template="Version 1")
+    client.register_prompt(name="test_prompt", template="Version 2")
+    client.set_prompt_alias("test_prompt", alias="production", version=1)
+
+    aliased_prompt = client.load_prompt("prompts:/test_prompt@production")
+    assert aliased_prompt.version == 1
+    assert aliased_prompt.template == "Version 1"
+
+    client.delete_prompt_version("test_prompt", "1")
+
+    with pytest.raises(
+        MlflowException,
+        match=r"Prompt (.*) does not exist.|Prompt alias (.*) not found.|Prompt.*version=1.*not found",
+    ):
+        client.load_prompt("prompts:/test_prompt@production")
+
+
 def test_delete_prompt_with_no_versions(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
     mlflow.set_experiment("test_delete_prompt_with_no_versions")
@@ -2495,6 +2556,22 @@ def test_delete_prompt_with_no_versions(tracking_uri):
     # Prompt should be gone
     prompt = client.get_prompt("empty_prompt")
     assert prompt is None
+
+
+def test_delete_prompt_invalidates_cached_load_prompt(tracking_uri, reset_prompt_cache):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    client.register_prompt(name="test_prompt", template="Version 1")
+    loaded = client.load_prompt("test_prompt", version=1)
+    assert loaded.template == "Version 1"
+
+    client.delete_prompt_version("test_prompt", "1")
+    client.delete_prompt("test_prompt")
+
+    assert client.get_prompt("test_prompt") is None
+
+    with pytest.raises(MlflowException, match=r"Prompt.*name=test_prompt.*not found"):
+        client.load_prompt("test_prompt", version=1)
 
 
 def test_delete_prompt_complete_workflow(tracking_uri):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2488,57 +2488,63 @@ def test_delete_prompt_version_no_auto_cleanup(tracking_uri):
 def test_delete_prompt_version_invalidates_cached_load_prompt(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
-    client.register_prompt(name="test_prompt", template="Version 1")
-    loaded = client.load_prompt("test_prompt", version=1)
+    prompt_ver = client.register_prompt(name="test_prompt", template="Version 1")
+    loaded = client.load_prompt(prompt_ver.name, version=prompt_ver.version)
     assert loaded.template == "Version 1"
 
-    client.delete_prompt_version("test_prompt", "1")
+    client.delete_prompt_version(prompt_ver.name, str(prompt_ver.version))
 
-    with pytest.raises(MlflowException, match=r"Prompt.*name=test_prompt.*version=1.*not found"):
-        client.get_prompt_version("test_prompt", 1)
+    with pytest.raises(
+        MlflowException,
+        match=rf"Prompt.*name={prompt_ver.name}.*version={prompt_ver.version}.*not found",
+    ):
+        client.get_prompt_version(prompt_ver.name, prompt_ver.version)
 
-    with pytest.raises(MlflowException, match=r"Prompt.*name=test_prompt.*version=1.*not found"):
-        client.load_prompt("test_prompt", version=1)
+    with pytest.raises(
+        MlflowException,
+        match=rf"Prompt.*name={prompt_ver.name}.*version={prompt_ver.version}.*not found",
+    ):
+        client.load_prompt(prompt_ver.name, version=prompt_ver.version)
 
 
 def test_delete_prompt_version_invalidates_latest_cache(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
-    client.register_prompt(name="test_prompt", template="Version 1")
-    client.register_prompt(name="test_prompt", template="Version 2")
+    prompt_v1 = client.register_prompt(name="test_prompt", template="Version 1")
+    prompt_v2 = client.register_prompt(name=prompt_v1.name, template="Version 2")
 
-    latest_prompt = client.load_prompt("prompts:/test_prompt@latest")
-    assert latest_prompt.version == 2
-    assert latest_prompt.template == "Version 2"
+    latest_prompt = client.load_prompt(f"prompts:/{prompt_v1.name}@latest")
+    assert latest_prompt.version == prompt_v2.version
+    assert latest_prompt.template == prompt_v2.template
 
-    client.delete_prompt_version("test_prompt", "2")
+    client.delete_prompt_version(prompt_v2.name, str(prompt_v2.version))
 
-    latest_prompt_after_delete = client.load_prompt("prompts:/test_prompt@latest")
-    assert latest_prompt_after_delete.version == 1
-    assert latest_prompt_after_delete.template == "Version 1"
+    latest_prompt_after_delete = client.load_prompt(f"prompts:/{prompt_v1.name}@latest")
+    assert latest_prompt_after_delete.version == prompt_v1.version
+    assert latest_prompt_after_delete.template == prompt_v1.template
 
 
 def test_delete_prompt_version_invalidates_alias_cache(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
-    client.register_prompt(name="test_prompt", template="Version 1")
-    client.register_prompt(name="test_prompt", template="Version 2")
-    client.set_prompt_alias("test_prompt", alias="production", version=1)
+    prompt_v1 = client.register_prompt(name="test_prompt", template="Version 1")
+    client.register_prompt(name=prompt_v1.name, template="Version 2")
+    client.set_prompt_alias(prompt_v1.name, alias="production", version=prompt_v1.version)
 
-    aliased_prompt = client.load_prompt("prompts:/test_prompt@production")
-    assert aliased_prompt.version == 1
-    assert aliased_prompt.template == "Version 1"
+    aliased_prompt = client.load_prompt(f"prompts:/{prompt_v1.name}@production")
+    assert aliased_prompt.version == prompt_v1.version
+    assert aliased_prompt.template == prompt_v1.template
 
-    client.delete_prompt_version("test_prompt", "1")
+    client.delete_prompt_version(prompt_v1.name, str(prompt_v1.version))
 
     with pytest.raises(
         MlflowException,
         match=(
             r"Prompt (.*) does not exist.|Prompt alias (.*) not found.|"
-            r"Prompt.*version=1.*not found"
+            rf"Prompt.*version={prompt_v1.version}.*not found"
         ),
     ):
-        client.load_prompt("prompts:/test_prompt@production")
+        client.load_prompt(f"prompts:/{prompt_v1.name}@production")
 
 
 def test_delete_prompt_with_no_versions(tracking_uri):
@@ -2564,16 +2570,16 @@ def test_delete_prompt_with_no_versions(tracking_uri):
 def test_delete_prompt_invalidates_cached_load_prompt(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
-    client.register_prompt(name="test_prompt", template="Version 1")
-    loaded = client.load_prompt("test_prompt", version=1)
+    prompt_ver = client.register_prompt(name="test_prompt", template="Version 1")
+    loaded = client.load_prompt(prompt_ver.name, version=prompt_ver.version)
     assert loaded.template == "Version 1"
 
-    client.delete_prompt("test_prompt")
+    client.delete_prompt(prompt_ver.name)
 
-    assert client.get_prompt("test_prompt") is None
+    assert client.get_prompt(prompt_ver.name) is None
 
-    with pytest.raises(MlflowException, match=r"Prompt.*name=test_prompt.*not found"):
-        client.load_prompt("test_prompt", version=1)
+    with pytest.raises(MlflowException, match=rf"Prompt.*name={prompt_ver.name}.*not found"):
+        client.load_prompt(prompt_ver.name, version=prompt_ver.version)
 
 
 def test_delete_prompt_complete_workflow(tracking_uri):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -50,6 +50,7 @@ from mlflow.exceptions import (
     MlflowTraceDataCorrupted,
     MlflowTraceDataNotFound,
 )
+from mlflow.prompt.registry_utils import PromptCache
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.sqlalchemy_store import (
@@ -77,7 +78,6 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_USER,
 )
 from mlflow.utils.os import is_windows
-from mlflow.prompt.registry_utils import PromptCache
 
 from tests.tracing.conftest import async_logging_enabled  # noqa: F401
 from tests.tracing.helper import create_test_trace_info, get_traces
@@ -686,7 +686,7 @@ def disable_prompt_cache():
     MLFLOW_VERSION_PROMPT_CACHE_TTL_SECONDS.unset()
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def reset_prompt_cache():
     PromptCache._reset_instance()
     yield
@@ -2485,7 +2485,7 @@ def test_delete_prompt_version_no_auto_cleanup(tracking_uri):
         client.get_prompt_version("test_prompt", 1)
 
 
-def test_delete_prompt_version_invalidates_cached_load_prompt(tracking_uri, reset_prompt_cache):
+def test_delete_prompt_version_invalidates_cached_load_prompt(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
     client.register_prompt(name="test_prompt", template="Version 1")
@@ -2501,7 +2501,7 @@ def test_delete_prompt_version_invalidates_cached_load_prompt(tracking_uri, rese
         client.load_prompt("test_prompt", version=1)
 
 
-def test_delete_prompt_version_invalidates_latest_cache(tracking_uri, reset_prompt_cache):
+def test_delete_prompt_version_invalidates_latest_cache(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
     client.register_prompt(name="test_prompt", template="Version 1")
@@ -2518,7 +2518,7 @@ def test_delete_prompt_version_invalidates_latest_cache(tracking_uri, reset_prom
     assert latest_prompt_after_delete.template == "Version 1"
 
 
-def test_delete_prompt_version_invalidates_alias_cache(tracking_uri, reset_prompt_cache):
+def test_delete_prompt_version_invalidates_alias_cache(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
     client.register_prompt(name="test_prompt", template="Version 1")
@@ -2533,7 +2533,10 @@ def test_delete_prompt_version_invalidates_alias_cache(tracking_uri, reset_promp
 
     with pytest.raises(
         MlflowException,
-        match=r"Prompt (.*) does not exist.|Prompt alias (.*) not found.|Prompt.*version=1.*not found",
+        match=(
+            r"Prompt (.*) does not exist.|Prompt alias (.*) not found.|"
+            r"Prompt.*version=1.*not found"
+        ),
     ):
         client.load_prompt("prompts:/test_prompt@production")
 
@@ -2558,14 +2561,13 @@ def test_delete_prompt_with_no_versions(tracking_uri):
     assert prompt is None
 
 
-def test_delete_prompt_invalidates_cached_load_prompt(tracking_uri, reset_prompt_cache):
+def test_delete_prompt_invalidates_cached_load_prompt(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
     client.register_prompt(name="test_prompt", template="Version 1")
     loaded = client.load_prompt("test_prompt", version=1)
     assert loaded.template == "Version 1"
 
-    client.delete_prompt_version("test_prompt", "1")
     client.delete_prompt("test_prompt")
 
     assert client.get_prompt("test_prompt") is None


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #21380

### What changes are proposed in this pull request?
<!-- Please fill in changes proposed in this PR. -->
This PR fixes stale prompt cache behavior after prompt deletion in `MlflowClient`. Previously, `load_prompt()` could still return a deleted prompt version from the in-process `PromptCache` after `delete_prompt_version()` or `delete_prompt()` succeeded. This change invalidates prompt cache entries for both delete flows and adds tests for cached direct-version, `@latest`, alias-based, and prompt deletion cases. For `delete_prompt_version()`, the invalidation is done at the prompt-name level so alias and `@latest` entries for the same prompt do not remain stale.

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests

<!-- Attach code, screenshot, video used for manual testing here. -->

uv run pytest tests/tracking/test_client.py tests/genai/utils/test_prompt_cache.py

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No. You can skip the rest of this section.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fixed a prompt registry cache invalidation bug where deleted prompt versions could still be loaded from long-lived Python processes via `MlflowClient.load_prompt()`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
