### PR TITLE
Add managed_platform field to SDK telemetry

### DIFF
--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -24,7 +24,12 @@ from mlflow.telemetry.constant import (
 )
 from mlflow.telemetry.installation_id import get_or_create_installation_id
 from mlflow.telemetry.schemas import Record, TelemetryConfig, TelemetryInfo, get_source_sdk
-from mlflow.telemetry.utils import _get_config_url, _log_error, is_telemetry_disabled
+from mlflow.telemetry.utils import (
+    _MANAGED_PLATFORM,
+    _get_config_url,
+    _log_error,
+    is_telemetry_disabled,
+)
 from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.logging_utils import should_suppress_logs_in_thread, suppress_logs_in_thread
 from mlflow.utils.rest_utils import http_request
@@ -110,6 +115,7 @@ class TelemetryClient:
             TelemetryInfo(
                 session_id=_MLFLOW_TELEMETRY_SESSION_ID.get() or uuid.uuid4().hex,
                 installation_id=get_or_create_installation_id(),
+                managed_platform=_MANAGED_PLATFORM,
             )
         )
         self._queue: Queue[list[Record]] = Queue(maxsize=MAX_QUEUE_SIZE)

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -74,6 +74,8 @@ class TelemetryInfo:
     # minimize the payload size, because these fields are included to every
     # telemetry event.
     ws_enabled: bool | None = None
+    # Managed notebook/ML platform, e.g. "colab", "sagemaker", "azureml", "kaggle"
+    managed_platform: str | None = None
 
 
 @dataclass

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -68,9 +68,39 @@ def _is_in_databricks() -> bool:
     return False
 
 
+def _detect_managed_platform() -> str | None:
+    """Detect if running on a managed notebook/ML platform."""
+    # Google Colab
+    if "COLAB_RELEASE_TAG" in os.environ or "COLAB_GPU" in os.environ:
+        return "colab"
+
+    # Amazon SageMaker
+    if "SAGEMAKER_APP_TYPE" in os.environ or "SAGEMAKER_INTERNAL_IMAGE_URI" in os.environ:
+        return "sagemaker"
+
+    # Azure ML
+    if "AZUREML_RUN_ID" in os.environ or "AZUREML_ARM_SUBSCRIPTION" in os.environ:
+        return "azureml"
+
+    # Kaggle
+    if "KAGGLE_KERNEL_RUN_TYPE" in os.environ:
+        return "kaggle"
+
+    # Paperspace Gradient
+    if "PAPERSPACE_CLUSTER_ID" in os.environ:
+        return "gradient"
+
+    # Deepnote
+    if "DEEPNOTE_PROJECT_ID" in os.environ:
+        return "deepnote"
+
+    return None
+
+
 _IS_MLFLOW_DEV_VERSION = Version(VERSION).is_devrelease
 _IS_IN_CI_ENV_OR_TESTING = _is_ci_env_or_testing()
 _IS_IN_DATABRICKS = _is_in_databricks()
+_MANAGED_PLATFORM = _detect_managed_platform()
 _IS_MLFLOW_TESTING_TELEMETRY = _MLFLOW_TESTING_TELEMETRY.get()
 
 

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from mlflow.telemetry.constant import (
     CONFIG_STAGING_URL,
     CONFIG_URL,
@@ -8,10 +10,46 @@ from mlflow.telemetry.constant import (
     UI_CONFIG_URL,
 )
 from mlflow.telemetry.utils import (
+    _detect_managed_platform,
     _get_config_url,
     fetch_ui_telemetry_config,
     is_telemetry_disabled,
 )
+
+
+@pytest.mark.parametrize(
+    ("env_var", "expected"),
+    [
+        ("COLAB_RELEASE_TAG", "colab"),
+        ("COLAB_GPU", "colab"),
+        ("SAGEMAKER_APP_TYPE", "sagemaker"),
+        ("SAGEMAKER_INTERNAL_IMAGE_URI", "sagemaker"),
+        ("AZUREML_RUN_ID", "azureml"),
+        ("AZUREML_ARM_SUBSCRIPTION", "azureml"),
+        ("KAGGLE_KERNEL_RUN_TYPE", "kaggle"),
+        ("PAPERSPACE_CLUSTER_ID", "gradient"),
+        ("DEEPNOTE_PROJECT_ID", "deepnote"),
+    ],
+)
+def test_detect_managed_platform(monkeypatch, env_var, expected):
+    monkeypatch.setenv(env_var, "some_value")
+    assert _detect_managed_platform() == expected
+
+
+def test_detect_managed_platform_none(monkeypatch):
+    for var in [
+        "COLAB_RELEASE_TAG",
+        "COLAB_GPU",
+        "SAGEMAKER_APP_TYPE",
+        "SAGEMAKER_INTERNAL_IMAGE_URI",
+        "AZUREML_RUN_ID",
+        "AZUREML_ARM_SUBSCRIPTION",
+        "KAGGLE_KERNEL_RUN_TYPE",
+        "PAPERSPACE_CLUSTER_ID",
+        "DEEPNOTE_PROJECT_ID",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    assert _detect_managed_platform() is None
 
 
 def test_is_telemetry_disabled(monkeypatch, bypass_env_check):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Adds a `managed_platform` field to telemetry payloads to identify when MLflow is running on managed notebook/ML platforms. This helps distinguish telemetry from ephemeral and shared environments (e.g., Google Colab, SageMaker) where installation IDs may churn or be shared across users.

Detected platforms:
- **Google Colab** (`colab`) — via `COLAB_RELEASE_TAG` or `COLAB_GPU`
- **Amazon SageMaker** (`sagemaker`) — via `SAGEMAKER_APP_TYPE` or `SAGEMAKER_INTERNAL_IMAGE_URI`
- **Azure ML** (`azureml`) — via `AZUREML_RUN_ID` or `AZUREML_ARM_SUBSCRIPTION`
- **Kaggle** (`kaggle`) — via `KAGGLE_KERNEL_RUN_TYPE`
- **Paperspace Gradient** (`gradient`) — via `PAPERSPACE_CLUSTER_ID`
- **Deepnote** (`deepnote`) — via `DEEPNOTE_PROJECT_ID`

Changes:
- `mlflow/telemetry/utils.py`: Added `_detect_managed_platform()` function and `_MANAGED_PLATFORM` module-level cache
- `mlflow/telemetry/schemas.py`: Added `managed_platform` field to `TelemetryInfo`
- `mlflow/telemetry/client.py`: Passes detected platform into `TelemetryInfo` on client init
- `tests/telemetry/test_utils.py`: Parametrized tests for all platforms plus the `None` case

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)