### PR TITLE
Add polars dataset support to autologging

### DIFF
--- a/mlflow/lightgbm/__init__.py
+++ b/mlflow/lightgbm/__init__.py
@@ -59,6 +59,7 @@ from mlflow.utils.autologging_utils import (
     resolve_input_example_and_signature,
     safe_patch,
 )
+from mlflow.utils.data_utils import is_polars_dataframe
 from mlflow.utils.databricks_utils import is_in_databricks_runtime as is_in_databricks_runtime
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
@@ -1050,6 +1051,10 @@ def _log_lightgbm_dataset(lgb_dataset, source, context, autologging_client, name
         dataset = from_numpy(features=arr_data, targets=label, source=source, name=name)
     elif isinstance(data, np.ndarray):
         dataset = from_numpy(features=data, targets=label, source=source, name=name)
+    elif is_polars_dataframe(data):
+        from mlflow.data.polars_dataset import from_polars
+
+        dataset = from_polars(df=data, source=source, name=name)
     else:
         _logger.warning("Unrecognized dataset type %s. Dataset logging skipped.", type(data))
         return

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -15,7 +15,7 @@ sklearn:
     minimum: "1.4.2"
     maximum: "1.8.0"
     requirements:
-      ">= 0.0.0": ["matplotlib"]
+      ">= 0.0.0": ["matplotlib", "polars"]
     run: |
       pytest tests/sklearn/test_sklearn_autolog.py
 
@@ -184,7 +184,7 @@ lightgbm:
     minimum: "4.4.0"
     maximum: "4.6.0"
     requirements:
-      ">= 0.0.0": ["scikit-learn", "matplotlib"]
+      ">= 0.0.0": ["scikit-learn", "matplotlib", "polars"]
     run: |
       pytest tests/lightgbm/test_lightgbm_autolog.py
 

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -56,6 +56,7 @@ from mlflow.utils.autologging_utils import (
     safe_patch,
     update_wrapper_extended,
 )
+from mlflow.utils.data_utils import is_polars_dataframe
 from mlflow.utils.databricks_utils import (
     is_in_databricks_model_serving_environment,
     is_in_databricks_runtime,
@@ -2088,6 +2089,10 @@ def _autolog(
                 dataset = from_numpy(features=X, targets=y, source=source, name=dataset_name)
             else:
                 dataset = from_numpy(features=X, source=source, name=dataset_name)
+        elif is_polars_dataframe(X):
+            from mlflow.data.polars_dataset import from_polars
+
+            dataset = from_polars(df=X, source=source, name=dataset_name)
         else:
             _logger.warning("Unrecognized dataset type %s. Dataset logging skipped.", type(X))
             return None

--- a/mlflow/utils/data_utils.py
+++ b/mlflow/utils/data_utils.py
@@ -1,4 +1,5 @@
 import urllib.parse
+from typing import Any
 
 
 def parse_s3_uri(uri):
@@ -14,3 +15,12 @@ def parse_s3_uri(uri):
 def is_uri(string):
     parsed_uri = urllib.parse.urlparse(string)
     return len(parsed_uri.scheme) > 0
+
+
+def is_polars_dataframe(data: Any) -> bool:
+    try:
+        import polars as pl
+
+        return isinstance(data, pl.DataFrame)
+    except ImportError:
+        return False

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -9,6 +9,7 @@ import lightgbm as lgb
 import matplotlib as mpl
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 from packaging.version import Version
 from sklearn import datasets
@@ -808,3 +809,21 @@ def test_lgb_log_datasets_with_valid_set_with_name(bst_params, train_set, valid_
     assert dataset_inputs[0].tags[0].value == "train"
     assert dataset_inputs[1].tags[0].value == "eval"
     assert dataset_inputs[1].dataset.name == "my_valid_set"
+
+
+def test_lgb_log_datasets_with_polars(bst_params):
+    iris = datasets.load_iris()
+    X = pl.DataFrame(iris.data[:, :2], schema=["f1", "f2"])
+    y = iris.target
+    train_set = lgb.Dataset(X, y, free_raw_data=False)
+
+    with mlflow.start_run() as run:
+        mlflow.lightgbm.autolog(log_datasets=True)
+        lgb.train(bst_params, train_set, num_boost_round=1)
+
+    run_id = run.info.run_id
+    client = MlflowClient()
+    dataset_inputs = client.get_run(run_id).inputs.dataset_inputs
+    assert len(dataset_inputs) == 1
+    assert dataset_inputs[0].tags[0].value == "train"
+    assert dataset_inputs[0].dataset.source_type == "code"

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -11,6 +11,7 @@ import joblib
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 import sklearn
 import sklearn.base
@@ -1224,6 +1225,23 @@ def test_sklearn_autolog_log_datasets_without_explicit_run():
             "targets": None,
         }
     })
+
+
+def test_sklearn_autolog_log_datasets_with_polars():
+    X, y = get_iris()
+    X_pl = pl.DataFrame(X, schema=["f1", "f2"])
+
+    with mlflow.start_run() as run:
+        mlflow.sklearn.autolog(log_datasets=True)
+        model = sklearn.linear_model.LinearRegression()
+        model.fit(X_pl, y)
+
+    run_id = run.info.run_id
+    client = MlflowClient()
+    dataset_inputs = client.get_run(run_id).inputs.dataset_inputs
+    assert len(dataset_inputs) == 1
+    assert dataset_inputs[0].tags[0].value == "train"
+    assert dataset_inputs[0].dataset.source_type == "code"
 
 
 def test_autolog_does_not_capture_runs_for_preprocessing_or_feature_manipulation_estimators():


### PR DESCRIPTION
### Related Issues/PRs

Closes #21463

### What changes are proposed in this pull request?

MLflow autologging currently does not support logging polars datasets. While general support for polars datasets exists via `from_polars`, the autologging dataset creation paths in sklearn and lightgbm only handle pandas DataFrames, numpy arrays, and sparse matrices.

This PR adds polars DataFrame detection and logging to the autologging paths for sklearn and lightgbm. A shared `is_polars_dataframe` utility in `mlflow/utils/data_utils.py` handles the optional import check safely.

XGBoost is excluded because `DMatrix.get_data()` always returns a sparse matrix regardless of input type, making the polars branch unreachable.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add polars DataFrame support to autologging dataset logging for sklearn and lightgbm flavors.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)