### PR TITLE
Add multimodal trace attachment support (Client SDK + Artifact Repo)

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -568,7 +568,7 @@ class LiveSpan(Span):
         from mlflow.tracing.attachments import Attachment
 
         if isinstance(value, Attachment):
-            ref = value.ref(self._trace_id)
+            ref = value.ref(self.trace_id)
             self._attachments[value.id] = value
             return ref
         if isinstance(value, dict):

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -573,7 +573,7 @@ class LiveSpan(Span):
             return ref
         if isinstance(value, dict):
             return {k: self._extract_attachments(v) for k, v in value.items()}
-        if isinstance(value, list):
+        if isinstance(value, (list, tuple)):
             return [self._extract_attachments(item) for item in value]
         return value
 

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -112,6 +112,7 @@ class Span:
         # Since the span is immutable, we can cache the attributes to avoid the redundant
         # deserialization of the attribute values.
         self._attributes = _CachedSpanAttributesRegistry(otel_span)
+        self._attachments: dict = {}
 
     @property
     @lru_cache(maxsize=1)
@@ -538,6 +539,7 @@ class LiveSpan(Span):
             )
 
         self._span = otel_span
+        self._attachments: dict = {}
         self._attributes = _SpanAttributesRegistry(otel_span)
         self._attributes.set(SpanAttributeKey.REQUEST_ID, trace_id)
         self._attributes.set(SpanAttributeKey.SPAN_TYPE, span_type)
@@ -554,11 +556,26 @@ class LiveSpan(Span):
 
     def set_inputs(self, inputs: Any):
         """Set the input values to the span."""
+        inputs = self._extract_attachments(inputs)
         self.set_attribute(SpanAttributeKey.INPUTS, inputs)
 
     def set_outputs(self, outputs: Any):
         """Set the output values to the span."""
+        outputs = self._extract_attachments(outputs)
         self.set_attribute(SpanAttributeKey.OUTPUTS, outputs)
+
+    def _extract_attachments(self, value: Any) -> Any:
+        from mlflow.tracing.attachments import Attachment
+
+        if isinstance(value, Attachment):
+            ref = value.ref(self._trace_id)
+            self._attachments[value.id] = value
+            return ref
+        if isinstance(value, dict):
+            return {k: self._extract_attachments(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._extract_attachments(item) for item in value]
+        return value
 
     def set_attributes(self, attributes: dict[str, Any]):
         """
@@ -701,7 +718,9 @@ class LiveSpan(Span):
         :meta private:
         """
         # All state of the live span is already persisted in the OpenTelemetry span object.
-        return Span(self._span)
+        span = Span(self._span)
+        span._attachments = dict(self._attachments)
+        return span
 
     @classmethod
     def from_immutable_span(

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -112,7 +112,7 @@ class Span:
         # Since the span is immutable, we can cache the attributes to avoid the redundant
         # deserialization of the attribute values.
         self._attributes = _CachedSpanAttributesRegistry(otel_span)
-        self._attachments: dict = {}
+        self._attachments: dict[str, Any] = {}
 
     @property
     @lru_cache(maxsize=1)
@@ -539,7 +539,7 @@ class LiveSpan(Span):
             )
 
         self._span = otel_span
-        self._attachments: dict = {}
+        self._attachments: dict[str, Any] = {}
         self._attributes = _SpanAttributesRegistry(otel_span)
         self._attributes.set(SpanAttributeKey.REQUEST_ID, trace_id)
         self._attributes.set(SpanAttributeKey.SPAN_TYPE, span_type)

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -394,6 +394,13 @@ class ArtifactRepository:
                 raise MlflowTraceDataNotFound(artifact_path=TRACE_DATA_FILE_NAME) from e
             return try_read_trace_data(temp_file)
 
+    def download_trace_attachment(self, path: str) -> bytes:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filename = Path(path).name
+            temp_file = Path(temp_dir, filename)
+            self._download_file(posixpath.join("attachments", path), temp_file)
+            return temp_file.read_bytes()
+
     def upload_trace_data(self, trace_data: str) -> None:
         """
         Upload the trace data.
@@ -403,6 +410,12 @@ class ArtifactRepository:
         """
         with write_local_temp_trace_data_file(trace_data) as temp_file:
             self.log_artifact(temp_file)
+
+    def upload_attachment(self, attachment_id: str, content_bytes: bytes) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file = Path(temp_dir, attachment_id)
+            temp_file.write_bytes(content_bytes)
+            self.log_artifact(temp_file, artifact_path="attachments")
 
 
 @contextmanager

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import posixpath
+import re
 import tempfile
 import traceback
 from abc import ABC, ABCMeta, abstractmethod
@@ -395,9 +396,9 @@ class ArtifactRepository:
             return try_read_trace_data(temp_file)
 
     def download_trace_attachment(self, path: str) -> bytes:
+        _validate_attachment_path(path)
         with tempfile.TemporaryDirectory() as temp_dir:
-            filename = Path(path).name
-            temp_file = Path(temp_dir, filename)
+            temp_file = Path(temp_dir, path)
             self._download_file(posixpath.join("attachments", path), temp_file)
             return temp_file.read_bytes()
 
@@ -412,6 +413,7 @@ class ArtifactRepository:
             self.log_artifact(temp_file)
 
     def upload_attachment(self, attachment_id: str, content_bytes: bytes) -> None:
+        _validate_attachment_path(attachment_id)
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_file = Path(temp_dir, attachment_id)
             temp_file.write_bytes(content_bytes)
@@ -519,4 +521,16 @@ def verify_artifact_path(artifact_path):
     if artifact_path and path_not_unique(artifact_path):
         raise MlflowException(
             f"Invalid artifact path: '{artifact_path}'. {bad_path_message(artifact_path)}"
+        )
+
+
+_ATTACHMENT_PATH_PATTERN = re.compile(r"^[a-f0-9\-]+$")
+
+
+def _validate_attachment_path(path: str) -> None:
+    if not path or not _ATTACHMENT_PATH_PATTERN.match(path):
+        raise MlflowException(
+            f"Invalid attachment path: '{path}'. "
+            "Attachment path must be a UUID (lowercase hex and hyphens only).",
+            error_code=INVALID_PARAMETER_VALUE,
         )

--- a/mlflow/tracing/attachments.py
+++ b/mlflow/tracing/attachments.py
@@ -1,7 +1,7 @@
 import mimetypes
 import uuid
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 
 class Attachment:
@@ -40,9 +40,8 @@ class Attachment:
         return self._content_bytes
 
     def ref(self, trace_id: str) -> str:
-        return (
-            f"mlflow-attachment://{self._id}?content_type={self._content_type}&trace_id={trace_id}"
-        )
+        query = urlencode({"content_type": self._content_type, "trace_id": trace_id})
+        return f"mlflow-attachment://{self._id}?{query}"
 
     @staticmethod
     def parse_ref(ref_uri: str) -> dict[str, str] | None:

--- a/mlflow/tracing/attachments.py
+++ b/mlflow/tracing/attachments.py
@@ -1,0 +1,64 @@
+import mimetypes
+import uuid
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+
+class Attachment:
+    """
+    Represents a binary attachment (image, audio, PDF, etc.) that can be logged
+    as part of a trace span's inputs or outputs.
+
+    When an Attachment is set as a span input/output value, it is automatically:
+    1. Replaced with a reference URI in the span data
+    2. Uploaded as a separate artifact file alongside the trace data
+    """
+
+    def __init__(self, *, content_type: str, content_bytes: bytes):
+        self._id = str(uuid.uuid4())
+        self._content_type = content_type
+        self._content_bytes = content_bytes
+
+    @classmethod
+    def from_file(cls, path: str | Path, content_type: str | None = None) -> "Attachment":
+        path = Path(path)
+        if content_type is None:
+            guessed, _ = mimetypes.guess_type(str(path))
+            content_type = guessed or "application/octet-stream"
+        return cls(content_type=content_type, content_bytes=path.read_bytes())
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def content_type(self) -> str:
+        return self._content_type
+
+    @property
+    def content_bytes(self) -> bytes:
+        return self._content_bytes
+
+    def ref(self, trace_id: str) -> str:
+        return (
+            f"mlflow-attachment://{self._id}"
+            f"?content_type={self._content_type}"
+            f"&trace_id={trace_id}"
+        )
+
+    @staticmethod
+    def parse_ref(ref_uri: str) -> dict[str, str] | None:
+        parsed = urlparse(ref_uri)
+        if parsed.scheme != "mlflow-attachment":
+            return None
+        params = parse_qs(parsed.query)
+        attachment_id = parsed.hostname
+        content_type = params.get("content_type", [None])[0]
+        trace_id = params.get("trace_id", [None])[0]
+        if not attachment_id or not content_type or not trace_id:
+            return None
+        return {
+            "attachment_id": attachment_id,
+            "content_type": content_type,
+            "trace_id": trace_id,
+        }

--- a/mlflow/tracing/attachments.py
+++ b/mlflow/tracing/attachments.py
@@ -41,9 +41,7 @@ class Attachment:
 
     def ref(self, trace_id: str) -> str:
         return (
-            f"mlflow-attachment://{self._id}"
-            f"?content_type={self._content_type}"
-            f"&trace_id={trace_id}"
+            f"mlflow-attachment://{self._id}?content_type={self._content_type}&trace_id={trace_id}"
         )
 
     @staticmethod

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -690,7 +690,7 @@ class TracingClient:
     def _upload_attachments(
         self,
         trace_info: TraceInfo,
-        attachments: dict[str, Any],
+        attachments: dict[str, "Attachment"],
     ) -> None:
         artifact_repo = self._get_artifact_repo_for_trace(trace_info)
         for attachment_id, attachment in attachments.items():

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -4,7 +4,7 @@ import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
-from typing import Sequence
+from typing import Any, Sequence
 
 import mlflow
 from mlflow.entities.assessment import Assessment
@@ -690,7 +690,7 @@ class TracingClient:
     def _upload_attachments(
         self,
         trace_info: TraceInfo,
-        attachments: dict,
+        attachments: dict[str, Any],
     ) -> None:
         artifact_repo = self._get_artifact_repo_for_trace(trace_info)
         for attachment_id, attachment in attachments.items():

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -687,6 +687,15 @@ class TracingClient:
         trace_data_json = json.dumps(trace_data.to_dict(), cls=TraceJSONEncoder, ensure_ascii=False)
         return artifact_repo.upload_trace_data(trace_data_json)
 
+    def _upload_attachments(
+        self,
+        trace_info: TraceInfo,
+        attachments: dict,
+    ) -> None:
+        artifact_repo = self._get_artifact_repo_for_trace(trace_info)
+        for attachment_id, attachment in attachments.items():
+            artifact_repo.upload_attachment(attachment_id, attachment.content_bytes)
+
     def link_prompt_versions_to_trace(
         self, trace_id: str, prompts: Sequence[PromptVersion]
     ) -> None:

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -204,6 +204,11 @@ class MlflowV3SpanExporter(SpanExporter):
                 returned_trace_info = self._client.start_trace(trace.info)
                 if self._should_log_spans_to_artifacts(returned_trace_info):
                     self._client._upload_trace_data(returned_trace_info, trace.data)
+                    attachments = {}
+                    for span in trace.data.spans:
+                        attachments.update(span._attachments)
+                    if attachments:
+                        self._client._upload_attachments(returned_trace_info, attachments)
             else:
                 _logger.warning("No trace or trace info provided, unable to export")
         except Exception as e:

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -204,11 +204,15 @@ class MlflowV3SpanExporter(SpanExporter):
                 returned_trace_info = self._client.start_trace(trace.info)
                 if self._should_log_spans_to_artifacts(returned_trace_info):
                     self._client._upload_trace_data(returned_trace_info, trace.data)
-                    attachments = {}
-                    for span in trace.data.spans:
-                        attachments.update(span._attachments)
-                    if attachments:
-                        self._client._upload_attachments(returned_trace_info, attachments)
+
+                # Upload attachments regardless of span storage mode.
+                # In TRACKING_STORE mode, spans are in the DB but attachments
+                # still go to the artifact repo via the mlflow.artifactLocation tag.
+                attachments = {}
+                for span in trace.data.spans:
+                    attachments.update(span._attachments)
+                if attachments:
+                    self._client._upload_attachments(returned_trace_info, attachments)
             else:
                 _logger.warning("No trace or trace info provided, unable to export")
         except Exception as e:

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -198,26 +198,35 @@ class MlflowV3SpanExporter(SpanExporter):
         1. Create the trace in MLflow
         2. Upload the trace data to blob storage using the returned trace info.
         """
+        returned_trace_info = None
         try:
             if trace:
                 add_size_stats_to_trace_metadata(trace)
                 returned_trace_info = self._client.start_trace(trace.info)
                 if self._should_log_spans_to_artifacts(returned_trace_info):
                     self._client._upload_trace_data(returned_trace_info, trace.data)
-
-                # Upload attachments regardless of span storage mode.
-                # In TRACKING_STORE mode, spans are in the DB but attachments
-                # still go to the artifact repo via the mlflow.artifactLocation tag.
-                attachments = {}
-                for span in trace.data.spans:
-                    attachments.update(span._attachments)
-                if attachments:
-                    self._client._upload_attachments(returned_trace_info, attachments)
             else:
                 _logger.warning("No trace or trace info provided, unable to export")
         except Exception as e:
             _logger.warning(
                 f"Failed to send trace to MLflow backend: {e}",
+                exc_info=_logger.isEnabledFor(logging.DEBUG),
+            )
+
+        # Upload attachments in a separate try-except so trace data still lands
+        # even if attachment upload fails. Runs regardless of span storage mode —
+        # in TRACKING_STORE mode, spans are in the DB but attachments still go
+        # to the artifact repo via the mlflow.artifactLocation tag.
+        try:
+            if trace and returned_trace_info:
+                attachments = {}
+                for span in trace.data.spans:
+                    attachments.update(span._attachments)
+                if attachments:
+                    self._client._upload_attachments(returned_trace_info, attachments)
+        except Exception as e:
+            _logger.warning(
+                f"Failed to upload trace attachments: {e}",
                 exc_info=_logger.isEnabledFor(logging.DEBUG),
             )
 

--- a/tests/entities/test_span_attachments.py
+++ b/tests/entities/test_span_attachments.py
@@ -1,0 +1,87 @@
+from mlflow.entities.span import LiveSpan, Span
+from mlflow.tracing.attachments import Attachment
+
+
+def _make_live_span(trace_id="tr-test123"):
+    from opentelemetry.sdk.trace import TracerProvider
+
+    tracer = TracerProvider().get_tracer("test")
+    otel_span = tracer.start_span("test_span")
+    return LiveSpan(otel_span, trace_id=trace_id)
+
+
+def test_set_inputs_extracts_attachment():
+    span = _make_live_span()
+    att = Attachment(content_type="image/png", content_bytes=b"img")
+    span.set_inputs({"image": att})
+
+    assert att.id in span._attachments
+    assert span._attachments[att.id] is att
+    inputs = span.inputs
+    assert isinstance(inputs["image"], str)
+    assert inputs["image"].startswith("mlflow-attachment://")
+
+
+def test_set_outputs_extracts_attachment():
+    span = _make_live_span()
+    att = Attachment(content_type="audio/wav", content_bytes=b"audio")
+    span.set_outputs({"sound": att})
+
+    assert att.id in span._attachments
+    outputs = span.outputs
+    assert isinstance(outputs["sound"], str)
+    assert "audio/wav" in outputs["sound"]
+
+
+def test_nested_dict_extraction():
+    span = _make_live_span()
+    att = Attachment(content_type="image/jpeg", content_bytes=b"jpg")
+    span.set_inputs({"nested": {"deep": att}})
+
+    assert att.id in span._attachments
+    inputs = span.inputs
+    assert isinstance(inputs["nested"]["deep"], str)
+    assert att.id in inputs["nested"]["deep"]
+
+
+def test_list_extraction():
+    span = _make_live_span()
+    att1 = Attachment(content_type="image/png", content_bytes=b"a")
+    att2 = Attachment(content_type="image/png", content_bytes=b"b")
+    span.set_inputs({"images": [att1, att2]})
+
+    assert att1.id in span._attachments
+    assert att2.id in span._attachments
+    inputs = span.inputs
+    assert len(inputs["images"]) == 2
+    assert all(isinstance(v, str) for v in inputs["images"])
+
+
+def test_mixed_values_only_replaces_attachments():
+    span = _make_live_span()
+    att = Attachment(content_type="image/png", content_bytes=b"img")
+    span.set_inputs({"image": att, "text": "hello", "number": 42})
+
+    assert att.id in span._attachments
+    inputs = span.inputs
+    assert inputs["text"] == "hello"
+    assert inputs["number"] == 42
+    assert isinstance(inputs["image"], str)
+
+
+def test_non_dict_input_without_attachment():
+    span = _make_live_span()
+    span.set_inputs("plain string")
+    assert span._attachments == {}
+    assert span.inputs == "plain string"
+
+
+def test_to_immutable_span_propagates_attachments():
+    span = _make_live_span()
+    att = Attachment(content_type="image/png", content_bytes=b"img")
+    span.set_inputs({"image": att})
+
+    immutable = span.to_immutable_span()
+    assert isinstance(immutable, Span)
+    assert att.id in immutable._attachments
+    assert immutable._attachments[att.id] is att

--- a/tests/entities/test_span_attachments.py
+++ b/tests/entities/test_span_attachments.py
@@ -77,6 +77,32 @@ def test_non_dict_input_without_attachment():
     assert span.inputs == "plain string"
 
 
+def test_tuple_extraction():
+    span = _make_live_span()
+    att = Attachment(content_type="image/png", content_bytes=b"img")
+    span.set_inputs({"images": (att, "text")})
+
+    assert att.id in span._attachments
+    inputs = span.inputs
+    assert isinstance(inputs["images"], list)
+    assert isinstance(inputs["images"][0], str)
+    assert inputs["images"][0].startswith("mlflow-attachment://")
+    assert inputs["images"][1] == "text"
+
+
+def test_set_inputs_twice_accumulates_attachments():
+    span = _make_live_span()
+    att1 = Attachment(content_type="image/png", content_bytes=b"first")
+    att2 = Attachment(content_type="image/jpeg", content_bytes=b"second")
+
+    span.set_inputs({"img": att1})
+    span.set_outputs({"img": att2})
+
+    assert att1.id in span._attachments
+    assert att2.id in span._attachments
+    assert len(span._attachments) == 2
+
+
 def test_to_immutable_span_propagates_attachments():
     span = _make_live_span()
     att = Attachment(content_type="image/png", content_bytes=b"img")

--- a/tests/entities/test_span_attachments.py
+++ b/tests/entities/test_span_attachments.py
@@ -20,6 +20,9 @@ def test_set_inputs_extracts_attachment():
     inputs = span.inputs
     assert isinstance(inputs["image"], str)
     assert inputs["image"].startswith("mlflow-attachment://")
+    parsed = Attachment.parse_ref(inputs["image"])
+    assert parsed["trace_id"] == "tr-test123"
+    assert parsed["attachment_id"] == att.id
 
 
 def test_set_outputs_extracts_attachment():

--- a/tests/entities/test_span_attachments.py
+++ b/tests/entities/test_span_attachments.py
@@ -30,7 +30,8 @@ def test_set_outputs_extracts_attachment():
     assert att.id in span._attachments
     outputs = span.outputs
     assert isinstance(outputs["sound"], str)
-    assert "audio/wav" in outputs["sound"]
+    parsed = Attachment.parse_ref(outputs["sound"])
+    assert parsed["content_type"] == "audio/wav"
 
 
 def test_nested_dict_extraction():

--- a/tests/store/artifact/test_artifact_repo_attachments.py
+++ b/tests/store/artifact/test_artifact_repo_attachments.py
@@ -1,0 +1,36 @@
+from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
+
+
+def test_upload_attachment(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+    attachment_id = "test-attachment-id"
+    content = b"fake image bytes"
+
+    repo.upload_attachment(attachment_id, content)
+
+    artifact_path = tmp_path / "attachments" / attachment_id
+    assert artifact_path.exists()
+    assert artifact_path.read_bytes() == content
+
+
+def test_download_trace_attachment(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+
+    # Manually place an attachment file
+    attachments_dir = tmp_path / "attachments"
+    attachments_dir.mkdir()
+    attachment_id = "test-attachment-id"
+    (attachments_dir / attachment_id).write_bytes(b"stored bytes")
+
+    result = repo.download_trace_attachment(attachment_id)
+    assert result == b"stored bytes"
+
+
+def test_upload_and_download_roundtrip(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+    attachment_id = "roundtrip-id"
+    content = b"\x89PNG\r\n\x1a\n fake png header"
+
+    repo.upload_attachment(attachment_id, content)
+    result = repo.download_trace_attachment(attachment_id)
+    assert result == content

--- a/tests/store/artifact/test_artifact_repo_attachments.py
+++ b/tests/store/artifact/test_artifact_repo_attachments.py
@@ -1,9 +1,14 @@
+import uuid
+
+import pytest
+
+from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
 
 
 def test_upload_attachment(tmp_path):
     repo = LocalArtifactRepository(str(tmp_path))
-    attachment_id = "test-attachment-id"
+    attachment_id = str(uuid.uuid4())
     content = b"fake image bytes"
 
     repo.upload_attachment(attachment_id, content)
@@ -19,7 +24,7 @@ def test_download_trace_attachment(tmp_path):
     # Manually place an attachment file
     attachments_dir = tmp_path / "attachments"
     attachments_dir.mkdir()
-    attachment_id = "test-attachment-id"
+    attachment_id = str(uuid.uuid4())
     (attachments_dir / attachment_id).write_bytes(b"stored bytes")
 
     result = repo.download_trace_attachment(attachment_id)
@@ -28,9 +33,27 @@ def test_download_trace_attachment(tmp_path):
 
 def test_upload_and_download_roundtrip(tmp_path):
     repo = LocalArtifactRepository(str(tmp_path))
-    attachment_id = "roundtrip-id"
+    attachment_id = str(uuid.uuid4())
     content = b"\x89PNG\r\n\x1a\n fake png header"
 
     repo.upload_attachment(attachment_id, content)
     result = repo.download_trace_attachment(attachment_id)
     assert result == content
+
+
+def test_upload_rejects_path_traversal(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+    with pytest.raises(MlflowException, match="Invalid attachment path"):
+        repo.upload_attachment("../../etc/passwd", b"data")
+
+
+def test_download_rejects_path_traversal(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+    with pytest.raises(MlflowException, match="Invalid attachment path"):
+        repo.download_trace_attachment("../../secrets.json")
+
+
+def test_rejects_non_uuid_attachment_id(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+    with pytest.raises(MlflowException, match="Invalid attachment path"):
+        repo.upload_attachment("not-a-valid-id!", b"data")

--- a/tests/tracing/export/test_mlflow_v3_attachments.py
+++ b/tests/tracing/export/test_mlflow_v3_attachments.py
@@ -54,6 +54,35 @@ def test_log_trace_uploads_attachments():
     assert att.id in call_args[0][1]
 
 
+def test_log_trace_uploads_attachments_in_tracking_store_mode():
+    """Attachments must be uploaded even when spans are stored in the database."""
+    att = Attachment(content_type="image/png", content_bytes=b"img")
+    trace = _make_trace({att.id: att})
+    # Override to TRACKING_STORE mode
+    trace.info.tags = {TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE.value}
+
+    mock_client = MagicMock()
+    returned_info = MagicMock()
+    returned_info.tags = {TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE.value}
+    mock_client.start_trace.return_value = returned_info
+
+    exporter = _make_exporter(mock_client)
+
+    with (
+        patch("mlflow.tracing.export.mlflow_v3.try_link_prompts_to_trace"),
+        patch("mlflow.tracing.export.mlflow_v3.add_size_stats_to_trace_metadata"),
+    ):
+        exporter._log_trace(trace, prompts=[])
+
+    # traces.json should NOT be uploaded in TRACKING_STORE mode
+    mock_client._upload_trace_data.assert_not_called()
+    # But attachments MUST still be uploaded to the artifact repo
+    mock_client._upload_attachments.assert_called_once()
+    call_args = mock_client._upload_attachments.call_args
+    assert call_args[0][0] is returned_info
+    assert att.id in call_args[0][1]
+
+
 def test_log_trace_skips_upload_when_no_attachments():
     trace = _make_trace()
 

--- a/tests/tracing/export/test_mlflow_v3_attachments.py
+++ b/tests/tracing/export/test_mlflow_v3_attachments.py
@@ -83,6 +83,30 @@ def test_log_trace_uploads_attachments_in_tracking_store_mode():
     assert att.id in call_args[0][1]
 
 
+def test_trace_data_still_lands_when_attachment_upload_fails():
+    """Trace data should be persisted even if attachment upload raises."""
+    att = Attachment(content_type="image/png", content_bytes=b"img")
+    trace = _make_trace({att.id: att})
+
+    mock_client = MagicMock()
+    returned_info = _make_trace_info_mock()
+    mock_client.start_trace.return_value = returned_info
+    mock_client._upload_attachments.side_effect = Exception("S3 timeout")
+
+    exporter = _make_exporter(mock_client)
+
+    with (
+        patch("mlflow.tracing.export.mlflow_v3.try_link_prompts_to_trace"),
+        patch("mlflow.tracing.export.mlflow_v3.add_size_stats_to_trace_metadata"),
+    ):
+        # Should not raise
+        exporter._log_trace(trace, prompts=[])
+
+    # Trace data was still uploaded despite attachment failure
+    mock_client._upload_trace_data.assert_called_once_with(returned_info, trace.data)
+    mock_client._upload_attachments.assert_called_once()
+
+
 def test_log_trace_skips_upload_when_no_attachments():
     trace = _make_trace()
 

--- a/tests/tracing/export/test_mlflow_v3_attachments.py
+++ b/tests/tracing/export/test_mlflow_v3_attachments.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+
+from mlflow.tracing.attachments import Attachment
+from mlflow.tracing.constant import SpansLocation, TraceTagKey
+from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
+
+
+def _make_trace_info_mock():
+    info = MagicMock()
+    info.trace_id = "tr-test123"
+    info.tags = {TraceTagKey.SPANS_LOCATION: SpansLocation.ARTIFACT_REPO.value}
+    info.metadata = {}
+    return info
+
+
+def _make_trace(attachments_map=None):
+    span = MagicMock()
+    span._attachments = attachments_map or {}
+
+    trace = MagicMock()
+    trace.info = _make_trace_info_mock()
+    trace.info.trace_id = "tr-test123"
+    trace.data.spans = [span]
+    return trace
+
+
+@patch("mlflow.tracing.export.mlflow_v3.try_link_prompts_to_trace")
+@patch("mlflow.tracing.export.mlflow_v3.add_size_stats_to_trace_metadata")
+def test_log_trace_uploads_attachments(mock_stats, mock_link, tmp_path):
+    att = Attachment(content_type="image/png", content_bytes=b"img")
+    trace = _make_trace({att.id: att})
+
+    mock_client = MagicMock()
+    returned_info = _make_trace_info_mock()
+    mock_client.start_trace.return_value = returned_info
+
+    exporter = MlflowV3SpanExporter(str(tmp_path))
+    exporter._client = mock_client
+    exporter._log_trace(trace, prompts=[])
+
+    mock_client._upload_trace_data.assert_called_once_with(returned_info, trace.data)
+    mock_client._upload_attachments.assert_called_once()
+    call_args = mock_client._upload_attachments.call_args
+    assert call_args[0][0] is returned_info
+    assert att.id in call_args[0][1]
+
+
+@patch("mlflow.tracing.export.mlflow_v3.try_link_prompts_to_trace")
+@patch("mlflow.tracing.export.mlflow_v3.add_size_stats_to_trace_metadata")
+def test_log_trace_skips_upload_when_no_attachments(mock_stats, mock_link, tmp_path):
+    trace = _make_trace()
+
+    mock_client = MagicMock()
+    returned_info = _make_trace_info_mock()
+    mock_client.start_trace.return_value = returned_info
+
+    exporter = MlflowV3SpanExporter(str(tmp_path))
+    exporter._client = mock_client
+    exporter._log_trace(trace, prompts=[])
+
+    mock_client._upload_trace_data.assert_called_once()
+    mock_client._upload_attachments.assert_not_called()

--- a/tests/tracing/export/test_mlflow_v3_attachments.py
+++ b/tests/tracing/export/test_mlflow_v3_attachments.py
@@ -24,7 +24,14 @@ def _make_trace(attachments_map=None):
     return trace
 
 
-def test_log_trace_uploads_attachments(tmp_path):
+def _make_exporter(mock_client):
+    with patch.object(MlflowV3SpanExporter, "__init__", return_value=None):
+        exporter = MlflowV3SpanExporter()
+    exporter._client = mock_client
+    return exporter
+
+
+def test_log_trace_uploads_attachments():
     att = Attachment(content_type="image/png", content_bytes=b"img")
     trace = _make_trace({att.id: att})
 
@@ -32,12 +39,12 @@ def test_log_trace_uploads_attachments(tmp_path):
     returned_info = _make_trace_info_mock()
     mock_client.start_trace.return_value = returned_info
 
+    exporter = _make_exporter(mock_client)
+
     with (
         patch("mlflow.tracing.export.mlflow_v3.try_link_prompts_to_trace"),
         patch("mlflow.tracing.export.mlflow_v3.add_size_stats_to_trace_metadata"),
     ):
-        exporter = MlflowV3SpanExporter(str(tmp_path))
-        exporter._client = mock_client
         exporter._log_trace(trace, prompts=[])
 
     mock_client._upload_trace_data.assert_called_once_with(returned_info, trace.data)
@@ -47,19 +54,19 @@ def test_log_trace_uploads_attachments(tmp_path):
     assert att.id in call_args[0][1]
 
 
-def test_log_trace_skips_upload_when_no_attachments(tmp_path):
+def test_log_trace_skips_upload_when_no_attachments():
     trace = _make_trace()
 
     mock_client = MagicMock()
     returned_info = _make_trace_info_mock()
     mock_client.start_trace.return_value = returned_info
 
+    exporter = _make_exporter(mock_client)
+
     with (
         patch("mlflow.tracing.export.mlflow_v3.try_link_prompts_to_trace"),
         patch("mlflow.tracing.export.mlflow_v3.add_size_stats_to_trace_metadata"),
     ):
-        exporter = MlflowV3SpanExporter(str(tmp_path))
-        exporter._client = mock_client
         exporter._log_trace(trace, prompts=[])
 
     mock_client._upload_trace_data.assert_called_once()

--- a/tests/tracing/export/test_mlflow_v3_attachments.py
+++ b/tests/tracing/export/test_mlflow_v3_attachments.py
@@ -24,9 +24,7 @@ def _make_trace(attachments_map=None):
     return trace
 
 
-@patch("mlflow.tracing.export.mlflow_v3.try_link_prompts_to_trace")
-@patch("mlflow.tracing.export.mlflow_v3.add_size_stats_to_trace_metadata")
-def test_log_trace_uploads_attachments(mock_stats, mock_link, tmp_path):
+def test_log_trace_uploads_attachments(tmp_path):
     att = Attachment(content_type="image/png", content_bytes=b"img")
     trace = _make_trace({att.id: att})
 
@@ -34,9 +32,13 @@ def test_log_trace_uploads_attachments(mock_stats, mock_link, tmp_path):
     returned_info = _make_trace_info_mock()
     mock_client.start_trace.return_value = returned_info
 
-    exporter = MlflowV3SpanExporter(str(tmp_path))
-    exporter._client = mock_client
-    exporter._log_trace(trace, prompts=[])
+    with (
+        patch("mlflow.tracing.export.mlflow_v3.try_link_prompts_to_trace"),
+        patch("mlflow.tracing.export.mlflow_v3.add_size_stats_to_trace_metadata"),
+    ):
+        exporter = MlflowV3SpanExporter(str(tmp_path))
+        exporter._client = mock_client
+        exporter._log_trace(trace, prompts=[])
 
     mock_client._upload_trace_data.assert_called_once_with(returned_info, trace.data)
     mock_client._upload_attachments.assert_called_once()
@@ -45,18 +47,20 @@ def test_log_trace_uploads_attachments(mock_stats, mock_link, tmp_path):
     assert att.id in call_args[0][1]
 
 
-@patch("mlflow.tracing.export.mlflow_v3.try_link_prompts_to_trace")
-@patch("mlflow.tracing.export.mlflow_v3.add_size_stats_to_trace_metadata")
-def test_log_trace_skips_upload_when_no_attachments(mock_stats, mock_link, tmp_path):
+def test_log_trace_skips_upload_when_no_attachments(tmp_path):
     trace = _make_trace()
 
     mock_client = MagicMock()
     returned_info = _make_trace_info_mock()
     mock_client.start_trace.return_value = returned_info
 
-    exporter = MlflowV3SpanExporter(str(tmp_path))
-    exporter._client = mock_client
-    exporter._log_trace(trace, prompts=[])
+    with (
+        patch("mlflow.tracing.export.mlflow_v3.try_link_prompts_to_trace"),
+        patch("mlflow.tracing.export.mlflow_v3.add_size_stats_to_trace_metadata"),
+    ):
+        exporter = MlflowV3SpanExporter(str(tmp_path))
+        exporter._client = mock_client
+        exporter._log_trace(trace, prompts=[])
 
     mock_client._upload_trace_data.assert_called_once()
     mock_client._upload_attachments.assert_not_called()

--- a/tests/tracing/test_attachments.py
+++ b/tests/tracing/test_attachments.py
@@ -84,3 +84,15 @@ def test_parse_ref_invalid():
     assert Attachment.parse_ref("https://example.com") is None
     assert Attachment.parse_ref("not-a-uri") is None
     assert Attachment.parse_ref("mlflow-attachment://") is None
+
+
+def test_from_file_nonexistent_path():
+    with pytest.raises(FileNotFoundError):
+        Attachment.from_file("/nonexistent/path/image.png")
+
+
+def test_ref_roundtrips_special_characters_in_content_type():
+    att = Attachment(content_type="application/vnd.custom+json", content_bytes=b"data")
+    ref = att.ref("tr-123")
+    parsed = Attachment.parse_ref(ref)
+    assert parsed["content_type"] == "application/vnd.custom+json"

--- a/tests/tracing/test_attachments.py
+++ b/tests/tracing/test_attachments.py
@@ -65,8 +65,9 @@ def test_attachment_ref():
     ref = att.ref("tr-abc123")
     assert ref.startswith("mlflow-attachment://")
     assert att.id in ref
-    assert "content_type=image/png" in ref
-    assert "trace_id=tr-abc123" in ref
+    parsed = Attachment.parse_ref(ref)
+    assert parsed["content_type"] == "image/png"
+    assert parsed["trace_id"] == "tr-abc123"
 
 
 def test_parse_ref_valid():

--- a/tests/tracing/test_attachments.py
+++ b/tests/tracing/test_attachments.py
@@ -1,0 +1,86 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mlflow.tracing.attachments import Attachment
+
+
+def test_attachment_init():
+    att = Attachment(content_type="image/png", content_bytes=b"fakepng")
+    assert att.id is not None
+    assert att.content_type == "image/png"
+    assert att.content_bytes == b"fakepng"
+
+
+def test_attachment_ids_are_unique():
+    a = Attachment(content_type="image/png", content_bytes=b"a")
+    b = Attachment(content_type="image/png", content_bytes=b"b")
+    assert a.id != b.id
+
+
+def test_attachment_from_file():
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        f.write(b"fakepng")
+        path = Path(f.name)
+    try:
+        att = Attachment.from_file(path)
+        assert att.content_type == "image/png"
+        assert att.content_bytes == b"fakepng"
+    finally:
+        path.unlink()
+
+
+def test_attachment_from_file_explicit_content_type():
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+        f.write(b"data")
+        path = Path(f.name)
+    try:
+        att = Attachment.from_file(path, content_type="custom/type")
+        assert att.content_type == "custom/type"
+    finally:
+        path.unlink()
+
+
+@pytest.mark.parametrize(
+    ("suffix", "expected"),
+    [
+        (".png", "image/png"),
+        (".jpg", "image/jpeg"),
+        (".jpeg", "image/jpeg"),
+        (".wav", "audio/x-wav"),
+        (".mp3", "audio/mpeg"),
+        (".pdf", "application/pdf"),
+        (".xyz_unknown", "application/octet-stream"),
+    ],
+)
+def test_attachment_from_file_mime_inference(suffix, expected, tmp_path):
+    file = tmp_path / f"test{suffix}"
+    file.write_bytes(b"data")
+    att = Attachment.from_file(file)
+    assert att.content_type == expected
+
+
+def test_attachment_ref():
+    att = Attachment(content_type="image/png", content_bytes=b"data")
+    ref = att.ref("tr-abc123")
+    assert ref.startswith("mlflow-attachment://")
+    assert att.id in ref
+    assert "content_type=image/png" in ref
+    assert "trace_id=tr-abc123" in ref
+
+
+def test_parse_ref_valid():
+    att = Attachment(content_type="audio/wav", content_bytes=b"data")
+    ref = att.ref("tr-xyz")
+    parsed = Attachment.parse_ref(ref)
+    assert parsed is not None
+    assert parsed["attachment_id"] == att.id
+    assert parsed["content_type"] == "audio/wav"
+    assert parsed["trace_id"] == "tr-xyz"
+
+
+def test_parse_ref_invalid():
+    assert Attachment.parse_ref("https://example.com") is None
+    assert Attachment.parse_ref("not-a-uri") is None
+    assert Attachment.parse_ref("mlflow-attachment://") is None

--- a/tests/tracing/test_attachments.py
+++ b/tests/tracing/test_attachments.py
@@ -48,7 +48,7 @@ def test_attachment_from_file_explicit_content_type():
         (".png", "image/png"),
         (".jpg", "image/jpeg"),
         (".jpeg", "image/jpeg"),
-        (".wav", "audio/x-wav"),
+        (".wav", {"audio/x-wav", "audio/wav"}),
         (".mp3", "audio/mpeg"),
         (".pdf", "application/pdf"),
         (".xyz_unknown", "application/octet-stream"),
@@ -58,7 +58,10 @@ def test_attachment_from_file_mime_inference(suffix, expected, tmp_path):
     file = tmp_path / f"test{suffix}"
     file.write_bytes(b"data")
     att = Attachment.from_file(file)
-    assert att.content_type == expected
+    if isinstance(expected, set):
+        assert att.content_type in expected
+    else:
+        assert att.content_type == expected
 
 
 def test_attachment_ref():

--- a/tests/tracing/test_attachments.py
+++ b/tests/tracing/test_attachments.py
@@ -48,7 +48,6 @@ def test_attachment_from_file_explicit_content_type():
         (".png", "image/png"),
         (".jpg", "image/jpeg"),
         (".jpeg", "image/jpeg"),
-        (".wav", {"audio/x-wav", "audio/wav"}),
         (".mp3", "audio/mpeg"),
         (".pdf", "application/pdf"),
         (".xyz_unknown", "application/octet-stream"),
@@ -58,10 +57,7 @@ def test_attachment_from_file_mime_inference(suffix, expected, tmp_path):
     file = tmp_path / f"test{suffix}"
     file.write_bytes(b"data")
     att = Attachment.from_file(file)
-    if isinstance(expected, set):
-        assert att.content_type in expected
-    else:
-        assert att.content_type == expected
+    assert att.content_type == expected
 
 
 def test_attachment_ref():

--- a/tests/tracing/test_attachments_integration.py
+++ b/tests/tracing/test_attachments_integration.py
@@ -1,0 +1,54 @@
+import mlflow
+from mlflow.tracing.attachments import Attachment
+
+
+def test_attachment_roundtrip_with_local_tracking(tmp_path):
+    """Full integration test: create a trace with attachments, verify they're stored and readable."""
+    tracking_uri = str(tmp_path / "mlruns")
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment("attachment-integration-test")
+
+    image_bytes = b"\x89PNG\r\n\x1a\n fake png content"
+    audio_bytes = b"RIFF fake wav content"
+
+    with mlflow.start_span(name="integration-span") as span:
+        span.set_inputs({
+            "prompt": "describe this",
+            "image": Attachment(content_type="image/png", content_bytes=image_bytes),
+        })
+        span.set_outputs({
+            "audio": Attachment(content_type="audio/wav", content_bytes=audio_bytes),
+            "text": "a cat",
+        })
+        trace_id = span.trace_id
+
+    # Retrieve the trace and verify reference URIs are stored
+    trace = mlflow.get_trace(trace_id)
+    root_span = trace.data.spans[0]
+
+    assert root_span.inputs["prompt"] == "describe this"
+    assert root_span.outputs["text"] == "a cat"
+
+    image_ref = root_span.inputs["image"]
+    audio_ref = root_span.outputs["audio"]
+
+    image_parsed = Attachment.parse_ref(image_ref)
+    audio_parsed = Attachment.parse_ref(audio_ref)
+
+    assert image_parsed["content_type"] == "image/png"
+    assert image_parsed["trace_id"] == trace_id
+    assert audio_parsed["content_type"] == "audio/wav"
+    assert audio_parsed["trace_id"] == trace_id
+
+    # Verify the attachment files were written to the artifact repo
+    from mlflow.tracing.client import TracingClient
+
+    client = TracingClient(tracking_uri)
+    trace_info = client.get_trace_info(trace_id)
+    artifact_repo = client._get_artifact_repo_for_trace(trace_info)
+
+    stored_image = artifact_repo.download_trace_attachment(image_parsed["attachment_id"])
+    stored_audio = artifact_repo.download_trace_attachment(audio_parsed["attachment_id"])
+
+    assert stored_image == image_bytes
+    assert stored_audio == audio_bytes


### PR DESCRIPTION
Introduce Attachment class for binary content (images, audio, PDFs) in trace spans. Attachments are automatically extracted from span inputs/outputs, replaced with reference URIs, and uploaded as separate artifact files alongside trace data. This keeps trace JSON lightweight while supporting rich media.

<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
