### PR TITLE
fix: stringify integer model_id in registry backend responses

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -193,9 +193,28 @@ def _stringify_all_experiment_ids(x):
             _stringify_all_experiment_ids(y)
 
 
+def _stringify_all_model_ids(x):
+    """Converts model_id fields which are defined as ints into strings in the given json.
+    This is necessary because non-Databricks registry backends may return model_id as a
+    JSON integer, but the ModelVersion protobuf defines model_id as a string field.
+    The Python JSON serializer is unwilling to convert ints to strings, so we need to
+    manually perform this conversion.
+    """
+    if isinstance(x, dict):
+        for k, v in x.items():
+            if k == "model_id":
+                x[k] = str(v)
+            elif k not in ("params", "tags", "metrics"):  # skip run data
+                _stringify_all_model_ids(v)
+    elif isinstance(x, list):
+        for y in x:
+            _stringify_all_model_ids(y)
+
+
 def parse_dict(js_dict, message):
     """Parses a JSON dictionary into a message proto, ignoring unknown fields in the JSON."""
     _stringify_all_experiment_ids(js_dict)
+    _stringify_all_model_ids(js_dict)
     ParseDict(js_dict=js_dict, message=message, ignore_unknown_fields=True)
 
 

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -20,6 +20,7 @@ from mlflow.utils.proto_json_utils import (
     MlflowFailedTypeConversion,
     _CustomJsonEncoder,
     _stringify_all_experiment_ids,
+    _stringify_all_model_ids,
     cast_df_types_according_to_schema,
     dataframe_from_parsed_json,
     dataframe_from_raw_json,
@@ -251,6 +252,45 @@ def test_back_compat():
         },
     }
     assert exp_json == in_json
+
+
+def test_stringify_all_model_ids():
+    in_json = {
+        "name": "test-model",
+        "version": "1",
+        "model_id": 123,
+        "nested": {
+            "model_id": 456,
+            "deeper": {"model_id": 789},
+        },
+    }
+
+    _stringify_all_model_ids(in_json)
+    assert in_json == {
+        "name": "test-model",
+        "version": "1",
+        "model_id": "123",
+        "nested": {
+            "model_id": "456",
+            "deeper": {"model_id": "789"},
+        },
+    }
+
+
+def test_parse_dict_with_integer_model_id():
+    from mlflow.protos.model_registry_pb2 import ModelVersion as ProtoModelVersion
+
+    response_dict = {
+        "name": "test-model",
+        "version": "1",
+        "model_id": 123,
+    }
+
+    model_version = ProtoModelVersion()
+    parse_dict(response_dict, model_version)
+    assert model_version.model_id == "123"
+    assert model_version.name == "test-model"
+    assert model_version.version == "1"
 
 
 def assert_result(result, expected_result):


### PR DESCRIPTION
### Related Issues/PRs

Closes #21420

### What changes are proposed in this pull request?

Non-Databricks registry backends may return `model_id` as a JSON integer, but the `ModelVersion` protobuf defines it as a string field. This causes `ParseDict` to raise `Failed to parse model_id field: expected string or bytes-like object`.

This PR adds `_stringify_all_model_ids` (mirroring the existing `_stringify_all_experiment_ids` pattern) and calls it from `parse_dict` to convert integer `model_id` values to strings before protobuf parsing.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Two new tests added in `tests/utils/test_proto_json_utils.py`:
- `test_stringify_all_model_ids` — verifies recursive int→string conversion
- `test_parse_dict_with_integer_model_id` — end-to-end test parsing into `ModelVersion` proto

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `ParseError` when non-Databricks registry backends return `model_id` as an integer instead of a string in JSON responses.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)