### PR TITLE
Refactor: Centralize and strengthen Model Registry name validation

### DIFF
--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -44,6 +44,7 @@ from mlflow.telemetry.track import record_usage_event
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS, utils
 from mlflow.utils.annotations import experimental
 from mlflow.utils.arguments_utils import _get_arg_names
+from mlflow.utils.validation import _validate_model_name
 
 _logger = logging.getLogger(__name__)
 
@@ -89,8 +90,7 @@ class ModelRegistryClient:
             created by backend.
 
         """
-        # TODO: Do we want to validate the name is legit here - non-empty without "/" and ":" ?
-        #       Those are constraints applicable to any backend, given the model URI format.
+        _validate_model_name(name)
         tags = tags or {}
         tags = [RegisteredModelTag(key, str(value)) for key, value in tags.items()]
         return self.store.create_registered_model(name, tags, description, deployment_job_id)
@@ -124,8 +124,7 @@ class ModelRegistryClient:
             A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
 
         """
-        if new_name.strip() == "":
-            raise MlflowException("The name must not be an empty string.")
+        _validate_model_name(new_name) 
         return self.store.rename_registered_model(name=name, new_name=new_name)
 
     def delete_registered_model(self, name):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -501,9 +501,20 @@ def _validate_list_param(param_name: str, param_value: Any, allow_none: bool = F
 
 
 def _validate_model_name(model_name):
-    if model_name is None or model_name == "":
+    if model_name is None or str(model_name).strip() == "":
         raise MlflowException(missing_value("name"), error_code=INVALID_PARAMETER_VALUE)
+    invalid_chars = ("/", ":")
+    if any(char in model_name for char in invalid_chars):
+        raise MlflowException(
+            f"Invalid model name '{model_name}'. Names cannot contain '/' or ':'.",
+            error_code=INVALID_PARAMETER_VALUE
+        )
 
+    if path_not_unique(model_name):
+        raise MlflowException(
+            invalid_value("name", model_name, bad_path_message(model_name)),
+            INVALID_PARAMETER_VALUE,
+        )
 
 def _validate_model_renaming(model_new_name):
     if model_new_name is None or model_new_name == "":


### PR DESCRIPTION
### Related Issues/PRs
### What changes are proposed in this pull request?
This PR centralizes and strengthens the input validation for Registered Model names, resolving a long-standing `TODO` in the Model Registry client codebase. 

Previously, the client only checked for empty strings. This PR shifts the validation logic to `mlflow.utils.validation._validate_model_name`, explicitly preventing the use of `/` and `:` characters to prevent URI parsing collisions.

### How is this PR tested?
- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?
- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:

### Does this PR require updating the MLflow Skills repository?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?
- [ ] `area/tracking`
- [ ] `area/models`
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

#### How should the PR be classified in the release notes? Choose one:
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`

#### Should this PR be included in the next patch release?
- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)