### PR TITLE
[Docs] Clarify custom scorer limitations for automatic evaluation

### DIFF
--- a/docs/docs/genai/eval-monitor/automatic-evaluations/index.mdx
+++ b/docs/docs/genai/eval-monitor/automatic-evaluations/index.mdx
@@ -42,7 +42,7 @@ These examples show how to set up LLM judges that automatically evaluate traces 
 
 :::note
 
-- Automatic evaluation only supports [LLM judges](/genai/eval-monitor/scorers/#llms-as-judges). Code-based scorers (using the [`@scorer` decorator](/genai/eval-monitor/scorers/custom)) are not supported. Use [built-in judges](/genai/eval-monitor/scorers/llm-judge/predefined) or create custom judges with [`make_judge()`](/genai/eval-monitor/scorers/llm-judge/custom-judges/create-custom-judge).
+- Automatic evaluation only supports [LLM judges](/genai/eval-monitor/scorers/#llms-as-judges). Code-based scorers (using the [`@scorer` decorator](/genai/eval-monitor/scorers/custom) or [`Scorer` class](/genai/eval-monitor/scorers/custom/#define-scorers-with-the-scorer-class)) are not supported. Use [built-in judges](/genai/eval-monitor/scorers/llm-judge/predefined) or create custom judges with [`make_judge()`](/genai/eval-monitor/scorers/llm-judge/custom-judges/create-custom-judge).
 - When a judge is created or enabled, it evaluates traces and sessions that are **at most one hour old**. Updating a judge's configuration does not trigger re-evaluation of previously assessed traces.
   :::
 

--- a/docs/docs/genai/eval-monitor/scorers/custom/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/custom/index.mdx
@@ -20,9 +20,15 @@ Use custom scorers for the following scenarios:
 
 For a tutorial with many examples, see [Code-based scorer examples](/genai/eval-monitor/scorers/custom/code-examples).
 
+:::note[Custom scorers are for offline evaluation only]
+
+Custom code-based scorers (both the [`@scorer` decorator](#define-scorers-with-the-scorer-decorator) and the [`Scorer` class](#define-scorers-with-the-scorer-class)) work with <APILink fn="mlflow.genai.evaluate">`mlflow.genai.evaluate()`</APILink> for offline evaluation. They are **not supported** for [automatic evaluation](/genai/eval-monitor/automatic-evaluations) (production monitoring), which only supports [LLM judges](/genai/eval-monitor/scorers/#llms-as-judges) such as [built-in judges](/genai/eval-monitor/scorers/llm-judge/predefined), [`make_judge()`](/genai/eval-monitor/scorers/llm-judge/custom-judges/create-custom-judge), and [Guidelines](/genai/eval-monitor/scorers/llm-judge/guidelines).
+
+:::
+
 ## How custom scorers work
 
-Custom scorers are written in Python and give you full control to evaluate any data from your app's traces. After you define a custom scorer, you can use it exactly like a [built-in LLM Judge](/genai/eval-monitor/scorers/llm-judge/predefined/#available-judges).
+Custom scorers are written in Python and give you full control to evaluate any data from your app's traces. After you define a custom scorer, you can use it with <APILink fn="mlflow.genai.evaluate">`mlflow.genai.evaluate()`</APILink> just like a [built-in LLM Judge](/genai/eval-monitor/scorers/llm-judge/predefined/#available-judges).
 
 For example, suppose you want a scorer that checks if the LLM's response exactly matches the `expected_response` and is short enough. The image of the MLflow UI below shows traces scored by these custom metrics.
 
@@ -381,6 +387,12 @@ The `error` parameter accepts:
 - <APILink fn="mlflow.entities.Feedback">`AssessmentError()`</APILink>: For structured error reporting with error codes
 
 ## Define scorers with the Scorer class
+
+:::note[Evaluation only]
+
+Class-based `Scorer` subclasses can only be used with <APILink fn="mlflow.genai.evaluate">`mlflow.genai.evaluate()`</APILink> for offline evaluation. They cannot be registered for [automatic evaluation](/genai/eval-monitor/automatic-evaluations) (production monitoring). If you need production monitoring, use [LLM judges](/genai/eval-monitor/scorers/#llms-as-judges) instead.
+
+:::
 
 The [`@scorer` decorator](#define-scorers-with-the-scorer-decorator) described above is simple and generally recommended, but when it is insufficient, you can instead use the <APILink fn="mlflow.genai.Scorer">`Scorer`</APILink> base class. Class-based definitions allow for more complex scorers, especially scorers that require state. The <APILink fn="mlflow.genai.Scorer">`Scorer`</APILink> class is a [Pydantic object](https://docs.pydantic.dev/latest/concepts/models/), so you can define additional fields and use them in the `__call__` method.
 

--- a/docs/docs/genai/eval-monitor/scorers/custom/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/custom/index.mdx
@@ -388,12 +388,6 @@ The `error` parameter accepts:
 
 ## Define scorers with the Scorer class
 
-:::note[Evaluation only]
-
-Class-based `Scorer` subclasses can only be used with <APILink fn="mlflow.genai.evaluate">`mlflow.genai.evaluate()`</APILink> for offline evaluation. They cannot be registered for [automatic evaluation](/genai/eval-monitor/automatic-evaluations) (production monitoring). If you need production monitoring, use [LLM judges](/genai/eval-monitor/scorers/#llms-as-judges) instead.
-
-:::
-
 The [`@scorer` decorator](#define-scorers-with-the-scorer-decorator) described above is simple and generally recommended, but when it is insufficient, you can instead use the <APILink fn="mlflow.genai.Scorer">`Scorer`</APILink> base class. Class-based definitions allow for more complex scorers, especially scorers that require state. The <APILink fn="mlflow.genai.Scorer">`Scorer`</APILink> class is a [Pydantic object](https://docs.pydantic.dev/latest/concepts/models/), so you can define additional fields and use them in the `__call__` method.
 
 You must define the `name` field to set the metric name. If you return a list of `Feedback` objects, then you must set the `name` field in each `Feedback` to avoid naming conflicts.


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

Clarifies that custom code-based scorers are for offline evaluation only, not automatic evaluation/production monitoring.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)