### PR TITLE
Add issue-warning workflow to prepend PR submission guidelines

### DIFF
--- a/.github/workflows/issue-warning.yml
+++ b/.github/workflows/issue-warning.yml
@@ -28,4 +28,5 @@ jobs:
 
           ${ISSUE_BODY}"
 
+          # Why not a comment, but editing the issue body? Coding agents (e.g. "Fix <issue URL>") may not see the comments.
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --body "$body"

--- a/.github/workflows/issue-warning.yml
+++ b/.github/workflows/issue-warning.yml
@@ -23,9 +23,9 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
           REPO: ${{ github.repository }}
         run: |
-          body='> [!WARNING]
-          > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+          body="> [!WARNING]
+          > Please submit a PR only if the issue has the \`ready\` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
 
-          '"${ISSUE_BODY}"
+          ${ISSUE_BODY}"
 
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --body "$body"

--- a/.github/workflows/issue-warning.yml
+++ b/.github/workflows/issue-warning.yml
@@ -10,6 +10,7 @@ defaults:
 
 jobs:
   prepend-warning:
+    if: github.repository == 'mlflow/mlflow'
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/issue-warning.yml
+++ b/.github/workflows/issue-warning.yml
@@ -1,0 +1,30 @@
+name: issue-warning
+
+on:
+  issues:
+    types: [opened]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepend-warning:
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          body='> [!WARNING]
+          > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+
+          '"${ISSUE_BODY}"
+
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --body "$body"

--- a/.github/workflows/issue-warning.yml
+++ b/.github/workflows/issue-warning.yml
@@ -19,7 +19,12 @@ jobs:
     steps:
       - env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
           REPO: ${{ github.repository }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body '> [!WARNING]
-          > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.'
+          body='> [!WARNING]
+          > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+
+          '"${ISSUE_BODY}"
+
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --body "$body"

--- a/.github/workflows/issue-warning.yml
+++ b/.github/workflows/issue-warning.yml
@@ -19,12 +19,7 @@ jobs:
     steps:
       - env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
           REPO: ${{ github.repository }}
         run: |
-          body='> [!WARNING]
-          > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
-
-          '"${ISSUE_BODY}"
-
-          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --body "$body"
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body '> [!WARNING]
+          > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.'


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a GitHub Actions workflow that automatically prepends a warning message to newly opened issues, reminding contributors to only submit PRs when:
- The issue has the `ready` label
- The issue has no assignee
- No duplicate PR exists

<img width="948" height="623" alt="image" src="https://github.com/user-attachments/assets/33cf1f36-3f46-498a-9997-6aa1a9417bb1" />


### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)