### PR TITLE
Fix `make_judge inference_params` loss on scorer deserialization

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -376,6 +376,7 @@ class Scorer(BaseModel):
                     instructions=data["instructions"],
                     model=data["model"],
                     feedback_value_type=feedback_value_type,
+                    inference_params=data.get("inference_params"),
                     # TODO: add aggregations here once we support boolean/numeric judge outputs
                 )
             except Exception as e:

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -1046,11 +1046,13 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     experiment = mlflow.create_experiment("test_judge_registration")
 
     original_instructions = "Evaluate if the {{ outputs }} is professional and formal."
+    inference_params = {"temperature": 0.2, "max_tokens": 64}
     judge = make_judge(
         name="test_judge",
         instructions=original_instructions,
         feedback_value_type=str,
         model="openai:/gpt-4",
+        inference_params=inference_params,
     )
 
     assert judge.instructions == original_instructions
@@ -1063,6 +1065,7 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     assert "instructions_judge_pydantic_data" in serialized
     assert serialized["instructions_judge_pydantic_data"]["instructions"] == original_instructions
     assert serialized["instructions_judge_pydantic_data"]["model"] == "openai:/gpt-4"
+    assert serialized["instructions_judge_pydantic_data"]["inference_params"] == inference_params
 
     store = _get_scorer_store()
     version = store.register_scorer(experiment, judge)
@@ -1074,6 +1077,7 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     assert retrieved_scorer.name == "test_judge"
     assert retrieved_scorer.instructions == original_instructions
     assert retrieved_scorer.model == "openai:/gpt-4"
+    assert retrieved_scorer.inference_params == inference_params
     assert retrieved_scorer.template_variables == {"outputs"}
 
     deserialized = Scorer.model_validate(serialized)
@@ -1081,6 +1085,7 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     assert deserialized.name == judge.name
     assert deserialized.instructions == original_instructions
     assert deserialized.model == judge.model
+    assert deserialized.inference_params == inference_params
     assert deserialized.template_variables == {"outputs"}
 
     test_output = {"response": "This output demonstrates professional communication."}
@@ -3664,3 +3669,20 @@ def test_inference_params_passed_to_invoke_judge_model(mock_invoke_judge_model):
     judge(outputs="test output")
 
     assert mock_invoke_judge_model.captured_args.get("inference_params") == inference_params
+
+
+def test_inference_params_preserved_after_round_trip_serialization():
+    inference_params = {"temperature": 0.5, "max_tokens": 200, "top_p": 0.9}
+    judge = make_judge(
+        name="test_judge",
+        instructions="Check if {{ outputs }} is good",
+        model="openai:/gpt-4",
+        inference_params=inference_params,
+    )
+
+    serialized = judge.model_dump()
+    restored = Scorer.model_validate(serialized)
+    restored_from_json = Scorer.model_validate_json(json.dumps(serialized))
+
+    assert restored.inference_params == inference_params
+    assert restored_from_json.inference_params == inference_params


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes  #21392

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR fixes a serialization round-trip bug where `inference_params` set via `mlflow.genai.make_judge(...)` was dropped after deserialization. It updates `Scorer.model_validate `to pass inference_params when reconstructing `InstructionsJudge`, and adds/updates tests to verify `inference_params` is preserved across `model_dump() -> model_validate(...)`, `model_validate_json(...)`, and scorer registration/retrieval flows.

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests

<!-- Attach code, screenshot, video used for manual testing here. -->

python -m pytest tests/genai/judges/test_make_judge.py

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.


### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No. You can skip the rest of this section.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fixed an issue where `inference_params` in judges created with `mlflow.genai.make_judge` could be lost after scorer serialization/deserialization round-trip, causing restored judges to run with different inference settings.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
