### PR TITLE
Fix spurious OTLP exporter warning in trace_disabled decorator

### DIFF
--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -748,35 +748,33 @@ def trace_disabled(f: Callable[P, R]) -> Callable[P, R]:
 
     @functools.wraps(f)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        is_func_called = False
-        result = None
+        if not is_tracing_enabled():
+            return f(*args, **kwargs)
+
+        # Save the current tracer provider and swap in a NoOp, then restore it
+        # after the function completes. This avoids calling enable() which would
+        # re-initialize the tracer provider from scratch and may fail if optional
+        # dependencies (e.g. OTLP exporter) are not installed.
         try:
-            if is_tracing_enabled():
-                disable()
-                try:
-                    is_func_called = True
-                    result = f(*args, **kwargs)
-                finally:
-                    enable()
-            else:
-                is_func_called = True
-                result = f(*args, **kwargs)
-        # We should only catch the exception from disable() and enable()
-        # and let other exceptions propagate.
-        except MlflowTracingException as e:
+            saved_provider = provider.get()
+            saved_once_done = provider.once._done
+            provider.set(trace.NoOpTracerProvider())
+            provider.once._done = True
+        except Exception as e:
             _logger.warning(
-                f"An error occurred while disabling or re-enabling tracing: {e} "
+                f"An error occurred while disabling tracing: {e} "
                 "The original function will still be executed, but the tracing "
                 "state may not be as expected. For full traceback, set "
                 "logging level to debug.",
                 exc_info=_logger.isEnabledFor(logging.DEBUG),
             )
-            # If the exception is raised before the original function
-            # is called, we should call the original function
-            if not is_func_called:
-                result = f(*args, **kwargs)
+            return f(*args, **kwargs)
 
-        return result
+        try:
+            return f(*args, **kwargs)
+        finally:
+            provider.set(saved_provider)
+            provider.once._done = saved_once_done
 
     return wrapper
 

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -295,21 +295,12 @@ def test_trace_disabled_decorator(enabled_initially):
     assert len(get_traces()) == 0
     assert is_tracing_enabled() == enabled_initially
 
-    # @trace_disabled should not block the decorated function even
-    # if it fails to disable tracing
-    with mock.patch(
-        "mlflow.tracing.provider.disable", side_effect=MlflowTracingException("error")
-    ) as disable_mock:
+    # @trace_disabled should not re-initialize the tracer provider.
+    # It saves/restores the existing provider, so enable() is never called.
+    with mock.patch("mlflow.tracing.provider.enable") as enable_mock:
         assert test_fn() == 0
         assert call_count == 3
-        assert disable_mock.call_count == (1 if enabled_initially else 0)
-
-    with mock.patch(
-        "mlflow.tracing.provider.enable", side_effect=MlflowTracingException("error")
-    ) as enable_mock:
-        assert test_fn() == 0
-        assert call_count == 4
-        assert enable_mock.call_count == (1 if enabled_initially else 0)
+        enable_mock.assert_not_called()
 
 
 def test_disable_enable_tracing_not_mutate_otel_provider(monkeypatch):


### PR DESCRIPTION
### Related Issues/PRs

N/A (reported internally)

### What changes are proposed in this pull request?

In Databricks model serving/apps, enabling the OTEL feature automatically injects `OTEL_EXPORTER_OTLP_*` environment variables into the container. When a user deploys a model **without** intending to use MLflow tracing, `load_model()` (decorated with `@trace_disabled`) would trigger a noisy warning:

```
WARNING mlflow.tracing.provider: An error occurred while disabling or re-enabling tracing:
HTTP OTLP exporter is not available. Please install the required dependency by running
`pip install opentelemetry-exporter-otlp-proto-http`.
```

**Root cause:** The `@trace_disabled` decorator called `disable()` then `enable()` to temporarily suppress tracing. The `enable()` call re-initialized the tracer provider from scratch, which tried to set up the OTLP exporter — failing when the package wasn't installed.

**Fix:** Instead of `disable()`/`enable()`, save the current tracer provider, swap in `NoOpTracerProvider`, and restore the original after the function completes. This avoids the full re-initialization while preserving the guarantee that the decorated function always executes even if tracing operations fail.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Repro script (`dev/repro_otlp_warning.py` — not included in the PR):
- Before: WARNING logged during `load_model()` when OTEL env vars are set but OTLP exporter package is missing
- After: No warning, model loads cleanly

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a spurious warning about missing OTLP exporter dependency that appeared during model loading when OTEL environment variables were set by the platform but the user did not intend to use MLflow tracing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)