### PR TITLE
Make simulator explicitly avoid stating goal in first message

### DIFF
--- a/mlflow/genai/simulators/prompts.py
+++ b/mlflow/genai/simulators/prompts.py
@@ -10,9 +10,12 @@ You are role-playing as a real user interacting with an AI assistant.
 - Do not reveal understanding or expertise the persona would not plausibly have.
 - Be concise (within 1-3 sentences), conversational, straightforward and not overly formal
   or verbose. Avoid structured explanations, lists, or polished phrasing.
-- Do NOT reveal all persona details upfront. If the goal has multiple components or requires
-  multiple steps, start with a single, natural subtask and pursue the remaining parts
-  gradually over the conversation, rather than requesting everything at once.
+- Do NOT reveal all persona details upfront.
+- **CRITICAL**: Your first message must NOT directly state, ask about, or summarize your goal.
+  Real users never open with "I want to [exact goal]." Instead, start with a specific,
+  concrete question or request that is a natural *first step* toward the goal. If the goal
+  has multiple components, pursue them gradually across turns — never request everything at
+  once. The full goal should only become apparent over multiple turns.
 - If simulation guidelines are provided, strictly follow them as requirements for how to
   conduct the conversation. They take precedence over default behavior. The guidelines
   describe how YOU (the user) should behave, not how the assistant should respond.
@@ -27,7 +30,8 @@ Your underlying goal in this conversation is:
 {goal}
 </goal>
 {guidelines_section}
-Begin the conversation with a concise, natural opening message."""
+Begin the conversation with a concise, natural opening message. Remember: do NOT state your
+goal directly — start with a concrete, narrow question that naturally leads toward it."""
 
 # NB: We embed history into the prompt instead of passing a message list directly to reduce
 #     noise, since the prompt only cares about message content and sender role.


### PR DESCRIPTION
### Related Issues/PRs

Relates to conversation simulation quality improvements

### What changes are proposed in this pull request?

The simulated user's initial prompt had a soft hint to "start with a single, natural subtask," but LLMs frequently ignored it and opened with "I want to [exact goal]." This PR makes the instruction explicit and unmissable:

- Adds a **CRITICAL** bullet to `INITIAL_USER_PROMPT` that forbids the simulated user from directly stating, asking about, or summarizing the goal in the first message
- Reinforces the constraint in the closing instruction line
- Consolidates the previously split "don't reveal everything upfront" / "start with a subtask" guidance into one clear place

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)