### PR TITLE
Add push-to-master trigger for UI preview deployment

### DIFF
--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -86,6 +86,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # For PRs, check out the PR head (safe because the build job only runs for
+          # maintainers/collaborators via the author_association check). For push
+          # events, falls back to github.sha.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: ./.github/actions/setup-python

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -30,8 +30,6 @@ defaults:
 
 env:
   COMMENT_MARKER: "<!-- ui-preview -->"
-  IS_PUSH: ${{ github.event_name == 'push' }}
-  IS_PR: ${{ github.event_name == 'pull_request_target' }}
 
 jobs:
   notify:

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -221,6 +221,12 @@ jobs:
           databricks workspace import-dir /tmp/app-deploy "$WORKSPACE_PATH" --overwrite
           databricks apps deploy "$APP_NAME" --source-code-path "/Workspace$WORKSPACE_PATH"
 
+      - name: Print app URL
+        if: github.event_name == 'push'
+        env:
+          APP_URL: ${{ steps.app.outputs.url }}
+        run: echo "Deployed to $APP_URL" >> $GITHUB_STEP_SUMMARY
+
       - name: Comment on PR
         if: github.event_name != 'push'
         env:

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -1,6 +1,13 @@
 name: UI Preview
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - mlflow/server/js/**
+      - .github/workflows/ui-preview.yml
+      - .github/ui-preview/**
   pull_request_target:
     types:
       - opened
@@ -14,7 +21,7 @@ on:
       - .github/ui-preview/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'master' }}
   cancel-in-progress: true
 
 defaults:
@@ -23,11 +30,14 @@ defaults:
 
 env:
   COMMENT_MARKER: "<!-- ui-preview -->"
+  IS_PUSH: ${{ github.event_name == 'push' }}
+  IS_PR: ${{ github.event_name == 'pull_request_target' }}
 
 jobs:
   notify:
     if: >-
-      github.event.action != 'closed'
+      github.event_name != 'push'
+      && github.event.action != 'closed'
       && contains(github.event.pull_request.labels.*.name, 'ui-preview')
       && (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
       && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
@@ -64,10 +74,13 @@ jobs:
 
   build:
     if: >-
-      github.event.action != 'closed'
-      && contains(github.event.pull_request.labels.*.name, 'ui-preview')
-      && (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
-      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      github.event_name == 'push'
+      || (
+        github.event.action != 'closed'
+        && contains(github.event.pull_request.labels.*.name, 'ui-preview')
+        && (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+        && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,9 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Check out the PR head, not the base branch.
-          # Safe because the build job only runs for maintainers/collaborators (author_association check).
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-node
@@ -164,14 +175,15 @@ jobs:
       - name: Create or update app
         id: app
         env:
-          APP_NAME: mlflow-ui-preview-pr-${{ github.event.pull_request.number }}
+          APP_NAME: ${{ github.event_name == 'push' && 'mlflow-ui-preview-dev' || format('mlflow-ui-preview-pr-{0}', github.event.pull_request.number) }}
+          APP_DESCRIPTION: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
         run: |
           if databricks apps get "$APP_NAME" > /dev/null 2>&1; then
             echo "App already exists"
           else
             echo "Creating app..."
             databricks apps create \
-              --json "{\"name\": \"$APP_NAME\", \"description\": \"${{ github.event.pull_request.html_url }}\"}" \
+              --json "{\"name\": \"$APP_NAME\", \"description\": \"$APP_DESCRIPTION\"}" \
               --no-wait
             for i in $(seq 1 40); do
               STATE=$(databricks apps get "$APP_NAME" -o json | jq -r '.compute_status.state')
@@ -201,14 +213,15 @@ jobs:
 
       - name: Upload files and deploy
         env:
-          APP_NAME: mlflow-ui-preview-pr-${{ github.event.pull_request.number }}
-          WORKSPACE_PATH: /Users/${{ secrets.DATABRICKS_CLIENT_ID }}/apps/mlflow-ui-preview-pr-${{ github.event.pull_request.number }}
+          APP_NAME: ${{ github.event_name == 'push' && 'mlflow-ui-preview-dev' || format('mlflow-ui-preview-pr-{0}', github.event.pull_request.number) }}
+          WORKSPACE_PATH: /Users/${{ secrets.DATABRICKS_CLIENT_ID }}/apps/${{ github.event_name == 'push' && 'mlflow-ui-preview-dev' || format('mlflow-ui-preview-pr-{0}', github.event.pull_request.number) }}
         run: |
           databricks workspace mkdirs "/Workspace$WORKSPACE_PATH" 2>/dev/null || true
           databricks workspace import-dir /tmp/app-deploy "$WORKSPACE_PATH" --overwrite
           databricks apps deploy "$APP_NAME" --source-code-path "/Workspace$WORKSPACE_PATH"
 
       - name: Comment on PR
+        if: github.event_name != 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APP_URL: ${{ steps.app.outputs.url }}
@@ -244,7 +257,8 @@ jobs:
 
   cleanup:
     if: >-
-      github.event.action == 'closed'
+      github.event_name != 'push'
+      && github.event.action == 'closed'
       && contains(github.event.pull_request.labels.*.name, 'ui-preview')
     runs-on: ubuntu-ui-preview
     permissions:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Add a `push` trigger to the UI Preview workflow so that a persistent `mlflow-ui-preview-dev` app is automatically deployed whenever commits land on `master` that touch `mlflow/server/js/**`. This gives maintainers an always-up-to-date preview of the latest master UI without relying on a PR.

PR-based preview behavior is unchanged — the `notify`, `cleanup`, and `Comment on PR` steps are gated to only run on `pull_request_target` events.

### How is this PR tested?

- [x] Manual tests

Verified the workflow YAML is valid and the conditional logic correctly gates PR-only steps for push events.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)