### PR TITLE
Add PreToolUse hook to validate PR body against template

### DIFF
--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -32,10 +32,12 @@ def main() -> None:
     except (json.JSONDecodeError, OSError):
         return
 
-    if input_data.get("tool_name") != "Bash":
-        return
+    match input_data:
+        case {"tool_name": "Bash", "tool_input": {"command": str(command)}}:
+            pass
+        case _:
+            return
 
-    command = input_data.get("tool_input", {}).get("command", "")
     if not re.search(r"gh\s+pr\s+create\b", command):
         return
 

--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -5,16 +5,12 @@ import re
 import sys
 from pathlib import Path
 
-TEMPLATE_PATH = Path(__file__).resolve().parents[2] / ".github" / "pull_request_template.md"
-
 
 def get_headers() -> list[str]:
     """Parse heading sections (#, ##, ###, etc.) from the PR template."""
-    return [
-        line.strip()
-        for line in TEMPLATE_PATH.read_text().splitlines()
-        if re.match(r"^#+\s", line.strip())
-    ]
+    pr_template = Path(__file__).resolve().parents[2] / ".github" / "pull_request_template.md"
+    lines = (l.strip() for l in pr_template.read_text().splitlines())
+    return [l for l in lines if re.match(r"^#+\s", l)]
 
 
 def deny(reason: str) -> None:
@@ -50,15 +46,12 @@ def main() -> None:
     if not re.search(r"(--body\b|-b\b)", command):
         return
 
-    if not TEMPLATE_PATH.exists():
-        return
-
     # Check section headings against the command lines rather than parsing the
     # body out. The headings (e.g. "### How is this PR tested?") are unique
     # enough that they won't appear in other flags like --title or --repo, so the
     # risk of false positives is negligible.
-    command_lines = {line.strip() for line in command.splitlines()}
     headers = get_headers()
+    command_lines = {line.strip() for line in command.splitlines()}
     missing = [s for s in headers if s not in command_lines]
 
     # If all sections are missing, the body is likely opaque (e.g. --body "$VAR")

--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -1,0 +1,65 @@
+"""Hook to validate that `gh pr create` includes all sections from the PR template."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+TEMPLATE_PATH = Path(__file__).resolve().parents[2] / ".github" / "pull_request_template.md"
+
+
+def get_required_sections() -> list[str]:
+    """Parse heading sections (##, ###, etc.) from the PR template."""
+    return [
+        line.strip()
+        for line in TEMPLATE_PATH.read_text().splitlines()
+        if re.match(r"^#{2,}\s", line.strip())
+    ]
+
+
+def deny(reason: str) -> None:
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        },
+        sys.stdout,
+    )
+
+
+def main() -> None:
+    input_data = json.loads(sys.stdin.read())
+
+    if input_data.get("tool_name") != "Bash":
+        return
+
+    command = input_data.get("tool_input", {}).get("command", "")
+    if not re.search(r"gh\s+pr\s+create\b", command):
+        return
+
+    # Skip commands without a body (e.g. --help)
+    if not re.search(r"(--body\b|-b\b)", command):
+        return
+
+    if not TEMPLATE_PATH.exists():
+        return
+
+    # Check section headings against the entire command string rather than parsing
+    # the body out. The headings (e.g. "### How is this PR tested?") are unique
+    # enough that they won't appear in other flags like --title or --repo, so the
+    # risk of false positives is negligible.
+    command_lines = {line.strip() for line in command.splitlines()}
+    if missing := [s for s in get_required_sections() if s not in command_lines]:
+        missing_list = "\n".join(f"  - {s}" for s in missing)
+        deny(
+            f"PR body is missing required sections from the PR template:\n"
+            f"{missing_list}\n"
+            f"Please include all sections from .github/pull_request_template.md."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 
-def get_headers() -> list[str]:
+def get_headings() -> list[str]:
     """Parse heading sections (#, ##, ###, etc.) from the PR template."""
     pr_template = Path(__file__).resolve().parents[2] / ".github" / "pull_request_template.md"
     lines = (l.strip() for l in pr_template.read_text().splitlines())
@@ -57,14 +57,14 @@ def main() -> None:
     # body out. The headings (e.g. "### How is this PR tested?") are unique
     # enough that they won't appear in other flags like --title or --repo, so the
     # risk of false positives is negligible.
-    headers = get_headers()
+    headings = get_headings()
     command_lines = {line.strip() for line in command.splitlines()}
-    missing = [s for s in headers if s not in command_lines]
+    missing = [s for s in headings if s not in command_lines]
 
     # If all sections are missing, the body is likely opaque (e.g. --body "$VAR")
     # and we can't validate it. Only deny when some sections are present but
     # others are missing, indicating an incomplete but visible body.
-    if missing and len(missing) < len(headers):
+    if missing and len(missing) < len(headings):
         missing_list = "\n".join(f"  - {s}" for s in missing)
         deny(
             f"PR body is missing required sections from the PR template:\n"

--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -33,7 +33,12 @@ def main() -> None:
         return
 
     match input_data:
-        case {"tool_name": "Bash", "tool_input": {"command": str(command)}}:
+        case {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": str(command),
+            },
+        }:
             pass
         case _:
             return

--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -31,7 +31,10 @@ def deny(reason: str) -> None:
 
 
 def main() -> None:
-    input_data = json.loads(sys.stdin.read())
+    try:
+        input_data = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, OSError):
+        return
 
     if input_data.get("tool_name") != "Bash":
         return
@@ -40,7 +43,10 @@ def main() -> None:
     if not re.search(r"gh\s+pr\s+create\b", command):
         return
 
-    # Skip commands without a body (e.g. --help)
+    # Skip commands without a body (e.g. --help) or with --body-file / -F
+    # (we can't validate file contents from the command string)
+    if re.search(r"(--body-file\b|-F\b)", command):
+        return
     if not re.search(r"(--body\b|-b\b)", command):
         return
 

--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -53,12 +53,18 @@ def main() -> None:
     if not TEMPLATE_PATH.exists():
         return
 
-    # Check section headings against the entire command string rather than parsing
-    # the body out. The headings (e.g. "### How is this PR tested?") are unique
+    # Check section headings against the command lines rather than parsing the
+    # body out. The headings (e.g. "### How is this PR tested?") are unique
     # enough that they won't appear in other flags like --title or --repo, so the
     # risk of false positives is negligible.
     command_lines = {line.strip() for line in command.splitlines()}
-    if missing := [s for s in get_required_sections() if s not in command_lines]:
+    required = get_required_sections()
+    missing = [s for s in required if s not in command_lines]
+
+    # If all sections are missing, the body is likely opaque (e.g. --body "$VAR")
+    # and we can't validate it. Only deny when some sections are present but
+    # others are missing, indicating an incomplete but visible body.
+    if missing and len(missing) < len(required):
         missing_list = "\n".join(f"  - {s}" for s in missing)
         deny(
             f"PR body is missing required sections from the PR template:\n"

--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -8,12 +8,12 @@ from pathlib import Path
 TEMPLATE_PATH = Path(__file__).resolve().parents[2] / ".github" / "pull_request_template.md"
 
 
-def get_required_sections() -> list[str]:
-    """Parse heading sections (##, ###, etc.) from the PR template."""
+def get_headers() -> list[str]:
+    """Parse heading sections (#, ##, ###, etc.) from the PR template."""
     return [
         line.strip()
         for line in TEMPLATE_PATH.read_text().splitlines()
-        if re.match(r"^#{2,}\s", line.strip())
+        if re.match(r"^#+\s", line.strip())
     ]
 
 
@@ -58,13 +58,13 @@ def main() -> None:
     # enough that they won't appear in other flags like --title or --repo, so the
     # risk of false positives is negligible.
     command_lines = {line.strip() for line in command.splitlines()}
-    required = get_required_sections()
-    missing = [s for s in required if s not in command_lines]
+    headers = get_headers()
+    missing = [s for s in headers if s not in command_lines]
 
     # If all sections are missing, the body is likely opaque (e.g. --body "$VAR")
     # and we can't validate it. Only deny when some sections are present but
     # others are missing, indicating an incomplete but visible body.
-    if missing and len(missing) < len(required):
+    if missing and len(missing) < len(headers):
         missing_list = "\n".join(f"  - {s}" for s in missing)
         deny(
             f"PR body is missing required sections from the PR template:\n"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/enforce-uv.sh",
             "timeout": 5.0
+          },
+          {
+            "type": "command",
+            "command": "uv run --directory=$CLAUDE_PROJECT_DIR --no-project .claude/hooks/validate_pr_body.py",
+            "timeout": 5.0
           }
         ]
       }


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a Claude Code PreToolUse hook that dynamically validates `gh pr create` bodies contain all required sections from `.github/pull_request_template.md`.

### How is this PR tested?

- [x] Manual tests

```bash
# --help (no --body) → skipped
printf '{"tool_name":"Bash","tool_input":{"command":"gh pr create --help"}}' | uv run --no-project .claude/hooks/validate_pr_body.py

# --body-file → skipped
printf '{"tool_name":"Bash","tool_input":{"command":"gh pr create --body-file pr.md"}}' | uv run --no-project .claude/hooks/validate_pr_body.py

# non-gh command → skipped
printf '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | uv run --no-project .claude/hooks/validate_pr_body.py

# --body with all sections missing (opaque body) → skipped
printf '{"tool_name":"Bash","tool_input":{"command":"gh pr create --body \"missing body\""}}' | uv run --no-project .claude/hooks/validate_pr_body.py

# --body with some sections present → denied with missing list
printf '{"tool_name":"Bash","tool_input":{"command":"gh pr create --body test\n### Related Issues/PRs\n### What changes are proposed in this pull request?\n### How is this PR tested?"}}' | uv run --no-project .claude/hooks/validate_pr_body.py
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)