### PR TITLE
Add granular telemetry tracking URI schemes for AWS and Azure

### DIFF
--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -286,8 +286,16 @@ def _get_tracking_scheme_with_resolved_uri(resolved_store_uri: str) -> str:
     if builder is None:
         return "None"
     if builder.__module__.split(".", 1)[0] != "mlflow":
-        return "custom_scheme"
+        return _resolve_custom_scheme(scheme, resolved_store_uri)
     return scheme
+
+
+def _resolve_custom_scheme(scheme: str, resolved_store_uri: str) -> str:
+    if scheme == "arn" or resolved_store_uri.startswith("arn:aws:"):
+        return "aws"
+    if scheme == "azureml":
+        return "azure"
+    return "custom_scheme"
 
 
 _artifact_repos_cache = OrderedDict()

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -31,6 +31,7 @@ from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
 from mlflow.tracking._tracking_service.utils import (
     _get_store,
     _get_tracking_scheme,
+    _resolve_custom_scheme,
     _resolve_tracking_uri,
     _use_tracking_uri,
     get_tracking_uri,
@@ -523,3 +524,17 @@ def test_get_tracking_scheme():
     assert _get_tracking_scheme("uc://profile@databricks") == "uc"
     # no builder registered for custom scheme
     assert _get_tracking_scheme("custom-scheme://") == "None"
+
+
+@pytest.mark.parametrize(
+    ("scheme", "uri", "expected"),
+    [
+        ("arn", "arn:aws:sagemaker:us-east-1:123456789:mlflow-tracking-server/my-server", "aws"),
+        ("arn", "arn:aws:sagemaker:eu-west-1:987654321:mlflow-tracking-server/test", "aws"),
+        ("azureml", "azureml://eastus.api.azureml.ms/mlflow/v2.0/subscriptions/123", "azure"),
+        ("azureml", "azureml://workspace", "azure"),
+        ("some-plugin", "some-plugin://host/path", "custom_scheme"),
+    ],
+)
+def test_resolve_custom_scheme(scheme, uri, expected):
+    assert _resolve_custom_scheme(scheme, uri) == expected


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Currently, all non-MLflow tracking URI schemes are reported as `"custom_scheme"` in telemetry. This PR adds more granular scheme detection for two major cloud providers:

- **AWS SageMaker**: URIs like `arn:aws:sagemaker:<REGION>:<ACCOUNT_ID>:mlflow-tracking-server/...` now report as `"aws"`
- **Azure ML**: URIs like `azureml://...` now report as `"azure"`

All other non-MLflow schemes continue to report as `"custom_scheme"`.

The detection is implemented in a new `_resolve_custom_scheme()` function extracted from `_get_tracking_scheme_with_resolved_uri()`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New parametrized test `test_resolve_custom_scheme` covers AWS ARN URIs, Azure ML URIs, and generic plugin URIs.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)