### PR TITLE
Add dev-mode logging to TelemetryClient logEvent

### DIFF
--- a/mlflow/server/js/src/telemetry/TelemetryClient.ts
+++ b/mlflow/server/js/src/telemetry/TelemetryClient.ts
@@ -118,7 +118,10 @@ class TelemetryClient {
 
     if (process.env['NODE_ENV'] === 'development' && isTelemetryDevLoggingEnabled()) {
       // eslint-disable-next-line no-console
-      console.log(`[TelemetryClient] Clicked ${record.componentId}, payload:`, payload);
+      console.log(
+        `[TelemetryClient] Event "${record.eventType}" on component "${record.componentId}", payload:`,
+        payload,
+      );
     }
 
     this.port?.postMessage({

--- a/mlflow/server/js/src/telemetry/TelemetryClient.ts
+++ b/mlflow/server/js/src/telemetry/TelemetryClient.ts
@@ -111,7 +111,7 @@ class TelemetryClient {
       },
     };
 
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env['NODE_ENV'] === 'development') {
       // eslint-disable-next-line no-console
       console.log(`[TelemetryClient] Clicked ${record.componentId}, payload:`, payload);
     }

--- a/mlflow/server/js/src/telemetry/TelemetryClient.ts
+++ b/mlflow/server/js/src/telemetry/TelemetryClient.ts
@@ -6,7 +6,12 @@
  */
 import { v4 as uuidv4 } from 'uuid';
 import type { TelemetryRecord } from './worker/types';
-import { isDesignSystemEvent, TELEMETRY_ENABLED_STORAGE_KEY, TELEMETRY_ENABLED_STORAGE_VERSION } from './utils';
+import {
+  isDesignSystemEvent,
+  isTelemetryDevLoggingEnabled,
+  TELEMETRY_ENABLED_STORAGE_KEY,
+  TELEMETRY_ENABLED_STORAGE_VERSION,
+} from './utils';
 import { WorkerToClientMessageType, ClientToWorkerMessageType } from './worker/types';
 import { getLocalStorageItem } from '../shared/web-shared/hooks/useLocalStorage';
 
@@ -111,7 +116,7 @@ class TelemetryClient {
       },
     };
 
-    if (process.env['NODE_ENV'] === 'development') {
+    if (process.env['NODE_ENV'] === 'development' && isTelemetryDevLoggingEnabled()) {
       // eslint-disable-next-line no-console
       console.log(`[TelemetryClient] Clicked ${record.componentId}, payload:`, payload);
     }

--- a/mlflow/server/js/src/telemetry/TelemetryClient.ts
+++ b/mlflow/server/js/src/telemetry/TelemetryClient.ts
@@ -111,6 +111,11 @@ class TelemetryClient {
       },
     };
 
+    if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.log(`[TelemetryClient] Clicked ${record.componentId}, payload:`, payload);
+    }
+
     this.port?.postMessage({
       type: ClientToWorkerMessageType.LOG_EVENT,
       payload,

--- a/mlflow/server/js/src/telemetry/utils.ts
+++ b/mlflow/server/js/src/telemetry/utils.ts
@@ -1,7 +1,10 @@
 import { has, isObject } from 'lodash';
 import type { DesignSystemObservabilityEvent } from './types';
+import { getLocalStorageItem } from '../shared/web-shared/hooks/useLocalStorage';
 
 export const TELEMETRY_ENABLED_STORAGE_VERSION = 1;
+
+export const TELEMETRY_ENABLE_DEV_LOGGING_STORAGE_KEY = 'mlflow.settings.telemetry.enable-dev-logging';
 
 export const TELEMETRY_ENABLED_STORAGE_KEY = 'mlflow.settings.telemetry.enabled';
 
@@ -24,4 +27,8 @@ export const isDesignSystemEvent = (event: any): event is DesignSystemObservabil
     has(event, 'eventType') &&
     typeof event.eventType === 'string'
   );
+};
+
+export const isTelemetryDevLoggingEnabled = (): boolean => {
+  return getLocalStorageItem(TELEMETRY_ENABLE_DEV_LOGGING_STORAGE_KEY, 1, false);
 };


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Adds a `console.log` in `TelemetryClient.logEvent` that fires only in development mode (`process.env.NODE_ENV === 'development'`) and when a specific localstorage key is set. This logs the clicked component ID and the telemetry payload to the browser console, making it easier to debug and inspect telemetry events during local development.

### How is this PR tested?

- [x] Manual tests

Verified the log appears in browser console when running the webpack dev server and clicking UI elements. The log is tree-shaken out in production builds.

**TO USE:** please manually set the `mlflow.settings.telemetry.enable-dev-logging_v1` localstorage key to `true`


https://github.com/user-attachments/assets/d813c20b-a9c4-4e2f-aa71-656de232a3e1



### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release