### PR TITLE
Fix stored XSS via unsafe YAML parsing of MLmodel artifacts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -447,7 +447,7 @@ mlflow.models.predict(
       getArtifact,
     )
       .then((response: any) => {
-        const parsedJson = yaml.load(response);
+        const parsedJson = yaml.safeLoad(response);
         if (parsedJson.signature) {
           const inputs = Array.isArray(parsedJson.signature.inputs)
             ? parsedJson.signature.inputs

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useValidateLoggedModelSignature.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useValidateLoggedModelSignature.ts
@@ -14,7 +14,7 @@ export const useValidateLoggedModelSignature = (loggedModel?: LoggedModelProto |
     const artifactLocation = getLoggedModelArtifactLocationUrl(MLMODEL_FILE_NAME, loggedModel.info.model_id);
     const blob = await getArtifactBlob(artifactLocation);
 
-    const yamlContent = (await lazyJsYaml()).load(await blob.text());
+    const yamlContent = (await lazyJsYaml()).safeLoad(await blob.text());
 
     const isValid = yamlContent?.signature?.inputs !== undefined && yamlContent?.signature?.outputs !== undefined;
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #21422

### What changes are proposed in this pull request?

Replace `yaml.load()` with `yaml.safeLoad()` when parsing untrusted `MLmodel` artifact content in the UI. In js-yaml v3.x, `yaml.load()` supports JavaScript-specific YAML tags (`!!js/function`, etc.) that allow arbitrary code execution via crafted artifact files. `yaml.safeLoad()` only supports standard YAML types, preventing this attack vector. Other parts of the codebase already use `yaml.safeLoad()` correctly.

<img width="979" height="449" alt="image" src="https://github.com/user-attachments/assets/28dc3056-a85c-449f-a121-ee777117acd6" />

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a stored XSS vulnerability where malicious `MLmodel` YAML artifacts could execute arbitrary JavaScript in the browser via unsafe `yaml.load()` parsing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)