### PR TITLE
Add valueHasNoPii to gateway Tabs.Root components for telemetry

### DIFF
--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -97,7 +97,11 @@ export const EditEndpointFormRenderer = ({
   const intl = useIntl();
   const [searchParams, setSearchParams] = useSearchParams();
   const [isUsageModalOpen, setIsUsageModalOpen] = useState(false);
-  const activeTab = searchParams.get('tab') || 'configuration';
+  const VALID_TABS = ['configuration', 'usage', 'traces'] as const;
+  const tabParam = searchParams.get('tab');
+  const activeTab = VALID_TABS.includes(tabParam as (typeof VALID_TABS)[number])
+    ? (tabParam as string)
+    : 'configuration';
 
   const trafficSplitModels = form.watch('trafficSplitModels');
   const fallbackModels = form.watch('fallbackModels');

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -189,6 +189,7 @@ export const EditEndpointFormRenderer = ({
 
       <Tabs.Root
         componentId="mlflow.gateway.endpoint.tabs"
+        valueHasNoPii
         value={activeTab}
         onValueChange={(value) => {
           setSearchParams(

--- a/mlflow/server/js/src/gateway/components/endpoints/EndpointUsageModal.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoints/EndpointUsageModal.tsx
@@ -306,6 +306,7 @@ export const EndpointUsageModal = ({ open, onClose, endpointName, baseUrl }: End
 
         <Tabs.Root
           componentId="mlflow.gateway.usage-modal.tabs"
+          valueHasNoPii
           value={activeTab}
           onValueChange={(value) => setActiveTab(value as 'unified' | 'passthrough')}
           css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}

--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
@@ -260,6 +260,7 @@ export const GatewayUsagePage = () => {
       {/* Tabs */}
       <Tabs.Root
         componentId="mlflow.gateway.usage.tabs"
+        valueHasNoPii
         value={activeTab}
         onValueChange={(value) => {
           setSearchParams(

--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
@@ -65,7 +65,9 @@ export const GatewayUsagePage = () => {
   const [selectedEndpointId, setSelectedEndpointId] = useState<string | null>(null);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
 
-  const activeTab = searchParams.get('tab') || 'usage';
+  const VALID_TABS = ['usage', 'logs'] as const;
+  const tabParam = searchParams.get('tab');
+  const activeTab = VALID_TABS.includes(tabParam as (typeof VALID_TABS)[number]) ? (tabParam as string) : 'usage';
 
   // Fetch all endpoints to get their experiment IDs
   const { data: endpoints, isLoading: isLoadingEndpoints } = useEndpointsQuery();


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds `valueHasNoPii` prop to three gateway `Tabs.Root` components so that the active tab value is logged in UI telemetry records:

- `GatewayUsagePage`
- `EndpointUsageModal`
- `EditEndpointFormRenderer`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release