### PR TITLE
Invalidate latest prompt cache after set/delete prompt model config

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -6159,9 +6159,9 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         registry_client.delete_prompt_version(name, version)
 
-        # Invalidate all cache entries for this prompt name since aliases and
-        # "latest" may also resolve to the deleted version.
-        PromptCache.get_instance().delete_all(name)
+        cache = PromptCache.get_instance()
+        cache.delete(name, version=int(version))
+        cache.delete(name, alias="latest")
 
     @require_prompt_registry
     @translate_prompt_exception

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1233,7 +1233,9 @@ class MlflowClient:
         """
         self._get_registry_client().set_prompt_version_tag(name, version, key, value)
 
-        PromptCache.get_instance().delete_all(name)
+        cache = PromptCache.get_instance()
+        cache.delete(name, version=int(version))
+        cache.delete(name, alias="latest")
 
     @require_prompt_registry
     @translate_prompt_exception
@@ -1248,7 +1250,9 @@ class MlflowClient:
         """
         self._get_registry_client().delete_prompt_version_tag(name, version, key)
 
-        PromptCache.get_instance().delete_all(name)
+        cache = PromptCache.get_instance()
+        cache.delete(name, version=int(version))
+        cache.delete(name, alias="latest")
 
     def _validate_prompt(self, name: str, version: int):
         registry_client = self._get_registry_client()

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1233,9 +1233,7 @@ class MlflowClient:
         """
         self._get_registry_client().set_prompt_version_tag(name, version, key, value)
 
-        cache = PromptCache.get_instance()
-        cache.delete(name, version=int(version))
-        cache.delete(name, alias="latest")
+        PromptCache.get_instance().delete_all(name)
 
     @require_prompt_registry
     @translate_prompt_exception
@@ -1250,9 +1248,7 @@ class MlflowClient:
         """
         self._get_registry_client().delete_prompt_version_tag(name, version, key)
 
-        cache = PromptCache.get_instance()
-        cache.delete(name, version=int(version))
-        cache.delete(name, alias="latest")
+        PromptCache.get_instance().delete_all(name)
 
     def _validate_prompt(self, name: str, version: int):
         registry_client = self._get_registry_client()
@@ -6159,9 +6155,7 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         registry_client.delete_prompt_version(name, version)
 
-        cache = PromptCache.get_instance()
-        cache.delete(name, version=int(version))
-        cache.delete(name, alias="latest")
+        PromptCache.get_instance().delete_all(name)
 
     @require_prompt_registry
     @translate_prompt_exception

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1233,8 +1233,7 @@ class MlflowClient:
         """
         self._get_registry_client().set_prompt_version_tag(name, version, key, value)
 
-        # Invalidate cache for this specific version
-        PromptCache.get_instance().delete(name, version=int(version))
+        PromptCache.get_instance().delete_all(name)
 
     @require_prompt_registry
     @translate_prompt_exception
@@ -1249,8 +1248,7 @@ class MlflowClient:
         """
         self._get_registry_client().delete_prompt_version_tag(name, version, key)
 
-        # Invalidate cache for this specific version
-        PromptCache.get_instance().delete(name, version=int(version))
+        PromptCache.get_instance().delete_all(name)
 
     def _validate_prompt(self, name: str, version: int):
         registry_client = self._get_registry_client()

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2524,6 +2524,44 @@ def test_delete_prompt_version_invalidates_latest_cache(tracking_uri):
     assert latest_prompt_after_delete.template == prompt_v1.template
 
 
+def test_set_prompt_model_config_invalidates_latest_cache(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    cache_ttl_seconds = 1
+    prompt = client.register_prompt(name="test_prompt", template="test")
+    prompt_before_update = client.load_prompt(prompt.name, cache_ttl_seconds=cache_ttl_seconds)
+    assert prompt_before_update.model_config is None
+
+    model_config = {"model_name": "gpt-4", "temperature": 0.7}
+    mlflow.genai.set_prompt_model_config(
+        name=prompt.name,
+        version=prompt.version,
+        model_config=model_config,
+    )
+
+    prompt_after_update = client.load_prompt(prompt.name, cache_ttl_seconds=cache_ttl_seconds)
+    assert prompt_after_update.model_config == model_config
+
+
+def test_delete_prompt_model_config_invalidates_latest_cache(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    cache_ttl_seconds = 1
+    model_config = {"model_name": "gpt-4", "temperature": 0.7}
+    prompt = client.register_prompt(
+        name="test_prompt",
+        template="test",
+        model_config=model_config,
+    )
+    prompt_before_delete = client.load_prompt(prompt.name, cache_ttl_seconds=cache_ttl_seconds)
+    assert prompt_before_delete.model_config == model_config
+
+    mlflow.genai.delete_prompt_model_config(name=prompt.name, version=prompt.version)
+
+    prompt_after_delete = client.load_prompt(prompt.name, cache_ttl_seconds=cache_ttl_seconds)
+    assert prompt_after_delete.model_config is None
+
+
 def test_delete_prompt_version_invalidates_alias_cache(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2527,7 +2527,7 @@ def test_delete_prompt_version_invalidates_latest_cache(tracking_uri):
 def test_set_prompt_model_config_invalidates_latest_cache(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
-    cache_ttl_seconds = 1
+    cache_ttl_seconds = 60
     prompt = client.register_prompt(name="test_prompt", template="test")
     prompt_before_update = client.load_prompt(prompt.name, cache_ttl_seconds=cache_ttl_seconds)
     assert prompt_before_update.model_config is None
@@ -2546,7 +2546,7 @@ def test_set_prompt_model_config_invalidates_latest_cache(tracking_uri):
 def test_delete_prompt_model_config_invalidates_latest_cache(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
-    cache_ttl_seconds = 1
+    cache_ttl_seconds = 60
     model_config = {"model_name": "gpt-4", "temperature": 0.7}
     prompt = client.register_prompt(
         name="test_prompt",


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #21489

### What changes are proposed in this pull request?
<!-- Please fill in changes proposed in this PR. -->
This PR fixes stale `load_prompt()` results after `set_prompt_model_config()` and `delete_prompt_model_config()`. It invalidates all cached entries for the prompt name when those prompt version tag mutations occur, so subsequent prompt loads return the updated model config state.

### How is this PR tested?

- [X] New unit/integration tests

<!-- Attach code, screenshot, video used for manual testing here. -->

  Added regression tests in `tests/tracking/test_client.py` covering:
  - `set_prompt_model_config()` invalidates cached latest prompt reads
  - `delete_prompt_model_config()` invalidates cached latest prompt reads

### Does this PR require documentation update?

- [X] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [X] No.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management


<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- 

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [X] This PR can wait for the next minor release
