### PR TITLE
Remove span name deduplication suffix from TypeScript SDK

### DIFF
--- a/libs/typescript/core/src/core/utils/index.ts
+++ b/libs/typescript/core/src/core/utils/index.ts
@@ -1,5 +1,5 @@
 import type { HrTime } from '@opentelemetry/api';
-import { LiveSpan, Span } from '../entities/span';
+import { Span } from '../entities/span';
 import { SpanAttributeKey } from '../constants';
 import { TokenUsage } from '../entities/trace_info';
 
@@ -95,50 +95,6 @@ export function decodeIdFromBase64(base64SpanId: string): string {
   return Array.from(bytes)
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
-}
-
-/**
- * Deduplicate span names in the trace data by appending an index number to the span name.
- *
- * This is only applied when there are multiple spans with the same name. The span names
- * are modified in place to avoid unnecessary copying.
- *
- * Examples:
- *   ["red", "red"] -> ["red_1", "red_2"]
- *   ["red", "red", "blue"] -> ["red_1", "red_2", "blue"]
- *
- * @param spans A list of spans to deduplicate
- */
-export function deduplicateSpanNamesInPlace(spans: LiveSpan[]): void {
-  // Count occurrences of each span name
-  const spanNameCounter = new Map<string, number>();
-
-  for (const span of spans) {
-    const name = span.name;
-    spanNameCounter.set(name, (spanNameCounter.get(name) || 0) + 1);
-  }
-
-  // Apply renaming only for duplicated spans
-  const spanNameIndexes = new Map<string, number>();
-  for (const [name, count] of spanNameCounter.entries()) {
-    if (count > 1) {
-      spanNameIndexes.set(name, 1);
-    }
-  }
-
-  // Add index to the duplicated span names
-  for (const span of spans) {
-    const name = span.name;
-    const currentIndex = spanNameIndexes.get(name);
-
-    if (currentIndex !== undefined) {
-      // Modify the span name in place by accessing the internal OpenTelemetry span
-      // The 'name' field is readonly in OTel but we need to jail-break it here
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      (span._span as any).name = `${name}_${currentIndex}`;
-      spanNameIndexes.set(name, currentIndex + 1);
-    }
-  }
 }
 
 /**

--- a/libs/typescript/core/src/exporters/mlflow.ts
+++ b/libs/typescript/core/src/exporters/mlflow.ts
@@ -20,7 +20,6 @@ import {
 } from '../core/constants';
 import {
   convertHrTimeToMs,
-  deduplicateSpanNamesInPlace,
   aggregateUsageFromSpans,
 } from '../core/utils';
 import { getConfig } from '../core/config';
@@ -115,8 +114,6 @@ export class MlflowSpanProcessor implements SpanProcessor {
     }
 
     this.updateTraceInfo(trace.info, span);
-    deduplicateSpanNamesInPlace(Array.from(trace.spanDict.values()));
-
     // Aggregate token usage from all spans and add to trace metadata
     const allSpans = Array.from(trace.spanDict.values());
     const aggregatedUsage = aggregateUsageFromSpans(allSpans);

--- a/libs/typescript/core/src/exporters/mlflow.ts
+++ b/libs/typescript/core/src/exporters/mlflow.ts
@@ -18,10 +18,7 @@ import {
   TRACE_SCHEMA_VERSION,
   TraceMetadataKey,
 } from '../core/constants';
-import {
-  convertHrTimeToMs,
-  aggregateUsageFromSpans,
-} from '../core/utils';
+import { convertHrTimeToMs, aggregateUsageFromSpans } from '../core/utils';
 import { getConfig } from '../core/config';
 import { MlflowClient } from '../clients';
 import { executeOnSpanEndHooks, executeOnSpanStartHooks } from './span_processor_hooks';

--- a/libs/typescript/core/tests/core/utils/index.test.ts
+++ b/libs/typescript/core/tests/core/utils/index.test.ts
@@ -5,12 +5,8 @@ import {
   encodeSpanIdToBase64,
   encodeTraceIdToBase64,
   decodeIdFromBase64,
-  deduplicateSpanNamesInPlace,
   mapArgsToObject,
 } from '../../../src/core/utils';
-import { createTestSpan } from '../../helper';
-import { LiveSpan } from '../../../src/core/entities/span';
-
 describe('utils', () => {
   describe('convertNanoSecondsToHrTime', () => {
     // Using table-driven tests with test.each for time conversion
@@ -279,63 +275,6 @@ describe('utils', () => {
       const traceBase64_2 = encodeTraceIdToBase64(traceId);
       expect(traceBase64_1).toBe(traceBase64_2);
     });
-  });
-});
-
-describe('deduplicateSpanNamesInPlace', () => {
-  it('should deduplicate spans with duplicate names', () => {
-    const spans = [createTestSpan('red'), createTestSpan('red')];
-
-    deduplicateSpanNamesInPlace(spans);
-
-    expect(spans[0].name).toBe('red_1');
-    expect(spans[1].name).toBe('red_2');
-  });
-
-  it('should deduplicate only duplicate names, leaving unique names unchanged', () => {
-    const spans = [createTestSpan('red'), createTestSpan('red'), createTestSpan('blue')];
-
-    deduplicateSpanNamesInPlace(spans);
-
-    expect(spans[0].name).toBe('red_1');
-    expect(spans[1].name).toBe('red_2');
-    expect(spans[2].name).toBe('blue');
-  });
-
-  it('should handle multiple sets of duplicates', () => {
-    const spans = [
-      createTestSpan('red'),
-      createTestSpan('blue'),
-      createTestSpan('red'),
-      createTestSpan('green'),
-      createTestSpan('blue'),
-      createTestSpan('red'),
-    ];
-    deduplicateSpanNamesInPlace(spans);
-
-    expect(spans[0].name).toBe('red_1');
-    expect(spans[1].name).toBe('blue_1');
-    expect(spans[2].name).toBe('red_2');
-    expect(spans[3].name).toBe('green');
-    expect(spans[4].name).toBe('blue_2');
-    expect(spans[5].name).toBe('red_3');
-  });
-
-  it('should handle spans with no duplicates', () => {
-    const spans = [createTestSpan('red'), createTestSpan('blue'), createTestSpan('green')];
-
-    deduplicateSpanNamesInPlace(spans);
-
-    expect(spans[0].name).toBe('red');
-    expect(spans[1].name).toBe('blue');
-    expect(spans[2].name).toBe('green');
-  });
-
-  it('should handle empty array', () => {
-    const spans: LiveSpan[] = [];
-
-    expect(() => deduplicateSpanNamesInPlace(spans)).not.toThrow();
-    expect(spans.length).toBe(0);
   });
 });
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

The TypeScript SDK currently appends numeric suffixes (`_1`, `_2`, ...) to duplicate span names during trace export via `deduplicateSpanNamesInPlace`. This behavior was already removed from the Python SDK as it is unnecessary. This PR aligns the TypeScript SDK by removing the same deduplication logic.

Changes:
- Remove `deduplicateSpanNamesInPlace` function from `libs/typescript/core/src/core/utils/index.ts`
- Remove the call to `deduplicateSpanNamesInPlace` in `MlflowSpanProcessor.onEnd` in `libs/typescript/core/src/exporters/mlflow.ts`
- Remove corresponding test suite and unused imports

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Span names in the TypeScript SDK will no longer have numeric suffixes (`_1`, `_2`, ...) appended to duplicate names, aligning behavior with the Python SDK.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)