### PR TITLE
Deprecate legacy fetch helpers in favor of fetchAPI/fetchOrFail

### DIFF
--- a/mlflow/server/js/src/common/utils/FetchUtils.ts
+++ b/mlflow/server/js/src/common/utils/FetchUtils.ts
@@ -106,6 +106,7 @@ export const defaultError = ({ reject, response, err }: any) => {
  * Makes a fetch request.
  * Note this is not intended to be used outside of this file,
  * use `fetchEndpoint` instead.
+ * @deprecated Use `fetchAPI` or `fetchOrFail` instead.
  */
 export const fetchEndpointRaw = ({
   relativeUrl,
@@ -212,6 +213,7 @@ const defaultFetchErrorConditionFn = (res: any) => !res || (!res.ok && !HTTPRetr
 
 /**
  * Makes a fetch request.
+ * @deprecated Use `fetchAPI` or `fetchOrFail` instead.
  * @param relativeUrl: relative URL to the shard URL
  * @param method: HTTP method for the request
  * @param body: request body
@@ -291,6 +293,7 @@ const generateJsonBody = (data: any) => {
 
 /* All functions below are essentially syntactic sugars for fetchEndpoint */
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const getJson = (props: any) => {
   const { relativeUrl, data } = props;
   const queryParams = new URLSearchParams(filterUndefinedFields(data)).toString();
@@ -303,6 +306,7 @@ export const getJson = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const postJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -313,6 +317,7 @@ export const postJson = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const putJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -323,6 +328,7 @@ export const putJson = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const patchJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -333,6 +339,7 @@ export const patchJson = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const deleteJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -343,6 +350,7 @@ export const deleteJson = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const getBigIntJson = (props: any) => {
   const { relativeUrl, data } = props;
   const queryParams = new URLSearchParams(filterUndefinedFields(data));
@@ -356,6 +364,7 @@ export const getBigIntJson = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const postBigIntJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -366,6 +375,7 @@ export const postBigIntJson = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const putBigIntJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -376,6 +386,7 @@ export const putBigIntJson = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const patchBigIntJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -386,6 +397,7 @@ export const patchBigIntJson = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const deleteBigIntJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -396,6 +408,7 @@ export const deleteBigIntJson = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const getYaml = (props: any) => {
   const { relativeUrl, data } = props;
   const queryParams = new URLSearchParams(filterUndefinedFields(data));
@@ -407,6 +420,7 @@ export const getYaml = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const postYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -417,6 +431,7 @@ export const postYaml = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const putYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -427,6 +442,7 @@ export const putYaml = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const patchYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -437,6 +453,7 @@ export const patchYaml = (props: any) => {
   });
 };
 
+/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
 export const deleteYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({

--- a/mlflow/server/js/src/common/utils/FetchUtils.ts
+++ b/mlflow/server/js/src/common/utils/FetchUtils.ts
@@ -408,7 +408,6 @@ export const deleteBigIntJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const getYaml = (props: any) => {
   const { relativeUrl, data } = props;
   const queryParams = new URLSearchParams(filterUndefinedFields(data));
@@ -420,7 +419,6 @@ export const getYaml = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const postYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -431,7 +429,6 @@ export const postYaml = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const putYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -442,7 +439,6 @@ export const putYaml = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const patchYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -453,7 +449,6 @@ export const patchYaml = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const deleteYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({

--- a/mlflow/server/js/src/common/utils/FetchUtils.ts
+++ b/mlflow/server/js/src/common/utils/FetchUtils.ts
@@ -104,8 +104,8 @@ export const defaultError = ({ reject, response, err }: any) => {
 
 /**
  * Makes a fetch request.
- * Note this is not intended to be used outside of this file,
- * use `fetchEndpoint` instead.
+ * Note: this function is intended for internal use within this module.
+ * External callers should use `fetchAPI` or `fetchOrFail` instead.
  * @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support.
  */
 export const fetchEndpointRaw = ({

--- a/mlflow/server/js/src/common/utils/FetchUtils.ts
+++ b/mlflow/server/js/src/common/utils/FetchUtils.ts
@@ -106,7 +106,7 @@ export const defaultError = ({ reject, response, err }: any) => {
  * Makes a fetch request.
  * Note this is not intended to be used outside of this file,
  * use `fetchEndpoint` instead.
- * @deprecated Use `fetchAPI` or `fetchOrFail` instead.
+ * @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support.
  */
 export const fetchEndpointRaw = ({
   relativeUrl,
@@ -213,7 +213,7 @@ const defaultFetchErrorConditionFn = (res: any) => !res || (!res.ok && !HTTPRetr
 
 /**
  * Makes a fetch request.
- * @deprecated Use `fetchAPI` or `fetchOrFail` instead.
+ * @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support.
  * @param relativeUrl: relative URL to the shard URL
  * @param method: HTTP method for the request
  * @param body: request body
@@ -293,7 +293,7 @@ const generateJsonBody = (data: any) => {
 
 /* All functions below are essentially syntactic sugars for fetchEndpoint */
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const getJson = (props: any) => {
   const { relativeUrl, data } = props;
   const queryParams = new URLSearchParams(filterUndefinedFields(data)).toString();
@@ -306,7 +306,7 @@ export const getJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const postJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -317,7 +317,7 @@ export const postJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const putJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -328,7 +328,7 @@ export const putJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const patchJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -339,7 +339,7 @@ export const patchJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const deleteJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -350,7 +350,7 @@ export const deleteJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const getBigIntJson = (props: any) => {
   const { relativeUrl, data } = props;
   const queryParams = new URLSearchParams(filterUndefinedFields(data));
@@ -364,7 +364,7 @@ export const getBigIntJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const postBigIntJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -375,7 +375,7 @@ export const postBigIntJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const putBigIntJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -386,7 +386,7 @@ export const putBigIntJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const patchBigIntJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -397,7 +397,7 @@ export const patchBigIntJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const deleteBigIntJson = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -408,7 +408,7 @@ export const deleteBigIntJson = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const getYaml = (props: any) => {
   const { relativeUrl, data } = props;
   const queryParams = new URLSearchParams(filterUndefinedFields(data));
@@ -420,7 +420,7 @@ export const getYaml = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const postYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -431,7 +431,7 @@ export const postYaml = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const putYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -442,7 +442,7 @@ export const putYaml = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const patchYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({
@@ -453,7 +453,7 @@ export const patchYaml = (props: any) => {
   });
 };
 
-/** @deprecated Use `fetchAPI` or `fetchOrFail` instead. */
+/** @deprecated Use `fetchAPI` (returns parsed JSON) or `fetchOrFail` (returns raw Response) for better error parsing support. */
 export const deleteYaml = (props: any) => {
   const { data } = props;
   return fetchEndpoint({


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Mark all legacy fetch helper functions in `FetchUtils.ts` as `@deprecated` in favor of `fetchAPI` and `fetchOrFail`. The deprecated functions are:

- `fetchEndpointRaw`, `fetchEndpoint`
- `getJson`, `postJson`, `putJson`, `patchJson`, `deleteJson`
- `getBigIntJson`, `postBigIntJson`, `putBigIntJson`, `patchBigIntJson`, `deleteBigIntJson`

This is a documentation-only change (JSDoc `@deprecated` tags) with no runtime impact.

### How is this PR tested?

- [x] Existing unit/integration tests

No behavioral changes — only JSDoc annotations added. This should show up in IDEs and coding agents will more likely respect it

<img width="866" height="310" alt="Screenshot 2026-03-10 at 11 07 53 AM" src="https://github.com/user-attachments/assets/3a46ea80-635e-4587-8c92-1e0de00593a8" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release