### PR TITLE
Add issue detection run details page with customizable breadcrumbs and tabs

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunPage.tsx
@@ -16,7 +16,7 @@ import Utils from '../../../common/utils/Utils';
 import { RunPageTabName } from '../../constants';
 import { RenameRunModal } from '../modals/RenameRunModal';
 import { RunViewArtifactTab } from './RunViewArtifactTab';
-import { RunViewHeader } from './RunViewHeader';
+import { RunViewHeader, type RunViewHeaderProps } from './RunViewHeader';
 import { RunViewOverview } from './RunViewOverview';
 import { useRunDetailsPageData } from './hooks/useRunDetailsPageData';
 import { useRunViewActiveTab } from './useRunViewActiveTab';
@@ -53,7 +53,17 @@ const RunPageLoadingState = () => (
   </PageContainer>
 );
 
-export const RunPage = () => {
+export interface RunPageProps {
+  /** Custom breadcrumbs to display in the header */
+  customBreadcrumbs?: RunViewHeaderProps['customBreadcrumbs'];
+  /** Props to pass to RunViewModeSwitch for custom tab configuration */
+  tabSwitchProps?: RunViewHeaderProps['tabSwitchProps'];
+  /** Custom callback after successful run deletion */
+  onDeleteSuccess?: (experimentId: string) => void;
+}
+
+export const RunPage = (props: RunPageProps) => {
+  const { customBreadcrumbs, tabSwitchProps, onDeleteSuccess } = props;
   const { runUuid, experimentId } = useParams<{
     runUuid: string;
     experimentId: string;
@@ -284,6 +294,8 @@ export const RunPage = () => {
           artifactRootUri={runInfo?.artifactUri ?? undefined}
           registeredModelVersionSummaries={registeredModelVersionSummaries}
           isLoading={loading || isLoadingLoggedModels}
+          customBreadcrumbs={customBreadcrumbs}
+          tabSwitchProps={tabSwitchProps}
         />
         {/* Scroll tab contents independently within own container */}
         <div css={{ flex: 1, overflow: 'auto', marginBottom: theme.spacing.sm, display: 'flex' }}>
@@ -302,7 +314,11 @@ export const RunPage = () => {
         onClose={() => setDeleteModalVisible(false)}
         isOpen={deleteModalVisible}
         onSuccess={() => {
-          navigate(Routes.getExperimentPageRoute(safeExperimentId));
+          if (onDeleteSuccess) {
+            onDeleteSuccess(safeExperimentId);
+          } else {
+            navigate(Routes.getExperimentPageRoute(safeExperimentId));
+          }
         }}
       />
     </>

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
@@ -4,7 +4,7 @@ import { OverflowMenu, PageHeader } from '../../../shared/building_blocks/PageHe
 import Routes, { PageId as ExperimentTrackingPageId } from '../../routes';
 import type { ExperimentEntity } from '../../types';
 import type { KeyValueEntity } from '../../../common/types';
-import { RunViewModeSwitch } from './RunViewModeSwitch';
+import { RunViewModeSwitch, type RunViewModeSwitchProps } from './RunViewModeSwitch';
 import Utils from '../../../common/utils/Utils';
 import { RunViewHeaderRegisterModelButton } from './RunViewHeaderRegisterModelButton';
 import type { UseGetRunQueryResponseExperiment, UseGetRunQueryResponseOutputs } from './hooks/useGetRunQuery';
@@ -35,6 +35,26 @@ const RunViewHeaderIcon = () => {
   );
 };
 
+export interface RunViewHeaderProps {
+  hasComparedExperimentsBefore?: boolean;
+  comparedExperimentIds?: string[];
+  runDisplayName: string;
+  runUuid: string;
+  runOutputs?: UseGetRunQueryResponseOutputs | null;
+  runTags: Record<string, KeyValueEntity>;
+  runParams: Record<string, KeyValueEntity>;
+  experiment: ExperimentEntity | UseGetRunQueryResponseExperiment;
+  handleRenameRunClick: () => void;
+  handleDeleteRunClick?: () => void;
+  artifactRootUri?: string;
+  registeredModelVersionSummaries: RunPageModelVersionSummary[];
+  isLoading?: boolean;
+  /** Custom breadcrumbs to display. If provided, overrides default breadcrumb generation. */
+  customBreadcrumbs?: React.ReactNode[];
+  /** Props to pass to RunViewModeSwitch for custom tab configuration */
+  tabSwitchProps?: Omit<RunViewModeSwitchProps, 'runTags'>;
+}
+
 /**
  * Run details page header component, common for all page view modes
  */
@@ -52,21 +72,9 @@ export const RunViewHeader = ({
   artifactRootUri,
   registeredModelVersionSummaries,
   isLoading,
-}: {
-  hasComparedExperimentsBefore?: boolean;
-  comparedExperimentIds?: string[];
-  runDisplayName: string;
-  runUuid: string;
-  runOutputs?: UseGetRunQueryResponseOutputs | null;
-  runTags: Record<string, KeyValueEntity>;
-  runParams: Record<string, KeyValueEntity>;
-  experiment: ExperimentEntity | UseGetRunQueryResponseExperiment;
-  handleRenameRunClick: () => void;
-  handleDeleteRunClick?: () => void;
-  artifactRootUri?: string;
-  registeredModelVersionSummaries: RunPageModelVersionSummary[];
-  isLoading?: boolean;
-}) => {
+  customBreadcrumbs,
+  tabSwitchProps,
+}: RunViewHeaderProps) => {
   const { theme } = useDesignSystemTheme();
   const experimentKind = useExperimentKind(experiment.tags);
 
@@ -99,9 +107,9 @@ export const RunViewHeader = ({
     );
   }
 
-  const breadcrumbs = [getExperimentPageLink()];
+  const defaultBreadcrumbs = [getExperimentPageLink()];
   if (experiment.experimentId) {
-    breadcrumbs.push(
+    defaultBreadcrumbs.push(
       <Link to={experimentPageTabRoute} data-testid="experiment-observatory-link-runs">
         {shouldRouteToEvaluations ? (
           <FormattedMessage
@@ -117,6 +125,8 @@ export const RunViewHeader = ({
       </Link>,
     );
   }
+
+  const breadcrumbs = customBreadcrumbs ?? defaultBreadcrumbs;
 
   const navigate = useNavigate();
 
@@ -200,7 +210,7 @@ export const RunViewHeader = ({
           ]}
         />
       </PageHeader>
-      <RunViewModeSwitch runTags={runTags} />
+      <RunViewModeSwitch runTags={runTags} {...tabSwitchProps} />
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from '../../../common/utils/RoutingUtils';
 import { RunIcon } from './assets/RunIcon';
 import { ExperimentPageTabName } from '@mlflow/mlflow/src/experiment-tracking/constants';
 import { useExperimentKind, isGenAIExperimentKind } from '../../utils/ExperimentKindUtils';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, type ReactNode } from 'react';
 import { shouldEnableImprovedEvalRunsComparison } from '../../../common/utils/FeatureUtils';
 const RunViewHeaderIcon = () => {
   const { theme } = useDesignSystemTheme();
@@ -50,7 +50,7 @@ export interface RunViewHeaderProps {
   registeredModelVersionSummaries: RunPageModelVersionSummary[];
   isLoading?: boolean;
   /** Custom breadcrumbs to display. If provided, overrides default breadcrumb generation. */
-  customBreadcrumbs?: React.ReactNode[];
+  customBreadcrumbs?: ReactNode[];
   /** Props to pass to RunViewModeSwitch for custom tab configuration */
   tabSwitchProps?: Omit<RunViewModeSwitchProps, 'runTags'>;
 }

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
@@ -10,10 +10,62 @@ import type { KeyValueEntity } from '../../../common/types';
 // Set of tabs that when active, the margin of the tab selector should be removed for better displaying
 const TABS_WITHOUT_MARGIN = [RunPageTabName.ARTIFACTS, RunPageTabName.EVALUATIONS];
 
+// Default tabs to show in the run view
+const DEFAULT_VISIBLE_TABS = [
+  RunPageTabName.OVERVIEW,
+  RunPageTabName.MODEL_METRIC_CHARTS,
+  RunPageTabName.SYSTEM_METRIC_CHARTS,
+  RunPageTabName.EVALUATIONS,
+  RunPageTabName.ARTIFACTS,
+];
+
+// Tab label configuration
+const TAB_LABELS: Record<RunPageTabName, React.ReactNode> = {
+  [RunPageTabName.OVERVIEW]: (
+    <FormattedMessage defaultMessage="Overview" description="Run details page > tab selector > overview tab" />
+  ),
+  [RunPageTabName.MODEL_METRIC_CHARTS]: (
+    <FormattedMessage
+      defaultMessage="Model metrics"
+      description="Run details page > tab selector > Model metrics tab"
+    />
+  ),
+  [RunPageTabName.SYSTEM_METRIC_CHARTS]: (
+    <FormattedMessage
+      defaultMessage="System metrics"
+      description="Run details page > tab selector > System metrics tab"
+    />
+  ),
+  [RunPageTabName.EVALUATIONS]: (
+    <FormattedMessage defaultMessage="Traces" description="Run details page > tab selector > Traces tab" />
+  ),
+  [RunPageTabName.TRACES]: (
+    <FormattedMessage defaultMessage="Traces" description="Run details page > tab selector > Traces tab" />
+  ),
+  [RunPageTabName.ARTIFACTS]: (
+    <FormattedMessage defaultMessage="Artifacts" description="Run details page > tab selector > artifacts tab" />
+  ),
+};
+
+export interface RunViewModeSwitchProps {
+  runTags?: Record<string, KeyValueEntity>;
+  /** Custom function to get the base route (overview tab) */
+  getBaseRoute?: (experimentId: string, runUuid: string) => string;
+  /** Custom function to get the route for a specific tab */
+  getTabRoute?: (experimentId: string, runUuid: string, tabName: string) => string;
+  /** List of tabs to show. Defaults to all tabs. */
+  visibleTabs?: RunPageTabName[];
+}
+
 /**
  * Mode switcher for the run details page.
  */
-export const RunViewModeSwitch = ({ runTags }: { runTags: Record<string, KeyValueEntity> }) => {
+export const RunViewModeSwitch = ({
+  runTags,
+  getBaseRoute,
+  getTabRoute,
+  visibleTabs = DEFAULT_VISIBLE_TABS,
+}: RunViewModeSwitchProps) => {
   const { experimentId, runUuid } = useParams<{ runUuid: string; experimentId: string }>();
   const navigate = useNavigate();
   const { theme } = useDesignSystemTheme();
@@ -28,50 +80,22 @@ export const RunViewModeSwitch = ({ runTags }: { runTags: Record<string, KeyValu
     setRemoveTabMargin(TABS_WITHOUT_MARGIN.includes(newTabKey as RunPageTabName));
 
     if (newTabKey === RunPageTabName.OVERVIEW) {
-      navigate(Routes.getRunPageRoute(experimentId, runUuid));
+      const route = getBaseRoute ? getBaseRoute(experimentId, runUuid) : Routes.getRunPageRoute(experimentId, runUuid);
+      navigate(route);
       return;
     }
-    navigate(Routes.getRunPageTabRoute(experimentId, runUuid, newTabKey));
+    const route = getTabRoute
+      ? getTabRoute(experimentId, runUuid, newTabKey)
+      : Routes.getRunPageTabRoute(experimentId, runUuid, newTabKey);
+    navigate(route);
   };
 
   return (
     // @ts-expect-error TS(2322)
     <LegacyTabs activeKey={currentTab} onChange={onTabChanged} tabBarStyle={{ margin: removeTabMargin && '0px' }}>
-      <LegacyTabs.TabPane
-        tab={
-          <FormattedMessage defaultMessage="Overview" description="Run details page > tab selector > overview tab" />
-        }
-        key={RunPageTabName.OVERVIEW}
-      />
-
-      <LegacyTabs.TabPane
-        tab={
-          <FormattedMessage
-            defaultMessage="Model metrics"
-            description="Run details page > tab selector > Model metrics tab"
-          />
-        }
-        key={RunPageTabName.MODEL_METRIC_CHARTS}
-      />
-      <LegacyTabs.TabPane
-        tab={
-          <FormattedMessage
-            defaultMessage="System metrics"
-            description="Run details page > tab selector > Model metrics tab"
-          />
-        }
-        key={RunPageTabName.SYSTEM_METRIC_CHARTS}
-      />
-      <LegacyTabs.TabPane
-        tab={<FormattedMessage defaultMessage="Traces" description="Run details page > tab selector > Traces tab" />}
-        key={RunPageTabName.EVALUATIONS}
-      />
-      <LegacyTabs.TabPane
-        tab={
-          <FormattedMessage defaultMessage="Artifacts" description="Run details page > tab selector > artifacts tab" />
-        }
-        key={RunPageTabName.ARTIFACTS}
-      />
+      {visibleTabs.map((tabName) => (
+        <LegacyTabs.TabPane tab={TAB_LABELS[tabName]} key={tabName} />
+      ))}
     </LegacyTabs>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from '../../../common/utils/RoutingUtils';
 import Routes from '../../routes';
 import { RunPageTabName } from '../../constants';
 import { useRunViewActiveTab } from './useRunViewActiveTab';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import type { KeyValueEntity } from '../../../common/types';
 
 // Set of tabs that when active, the margin of the tab selector should be removed for better displaying
@@ -20,7 +20,7 @@ const DEFAULT_VISIBLE_TABS = [
 ];
 
 // Tab label configuration
-const TAB_LABELS: Record<RunPageTabName, React.ReactNode> = {
+const TAB_LABELS: Record<RunPageTabName, ReactNode> = {
   [RunPageTabName.OVERVIEW]: (
     <FormattedMessage defaultMessage="Overview" description="Run details page > tab selector > overview tab" />
   ),

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -15,7 +15,7 @@ import {
 } from '@databricks/design-system';
 import type { ColumnDef, HeaderContext } from '@tanstack/react-table';
 import { DatasetSourceTypes, RunEntity } from '../../types';
-import { Link } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import { Link, useNavigate } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import { useGetLoggedModelQuery } from '../../hooks/logged-models/useGetLoggedModelQuery';
 import Routes from '../../routes';
 import { useSaveExperimentRunColor } from '../../components/experiment-page/hooks/useExperimentRunColor';
@@ -67,20 +67,23 @@ export const RunNameCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({
   const { theme } = useDesignSystemTheme();
   const saveRunColor = useSaveExperimentRunColor();
   const getRunColor = useGetExperimentRunColor();
+  const navigate = useNavigate();
 
   if ('subRuns' in row.original) {
     return <div>-</div>;
   }
 
   const runUuid = row.original.info.runUuid;
+  const experimentId = row.original.info.experimentId;
   const tags = row.original.data?.tags ?? [];
   const isIssueDetectionRun = tags.some((tag) => tag.key === MLFLOW_RUN_IS_ISSUE_DETECTION_TAG);
   const showIssuesPanelFlag = shouldShowEvalRunsIssuesPanel();
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    // When flag is ON and clicking on an issue detection run, do nothing for now
+    // When flag is ON and clicking on an issue detection run, navigate to the issue detection run details page
     if (isIssueDetectionRun && showIssuesPanelFlag) {
+      navigate(Routes.getIssueDetectionRunDetailsRoute(experimentId, runUuid));
       return;
     }
     // Otherwise follow old behavior - open the right-side panel

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -12,6 +12,7 @@ import {
   SortUnsortedIcon,
   VisibleIcon,
   VisibleOffIcon,
+  SparkleIcon,
 } from '@databricks/design-system';
 import type { ColumnDef, HeaderContext } from '@tanstack/react-table';
 import { DatasetSourceTypes, RunEntity } from '../../types';
@@ -96,10 +97,24 @@ export const RunNameCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({
       onClick={handleClick}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <RunColorPill
-        color={getRunColor(runUuid)}
-        onChangeColor={(colorValue) => saveRunColor({ runUuid, colorValue })}
-      />
+      {isIssueDetectionRun && showIssuesPanelFlag ? (
+        <Tooltip
+          content={
+            <FormattedMessage
+              defaultMessage="Issue detection run"
+              description="Tooltip for the AI icon indicating this is an issue detection run"
+            />
+          }
+          componentId="mlflow.eval-runs.issue-detection-run-icon-tooltip"
+        >
+          <SparkleIcon color="ai" css={{ flexShrink: 0, fontSize: 14, marginLeft: -1, marginRight: -1 }} />
+        </Tooltip>
+      ) : (
+        <RunColorPill
+          color={getRunColor(runUuid)}
+          onChangeColor={(colorValue) => saveRunColor({ runUuid, colorValue })}
+        />
+      )}
       <Typography.Link
         css={{ textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden', flexShrink: 1 }}
         componentId="mlflow.eval-runs.run-name-cell"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { Link, useNavigate, useParams } from '../../../common/utils/RoutingUtils';
+import { RunPage } from '../../components/run-page/RunPage';
+import { ExperimentPageTabName, RunPageTabName } from '../../constants';
+import Routes from '../../routes';
+import { useGetExperimentQuery } from '../../hooks/useExperimentQuery';
+
+/**
+ * Thin wrapper around RunPage for issue detection run details.
+ * Customizes breadcrumbs and tab navigation to stay within /evaluation-runs/ routes.
+ */
+export const IssueDetectionRunDetailsPage = () => {
+  const { experimentId } = useParams<{ experimentId: string }>();
+  const navigate = useNavigate();
+
+  const safeExperimentId = experimentId as string;
+
+  // Fetch experiment data for breadcrumb
+  const { data: experiment } = useGetExperimentQuery({ experimentId: safeExperimentId });
+
+  const customBreadcrumbs = useMemo(() => {
+    const experimentName = experiment?.name ?? safeExperimentId;
+    return [
+      <Link key="experiments" to={Routes.experimentsObservatoryRoute}>
+        <FormattedMessage
+          defaultMessage="Experiments"
+          description="Issue detection run details > Breadcrumb > Experiments"
+        />
+      </Link>,
+      <Link key="experiment" to={Routes.getExperimentPageRoute(safeExperimentId)}>
+        {experimentName}
+      </Link>,
+      <Link
+        key="evaluation-runs"
+        to={Routes.getExperimentPageTabRoute(safeExperimentId, ExperimentPageTabName.EvaluationRuns)}
+      >
+        <FormattedMessage
+          defaultMessage="Evaluation runs"
+          description="Issue detection run details > Breadcrumb > Evaluation runs"
+        />
+      </Link>,
+    ];
+  }, [experiment?.name, safeExperimentId]);
+
+  const handleDeleteSuccess = (expId: string) => {
+    navigate(Routes.getExperimentPageTabRoute(expId, ExperimentPageTabName.EvaluationRuns));
+  };
+
+  return (
+    <RunPage
+      customBreadcrumbs={customBreadcrumbs}
+      tabSwitchProps={{
+        getBaseRoute: Routes.getIssueDetectionRunDetailsRoute,
+        getTabRoute: Routes.getIssueDetectionRunDetailsTabRoute,
+        visibleTabs: [RunPageTabName.OVERVIEW, RunPageTabName.TRACES],
+      }}
+      onDeleteSuccess={handleDeleteSuccess}
+    />
+  );
+};
+
+export default IssueDetectionRunDetailsPage;

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -287,6 +287,24 @@ export const getRouteDefs = () => [
     } satisfies RouteHandle,
   },
   {
+    path: RoutePaths.experimentPageTabIssueDetectionRunDetailsWithTab,
+    element: createLazyRouteElement(() => import('./pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage')),
+    pageId: 'mlflow.issue-detection-run-details',
+    handle: {
+      getPageTitle: (params) => `Issue Detection Run ${params['runUuid']}`,
+      getAssistantPrompts: () => ['Summarize this issue detection run.', 'What issues were detected?'],
+    } satisfies RouteHandle,
+  },
+  {
+    path: RoutePaths.experimentPageTabIssueDetectionRunDetails,
+    element: createLazyRouteElement(() => import('./pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage')),
+    pageId: 'mlflow.issue-detection-run-details',
+    handle: {
+      getPageTitle: (params) => `Issue Detection Run ${params['runUuid']}`,
+      getAssistantPrompts: () => ['Summarize this issue detection run.', 'What issues were detected?'],
+    } satisfies RouteHandle,
+  },
+  {
     path: RoutePaths.runPageDirect,
     element: createLazyRouteElement(() => import('./components/DirectRunPage')),
     pageId: PageId.runPageDirect,

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -70,6 +70,12 @@ export class RoutePaths {
   static get experimentPageTabEvaluationRuns() {
     return createMLflowRoutePath('/experiments/:experimentId/evaluation-runs');
   }
+  static get experimentPageTabIssueDetectionRunDetails() {
+    return createMLflowRoutePath('/experiments/:experimentId/evaluation-runs/:runUuid');
+  }
+  static get experimentPageTabIssueDetectionRunDetailsWithTab() {
+    return createMLflowRoutePath('/experiments/:experimentId/evaluation-runs/:runUuid/*');
+  }
   static get experimentPageTabDatasets() {
     return createMLflowRoutePath('/experiments/:experimentId/datasets');
   }
@@ -222,6 +228,14 @@ class Routes {
       runUuid,
       '*': tabPath,
     });
+  }
+
+  static getIssueDetectionRunDetailsRoute(experimentId: string, runUuid: string) {
+    return generatePath(RoutePaths.experimentPageTabIssueDetectionRunDetails, { experimentId, runUuid });
+  }
+
+  static getIssueDetectionRunDetailsTabRoute(experimentId: string, runUuid: string, tabName: string) {
+    return `${generatePath(RoutePaths.experimentPageTabIssueDetectionRunDetails, { experimentId, runUuid })}/${tabName}`;
   }
 
   /**

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -167,6 +167,10 @@
     "defaultMessage": "Error",
     "description": "Error assessment label for filter dropdown"
   },
+  "/FWWkj": {
+    "defaultMessage": "Issue detection run",
+    "description": "Tooltip for the AI icon indicating this is an issue detection run"
+  },
   "/G/eHs": {
     "defaultMessage": "Run judge",
     "description": "Button text for running judge"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3750,6 +3750,10 @@
     "defaultMessage": "False",
     "description": "False value in the evaluations table."
   },
+  "Ob5d+s": {
+    "defaultMessage": "System metrics",
+    "description": "Run details page > tab selector > System metrics tab"
+  },
   "OcYzCN": {
     "defaultMessage": "Unresolved",
     "description": "Label for a user_frustration assessment with 'unresolved' value"
@@ -3829,6 +3833,10 @@
   "PGbCZD": {
     "defaultMessage": "Production",
     "description": "Column title for production phase version in the registered model page"
+  },
+  "PIsgM0": {
+    "defaultMessage": "Experiments",
+    "description": "Issue detection run details > Breadcrumb > Experiments"
   },
   "PKYh23": {
     "defaultMessage": "Additional runs",
@@ -6519,10 +6527,6 @@
     "defaultMessage": "Fallback Model {order}",
     "description": "Label for fallback model"
   },
-  "hFlaPP": {
-    "defaultMessage": "System metrics",
-    "description": "Run details page > tab selector > Model metrics tab"
-  },
   "hHNj31": {
     "defaultMessage": "Cancel",
     "description": "Cancel button text"
@@ -7882,6 +7886,10 @@
   "qH2cN+": {
     "defaultMessage": "Experiment id copied",
     "description": "Tooltip displayed after experiment id was successfully copied to clipboard"
+  },
+  "qIHqi7": {
+    "defaultMessage": "Evaluation runs",
+    "description": "Issue detection run details > Breadcrumb > Evaluation runs"
   },
   "qIsNL0": {
     "defaultMessage": "Value",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21408/files) to review incremental changes.
- [**stack/search_issues_for_run**](https://github.com/mlflow/mlflow/pull/21408) [[Files changed](https://github.com/mlflow/mlflow/pull/21408/files)]
  - [stack/issue_progress_section](https://github.com/mlflow/mlflow/pull/21409) [[Files changed](https://github.com/mlflow/mlflow/pull/21409/files/a60180cdb63b985fa915002a3470f2f72d43b417..d7ea3e64bbf3aa4381a073816e2a1d030bc6acbe)]
    - [stack/issues_tab](https://github.com/mlflow/mlflow/pull/21497) [[Files changed](https://github.com/mlflow/mlflow/pull/21497/files/d7ea3e64bbf3aa4381a073816e2a1d030bc6acbe..36143f892b80b46c79b2c8db7e9601ff46c7cc41)]
      - [stack/search_issues_with_run](https://github.com/mlflow/mlflow/pull/21498) [[Files changed](https://github.com/mlflow/mlflow/pull/21498/files/36143f892b80b46c79b2c8db7e9601ff46c7cc41..5b4a58d043df2671165ca68859cf607b23bd3861)]
        - [stack/issue_display](https://github.com/mlflow/mlflow/pull/21499) [[Files changed](https://github.com/mlflow/mlflow/pull/21499/files/5b4a58d043df2671165ca68859cf607b23bd3861..eb9404c5f516f7625587b55c0d399ab493dc3f62)]
          - [stack/issues_traces_display](https://github.com/mlflow/mlflow/pull/21500) [[Files changed](https://github.com/mlflow/mlflow/pull/21500/files/eb9404c5f516f7625587b55c0d399ab493dc3f62..5e2f0bd42e5432cbb2f2be3059c9260fadff8b68)]
            - [stack/enable_show_issues_panel](https://github.com/mlflow/mlflow/pull/21407) [[Files changed](https://github.com/mlflow/mlflow/pull/21407/files/5e2f0bd42e5432cbb2f2be3059c9260fadff8b68..c929ac0d1ed00d7b1da0a98cc3c8fa2bc614b713)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Display the runs page when clicking on the run name of an issue detection run, the details will be updated in next PR and currently it only displays the old run page


https://github.com/user-attachments/assets/6b7a482d-e88b-469b-a07f-8666da016327



<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
