### PR TITLE
Fix Strands autolog tool input format for `SpanType.TOOL`

### DIFF
--- a/mlflow/strands/autolog.py
+++ b/mlflow/strands/autolog.py
@@ -132,18 +132,32 @@ def _parse_json(value):
 
 
 def _set_inputs_outputs(mlflow_span: LiveSpan, span: OTelReadableSpan) -> None:
-    inputs = []
     outputs = []
-    for event in span.events:
-        if event.name in {"gen_ai.user.message", "gen_ai.tool.message"}:
-            content = _parse_json(event.attributes.get("content"))
-            role = "user" if event.name == "gen_ai.user.message" else "tool"
-            inputs.append({"role": role, "content": content})
-        elif event.name == "gen_ai.choice":
-            message = _parse_json(event.attributes.get("message"))
-            outputs.append(message)
-    if inputs:
-        mlflow_span.set_inputs(inputs)
+    span_type = mlflow_span.get_attribute(SpanAttributeKey.SPAN_TYPE)
+
+    if span_type == SpanType.TOOL:
+        for event in span.events:
+            if event.name == "gen_ai.tool.message":
+                content = _parse_json(event.attributes.get("content"))
+                mlflow_span.set_inputs(content)
+            elif event.name == "gen_ai.choice":
+                message = _parse_json(event.attributes.get("message"))
+                outputs.append(message)
+    else:
+        # CHAT_MODEL/AGENT spans: collect into conversation list
+        inputs = []
+        for event in span.events:
+            if event.name in ("gen_ai.user.message", "gen_ai.tool.message"):
+                content = _parse_json(event.attributes.get("content"))
+                role = "user" if event.name == "gen_ai.user.message" else "tool"
+                inputs.append({"role": role, "content": content})
+            elif event.name == "gen_ai.choice":
+                message = _parse_json(event.attributes.get("message"))
+                outputs.append(message)
+
+        if inputs:
+            mlflow_span.set_inputs(inputs)
+
     if outputs:
         mlflow_span.set_outputs(outputs if len(outputs) > 1 else outputs[0])
 

--- a/tests/strands/test_strands_tracing.py
+++ b/tests/strands/test_strands_tracing.py
@@ -209,7 +209,7 @@ def test_function_calling_creates_single_trace():
     assert tool_span.span_type == SpanType.TOOL
     assert agent_span.inputs == [{"role": "user", "content": [{"text": "add numbers 1 2 1 2"}]}]
     assert agent_span.outputs == 3
-    assert tool_span.inputs == [{"role": "tool", "content": {"a": 1, "b": 2}}]
+    assert tool_span.inputs == {"a": 1, "b": 2}
     assert tool_span.outputs == [{"json": 3}]
 
 
@@ -259,7 +259,7 @@ def test_multiple_agents_single_trace():
     assert agent2_span.name == "invoke_agent agent2"
     assert agent1_span.inputs == [{"role": "user", "content": [{"text": "add numbers 1 2"}]}]
     assert agent1_span.outputs == 3
-    assert tool_span.inputs == [{"role": "tool", "content": {"a": 1, "b": 2}}]
+    assert tool_span.inputs == {"a": 1, "b": 2}
     assert tool_span.outputs == [{"json": 3}]
     assert agent2_span.inputs == [{"role": "user", "content": [{"text": "hello"}]}]
     assert agent2_span.outputs.strip() == "hi"


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes https://github.com/mlflow/mlflow/issues/21487

### What changes are proposed in this pull request?

1. **Updated `_set_inputs_outputs` function** in `mlflow/strands/autolog.py`:
   - Added span type detection to differentiate between TOOL spans and CHAT_MODEL/AGENT spans
   - TOOL spans now use direct content format (e.g., `{"a": 1, "b": 2}`) instead of wrapped conversation format
   - CHAT_MODEL/AGENT spans continue using the conversation list format with roles

2. **Updated test assertions** in `tests/strands/test_strands_tracing.py`:
   - Modified expected assertions for TOOL span inputs to match the new format
   - Updated both `test_function_calling_creates_single_trace` and `test_multiple_agents_single_trace`

**Problem solved:**
Previously, TOOL spans were incorrectly formatted as `[{"role": "tool", "content": {"a": 1, "b": 2}}]`, which caused parsing errors when extracting tools called from traces during evaluation runs. This fix aligns the format with other MLflow tracing integrations and ensures proper parsing of tool inputs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
