### PR TITLE
Use CLI command instead of inline Python for Claude Code hooks

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/claude_code.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/claude_code.mdx
@@ -47,7 +47,7 @@ Use CLI tracing to automatically capture your interactive Claude Code CLI conver
 mlflow autolog claude
 
 # Set up tracing in specific directory
-mlflow autolog claude ~/my-project
+mlflow autolog claude -d ~/my-project
 
 # Check tracing status
 mlflow autolog claude --status
@@ -80,7 +80,7 @@ mlflow autolog claude -n "My AI Project"
 
 ```bash
 # Set up tracing in your project
-mlflow autolog claude ~/my-project
+mlflow autolog claude -d ~/my-project
 
 # Navigate to project directory
 cd ~/my-project

--- a/mlflow/claude_code/README.md
+++ b/mlflow/claude_code/README.md
@@ -25,7 +25,7 @@ Set up Claude Code tracing in any project directory:
 mlflow autolog claude
 
 # Set up tracing in specific directory
-mlflow autolog claude ~/my-project
+mlflow autolog claude -d ~/my-project
 
 # Set up with custom tracking URI
 mlflow autolog claude -u file://./custom-mlruns
@@ -84,7 +84,7 @@ claude "analyze this data"
 ### Custom Project Setup
 
 ```bash
-mlflow autolog claude ~/my-ai-project -u sqlite:///mlflow.db -n "My AI Project"
+mlflow autolog claude -d ~/my-ai-project -u sqlite:///mlflow.db -n "My AI Project"
 cd ~/my-ai-project
 claude "refactor this code"
 mlflow server --backend-store-uri sqlite:///mlflow.db

--- a/mlflow/claude_code/cli.py
+++ b/mlflow/claude_code/cli.py
@@ -13,7 +13,7 @@ def commands():
     """Commands for autologging with MLflow."""
 
 
-@commands.command("claude")
+@commands.group("claude", invoke_without_command=True)
 @click.argument("directory", default=".", type=click.Path(file_okay=False, dir_okay=True))
 @click.option(
     "--tracking-uri", "-u", help="MLflow tracking URI (e.g., 'databricks' or 'file://mlruns')"
@@ -22,7 +22,9 @@ def commands():
 @click.option("--experiment-name", "-n", help="MLflow experiment name")
 @click.option("--disable", is_flag=True, help="Disable Claude tracing in the specified directory")
 @click.option("--status", is_flag=True, help="Show current tracing status")
+@click.pass_context
 def claude(
+    ctx: click.Context,
     directory: str,
     tracking_uri: str | None,
     experiment_id: str | None,
@@ -55,6 +57,10 @@ def claude(
       # Disable tracing in current directory
       mlflow autolog claude --disable
     """
+    # Skip setup when a subcommand (e.g., stop-hook) is being invoked
+    if ctx.invoked_subcommand is not None:
+        return
+
     target_dir = Path(directory).resolve()
     claude_dir = target_dir / ".claude"
     settings_file = claude_dir / "settings.json"
@@ -160,3 +166,11 @@ def _show_setup_status(
 
     click.echo("\n🔧 To disable tracing later:")
     click.echo("   mlflow autolog claude --disable")
+
+
+@claude.command("stop-hook", hidden=True)
+def stop_hook() -> None:
+    """Hook handler invoked when a Claude Code conversation ends."""
+    from mlflow.claude_code.hooks import stop_hook_handler
+
+    stop_hook_handler()

--- a/mlflow/claude_code/cli.py
+++ b/mlflow/claude_code/cli.py
@@ -14,7 +14,13 @@ def commands():
 
 
 @commands.group("claude", invoke_without_command=True)
-@click.argument("directory", default=".", type=click.Path(file_okay=False, dir_okay=True))
+@click.option(
+    "--directory",
+    "-d",
+    default=".",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Directory to set up tracing in (default: current directory)",
+)
 @click.option(
     "--tracking-uri", "-u", help="MLflow tracking URI (e.g., 'databricks' or 'file://mlruns')"
 )
@@ -38,15 +44,13 @@ def claude(
     to MLflow. After setup, use the regular 'claude' command and traces will be
     automatically created.
 
-    DIRECTORY: Directory to set up tracing in (default: current directory)
-
     Examples:
 
       # Set up tracing in current directory with local storage
       mlflow autolog claude
 
       # Set up tracing in a specific project directory
-      mlflow autolog claude ~/my-project
+      mlflow autolog claude -d ~/my-project
 
       # Set up tracing with Databricks
       mlflow autolog claude -u databricks -e 123456789

--- a/mlflow/claude_code/cli.py
+++ b/mlflow/claude_code/cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import click
 
 from mlflow.claude_code.config import get_tracing_status, setup_environment_config
-from mlflow.claude_code.hooks import disable_tracing_hooks, setup_hooks_config
+from mlflow.claude_code.hooks import disable_tracing_hooks, setup_hooks_config, stop_hook_handler
 
 
 @click.group("autolog")
@@ -171,6 +171,4 @@ def _show_setup_status(
 @claude.command("stop-hook", hidden=True)
 def stop_hook() -> None:
     """Hook handler invoked when a Claude Code conversation ends."""
-    from mlflow.claude_code.hooks import stop_hook_handler
-
     stop_hook_handler()

--- a/mlflow/claude_code/config.py
+++ b/mlflow/claude_code/config.py
@@ -18,7 +18,9 @@ HOOK_FIELD_COMMAND = "command"
 ENVIRONMENT_FIELD = "env"
 
 # MLflow environment variable constants
-MLFLOW_HOOK_IDENTIFIER = "mlflow.claude_code.hooks"
+MLFLOW_HOOK_IDENTIFIER = "mlflow autolog claude"
+# Legacy identifier used in older versions (inline python -c commands)
+MLFLOW_LEGACY_HOOK_IDENTIFIER = "mlflow.claude_code.hooks"
 MLFLOW_TRACING_ENABLED = "MLFLOW_CLAUDE_TRACING_ENABLED"
 
 

--- a/mlflow/claude_code/hooks.py
+++ b/mlflow/claude_code/hooks.py
@@ -13,6 +13,7 @@ from mlflow.claude_code.config import (
     MLFLOW_EXPERIMENT_ID,
     MLFLOW_EXPERIMENT_NAME,
     MLFLOW_HOOK_IDENTIFIER,
+    MLFLOW_LEGACY_HOOK_IDENTIFIER,
     MLFLOW_TRACING_ENABLED,
     MLFLOW_TRACKING_URI,
     load_claude_config,
@@ -33,22 +34,19 @@ from mlflow.claude_code.tracing import (
 # ============================================================================
 
 
-def upsert_hook(config: dict[str, Any], hook_type: str, handler_name: str) -> None:
+def upsert_hook(config: dict[str, Any], hook_type: str, subcommand: str) -> None:
     """Insert or update a single MLflow hook in the configuration.
 
     Args:
         config: The hooks configuration dictionary to modify
         hook_type: The hook type (e.g., 'PostToolUse', 'Stop')
-        handler_name: The handler function name (e.g., 'post_tool_use_handler')
+        subcommand: The CLI subcommand name (e.g., 'stop-hook')
     """
     if hook_type not in config[HOOK_FIELD_HOOKS]:
         config[HOOK_FIELD_HOOKS][hook_type] = []
 
-    python_cmd = "uv run python" if "UV" in os.environ else "python"
-    hook_command = (
-        f"{python_cmd} -I -c "
-        f'"from mlflow.claude_code.hooks import {handler_name}; {handler_name}()"'
-    )
+    mlflow_cmd = "uv run mlflow" if "UV" in os.environ else "mlflow"
+    hook_command = f"{mlflow_cmd} autolog claude {subcommand}"
 
     mlflow_hook = {"type": "command", HOOK_FIELD_COMMAND: hook_command}
 
@@ -57,7 +55,8 @@ def upsert_hook(config: dict[str, Any], hook_type: str, handler_name: str) -> No
     for hook_group in config[HOOK_FIELD_HOOKS][hook_type]:
         if HOOK_FIELD_HOOKS in hook_group:
             for hook in hook_group[HOOK_FIELD_HOOKS]:
-                if MLFLOW_HOOK_IDENTIFIER in hook.get(HOOK_FIELD_COMMAND, ""):
+                cmd = hook.get(HOOK_FIELD_COMMAND, "")
+                if MLFLOW_HOOK_IDENTIFIER in cmd or MLFLOW_LEGACY_HOOK_IDENTIFIER in cmd:
                     hook.update(mlflow_hook)
                     hook_exists = True
                     break
@@ -81,7 +80,7 @@ def setup_hooks_config(settings_path: Path) -> None:
     if HOOK_FIELD_HOOKS not in config:
         config[HOOK_FIELD_HOOKS] = {}
 
-    upsert_hook(config, "Stop", "stop_hook_handler")
+    upsert_hook(config, "Stop", "stop-hook")
 
     save_claude_config(settings_path, config)
 
@@ -118,6 +117,7 @@ def disable_tracing_hooks(settings_path: Path) -> bool:
                     hook
                     for hook in group[HOOK_FIELD_HOOKS]
                     if MLFLOW_HOOK_IDENTIFIER not in hook.get(HOOK_FIELD_COMMAND, "")
+                    and MLFLOW_LEGACY_HOOK_IDENTIFIER not in hook.get(HOOK_FIELD_COMMAND, "")
                 ]
 
                 if filtered_hooks:

--- a/tests/claude_code/test_cli.py
+++ b/tests/claude_code/test_cli.py
@@ -67,10 +67,7 @@ def test_claude_setup_with_uv_env_var(runner, monkeypatch):
         assert result.exit_code == 0
 
         hook_command = _get_hook_command_from_settings()
-        assert hook_command == (
-            "uv run python -I -c "
-            '"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
-        )
+        assert hook_command == "uv run mlflow autolog claude stop-hook"
 
 
 def test_claude_setup_without_uv_env_var(runner, monkeypatch):
@@ -81,16 +78,28 @@ def test_claude_setup_without_uv_env_var(runner, monkeypatch):
         assert result.exit_code == 0
 
         hook_command = _get_hook_command_from_settings()
-        assert hook_command == (
-            "python -I -c "
-            '"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
-        )
+        assert hook_command == "mlflow autolog claude stop-hook"
 
 
-def test_upsert_hook_uses_isolated_mode():
+def test_upsert_hook_uses_cli_command():
     config = {HOOK_FIELD_HOOKS: {}}
-    upsert_hook(config, "Stop", "stop_hook_handler")
+    upsert_hook(config, "Stop", "stop-hook")
 
     hook_command = config[HOOK_FIELD_HOOKS]["Stop"][0][HOOK_FIELD_HOOKS][0][HOOK_FIELD_COMMAND]
-    assert " -I -c " in hook_command
-    assert "from mlflow.claude_code.hooks import stop_hook_handler" in hook_command
+    assert "mlflow autolog claude stop-hook" in hook_command
+
+
+def test_upsert_hook_upgrades_legacy_hook():
+    legacy_command = (
+        'python -I -c "from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()"'
+    )
+    config = {
+        HOOK_FIELD_HOOKS: {
+            "Stop": [{HOOK_FIELD_HOOKS: [{"type": "command", HOOK_FIELD_COMMAND: legacy_command}]}]
+        }
+    }
+    upsert_hook(config, "Stop", "stop-hook")
+
+    hook_command = config[HOOK_FIELD_HOOKS]["Stop"][0][HOOK_FIELD_HOOKS][0][HOOK_FIELD_COMMAND]
+    assert "mlflow autolog claude stop-hook" in hook_command
+    assert "python -I -c" not in hook_command

--- a/tests/claude_code/test_cli.py
+++ b/tests/claude_code/test_cli.py
@@ -103,3 +103,12 @@ def test_upsert_hook_upgrades_legacy_hook():
     hook_command = config[HOOK_FIELD_HOOKS]["Stop"][0][HOOK_FIELD_HOOKS][0][HOOK_FIELD_COMMAND]
     assert "mlflow autolog claude stop-hook" in hook_command
     assert "python -I -c" not in hook_command
+
+
+def test_stop_hook_subcommand_is_routable(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(commands, ["claude", "stop-hook"], input="{}")
+        # The command should be routed to stop-hook (not treated as a directory argument).
+        # It will fail because stdin doesn't have valid hook data, but that's expected —
+        # we're only checking that Click routes to the subcommand.
+        assert "Configuring Claude tracing" not in result.output

--- a/tests/claude_code/test_cli.py
+++ b/tests/claude_code/test_cli.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from click.testing import CliRunner
@@ -106,9 +107,7 @@ def test_upsert_hook_upgrades_legacy_hook():
 
 
 def test_stop_hook_subcommand_is_routable(runner):
-    with runner.isolated_filesystem():
-        result = runner.invoke(commands, ["claude", "stop-hook"], input="{}")
-        # The command should be routed to stop-hook (not treated as a directory argument).
-        # It will fail because stdin doesn't have valid hook data, but that's expected —
-        # we're only checking that Click routes to the subcommand.
-        assert "Configuring Claude tracing" not in result.output
+    with mock.patch("mlflow.claude_code.cli.stop_hook_handler") as mock_handler:
+        result = runner.invoke(commands, ["claude", "stop-hook"])
+        assert result.exit_code == 0
+        mock_handler.assert_called_once()


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/mlflow/pull/21343#discussion_r2886939073

### What changes are proposed in this pull request?

Replace inline Python hook commands (`python -c "from mlflow.claude_code.hooks import handler; handler()"`) with proper CLI subcommands (`mlflow autolog claude stop-hook`).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_upsert_hook_upgrades_legacy_hook` to verify that old inline-python hooks are properly replaced with CLI commands.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)