### PR TITLE
[DRAFT] Multimodal trace attachments UI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+
+import { Spinner, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import { getTraceAttachment } from '../oss-notebook-renderer/mlflow-fetch-utils';
+
+export const ModelTraceExplorerAttachmentRenderer = ({
+  title,
+  attachmentId,
+  traceId,
+  contentType,
+}: {
+  title: string;
+  attachmentId: string;
+  traceId: string;
+  contentType: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const [mediaUrl, setMediaUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let revoked = false;
+    getTraceAttachment(traceId, attachmentId).then((data) => {
+      if (revoked) {
+        return;
+      }
+      if (data) {
+        const url = URL.createObjectURL(new Blob([data], { type: contentType }));
+        setMediaUrl(url);
+      } else {
+        setError('Failed to load attachment');
+      }
+    });
+    return () => {
+      revoked = true;
+      if (mediaUrl) {
+        URL.revokeObjectURL(mediaUrl);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attachmentId, traceId, contentType]);
+
+  if (error) {
+    return (
+      <Typography.Text color="error">
+        <FormattedMessage
+          defaultMessage="Failed to load attachment"
+          description="Error message when trace attachment fails to load"
+        />
+      </Typography.Text>
+    );
+  }
+
+  if (!mediaUrl) {
+    return <Spinner size="small" />;
+  }
+
+  if (contentType.startsWith('image/')) {
+    return (
+      <div css={{ padding: theme.spacing.sm }}>
+        {title && (
+          <Typography.Text bold css={{ display: 'block', marginBottom: theme.spacing.xs }}>
+            {title}
+          </Typography.Text>
+        )}
+        <img
+          src={mediaUrl}
+          alt={`Attachment ${attachmentId}`}
+          css={{ maxWidth: '100%', maxHeight: 400, borderRadius: theme.borders.borderRadiusSm }}
+        />
+      </div>
+    );
+  }
+
+  if (contentType.startsWith('audio/')) {
+    return (
+      <div css={{ padding: theme.spacing.sm }}>
+        {title && (
+          <Typography.Text bold css={{ display: 'block', marginBottom: theme.spacing.xs }}>
+            {title}
+          </Typography.Text>
+        )}
+        <audio controls>
+          <source src={mediaUrl} type={contentType} />
+        </audio>
+      </div>
+    );
+  }
+
+  if (contentType === 'application/pdf') {
+    return (
+      <div css={{ padding: theme.spacing.sm }}>
+        {title && (
+          <Typography.Text bold css={{ display: 'block', marginBottom: theme.spacing.xs }}>
+            {title}
+          </Typography.Text>
+        )}
+        <iframe
+          src={mediaUrl}
+          title={`PDF Attachment ${attachmentId}`}
+          css={{
+            width: '100%',
+            height: 600,
+            border: `1px solid ${theme.colors.border}`,
+            borderRadius: theme.borders.borderRadiusSm,
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div css={{ padding: theme.spacing.sm }}>
+      <a href={mediaUrl} download={`attachment-${attachmentId}`}>
+        <FormattedMessage
+          defaultMessage="Download attachment ({contentType})"
+          description="Download link for trace attachment with unknown content type"
+          values={{ contentType }}
+        />
+      </a>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerAttachmentRenderer.tsx
@@ -82,6 +82,7 @@ export const ModelTraceExplorerAttachmentRenderer = ({
             {title}
           </Typography.Text>
         )}
+        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
         <audio controls>
           <source src={mediaUrl} type={contentType} />
         </audio>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
+import { ModelTraceExplorerAttachmentRenderer } from './ModelTraceExplorerAttachmentRenderer';
 import { ModelTraceExplorerChatToolsRenderer } from './ModelTraceExplorerChatToolsRenderer';
 import { ModelTraceExplorerRetrieverFieldRenderer } from './ModelTraceExplorerRetrieverFieldRenderer';
 import { ModelTraceExplorerTextFieldRenderer } from './ModelTraceExplorerTextFieldRenderer';
@@ -12,6 +13,24 @@ import { CodeSnippetRenderMode } from '../ModelTrace.types';
 import { isModelTraceChatTool, isRetrieverDocument, normalizeConversation } from '../ModelTraceExplorer.utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerConversation } from '../right-pane/ModelTraceExplorerConversation';
+
+function parseAttachmentUri(uri: string): { attachmentId: string; traceId: string; contentType: string } | null {
+  try {
+    const parsed = new URL(uri);
+    if (parsed.protocol !== 'mlflow-attachment:') {
+      return null;
+    }
+    const attachmentId = parsed.hostname;
+    const contentType = parsed.searchParams.get('content_type');
+    const traceId = parsed.searchParams.get('trace_id');
+    if (!attachmentId || !contentType || !traceId) {
+      return null;
+    }
+    return { attachmentId, contentType, traceId };
+  } catch {
+    return null;
+  }
+}
 
 export const DEFAULT_MAX_VISIBLE_CHAT_MESSAGES = 3;
 
@@ -111,6 +130,19 @@ export const ModelTraceExplorerFieldRenderer = ({
   }
 
   if (dataIsScalar) {
+    if (isString(parsedData)) {
+      const attachment = parseAttachmentUri(parsedData);
+      if (attachment) {
+        return (
+          <ModelTraceExplorerAttachmentRenderer
+            title={title}
+            attachmentId={attachment.attachmentId}
+            traceId={attachment.traceId}
+            contentType={attachment.contentType}
+          />
+        );
+      }
+    }
     return <ModelTraceExplorerTextFieldRenderer title={title} value={String(parsedData)} />;
   }
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/mlflow-fetch-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/mlflow-fetch-utils.ts
@@ -34,3 +34,19 @@ export async function getTraceArtifact(requestId: string): Promise<ModelTrace | 
     return 'Unknown error occurred';
   }
 }
+
+export async function getTraceAttachment(traceId: string, attachmentId: string): Promise<ArrayBuffer | undefined> {
+  try {
+    const url = getAjaxUrl(
+      `ajax-api/2.0/mlflow/get-trace-artifact?request_id=${encodeURIComponent(traceId)}&path=${encodeURIComponent(attachmentId)}`,
+    );
+    // eslint-disable-next-line no-restricted-globals -- direct fetch needed for binary response
+    const response = await fetch(url);
+    if (!response.ok) {
+      return undefined;
+    }
+    return await response.arrayBuffer();
+  } catch (e) {
+    return undefined;
+  }
+}


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

  - ModelTraceExplorerAttachmentRenderer.tsx (NEW) — Renders image/audio/PDF/download based on content type, with loading spinner and error handling                                                                                                
  - ModelTraceExplorerFieldRenderer.tsx — Detects mlflow-attachment:// URIs in scalar values, routes to AttachmentRenderer                                                                                                                          
  - mlflow-fetch-utils.ts — New getTraceAttachment() function for binary downloads via get-trace-artifact?path= 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
