### PR TITLE
Add PR submission warning to issue templates and issue-warning workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.yaml
@@ -7,6 +7,11 @@ body:
   - type: markdown
     attributes:
       value: |
+        > [!WARNING]
+        > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+  - type: markdown
+    attributes:
+      value: |
         Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for additional information about bug reports. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
         #### Please fill in this bug report template to ensure a timely and thorough response.
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.yaml
@@ -8,7 +8,12 @@ body:
     attributes:
       value: |
         > [!WARNING]
-        > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+        > Before submitting a PR, please make sure that:
+        > - A maintainer has triaged this issue and applied the `ready` label
+        > - This issue has no assignee
+        > - No duplicate PR exists
+        >
+        > PRs not meeting these requirements may be automatically closed.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/doc_fix_template.yaml
+++ b/.github/ISSUE_TEMPLATE/doc_fix_template.yaml
@@ -7,6 +7,11 @@ body:
   - type: markdown
     attributes:
       value: |
+        > [!WARNING]
+        > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+  - type: markdown
+    attributes:
+      value: |
         Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for information on what types of issues we address.
 
         **Is this the right repository?**

--- a/.github/ISSUE_TEMPLATE/doc_fix_template.yaml
+++ b/.github/ISSUE_TEMPLATE/doc_fix_template.yaml
@@ -8,7 +8,12 @@ body:
     attributes:
       value: |
         > [!WARNING]
-        > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+        > Before submitting a PR, please make sure that:
+        > - A maintainer has triaged this issue and applied the `ready` label
+        > - This issue has no assignee
+        > - No duplicate PR exists
+        >
+        > PRs not meeting these requirements may be automatically closed.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/feature_request_template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.yaml
@@ -7,6 +7,11 @@ body:
   - type: markdown
     attributes:
       value: |
+        > [!WARNING]
+        > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+  - type: markdown
+    attributes:
+      value: |
         Thank you for submitting a feature request. **Before proceeding, please review MLflow's [Issue Policy for feature requests](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md#feature-requests) and the [MLflow Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md)**.
         **Please fill in this feature request template to ensure a timely and thorough response.**
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request_template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.yaml
@@ -8,7 +8,12 @@ body:
     attributes:
       value: |
         > [!WARNING]
-        > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+        > Before submitting a PR, please make sure that:
+        > - A maintainer has triaged this issue and applied the `ready` label
+        > - This issue has no assignee
+        > - No duplicate PR exists
+        >
+        > PRs not meeting these requirements may be automatically closed.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/installation_issue_template.yaml
+++ b/.github/ISSUE_TEMPLATE/installation_issue_template.yaml
@@ -7,6 +7,11 @@ body:
   - type: markdown
     attributes:
       value: |
+        > [!WARNING]
+        > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+  - type: markdown
+    attributes:
+      value: |
         Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for information on what types of issues we address.
         **Please fill in this installation issue template to ensure a timely and thorough response.**
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/installation_issue_template.yaml
+++ b/.github/ISSUE_TEMPLATE/installation_issue_template.yaml
@@ -8,7 +8,12 @@ body:
     attributes:
       value: |
         > [!WARNING]
-        > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+        > Before submitting a PR, please make sure that:
+        > - A maintainer has triaged this issue and applied the `ready` label
+        > - This issue has no assignee
+        > - No duplicate PR exists
+        >
+        > PRs not meeting these requirements may be automatically closed.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
@@ -7,6 +7,11 @@ body:
   - type: markdown
     attributes:
       value: |
+        > [!WARNING]
+        > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+  - type: markdown
+    attributes:
+      value: |
         Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for additional information about bug reports. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
         #### Please fill in this UI bug report template to ensure a timely and thorough response.
 

--- a/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
@@ -8,7 +8,12 @@ body:
     attributes:
       value: |
         > [!WARNING]
-        > Please submit a PR only if the issue has the `ready` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+        > Before submitting a PR, please make sure that:
+        > - A maintainer has triaged this issue and applied the `ready` label
+        > - This issue has no assignee
+        > - No duplicate PR exists
+        >
+        > PRs not meeting these requirements may be automatically closed.
   - type: markdown
     attributes:
       value: |

--- a/.github/workflows/issue-warning.yml
+++ b/.github/workflows/issue-warning.yml
@@ -30,7 +30,12 @@ jobs:
 
           body="<!-- issue-warning -->
           > [!WARNING]
-          > Please submit a PR only if the issue has the \`ready\` label, has no assignee, and no duplicate PR exists. PRs not meeting these requirements may be automatically closed.
+          > Before submitting a PR, please make sure that:
+          > - A maintainer has triaged this issue and applied the \`ready\` label
+          > - This issue has no assignee
+          > - No duplicate PR exists
+          >
+          > PRs not meeting these requirements may be automatically closed.
 
           ${ISSUE_BODY}"
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds a PR submission warning to all user-facing issue templates and the `issue-warning` workflow so contributors see the requirements **before** submitting a PR:

- A maintainer has triaged the issue and applied the `ready` label
- The issue has no assignee
- No duplicate PR exists

> [!NOTE]
> The `issue-warning` workflow is still needed because `markdown` fields in GitHub issue forms are only rendered in the form UI — they do **not** appear in the submitted issue body.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)