### PR TITLE
Update Anthropic gateway to use GA structured outputs API

### DIFF
--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -22,8 +22,6 @@ from mlflow.types.chat import Function, ToolCallDelta
 
 _logger = logging.getLogger(__name__)
 
-_ANTHROPIC_STRUCTURED_OUTPUTS_HEADER = "structured-outputs-2025-11-13"
-
 
 class AnthropicAdapter(ProviderAdapter):
     @classmethod
@@ -143,12 +141,15 @@ class AnthropicAdapter(ProviderAdapter):
                     payload["tool_choice"] = {"type": "tool", "name": name}
 
         # Transform response_format for Anthropic structured outputs
-        # Anthropic uses output_format with {"type": "json_schema", "schema": {...}}
+        # Anthropic uses output_config.format with {"type": "json_schema", "schema": {...}}
         if response_format := payload.pop("response_format", None):
             if response_format.get("type") == "json_schema" and "json_schema" in response_format:
-                payload["output_format"] = {
-                    "type": "json_schema",
-                    "schema": response_format["json_schema"],
+                json_schema = response_format["json_schema"]
+                payload["output_config"] = {
+                    "format": {
+                        "type": "json_schema",
+                        "schema": json_schema.get("schema", {}),
+                    }
                 }
 
         return payload
@@ -431,17 +432,6 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
             Merged headers with provider headers taking precedence
         """
         result_headers = self.headers.copy()
-
-        # Add conditional beta header based on payload
-        if payload and payload.get("output_format"):
-            if payload["output_format"].get("type") == "json_schema":
-                if "anthropic-beta" not in result_headers:
-                    result_headers["anthropic-beta"] = _ANTHROPIC_STRUCTURED_OUTPUTS_HEADER
-                else:
-                    if _ANTHROPIC_STRUCTURED_OUTPUTS_HEADER not in result_headers["anthropic-beta"]:
-                        result_headers["anthropic-beta"] = (
-                            f"{result_headers['anthropic-beta']},{_ANTHROPIC_STRUCTURED_OUTPUTS_HEADER}"
-                        )
 
         if headers:
             client_headers = headers.copy()

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -1053,14 +1053,16 @@ async def test_chat_with_structured_output():
         assert response.choices[0].finish_reason == "stop"
 
         call_kwargs = mock_session_client.post.call_args[1]
-        assert call_kwargs["json"]["output_format"] == {
-            "type": "json_schema",
-            "schema": json_schema,
+        assert call_kwargs["json"]["output_config"] == {
+            "format": {
+                "type": "json_schema",
+                "schema": json_schema["schema"],
+            }
         }
 
         assert captured_session_headers["x-api-key"] == "key"
         assert captured_session_headers["anthropic-version"] == "2023-06-01"
-        assert captured_session_headers["anthropic-beta"] == "structured-outputs-2025-11-13"
+        assert "anthropic-beta" not in captured_session_headers
 
 
 def test_anthropic_extract_passthrough_token_usage():


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Anthropic made structured output a GA feature: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations
This PR updates the Anthropic gateway provider's structured output handling to match the current GA API spec:

1. **`output_format` → `output_config.format`**: The Anthropic API now uses `output_config.format` (GA) instead of the beta `output_format` parameter.
2. **Remove beta header**: Removed the `structured-outputs-2025-11-13` beta header since `output_config` is the GA API.

```python
from openai import OpenAI

client = OpenAI(
    base_url="http://localhost:3000/gateway/mlflow/v1",
    api_key="",  
)

from pydantic import BaseModel
class ProgrammingLanguage(BaseModel):
    name: str
    primary_use_case: str
    year_created: int
    is_compiled: bool

class LanguageList(BaseModel):
    languages: list[ProgrammingLanguage]

response = client.beta.chat.completions.parse(
    model="anthropic",
    messages=[
        {"role": "system", "content": "You are a knowledgeable programming expert."},
        {"role": "user", "content": "Give me 3 popular programming languages with details"}
    ],
    response_format=LanguageList
)

parsed_data = response.choices[0].message.parsed
for lang in parsed_data.languages:
    print(f"- {lang.name} ({lang.year_created}): {lang.primary_use_case}")
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes `Schema type is missing` errors when using `gateway:/anthropic` endpoints with structured outputs (e.g., DeepEval's `AnswerRelevancy` scorer). The Anthropic gateway provider now uses the GA `output_config.format` API instead of the beta `output_format` parameter.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)