### PR TITLE
Deprecate `generate_signature_output` in favor of input_example

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,12 +11,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/enforce-uv.sh\"",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/enforce-uv.sh",
             "timeout": 5.0
           },
           {
             "type": "command",
-            "command": "uv run --directory=\"$CLAUDE_PROJECT_DIR\" --no-project .claude/hooks/validate_pr_body.py",
+            "command": "uv run --directory=$CLAUDE_PROJECT_DIR --no-project .claude/hooks/validate_pr_body.py",
             "timeout": 5.0
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --directory=\"$CLAUDE_PROJECT_DIR\" --no-project .claude/hooks/lint.py",
+            "command": "uv run --directory=$CLAUDE_PROJECT_DIR --no-project .claude/hooks/lint.py",
             "timeout": 10.0
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,12 +11,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/enforce-uv.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/enforce-uv.sh\"",
             "timeout": 5.0
           },
           {
             "type": "command",
-            "command": "uv run --directory=$CLAUDE_PROJECT_DIR --no-project .claude/hooks/validate_pr_body.py",
+            "command": "uv run --directory=\"$CLAUDE_PROJECT_DIR\" --no-project .claude/hooks/validate_pr_body.py",
             "timeout": 5.0
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --directory=$CLAUDE_PROJECT_DIR --no-project .claude/hooks/lint.py",
+            "command": "uv run --directory=\"$CLAUDE_PROJECT_DIR\" --no-project .claude/hooks/lint.py",
             "timeout": 10.0
           }
         ]

--- a/docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx
@@ -171,19 +171,12 @@ import transformers
 # Read a pre-trained conversation pipeline from HuggingFace hub
 conversational_pipeline = transformers.pipeline(model="microsoft/DialoGPT-medium")
 
-# Define the signature
-signature = mlflow.models.infer_signature(
-    "Hi there, chatbot!",
-    mlflow.transformers.generate_signature_output(conversational_pipeline, "Hi there, chatbot!"),
-)
-
 # Log the pipeline
 with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=conversational_pipeline,
         name="chatbot",
         task="conversational",
-        signature=signature,
         input_example="A clever and witty question",
     )
 
@@ -224,8 +217,6 @@ per each of the samples.
 
 ```python
 import mlflow
-from mlflow.models import infer_signature
-from mlflow.transformers import generate_signature_output
 import transformers
 
 architecture = "mrm8488/t5-base-finetuned-common_gen"
@@ -236,12 +227,6 @@ model = transformers.pipeline(
 )
 data = "pencil draw paper"
 
-# Infer the signature
-signature = infer_signature(
-    data,
-    generate_signature_output(model, data),
-)
-
 # Define an model_config
 model_config = {
     "num_beams": 5,
@@ -250,12 +235,12 @@ model_config = {
     "remove_invalid_values": True,
 }
 
-# Saving model_config with the model
+# Saving model_config with the model, signature is inferred from input_example
 mlflow.transformers.save_model(
     model,
     path="text2text",
     model_config=model_config,
-    signature=signature,
+    input_example=data,
 )
 
 pyfunc_loaded = mlflow.pyfunc.load_model("text2text")
@@ -275,8 +260,6 @@ when calling `predict`.
 
 ```python
 import mlflow
-from mlflow.models import infer_signature
-from mlflow.transformers import generate_signature_output
 import transformers
 
 architecture = "mrm8488/t5-base-finetuned-common_gen"
@@ -299,19 +282,12 @@ inference_params = {
     "do_sample": True,
 }
 
-# Infer the signature including params
-signature_with_params = infer_signature(
-    data,
-    generate_signature_output(model, data),
-    params=inference_params,
-)
-
-# Saving model with signature and model config
+# Saving model with model config, signature is inferred from input_example
 mlflow.transformers.save_model(
     model,
     path="text2text",
     model_config=model_config,
-    signature=signature_with_params,
+    input_example=(data, inference_params),
 )
 
 pyfunc_loaded = mlflow.pyfunc.load_model("text2text")
@@ -493,7 +469,7 @@ in order to determine what restrictions exist regarding the use of the model.
 
 For pipelines that support `pyfunc`, there are 3 means of attaching a model signature to the `MLmodel` file.
 
-- Provide a model signature explicitly via setting a valid `ModelSignature` to the `signature` attribute. This can be generated via the helper utility <APILink fn="mlflow.transformers.generate_signature_output" />
+- Provide a model signature explicitly via setting a valid `ModelSignature` to the `signature` attribute.
 
 - Provide an `input_example`. The signature will be inferred and validated that it matches the appropriate input type. The output type will be validated by performing inference automatically (if the model is a `pyfunc` supported type).
 
@@ -631,16 +607,14 @@ to be thrown from the serving process stating that the soundfile is corrupt.
 An example of specifying an appropriate uri-based input model signature for an audio model is shown below:
 
 ```python
-from mlflow.models import infer_signature
-from mlflow.transformers import generate_signature_output
+import mlflow
 
 url = "https://www.mywebsite.com/sound/files/for/transcription/file111.mp3"
-signature = infer_signature(url, generate_signature_output(my_audio_pipeline, url))
 with mlflow.start_run():
     mlflow.transformers.log_model(
         transformers_model=my_audio_pipeline,
         name="my_transcriber",
-        signature=signature,
+        input_example=url,
     )
 ```
 

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/audio-transcription/whisper.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/audio-transcription/whisper.ipynb
@@ -118,7 +118,7 @@
     "task = \"automatic-speech-recognition\"\n",
     "\n",
     "# Define the model instance\n",
-    "architecture = \"openai/whisper-large-v3\"\n",
+    "architecture = \"openai/whisper-tiny\"\n",
     "\n",
     "# Load the components and necessary configuration for Whisper ASR from the Hugging Face Hub\n",
     "model = transformers.WhisperForConditionalGeneration.from_pretrained(architecture)\n",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/audio-transcription/whisper.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/audio-transcription/whisper.ipynb
@@ -213,14 +213,34 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Model Configuration\n\nConfigure key parameters for the Whisper model to optimize audio processing.\n\n#### Handling Different Audio Formats\nWhile the default signature covers binary audio data, the `transformers` flavor accommodates multiple formats, including numpy arrays and URL-based inputs. This flexibility allows Whisper to transcribe from various sources.\n\n#### Model Configuration\nSetting the model configuration involves parameters like *chunk* and *stride* lengths for audio processing. These settings are adjustable to suit different transcription needs, enhancing Whisper's performance for specific scenarios.\n\nWhen you provide an `input_example` to `log_model()`, MLflow will automatically infer the model signature, including the input and output schema and any inference parameters.\n\nRun the next code block to configure key parameters, aligning Whisper's functionality with your project's requirements."
+   "source": [
+    "### Model Configuration\n",
+    "\n",
+    "Configure key parameters for the Whisper model to optimize audio processing.\n",
+    "\n",
+    "#### Handling Different Audio Formats\n",
+    "While the default signature covers binary audio data, the `transformers` flavor accommodates multiple formats, including numpy arrays and URL-based inputs. This flexibility allows Whisper to transcribe from various sources.\n",
+    "\n",
+    "#### Model Configuration\n",
+    "Setting the model configuration involves parameters like *chunk* and *stride* lengths for audio processing. These settings are adjustable to suit different transcription needs, enhancing Whisper's performance for specific scenarios.\n",
+    "\n",
+    "When you provide an `input_example` to `log_model()`, MLflow will automatically infer the model signature, including the input and output schema and any inference parameters.\n",
+    "\n",
+    "Run the next code block to configure key parameters, aligning Whisper's functionality with your project's requirements."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Specify parameters and their defaults that we would like to be exposed for manipulation during inference time\nmodel_config = {\n    \"chunk_length_s\": 20,\n    \"stride_length_s\": [5, 3],\n}"
+   "source": [
+    "# Specify parameters and their defaults that we would like to be exposed for manipulation during inference time\n",
+    "model_config = {\n",
+    "    \"chunk_length_s\": 20,\n",
+    "    \"stride_length_s\": [5, 3],\n",
+    "}"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -282,7 +302,20 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Log the pipeline. The signature is automatically inferred from input_example.\nwith mlflow.start_run():\n    model_info = mlflow.transformers.log_model(\n        transformers_model=audio_transcription_pipeline,\n        name=\"whisper_transcriber\",\n        input_example=(audio, model_config),\n        model_config=model_config,\n        # Since MLflow 2.11.0, you can save the model in 'reference-only' mode to reduce storage usage by not saving\n        # the base model weights but only the reference to the HuggingFace model hub. To enable this, uncomment the\n        # following line:\n        # save_pretrained=False,\n    )"
+   "source": [
+    "# Log the pipeline. The signature is automatically inferred from input_example.\n",
+    "with mlflow.start_run():\n",
+    "    model_info = mlflow.transformers.log_model(\n",
+    "        transformers_model=audio_transcription_pipeline,\n",
+    "        name=\"whisper_transcriber\",\n",
+    "        input_example=(audio, model_config),\n",
+    "        model_config=model_config,\n",
+    "        # Since MLflow 2.11.0, you can save the model in 'reference-only' mode to reduce storage usage by not saving\n",
+    "        # the base model weights but only the reference to the HuggingFace model hub. To enable this, uncomment the\n",
+    "        # following line:\n",
+    "        # save_pretrained=False,\n",
+    "    )"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -438,7 +471,18 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Tutorial Roundup\n\nThroughout this tutorial, we've explored how to:\n\n- Set up an audio transcription pipeline using the OpenAI Whisper model.\n- Format and prepare audio data for transcription.\n- Log, load, and use the model with MLflow, leveraging both the native and pyfunc flavors for inference.\n- Format the output for readability and practical use in a Jupyter Notebook environment.\n\nWe've seen the benefits of using MLflow for managing ML model development, including experiment tracking, model versioning, reproducibility, and deployment. By integrating MLflow with the Transformers library, we've streamlined the process of working with state-of-the-art NLP models, making it easier to track, manage, and deploy cutting-edge NLP applications."
+   "source": [
+    "### Tutorial Roundup\n",
+    "\n",
+    "Throughout this tutorial, we've explored how to:\n",
+    "\n",
+    "- Set up an audio transcription pipeline using the OpenAI Whisper model.\n",
+    "- Format and prepare audio data for transcription.\n",
+    "- Log, load, and use the model with MLflow, leveraging both the native and pyfunc flavors for inference.\n",
+    "- Format the output for readability and practical use in a Jupyter Notebook environment.\n",
+    "\n",
+    "We've seen the benefits of using MLflow for managing ML model development, including experiment tracking, model versioning, reproducibility, and deployment. By integrating MLflow with the Transformers library, we've streamlined the process of working with state-of-the-art NLP models, making it easier to track, manage, and deploy cutting-edge NLP applications."
+   ]
   }
  ],
  "metadata": {

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/audio-transcription/whisper.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/audio-transcription/whisper.ipynb
@@ -213,61 +213,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Model Signature and Configuration\n",
-    "\n",
-    "Generate a model signature for Whisper to understand its input and output data requirements.\n",
-    "\n",
-    "The model signature is critical for defining the schema for the Whisper model's inputs and outputs, clarifying the data types and structures expected. This step ensures the model processes inputs correctly and outputs structured data.\n",
-    "\n",
-    "#### Handling Different Audio Formats\n",
-    "While the default signature covers binary audio data, the `transformers` flavor accommodates multiple formats, including numpy arrays and URL-based inputs. This flexibility allows Whisper to transcribe from various sources, although URL-based transcription isn't demonstrated here.\n",
-    "\n",
-    "#### Model Configuration\n",
-    "Setting the model configuration involves parameters like *chunk* and *stride* lengths for audio processing. These settings are adjustable to suit different transcription needs, enhancing Whisper's performance for specific scenarios.\n",
-    "\n",
-    "Run the next code block to infer the model's signature and configure key parameters, aligning Whisper's functionality with your project's requirements."
-   ]
+   "source": "### Model Configuration\n\nConfigure key parameters for the Whisper model to optimize audio processing.\n\n#### Handling Different Audio Formats\nWhile the default signature covers binary audio data, the `transformers` flavor accommodates multiple formats, including numpy arrays and URL-based inputs. This flexibility allows Whisper to transcribe from various sources.\n\n#### Model Configuration\nSetting the model configuration involves parameters like *chunk* and *stride* lengths for audio processing. These settings are adjustable to suit different transcription needs, enhancing Whisper's performance for specific scenarios.\n\nWhen you provide an `input_example` to `log_model()`, MLflow will automatically infer the model signature, including the input and output schema and any inference parameters.\n\nRun the next code block to configure key parameters, aligning Whisper's functionality with your project's requirements."
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "inputs: \n",
-       "  [binary]\n",
-       "outputs: \n",
-       "  [string]\n",
-       "params: \n",
-       "  ['chunk_length_s': long (default: 20), 'stride_length_s': long (default: [5, 3]) (shape: (-1,))]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Specify parameters and their defaults that we would like to be exposed for manipulation during inference time\n",
-    "model_config = {\n",
-    "    \"chunk_length_s\": 20,\n",
-    "    \"stride_length_s\": [5, 3],\n",
-    "}\n",
-    "\n",
-    "# Define the model signature by using the input and output of our pipeline, as well as specifying our inference parameters that will allow for those parameters to\n",
-    "# be overridden at inference time.\n",
-    "signature = mlflow.models.infer_signature(\n",
-    "    audio,\n",
-    "    mlflow.transformers.generate_signature_output(audio_transcription_pipeline, audio),\n",
-    "    params=model_config,\n",
-    ")\n",
-    "\n",
-    "# Visualize the signature\n",
-    "signature"
-   ]
+   "outputs": [],
+   "source": "# Specify parameters and their defaults that we would like to be exposed for manipulation during inference time\nmodel_config = {\n    \"chunk_length_s\": 20,\n    \"stride_length_s\": [5, 3],\n}"
   },
   {
    "cell_type": "markdown",
@@ -326,24 +279,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Log the pipeline\n",
-    "with mlflow.start_run():\n",
-    "    model_info = mlflow.transformers.log_model(\n",
-    "        transformers_model=audio_transcription_pipeline,\n",
-    "        name=\"whisper_transcriber\",\n",
-    "        signature=signature,\n",
-    "        input_example=audio,\n",
-    "        model_config=model_config,\n",
-    "        # Since MLflow 2.11.0, you can save the model in 'reference-only' mode to reduce storage usage by not saving\n",
-    "        # the base model weights but only the reference to the HuggingFace model hub. To enable this, uncomment the\n",
-    "        # following line:\n",
-    "        # save_pretrained=False,\n",
-    "    )"
-   ]
+   "source": "# Log the pipeline. The signature is automatically inferred from input_example.\nwith mlflow.start_run():\n    model_info = mlflow.transformers.log_model(\n        transformers_model=audio_transcription_pipeline,\n        name=\"whisper_transcriber\",\n        input_example=(audio, model_config),\n        model_config=model_config,\n        # Since MLflow 2.11.0, you can save the model in 'reference-only' mode to reduce storage usage by not saving\n        # the base model weights but only the reference to the HuggingFace model hub. To enable this, uncomment the\n        # following line:\n        # save_pretrained=False,\n    )"
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/audio-transcription/whisper.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/audio-transcription/whisper.ipynb
@@ -471,18 +471,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Tutorial Roundup\n",
-    "\n",
-    "Throughout this tutorial, we've explored how to:\n",
-    "\n",
-    "- Set up an audio transcription pipeline using the OpenAI Whisper model.\n",
-    "- Format and prepare audio data for transcription.\n",
-    "- Log, load, and use the model with MLflow, leveraging both the native and pyfunc flavors for inference.\n",
-    "- Format the output for readability and practical use in a Jupyter Notebook environment.\n",
-    "\n",
-    "We've seen the benefits of using MLflow for managing ML model development, including experiment tracking, model versioning, reproducibility, and deployment. By integrating MLflow with the Transformers library, we've streamlined the process of working with state-of-the-art NLP models, making it easier to track, manage, and deploy cutting-edge NLP applications."
-   ]
+   "source": "### Tutorial Roundup\n\nThroughout this tutorial, we've explored how to:\n\n- Set up an audio transcription pipeline using the OpenAI Whisper model.\n- Format and prepare audio data for transcription.\n- Log, load, and use the model with MLflow, leveraging both the native and pyfunc flavors for inference.\n- Format the output for readability and practical use in a Jupyter Notebook environment.\n\nWe've seen the benefits of using MLflow for managing ML model development, including experiment tracking, model versioning, reproducibility, and deployment. By integrating MLflow with the Transformers library, we've streamlined the process of working with state-of-the-art NLP models, making it easier to track, manage, and deploy cutting-edge NLP applications."
   }
  ],
  "metadata": {

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/conversational/conversational-model.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/conversational/conversational-model.ipynb
@@ -64,14 +64,35 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Setting Up the Conversational Pipeline\n\nWe begin by setting up a conversational pipeline with DialoGPT using `transformers` and managing it with MLflow.\n\nWe start by importing essential libraries. The `transformers` library from Hugging Face offers a rich collection of pre-trained models, including DialoGPT, for various NLP tasks. MLflow, an open-source AI engineering platform, aids in experiment tracking, reproducibility, and deployment.\n\n#### Initializing the Conversational Pipeline\nUsing the `transformers.pipeline` function, we set up a conversational pipeline. We choose the \"`microsoft/DialoGPT-medium`\" model, balancing performance and resource efficiency, ideal for conversational AI. This step is pivotal for ensuring the model is ready for interaction and integration into various applications.\n\n#### Automatic Signature Inference with MLflow\nModel signature is key in defining how the model interacts with input data. When you provide an `input_example` to `log_model()`, MLflow will automatically infer the model's input-output schema. This ensures clarity in the model's data requirements and prediction format, crucial for seamless deployment and usage.\n\nThis configuration phase sets the stage for a robust conversational AI system, leveraging the strengths of DialoGPT and MLflow for efficient and effective conversational interactions."
+   "source": [
+    "### Setting Up the Conversational Pipeline\n",
+    "\n",
+    "We begin by setting up a conversational pipeline with DialoGPT using `transformers` and managing it with MLflow.\n",
+    "\n",
+    "We start by importing essential libraries. The `transformers` library from Hugging Face offers a rich collection of pre-trained models, including DialoGPT, for various NLP tasks. MLflow, an open-source AI engineering platform, aids in experiment tracking, reproducibility, and deployment.\n",
+    "\n",
+    "#### Initializing the Conversational Pipeline\n",
+    "Using the `transformers.pipeline` function, we set up a conversational pipeline. We choose the \"`microsoft/DialoGPT-medium`\" model, balancing performance and resource efficiency, ideal for conversational AI. This step is pivotal for ensuring the model is ready for interaction and integration into various applications.\n",
+    "\n",
+    "#### Automatic Signature Inference with MLflow\n",
+    "Model signature is key in defining how the model interacts with input data. When you provide an `input_example` to `log_model()`, MLflow will automatically infer the model's input-output schema. This ensures clarity in the model's data requirements and prediction format, crucial for seamless deployment and usage.\n",
+    "\n",
+    "This configuration phase sets the stage for a robust conversational AI system, leveraging the strengths of DialoGPT and MLflow for efficient and effective conversational interactions."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import transformers\n\nimport mlflow\n\n# Define our pipeline, using the default configuration specified in the model card for DialoGPT-medium\nconversational_pipeline = transformers.pipeline(model=\"microsoft/DialoGPT-medium\")"
+   "source": [
+    "import transformers\n",
+    "\n",
+    "import mlflow\n",
+    "\n",
+    "# Define our pipeline, using the default configuration specified in the model card for DialoGPT-medium\n",
+    "conversational_pipeline = transformers.pipeline(model=\"microsoft/DialoGPT-medium\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -136,7 +157,15 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "with mlflow.start_run():\n    model_info = mlflow.transformers.log_model(\n        transformers_model=conversational_pipeline,\n        name=\"chatbot\",\n        task=\"conversational\",\n        input_example=\"A clever and witty question\",\n    )"
+   "source": [
+    "with mlflow.start_run():\n",
+    "    model_info = mlflow.transformers.log_model(\n",
+    "        transformers_model=conversational_pipeline,\n",
+    "        name=\"chatbot\",\n",
+    "        task=\"conversational\",\n",
+    "        input_example=\"A clever and witty question\",\n",
+    "    )"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/conversational/conversational-model.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/conversational/conversational-model.ipynb
@@ -64,21 +64,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Setting Up the Conversational Pipeline\n",
-    "\n",
-    "We begin by setting up a conversational pipeline with DialoGPT using `transformers` and managing it with MLflow.\n",
-    "\n",
-    "We start by importing essential libraries. The `transformers` library from Hugging Face offers a rich collection of pre-trained models, including DialoGPT, for various NLP tasks. MLflow, an open-source AI engineering platform, aids in experiment tracking, reproducibility, and deployment.\n",
-    "\n",
-    "#### Initializing the Conversational Pipeline\n",
-    "Using the `transformers.pipeline` function, we set up a conversational pipeline. We choose the \"`microsoft/DialoGPT-medium`\" model, balancing performance and resource efficiency, ideal for conversational AI. This step is pivotal for ensuring the model is ready for interaction and integration into various applications.\n",
-    "\n",
-    "#### Automatic Signature Inference with MLflow\n",
-    "Model signature is key in defining how the model interacts with input data. When you provide an `input_example` to `log_model()`, MLflow will automatically infer the model's input-output schema. This ensures clarity in the model's data requirements and prediction format, crucial for seamless deployment and usage.\n",
-    "\n",
-    "This configuration phase sets the stage for a robust conversational AI system, leveraging the strengths of DialoGPT and MLflow for efficient and effective conversational interactions."
-   ]
+   "source": "### Setting Up the Conversational Pipeline\n\nWe begin by setting up a conversational pipeline with DialoGPT using `transformers` and managing it with MLflow.\n\nWe start by importing essential libraries. The `transformers` library from Hugging Face offers a rich collection of pre-trained models, including DialoGPT, for various NLP tasks. MLflow, an open-source AI engineering platform, aids in experiment tracking, reproducibility, and deployment.\n\n#### Initializing the Conversational Pipeline\nUsing the `transformers.pipeline` function, we set up a conversational pipeline. We choose the \"`microsoft/DialoGPT-medium`\" model, balancing performance and resource efficiency, ideal for conversational AI. This step is pivotal for ensuring the model is ready for interaction and integration into various applications.\n\n#### Automatic Signature Inference with MLflow\nModel signature is key in defining how the model interacts with input data. When you provide an `input_example` to `log_model()`, MLflow will automatically infer the model's input-output schema. This ensures clarity in the model's data requirements and prediction format, crucial for seamless deployment and usage.\n\nThis configuration phase sets the stage for a robust conversational AI system, leveraging the strengths of DialoGPT and MLflow for efficient and effective conversational interactions."
   },
   {
    "cell_type": "code",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/conversational/conversational-model.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/conversational/conversational-model.ipynb
@@ -64,37 +64,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Setting Up the Conversational Pipeline\n\nWe begin by setting up a conversational pipeline with DialoGPT using `transformers` and managing it with MLflow.\n\nWe start by importing essential libraries. The `transformers` library from Hugging Face offers a rich collection of pre-trained models, including DialoGPT, for various NLP tasks. MLflow, an open-source AI engineering platform, aids in experiment tracking, reproducibility, and deployment.\n\n#### Initializing the Conversational Pipeline\nUsing the `transformers.pipeline` function, we set up a conversational pipeline. We choose the \"`microsoft/DialoGPT-medium`\" model, balancing performance and resource efficiency, ideal for conversational AI. This step is pivotal for ensuring the model is ready for interaction and integration into various applications.\n\n#### Inferring the Model Signature with MLflow\nModel signature is key in defining how the model interacts with input data. To infer it, we use a sample input (\"`Hi there, chatbot!`\") and leverage `mlflow.transformers.generate_signature_output` to understand the model's input-output schema. This process ensures clarity in the model's data requirements and prediction format, crucial for seamless deployment and usage.\n\nThis configuration phase sets the stage for a robust conversational AI system, leveraging the strengths of DialoGPT and MLflow for efficient and effective conversational interactions."
+   "source": "### Setting Up the Conversational Pipeline\n\nWe begin by setting up a conversational pipeline with DialoGPT using `transformers` and managing it with MLflow.\n\nWe start by importing essential libraries. The `transformers` library from Hugging Face offers a rich collection of pre-trained models, including DialoGPT, for various NLP tasks. MLflow, an open-source AI engineering platform, aids in experiment tracking, reproducibility, and deployment.\n\n#### Initializing the Conversational Pipeline\nUsing the `transformers.pipeline` function, we set up a conversational pipeline. We choose the \"`microsoft/DialoGPT-medium`\" model, balancing performance and resource efficiency, ideal for conversational AI. This step is pivotal for ensuring the model is ready for interaction and integration into various applications.\n\n#### Automatic Signature Inference with MLflow\nModel signature is key in defining how the model interacts with input data. When you provide an `input_example` to `log_model()`, MLflow will automatically infer the model's input-output schema. This ensures clarity in the model's data requirements and prediction format, crucial for seamless deployment and usage.\n\nThis configuration phase sets the stage for a robust conversational AI system, leveraging the strengths of DialoGPT and MLflow for efficient and effective conversational interactions."
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
-      "Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.\n",
-      "A decoder-only architecture is being used, but right-padding was detected! For correct generation results, please set `padding_side='left'` when initializing the tokenizer.\n"
-     ]
-    }
-   ],
-   "source": [
-    "import transformers\n",
-    "\n",
-    "import mlflow\n",
-    "\n",
-    "# Define our pipeline, using the default configuration specified in the model card for DialoGPT-medium\n",
-    "conversational_pipeline = transformers.pipeline(model=\"microsoft/DialoGPT-medium\")\n",
-    "\n",
-    "# Infer the signature by providing a representnative input and the output from the pipeline inference abstraction in the transformers flavor in MLflow\n",
-    "signature = mlflow.models.infer_signature(\n",
-    "    \"Hi there, chatbot!\",\n",
-    "    mlflow.transformers.generate_signature_output(conversational_pipeline, \"Hi there, chatbot!\"),\n",
-    ")"
-   ]
+   "outputs": [],
+   "source": "import transformers\n\nimport mlflow\n\n# Define our pipeline, using the default configuration specified in the model card for DialoGPT-medium\nconversational_pipeline = transformers.pipeline(model=\"microsoft/DialoGPT-medium\")"
   },
   {
    "cell_type": "markdown",
@@ -156,19 +133,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "with mlflow.start_run():\n",
-    "    model_info = mlflow.transformers.log_model(\n",
-    "        transformers_model=conversational_pipeline,\n",
-    "        name=\"chatbot\",\n",
-    "        task=\"conversational\",\n",
-    "        signature=signature,\n",
-    "        input_example=\"A clever and witty question\",\n",
-    "    )"
-   ]
+   "source": "with mlflow.start_run():\n    model_info = mlflow.transformers.log_model(\n        transformers_model=conversational_pipeline,\n        name=\"chatbot\",\n        task=\"conversational\",\n        input_example=\"A clever and witty question\",\n    )"
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/fine-tuning/transformers-fine-tuning.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/fine-tuning/transformers-fine-tuning.ipynb
@@ -840,47 +840,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Model Configuration and Signature Inference\n",
-    "\n",
-    "In this next step, we generate a signature for our pipeline in preparation for logging.\n",
-    "    \n",
-    "After validating our model's performance, the next critical step is to prepare it for logging to MLflow. This involves setting up the model's configuration and inferring its signature, which are essential aspects of the model management process.\n",
-    "\n",
-    "#### Configuring the Model for MLflow\n",
-    "\n",
-    "- **Setting Model Configuration**: We define a `model_config` dictionary to specify configuration parameters such as batch size and the device type (e.g., `\"mps\"` for Apple Silicon). This configuration is vital for ensuring that the model operates correctly in different environments.\n",
-    "\n",
-    "#### Inferring the Model Signature\n",
-    "\n",
-    "- **Purpose of Signature Inference**: The model signature defines the input and output schema of the model. Inferring this signature is crucial as it helps MLflow understand the data types and shapes that the model expects and produces.\n",
-    "- **Using mlflow.models.infer_signature**: We use this function to automatically infer the model signature. We provide sample input and output data to the function, which analyzes them to determine the appropriate schema.\n",
-    "- **Including Model Parameters**: Along with the input and output, we also include the `model_config` in the signature. This ensures that all relevant information about how the model should be run is captured.\n",
-    "\n",
-    "#### Importance of Signature Inference\n",
-    "Inferring the signature is a key step in preparing the model for logging and future deployment. It ensures that anyone who uses the model later, either for further development or in production, has clear information about the expected data format, making the model more robust and user-friendly.\n",
-    "\n",
-    "With the model configuration set and its signature inferred, we are now ready to log the model into MLflow. This will be our next step, ensuring our model is properly managed and ready for deployment."
-   ]
+   "source": "### Model Configuration and Input Example\n\nIn this next step, we prepare our model configuration and input example for logging.\n    \nAfter validating our model's performance, the next critical step is to prepare it for logging to MLflow. This involves setting up the model's configuration and defining an input example, which are essential aspects of the model management process.\n\n#### Configuring the Model for MLflow\n\n- **Setting Model Configuration**: We define a `model_config` dictionary to specify configuration parameters such as batch size and the device type (e.g., `\"mps\"` for Apple Silicon). This configuration is vital for ensuring that the model operates correctly in different environments.\n\n#### Defining the Input Example\n\n- **Purpose of Input Example**: When you provide an `input_example` to `log_model()`, MLflow will automatically infer the model signature, which defines the input and output schema. This ensures that anyone who uses the model later has clear information about the expected data format.\n- **Including Model Parameters**: Along with the input data, we can also include inference parameters by passing a tuple of `(data, params)` as the `input_example`. This ensures that all relevant information about how the model should be run is captured.\n\nWith the model configuration set and input example defined, we are now ready to log the model into MLflow. This will be our next step, ensuring our model is properly managed and ready for deployment."
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Define a set of parameters that we would like to be able to flexibly override at inference time, along with their default values\n",
-    "model_config = {\"batch_size\": 8}\n",
-    "\n",
-    "# Infer the model signature, including a representative input, the expected output, and the parameters that we would like to be able to override at inference time.\n",
-    "signature = mlflow.models.infer_signature(\n",
-    "    [\"This is a test!\", \"And this is also a test.\"],\n",
-    "    mlflow.transformers.generate_signature_output(\n",
-    "        tuned_pipeline, [\"This is a test response!\", \"So is this.\"]\n",
-    "    ),\n",
-    "    params=model_config,\n",
-    ")"
-   ]
+   "source": "# Define a set of parameters that we would like to be able to flexibly override at inference time, along with their default values\nmodel_config = {\"batch_size\": 8}\n\n# Define sample inputs for the model\nsample_inputs = [\"This is a test!\", \"And this is also a test.\"]"
   },
   {
    "cell_type": "markdown",
@@ -919,28 +886,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023/11/30 12:17:11 WARNING mlflow.utils.environment: Encountered an unexpected error while inferring pip requirements (model URI: /var/folders/cd/n8n0rm2x53l_s0xv_j_xklb00000gp/T/tmp77_imuy9/model, flavor: transformers), fall back to return ['transformers==4.34.1', 'torch==2.1.0', 'torchvision==0.16.0', 'accelerate==0.21.0']. Set logging level to DEBUG to see the full traceback.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Log the pipeline to the existing training run\n",
-    "with mlflow.start_run(run_id=run.info.run_id):\n",
-    "    model_info = mlflow.transformers.log_model(\n",
-    "        transformers_model=tuned_pipeline,\n",
-    "        name=\"fine_tuned\",\n",
-    "        signature=signature,\n",
-    "        input_example=[\"Pass in a string\", \"And have it mark as spam or not.\"],\n",
-    "        model_config=model_config,\n",
-    "    )"
-   ]
+   "outputs": [],
+   "source": "# Log the pipeline to the existing training run\nwith mlflow.start_run(run_id=run.info.run_id):\n    model_info = mlflow.transformers.log_model(\n        transformers_model=tuned_pipeline,\n        name=\"fine_tuned\",\n        input_example=(sample_inputs, model_config),\n        model_config=model_config,\n    )"
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/fine-tuning/transformers-fine-tuning.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/fine-tuning/transformers-fine-tuning.ipynb
@@ -840,14 +840,37 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Model Configuration and Input Example\n\nIn this next step, we prepare our model configuration and input example for logging.\n    \nAfter validating our model's performance, the next critical step is to prepare it for logging to MLflow. This involves setting up the model's configuration and defining an input example, which are essential aspects of the model management process.\n\n#### Configuring the Model for MLflow\n\n- **Setting Model Configuration**: We define a `model_config` dictionary to specify configuration parameters such as batch size and the device type (e.g., `\"mps\"` for Apple Silicon). This configuration is vital for ensuring that the model operates correctly in different environments.\n\n#### Defining the Input Example\n\n- **Purpose of Input Example**: When you provide an `input_example` to `log_model()`, MLflow will automatically infer the model signature, which defines the input and output schema. This ensures that anyone who uses the model later has clear information about the expected data format.\n- **Including Model Parameters**: Along with the input data, we can also include inference parameters by passing a tuple of `(data, params)` as the `input_example`. This ensures that all relevant information about how the model should be run is captured.\n\nWith the model configuration set and input example defined, we are now ready to log the model into MLflow. This will be our next step, ensuring our model is properly managed and ready for deployment."
+   "source": [
+    "### Model Configuration and Input Example\n",
+    "\n",
+    "In this next step, we prepare our model configuration and input example for logging.\n",
+    "    \n",
+    "After validating our model's performance, the next critical step is to prepare it for logging to MLflow. This involves setting up the model's configuration and defining an input example, which are essential aspects of the model management process.\n",
+    "\n",
+    "#### Configuring the Model for MLflow\n",
+    "\n",
+    "- **Setting Model Configuration**: We define a `model_config` dictionary to specify configuration parameters such as batch size and the device type (e.g., `\"mps\"` for Apple Silicon). This configuration is vital for ensuring that the model operates correctly in different environments.\n",
+    "\n",
+    "#### Defining the Input Example\n",
+    "\n",
+    "- **Purpose of Input Example**: When you provide an `input_example` to `log_model()`, MLflow will automatically infer the model signature, which defines the input and output schema. This ensures that anyone who uses the model later has clear information about the expected data format.\n",
+    "- **Including Model Parameters**: Along with the input data, we can also include inference parameters by passing a tuple of `(data, params)` as the `input_example`. This ensures that all relevant information about how the model should be run is captured.\n",
+    "\n",
+    "With the model configuration set and input example defined, we are now ready to log the model into MLflow. This will be our next step, ensuring our model is properly managed and ready for deployment."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Define a set of parameters that we would like to be able to flexibly override at inference time, along with their default values\nmodel_config = {\"batch_size\": 8}\n\n# Define sample inputs for the model\nsample_inputs = [\"This is a test!\", \"And this is also a test.\"]"
+   "source": [
+    "# Define a set of parameters that we would like to be able to flexibly override at inference time, along with their default values\n",
+    "model_config = {\"batch_size\": 8}\n",
+    "\n",
+    "# Define sample inputs for the model\n",
+    "sample_inputs = [\"This is a test!\", \"And this is also a test.\"]"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -889,7 +912,16 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Log the pipeline to the existing training run\nwith mlflow.start_run(run_id=run.info.run_id):\n    model_info = mlflow.transformers.log_model(\n        transformers_model=tuned_pipeline,\n        name=\"fine_tuned\",\n        input_example=(sample_inputs, model_config),\n        model_config=model_config,\n    )"
+   "source": [
+    "# Log the pipeline to the existing training run\n",
+    "with mlflow.start_run(run_id=run.info.run_id):\n",
+    "    model_info = mlflow.transformers.log_model(\n",
+    "        transformers_model=tuned_pipeline,\n",
+    "        name=\"fine_tuned\",\n",
+    "        input_example=(sample_inputs, model_config),\n",
+    "        model_config=model_config,\n",
+    "    )"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/prompt-templating/prompt-templating.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/prompt-templating/prompt-templating.ipynb
@@ -133,14 +133,33 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Saving the model and template with MLflow\n\nNow that we've experimented with a few prompt templates, let's pick one, and save it together with our pipeline using MLflow. Before we do this, let's take a few minutes to learn about an important component of MLflow models—signatures!\n\n### Creating a model signature\n\nA model signature codifies a model's expected inputs, outputs, and inference params. MLflow enforces this signature at inference time, and will raise a helpful exception if the user input does not match up with the expected format.\n\nWhen you provide an `input_example` to `log_model()` or `save_model()`, MLflow will automatically infer the signature for you. If you want to pass any additional arguments to the pipeline at inference time (e.g. `max_new_tokens` above), you can include them by passing a tuple of `(data, params)` as the `input_example`."
+   "source": [
+    "## Saving the model and template with MLflow\n",
+    "\n",
+    "Now that we've experimented with a few prompt templates, let's pick one, and save it together with our pipeline using MLflow. Before we do this, let's take a few minutes to learn about an important component of MLflow models—signatures!\n",
+    "\n",
+    "### Creating a model signature\n",
+    "\n",
+    "A model signature codifies a model's expected inputs, outputs, and inference params. MLflow enforces this signature at inference time, and will raise a helpful exception if the user input does not match up with the expected format.\n",
+    "\n",
+    "When you provide an `input_example` to `log_model()` or `save_model()`, MLflow will automatically infer the signature for you. If you want to pass any additional arguments to the pipeline at inference time (e.g. `max_new_tokens` above), you can include them by passing a tuple of `(data, params)` as the `input_example`."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import mlflow\n\nsample_input = \"Tell me the largest bird\"\nparams = {\"max_new_tokens\": 15}\n\n# The input_example can be a tuple of (data, params) to include inference parameters.\n# The signature will be automatically inferred when input_example is provided to log_model.\ninput_example = (sample_input, params)"
+   "source": [
+    "import mlflow\n",
+    "\n",
+    "sample_input = \"Tell me the largest bird\"\n",
+    "params = {\"max_new_tokens\": 15}\n",
+    "\n",
+    "# The input_example can be a tuple of (data, params) to include inference parameters.\n",
+    "# The signature will be automatically inferred when input_example is provided to log_model.\n",
+    "input_example = (sample_input, params)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -164,7 +183,29 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# If you are running this tutorial in local mode, leave the next line commented out.\n# Otherwise, uncomment the following line and set your tracking uri to your local or remote tracking server.\n\nmlflow.set_tracking_uri(\"http://127.0.0.1:5000\")\n\n# Set a name for the experiment that is indicative of what the runs being created within it are in regards to\nmlflow.set_experiment(\"prompt-templating\")\n\nprompt_template = \"Q: {prompt}\\nA:\"\nwith mlflow.start_run():\n    model_info = mlflow.transformers.log_model(\n        transformers_model=generator,\n        name=\"model\",\n        task=\"text-generation\",\n        input_example=input_example,\n        prompt_template=prompt_template,\n        # Since MLflow 2.11.0, you can save the model in 'reference-only' mode to reduce storage usage by not saving\n        # the base model weights but only the reference to the HuggingFace model hub. To enable this, uncomment the\n        # following line:\n        # save_pretrained=False,\n    )"
+   "source": [
+    "# If you are running this tutorial in local mode, leave the next line commented out.\n",
+    "# Otherwise, uncomment the following line and set your tracking uri to your local or remote tracking server.\n",
+    "\n",
+    "mlflow.set_tracking_uri(\"http://127.0.0.1:5000\")\n",
+    "\n",
+    "# Set a name for the experiment that is indicative of what the runs being created within it are in regards to\n",
+    "mlflow.set_experiment(\"prompt-templating\")\n",
+    "\n",
+    "prompt_template = \"Q: {prompt}\\nA:\"\n",
+    "with mlflow.start_run():\n",
+    "    model_info = mlflow.transformers.log_model(\n",
+    "        transformers_model=generator,\n",
+    "        name=\"model\",\n",
+    "        task=\"text-generation\",\n",
+    "        input_example=input_example,\n",
+    "        prompt_template=prompt_template,\n",
+    "        # Since MLflow 2.11.0, you can save the model in 'reference-only' mode to reduce storage usage by not saving\n",
+    "        # the base model weights but only the reference to the HuggingFace model hub. To enable this, uncomment the\n",
+    "        # following line:\n",
+    "        # save_pretrained=False,\n",
+    "    )"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/prompt-templating/prompt-templating.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/prompt-templating/prompt-templating.ipynb
@@ -133,60 +133,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Saving the model and template with MLflow\n",
-    "\n",
-    "Now that we've experimented with a few prompt templates, let's pick one, and save it together with our pipeline using MLflow. Before we do this, let's take a few minutes to learn about an important component of MLflow models—signatures!\n",
-    "\n",
-    "### Creating a model signature\n",
-    "\n",
-    "A model signature codifies a model's expected inputs, outputs, and inference params. MLflow enforces this signature at inference time, and will raise a helpful exception if the user input does not match up with the expected format.\n",
-    "\n",
-    "Creating a signature can be done simply by calling `mlflow.models.infer_signature()`, and providing a sample input and output value. We can use `mlflow.transformers.generate_signature_output()` to easily generate a sample output. If we want to pass any additional arguments to the pipeline at inference time (e.g. `max_new_tokens` above), we can do so via `params`."
-   ]
+   "source": "## Saving the model and template with MLflow\n\nNow that we've experimented with a few prompt templates, let's pick one, and save it together with our pipeline using MLflow. Before we do this, let's take a few minutes to learn about an important component of MLflow models—signatures!\n\n### Creating a model signature\n\nA model signature codifies a model's expected inputs, outputs, and inference params. MLflow enforces this signature at inference time, and will raise a helpful exception if the user input does not match up with the expected format.\n\nWhen you provide an `input_example` to `log_model()` or `save_model()`, MLflow will automatically infer the signature for you. If you want to pass any additional arguments to the pipeline at inference time (e.g. `max_new_tokens` above), you can include them by passing a tuple of `(data, params)` as the `input_example`."
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024/01/16 17:28:42 WARNING mlflow.transformers: params provided to the `predict` method will override the inference configuration saved with the model. If the params provided are not valid for the pipeline, MlflowException will be raised.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "inputs: \n",
-       "  [string (required)]\n",
-       "outputs: \n",
-       "  [string (required)]\n",
-       "params: \n",
-       "  ['max_new_tokens': long (default: 15)]"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import mlflow\n",
-    "\n",
-    "sample_input = \"Tell me the largest bird\"\n",
-    "params = {\"max_new_tokens\": 15}\n",
-    "signature = mlflow.models.infer_signature(\n",
-    "    sample_input,\n",
-    "    mlflow.transformers.generate_signature_output(generator, sample_input, params=params),\n",
-    "    params=params,\n",
-    ")\n",
-    "\n",
-    "# visualize the signature\n",
-    "signature"
-   ]
+   "outputs": [],
+   "source": "import mlflow\n\nsample_input = \"Tell me the largest bird\"\nparams = {\"max_new_tokens\": 15}\n\n# The input_example can be a tuple of (data, params) to include inference parameters.\n# The signature will be automatically inferred when input_example is provided to log_model.\ninput_example = (sample_input, params)"
   },
   {
    "cell_type": "markdown",
@@ -207,43 +161,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024/01/16 17:28:45 INFO mlflow.tracking.fluent: Experiment with name 'prompt-templating' does not exist. Creating a new experiment.\n",
-      "2024/01/16 17:28:52 INFO mlflow.transformers: text-generation pipelines saved with prompt templates have the `return_full_text` pipeline kwarg set to False by default. To override this behavior, provide a `model_config` dict with `return_full_text` set to `True` when saving the model.\n",
-      "2024/01/16 17:32:57 WARNING mlflow.utils.environment: Encountered an unexpected error while inferring pip requirements (model URI: /var/folders/qd/9rwd0_gd0qs65g4sdqlm51hr0000gp/T/tmpbs0poq1a/model, flavor: transformers), fall back to return ['transformers==4.34.1', 'torch==2.1.1', 'torchvision==0.16.1', 'accelerate==0.25.0']. Set logging level to DEBUG to see the full traceback.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# If you are running this tutorial in local mode, leave the next line commented out.\n",
-    "# Otherwise, uncomment the following line and set your tracking uri to your local or remote tracking server.\n",
-    "\n",
-    "mlflow.set_tracking_uri(\"http://127.0.0.1:5000\")\n",
-    "\n",
-    "# Set a name for the experiment that is indicative of what the runs being created within it are in regards to\n",
-    "mlflow.set_experiment(\"prompt-templating\")\n",
-    "\n",
-    "prompt_template = \"Q: {prompt}\\nA:\"\n",
-    "with mlflow.start_run():\n",
-    "    model_info = mlflow.transformers.log_model(\n",
-    "        transformers_model=generator,\n",
-    "        name=\"model\",\n",
-    "        task=\"text-generation\",\n",
-    "        signature=signature,\n",
-    "        input_example=\"Tell me the largest bird\",\n",
-    "        prompt_template=prompt_template,\n",
-    "        # Since MLflow 2.11.0, you can save the model in 'reference-only' mode to reduce storage usage by not saving\n",
-    "        # the base model weights but only the reference to the HuggingFace model hub. To enable this, uncomment the\n",
-    "        # following line:\n",
-    "        # save_pretrained=False,\n",
-    "    )"
-   ]
+   "outputs": [],
+   "source": "# If you are running this tutorial in local mode, leave the next line commented out.\n# Otherwise, uncomment the following line and set your tracking uri to your local or remote tracking server.\n\nmlflow.set_tracking_uri(\"http://127.0.0.1:5000\")\n\n# Set a name for the experiment that is indicative of what the runs being created within it are in regards to\nmlflow.set_experiment(\"prompt-templating\")\n\nprompt_template = \"Q: {prompt}\\nA:\"\nwith mlflow.start_run():\n    model_info = mlflow.transformers.log_model(\n        transformers_model=generator,\n        name=\"model\",\n        task=\"text-generation\",\n        input_example=input_example,\n        prompt_template=prompt_template,\n        # Since MLflow 2.11.0, you can save the model in 'reference-only' mode to reduce storage usage by not saving\n        # the base model weights but only the reference to the HuggingFace model hub. To enable this, uncomment the\n        # following line:\n        # save_pretrained=False,\n    )"
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/text-generation/text-generation.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/text-generation/text-generation.ipynb
@@ -124,14 +124,51 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Introduction to Model Signatures in MLflow\n\nIn the realm of machine learning, model signatures play a crucial role in ensuring that models receive and produce the expected data types and structures. MLflow includes a feature for defining model signatures, helping to standardize and enforce correct model usage.\n\n#### Quick Learning Points\n\n- **Model Signature Purpose**: Ensures consistent data types and structures for model inputs and outputs.\n- **Visibility and Validation**: Visible in MLflow's UI and validated by MLflow's deployment tools.\n- **Signature Types**: Column-based for tabular data, tensor-based for tensor inputs/outputs, and with params for models requiring additional inference parameters.\n\n#### Understanding Model Signatures\nA model signature in MLflow describes the schema for inputs, outputs, and parameters of an ML model. It is a blueprint that details the expected data types and shapes, facilitating a clear interface for model usage. Signatures are particularly useful as they are:\n\n- Displayed in MLflow's UI for easy reference.\n- Employed by MLflow's deployment tools to validate inputs during inference.\n- Stored in a standardized JSON format alongside the model's metadata.\n\n#### The Role of Signatures in Code\nIn the following section, we define the `input_example` along with inference parameters. When we pass `input_example` to `log_model()`, MLflow will automatically infer the model signature, including input types, output types, and any inference parameters.\n\n#### Types of Model Signatures\nModel signatures can be:\n\n- **Column-based**: Suitable for models that operate on tabular data, with each column having a specified data type and optional name.\n- **Tensor-based**: Designed for models that take tensors as inputs and outputs, with each tensor having a specified data type, shape, and optional name.\n- **With Params**: Some models require additional parameters for inference, which can also be included in the signature.\n\nFor the transformers flavor, all input types are of the Column-based type (referred to within MLflow as `ColSpec` types).\n\n#### Signature Enforcement\nMLflow enforces the signature at the time of model inference, ensuring that the provided input and parameters match the expected schema. If there's a mismatch, MLflow will raise an exception or issue a warning, depending on the nature of the mismatch."
+   "source": [
+    "### Introduction to Model Signatures in MLflow\n",
+    "\n",
+    "In the realm of machine learning, model signatures play a crucial role in ensuring that models receive and produce the expected data types and structures. MLflow includes a feature for defining model signatures, helping to standardize and enforce correct model usage.\n",
+    "\n",
+    "#### Quick Learning Points\n",
+    "\n",
+    "- **Model Signature Purpose**: Ensures consistent data types and structures for model inputs and outputs.\n",
+    "- **Visibility and Validation**: Visible in MLflow's UI and validated by MLflow's deployment tools.\n",
+    "- **Signature Types**: Column-based for tabular data, tensor-based for tensor inputs/outputs, and with params for models requiring additional inference parameters.\n",
+    "\n",
+    "#### Understanding Model Signatures\n",
+    "A model signature in MLflow describes the schema for inputs, outputs, and parameters of an ML model. It is a blueprint that details the expected data types and shapes, facilitating a clear interface for model usage. Signatures are particularly useful as they are:\n",
+    "\n",
+    "- Displayed in MLflow's UI for easy reference.\n",
+    "- Employed by MLflow's deployment tools to validate inputs during inference.\n",
+    "- Stored in a standardized JSON format alongside the model's metadata.\n",
+    "\n",
+    "#### The Role of Signatures in Code\n",
+    "In the following section, we define the `input_example` along with inference parameters. When we pass `input_example` to `log_model()`, MLflow will automatically infer the model signature, including input types, output types, and any inference parameters.\n",
+    "\n",
+    "#### Types of Model Signatures\n",
+    "Model signatures can be:\n",
+    "\n",
+    "- **Column-based**: Suitable for models that operate on tabular data, with each column having a specified data type and optional name.\n",
+    "- **Tensor-based**: Designed for models that take tensors as inputs and outputs, with each tensor having a specified data type, shape, and optional name.\n",
+    "- **With Params**: Some models require additional parameters for inference, which can also be included in the signature.\n",
+    "\n",
+    "For the transformers flavor, all input types are of the Column-based type (referred to within MLflow as `ColSpec` types).\n",
+    "\n",
+    "#### Signature Enforcement\n",
+    "MLflow enforces the signature at the time of model inference, ensuring that the provided input and parameters match the expected schema. If there's a mismatch, MLflow will raise an exception or issue a warning, depending on the nature of the mismatch."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# The signature will be automatically inferred when input_example is provided to log_model.\n# We can define the input_example as a tuple of (data, params) to include inference parameters.\ninput_with_params = (input_example, parameters)\ninput_with_params"
+   "source": [
+    "# The signature will be automatically inferred when input_example is provided to log_model.\n",
+    "# We can define the input_example as a tuple of (data, params) to include inference parameters.\n",
+    "input_with_params = (input_example, parameters)\n",
+    "input_with_params"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -196,7 +233,16 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "with mlflow.start_run():\n    model_info = mlflow.transformers.log_model(\n        transformers_model=generation_pipeline,\n        name=\"text_generator\",\n        input_example=input_with_params,\n        # Uncomment the following line to save the model in 'reference-only' mode:\n        # save_pretrained=False,\n    )"
+   "source": [
+    "with mlflow.start_run():\n",
+    "    model_info = mlflow.transformers.log_model(\n",
+    "        transformers_model=generation_pipeline,\n",
+    "        name=\"text_generator\",\n",
+    "        input_example=input_with_params,\n",
+    "        # Uncomment the following line to save the model in 'reference-only' mode:\n",
+    "        # save_pretrained=False,\n",
+    "    )"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/text-generation/text-generation.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/text-generation/text-generation.ipynb
@@ -124,72 +124,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Introduction to Model Signatures in MLflow\n",
-    "\n",
-    "In the realm of machine learning, model signatures play a crucial role in ensuring that models receive and produce the expected data types and structures. MLflow includes a feature for defining model signatures, helping to standardize and enforce correct model usage.\n",
-    "\n",
-    "#### Quick Learning Points\n",
-    "\n",
-    "- **Model Signature Purpose**: Ensures consistent data types and structures for model inputs and outputs.\n",
-    "- **Visibility and Validation**: Visible in MLflow's UI and validated by MLflow's deployment tools.\n",
-    "- **Signature Types**: Column-based for tabular data, tensor-based for tensor inputs/outputs, and with params for models requiring additional inference parameters.\n",
-    "\n",
-    "#### Understanding Model Signatures\n",
-    "A model signature in MLflow describes the schema for inputs, outputs, and parameters of an ML model. It is a blueprint that details the expected data types and shapes, facilitating a clear interface for model usage. Signatures are particularly useful as they are:\n",
-    "\n",
-    "- Displayed in MLflow's UI for easy reference.\n",
-    "- Employed by MLflow's deployment tools to validate inputs during inference.\n",
-    "- Stored in a standardized JSON format alongside the model's metadata.\n",
-    "\n",
-    "#### The Role of Signatures in Code\n",
-    "In the following section, we are using MLflow to infer the signature of a machine learning model. This involves specifying an input example, generating a model output example, and defining any additional inference parameters. The resulting signature is used to validate future inputs and document the expected data formats.\n",
-    "\n",
-    "#### Types of Model Signatures\n",
-    "Model signatures can be:\n",
-    "\n",
-    "- **Column-based**: Suitable for models that operate on tabular data, with each column having a specified data type and optional name.\n",
-    "- **Tensor-based**: Designed for models that take tensors as inputs and outputs, with each tensor having a specified data type, shape, and optional name.\n",
-    "- **With Params**: Some models require additional parameters for inference, which can also be included in the signature.\n",
-    "\n",
-    "For the transformers flavor, all input types are of the Column-based type (referred to within MLflow as `ColSpec` types).\n",
-    "\n",
-    "#### Signature Enforcement\n",
-    "MLflow enforces the signature at the time of model inference, ensuring that the provided input and parameters match the expected schema. If there's a mismatch, MLflow will raise an exception or issue a warning, depending on the nature of the mismatch."
-   ]
+   "source": "### Introduction to Model Signatures in MLflow\n\nIn the realm of machine learning, model signatures play a crucial role in ensuring that models receive and produce the expected data types and structures. MLflow includes a feature for defining model signatures, helping to standardize and enforce correct model usage.\n\n#### Quick Learning Points\n\n- **Model Signature Purpose**: Ensures consistent data types and structures for model inputs and outputs.\n- **Visibility and Validation**: Visible in MLflow's UI and validated by MLflow's deployment tools.\n- **Signature Types**: Column-based for tabular data, tensor-based for tensor inputs/outputs, and with params for models requiring additional inference parameters.\n\n#### Understanding Model Signatures\nA model signature in MLflow describes the schema for inputs, outputs, and parameters of an ML model. It is a blueprint that details the expected data types and shapes, facilitating a clear interface for model usage. Signatures are particularly useful as they are:\n\n- Displayed in MLflow's UI for easy reference.\n- Employed by MLflow's deployment tools to validate inputs during inference.\n- Stored in a standardized JSON format alongside the model's metadata.\n\n#### The Role of Signatures in Code\nIn the following section, we define the `input_example` along with inference parameters. When we pass `input_example` to `log_model()`, MLflow will automatically infer the model signature, including input types, output types, and any inference parameters.\n\n#### Types of Model Signatures\nModel signatures can be:\n\n- **Column-based**: Suitable for models that operate on tabular data, with each column having a specified data type and optional name.\n- **Tensor-based**: Designed for models that take tensors as inputs and outputs, with each tensor having a specified data type, shape, and optional name.\n- **With Params**: Some models require additional parameters for inference, which can also be included in the signature.\n\nFor the transformers flavor, all input types are of the Column-based type (referred to within MLflow as `ColSpec` types).\n\n#### Signature Enforcement\nMLflow enforces the signature at the time of model inference, ensuring that the provided input and parameters match the expected schema. If there's a mismatch, MLflow will raise an exception or issue a warning, depending on the nature of the mismatch."
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "inputs: \n",
-       "  [string]\n",
-       "outputs: \n",
-       "  [string]\n",
-       "params: \n",
-       "  ['max_length': long (default: 512), 'do_sample': boolean (default: True), 'temperature': double (default: 0.4)]"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Generate the signature for the model that will be used for inference validation and type checking (as well as validation of parameters being submitted during inference)\n",
-    "signature = mlflow.models.infer_signature(\n",
-    "    input_example,\n",
-    "    mlflow.transformers.generate_signature_output(generation_pipeline, input_example),\n",
-    "    parameters,\n",
-    ")\n",
-    "\n",
-    "# Visualize the signature\n",
-    "signature"
-   ]
+   "outputs": [],
+   "source": "# The signature will be automatically inferred when input_example is provided to log_model.\n# We can define the input_example as a tuple of (data, params) to include inference parameters.\ninput_with_params = (input_example, parameters)\ninput_with_params"
   },
   {
    "cell_type": "markdown",
@@ -251,20 +193,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "with mlflow.start_run():\n",
-    "    model_info = mlflow.transformers.log_model(\n",
-    "        transformers_model=generation_pipeline,\n",
-    "        name=\"text_generator\",\n",
-    "        input_example=input_example,\n",
-    "        signature=signature,\n",
-    "        # Uncomment the following line to save the model in 'reference-only' mode:\n",
-    "        # save_pretrained=False,\n",
-    "    )"
-   ]
+   "source": "with mlflow.start_run():\n    model_info = mlflow.transformers.log_model(\n        transformers_model=generation_pipeline,\n        name=\"text_generator\",\n        input_example=input_with_params,\n        # Uncomment the following line to save the model in 'reference-only' mode:\n        # save_pretrained=False,\n    )"
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/translation/component-translation.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/translation/component-translation.ipynb
@@ -170,86 +170,26 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Setting Model Parameters and Inferring Signature\n",
-    "\n",
-    "We establish crucial model parameters and infer the signature to ensure consistency and reliability in our model's deployment.\n",
-    "\n",
-    "#### Defining Model Parameters\n",
-    "Setting key parameters like `max_length` is vital for controlling model behavior during inference. For example, a `max_length` of 1000 ensures the model handles longer sentences effectively, crucial for maintaining context in translations.\n",
-    "\n",
-    "#### Importance of Inferring Signature\n",
-    "The signature, defining the model's input and output schema, is critical for MLflow's understanding of the expected data structures. By inferring this signature, we document the types and structures of data that the model works with, enhancing its reliability and portability.\n",
-    "\n",
-    "#### Benefits of This Process\n",
-    "\n",
-    "- **Enhanced Portability**: Properly defined parameters and signatures make the model more adaptable to different environments.\n",
-    "- **Error Reduction**: This step minimizes the risk of encountering schema-related errors during deployment.\n",
-    "- **Clear Documentation**: It serves as a clear guide for developers and users, simplifying the model's integration into applications.\n",
-    "\n",
-    "By establishing these parameters and signature, we lay a robust foundation for our model's subsequent tracking, management, and serving via MLflow."
-   ]
+   "source": "### Setting Model Parameters and Input Example\n\nWe establish crucial model parameters and define an input example to ensure consistency and reliability in our model's deployment.\n\n#### Defining Model Parameters\nSetting key parameters like `max_length` is vital for controlling model behavior during inference. For example, a `max_length` of 1000 ensures the model handles longer sentences effectively, crucial for maintaining context in translations.\n\n#### Automatic Signature Inference\nWhen you provide an `input_example` to `log_model()`, MLflow will automatically infer the model signature, which defines the input and output schema. By passing a tuple of `(data, params)` as the `input_example`, we can include inference parameters in the signature as well.\n\n#### Benefits of This Process\n\n- **Enhanced Portability**: Properly defined parameters and input examples make the model more adaptable to different environments.\n- **Error Reduction**: This step minimizes the risk of encountering schema-related errors during deployment.\n- **Clear Documentation**: It serves as a clear guide for developers and users, simplifying the model's integration into applications.\n\nBy establishing these parameters and input example, we lay a robust foundation for our model's subsequent tracking, management, and serving via MLflow."
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Define the parameters that we are permitting to be used at inference time, along with their default values if not overridden\n",
-    "model_params = {\"max_length\": 1000}\n",
-    "\n",
-    "# Generate the model signature by providing an input, the expected output, and (optionally), parameters available for overriding at inference time\n",
-    "signature = mlflow.models.infer_signature(\n",
-    "    \"This is a sample input sentence.\",\n",
-    "    mlflow.transformers.generate_signature_output(translation_pipeline, \"This is another sample.\"),\n",
-    "    params=model_params,\n",
-    ")"
-   ]
+   "source": "# Define the parameters that we are permitting to be used at inference time, along with their default values if not overridden\nmodel_params = {\"max_length\": 1000}\n\n# The input_example can be a tuple of (data, params) to include inference parameters.\n# The signature will be automatically inferred when input_example is provided to log_model.\ninput_example = (\"This is a sample input sentence.\", model_params)"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Reviewing the Model Signature\n",
-    "\n",
-    "After configuring the translation model and inferring its signature, it's crucial to review the signature to confirm it matches our model's input and output structures.\n",
-    "    \n",
-    "The model signature serves as a blueprint for MLflow to interact with the model, encompassing:\n",
-    "\n",
-    "- **Inputs:** The expected input types, such as a string for the text to be translated.\n",
-    "- **Outputs:** The output data types, which in our case is a string representing the translated text.\n",
-    "- **Parameters:** Additional configurable settings like `max_length`, determining the maximum length of the translation output.\n",
-    "\n",
-    "Reviewing the signature through the `signature` command allows us to validate the data formats and ensure that our model will function as expected when deployed. This step is vital for consistent model performance and avoiding errors in a production environment.\n",
-    "Furthermore, the inclusion of parameters in the signature with default values ensures that any modifications during inference are deliberate and well-documented, contributing to the model's predictability and transparency."
-   ]
+   "source": "### Reviewing the Input Example\n\nAfter configuring the translation model and defining the input example, let's review it to confirm it captures our model's expected input format and parameters.\n\nThe input example serves as a blueprint for MLflow to interact with the model, encompassing:\n\n- **Input Data:** The text to be translated.\n- **Parameters:** Additional configurable settings like `max_length`, determining the maximum length of the translation output.\n\nReviewing the input example allows us to validate the data formats and ensure that our model will function as expected when deployed."
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "inputs: \n",
-       "  [string]\n",
-       "outputs: \n",
-       "  [string]\n",
-       "params: \n",
-       "  ['max_length': long (default: 1000)]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Visualize the model signature\n",
-    "signature"
-   ]
+   "outputs": [],
+   "source": "# Visualize the input example that will be used for automatic signature inference\ninput_example"
   },
   {
    "cell_type": "markdown",
@@ -310,18 +250,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "with mlflow.start_run():\n",
-    "    model_info = mlflow.transformers.log_model(\n",
-    "        transformers_model=translation_pipeline,\n",
-    "        name=\"french_translator\",\n",
-    "        signature=signature,\n",
-    "        model_params=model_params,\n",
-    "    )"
-   ]
+   "source": "with mlflow.start_run():\n    model_info = mlflow.transformers.log_model(\n        transformers_model=translation_pipeline,\n        name=\"french_translator\",\n        input_example=input_example,\n        model_params=model_params,\n    )"
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/translation/component-translation.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/translation/component-translation.ipynb
@@ -170,26 +170,65 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Setting Model Parameters and Input Example\n\nWe establish crucial model parameters and define an input example to ensure consistency and reliability in our model's deployment.\n\n#### Defining Model Parameters\nSetting key parameters like `max_length` is vital for controlling model behavior during inference. For example, a `max_length` of 1000 ensures the model handles longer sentences effectively, crucial for maintaining context in translations.\n\n#### Automatic Signature Inference\nWhen you provide an `input_example` to `log_model()`, MLflow will automatically infer the model signature, which defines the input and output schema. By passing a tuple of `(data, params)` as the `input_example`, we can include inference parameters in the signature as well.\n\n#### Benefits of This Process\n\n- **Enhanced Portability**: Properly defined parameters and input examples make the model more adaptable to different environments.\n- **Error Reduction**: This step minimizes the risk of encountering schema-related errors during deployment.\n- **Clear Documentation**: It serves as a clear guide for developers and users, simplifying the model's integration into applications.\n\nBy establishing these parameters and input example, we lay a robust foundation for our model's subsequent tracking, management, and serving via MLflow."
+   "source": [
+    "### Setting Model Parameters and Input Example\n",
+    "\n",
+    "We establish crucial model parameters and define an input example to ensure consistency and reliability in our model's deployment.\n",
+    "\n",
+    "#### Defining Model Parameters\n",
+    "Setting key parameters like `max_length` is vital for controlling model behavior during inference. For example, a `max_length` of 1000 ensures the model handles longer sentences effectively, crucial for maintaining context in translations.\n",
+    "\n",
+    "#### Automatic Signature Inference\n",
+    "When you provide an `input_example` to `log_model()`, MLflow will automatically infer the model signature, which defines the input and output schema. By passing a tuple of `(data, params)` as the `input_example`, we can include inference parameters in the signature as well.\n",
+    "\n",
+    "#### Benefits of This Process\n",
+    "\n",
+    "- **Enhanced Portability**: Properly defined parameters and input examples make the model more adaptable to different environments.\n",
+    "- **Error Reduction**: This step minimizes the risk of encountering schema-related errors during deployment.\n",
+    "- **Clear Documentation**: It serves as a clear guide for developers and users, simplifying the model's integration into applications.\n",
+    "\n",
+    "By establishing these parameters and input example, we lay a robust foundation for our model's subsequent tracking, management, and serving via MLflow."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Define the parameters that we are permitting to be used at inference time, along with their default values if not overridden\nmodel_params = {\"max_length\": 1000}\n\n# The input_example can be a tuple of (data, params) to include inference parameters.\n# The signature will be automatically inferred when input_example is provided to log_model.\ninput_example = (\"This is a sample input sentence.\", model_params)"
+   "source": [
+    "# Define the parameters that we are permitting to be used at inference time, along with their default values if not overridden\n",
+    "model_params = {\"max_length\": 1000}\n",
+    "\n",
+    "# The input_example can be a tuple of (data, params) to include inference parameters.\n",
+    "# The signature will be automatically inferred when input_example is provided to log_model.\n",
+    "input_example = (\"This is a sample input sentence.\", model_params)"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Reviewing the Input Example\n\nAfter configuring the translation model and defining the input example, let's review it to confirm it captures our model's expected input format and parameters.\n\nThe input example serves as a blueprint for MLflow to interact with the model, encompassing:\n\n- **Input Data:** The text to be translated.\n- **Parameters:** Additional configurable settings like `max_length`, determining the maximum length of the translation output.\n\nReviewing the input example allows us to validate the data formats and ensure that our model will function as expected when deployed."
+   "source": [
+    "### Reviewing the Input Example\n",
+    "\n",
+    "After configuring the translation model and defining the input example, let's review it to confirm it captures our model's expected input format and parameters.\n",
+    "\n",
+    "The input example serves as a blueprint for MLflow to interact with the model, encompassing:\n",
+    "\n",
+    "- **Input Data:** The text to be translated.\n",
+    "- **Parameters:** Additional configurable settings like `max_length`, determining the maximum length of the translation output.\n",
+    "\n",
+    "Reviewing the input example allows us to validate the data formats and ensure that our model will function as expected when deployed."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Visualize the input example that will be used for automatic signature inference\ninput_example"
+   "source": [
+    "# Visualize the input example that will be used for automatic signature inference\n",
+    "input_example"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -253,7 +292,15 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "with mlflow.start_run():\n    model_info = mlflow.transformers.log_model(\n        transformers_model=translation_pipeline,\n        name=\"french_translator\",\n        input_example=input_example,\n        model_params=model_params,\n    )"
+   "source": [
+    "with mlflow.start_run():\n",
+    "    model_info = mlflow.transformers.log_model(\n",
+    "        transformers_model=translation_pipeline,\n",
+    "        name=\"french_translator\",\n",
+    "        input_example=input_example,\n",
+    "        model_params=model_params,\n",
+    "    )"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/examples/transformers/conversational.py
+++ b/examples/transformers/conversational.py
@@ -4,17 +4,11 @@ import mlflow
 
 conversational_pipeline = transformers.pipeline(model="microsoft/DialoGPT-medium")
 
-signature = mlflow.models.infer_signature(
-    "Hi there, chatbot!",
-    mlflow.transformers.generate_signature_output(conversational_pipeline, "Hi there, chatbot!"),
-)
-
 with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=conversational_pipeline,
         name="chatbot",
         task="conversational",
-        signature=signature,
         input_example="A clever and witty question",
     )
 

--- a/examples/transformers/load_components.py
+++ b/examples/transformers/load_components.py
@@ -8,16 +8,11 @@ pipeline = transformers.pipeline(
     tokenizer=transformers.AutoTokenizer.from_pretrained("distilbert-base-uncased"),
 )
 
-signature = mlflow.models.infer_signature(
-    "MLflow is [MASK]!",
-    mlflow.transformers.generate_signature_output(pipeline, "MLflow is [MASK]!"),
-)
-
 with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=pipeline,
         name="mask_filler",
-        signature=signature,
+        input_example="MLflow is [MASK]!",
     )
 
 components = mlflow.transformers.load_model(model_info.model_uri, return_type="components")

--- a/examples/transformers/whisper.py
+++ b/examples/transformers/whisper.py
@@ -25,27 +25,17 @@ audio_transcription_pipeline = transformers.pipeline(
     task=task, model=model, tokenizer=tokenizer, feature_extractor=feature_extractor
 )
 
-# Note that if the input type is of raw binary audio, the generated signature will match the
-# one created here. For other supported types (i.e., numpy array of float32 with the
-# correct bitrate extraction), a signature is required to override the default of "binary" input
-# type.
-signature = mlflow.models.infer_signature(
-    audio,
-    mlflow.transformers.generate_signature_output(audio_transcription_pipeline, audio),
-)
-
 inference_config = {
     "return_timestamps": False,
     "chunk_length_s": 20,
     "stride_length_s": [5, 3],
 }
 
-# Log the pipeline
+# Log the pipeline. The signature is automatically inferred from input_example.
 with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=audio_transcription_pipeline,
         name="whisper_transcriber",
-        signature=signature,
         input_example=audio,
         inference_config=inference_config,
     )

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -222,9 +222,6 @@ def infer_signature(
 
               .. code-block:: python
 
-                    from mlflow.models import infer_signature
-                    from mlflow.transformers import generate_signature_output
-
                     # Define parameters for inference
                     params = {
                         "num_beams": 5,
@@ -233,18 +230,12 @@ def infer_signature(
                         "remove_invalid_values": True,
                     }
 
-                    # Infer the signature including parameters
-                    signature = infer_signature(
-                        data,
-                        generate_signature_output(model, data),
-                        params=params,
-                    )
-
-                    # Saving model with model signature
+                    # For transformers models, pass input_example directly to
+                    # log_model/save_model to automatically infer the signature:
                     mlflow.transformers.save_model(
                         model,
                         path=model_path,
-                        signature=signature,
+                        input_example=(data, params),
                     )
 
                     pyfunc_loaded = mlflow.pyfunc.load_model(model_path)

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -230,6 +230,8 @@ def infer_signature(
                         "remove_invalid_values": True,
                     }
 
+                    import mlflow
+
                     # For transformers models, pass input_example directly to
                     # log_model/save_model to automatically infer the signature:
                     mlflow.transformers.save_model(

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1729,7 +1729,7 @@ def _is_question_answering_pipeline(pipeline):
 
 
 @deprecated(
-    since="3.10.2",
+    since="3.11.0",
     impact="Signatures are now automatically inferred when `input_example` is provided "
     "to `mlflow.transformers.log_model()` or `mlflow.transformers.save_model()`. "
     "This method will be removed in a future release.",
@@ -1740,7 +1740,7 @@ def generate_signature_output(pipeline, data, model_config=None, params=None, fl
     for model saving and logging. This function simulates loading of a saved model or pipeline
     as a ``pyfunc`` model without having to incur a write to disk.
 
-    .. deprecated:: 3.10.2
+    .. deprecated:: 3.11.0
         Use the ``input_example`` parameter in
         :func:`mlflow.transformers.log_model()` or :func:`mlflow.transformers.save_model()`
         instead. Signatures are now automatically inferred when ``input_example`` is provided.

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1768,7 +1768,9 @@ def generate_signature_output(pipeline, data, model_config=None, params=None, fl
             error_code=INVALID_PARAMETER_VALUE,
         )
 
-    return signature.generate_signature_output(pipeline, data, model_config, params)
+    return signature.generate_signature_output(
+        pipeline, data, model_config=model_config, params=params, flavor_config=flavor_config
+    )
 
 
 class _TransformersWrapper:

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -97,6 +97,7 @@ from mlflow.transformers.signature import (
 from mlflow.transformers.torch_utils import _TORCH_DTYPE_KEY, _deserialize_torch_dtype
 from mlflow.types.utils import _validate_input_dictionary_contains_only_strings_and_lists_of_strings
 from mlflow.utils import _truncate_and_ellipsize
+from mlflow.utils.annotations import deprecated
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     disable_discrete_autologging,
@@ -401,20 +402,15 @@ def save_model(
             .. code-block:: python
                 :caption: Example
 
-                from mlflow.models import infer_signature
-                from mlflow.transformers import generate_signature_output
                 from transformers import pipeline
 
                 en_to_de = pipeline("translation_en_to_de")
 
                 data = "MLflow is great!"
-                output = generate_signature_output(en_to_de, data)
-                signature = infer_signature(data, output)
 
                 mlflow.transformers.save_model(
                     transformers_model=en_to_de,
                     path="/path/to/save/model",
-                    signature=signature,
                     input_example=data,
                 )
 
@@ -912,21 +908,16 @@ def log_model(
             .. code-block:: python
                 :caption: Example
 
-                from mlflow.models import infer_signature
-                from mlflow.transformers import generate_signature_output
                 from transformers import pipeline
 
                 en_to_de = pipeline("translation_en_to_de")
 
                 data = "MLflow is great!"
-                output = generate_signature_output(en_to_de, data)
-                signature = infer_signature(data, output)
 
                 with mlflow.start_run() as run:
                     mlflow.transformers.log_model(
                         transformers_model=en_to_de,
                         name="english_to_german_translator",
-                        signature=signature,
                         input_example=data,
                     )
 
@@ -1737,11 +1728,22 @@ def _is_question_answering_pipeline(pipeline):
         return getattr(pipeline, "task", None) == "question-answering"
 
 
+@deprecated(
+    since="3.10.2",
+    impact="Signatures are now automatically inferred when `input_example` is provided "
+    "to `mlflow.transformers.log_model()` or `mlflow.transformers.save_model()`. "
+    "This method will be removed in a future release.",
+)
 def generate_signature_output(pipeline, data, model_config=None, params=None, flavor_config=None):
     """
     Utility for generating the response output for the purposes of extracting an output signature
     for model saving and logging. This function simulates loading of a saved model or pipeline
     as a ``pyfunc`` model without having to incur a write to disk.
+
+    .. deprecated:: 3.10.2
+        Use the ``input_example`` parameter in
+        :func:`mlflow.transformers.log_model()` or :func:`mlflow.transformers.save_model()`
+        instead. Signatures are now automatically inferred when ``input_example`` is provided.
 
     Args:
         pipeline: A ``transformers`` pipeline object. Note that component-level or model-level

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -12,7 +12,6 @@ from unittest import mock
 
 import aiohttp
 import requests
-import transformers
 import uvicorn
 import yaml
 from sentence_transformers import SentenceTransformer
@@ -248,32 +247,6 @@ def log_sentence_transformers_model():
         model_info = mlflow.sentence_transformers.log_model(
             model,
             name=artifact_path,
-        )
-        return model_info.model_uri
-
-
-def log_completions_transformers_model():
-    architecture = "distilbert-base-uncased"
-
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
-    model = transformers.AutoModelForMaskedLM.from_pretrained(architecture)
-    pipe = transformers.pipeline(task="fill-mask", model=model, tokenizer=tokenizer)
-
-    inference_params = {"top_k": 1}
-
-    signature = mlflow.models.infer_signature(
-        ["test1 [MASK]", "[MASK] test2"],
-        mlflow.transformers.generate_signature_output(pipe, ["test3 [MASK]"]),
-        inference_params,
-    )
-
-    artifact_path = "mask_model"
-
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(
-            pipe,
-            name=artifact_path,
-            signature=signature,
         )
         return model_info.model_uri
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #13327
Relates to #18298

### What changes are proposed in this pull request?

Deprecate `mlflow.transformers.generate_signature_output()` in favor of using the `input_example` parameter directly in `log_model()` / `save_model()`, which now automatically infers model signatures.

The function is **not removed** — it still works but now emits a deprecation warning guiding users to the new approach.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Existing tests in `tests/transformers/test_transformers_model_export.py` (23+ test functions) and `tests/gateway/tools.py` continue to exercise `generate_signature_output` and verify it still works. The `@deprecated` decorator is a well-tested utility from `mlflow.utils.annotations` already used across 20+ other deprecated APIs in the codebase.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.transformers.generate_signature_output()` is now deprecated. Users should pass `input_example` directly to `mlflow.transformers.log_model()` or `mlflow.transformers.save_model()` instead — signatures are now automatically inferred.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
