### PR TITLE
Add `serialization_format` to CreateLoggedModel telemetry event

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1152,7 +1152,6 @@ class Model:
             if model_id is not None:
                 model = client.get_logged_model(model_id)
             else:
-                serialization_format = kwargs.pop("serialization_format", None)
                 params = {
                     **(params or {}),
                     **(client.get_run(run_id).data.params if run_id else {}),
@@ -1169,7 +1168,7 @@ class Model:
                     if tags is not None
                     else None,
                     flavor=flavor_name,
-                    serialization_format=serialization_format,
+                    serialization_format=kwargs.pop("serialization_format", None),
                 )
                 _last_logged_model_id.set(model.model_id)
                 if (

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1149,10 +1149,10 @@ class Model:
                 run_id = active_run.info.run_id if (active_run := mlflow.active_run()) else None
 
             flavor_name = kwargs.pop("flavor_name", None)
-            serialization_format = kwargs.get("serialization_format")
             if model_id is not None:
                 model = client.get_logged_model(model_id)
             else:
+                serialization_format = kwargs.get("serialization_format")
                 params = {
                     **(params or {}),
                     **(client.get_run(run_id).data.params if run_id else {}),

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1168,7 +1168,7 @@ class Model:
                     if tags is not None
                     else None,
                     flavor=flavor_name,
-                    serialization_format=kwargs.pop("serialization_format", None),
+                    serialization_format=kwargs.get("serialization_format"),
                 )
                 _last_logged_model_id.set(model.model_id)
                 if (

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1149,6 +1149,7 @@ class Model:
                 run_id = active_run.info.run_id if (active_run := mlflow.active_run()) else None
 
             flavor_name = kwargs.pop("flavor_name", None)
+            serialization_format = kwargs.get("serialization_format")
             if model_id is not None:
                 model = client.get_logged_model(model_id)
             else:
@@ -1168,6 +1169,7 @@ class Model:
                     if tags is not None
                     else None,
                     flavor=flavor_name,
+                    serialization_format=serialization_format,
                 )
                 _last_logged_model_id.set(model.model_id)
                 if (

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1152,7 +1152,7 @@ class Model:
             if model_id is not None:
                 model = client.get_logged_model(model_id)
             else:
-                serialization_format = kwargs.pop("serialization_format")
+                serialization_format = kwargs.pop("serialization_format", None)
                 params = {
                     **(params or {}),
                     **(client.get_run(run_id).data.params if run_id else {}),

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1152,7 +1152,7 @@ class Model:
             if model_id is not None:
                 model = client.get_logged_model(model_id)
             else:
-                serialization_format = kwargs.get("serialization_format")
+                serialization_format = kwargs.pop("serialization_format")
                 params = {
                     **(params or {}),
                     **(client.get_run(run_id).data.params if run_id else {}),

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -160,8 +160,15 @@ class CreateLoggedModelEvent(Event):
 
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
-        if flavor := arguments.get("flavor"):
-            return {"flavor": flavor.removeprefix("mlflow.")}
+        flavor = arguments.get("flavor")
+        serialization_format = arguments.get("serialization_format")
+        if flavor or serialization_format:
+            data: dict[str, Any] = {}
+            if flavor:
+                data["flavor"] = flavor.removeprefix("mlflow.")
+            if serialization_format:
+                data["serialization_format"] = serialization_format
+            return data
         return None
 
 

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -160,16 +160,12 @@ class CreateLoggedModelEvent(Event):
 
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
-        flavor = arguments.get("flavor")
-        serialization_format = arguments.get("serialization_format")
-        if flavor or serialization_format:
-            data: dict[str, Any] = {}
-            if flavor:
-                data["flavor"] = flavor.removeprefix("mlflow.")
-            if serialization_format:
-                data["serialization_format"] = serialization_format
-            return data
-        return None
+        data: dict[str, Any] = {}
+        if flavor := arguments.get("flavor"):
+            data["flavor"] = flavor.removeprefix("mlflow.")
+        if serialization_format := arguments.get("serialization_format"):
+            data["serialization_format"] = serialization_format
+        return data or None
 
 
 class GetLoggedModelEvent(Event):

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -872,9 +872,10 @@ class TrackingServiceClient:
         tags: dict[str, str] | None = None,
         params: dict[str, str] | None = None,
         model_type: str | None = None,
-        # This parameter is only used for telemetry purposes, and
-        # does not affect the logged model.
+        # These parameters are only used for telemetry purposes, and
+        # do not affect the logged model.
         flavor: str | None = None,
+        serialization_format: str | None = None,
     ) -> LoggedModel:
         return self.store.create_logged_model(
             experiment_id=experiment_id,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -5774,9 +5774,10 @@ class MlflowClient:
         params: dict[str, str] | None = None,
         model_type: str | None = None,
         flavor: str | None = None,
+        serialization_format: str | None = None,
     ) -> LoggedModel:
         return self._tracking_client.create_logged_model(
-            experiment_id, name, source_run_id, tags, params, model_type, flavor
+            experiment_id, name, source_run_id, tags, params, model_type, flavor, serialization_format
         )
 
     def log_model_params(self, model_id: str, params: dict[str, str]) -> None:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -5777,7 +5777,14 @@ class MlflowClient:
         serialization_format: str | None = None,
     ) -> LoggedModel:
         return self._tracking_client.create_logged_model(
-            experiment_id, name, source_run_id, tags, params, model_type, flavor, serialization_format
+            experiment_id=experiment_id,
+            name=name,
+            source_run_id=source_run_id,
+            tags=tags,
+            params=params,
+            model_type=model_type,
+            flavor=flavor,
+            serialization_format=serialization_format,
         )
 
     def log_model_params(self, model_id: str, params: dict[str, str]) -> None:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2409,6 +2409,7 @@ def _create_logged_model(
     model_type: str | None = None,
     experiment_id: str | None = None,
     flavor: str | None = None,
+    serialization_format: str | None = None,
 ) -> LoggedModel:
     """
     Create a new LoggedModel in the ``PENDING`` state.
@@ -2425,6 +2426,7 @@ def _create_logged_model(
                     type ``"agent"`` in the future.
         experiment_id: The experiment ID of the experiment to which the model belongs.
         flavor: The flavor of the model.
+        serialization_format: The serialization format of the model.
 
     Returns:
         A new LoggedModel in the ``PENDING`` state.
@@ -2447,6 +2449,7 @@ def _create_logged_model(
         params=params,
         model_type=model_type,
         flavor=flavor,
+        serialization_format=serialization_format,
     )
 
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2425,8 +2425,10 @@ def _create_logged_model(
                     enables you to easily search for this model and compare it to other models of
                     type ``"agent"`` in the future.
         experiment_id: The experiment ID of the experiment to which the model belongs.
-        flavor: The flavor of the model.
-        serialization_format: The serialization format of the model.
+        flavor: The flavor of the model, recorded for telemetry and analytics only; it does not
+                affect the stored LoggedModel.
+        serialization_format: The serialization format of the model, recorded for telemetry and
+                              analytics only; it does not affect the stored LoggedModel.
 
     Returns:
         A new LoggedModel in the ``PENDING`` state.

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -43,6 +43,14 @@ from mlflow.telemetry.events import (
             {"flavor": "sklearn"},
         ),
         (
+            {"flavor": "mlflow.pyfunc", "serialization_format": "cloudpickle"},
+            {"flavor": "pyfunc", "serialization_format": "cloudpickle"},
+        ),
+        (
+            {"serialization_format": "cloudpickle"},
+            {"serialization_format": "cloudpickle"},
+        ),
+        (
             {
                 "flavor": None,
             },

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -150,7 +150,22 @@ def test_create_logged_model(mock_requests, mock_telemetry_client: TelemetryClie
         name="model",
     )
     validate_telemetry_record(
-        mock_telemetry_client, mock_requests, event_name, {"flavor": "sklearn"}
+        mock_telemetry_client,
+        mock_requests,
+        event_name,
+        {"flavor": "sklearn", "serialization_format": "cloudpickle"},
+    )
+
+    mlflow.sklearn.log_model(
+        knn.KNeighborsClassifier(),
+        name="model",
+        serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE,
+    )
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        event_name,
+        {"flavor": "sklearn", "serialization_format": "pickle"},
     )
 
     class SimpleResponsesAgent(ResponsesAgent):


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Adds serialization_format as a telemetry argument to the CreateLoggedModel event, enabling tracking of the serialization format (e.g., cloudpickle, pickle, skops) used when logging a model.                                                          
                                         
  - CreateLoggedModelEvent.parse now includes serialization_format in the returned telemetry data when the argument i present.
  - serialization_format is added as a telemetry-only parameter (not forwarded to the store) to create_logged_model in _tracking_service/client.py, mirroring how flavor is handled.
### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
