### PR TITLE
Add missing Azure Blob Storage deps to full Docker image

### DIFF
--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -1,4 +1,5 @@
 FROM python:3.10-slim-bullseye
 ARG VERSION
 
-RUN pip install --no-cache-dir mlflow[extras,db,gateway,genai]==$VERSION
+RUN pip install --no-cache-dir mlflow[extras,db,gateway,genai]==$VERSION \
+    azure-storage-blob azure-identity adlfs


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `azure-storage-blob`, `azure-identity`, and `adlfs` to the pip install in `docker/Dockerfile.full`.

Resolves #21521

### Why

The `-full` Docker image documents "Cloud storage integrations (Azure Blob)" as included, and the `docker/README.md` shows an Azure Blob Storage example:

```bash
docker run -p 5000:5000   -e AZURE_STORAGE_CONNECTION_STRING="your-connection-string"   mlflow:latest-full   mlflow server --artifacts-destination wasbs://container@account.blob.core.windows.net/path --host 0.0.0.0
```

However, none of the installed extras (`extras`, `db`, `gateway`, `genai`) include `azure-storage-blob`. The import in `AzureBlobArtifactRepository.__init__()` is lazy, so `mlflow server` starts fine, but any attempt to store or retrieve artifacts via a `wasbs://` URI fails at runtime:

```
ModuleNotFoundError: No module named 'azure.storage'
```

### What's missing

Verified against `ghcr.io/mlflow/mlflow:v3.10.1-full`:

```
$ pip show azure-storage-blob
WARNING: Package(s) not found: azure-storage-blob

$ pip show adlfs
WARNING: Package(s) not found: adlfs

$ pip show azure-identity
WARNING: Package(s) not found: azure-identity
```

The image does have `azure-core`, `azure-mgmt-storage`, and other azure packages (via `azureml-core`), but these are management-plane packages, not the data-plane packages needed for actual blob storage I/O.

### Fix

One-line change to `docker/Dockerfile.full` — append the three missing packages to the existing pip install.

## How is this patch tested?

- Built the updated image locally
- Verified `pip show azure-storage-blob azure-identity adlfs` succeeds
- Verified `python -c "from azure.storage.blob import BlobServiceClient"` succeeds (previously failed)

## Does this PR change the currently-logged metrics?

No.

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
