### PR TITLE
Add search issues query to `RunViewIssuesTab` with loading and empty states

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewIssuesTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewIssuesTab.tsx
@@ -1,5 +1,6 @@
-import { useDesignSystemTheme } from '@databricks/design-system';
+import { TableSkeleton, useDesignSystemTheme } from '@databricks/design-system';
 import { IssuesTabEmptyState } from './IssuesTabEmptyState';
+import { useSearchIssuesQuery } from './hooks/useSearchIssuesQuery';
 
 export interface RunViewIssuesTabProps {
   runUuid: string;
@@ -8,20 +9,51 @@ export interface RunViewIssuesTabProps {
 
 export const RunViewIssuesTab = ({ runUuid, experimentId }: RunViewIssuesTabProps) => {
   const { theme } = useDesignSystemTheme();
+  const { issues, isLoading } = useSearchIssuesQuery({
+    experimentId,
+    sourceRunId: runUuid,
+  });
+
+  if (isLoading) {
+    return (
+      <div css={{ padding: theme.spacing.md }}>
+        <TableSkeleton lines={5} />
+      </div>
+    );
+  }
+
+  if (issues.length === 0) {
+    return (
+      <div
+        css={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: theme.spacing.md,
+        }}
+      >
+        <IssuesTabEmptyState />
+      </div>
+    );
+  }
 
   return (
+    // TODO: implement real issues table
     <div
       css={{
         width: '100%',
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
         padding: theme.spacing.md,
       }}
     >
-      <IssuesTabEmptyState />
+      {issues.map((issue) => (
+        <div key={issue.issue_id}>{issue.name}</div>
+      ))}
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useSearchIssuesQuery.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useSearchIssuesQuery.tsx
@@ -1,0 +1,61 @@
+import { useQuery } from '@databricks/web-shared/query-client';
+import { fetchAPI, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+
+export const SEARCH_ISSUES_QUERY_KEY = 'SEARCH_ISSUES';
+
+export type IssueStatus = 'pending' | 'accepted' | 'rejected';
+
+export interface Issue {
+  issue_id: string;
+  experiment_id: string;
+  name: string;
+  description?: string;
+  status: IssueStatus;
+  source_run_id?: string;
+  created_by?: string;
+  created_timestamp: number;
+  last_updated_timestamp: number;
+}
+
+type SearchIssuesResponse = {
+  issues?: Issue[];
+  next_page_token?: string;
+};
+
+export const useSearchIssuesQuery = ({
+  experimentId,
+  sourceRunId,
+  enabled = true,
+}: {
+  experimentId: string;
+  sourceRunId: string;
+  enabled?: boolean;
+}) => {
+  const { data, isLoading, isFetching, refetch, error } = useQuery<SearchIssuesResponse, Error>({
+    queryKey: [SEARCH_ISSUES_QUERY_KEY, experimentId, sourceRunId],
+    queryFn: async () => {
+      const filterString = `source_run_id = '${sourceRunId}'`;
+      const requestBody = {
+        experiment_id: experimentId,
+        filter_string: filterString,
+      };
+
+      return (await fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/issues/search'), {
+        method: 'POST',
+        body: requestBody,
+      })) as SearchIssuesResponse;
+    },
+    cacheTime: 0,
+    refetchOnWindowFocus: false,
+    retry: false,
+    enabled,
+  });
+
+  return {
+    issues: data?.issues ?? [],
+    isLoading,
+    isFetching,
+    refetch,
+    error,
+  };
+};


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21498/files) to review incremental changes.
- [**stack/search_issues_with_run**](https://github.com/mlflow/mlflow/pull/21498) [[Files changed](https://github.com/mlflow/mlflow/pull/21498/files)]
  - [stack/issue_display](https://github.com/mlflow/mlflow/pull/21499) [[Files changed](https://github.com/mlflow/mlflow/pull/21499/files/c8500a30881936f62b58f233bf8c2fc7f1d7b6c8..0c6fc102fe934b2260be4664e29109bfc1dbe109)]
    - [stack/issues_traces_display](https://github.com/mlflow/mlflow/pull/21500) [[Files changed](https://github.com/mlflow/mlflow/pull/21500/files/0c6fc102fe934b2260be4664e29109bfc1dbe109..79750233225eeb5fc4ed96f432cd3ff07793773d)]
      - [stack/enable_show_issues_panel](https://github.com/mlflow/mlflow/pull/21407) [[Files changed](https://github.com/mlflow/mlflow/pull/21407/files/79750233225eeb5fc4ed96f432cd3ff07793773d..671f942074cbad1977d974c36890e4351433a38c)]
        - [stack/fix_issue_rendering](https://github.com/mlflow/mlflow/pull/21509) [[Files changed](https://github.com/mlflow/mlflow/pull/21509/files/671f942074cbad1977d974c36890e4351433a38c..65aee124a16d61516c008d7e8913aa023a1e1e60)]
          - [stack/issues_display_in_traces_view](https://github.com/mlflow/mlflow/pull/21510) [[Files changed](https://github.com/mlflow/mlflow/pull/21510/files/65aee124a16d61516c008d7e8913aa023a1e1e60..6d4d4b687bd33b40a660cc18575d502f9cdfa357)]
            - stack/issue_column_link

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Add search issues with the run query for `issues` tab.

<img width="1298" height="561" alt="image" src="https://github.com/user-attachments/assets/13c9edf0-cc31-45ee-bfcc-afbb54c61495" />


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
