### PR TITLE
Add issues table with title, description, and creation time display

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/run-page/IssueCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/IssueCard.tsx
@@ -1,0 +1,87 @@
+import { Card, CopyIcon, InfoPopover, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import Utils from '../../../common/utils/Utils';
+import { type Issue } from './hooks/useSearchIssuesQuery';
+
+export const IssueCard = ({ issue }: { issue: Issue }) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  return (
+    <Card
+      componentId="mlflow.issues.issue-card"
+      css={{
+        padding: theme.spacing.md,
+        width: '100%',
+        boxSizing: 'border-box',
+      }}
+    >
+      <div
+        css={{
+          display: 'grid',
+          gridTemplateColumns: '1fr auto',
+          gap: theme.spacing.xs,
+          alignItems: 'flex-start',
+        }}
+      >
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+            <Typography.Title level={4} css={{ margin: 0, marginBottom: '0 !important' }}>
+              {issue.name}
+            </Typography.Title>
+            <InfoPopover iconTitle="Info">
+              <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                <div css={{ display: 'flex', alignItems: 'center', whiteSpace: 'nowrap' }}>
+                  <FormattedMessage defaultMessage="Issue ID" description="Label for issue ID in popover" />
+                  {': '}
+                  {issue.issue_id}{' '}
+                  <Typography.Text
+                    size="md"
+                    dangerouslySetAntdProps={{
+                      copyable: {
+                        text: issue.issue_id,
+                        icon: <CopyIcon />,
+                        tooltips: [
+                          intl.formatMessage({
+                            defaultMessage: 'Copy issue ID',
+                            description: 'Tooltip to copy issue ID',
+                          }),
+                          intl.formatMessage({
+                            defaultMessage: 'Issue ID copied',
+                            description: 'Tooltip after issue ID was copied',
+                          }),
+                        ],
+                      },
+                    }}
+                  />
+                </div>
+              </div>
+            </InfoPopover>
+          </div>
+          {issue.description && (
+            <Typography.Text
+              color="secondary"
+              css={{
+                display: '-webkit-box',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                WebkitBoxOrient: 'vertical',
+                WebkitLineClamp: 2,
+              }}
+              title={issue.description}
+            >
+              {issue.description}
+            </Typography.Text>
+          )}
+          <Typography.Hint>
+            <FormattedMessage
+              defaultMessage="Created: {date}"
+              description="Issue creation date label"
+              values={{ date: Utils.formatTimestamp(issue.created_timestamp, intl) }}
+            />
+          </Typography.Hint>
+        </div>
+      </div>
+    </Card>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewIssuesTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewIssuesTab.tsx
@@ -1,5 +1,6 @@
 import { TableSkeleton, useDesignSystemTheme } from '@databricks/design-system';
 import { IssuesTabEmptyState } from './IssuesTabEmptyState';
+import { IssueCard } from './IssueCard';
 import { useSearchIssuesQuery } from './hooks/useSearchIssuesQuery';
 
 export interface RunViewIssuesTabProps {
@@ -41,18 +42,19 @@ export const RunViewIssuesTab = ({ runUuid, experimentId }: RunViewIssuesTabProp
   }
 
   return (
-    // TODO: implement real issues table
     <div
       css={{
         width: '100%',
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
+        gap: theme.spacing.sm,
         padding: theme.spacing.md,
+        overflow: 'auto',
       }}
     >
       {issues.map((issue) => (
-        <div key={issue.issue_id}>{issue.name}</div>
+        <IssueCard key={issue.issue_id} issue={issue} />
       ))}
     </div>
   );

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4783,6 +4783,10 @@
     "defaultMessage": "using Prompt Engineering",
     "description": "String for creating a new run with prompt engineering modal"
   },
+  "UnQIPJ": {
+    "defaultMessage": "Created: {date}",
+    "description": "Issue creation date label"
+  },
   "Uq6/bl": {
     "defaultMessage": "Create prompt",
     "description": "A header for the empty state in the prompts table"
@@ -7168,6 +7172,10 @@
     "defaultMessage": "Detect unsatisfactory user experiences and unmet user needs",
     "description": "Issue category description for negative user experiences"
   },
+  "k4F8aJ": {
+    "defaultMessage": "Copy issue ID",
+    "description": "Tooltip to copy issue ID"
+  },
   "k7itje": {
     "defaultMessage": "Create webhook",
     "description": "Create webhook button"
@@ -7691,6 +7699,10 @@
   "nIk08y": {
     "defaultMessage": "Trace view",
     "description": "Tooltip for traces preview mode toggle in evaluation runs table controls"
+  },
+  "nIkC92": {
+    "defaultMessage": "Issue ID copied",
+    "description": "Tooltip after issue ID was copied"
   },
   "nJxDSh": {
     "defaultMessage": "Inputs",
@@ -8610,6 +8622,10 @@
   "tEwQWS": {
     "defaultMessage": "Active",
     "description": "Webhook active status"
+  },
+  "tFVXU7": {
+    "defaultMessage": "Issue ID",
+    "description": "Label for issue ID in popover"
   },
   "tGqJL4": {
     "defaultMessage": "Output",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21499/files) to review incremental changes.
- [**stack/issue_display**](https://github.com/mlflow/mlflow/pull/21499) [[Files changed](https://github.com/mlflow/mlflow/pull/21499/files)]
  - [stack/issues_traces_display](https://github.com/mlflow/mlflow/pull/21500) [[Files changed](https://github.com/mlflow/mlflow/pull/21500/files/104f96dbf659e3b63b39ea8aede6e0c8a7272463..3d8ddc39c39e0ef48b59b7b808c69b5a7c66715a)]
    - [stack/enable_show_issues_panel](https://github.com/mlflow/mlflow/pull/21407) [[Files changed](https://github.com/mlflow/mlflow/pull/21407/files/3d8ddc39c39e0ef48b59b7b808c69b5a7c66715a..35eabd5e01f9bb894806e054e65399d2709c29e9)]
      - [stack/fix_issue_rendering](https://github.com/mlflow/mlflow/pull/21509) [[Files changed](https://github.com/mlflow/mlflow/pull/21509/files/35eabd5e01f9bb894806e054e65399d2709c29e9..886a3da9b0134217efe1a6a8517b29580c8bfbcd)]
        - [stack/issues_display_in_traces_view](https://github.com/mlflow/mlflow/pull/21510) [[Files changed](https://github.com/mlflow/mlflow/pull/21510/files/886a3da9b0134217efe1a6a8517b29580c8bfbcd..b6495e22cc79ad5895c6b093f41d4e87a8b1fe52)]
          - stack/issue_column_link

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Add basic issues table, including each issue's title, description and creation time. The icon next to title includes information about issue id.

<img width="1281" height="825" alt="image" src="https://github.com/user-attachments/assets/98cb970f-320a-4259-8897-b5e7b3f80c90" />
<img width="486" height="110" alt="image" src="https://github.com/user-attachments/assets/fd82c9a7-e128-4d01-aca0-e462b6fc8dc8" />

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
