### PR TITLE
Add budget alert webhooks UI and fix budgets table borders

### DIFF
--- a/mlflow/server/js/src/gateway/components/budgets/BudgetsList.tsx
+++ b/mlflow/server/js/src/gateway/components/budgets/BudgetsList.tsx
@@ -104,10 +104,15 @@ export const BudgetsList = ({ onEditClick, onDeleteClick }: BudgetsListProps) =>
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       <Table
         scrollable
+        noMinHeight
         empty={getEmptyState()}
         css={{
-          border: `1px solid ${theme.colors.borderDecorative}`,
+          borderLeft: `1px solid ${theme.colors.border}`,
+          borderRight: `1px solid ${theme.colors.border}`,
+          borderTop: `1px solid ${theme.colors.border}`,
+          borderBottom: budgetPolicies.length === 0 ? `1px solid ${theme.colors.border}` : 'none',
           borderRadius: theme.general.borderRadiusBase,
+          overflow: 'hidden',
         }}
       >
         <TableRow isHeader>

--- a/mlflow/server/js/src/gateway/pages/BudgetsPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/BudgetsPage.tsx
@@ -82,7 +82,11 @@ const BudgetsPage = () => {
               description="Budget webhooks section description on budgets page"
             />
           }
-          componentIdPrefix="mlflow.gateway.budgets.webhooks"
+          componentIds={{
+            createButton: 'mlflow.gateway.budgets.webhooks.create-button',
+            errorAlert: 'mlflow.gateway.budgets.webhooks.error-alert',
+            testResultAlert: 'mlflow.gateway.budgets.webhooks.test-result-alert',
+          }}
         />
       </div>
 

--- a/mlflow/server/js/src/gateway/pages/BudgetsPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/BudgetsPage.tsx
@@ -7,6 +7,7 @@ import { CreateBudgetPolicyModal } from '../components/budgets/CreateBudgetPolic
 import { EditBudgetPolicyModal } from '../components/budgets/EditBudgetPolicyModal';
 import { DeleteBudgetPolicyModal } from '../components/budgets/DeleteBudgetPolicyModal';
 import { useBudgetsPage } from '../hooks/useBudgetsPage';
+import WebhooksSettings from '../../settings/WebhooksSettings';
 
 const BudgetsPage = () => {
   const { theme } = useDesignSystemTheme();
@@ -56,8 +57,33 @@ const BudgetsPage = () => {
       </div>
 
       {/* Content */}
-      <div css={{ flex: 1, overflow: 'auto', padding: theme.spacing.md }}>
+      <div
+        css={{
+          flex: 1,
+          overflow: 'auto',
+          padding: theme.spacing.md,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.lg,
+        }}
+      >
         <BudgetsList onEditClick={handleEditClick} onDeleteClick={handleDeleteClick} />
+        <WebhooksSettings
+          eventFilter="BUDGET_POLICY"
+          title={
+            <FormattedMessage
+              defaultMessage="Budget alert webhooks"
+              description="Budget webhooks section title on budgets page"
+            />
+          }
+          description={
+            <FormattedMessage
+              defaultMessage="Receive HTTP notifications when a budget policy is exceeded."
+              description="Budget webhooks section description on budgets page"
+            />
+          }
+          componentIdPrefix="mlflow.gateway.budgets.webhooks"
+        />
       </div>
 
       {/* Modals */}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2276,6 +2276,10 @@
     "defaultMessage": "Provider",
     "description": "Provider column header"
   },
+  "CwJcIQ": {
+    "defaultMessage": "Receive HTTP notifications when a budget policy is exceeded.",
+    "description": "Budget webhooks section description on budgets page"
+  },
   "CyTYL6": {
     "defaultMessage": "Line chart",
     "description": "Experiment tracking > runs charts > add chart menu > line chart"
@@ -5700,6 +5704,10 @@
   "aXw0NO": {
     "defaultMessage": "Please select metric",
     "description": "Placeholder text where one can select metrics from the list of available metrics to render on the graph"
+  },
+  "aZ9uZO": {
+    "defaultMessage": "Budget alert webhooks",
+    "description": "Budget webhooks section title on budgets page"
   },
   "aZV8M7": {
     "defaultMessage": "Delete",

--- a/mlflow/server/js/src/settings/WebhookFormModal.tsx
+++ b/mlflow/server/js/src/settings/WebhookFormModal.tsx
@@ -27,9 +27,11 @@ interface WebhookFormModalProps {
   editingWebhook: Webhook | null;
   onClose: () => void;
   onSaved: () => void;
+  /** If set, only show events matching this entity */
+  eventFilter?: string;
 }
 
-const WebhookFormModal = ({ visible, editingWebhook, onClose, onSaved }: WebhookFormModalProps) => {
+const WebhookFormModal = ({ visible, editingWebhook, onClose, onSaved, eventFilter }: WebhookFormModalProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -45,6 +47,8 @@ const WebhookFormModal = ({ visible, editingWebhook, onClose, onSaved }: Webhook
       events: editingWebhook?.events.map((e) => eventKey(e.entity, e.action)) ?? [],
     },
   });
+
+  const displayedEvents = eventFilter ? VALID_EVENTS.filter((e) => e.entity === eventFilter) : VALID_EVENTS;
 
   const formatEventLabel = (entity: string, action: string) => {
     const key = eventKey(entity, action);
@@ -243,7 +247,7 @@ const WebhookFormModal = ({ visible, editingWebhook, onClose, onSaved }: Webhook
               }}
               render={({ field }) => (
                 <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-                  {VALID_EVENTS.map((event) => {
+                  {displayedEvents.map((event) => {
                     const key = eventKey(event.entity, event.action);
                     return (
                       <Checkbox

--- a/mlflow/server/js/src/settings/WebhooksSettings.test.tsx
+++ b/mlflow/server/js/src/settings/WebhooksSettings.test.tsx
@@ -33,11 +33,22 @@ const SAMPLE_WEBHOOK = {
   description: 'A test webhook',
 };
 
+const BUDGET_WEBHOOK = {
+  webhook_id: 'wh-2',
+  name: 'Budget Alert',
+  url: 'https://example.com/budget',
+  events: [{ entity: 'BUDGET_POLICY', action: 'EXCEEDED' }],
+  status: 'ACTIVE',
+  creation_timestamp: '1700000000000',
+  last_updated_timestamp: '1700000000000',
+  description: 'A budget webhook',
+};
+
 describe('WebhooksSettings', () => {
-  const renderComponent = () =>
+  const renderComponent = (props?: Partial<React.ComponentProps<typeof WebhooksSettings>>) =>
     renderWithIntl(
       <DesignSystemProvider>
-        <WebhooksSettings />
+        <WebhooksSettings {...props} />
       </DesignSystemProvider>,
     );
 
@@ -188,6 +199,28 @@ describe('WebhooksSettings', () => {
     await waitFor(() => {
       expect(screen.getByText('Test succeeded (HTTP 200)')).toBeInTheDocument();
     });
+  });
+
+  it('filters webhooks by eventFilter when provided', async () => {
+    mockListWebhooks.mockResolvedValue({ webhooks: [SAMPLE_WEBHOOK, BUDGET_WEBHOOK] });
+
+    renderComponent({ eventFilter: 'BUDGET_POLICY' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Budget Alert')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Test Webhook')).not.toBeInTheDocument();
+  });
+
+  it('shows all webhooks when eventFilter is not provided', async () => {
+    mockListWebhooks.mockResolvedValue({ webhooks: [SAMPLE_WEBHOOK, BUDGET_WEBHOOK] });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Webhook')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Budget Alert')).toBeInTheDocument();
   });
 
   it('shows error when loading webhooks fails', async () => {

--- a/mlflow/server/js/src/settings/WebhooksSettings.tsx
+++ b/mlflow/server/js/src/settings/WebhooksSettings.tsx
@@ -8,7 +8,7 @@ import WebhookFormModal from './WebhookFormModal';
 import WebhookDeleteModal from './WebhookDeleteModal';
 
 interface WebhooksSettingsProps {
-  /** Filter displayed webhooks to only those containing at least one event matching this entity prefix */
+  /** Filter displayed webhooks to only those containing at least one event whose entity matches this value exactly */
   eventFilter?: string;
   /** Title override */
   title?: React.ReactNode;
@@ -160,7 +160,7 @@ const WebhooksSettings = ({
 
       {error && (
         <Alert
-          componentId="mlflow.settings.webhooks.error-alert"
+          componentId={`${componentIdPrefix}.error-alert`}
           type="error"
           message={error}
           closable
@@ -170,7 +170,7 @@ const WebhooksSettings = ({
 
       {testResult && (
         <Alert
-          componentId="mlflow.settings.webhooks.test-result-alert"
+          componentId={`${componentIdPrefix}.test-result-alert`}
           type={testResult.success ? 'info' : 'error'}
           message={testResult.message}
           closable

--- a/mlflow/server/js/src/settings/WebhooksSettings.tsx
+++ b/mlflow/server/js/src/settings/WebhooksSettings.tsx
@@ -7,6 +7,18 @@ import WebhookListItem from './WebhookListItem';
 import WebhookFormModal from './WebhookFormModal';
 import WebhookDeleteModal from './WebhookDeleteModal';
 
+interface WebhooksComponentIds {
+  createButton: string;
+  errorAlert: string;
+  testResultAlert: string;
+}
+
+const DEFAULT_COMPONENT_IDS: WebhooksComponentIds = {
+  createButton: 'mlflow.settings.webhooks.create-button',
+  errorAlert: 'mlflow.settings.webhooks.error-alert',
+  testResultAlert: 'mlflow.settings.webhooks.test-result-alert',
+};
+
 interface WebhooksSettingsProps {
   /** Filter displayed webhooks to only those containing at least one event whose entity matches this value exactly */
   eventFilter?: string;
@@ -14,15 +26,15 @@ interface WebhooksSettingsProps {
   title?: React.ReactNode;
   /** Description override */
   description?: React.ReactNode;
-  /** componentId prefix for namespacing */
-  componentIdPrefix?: string;
+  /** Static componentIds for namespacing */
+  componentIds?: WebhooksComponentIds;
 }
 
 const WebhooksSettings = ({
   eventFilter,
   title,
   description,
-  componentIdPrefix = 'mlflow.settings.webhooks',
+  componentIds = DEFAULT_COMPONENT_IDS,
 }: WebhooksSettingsProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -153,14 +165,14 @@ const WebhooksSettings = ({
             )}
           </Typography.Text>
         </div>
-        <Button componentId={`${componentIdPrefix}.create-button`} type="primary" onClick={openCreateModal}>
+        <Button componentId={componentIds.createButton} type="primary" onClick={openCreateModal}>
           <FormattedMessage defaultMessage="Create webhook" description="Create webhook button" />
         </Button>
       </div>
 
       {error && (
         <Alert
-          componentId={`${componentIdPrefix}.error-alert`}
+          componentId={componentIds.errorAlert}
           type="error"
           message={error}
           closable
@@ -170,7 +182,7 @@ const WebhooksSettings = ({
 
       {testResult && (
         <Alert
-          componentId={`${componentIdPrefix}.test-result-alert`}
+          componentId={componentIds.testResultAlert}
           type={testResult.success ? 'info' : 'error'}
           message={testResult.message}
           closable

--- a/mlflow/server/js/src/settings/WebhooksSettings.tsx
+++ b/mlflow/server/js/src/settings/WebhooksSettings.tsx
@@ -7,7 +7,23 @@ import WebhookListItem from './WebhookListItem';
 import WebhookFormModal from './WebhookFormModal';
 import WebhookDeleteModal from './WebhookDeleteModal';
 
-const WebhooksSettings = () => {
+interface WebhooksSettingsProps {
+  /** Filter displayed webhooks to only those containing at least one event matching this entity prefix */
+  eventFilter?: string;
+  /** Title override */
+  title?: React.ReactNode;
+  /** Description override */
+  description?: React.ReactNode;
+  /** componentId prefix for namespacing */
+  componentIdPrefix?: string;
+}
+
+const WebhooksSettings = ({
+  eventFilter,
+  title,
+  description,
+  componentIdPrefix = 'mlflow.settings.webhooks',
+}: WebhooksSettingsProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
 
@@ -34,13 +50,18 @@ const WebhooksSettings = () => {
     setError(null);
     try {
       const response = await WebhooksApi.listWebhooks();
-      setWebhooks(response?.webhooks ?? []);
+      const all = response?.webhooks ?? [];
+      if (eventFilter) {
+        setWebhooks(all.filter((w) => w.events.some((e) => e.entity === eventFilter)));
+      } else {
+        setWebhooks(all);
+      }
     } catch (e: any) {
       setError(e?.message ?? intl.formatMessage({ defaultMessage: 'Failed to load webhooks' }));
     } finally {
       setLoading(false);
     }
-  }, [intl]);
+  }, [intl, eventFilter]);
 
   useEffect(() => {
     fetchWebhooks();
@@ -121,16 +142,18 @@ const WebhooksSettings = () => {
       <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div>
           <Typography.Title level={4} withoutMargins>
-            <FormattedMessage defaultMessage="Webhooks" description="Webhooks settings section title" />
+            {title ?? <FormattedMessage defaultMessage="Webhooks" description="Webhooks settings section title" />}
           </Typography.Title>
           <Typography.Text color="secondary">
-            <FormattedMessage
-              defaultMessage="Manage webhooks to receive HTTP notifications when events occur in MLflow."
-              description="Webhooks settings section description"
-            />
+            {description ?? (
+              <FormattedMessage
+                defaultMessage="Manage webhooks to receive HTTP notifications when events occur in MLflow."
+                description="Webhooks settings section description"
+              />
+            )}
           </Typography.Text>
         </div>
-        <Button componentId="mlflow.settings.webhooks.create-button" type="primary" onClick={openCreateModal}>
+        <Button componentId={`${componentIdPrefix}.create-button`} type="primary" onClick={openCreateModal}>
           <FormattedMessage defaultMessage="Create webhook" description="Create webhook button" />
         </Button>
       </div>
@@ -174,11 +197,7 @@ const WebhooksSettings = () => {
               description="Empty state for webhooks list"
               values={{
                 link: (chunks: any) => (
-                  <a
-                    href="https://mlflow.org/docs/latest/python_api/mlflow.webhooks.html"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
+                  <a href="https://mlflow.org/docs/latest/ml/webhooks/" target="_blank" rel="noopener noreferrer">
                     {chunks}
                   </a>
                 ),
@@ -215,6 +234,7 @@ const WebhooksSettings = () => {
           editingWebhook={editingWebhook}
           onClose={closeModal}
           onSaved={handleSaved}
+          eventFilter={eventFilter}
         />
       )}
 


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Add a **Budget alert webhooks** section to the Budgets page, allowing users to manage webhooks filtered to `BUDGET_POLICY` events directly from the budgets UI

<img width="1506" height="471" alt="image" src="https://github.com/user-attachments/assets/8acb6981-cccf-4c07-923b-e5d592b7e659" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified visually that:
- Budget alert webhooks section appears below the budgets list
- Only BUDGET_POLICY events are shown in the webhook form modal
- Table borders render correctly without double borders or extended side borders

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Add budget alert webhooks management UI to the Budgets page, allowing users to configure webhook notifications for budget policy exceeded events.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release