### PR TITLE
Allow searching runs across all experiments using experiment_ids=["ALL"]

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -278,7 +278,11 @@ from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.jobs.abstract_store import AbstractJobStore
 from mlflow.store.model_registry.abstract_store import AbstractStore as AbstractModelRegistryStore
 from mlflow.store.model_registry.rest_store import RestStore as ModelRegistryRestStore
-from mlflow.store.tracking import MAX_RESULTS_QUERY_TRACE_METRICS, SEARCH_MAX_RESULTS_DEFAULT
+from mlflow.store.tracking import (
+    MAX_RESULTS_QUERY_TRACE_METRICS,
+    SEARCH_ALL_EXPERIMENTS,
+    SEARCH_MAX_RESULTS_DEFAULT,
+)
 from mlflow.store.tracking.abstract_store import AbstractStore as AbstractTrackingStore
 from mlflow.store.tracking.databricks_rest_store import DatabricksTracingRestStore
 from mlflow.store.workspace.abstract_store import WorkspaceNameValidator
@@ -1718,7 +1722,16 @@ def search_runs_impl(request_message):
         from mlflow.server import auth
 
         if auth.auth_config:
-            experiment_ids = auth.filter_experiment_ids(experiment_ids)
+            if SEARCH_ALL_EXPERIMENTS in experiment_ids:
+                # When searching all experiments with auth enabled, resolve all
+                # experiment IDs and run them through auth filtering so that users
+                # only see runs from experiments they can read.
+                all_exps = _get_tracking_store().search_experiments(view_type=ViewType.ALL)
+                experiment_ids = auth.filter_experiment_ids(
+                    [e.experiment_id for e in all_exps]
+                )
+            else:
+                experiment_ids = auth.filter_experiment_ids(experiment_ids)
     except ImportError:
         # Auth module not available (Flask-WTF not installed), skip filtering
         pass

--- a/mlflow/store/tracking/__init__.py
+++ b/mlflow/store/tracking/__init__.py
@@ -18,6 +18,9 @@ DEFAULT_TRACKING_URI = "sqlite:///mlflow.db"
 # storage location will be `DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH`.
 DEFAULT_ARTIFACTS_URI = "mlflow-artifacts:/"
 SEARCH_MAX_RESULTS_DEFAULT = 1000
+# Reserved value in experiment_ids to indicate "search all experiments".
+# Since experiment IDs are always numeric, there is no collision risk.
+SEARCH_ALL_EXPERIMENTS = "ALL"
 SEARCH_MAX_RESULTS_THRESHOLD = 50000
 GET_METRIC_HISTORY_MAX_RESULTS = 25000
 SEARCH_TRACES_DEFAULT_MAX_RESULTS = 100

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -59,6 +59,7 @@ from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.file_store import FileStore as ModelRegistryFileStore
 from mlflow.store.tracking import (
     DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
+    SEARCH_ALL_EXPERIMENTS,
     SEARCH_LOGGED_MODEL_MAX_RESULTS_DEFAULT,
     SEARCH_MAX_RESULTS_DEFAULT,
     SEARCH_MAX_RESULTS_THRESHOLD,
@@ -1059,6 +1060,11 @@ class FileStore(AbstractStore):
                 f"most {SEARCH_MAX_RESULTS_THRESHOLD}, but got value {max_results}",
                 databricks_pb2.INVALID_PARAMETER_VALUE,
             )
+        if SEARCH_ALL_EXPERIMENTS in experiment_ids:
+            experiment_ids = [
+                exp.experiment_id
+                for exp in self.search_experiments(view_type=ViewType.ALL)
+            ]
         runs = []
         for experiment_id in experiment_ids:
             run_infos = self._list_run_infos(experiment_id, run_view_type)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -115,6 +115,7 @@ from mlflow.store.tracking import (
     MAX_RESULTS_GET_METRIC_HISTORY,
     MAX_RESULTS_QUERY_TRACE_METRICS,
     MAX_TRACE_LINKS_PER_REQUEST,
+    SEARCH_ALL_EXPERIMENTS,
     SEARCH_ISSUES_DEFAULT_MAX_RESULTS,
     SEARCH_LOGGED_MODEL_MAX_RESULTS_DEFAULT,
     SEARCH_MAX_RESULTS_DEFAULT,
@@ -1883,17 +1884,23 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 stmt = stmt.outerjoin(j)
 
             offset = SearchUtils.parse_start_offset_from_page_token(page_token)
-            experiment_ids = [int(e) for e in experiment_ids]
-            experiment_ids = self._filter_experiment_ids(session, experiment_ids)
+
+            # Build base filters — skip the experiment_id IN(...) predicate when the
+            # caller passes the reserved "ALL" value, which is the key performance win.
+            base_filters = [
+                SqlRun.lifecycle_stage.in_(stages),
+                *attribute_filters,
+            ]
+            if SEARCH_ALL_EXPERIMENTS not in experiment_ids:
+                experiment_ids = [int(e) for e in experiment_ids]
+                experiment_ids = self._filter_experiment_ids(session, experiment_ids)
+                base_filters.insert(0, SqlRun.experiment_id.in_(experiment_ids))
+
             stmt = (
                 stmt
                 .distinct()
                 .options(*self._get_eager_run_query_options())
-                .filter(
-                    SqlRun.experiment_id.in_(experiment_ids),
-                    SqlRun.lifecycle_stage.in_(stages),
-                    *attribute_filters,
-                )
+                .filter(*base_filters)
                 .order_by(*parsed_orderby)
                 .offset(offset)
             )

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -50,7 +50,7 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
     RESOURCE_DOES_NOT_EXIST,
 )
-from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
+from mlflow.store.tracking import SEARCH_ALL_EXPERIMENTS, SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.telemetry.events import AutologgingEvent
 from mlflow.telemetry.track import _record_event
 from mlflow.tracing.provider import (
@@ -3183,7 +3183,8 @@ def search_runs(
             is returned and, if ``list``, a list of :py:class:`mlflow.entities.Run`
             is returned.
         search_all_experiments: Boolean specifying whether all experiments should be searched.
-            Only honored if ``experiment_ids`` is ``[]`` or ``None``.
+            Only honored if ``experiment_ids`` is ``[]`` or ``None``. Equivalent to
+            passing ``experiment_ids=["ALL"]``.
         experiment_names: List of experiment names. Search can work with experiment IDs or
             experiment names, but not both in the same call. Values other
             than ``None`` or ``[]`` will result in error if ``experiment_ids``
@@ -3251,9 +3252,7 @@ def search_runs(
         )
 
     if search_all_experiments and no_ids_or_names:
-        experiment_ids = [
-            exp.experiment_id for exp in search_experiments(view_type=ViewType.ACTIVE_ONLY)
-        ]
+        experiment_ids = [SEARCH_ALL_EXPERIMENTS]
     elif no_ids_or_names:
         experiment_ids = [_get_experiment_id()]
     elif not no_names:

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -4065,3 +4065,47 @@ def test_malicious_meta_yaml_in_artifact_folder_path_traversal(tmp_path):
     # The fix should prevent the artifact folder from being treated as a run directory
     with pytest.raises(MlflowException, match="Run 'artifacts' not found"):
         fs.get_run("artifacts")
+
+
+def test_search_runs_experiment_ids_all(store):
+    """Test that experiment_ids=["ALL"] searches across all experiments."""
+    experiments, _, _ = _create_root(store)
+    exp1, exp2 = experiments[0], experiments[1]
+
+    run1 = store.create_run(exp1, "user", 0, [], "test_run_exp1")
+    run2 = store.create_run(exp2, "user", 0, [], "test_run_exp2")
+
+    store.set_tag(run1.info.run_id, RunTag("search_all_test", "yes"))
+    store.set_tag(run2.info.run_id, RunTag("search_all_test", "yes"))
+
+    result = store.search_runs(
+        experiment_ids=["ALL"],
+        filter_string="tags.search_all_test = 'yes'",
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    run_ids = [r.info.run_id for r in result]
+    assert run1.info.run_id in run_ids
+    assert run2.info.run_id in run_ids
+
+
+def test_search_runs_experiment_ids_all_with_filter(store):
+    """Test that experiment_ids=["ALL"] works correctly with tag filters."""
+    experiments, _, _ = _create_root(store)
+    exp1, exp2 = experiments[0], experiments[1]
+
+    run1 = store.create_run(exp1, "user", 0, [], "test_run1")
+    run2 = store.create_run(exp2, "user", 0, [], "test_run2")
+    run3 = store.create_run(exp1, "user", 0, [], "test_run3")
+
+    store.set_tag(run1.info.run_id, RunTag("include_in_leaderboard", "true"))
+    store.set_tag(run2.info.run_id, RunTag("include_in_leaderboard", "true"))
+
+    result = store.search_runs(
+        experiment_ids=["ALL"],
+        filter_string="tags.include_in_leaderboard = 'true'",
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    run_ids = [r.info.run_id for r in result]
+    assert run1.info.run_id in run_ids
+    assert run2.info.run_id in run_ids
+    assert run3.info.run_id not in run_ids

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -13954,3 +13954,76 @@ def test_get_decrypted_secret_integration_multiple_secrets(store):
 
     assert decrypted1 == {"api_key": "key-1"}
     assert decrypted2 == {"api_key": "key-2"}
+
+
+def test_search_runs_experiment_ids_all(store: SqlAlchemyStore):
+    """Test that experiment_ids=["ALL"] searches across all experiments."""
+    exp1 = store.create_experiment("search_all_exp1")
+    exp2 = store.create_experiment("search_all_exp2")
+    exp3 = store.create_experiment("search_all_exp3")
+
+    run1 = _run_factory(store, _get_run_configs(exp1))
+    run2 = _run_factory(store, _get_run_configs(exp2))
+    run3 = _run_factory(store, _get_run_configs(exp3))
+
+    result = store.search_runs(
+        experiment_ids=["ALL"],
+        filter_string=None,
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    run_ids = [r.info.run_id for r in result]
+    assert run1.info.run_id in run_ids
+    assert run2.info.run_id in run_ids
+    assert run3.info.run_id in run_ids
+
+
+def test_search_runs_experiment_ids_all_with_filter(store: SqlAlchemyStore):
+    """Test that experiment_ids=["ALL"] works correctly with tag filters."""
+    exp1 = store.create_experiment("search_all_filter_exp1")
+    exp2 = store.create_experiment("search_all_filter_exp2")
+
+    run1 = _run_factory(store, _get_run_configs(exp1))
+    run2 = _run_factory(store, _get_run_configs(exp2))
+    run3 = _run_factory(store, _get_run_configs(exp1))
+
+    store.set_tag(run1.info.run_id, RunTag("include_in_leaderboard", "true"))
+    store.set_tag(run2.info.run_id, RunTag("include_in_leaderboard", "true"))
+
+    result = store.search_runs(
+        experiment_ids=["ALL"],
+        filter_string="tags.include_in_leaderboard = 'true'",
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    run_ids = [r.info.run_id for r in result]
+    assert run1.info.run_id in run_ids
+    assert run2.info.run_id in run_ids
+    assert run3.info.run_id not in run_ids
+
+
+def test_search_runs_experiment_ids_all_respects_lifecycle(store: SqlAlchemyStore):
+    """Test that experiment_ids=["ALL"] respects run_view_type."""
+    exp1 = store.create_experiment("search_all_lifecycle_exp1")
+    exp2 = store.create_experiment("search_all_lifecycle_exp2")
+
+    run1 = _run_factory(store, _get_run_configs(exp1))
+    run2 = _run_factory(store, _get_run_configs(exp2))
+
+    store.delete_run(run2.info.run_id)
+
+    result = store.search_runs(
+        experiment_ids=["ALL"],
+        filter_string=None,
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    run_ids = [r.info.run_id for r in result]
+    assert run1.info.run_id in run_ids
+    assert run2.info.run_id not in run_ids
+
+    result = store.search_runs(
+        experiment_ids=["ALL"],
+        filter_string=None,
+        run_view_type=ViewType.DELETED_ONLY,
+    )
+    run_ids = [r.info.run_id for r in result]
+    assert run1.info.run_id not in run_ids
+    assert run2.info.run_id in run_ids

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1042,24 +1042,19 @@ def test_search_runs_no_arguments(search_runs_output_format):
 
 def test_search_runs_all_experiments(search_runs_output_format):
     """
-    When no experiment ID is specified but flag is passed, it should search all experiments.
+    When search_all_experiments=True is passed, it should pass ["ALL"] to the backend
+    without resolving experiment IDs.
     """
-    from mlflow.entities import Experiment
-
-    mock_experiment_id = mock.Mock()
-    mock_experiment = mock.Mock(Experiment)
     experiment_id_patch = mock.patch(
-        "mlflow.tracking.fluent._get_experiment_id", return_value=mock_experiment_id
-    )
-    experiment_list_patch = mock.patch(
-        "mlflow.tracking.fluent.search_experiments", return_value=[mock_experiment]
+        "mlflow.tracking.fluent._get_experiment_id", return_value=mock.Mock()
     )
     get_paginated_runs_patch = mock.patch(
         "mlflow.tracking.fluent.get_results_from_paginated_fn", return_value=[]
     )
-    with experiment_id_patch, experiment_list_patch, get_paginated_runs_patch:
+    with experiment_id_patch, get_paginated_runs_patch:
         search_runs(output_format=search_runs_output_format, search_all_experiments=True)
-        mlflow.tracking.fluent.search_experiments.assert_called_once()
+        mlflow.tracking.fluent.get_results_from_paginated_fn.assert_called_once()
+        # Should NOT resolve experiment IDs when search_all_experiments=True
         mlflow.tracking.fluent._get_experiment_id.assert_not_called()
 
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #21387 , previously closed PR: https://github.com/mlflow/mlflow/pull/21237

Problem: We have an MLflow instance with millions of runs and tens of thousands of experiments. We are trying to find experiment runs that have a particular tag. The current API is very slow, taking around 1 minute if we provide all experiment ids.

### What changes are proposed in this pull request?

Reserve `"ALL"` as a special value in the existing `experiment_ids` field to allow searching runs across all experiments without requiring callers to first enumerate and pass all experiment IDs. Since experiment IDs are always numeric, there is no collision risk. This avoids proto changes and signature changes across the stack while still giving the SQLAlchemy store the key optimization (skipping the `IN(...)` filter).

This is a revision of #21237. Per reviewer feedback, instead of plumbing a new `search_all_experiments` boolean through every layer (proto, handler, stores, clients), we use a reserved value in the existing field.

**Semantics:**
- `experiment_ids=["ALL"]` → search all experiments (skips `IN(...)` filter)
- `experiment_ids=[...]` → search those experiments (existing behavior)
- `experiment_ids=[]` → return nothing (existing behavior)

**Changes by layer:**

- **Constant** (`mlflow/store/tracking/__init__.py`): Added `SEARCH_ALL_EXPERIMENTS = "ALL"`.
- **SqlAlchemyStore**: When `"ALL"` is in `experiment_ids`, omits the `experiment_id IN(...)` filter from the SQL query entirely — the key performance win.
- **FileStore**: Resolves all experiment IDs internally when `"ALL"` is in `experiment_ids`.
- **Server** (`handlers.py`): When `"ALL"` is in `experiment_ids` and auth is enabled, resolves all experiment IDs from the store and runs them through `auth.filter_experiment_ids()` so users only see runs from experiments they can read. Without auth, `["ALL"]` passes through to the store directly.
- **Fluent API** (`fluent.py`): The existing `search_all_experiments=True` parameter now maps to `["ALL"]` internally instead of resolving all experiment IDs client-side.


**Example usage:**

```python
import mlflow

# Old way — had to fetch all experiment IDs first
all_exps = mlflow.search_experiments()
runs = mlflow.search_runs(
    experiment_ids=[e.experiment_id for e in all_exps],
    filter_string="tags.execution_id = 'abc123'",
)

# New way — fluent API
runs = mlflow.search_runs(
    search_all_experiments=True,
    filter_string="tags.execution_id = 'abc123'",
)

# New way — MlflowClient with reserved value
client = mlflow.MlflowClient()
runs = client.search_runs(
    experiment_ids=["ALL"],
    filter_string="tags.execution_id = 'abc123'",
)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests - created 100 expts/50 runs (5000 runs total) with 2 runs with a specific tag

```
--- Narrow filter benchmark ---
Filter: tags.query_case = 'needle'
Old way: 2 runs (59.35 ms)
New way: 2 runs (11.12 ms)
```

New tests added for:

- **FileStore**: `experiment_ids=["ALL"]` searches all experiments, tag filtering
- **SqlAlchemyStore**: `experiment_ids=["ALL"]` searches all experiments, tag filtering, lifecycle stage respect
- **Fluent API**: verifies `search_all_experiments=True` passes `["ALL"]` to backend without resolving IDs

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`MlflowClient.search_runs(experiment_ids=["ALL"])` now skip the `experiment_id IN(...)` SQL
  filter, significantly improving performance for cross-experiment queries like tag-based lookups.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [x] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)