### PR TITLE
[1/5] Remove redundant convert_mlflow_uri_to_litellm

### DIFF
--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -22,7 +22,10 @@ from mlflow.genai.utils.trace_utils import (
     extract_request_from_trace,
     extract_response_from_trace,
 )
-from mlflow.metrics.genai.model_utils import _parse_model_uri
+from mlflow.metrics.genai.model_utils import (
+    _parse_model_uri,
+    convert_mlflow_uri_to_litellm,
+)
 from mlflow.utils import AttrDict
 
 # Import dspy - raise exception if not installed
@@ -283,32 +286,6 @@ def _sanitize_assessment_name(name: str) -> str:
     Sanitize a name by converting it to lowercase and stripping whitespace.
     """
     return name.lower().strip()
-
-
-def convert_mlflow_uri_to_litellm(model_uri: str) -> str:
-    """
-    Convert MLflow model URI format to LiteLLM format.
-
-    MLflow uses URIs like 'openai:/gpt-4' while LiteLLM expects 'openai/gpt-4'.
-    For Databricks endpoints, MLflow uses 'endpoints:/endpoint-name' which needs
-    to be converted to 'databricks/endpoints/endpoint-name' for LiteLLM.
-
-    Args:
-        model_uri: MLflow model URI (e.g., 'openai:/gpt-4', 'endpoints:/my-endpoint')
-
-    Returns:
-        LiteLLM-compatible model string (e.g., 'openai/gpt-4', 'databricks/endpoints/my-endpoint')
-    """
-    try:
-        scheme, path = _parse_model_uri(model_uri)
-        # MLflow's "endpoints:/my-endpoint" is a Databricks serving endpoint URI.
-        # LiteLLM expects "databricks/{endpoint-name}" for Databricks endpoints,
-        # so we normalize both "endpoints" and "databricks" schemes to "databricks".
-        if scheme in ("endpoints", "databricks"):
-            return f"databricks/{path}"
-        return f"{scheme}/{path}"
-    except Exception as e:
-        raise MlflowException(f"Failed to convert MLflow URI to LiteLLM format: {e}")
 
 
 def convert_litellm_to_mlflow_uri(litellm_model: str) -> str:

--- a/mlflow/genai/judges/optimizers/memalign/optimizer.py
+++ b/mlflow/genai/judges/optimizers/memalign/optimizer.py
@@ -12,7 +12,6 @@ from mlflow.genai.judges.base import AlignmentOptimizer, Judge, JudgeField
 from mlflow.genai.judges.optimizers.dspy_utils import (
     _check_dspy_installed,
     construct_dspy_lm,
-    convert_mlflow_uri_to_litellm,
     create_dspy_signature,
     trace_to_dspy_example,
 )
@@ -37,6 +36,7 @@ from mlflow.genai.utils.trace_utils import (
     resolve_inputs_from_trace,
     resolve_outputs_from_trace,
 )
+from mlflow.metrics.genai.model_utils import convert_mlflow_uri_to_litellm
 from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, INVALID_PARAMETER_VALUE
 from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import format_docstring

--- a/mlflow/genai/judges/optimizers/memalign/utils.py
+++ b/mlflow/genai/judges/optimizers/memalign/utils.py
@@ -18,7 +18,6 @@ from mlflow.entities.trace import Trace
 from mlflow.environment_variables import MLFLOW_GENAI_OPTIMIZE_MAX_WORKERS
 from mlflow.genai.judges.optimizers.dspy_utils import (
     construct_dspy_lm,
-    convert_mlflow_uri_to_litellm,
 )
 from mlflow.genai.judges.optimizers.memalign.prompts import (
     DISTILLATION_PROMPT_TEMPLATE,
@@ -29,6 +28,7 @@ from mlflow.genai.utils.trace_utils import (
     extract_request_from_trace,
     extract_response_from_trace,
 )
+from mlflow.metrics.genai.model_utils import convert_mlflow_uri_to_litellm
 
 # Try to import litellm at module level
 try:

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -107,11 +107,11 @@ def convert_mlflow_uri_to_litellm(model_uri: str) -> str:
     """
     try:
         scheme, path = _parse_model_uri(model_uri)
-        if scheme in ("endpoints", "databricks"):
-            return f"databricks/{path}"
-        return f"{scheme}/{path}"
     except Exception as e:
-        raise MlflowException(f"Failed to convert MLflow URI to LiteLLM format: {e}")
+        raise MlflowException(f"Failed to convert MLflow model URI to LiteLLM format: {e}")
+    if scheme in ("endpoints", "databricks"):
+        return f"databricks/{path}"
+    return f"{scheme}/{path}"
 
 
 _PREDICT_ERROR_MSG = """\

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -91,6 +91,29 @@ def _parse_model_uri(model_uri: str) -> tuple[str, str]:
             )
 
 
+def convert_mlflow_uri_to_litellm(model_uri: str) -> str:
+    """
+    Convert MLflow model URI format to LiteLLM format.
+
+    MLflow uses URIs like 'openai:/gpt-4' while LiteLLM expects 'openai/gpt-4'.
+    For Databricks endpoints, MLflow uses 'endpoints:/endpoint-name' which needs
+    to be converted to 'databricks/endpoints/endpoint-name' for LiteLLM.
+
+    Args:
+        model_uri: MLflow model URI (e.g., 'openai:/gpt-4', 'endpoints:/my-endpoint')
+
+    Returns:
+        LiteLLM-compatible model string (e.g., 'openai/gpt-4', 'databricks/endpoints/my-endpoint')
+    """
+    try:
+        scheme, path = _parse_model_uri(model_uri)
+        if scheme in ("endpoints", "databricks"):
+            return f"databricks/{path}"
+        return f"{scheme}/{path}"
+    except Exception as e:
+        raise MlflowException(f"Failed to convert MLflow URI to LiteLLM format: {e}")
+
+
 _PREDICT_ERROR_MSG = """\
 Failed to call the deployment endpoint. Please check the deployment URL \
 is set correctly and the input payload is valid.\n

--- a/tests/genai/judges/optimizers/test_dspy_base.py
+++ b/tests/genai/judges/optimizers/test_dspy_base.py
@@ -9,10 +9,8 @@ from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.judges import make_judge
 from mlflow.genai.judges.optimizers.dspy import DSPyAlignmentOptimizer
-from mlflow.genai.judges.optimizers.dspy_utils import (
-    AgentEvalLM,
-    convert_mlflow_uri_to_litellm,
-)
+from mlflow.genai.judges.optimizers.dspy_utils import AgentEvalLM
+from mlflow.metrics.genai.model_utils import convert_mlflow_uri_to_litellm
 
 from tests.genai.judges.optimizers.conftest import MockDSPyLM, MockJudge
 

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -254,7 +254,7 @@ def test_convert_mlflow_uri_to_litellm(mlflow_uri, expected_litellm_uri):
     ],
 )
 def test_convert_mlflow_uri_to_litellm_invalid(invalid_uri):
-    with pytest.raises(MlflowException, match="Failed to convert MLflow URI"):
+    with pytest.raises(MlflowException, match="Failed to convert MLflow model URI"):
         convert_mlflow_uri_to_litellm(invalid_uri)
 
 

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -11,7 +11,6 @@ from mlflow.genai.judges.optimizers.dspy_utils import (
     append_input_fields_section,
     construct_dspy_lm,
     convert_litellm_to_mlflow_uri,
-    convert_mlflow_uri_to_litellm,
     create_dspy_signature,
     format_demos_as_examples,
     trace_to_dspy_example,
@@ -21,6 +20,7 @@ from mlflow.genai.utils.trace_utils import (
     extract_request_from_trace,
     extract_response_from_trace,
 )
+from mlflow.metrics.genai.model_utils import convert_mlflow_uri_to_litellm
 
 from tests.genai.judges.optimizers.conftest import MockJudge
 


### PR DESCRIPTION
### Stack: `discover_issues()` pipeline

> **Note:** This is PR 1/5 in the `discover_issues()` stack. Each PR builds on the previous one.

| # | PR | Description | Base |
|---|---|---|---|
| 1 | **this PR** | dspy_utils import cleanup | `master` |
| 2 | #21428 | Discovery foundation (entities, constants, utils) | this PR |
| 3 | #21429 | Sampling + extraction modules | #21428 |
| 4 | #21430 | Clustering module | #21429 |
| 5 | #21431 | Pipeline + public API | #21430 |

### Related Issues/PRs

Supersedes the dspy_utils portion of #21246

### What changes are proposed in this pull request?

`dspy_utils.py` had its own `convert_mlflow_uri_to_litellm` helper that duplicated the canonical `model_utils.convert_model_uri_to_litellm`. This PR removes the local copy and updates all callers (dspy_utils, memalign optimizer/utils, and their tests) to use the canonical version.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)