### PR TITLE
Fix Pydantic AI Chat UI rendering for InstrumentedModel LLM spans

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/pydanticai.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/pydanticai.test.ts
@@ -479,11 +479,7 @@ describe('PydanticAI message normalization', () => {
 
     it('should handle InstrumentedModel inputs with multiple request messages', () => {
       const instrumentedModelInput = {
-        messages: [
-          MOCK_PYDANTIC_AI_REQUEST,
-          MOCK_PYDANTIC_AI_RESPONSE,
-          MOCK_PYDANTIC_AI_REQUEST_WITH_TOOL_RETURN,
-        ],
+        messages: [MOCK_PYDANTIC_AI_REQUEST, MOCK_PYDANTIC_AI_RESPONSE, MOCK_PYDANTIC_AI_REQUEST_WITH_TOOL_RETURN],
         model_request_parameters: {
           function_tools: [],
           allow_text_output: true,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/pydanticai.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/pydanticai.test.ts
@@ -452,6 +452,55 @@ describe('PydanticAI message normalization', () => {
       });
     });
 
+    it('should handle InstrumentedModel inputs with messages key', () => {
+      const instrumentedModelInput = {
+        messages: [MOCK_PYDANTIC_AI_REQUEST],
+        model_request_parameters: {
+          function_tools: [],
+          allow_text_output: true,
+        },
+      };
+
+      const result = normalizeConversation(instrumentedModelInput, 'pydantic_ai');
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(2); // system + user
+
+      expect(result![0]).toMatchObject({
+        role: 'system',
+        content: 'You are a helpful assistant.',
+      });
+
+      expect(result![1]).toMatchObject({
+        role: 'user',
+        content: 'Hello, how are you?',
+      });
+    });
+
+    it('should handle InstrumentedModel inputs with multiple request messages', () => {
+      const instrumentedModelInput = {
+        messages: [
+          MOCK_PYDANTIC_AI_REQUEST,
+          MOCK_PYDANTIC_AI_RESPONSE,
+          MOCK_PYDANTIC_AI_REQUEST_WITH_TOOL_RETURN,
+        ],
+        model_request_parameters: {
+          function_tools: [],
+          allow_text_output: true,
+        },
+      };
+
+      const result = normalizeConversation(instrumentedModelInput, 'pydantic_ai');
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(4); // system + user + assistant + user
+
+      expect(result![0].role).toBe('system');
+      expect(result![1].role).toBe('user');
+      expect(result![2].role).toBe('assistant');
+      expect(result![3].role).toBe('user');
+    });
+
     it('should handle outputs with _new_messages_serialized field', () => {
       const outputWithSerializedMessages = {
         data: 'Paris',

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/pydanticai.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/pydanticai.ts
@@ -205,6 +205,25 @@ export const normalizePydanticAIChatInput = (obj: unknown): ModelTraceChatMessag
     }
   }
 
+  // Handle InstrumentedModel span inputs which have a `messages` key
+  // containing an array of request/response objects
+  if (isObject(obj) && has(obj, 'messages')) {
+    const messagesArray = (obj as any).messages;
+    if (isArray(messagesArray) && messagesArray.length > 0) {
+      const messages: ModelTraceChatMessage[] = [];
+
+      for (const item of messagesArray) {
+        if (isPydanticAIModelRequest(item)) {
+          messages.push(...normalizeModelRequest(item));
+        } else if (isPydanticAIModelResponse(item)) {
+          messages.push(...normalizeModelResponse(item));
+        }
+      }
+
+      return messages.length > 0 ? messages : null;
+    }
+  }
+
   if (isArray(obj) && obj.length > 0) {
     const messages: ModelTraceChatMessage[] = [];
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21278

### What changes are proposed in this pull request?

- Handle `InstrumentedModel` span inputs which have a `messages` key containing an array of request/response objects, enabling proper Chat UI rendering for Pydantic AI LLM-level spans.
- This was split from #21278 per review feedback to keep TypeScript changes in a separate PR.

### How is this PR tested?

- [x] New unit/integration tests

Added tests for `normalizePydanticAIChatInput` with the `messages` key format used by InstrumentedModel spans.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix Chat UI rendering for Pydantic AI LLM-level spans (InstrumentedModel) by supporting the `messages` input format.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)