### PR TITLE
Add wildcard subdomain support to CORS origins validation

### DIFF
--- a/mlflow/server/security_utils.py
+++ b/mlflow/server/security_utils.py
@@ -115,8 +115,11 @@ def should_block_cors_request(origin: str, method: str, allowed_origins: list[st
         # If wildcard "*" is in the list, allow all origins
         if "*" in allowed_origins:
             return False
-        if origin in allowed_origins:
-            return False
+
+        return not any(
+            fnmatch.fnmatch(origin, allowed) if "*" in allowed else origin == allowed
+            for allowed in allowed_origins
+        )
 
     return True
 

--- a/tests/server/test_security.py
+++ b/tests/server/test_security.py
@@ -199,13 +199,23 @@ def test_notebook_trace_renderer_skips_x_frame_options(monkeypatch: pytest.Monke
     assert response.headers.get("X-Frame-Options") == "DENY"
 
 
-def test_wildcard_hosts(test_app, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("MLFLOW_SERVER_ALLOWED_HOSTS", "*")
+@pytest.mark.parametrize(
+    ("allowed_hosts", "host_header", "expected_status"),
+    [
+        ("*", "any.domain.com", 200),
+        ("*.example.com", "app.example.com", 200),
+        ("*.example.com", "evil.com", 403),
+    ],
+)
+def test_wildcard_hosts(
+    test_app, allowed_hosts, host_header, expected_status, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("MLFLOW_SERVER_ALLOWED_HOSTS", allowed_hosts)
     security.init_security_middleware(test_app)
     client = Client(test_app)
 
-    response = client.get("/test", headers={"Host": "any.domain.com"})
-    assert response.status_code == 200
+    response = client.get("/test", headers={"Host": host_header})
+    assert response.status_code == expected_status
 
 
 @pytest.mark.parametrize(

--- a/tests/server/test_security.py
+++ b/tests/server/test_security.py
@@ -204,6 +204,7 @@ def test_notebook_trace_renderer_skips_x_frame_options(monkeypatch: pytest.Monke
     [
         ("*", "any.domain.com", 200),
         ("*.example.com", "app.example.com", 200),
+        ("*.example.com", "sub.app.example.com", 200),
         ("*.example.com", "evil.com", 403),
     ],
 )
@@ -215,6 +216,26 @@ def test_wildcard_hosts(
     client = Client(test_app)
 
     response = client.get("/test", headers={"Host": host_header})
+    assert response.status_code == expected_status
+
+
+@pytest.mark.parametrize(
+    ("allowed_origins", "origin", "expected_status"),
+    [
+        ("*", "http://any.domain.com", 200),
+        ("http://*.example.com", "http://app.example.com", 200),
+        ("http://*.example.com", "http://sub.app.example.com", 200),
+        ("http://*.example.com", "http://evil.com", 403),
+    ],
+)
+def test_wildcard_origins(
+    test_app, allowed_origins, origin, expected_status, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("MLFLOW_SERVER_CORS_ALLOWED_ORIGINS", allowed_origins)
+    security.init_security_middleware(test_app)
+    client = Client(test_app)
+
+    response = client.post("/api/2.0/mlflow/experiments/list", headers={"Origin": origin})
     assert response.status_code == expected_status
 
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #21467

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Add support for wildcard subdomains in CORS Origins

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
