### PR TITLE
Gate env-var API key resolution behind MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -632,6 +632,14 @@ MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI = _EnvironmentVariable(
     "MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI", str, None
 )
 
+#: If True, the gateway will attempt to resolve API keys from environment variables
+#: (``$``-prefixed values). This is only enabled for the legacy YAML-config gateway
+#: (``mlflow gateway start``).
+#: (default: ``False``)
+MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV = _BooleanEnvironmentVariable(
+    "MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV", False
+)
+
 #: If True, the gateway will attempt to resolve API keys from local file paths.
 #: This is only enabled for the legacy YAML-config gateway (``mlflow gateway start``).
 #: (default: ``False``)

--- a/mlflow/gateway/app.py
+++ b/mlflow/gateway/app.py
@@ -22,6 +22,7 @@ from mlflow.deployments.server.constants import (
 from mlflow.environment_variables import (
     MLFLOW_GATEWAY_CONFIG,
     MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI,
+    MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV,
     MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_FILE,
 )
 from mlflow.exceptions import MlflowException
@@ -465,7 +466,8 @@ def create_app_from_path(config_path: str | Path) -> GatewayAPI:
     """
     Load the path and generate the GatewayAPI app instance.
     """
-    # Enable file-based API key resolution for the legacy YAML-config gateway
+    # Enable env-var and file-based API key resolution for the legacy YAML-config gateway
+    os.environ[MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV.name] = "true"
     os.environ[MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_FILE.name] = "true"
     config = _load_gateway_config(config_path)
     return create_app_from_config(config)

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -11,7 +11,10 @@ import yaml
 from pydantic import ConfigDict, ValidationError, field_validator, model_validator
 from pydantic.json import pydantic_encoder
 
-from mlflow.environment_variables import MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_FILE
+from mlflow.environment_variables import (
+    MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV,
+    MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_FILE,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.base_models import ConfigModel, LimitModel, ResponseModel
 from mlflow.gateway.constants import (
@@ -301,6 +304,7 @@ def _resolve_api_key_from_input(api_key_input):
     Input formats accepted:
 
     - environment variable name that stores the api key (prefixed with ``$``)
+      (only when ``MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV`` is ``true``)
     - Path to a file as a string which will have the key loaded from it
       (only when ``MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_FILE`` is ``true``)
     - the api key itself
@@ -311,8 +315,8 @@ def _resolve_api_key_from_input(api_key_input):
             "variable key, a path to a file containing the api key, or the api key itself"
         )
 
-    # try reading as an environment variable
-    if api_key_input.startswith("$"):
+    # try reading as an environment variable (only for legacy YAML-config gateway)
+    if api_key_input.startswith("$") and MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV.get():
         env_var_name = api_key_input[1:]
         if env_var := os.environ.get(env_var_name):
             return env_var

--- a/mlflow/gateway/runner.py
+++ b/mlflow/gateway/runner.py
@@ -8,6 +8,7 @@ from watchfiles import watch
 
 from mlflow.environment_variables import (
     MLFLOW_GATEWAY_CONFIG,
+    MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV,
     MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_FILE,
 )
 from mlflow.gateway import app
@@ -76,6 +77,7 @@ class Runner:
             env={
                 **os.environ,
                 MLFLOW_GATEWAY_CONFIG.name: self.config_path,
+                MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV.name: "true",
                 MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_FILE.name: "true",
             },
         )

--- a/tests/gateway/test_gateway_config_parsing.py
+++ b/tests/gateway/test_gateway_config_parsing.py
@@ -77,6 +77,8 @@ def test_assemble_uri_path(paths, expected):
 
 
 def test_api_key_parsing_env(tmp_path, monkeypatch):
+    # Env-var resolution requires the flag to be enabled
+    monkeypatch.setenv("MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV", "true")
     monkeypatch.setenv("KEY_AS_ENV", "my_key")
 
     assert _resolve_api_key_from_input("$KEY_AS_ENV") == "my_key"
@@ -97,6 +99,14 @@ def test_api_key_parsing_env(tmp_path, monkeypatch):
     conf_path.write_text(file_key)
 
     assert _resolve_api_key_from_input(str(conf_path)) == file_key
+
+
+def test_api_key_env_resolution_blocked_without_flag(monkeypatch):
+    monkeypatch.setenv("KEY_AS_ENV", "my_key")
+    monkeypatch.delenv("MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV", raising=False)
+
+    # Without the flag, $-prefixed values are returned as literal strings
+    assert _resolve_api_key_from_input("$KEY_AS_ENV") == "$KEY_AS_ENV"
 
 
 def test_api_key_input_exceeding_maximum_filename_length():


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a new boolean environment variable `MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV` (default: `false`) that controls whether `$`-prefixed API key values in gateway route configs are resolved from environment variables. This mirrors the existing `MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_FILE` pattern — both are only enabled for the legacy YAML-config gateway (`mlflow gateway start`).

Without this flag, `$`-prefixed values are now treated as literal strings and returned as-is.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Existing unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)