### PR TITLE
Fix scorer re-registration raising RESOURCE_ALREADY_EXISTS in auth layer

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -2183,7 +2183,13 @@ def set_can_manage_scorer_permission(resp: Response):
     experiment_id = response_message.experiment_id
     name = response_message.name
     username = authenticate_request().username
-    store.create_scorer_permission(experiment_id, name, username, MANAGE.name)
+    try:
+        store.create_scorer_permission(experiment_id, name, username, MANAGE.name)
+    except MlflowException as e:
+        if e.error_code == "RESOURCE_ALREADY_EXISTS":
+            pass  # Permission already exists from a previous registration
+        else:
+            raise
 
 
 def delete_scorer_permissions_cascade(resp: Response):

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -51,6 +51,7 @@ from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
     INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
+    RESOURCE_ALREADY_EXISTS,
     RESOURCE_DOES_NOT_EXIST,
     ErrorCode,
 )
@@ -2186,7 +2187,7 @@ def set_can_manage_scorer_permission(resp: Response):
     try:
         store.create_scorer_permission(experiment_id, name, username, MANAGE.name)
     except MlflowException as e:
-        if e.error_code == "RESOURCE_ALREADY_EXISTS":
+        if e.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS):
             pass  # Permission already exists from a previous registration
         else:
             raise

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -969,6 +969,46 @@ def test_register_and_delete_scorer(client, monkeypatch):
     assert response.json()["error_code"] == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
 
+def test_reregister_scorer_does_not_raise(client, monkeypatch):
+    username1, password1 = create_user(client.tracking_uri)
+
+    with User(username1, password1, monkeypatch):
+        experiment_id = client.create_experiment("test_experiment")
+
+    scorer_json = '{"name": "test_scorer", "type": "pyfunc"}'
+
+    # First registration
+    with User(username1, password1, monkeypatch):
+        response = _send_rest_tracking_post_request(
+            client.tracking_uri,
+            "/api/3.0/mlflow/scorers/register",
+            json_payload={
+                "experiment_id": experiment_id,
+                "name": "test_scorer",
+                "serialized_scorer": scorer_json,
+            },
+            auth=(username1, password1),
+        )
+    assert response.status_code == 200
+    assert response.json()["version"] == 1
+
+    # Re-registration with the same name should succeed (not raise RESOURCE_ALREADY_EXISTS)
+    updated_scorer_json = '{"name": "test_scorer", "type": "pyfunc", "updated": true}'
+    with User(username1, password1, monkeypatch):
+        response = _send_rest_tracking_post_request(
+            client.tracking_uri,
+            "/api/3.0/mlflow/scorers/register",
+            json_payload={
+                "experiment_id": experiment_id,
+                "name": "test_scorer",
+                "serialized_scorer": updated_scorer_json,
+            },
+            auth=(username1, password1),
+        )
+    assert response.status_code == 200
+    assert response.json()["version"] == 2
+
+
 def test_scorer_permission_denial(client, monkeypatch):
     username1, password1 = create_user(client.tracking_uri)
     username2, password2 = create_user(client.tracking_uri)


### PR DESCRIPTION
### Related Issues/PRs

Closes #21551

### What changes are proposed in this pull request?

When re-registering a scorer (calling `.register()` with a name that is already registered for the same experiment), the scorer version was successfully created, but the auth layer's `after_request` hook (`set_can_manage_scorer_permission`) unconditionally called `create_scorer_permission`, which raised `RESOURCE_ALREADY_EXISTS` because the permission already existed from the first registration.

This PR catches the `RESOURCE_ALREADY_EXISTS` error in `set_can_manage_scorer_permission` and ignores it, since the permission already exists and doesn't need to be recreated. Other errors are still re-raised.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New integration test `test_reregister_scorer_does_not_raise` verifies that registering a scorer twice with the same name returns 200 both times and increments the version.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix scorer re-registration raising `RESOURCE_ALREADY_EXISTS` error when auth is enabled, even though the scorer version is successfully created.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release