### PR TITLE
Add server installation ID to UI telemetry records

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -279,6 +279,7 @@ from mlflow.store.tracking.abstract_store import AbstractStore as AbstractTracki
 from mlflow.store.tracking.databricks_rest_store import DatabricksTracingRestStore
 from mlflow.store.workspace.abstract_store import WorkspaceNameValidator
 from mlflow.telemetry import get_telemetry_client
+from mlflow.telemetry.installation_id import get_or_create_installation_id
 from mlflow.telemetry.schemas import Record, Status
 from mlflow.telemetry.utils import (
     FALLBACK_UI_CONFIG,
@@ -6054,6 +6055,7 @@ def post_ui_telemetry_handler():
         if config.get("disable_ui_telemetry", True) or config.get("disable_telemetry", True):
             return jsonify({"status": "disabled"})
 
+        server_installation_id = get_or_create_installation_id()
         records = [
             Record(
                 event_name=event["event_name"],
@@ -6062,6 +6064,7 @@ def post_ui_telemetry_handler():
                 status=Status.SUCCESS,
                 installation_id=event["installation_id"],
                 session_id=event["session_id"],
+                server_installation_id=server_installation_id,
                 duration_ms=0,
             )
             for event in data

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -25,6 +25,7 @@ class Record:
     # but callers can override with these fields (e.g. in UI telemetry records)
     installation_id: str | None = None
     session_id: str | None = None
+    server_installation_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         result = {
@@ -39,6 +40,8 @@ class Record:
             result["installation_id"] = self.installation_id
         if self.session_id:
             result["session_id"] = self.session_id
+        if self.server_installation_id:
+            result["server_installation_id"] = self.server_installation_id
         return result
 
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -3207,12 +3207,17 @@ def test_post_ui_telemetry_handler_success(
     config = {"disable_ui_telemetry": False, "disable_telemetry": False}
     mock_client = mock.MagicMock()
 
+    server_install_id = "server-install-789"
     with (
         test_app.test_request_context(
             "/ui-telemetry", method="POST", data=request, content_type="application/json"
         ),
         mock.patch("mlflow.server.handlers.fetch_ui_telemetry_config", return_value=config),
         mock.patch("mlflow.server.handlers.get_telemetry_client", return_value=mock_client),
+        mock.patch(
+            "mlflow.server.handlers.get_or_create_installation_id",
+            return_value=server_install_id,
+        ),
     ):
         response = post_ui_telemetry_handler()
 
@@ -3224,8 +3229,18 @@ def test_post_ui_telemetry_handler_success(
         assert response_data["status"] == "success"
         assert mock_client.add_records.call_count == 1
         assert mock_client.add_records.call_args[0][0] == [
-            Record(**event1, duration_ms=0, status=Status.SUCCESS),
-            Record(**event2, duration_ms=0, status=Status.SUCCESS),
+            Record(
+                **event1,
+                duration_ms=0,
+                status=Status.SUCCESS,
+                server_installation_id=server_install_id,
+            ),
+            Record(
+                **event2,
+                duration_ms=0,
+                status=Status.SUCCESS,
+                server_installation_id=server_install_id,
+            ),
         ]
 
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Include the server's `installation_id` as a separate `server_installation_id` field in UI telemetry records. This allows correlating UI events with the server instance that processed them.

Changes:
- Added `server_installation_id` field to the `Record` dataclass and its `to_dict()` serialization
- Inject the server installation ID in `post_ui_telemetry_handler()` by calling `get_or_create_installation_id()`
- No frontend changes needed — the field is injected server-side

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Updated `test_post_ui_telemetry_handler_success` to mock and verify `server_installation_id` is included in records.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)