### PR TITLE
Fix: Stringify integer model_id in protobuf JSON parsing

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -193,9 +193,26 @@ def _stringify_all_experiment_ids(x):
             _stringify_all_experiment_ids(y)
 
 
+def _stringify_all_model_ids(x):
+    """Converts model_id fields which are defined as ints into strings in the given json.
+    This is necessary because some registry backends return model_id as a JSON integer,
+    but the ModelVersion protobuf defines it as TYPE_STRING.
+    """
+    if isinstance(x, dict):
+        for k, v in x.items():
+            if k == "model_id":
+                x[k] = str(v)
+            else:
+                _stringify_all_model_ids(v)
+    elif isinstance(x, list):
+        for y in x:
+            _stringify_all_model_ids(y)
+
+
 def parse_dict(js_dict, message):
     """Parses a JSON dictionary into a message proto, ignoring unknown fields in the JSON."""
     _stringify_all_experiment_ids(js_dict)
+    _stringify_all_model_ids(js_dict)
     ParseDict(js_dict=js_dict, message=message, ignore_unknown_fields=True)
 
 

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -20,6 +20,7 @@ from mlflow.utils.proto_json_utils import (
     MlflowFailedTypeConversion,
     _CustomJsonEncoder,
     _stringify_all_experiment_ids,
+    _stringify_all_model_ids,
     cast_df_types_according_to_schema,
     dataframe_from_parsed_json,
     dataframe_from_raw_json,
@@ -251,6 +252,33 @@ def test_back_compat():
         },
     }
     assert exp_json == in_json
+
+
+def test_stringify_all_model_ids():
+    in_json = {
+        "model_id": 456,
+        "name": "my-model",
+        "versions": [
+            {"version": "1", "model_id": 789},
+        ],
+    }
+    _stringify_all_model_ids(in_json)
+    assert in_json == {
+        "model_id": "456",
+        "name": "my-model",
+        "versions": [
+            {"version": "1", "model_id": "789"},
+        ],
+    }
+
+
+def test_parse_dict_with_integer_model_id():
+    from mlflow.protos.model_registry_pb2 import ModelVersion as ProtoModelVersion
+
+    in_json = {"name": "my-model", "version": "1", "model_id": 12345}
+    message = ProtoModelVersion()
+    parse_dict(in_json, message)
+    assert message.model_id == "12345"
 
 
 def assert_result(result, expected_result):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21420

### What changes are proposed in this pull request?

Some registry backends return `model_id` as a JSON integer, but the `ModelVersion` protobuf defines it as `TYPE_STRING`. `google.protobuf.json_format.ParseDict` refuses to convert ints to strings, causing a `ParseError`. This PR adds `_stringify_all_model_ids` to recursively convert integer `model_id` values to strings before parsing, mirroring the existing `_stringify_all_experiment_ids` pattern.

### How is this PR tested?

- [x] New unit/integration tests

Two new tests added in `tests/utils/test_proto_json_utils.py`:
- `test_stringify_all_model_ids` — unit test for recursive stringification
- `test_parse_dict_with_integer_model_id` — end-to-end test parsing into `ModelVersion` protobuf

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `ParseError` when registry backends return `model_id` as an integer instead of a string.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)