### PR TITLE
Add telemetry tracking for `migrate-filestore` command

### DIFF
--- a/mlflow/store/fs2db/__init__.py
+++ b/mlflow/store/fs2db/__init__.py
@@ -1,9 +1,17 @@
 # ruff: noqa: T201
+from __future__ import annotations
+
 import warnings
 from functools import partial
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from mlflow.exceptions import MlflowException
+from mlflow.telemetry.events import MigrateFilestoreEvent
+from mlflow.telemetry.track import record_usage_event
+
+if TYPE_CHECKING:
+    from mlflow.store.fs2db._utils import MigrationStats
 
 
 def _log(progress: bool, msg: str) -> None:
@@ -82,7 +90,8 @@ def _query_row_counts(engine) -> dict[str, int]:
     return counts
 
 
-def migrate(source: Path, target_uri: str, *, progress: bool = True) -> None:
+@record_usage_event(MigrateFilestoreEvent)
+def migrate(source: Path, target_uri: str, *, progress: bool = True) -> MigrationStats:
     from sqlalchemy import create_engine, event
     from sqlalchemy.orm import Session
 
@@ -163,3 +172,5 @@ def migrate(source: Path, target_uri: str, *, progress: bool = True) -> None:
     db_counts = _query_row_counts(engine)
     print()
     print(stats.summary(str(mlruns), target_uri, db_counts))
+
+    return stats

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import sys
+from dataclasses import asdict
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -617,6 +618,17 @@ class OptimizePromptsJobEvent(Event):
             result["scorer_count"] = len(scorer_names)
 
         return result or None
+
+
+class MigrateFilestoreEvent(Event):
+    name: str = "migrate_filestore"
+
+    @classmethod
+    def parse_result(cls, result: Any) -> dict[str, Any] | None:
+        if result is None:
+            return None
+
+        return {k: v for k, v in asdict(result).items() if v > 0}
 
 
 class ScorerCallEvent(Event):

--- a/tests/store/fs2db/test_migration.py
+++ b/tests/store/fs2db/test_migration.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine, text
 
 from mlflow.entities import Experiment, Run, ViewType
 from mlflow.store.fs2db import migrate
+from mlflow.telemetry.schemas import Status
 from mlflow.tracking import MlflowClient
 from mlflow.utils.file_utils import local_file_uri_to_path
 
@@ -270,6 +271,35 @@ def test_prompts(clients: Clients) -> None:
         assert src_pv is not None
         assert dst_pv is not None
         assert dst_pv.template == src_pv.template
+
+
+def test_migrate_filestore(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    client = MlflowClient(tracking_uri=source.as_uri())
+    exp_id = client.create_experiment("test")
+    run = client.create_run(exp_id)
+    client.log_param(run.info.run_id, "key", "value")
+
+    target_uri = f"sqlite:///{tmp_path / 'telemetry.db'}"
+    mock_client = mock.MagicMock()
+    mock_client.config.disable_events = []
+
+    with (
+        mock.patch("mlflow.telemetry.track.is_telemetry_disabled", return_value=False),
+        mock.patch("mlflow.telemetry.track.get_telemetry_client", return_value=mock_client),
+    ):
+        migrate(source, target_uri, progress=False)
+
+    mock_client.add_record.assert_called_once()
+    record = mock_client.add_record.call_args[0][0]
+    assert record.event_name == "migrate_filestore"
+    assert record.status == Status.SUCCESS
+    assert record.duration_ms > 0
+    assert record.params["experiments"] > 0
+    assert record.params["runs"] > 0
+    assert all(v > 0 for v in record.params.values())
+    assert "traces" not in record.params
+    assert "registered_models" not in record.params
 
 
 def test_rollback_on_failure(clients: Clients, tmp_path: Path) -> None:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a `migrate_filestore` telemetry event to track usage of the `mlflow migrate-filestore` command. The event captures migration statistics (non-zero entity counts such as experiments, runs, traces, etc.) along with duration and success/failure status.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)