### PR TITLE
Add back virtualenv to fix the docker build until the next release (#…

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -4,6 +4,8 @@ from subprocess import Popen
 from typing import Literal
 from urllib.parse import urlparse
 
+from packaging.version import Version
+
 from mlflow.environment_variables import MLFLOW_DOCKER_OPENJDK_VERSION
 from mlflow.utils import env_manager as em
 from mlflow.utils.file_utils import _copy_project
@@ -187,6 +189,9 @@ def _pip_mlflow_install_step(dockerfile_context_dir, mlflow_home):
             "RUN pip install /opt/mlflow"
         )
     else:
+        # Dev version is not available on PyPI, install from GitHub instead
+        if Version(VERSION).is_devrelease:
+            return "# Install MLflow\nRUN pip install https://github.com/mlflow/mlflow/archive/refs/heads/master.zip"
         return f"# Install MLflow\nRUN pip install mlflow=={VERSION}"
 
 

--- a/tests/pyfunc/docker/test_docker.py
+++ b/tests/pyfunc/docker/test_docker.py
@@ -8,6 +8,7 @@ from unittest import mock
 import pytest
 import sklearn
 import sklearn.neighbors
+from packaging.version import Version
 
 import mlflow
 from mlflow.environment_variables import _MLFLOW_RUN_SLOW_TESTS
@@ -21,13 +22,17 @@ from mlflow.version import VERSION
 from tests.pyfunc.docker.conftest import RESOURCE_DIR, get_released_mlflow_version
 
 
+def _get_mlflow_install_specifier():
+    if Version(VERSION).is_devrelease:
+        return "https://github.com/mlflow/mlflow/archive/refs/heads/master.zip"
+    return f"mlflow=={VERSION}"
+
+
 def assert_dockerfiles_equal(actual_dockerfile_path: Path, expected_dockerfile_path: Path):
-    actual_dockerfile = actual_dockerfile_path.read_text().replace(
-        VERSION, get_released_mlflow_version()
-    )
+    actual_dockerfile = actual_dockerfile_path.read_text()
     expected_dockerfile = (
         expected_dockerfile_path.read_text()
-        .replace("${{ MLFLOW_VERSION }}", get_released_mlflow_version())
+        .replace("${{ MLFLOW_INSTALL }}", _get_mlflow_install_specifier())
         .replace("${{ PYTHON_VERSION }}", PYTHON_VERSION)
     )
     assert actual_dockerfile == expected_dockerfile, (
@@ -90,11 +95,6 @@ def test_build_image(tmp_path, params):
 
     # Copy the context dir to a temp dir so we can verify the generated Dockerfile
     def _build_image_with_copy(context_dir, image_name):
-        # Replace mlflow dev version in Dockerfile with the latest released one
-        dockerfile = Path(context_dir) / "Dockerfile"
-        content = dockerfile.read_text()
-        content = content.replace(VERSION, get_released_mlflow_version())
-        dockerfile.write_text(content)
         shutil.copytree(context_dir, dst_dir)
         # Build the image if the slow-tests flag is enabled
         if _MLFLOW_RUN_SLOW_TESTS.get():

--- a/tests/resources/dockerfile/Dockerfile_conda
+++ b/tests/resources/dockerfile/Dockerfile_conda
@@ -19,7 +19,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 WORKDIR /opt/mlflow
 
 # Install MLflow
-RUN pip install mlflow==${{ MLFLOW_VERSION }}
+RUN pip install ${{ MLFLOW_INSTALL }}
 
 # Copy model to image and install dependencies
 COPY model_dir/model /opt/ml/model

--- a/tests/resources/dockerfile/Dockerfile_custom_scipy
+++ b/tests/resources/dockerfile/Dockerfile_custom_scipy
@@ -8,7 +8,7 @@ FROM quay.io/jupyter/scipy-notebook:latest
 WORKDIR /opt/mlflow
 
 # Install MLflow
-RUN pip install mlflow==${{ MLFLOW_VERSION }}
+RUN pip install ${{ MLFLOW_INSTALL }}
 
 # Copy model to image and install dependencies
 COPY model_dir/model /opt/ml/model

--- a/tests/resources/dockerfile/Dockerfile_default
+++ b/tests/resources/dockerfile/Dockerfile_default
@@ -8,7 +8,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends nginx
 WORKDIR /opt/mlflow
 
 # Install MLflow
-RUN pip install mlflow==${{ MLFLOW_VERSION }}
+RUN pip install ${{ MLFLOW_INSTALL }}
 
 # Copy model to image and install dependencies
 COPY model_dir/model /opt/ml/model

--- a/tests/resources/dockerfile/Dockerfile_enable_mlserver
+++ b/tests/resources/dockerfile/Dockerfile_enable_mlserver
@@ -8,7 +8,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends nginx
 WORKDIR /opt/mlflow
 
 # Install MLflow
-RUN pip install mlflow==${{ MLFLOW_VERSION }}
+RUN pip install ${{ MLFLOW_INSTALL }}
 
 # Copy model to image and install dependencies
 COPY model_dir/model /opt/ml/model

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow
@@ -8,7 +8,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends nginx
 WORKDIR /opt/mlflow
 
 # Install MLflow
-RUN pip install mlflow==${{ MLFLOW_VERSION }}
+RUN pip install ${{ MLFLOW_INSTALL }}
 
 # Copy model to image and install dependencies
 COPY model_dir/model /opt/ml/model

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -32,7 +32,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 WORKDIR /opt/mlflow
 
 # Install MLflow
-RUN pip install mlflow==${{ MLFLOW_VERSION }}
+RUN pip install ${{ MLFLOW_INSTALL }}
 
 # Copy model to image and install dependencies
 COPY model_dir/model /opt/ml/model

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -32,7 +32,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 WORKDIR /opt/mlflow
 
 # Install MLflow
-RUN pip install mlflow==${{ MLFLOW_VERSION }}
+RUN pip install ${{ MLFLOW_INSTALL }}
 
 # Copy model to image and install dependencies
 COPY model_dir/model /opt/ml/model

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -32,7 +32,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 WORKDIR /opt/mlflow
 
 # Install MLflow
-RUN pip install mlflow==${{ MLFLOW_VERSION }}
+RUN pip install ${{ MLFLOW_INSTALL }}
 
 
 


### PR DESCRIPTION
…20740)

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

Cherry pick test fix

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
