### PR TITLE
Add componentId to <Link>, and fill in missing component IDs

### DIFF
--- a/mlflow/server/js/src/common/components/ErrorView.tsx
+++ b/mlflow/server/js/src/common/components/ErrorView.tsx
@@ -81,7 +81,7 @@ class ErrorViewImpl extends Component<ErrorViewImplProps> {
           description="Default error message for error views in MLflow"
           values={{
             link: (chunks) => (
-              <Link data-testid="error-view-link" componentId="mlflow.common.error_view.fallback_link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
+              <Link data-testid="error-view-link" componentId="mlflow.common.error_view.home_link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
                 {chunks}
               </Link>
             ),

--- a/mlflow/server/js/src/common/components/ErrorView.tsx
+++ b/mlflow/server/js/src/common/components/ErrorView.tsx
@@ -81,7 +81,7 @@ class ErrorViewImpl extends Component<ErrorViewImplProps> {
           description="Default error message for error views in MLflow"
           values={{
             link: (chunks) => (
-              <Link data-testid="error-view-link" componentId="mlflow.common.error_view.home_link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
+              <Link data-testid="error-view-link" componentId="mlflow.common.error_view.fallback_link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
                 {chunks}
               </Link>
             ),

--- a/mlflow/server/js/src/common/components/ErrorView.tsx
+++ b/mlflow/server/js/src/common/components/ErrorView.tsx
@@ -66,7 +66,7 @@ class ErrorViewImpl extends Component<ErrorViewImplProps> {
           description="Default error message for error views in MLflow"
           values={{
             link: (chunks) => (
-              <Link data-testid="error-view-link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
+              <Link data-testid="error-view-link" componentId="mlflow.common.error_view.fallback_link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
                 {chunks}
               </Link>
             ),
@@ -81,7 +81,7 @@ class ErrorViewImpl extends Component<ErrorViewImplProps> {
           description="Default error message for error views in MLflow"
           values={{
             link: (chunks) => (
-              <Link data-testid="error-view-link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
+              <Link data-testid="error-view-link" componentId="mlflow.common.error_view.fallback_link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
                 {chunks}
               </Link>
             ),

--- a/mlflow/server/js/src/common/components/ErrorView.tsx
+++ b/mlflow/server/js/src/common/components/ErrorView.tsx
@@ -66,7 +66,11 @@ class ErrorViewImpl extends Component<ErrorViewImplProps> {
           description="Default error message for error views in MLflow"
           values={{
             link: (chunks) => (
-              <Link data-testid="error-view-link" componentId="mlflow.common.error_view.fallback_link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
+              <Link
+                data-testid="error-view-link"
+                componentId="mlflow.common.error_view.fallback_link"
+                to={fallbackHomePageReactRoute || Routes.rootRoute}
+              >
                 {chunks}
               </Link>
             ),
@@ -81,7 +85,11 @@ class ErrorViewImpl extends Component<ErrorViewImplProps> {
           description="Default error message for error views in MLflow"
           values={{
             link: (chunks) => (
-              <Link data-testid="error-view-link" componentId="mlflow.common.error_view.fallback_link" to={fallbackHomePageReactRoute || Routes.rootRoute}>
+              <Link
+                data-testid="error-view-link"
+                componentId="mlflow.common.error_view.fallback_link"
+                to={fallbackHomePageReactRoute || Routes.rootRoute}
+              >
                 {chunks}
               </Link>
             ),

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -257,7 +257,7 @@ export function MlflowSidebar({
       <div css={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
         {showSidebar && (
           <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-            <Link to={ExperimentTrackingRoutes.rootRoute}>
+            <Link componentId="mlflow.sidebar.logo_home_link" to={ExperimentTrackingRoutes.rootRoute}>
               <MlflowLogo
                 css={{
                   display: 'block',

--- a/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
@@ -1,14 +1,6 @@
-import { v4 as uuidv4 } from 'uuid';
 import type { Location, To } from '../utils/RoutingUtils';
 import { Link, useLocation } from '../utils/RoutingUtils';
-import {
-  DesignSystemEventProviderAnalyticsEventTypes,
-  DesignSystemEventProviderComponentTypes,
-  Tooltip,
-  useDesignSystemTheme,
-} from '@databricks/design-system';
-import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
-import { useMemo } from 'react';
+import { Tooltip, useDesignSystemTheme } from '@databricks/design-system';
 
 export const MlflowSidebarLink = ({
   className,
@@ -36,8 +28,6 @@ export const MlflowSidebarLink = ({
   tooltipContent?: React.ReactNode;
 }) => {
   const { theme } = useDesignSystemTheme();
-  const logTelemetryEvent = useLogTelemetryEvent();
-  const viewId = useMemo(() => uuidv4(), []);
   const location = useLocation();
 
   return (
@@ -75,13 +65,6 @@ export const MlflowSidebarLink = ({
             },
           }}
           onClick={() => {
-            logTelemetryEvent({
-              componentId,
-              componentViewId: viewId,
-              componentType: DesignSystemEventProviderComponentTypes.Button,
-              componentSubType: null,
-              eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
-            });
             onClick?.();
           }}
           target={openInNewTab ? '_blank' : undefined}

--- a/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarLink.tsx
@@ -50,6 +50,7 @@ export const MlflowSidebarLink = ({
         delayDuration={0}
       >
         <Link
+          componentId={componentId}
           disableWorkspacePrefix={disableWorkspacePrefix}
           to={to}
           aria-current={isActive(location) ? 'page' : undefined}

--- a/mlflow/server/js/src/common/utils/RoutingUtils.tsx
+++ b/mlflow/server/js/src/common/utils/RoutingUtils.tsx
@@ -37,7 +37,13 @@ import {
  */
 import { HashRouter as HashRouterV5, Link as LinkV5, NavLink as NavLinkV5 } from 'react-router-dom';
 import type { ComponentProps } from 'react';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+} from '@databricks/design-system';
+import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
 
 import {
   prefixRouteWithWorkspace,
@@ -134,11 +140,25 @@ const prefixRouteWithWorkspaceForTo = (to: To): To => {
 
 const Link = React.forwardRef<
   HTMLAnchorElement,
-  ComponentProps<typeof LinkDirect> & { disableWorkspacePrefix?: boolean }
+  ComponentProps<typeof LinkDirect> & { disableWorkspacePrefix?: boolean; componentId: string }
 >(function Link(props, ref) {
-  const { to, disableWorkspacePrefix, ...rest } = props;
+  const { to, disableWorkspacePrefix, componentId, onClick, ...rest } = props;
   const finalTo = disableWorkspacePrefix ? to : prefixRouteWithWorkspaceForTo(to);
-  return <LinkDirect ref={ref} to={finalTo} {...rest} />;
+  const logTelemetryEvent = useLogTelemetryEvent();
+  const viewId = useMemo(() => uuidv4(), []);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    logTelemetryEvent({
+      componentId,
+      componentViewId: viewId,
+      componentType: DesignSystemEventProviderComponentTypes.Button,
+      componentSubType: null,
+      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+    });
+    onClick?.(e);
+  };
+
+  return <LinkDirect ref={ref} to={finalTo} onClick={handleClick} {...rest} />;
 });
 
 const NavLink = React.forwardRef<

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
@@ -602,7 +602,13 @@ function ModelVersionInfoSection(props: ModelVersionInfoSectionProps) {
   const modelVersionLink = (
     <Tooltip componentId="mlflow.artifacts.model_version.link" content={`${name} version ${version}`}>
       <span>
-        <Link componentId="mlflow.experiment_tracking.artifacts.model_version_link" to={mvPageRoute} className="model-version-link" target="_blank" rel="noreferrer">
+        <Link
+          componentId="mlflow.experiment_tracking.artifacts.model_version_link"
+          to={mvPageRoute}
+          className="model-version-link"
+          target="_blank"
+          rel="noreferrer"
+        >
           <span className="model-name">{name}</span>
           <span>,&nbsp;v{version}&nbsp;</span>
           <i className="fa fa-external-link-o" />

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
@@ -602,7 +602,7 @@ function ModelVersionInfoSection(props: ModelVersionInfoSectionProps) {
   const modelVersionLink = (
     <Tooltip componentId="mlflow.artifacts.model_version.link" content={`${name} version ${version}`}>
       <span>
-        <Link to={mvPageRoute} className="model-version-link" target="_blank" rel="noreferrer">
+        <Link componentId="mlflow.experiment_tracking.artifacts.model_version_link" to={mvPageRoute} className="model-version-link" target="_blank" rel="noreferrer">
           <span className="model-name">{name}</span>
           <span>,&nbsp;v{version}&nbsp;</span>
           <i className="fa fa-external-link-o" />

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunMetricTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunMetricTable.tsx
@@ -237,7 +237,7 @@ function CompareRunMetricTableHeaderCell({
         textAlign: 'left',
       }}
     >
-      <Link to={metricPageRoute} title="Plot chart">
+      <Link componentId="mlflow.experiment_tracking.compare_runs.metric_chart_link" to={metricPageRoute} title="Plot chart">
         {metricRowKey}
         <i className="fa fa-chart-line" css={{ paddingLeft: '6px' }} />
       </Link>

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunMetricTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunMetricTable.tsx
@@ -237,7 +237,11 @@ function CompareRunMetricTableHeaderCell({
         textAlign: 'left',
       }}
     >
-      <Link componentId="mlflow.experiment_tracking.compare_runs.metric_chart_link" to={metricPageRoute} title="Plot chart">
+      <Link
+        componentId="mlflow.experiment_tracking.compare_runs.metric_chart_link"
+        to={metricPageRoute}
+        title="Plot chart"
+      >
         {metricRowKey}
         <i className="fa fa-chart-line" css={{ paddingLeft: '6px' }} />
       </Link>

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -137,7 +137,11 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
       const { name, basename } = experimentNameMap[experimentId];
       return (
         <td className="meta-info" key={runUuid}>
-          <Link componentId="mlflow.experiment_tracking.compare_runs.experiment_name_link" to={Routes.getExperimentPageRoute(experimentId)} title={name}>
+          <Link
+            componentId="mlflow.experiment_tracking.compare_runs.experiment_name_link"
+            to={Routes.getExperimentPageRoute(experimentId)}
+            title={name}
+          >
             {basename}
           </Link>
         </td>
@@ -154,7 +158,14 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
   }
 
   getExperimentPageLink(experimentId: any, experimentName: any) {
-    return <Link componentId="mlflow.experiment_tracking.compare_runs.experiment_link" to={Routes.getExperimentPageRoute(experimentId)}>{experimentName}</Link>;
+    return (
+      <Link
+        componentId="mlflow.experiment_tracking.compare_runs.experiment_link"
+        to={Routes.getExperimentPageRoute(experimentId)}
+      >
+        {experimentName}
+      </Link>
+    );
   }
 
   getCompareExperimentsPageLinkText(numExperiments: any) {
@@ -169,7 +180,10 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
 
   getCompareExperimentsPageLink(experimentIds: any) {
     return (
-      <Link componentId="mlflow.experiment_tracking.compare_runs.compare_experiments_link" to={Routes.getCompareExperimentsPageRoute(experimentIds)}>
+      <Link
+        componentId="mlflow.experiment_tracking.compare_runs.compare_experiments_link"
+        to={Routes.getCompareExperimentsPageRoute(experimentIds)}
+      >
         {this.getCompareExperimentsPageLinkText(experimentIds.length)}
       </Link>
     );
@@ -522,7 +536,12 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
                       align="end"
                       maxWidth={400}
                     >
-                      <Link componentId="mlflow.experiment_tracking.compare_runs.run_uuid_link" to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
+                      <Link
+                        componentId="mlflow.experiment_tracking.compare_runs.run_uuid_link"
+                        to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}
+                      >
+                        {r.runUuid}
+                      </Link>
                     </Tooltip>
                   </th>
                 ))}

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -137,7 +137,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
       const { name, basename } = experimentNameMap[experimentId];
       return (
         <td className="meta-info" key={runUuid}>
-          <Link to={Routes.getExperimentPageRoute(experimentId)} title={name}>
+          <Link componentId="mlflow.experiment_tracking.compare_runs.experiment_name_link" to={Routes.getExperimentPageRoute(experimentId)} title={name}>
             {basename}
           </Link>
         </td>
@@ -154,7 +154,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
   }
 
   getExperimentPageLink(experimentId: any, experimentName: any) {
-    return <Link to={Routes.getExperimentPageRoute(experimentId)}>{experimentName}</Link>;
+    return <Link componentId="mlflow.experiment_tracking.compare_runs.experiment_link" to={Routes.getExperimentPageRoute(experimentId)}>{experimentName}</Link>;
   }
 
   getCompareExperimentsPageLinkText(numExperiments: any) {
@@ -169,7 +169,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
 
   getCompareExperimentsPageLink(experimentIds: any) {
     return (
-      <Link to={Routes.getCompareExperimentsPageRoute(experimentIds)}>
+      <Link componentId="mlflow.experiment_tracking.compare_runs.compare_experiments_link" to={Routes.getCompareExperimentsPageRoute(experimentIds)}>
         {this.getCompareExperimentsPageLinkText(experimentIds.length)}
       </Link>
     );
@@ -522,7 +522,7 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
                       align="end"
                       maxWidth={400}
                     >
-                      <Link to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
+                      <Link componentId="mlflow.experiment_tracking.compare_runs.run_uuid_link" to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
                     </Tooltip>
                   </th>
                 ))}

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
@@ -270,6 +270,7 @@ const ExperimentListTableCell: ExperimentTableColumnDef['cell'] = ({ row: { orig
     return (
       <div css={{ display: 'flex', alignItems: 'center', gap: 4 }}>
         <Link
+          componentId="mlflow.experiment_tracking.experiment_list.demo_experiment_link"
           to={Routes.getExperimentPageRoute(original.experimentId)}
           title={original.name}
           data-testid="experiment-list-item-link"
@@ -300,6 +301,7 @@ const ExperimentListTableCell: ExperimentTableColumnDef['cell'] = ({ row: { orig
   }
   return (
     <Link
+      componentId="mlflow.experiment_tracking.experiment_list.experiment_name_link"
       className="experiment-link"
       css={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', flex: 1 }}
       to={Routes.getExperimentPageRoute(original.experimentId)}

--- a/mlflow/server/js/src/experiment-tracking/components/MetricView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricView.tsx
@@ -59,11 +59,25 @@ export class MetricViewImpl extends Component<MetricViewImplProps> {
     }
 
     if (runUuids.length === 1) {
-      return <Link componentId="mlflow.experiment_tracking.metric_view.run_link" to={Routes.getRunPageRoute(experimentIds[0], runUuids[0])}>{runNames[0]}</Link>;
+      return (
+        <Link
+          componentId="mlflow.experiment_tracking.metric_view.run_link"
+          to={Routes.getRunPageRoute(experimentIds[0], runUuids[0])}
+        >
+          {runNames[0]}
+        </Link>
+      );
     }
 
     const text = this.getCompareRunsPageText(runUuids.length, experimentIds.length);
-    return <Link componentId="mlflow.experiment_tracking.metric_view.compare_runs_link" to={Routes.getCompareRunPageRoute(runUuids, experimentIds)}>{text}</Link>;
+    return (
+      <Link
+        componentId="mlflow.experiment_tracking.metric_view.compare_runs_link"
+        to={Routes.getCompareRunPageRoute(runUuids, experimentIds)}
+      >
+        {text}
+      </Link>
+    );
   }
 
   getCompareExperimentsPageLinkText(numExperiments: any) {
@@ -81,15 +95,36 @@ export class MetricViewImpl extends Component<MetricViewImplProps> {
 
     if (hasComparedExperimentsBefore && comparedExperimentIds) {
       const text = this.getCompareExperimentsPageLinkText(comparedExperimentIds.length);
-      return <Link componentId="mlflow.experiment_tracking.metric_view.compare_experiments_link" to={Routes.getCompareExperimentsPageRoute(comparedExperimentIds)}>{text}</Link>;
+      return (
+        <Link
+          componentId="mlflow.experiment_tracking.metric_view.compare_experiments_link"
+          to={Routes.getCompareExperimentsPageRoute(comparedExperimentIds)}
+        >
+          {text}
+        </Link>
+      );
     }
 
     if (this.hasMultipleExperiments()) {
       const text = this.getCompareExperimentsPageLinkText(experimentIds.length);
-      return <Link componentId="mlflow.experiment_tracking.metric_view.multiple_experiments_link" to={Routes.getCompareExperimentsPageRoute(experimentIds)}>{text}</Link>;
+      return (
+        <Link
+          componentId="mlflow.experiment_tracking.metric_view.multiple_experiments_link"
+          to={Routes.getCompareExperimentsPageRoute(experimentIds)}
+        >
+          {text}
+        </Link>
+      );
     }
 
-    return <Link componentId="mlflow.experiment_tracking.metric_view.experiment_link" to={Routes.getExperimentPageRoute(experimentIds[0])}>{experiments[0].name}</Link>;
+    return (
+      <Link
+        componentId="mlflow.experiment_tracking.metric_view.experiment_link"
+        to={Routes.getExperimentPageRoute(experimentIds[0])}
+      >
+        {experiments[0].name}
+      </Link>
+    );
   }
 
   render() {

--- a/mlflow/server/js/src/experiment-tracking/components/MetricView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricView.tsx
@@ -86,7 +86,7 @@ export class MetricViewImpl extends Component<MetricViewImplProps> {
 
     if (this.hasMultipleExperiments()) {
       const text = this.getCompareExperimentsPageLinkText(experimentIds.length);
-      return <Link componentId="mlflow.experiment_tracking.metric_view.compare_experiments_link" to={Routes.getCompareExperimentsPageRoute(experimentIds)}>{text}</Link>;
+      return <Link componentId="mlflow.experiment_tracking.metric_view.multiple_experiments_link" to={Routes.getCompareExperimentsPageRoute(experimentIds)}>{text}</Link>;
     }
 
     return <Link componentId="mlflow.experiment_tracking.metric_view.experiment_link" to={Routes.getExperimentPageRoute(experimentIds[0])}>{experiments[0].name}</Link>;

--- a/mlflow/server/js/src/experiment-tracking/components/MetricView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricView.tsx
@@ -59,11 +59,11 @@ export class MetricViewImpl extends Component<MetricViewImplProps> {
     }
 
     if (runUuids.length === 1) {
-      return <Link to={Routes.getRunPageRoute(experimentIds[0], runUuids[0])}>{runNames[0]}</Link>;
+      return <Link componentId="mlflow.experiment_tracking.metric_view.run_link" to={Routes.getRunPageRoute(experimentIds[0], runUuids[0])}>{runNames[0]}</Link>;
     }
 
     const text = this.getCompareRunsPageText(runUuids.length, experimentIds.length);
-    return <Link to={Routes.getCompareRunPageRoute(runUuids, experimentIds)}>{text}</Link>;
+    return <Link componentId="mlflow.experiment_tracking.metric_view.compare_runs_link" to={Routes.getCompareRunPageRoute(runUuids, experimentIds)}>{text}</Link>;
   }
 
   getCompareExperimentsPageLinkText(numExperiments: any) {
@@ -81,15 +81,15 @@ export class MetricViewImpl extends Component<MetricViewImplProps> {
 
     if (hasComparedExperimentsBefore && comparedExperimentIds) {
       const text = this.getCompareExperimentsPageLinkText(comparedExperimentIds.length);
-      return <Link to={Routes.getCompareExperimentsPageRoute(comparedExperimentIds)}>{text}</Link>;
+      return <Link componentId="mlflow.experiment_tracking.metric_view.compare_experiments_link" to={Routes.getCompareExperimentsPageRoute(comparedExperimentIds)}>{text}</Link>;
     }
 
     if (this.hasMultipleExperiments()) {
       const text = this.getCompareExperimentsPageLinkText(experimentIds.length);
-      return <Link to={Routes.getCompareExperimentsPageRoute(experimentIds)}>{text}</Link>;
+      return <Link componentId="mlflow.experiment_tracking.metric_view.compare_experiments_link" to={Routes.getCompareExperimentsPageRoute(experimentIds)}>{text}</Link>;
     }
 
-    return <Link to={Routes.getExperimentPageRoute(experimentIds[0])}>{experiments[0].name}</Link>;
+    return <Link componentId="mlflow.experiment_tracking.metric_view.experiment_link" to={Routes.getExperimentPageRoute(experimentIds[0])}>{experiments[0].name}</Link>;
   }
 
   render() {

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsSummaryTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsSummaryTable.tsx
@@ -156,7 +156,14 @@ const getMetricValuesByRun = (
     const runName = runDisplayNames[runIdx];
     return {
       runName: runName,
-      runLink: <Link componentId="mlflow.experiment_tracking.metrics_summary.run_link" to={Routes.getRunPageRoute(runExperimentIds[runUuid] || '', runUuid)}>{runName}</Link>,
+      runLink: (
+        <Link
+          componentId="mlflow.experiment_tracking.metrics_summary.run_link"
+          to={Routes.getRunPageRoute(runExperimentIds[runUuid] || '', runUuid)}
+        >
+          {runName}
+        </Link>
+      ),
       key: runUuid,
       ...rowData(runUuid, metricKey, latestMetrics, minMetrics, maxMetrics, intl),
     };

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsSummaryTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsSummaryTable.tsx
@@ -156,7 +156,7 @@ const getMetricValuesByRun = (
     const runName = runDisplayNames[runIdx];
     return {
       runName: runName,
-      runLink: <Link to={Routes.getRunPageRoute(runExperimentIds[runUuid] || '', runUuid)}>{runName}</Link>,
+      runLink: <Link componentId="mlflow.experiment_tracking.metrics_summary.run_link" to={Routes.getRunPageRoute(runExperimentIds[runUuid] || '', runUuid)}>{runName}</Link>,
       key: runUuid,
       ...rowData(runUuid, metricKey, latestMetrics, minMetrics, maxMetrics, intl),
     };

--- a/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.tsx
@@ -34,7 +34,7 @@ export class RunLinksPopover extends React.Component<Props> {
           const key = `${runId}-${index}`;
           const to = Routes.getRunPageRoute(experimentId, runId);
           return (
-            <Link key={key} to={to}>
+            <Link componentId="mlflow.experiment_tracking.run_links.run_link" key={key} to={to}>
               <p style={{ color }}>
                 <i className="fa fa-external-link-o" style={{ marginRight: 5 }} />
                 {`${name}, ${Utils.formatMetric(y)}`}

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/FallbackToLoggedModelArtifactsInfo.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/FallbackToLoggedModelArtifactsInfo.tsx
@@ -19,7 +19,7 @@ export const FallbackToLoggedModelArtifactsInfo = ({ loggedModelId }: { loggedMo
           values={{
             link: (chunks) =>
               experimentId ? (
-                <Link to={Routes.getExperimentLoggedModelDetailsPage(experimentId, loggedModelId)}>{chunks}</Link>
+                <Link componentId="mlflow.experiment_tracking.artifacts.logged_model_fallback_link" to={Routes.getExperimentLoggedModelDetailsPage(experimentId, loggedModelId)}>{chunks}</Link>
               ) : (
                 <>{chunks}</>
               ),

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/FallbackToLoggedModelArtifactsInfo.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/FallbackToLoggedModelArtifactsInfo.tsx
@@ -19,7 +19,12 @@ export const FallbackToLoggedModelArtifactsInfo = ({ loggedModelId }: { loggedMo
           values={{
             link: (chunks) =>
               experimentId ? (
-                <Link componentId="mlflow.experiment_tracking.artifacts.logged_model_fallback_link" to={Routes.getExperimentLoggedModelDetailsPage(experimentId, loggedModelId)}>{chunks}</Link>
+                <Link
+                  componentId="mlflow.experiment_tracking.artifacts.logged_model_fallback_link"
+                  to={Routes.getExperimentLoggedModelDetailsPage(experimentId, loggedModelId)}
+                >
+                  {chunks}
+                </Link>
               ) : (
                 <>{chunks}</>
               ),

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationRunHeaderCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationRunHeaderCellRenderer.tsx
@@ -95,7 +95,7 @@ export const EvaluationRunHeaderCellRenderer = ({
       >
         <span css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
           <RunColorPill color={getRunColor(run.runUuid)} />
-          <Link to={ExperimentRoutes.getRunPageRoute(run.experimentId || '', run.runUuid)} target="_blank">
+          <Link componentId="mlflow.experiment_tracking.evaluation.run_header_link" to={ExperimentRoutes.getRunPageRoute(run.experimentId || '', run.runUuid)} target="_blank">
             {run.runName}
           </Link>
         </span>

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationRunHeaderCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationRunHeaderCellRenderer.tsx
@@ -95,7 +95,11 @@ export const EvaluationRunHeaderCellRenderer = ({
       >
         <span css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
           <RunColorPill color={getRunColor(run.runUuid)} />
-          <Link componentId="mlflow.experiment_tracking.evaluation.run_header_link" to={ExperimentRoutes.getRunPageRoute(run.experimentId || '', run.runUuid)} target="_blank">
+          <Link
+            componentId="mlflow.experiment_tracking.evaluation.run_header_link"
+            to={ExperimentRoutes.getRunPageRoute(run.experimentId || '', run.runUuid)}
+            target="_blank"
+          >
             {run.runName}
           </Link>
         </span>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsHeader.tsx
@@ -60,11 +60,11 @@ export const ExperimentLoggedModelDetailsHeader = ({
 
   const breadcrumbs = [
     // eslint-disable-next-line react/jsx-key
-    <Link to={Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Models)}>
+    <Link componentId="mlflow.logged_models.details_header.experiment_link" to={Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Models)}>
       {getExperimentName()}
     </Link>,
     // eslint-disable-next-line react/jsx-key
-    <Link to={Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Models)}>
+    <Link componentId="mlflow.logged_models.details_header.models_tab_link" to={Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Models)}>
       <FormattedMessage
         defaultMessage="Models"
         description="Breadcrumb for models tab of experiments page on the logged model details page"

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsHeader.tsx
@@ -60,11 +60,17 @@ export const ExperimentLoggedModelDetailsHeader = ({
 
   const breadcrumbs = [
     // eslint-disable-next-line react/jsx-key
-    <Link componentId="mlflow.logged_models.details_header.experiment_link" to={Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Models)}>
+    <Link
+      componentId="mlflow.logged_models.details_header.experiment_link"
+      to={Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Models)}
+    >
       {getExperimentName()}
     </Link>,
     // eslint-disable-next-line react/jsx-key
-    <Link componentId="mlflow.logged_models.details_header.models_tab_link" to={Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Models)}>
+    <Link
+      componentId="mlflow.logged_models.details_header.models_tab_link"
+      to={Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Models)}
+    >
       <FormattedMessage
         defaultMessage="Models"
         description="Breadcrumb for models tab of experiments page on the logged model details page"

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsModelVersionsList.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsModelVersionsList.tsx
@@ -25,6 +25,7 @@ export const ExperimentLoggedModelDetailsModelVersionsList = ({
     <Overflow>
       {modelVersions?.map(({ displayedName, version, link }) => (
         <Link
+          componentId="mlflow.logged_models.details.model_version_link"
           to={link}
           key={`${displayedName}-${version}`}
           css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsNav.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsNav.tsx
@@ -17,7 +17,10 @@ export const ExperimentLoggedModelDetailsNav = ({
     <NavigationMenu.Root>
       <NavigationMenu.List>
         <NavigationMenu.Item key="overview" active={!activeTabName}>
-          <Link componentId="mlflow.logged_models.details_nav.overview_link" to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId)}>
+          <Link
+            componentId="mlflow.logged_models.details_nav.overview_link"
+            to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId)}
+          >
             <FormattedMessage
               defaultMessage="Overview"
               description="Label for the overview tab on the logged model details page"
@@ -34,7 +37,10 @@ export const ExperimentLoggedModelDetailsNav = ({
           </Link>
         </NavigationMenu.Item> */}
         <NavigationMenu.Item key="traces" active={activeTabName === 'traces'}>
-          <Link componentId="mlflow.logged_models.details_nav.traces_link" to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId, 'traces')}>
+          <Link
+            componentId="mlflow.logged_models.details_nav.traces_link"
+            to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId, 'traces')}
+          >
             <FormattedMessage
               defaultMessage="Traces"
               description="Label for the traces tab on the logged model details page"
@@ -42,7 +48,10 @@ export const ExperimentLoggedModelDetailsNav = ({
           </Link>
         </NavigationMenu.Item>
         <NavigationMenu.Item key="artifacts" active={activeTabName === 'artifacts'}>
-          <Link componentId="mlflow.logged_models.details_nav.artifacts_link" to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId, 'artifacts')}>
+          <Link
+            componentId="mlflow.logged_models.details_nav.artifacts_link"
+            to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId, 'artifacts')}
+          >
             <FormattedMessage
               defaultMessage="Artifacts"
               description="Label for the artifacts tab on the logged model details page"

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsNav.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsNav.tsx
@@ -17,7 +17,7 @@ export const ExperimentLoggedModelDetailsNav = ({
     <NavigationMenu.Root>
       <NavigationMenu.List>
         <NavigationMenu.Item key="overview" active={!activeTabName}>
-          <Link to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId)}>
+          <Link componentId="mlflow.logged_models.details_nav.overview_link" to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId)}>
             <FormattedMessage
               defaultMessage="Overview"
               description="Label for the overview tab on the logged model details page"
@@ -34,7 +34,7 @@ export const ExperimentLoggedModelDetailsNav = ({
           </Link>
         </NavigationMenu.Item> */}
         <NavigationMenu.Item key="traces" active={activeTabName === 'traces'}>
-          <Link to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId, 'traces')}>
+          <Link componentId="mlflow.logged_models.details_nav.traces_link" to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId, 'traces')}>
             <FormattedMessage
               defaultMessage="Traces"
               description="Label for the traces tab on the logged model details page"
@@ -42,7 +42,7 @@ export const ExperimentLoggedModelDetailsNav = ({
           </Link>
         </NavigationMenu.Item>
         <NavigationMenu.Item key="artifacts" active={activeTabName === 'artifacts'}>
-          <Link to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId, 'artifacts')}>
+          <Link componentId="mlflow.logged_models.details_nav.artifacts_link" to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, modelId, 'artifacts')}>
             <FormattedMessage
               defaultMessage="Artifacts"
               description="Label for the artifacts tab on the logged model details page"

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsOverview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsOverview.tsx
@@ -116,7 +116,10 @@ export const ExperimentLoggedModelDetailsOverview = ({
                 relatedRunsLoading ? (
                   <GenericSkeleton css={{ width: 200, height: theme.spacing.md }} />
                 ) : (
-                  <Link componentId="mlflow.logged_models.details_overview.source_run_link" to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}>
+                  <Link
+                    componentId="mlflow.logged_models.details_overview.source_run_link"
+                    to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}
+                  >
                     {relatedSourceRun?.info?.runName}
                   </Link>
                 )

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsOverview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsOverview.tsx
@@ -116,7 +116,7 @@ export const ExperimentLoggedModelDetailsOverview = ({
                 relatedRunsLoading ? (
                   <GenericSkeleton css={{ width: 200, height: theme.spacing.md }} />
                 ) : (
-                  <Link to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}>
+                  <Link componentId="mlflow.logged_models.details_overview.source_run_link" to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}>
                     {relatedSourceRun?.info?.runName}
                   </Link>
                 )

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsTableRunCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsTableRunCellRenderer.tsx
@@ -14,5 +14,9 @@ export const ExperimentLoggedModelDetailsTableRunCellRenderer: ColumnDefTemplate
 > = ({ getValue }) => {
   const { runName, runId } = getValue() ?? {};
 
-  return <Link componentId="mlflow.logged_models.details_table.run_cell_link" to={Routes.getDirectRunPageRoute(runId ?? '')}>{runName || runId}</Link>;
+  return (
+    <Link componentId="mlflow.logged_models.details_table.run_cell_link" to={Routes.getDirectRunPageRoute(runId ?? '')}>
+      {runName || runId}
+    </Link>
+  );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsTableRunCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsTableRunCellRenderer.tsx
@@ -14,5 +14,5 @@ export const ExperimentLoggedModelDetailsTableRunCellRenderer: ColumnDefTemplate
 > = ({ getValue }) => {
   const { runName, runId } = getValue() ?? {};
 
-  return <Link to={Routes.getDirectRunPageRoute(runId ?? '')}>{runName || runId}</Link>;
+  return <Link componentId="mlflow.logged_models.details_table.run_cell_link" to={Routes.getDirectRunPageRoute(runId ?? '')}>{runName || runId}</Link>;
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableGroupCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableGroupCell.tsx
@@ -23,6 +23,7 @@ export const ExperimentLoggedModelTableGroupCell = ({ data }: { data: LoggedMode
       />
       {data.groupData?.sourceRun ? (
         <Link
+          componentId="mlflow.logged_models.table.group_source_run_link"
           to={Routes.getRunPageRoute(data.groupData.sourceRun.info.experimentId, data.groupData.sourceRun.info.runUuid)}
           target="_blank"
         >

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableNameCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableNameCell.tsx
@@ -72,7 +72,7 @@ export const ExperimentLoggedModelTableNameCell = (props: { data: LoggedModelsTa
           description="Tooltip text with link to the original logged model"
           values={{
             originalModelLink: (
-              <Link to={linkUrl} css={{ color: 'inherit', textDecoration: 'underline' }}>
+              <Link componentId="mlflow.logged_models.table.original_model_tooltip_link" to={linkUrl} css={{ color: 'inherit', textDecoration: 'underline' }}>
                 {originalName}
               </Link>
             ),
@@ -122,7 +122,7 @@ export const ExperimentLoggedModelTableNameCell = (props: { data: LoggedModelsTa
           }}
         >
           <RunColorPill color={getStableColorForRun(data.info?.model_id || '')} />
-          <Link to={primaryModel.link} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+          <Link componentId="mlflow.logged_models.table.model_name_link" to={primaryModel.link} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
             {primaryModel.displayedName}
             <Tag
               componentId="mlflow.logged_model.name_cell_version_tag"
@@ -159,7 +159,7 @@ export const ExperimentLoggedModelTableNameCell = (props: { data: LoggedModelsTa
         <Overflow>
           {registeredModelVersions.map((modelVersion) => (
             <React.Fragment key={modelVersion.link}>
-              <Link to={modelVersion.link} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+              <Link componentId="mlflow.logged_models.table.model_version_link" to={modelVersion.link} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
                 {modelVersion.displayedName}
                 <Tag
                   componentId="mlflow.logged_model.name_cell_version_tag"
@@ -205,7 +205,7 @@ export const ExperimentLoggedModelTableNameCell = (props: { data: LoggedModelsTa
       }}
     >
       <RunColorPill color={getStableColorForRun(data.info?.model_id || '')} />
-      <Link to={linkUrl}>{originalName}</Link>
+      <Link componentId="mlflow.logged_models.table.name_link" to={linkUrl}>{originalName}</Link>
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableNameCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableNameCell.tsx
@@ -72,7 +72,11 @@ export const ExperimentLoggedModelTableNameCell = (props: { data: LoggedModelsTa
           description="Tooltip text with link to the original logged model"
           values={{
             originalModelLink: (
-              <Link componentId="mlflow.logged_models.table.original_model_tooltip_link" to={linkUrl} css={{ color: 'inherit', textDecoration: 'underline' }}>
+              <Link
+                componentId="mlflow.logged_models.table.original_model_tooltip_link"
+                to={linkUrl}
+                css={{ color: 'inherit', textDecoration: 'underline' }}
+              >
                 {originalName}
               </Link>
             ),
@@ -122,7 +126,11 @@ export const ExperimentLoggedModelTableNameCell = (props: { data: LoggedModelsTa
           }}
         >
           <RunColorPill color={getStableColorForRun(data.info?.model_id || '')} />
-          <Link componentId="mlflow.logged_models.table.model_name_link" to={primaryModel.link} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+          <Link
+            componentId="mlflow.logged_models.table.model_name_link"
+            to={primaryModel.link}
+            css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}
+          >
             {primaryModel.displayedName}
             <Tag
               componentId="mlflow.logged_model.name_cell_version_tag"
@@ -159,7 +167,11 @@ export const ExperimentLoggedModelTableNameCell = (props: { data: LoggedModelsTa
         <Overflow>
           {registeredModelVersions.map((modelVersion) => (
             <React.Fragment key={modelVersion.link}>
-              <Link componentId="mlflow.logged_models.table.model_version_link" to={modelVersion.link} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+              <Link
+                componentId="mlflow.logged_models.table.model_version_link"
+                to={modelVersion.link}
+                css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}
+              >
                 {modelVersion.displayedName}
                 <Tag
                   componentId="mlflow.logged_model.name_cell_version_tag"
@@ -205,7 +217,9 @@ export const ExperimentLoggedModelTableNameCell = (props: { data: LoggedModelsTa
       }}
     >
       <RunColorPill color={getStableColorForRun(data.info?.model_id || '')} />
-      <Link componentId="mlflow.logged_models.table.name_link" to={linkUrl}>{originalName}</Link>
+      <Link componentId="mlflow.logged_models.table.name_link" to={linkUrl}>
+        {originalName}
+      </Link>
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableRegisteredModelsCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableRegisteredModelsCell.tsx
@@ -19,7 +19,11 @@ export const ExperimentLoggedModelTableRegisteredModelsCell = ({ data }: { data:
       <Overflow>
         {modelVersions.map((modelVersion) => (
           <React.Fragment key={modelVersion.link}>
-            <Link componentId="mlflow.logged_models.table.registered_model_link" to={modelVersion.link} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+            <Link
+              componentId="mlflow.logged_models.table.registered_model_link"
+              to={modelVersion.link}
+              css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}
+            >
               <RegisteredModelOkIcon />
               {modelVersion.displayedName}
               <Tag

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableRegisteredModelsCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableRegisteredModelsCell.tsx
@@ -19,7 +19,7 @@ export const ExperimentLoggedModelTableRegisteredModelsCell = ({ data }: { data:
       <Overflow>
         {modelVersions.map((modelVersion) => (
           <React.Fragment key={modelVersion.link}>
-            <Link to={modelVersion.link} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+            <Link componentId="mlflow.logged_models.table.registered_model_link" to={modelVersion.link} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
               <RegisteredModelOkIcon />
               {modelVersion.displayedName}
               <Tag

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableSourceRunCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableSourceRunCell.tsx
@@ -9,7 +9,7 @@ interface LoggedModelWithSourceRun extends LoggedModelProto {
 export const ExperimentLoggedModelTableSourceRunCell = ({ data }: { data: LoggedModelWithSourceRun }) => {
   if (data.info?.experiment_id && data.info?.source_run_id) {
     return (
-      <Link to={Routes.getRunPageRoute(data.info?.experiment_id, data.info?.source_run_id)} target="_blank">
+      <Link componentId="mlflow.logged_models.table.source_run_link" to={Routes.getRunPageRoute(data.info?.experiment_id, data.info?.source_run_id)} target="_blank">
         {data.sourceRun?.info?.runName ?? data.info?.source_run_id}
       </Link>
     );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableSourceRunCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelTableSourceRunCell.tsx
@@ -9,7 +9,11 @@ interface LoggedModelWithSourceRun extends LoggedModelProto {
 export const ExperimentLoggedModelTableSourceRunCell = ({ data }: { data: LoggedModelWithSourceRun }) => {
   if (data.info?.experiment_id && data.info?.source_run_id) {
     return (
-      <Link componentId="mlflow.logged_models.table.source_run_link" to={Routes.getRunPageRoute(data.info?.experiment_id, data.info?.source_run_id)} target="_blank">
+      <Link
+        componentId="mlflow.logged_models.table.source_run_link"
+        to={Routes.getRunPageRoute(data.info?.experiment_id, data.info?.source_run_id)}
+        target="_blank"
+      >
         {data.sourceRun?.info?.runName ?? data.info?.source_run_id}
       </Link>
     );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelDetailsMetadataV2.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelDetailsMetadataV2.tsx
@@ -81,7 +81,7 @@ export const useExperimentLoggedModelDetailsMetadataV2 = ({
               relatedRunsLoading ? (
                 <GenericSkeleton css={{ width: 200, height: theme.spacing.md }} />
               ) : (
-                <Link to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}>
+                <Link componentId="mlflow.logged_models.details_metadata.source_run_name_link" to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}>
                   {relatedSourceRun?.info?.runName}
                 </Link>
               )
@@ -99,7 +99,7 @@ export const useExperimentLoggedModelDetailsMetadataV2 = ({
               value={loggedModel.info?.source_run_id ?? ''}
               element={
                 loggedModel.info?.experiment_id ? (
-                  <Link to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}>
+                  <Link componentId="mlflow.logged_models.details_metadata.source_run_id_link" to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}>
                     {loggedModel.info?.source_run_id}
                   </Link>
                 ) : undefined

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelDetailsMetadataV2.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelDetailsMetadataV2.tsx
@@ -81,7 +81,10 @@ export const useExperimentLoggedModelDetailsMetadataV2 = ({
               relatedRunsLoading ? (
                 <GenericSkeleton css={{ width: 200, height: theme.spacing.md }} />
               ) : (
-                <Link componentId="mlflow.logged_models.details_metadata.source_run_name_link" to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}>
+                <Link
+                  componentId="mlflow.logged_models.details_metadata.source_run_name_link"
+                  to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}
+                >
                   {relatedSourceRun?.info?.runName}
                 </Link>
               )
@@ -99,7 +102,10 @@ export const useExperimentLoggedModelDetailsMetadataV2 = ({
               value={loggedModel.info?.source_run_id ?? ''}
               element={
                 loggedModel.info?.experiment_id ? (
-                  <Link componentId="mlflow.logged_models.details_metadata.source_run_id_link" to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}>
+                  <Link
+                    componentId="mlflow.logged_models.details_metadata.source_run_id_link"
+                    to={Routes.getRunPageRoute(loggedModel.info?.experiment_id, loggedModel.info?.source_run_id)}
+                  >
                     {loggedModel.info?.source_run_id}
                   </Link>
                 ) : undefined

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
@@ -96,13 +96,21 @@ export const ExperimentViewHeader = React.memo(
     const breadcrumbs: React.ReactNode[] = useMemo(
       () => [
         // eslint-disable-next-line react/jsx-key
-        <Link componentId="mlflow.experiment_tracking.header.experiments_breadcrumb_link" to={Routes.experimentsObservatoryRoute} data-testid="experiment-observatory-link">
+        <Link
+          componentId="mlflow.experiment_tracking.header.experiments_breadcrumb_link"
+          to={Routes.experimentsObservatoryRoute}
+          data-testid="experiment-observatory-link"
+        >
           <FormattedMessage
             defaultMessage="Experiments"
             description="Breadcrumb nav item to link to the list of experiments page"
           />
         </Link>,
-        <Link componentId="mlflow.experiment_tracking.header.experiment_name_breadcrumb_link" to={Routes.getExperimentPageRoute(experiment.experimentId ?? '')} data-testid="experiment-link">
+        <Link
+          componentId="mlflow.experiment_tracking.header.experiment_name_breadcrumb_link"
+          to={Routes.getExperimentPageRoute(experiment.experimentId ?? '')}
+          data-testid="experiment-link"
+        >
           {normalizedExperimentName}
         </Link>,
       ],

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
@@ -96,13 +96,13 @@ export const ExperimentViewHeader = React.memo(
     const breadcrumbs: React.ReactNode[] = useMemo(
       () => [
         // eslint-disable-next-line react/jsx-key
-        <Link to={Routes.experimentsObservatoryRoute} data-testid="experiment-observatory-link">
+        <Link componentId="mlflow.experiment_tracking.header.experiments_breadcrumb_link" to={Routes.experimentsObservatoryRoute} data-testid="experiment-observatory-link">
           <FormattedMessage
             defaultMessage="Experiments"
             description="Breadcrumb nav item to link to the list of experiments page"
           />
         </Link>,
-        <Link to={Routes.getExperimentPageRoute(experiment.experimentId ?? '')} data-testid="experiment-link">
+        <Link componentId="mlflow.experiment_tracking.header.experiment_name_breadcrumb_link" to={Routes.getExperimentPageRoute(experiment.experimentId ?? '')} data-testid="experiment-link">
           {normalizedExperimentName}
         </Link>,
       ],

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeaderCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeaderCompare.tsx
@@ -27,6 +27,7 @@ export const ExperimentViewHeaderCompare = React.memo(({ experiments }: { experi
   const breadcrumbs = useMemo(
     () => [
       <Link
+        componentId="mlflow.experiment_tracking.compare_header.experiments_breadcrumb_link"
         key={Routes.experimentsObservatoryRoute}
         to={Routes.experimentsObservatoryRoute}
         data-testid="experiment-observatory-link"

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/tab-selector-bar/TabSelectorBar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/tab-selector-bar/TabSelectorBar.tsx
@@ -115,6 +115,7 @@ export const TabSelectorBar = ({ experimentKind }: { experimentKind?: Experiment
         return (
           <React.Fragment key={tabName}>
             <Link
+              componentId="mlflow.experiment_tracking.tab_selector.tab_text_link"
               css={{ display: 'none' }}
               className="tab-icon-text"
               key={`${tabName}-text`}
@@ -130,6 +131,7 @@ export const TabSelectorBar = ({ experimentKind }: { experimentKind?: Experiment
               </SegmentedControlButton>
             </Link>
             <Link
+              componentId="mlflow.experiment_tracking.tab_selector.tab_icon_link"
               className="tab-icon-with-tooltip"
               key={`${tabName}-tooltip`}
               to={tabConfig.getRoute(experimentId ?? '')}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetDrawer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetDrawer.tsx
@@ -90,7 +90,7 @@ const ExperimentViewDatasetDrawerImpl = ({
                 description="Text for data details for the experiment run in the dataset drawer"
               />
             </Typography.Title>
-            <Link to={Routes.getRunPageRoute(experimentId, runData.runUuid)} css={styles.runLink}>
+            <Link componentId="mlflow.experiment_tracking.dataset_drawer.run_link" to={Routes.getRunPageRoute(experimentId, runData.runUuid)} css={styles.runLink}>
               <RunColorPill color={getRunColor(runData.runUuid)} />
               <span css={styles.runName}>{runData.runName}</span>
             </Link>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetDrawer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetDrawer.tsx
@@ -90,7 +90,11 @@ const ExperimentViewDatasetDrawerImpl = ({
                 description="Text for data details for the experiment run in the dataset drawer"
               />
             </Typography.Title>
-            <Link componentId="mlflow.experiment_tracking.dataset_drawer.run_link" to={Routes.getRunPageRoute(experimentId, runData.runUuid)} css={styles.runLink}>
+            <Link
+              componentId="mlflow.experiment_tracking.dataset_drawer.run_link"
+              to={Routes.getRunPageRoute(experimentId, runData.runUuid)}
+              css={styles.runLink}
+            >
               <RunColorPill color={getRunColor(runData.runUuid)} />
               <span css={styles.runName}>{runData.runName}</span>
             </Link>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/ExperimentNameCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/ExperimentNameCellRenderer.tsx
@@ -14,7 +14,11 @@ export interface ExperimentNameCellRendererProps {
 // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
 export const ExperimentNameCellRenderer = React.memo(({ data, value }: ExperimentNameCellRendererProps) =>
   !data.experimentId ? null : (
-    <Link componentId="mlflow.experiment_tracking.runs_table.experiment_name_link" to={Routes.getExperimentPageRoute(data.experimentId)} title={value.name}>
+    <Link
+      componentId="mlflow.experiment_tracking.runs_table.experiment_name_link"
+      to={Routes.getExperimentPageRoute(data.experimentId)}
+      title={value.name}
+    >
       {value.basename}
     </Link>
   ),

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/ExperimentNameCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/ExperimentNameCellRenderer.tsx
@@ -14,7 +14,7 @@ export interface ExperimentNameCellRendererProps {
 // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
 export const ExperimentNameCellRenderer = React.memo(({ data, value }: ExperimentNameCellRendererProps) =>
   !data.experimentId ? null : (
-    <Link to={Routes.getExperimentPageRoute(data.experimentId)} title={value.name}>
+    <Link componentId="mlflow.experiment_tracking.runs_table.experiment_name_link" to={Routes.getExperimentPageRoute(data.experimentId)} title={value.name}>
       {value.basename}
     </Link>
   ),

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/GroupParentCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/GroupParentCellRenderer.tsx
@@ -137,6 +137,7 @@ export const GroupParentCellRenderer = ({ data, isComparingRuns }: GroupParentCe
           }
         >
           <Link
+            componentId="mlflow.experiment_tracking.runs_table.group_parent_link"
             to={urlToRunUuidsFilter}
             target="_blank"
             css={{

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/ModelsCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/ModelsCellRenderer.tsx
@@ -69,6 +69,7 @@ const ModelLink = ({
             values={{
               originalModelLink: (
                 <Link
+                  componentId="mlflow.experiment_tracking.runs_table.logged_model_tooltip_link"
                   to={Routes.getExperimentLoggedModelDetailsPage(loggedModelExperimentId, loggedModelId)}
                   css={{ color: 'inherit', textDecoration: 'underline' }}
                 >
@@ -135,6 +136,7 @@ const ModelLink = ({
         {renderModelIcon()}
       </div>
       <Link
+        componentId="mlflow.experiment_tracking.runs_table.model_version_link"
         to={renderModelLink()}
         target="_blank"
         css={{ textOverflow: 'ellipsis', overflow: 'hidden', cursor: 'pointer' }}
@@ -157,6 +159,7 @@ const LoggedModelV3Link = ({ model }: { model: LoggedModelProto }) => {
         <ModelsIcon css={{ color: theme.colors.actionPrimaryBackgroundDefault }} />
       </div>
       <Link
+        componentId="mlflow.experiment_tracking.runs_table.logged_model_v3_link"
         to={Routes.getExperimentLoggedModelDetailsPage(model.info.experiment_id, model.info.model_id)}
         target="_blank"
         css={{ textOverflow: 'ellipsis', overflow: 'hidden', cursor: 'pointer' }}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RunNameCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RunNameCellRenderer.tsx
@@ -78,7 +78,7 @@ export const RunNameCellRenderer = React.memo((props: RunNameCellRendererProps) 
             onChangeColor={(colorValue) => saveRunColor({ runUuid, colorValue })}
           />
         )}
-        <Link to={Routes.getRunPageRoute(experimentId, runUuid)} css={styles.runLink} tabIndex={0}>
+        <Link componentId="mlflow.experiment_tracking.runs_table.run_name_link" to={Routes.getRunPageRoute(experimentId, runUuid)} css={styles.runLink} tabIndex={0}>
           <span css={styles.runName}>{runName}</span>
         </Link>
       </div>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RunNameCellRenderer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/cells/RunNameCellRenderer.tsx
@@ -78,7 +78,12 @@ export const RunNameCellRenderer = React.memo((props: RunNameCellRendererProps) 
             onChangeColor={(colorValue) => saveRunColor({ runUuid, colorValue })}
           />
         )}
-        <Link componentId="mlflow.experiment_tracking.runs_table.run_name_link" to={Routes.getRunPageRoute(experimentId, runUuid)} css={styles.runLink} tabIndex={0}>
+        <Link
+          componentId="mlflow.experiment_tracking.runs_table.run_name_link"
+          to={Routes.getRunPageRoute(experimentId, runUuid)}
+          css={styles.runLink}
+          tabIndex={0}
+        >
           <span css={styles.runName}>{runName}</span>
         </Link>
       </div>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useIssueDetectionNotification.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useIssueDetectionNotification.tsx
@@ -48,7 +48,10 @@ export const useIssueDetectionNotification = (experimentId?: string) => {
             <Notification.Description>
               <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
                 {evaluationRunsLink && (
-                  <Link componentId="mlflow.experiment_tracking.traces.issue_detection_notification_link" to={evaluationRunsLink}>
+                  <Link
+                    componentId="mlflow.experiment_tracking.traces.issue_detection_notification_link"
+                    to={evaluationRunsLink}
+                  >
                     <FormattedMessage
                       defaultMessage="View status"
                       description="Link to view issue detection job status"

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useIssueDetectionNotification.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useIssueDetectionNotification.tsx
@@ -48,7 +48,7 @@ export const useIssueDetectionNotification = (experimentId?: string) => {
             <Notification.Description>
               <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
                 {evaluationRunsLink && (
-                  <Link to={evaluationRunsLink}>
+                  <Link componentId="mlflow.experiment_tracking.traces.issue_detection_notification_link" to={evaluationRunsLink}>
                     <FormattedMessage
                       defaultMessage="View status"
                       description="Link to view issue detection job status"

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-prompts/ExperimentLinkedPromptsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-prompts/ExperimentLinkedPromptsTable.tsx
@@ -40,10 +40,10 @@ const PromptNameCellRenderer: ColumnDef<LinkedPromptsRow>['cell'] = ({ row }) =>
     const searchParams = new URLSearchParams();
     searchParams.set(PROMPT_VERSION_QUERY_PARAM, version);
     const routeWithVersion = `${baseRoute}?${searchParams.toString()}`;
-    return <Link to={routeWithVersion}>{name}</Link>;
+    return <Link componentId="mlflow.experiment_tracking.linked_prompts.prompt_version_link" to={routeWithVersion}>{name}</Link>;
   }
 
-  return <Link to={baseRoute}>{name}</Link>;
+  return <Link componentId="mlflow.experiment_tracking.linked_prompts.prompt_name_link" to={baseRoute}>{name}</Link>;
 };
 
 const VersionCellRenderer: ColumnDef<LinkedPromptsRow>['cell'] = ({ row }) => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-prompts/ExperimentLinkedPromptsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-prompts/ExperimentLinkedPromptsTable.tsx
@@ -40,10 +40,18 @@ const PromptNameCellRenderer: ColumnDef<LinkedPromptsRow>['cell'] = ({ row }) =>
     const searchParams = new URLSearchParams();
     searchParams.set(PROMPT_VERSION_QUERY_PARAM, version);
     const routeWithVersion = `${baseRoute}?${searchParams.toString()}`;
-    return <Link componentId="mlflow.experiment_tracking.linked_prompts.prompt_version_link" to={routeWithVersion}>{name}</Link>;
+    return (
+      <Link componentId="mlflow.experiment_tracking.linked_prompts.prompt_version_link" to={routeWithVersion}>
+        {name}
+      </Link>
+    );
   }
 
-  return <Link componentId="mlflow.experiment_tracking.linked_prompts.prompt_name_link" to={baseRoute}>{name}</Link>;
+  return (
+    <Link componentId="mlflow.experiment_tracking.linked_prompts.prompt_name_link" to={baseRoute}>
+      {name}
+    </Link>
+  );
 };
 
 const VersionCellRenderer: ColumnDef<LinkedPromptsRow>['cell'] = ({ row }) => {

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
@@ -91,7 +91,10 @@ export const RunViewHeader = ({
 
   function getExperimentPageLink() {
     return hasComparedExperimentsBefore && comparedExperimentIds ? (
-      <Link componentId="mlflow.run_page.header.compare_experiments_link" to={Routes.getCompareExperimentsPageRoute(comparedExperimentIds)}>
+      <Link
+        componentId="mlflow.run_page.header.compare_experiments_link"
+        to={Routes.getCompareExperimentsPageRoute(comparedExperimentIds)}
+      >
         <FormattedMessage
           defaultMessage="Displaying Runs from {numExperiments} Experiments"
           description="Breadcrumb nav item to link to the compare-experiments page on compare runs page"
@@ -101,7 +104,11 @@ export const RunViewHeader = ({
         />
       </Link>
     ) : (
-      <Link componentId="mlflow.run_page.header.experiment_name_link" to={experimentPageTabRoute} data-testid="experiment-runs-link">
+      <Link
+        componentId="mlflow.run_page.header.experiment_name_link"
+        to={experimentPageTabRoute}
+        data-testid="experiment-runs-link"
+      >
         {experiment.name}
       </Link>
     );
@@ -110,7 +117,11 @@ export const RunViewHeader = ({
   const defaultBreadcrumbs = [getExperimentPageLink()];
   if (experiment.experimentId) {
     defaultBreadcrumbs.push(
-      <Link componentId="mlflow.run_page.header.experiment_tab_link" to={experimentPageTabRoute} data-testid="experiment-observatory-link-runs">
+      <Link
+        componentId="mlflow.run_page.header.experiment_tab_link"
+        to={experimentPageTabRoute}
+        data-testid="experiment-observatory-link-runs"
+      >
         {shouldRouteToEvaluations ? (
           <FormattedMessage
             defaultMessage="Evaluations"

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.tsx
@@ -91,7 +91,7 @@ export const RunViewHeader = ({
 
   function getExperimentPageLink() {
     return hasComparedExperimentsBefore && comparedExperimentIds ? (
-      <Link to={Routes.getCompareExperimentsPageRoute(comparedExperimentIds)}>
+      <Link componentId="mlflow.run_page.header.compare_experiments_link" to={Routes.getCompareExperimentsPageRoute(comparedExperimentIds)}>
         <FormattedMessage
           defaultMessage="Displaying Runs from {numExperiments} Experiments"
           description="Breadcrumb nav item to link to the compare-experiments page on compare runs page"
@@ -101,7 +101,7 @@ export const RunViewHeader = ({
         />
       </Link>
     ) : (
-      <Link to={experimentPageTabRoute} data-testid="experiment-runs-link">
+      <Link componentId="mlflow.run_page.header.experiment_name_link" to={experimentPageTabRoute} data-testid="experiment-runs-link">
         {experiment.name}
       </Link>
     );
@@ -110,7 +110,7 @@ export const RunViewHeader = ({
   const defaultBreadcrumbs = [getExperimentPageLink()];
   if (experiment.experimentId) {
     defaultBreadcrumbs.push(
-      <Link to={experimentPageTabRoute} data-testid="experiment-observatory-link-runs">
+      <Link componentId="mlflow.run_page.header.experiment_tab_link" to={experimentPageTabRoute} data-testid="experiment-observatory-link-runs">
         {shouldRouteToEvaluations ? (
           <FormattedMessage
             defaultMessage="Evaluations"

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterFromLoggedModelV3Button.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterFromLoggedModelV3Button.tsx
@@ -65,6 +65,7 @@ export const RunViewHeaderRegisterFromLoggedModelV3Button = ({
                   <div css={{ marginRight: theme.spacing.md }}>{model.info?.name}</div>
                   <DropdownMenu.HintColumn>
                     <Link
+                      componentId="mlflow.run_page.header.register_model_v3_view_link"
                       target="_blank"
                       to={Routes.getExperimentLoggedModelDetailsPage(experimentId, model.info?.model_id ?? '')}
                     >

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterModelButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterModelButton.tsx
@@ -57,6 +57,7 @@ function LoggedModelsDropdownContent({
                 <div css={{ marginRight: theme.spacing.md }}>{last(model.path.split('/'))}</div>
                 <DropdownMenu.HintColumn>
                   <Link
+                    componentId="mlflow.run_page.header.register_model_view_link"
                     target="_blank"
                     to={Routes.getRunPageTabRoute(experimentId, runUuid, 'artifacts/' + model.path)}
                   >
@@ -82,7 +83,7 @@ function LoggedModelsDropdownContent({
           const { status, displayedName, version, link } = registeredModelSummary;
 
           return (
-            <Link target="_blank" to={link} key={model.absolutePath}>
+            <Link componentId="mlflow.run_page.header.registered_model_version_link" target="_blank" to={link} key={model.absolutePath}>
               <DropdownMenu.Item componentId="codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_80">
                 <DropdownMenu.IconWrapper css={{ display: 'flex', alignItems: 'center' }}>
                   {status === 'READY' ? <RegisteredModelOkIcon /> : status ? ModelVersionStatusIcons[status] : null}
@@ -236,7 +237,7 @@ export const RunViewHeaderRegisterModelButton = ({
 
   if (registeredModelVersionSummary) {
     return (
-      <Link to={registeredModelVersionSummary.link} target="_blank" css={{ marginLeft: theme.spacing.sm }}>
+      <Link componentId="mlflow.run_page.header.view_registered_model_link" to={registeredModelVersionSummary.link} target="_blank" css={{ marginLeft: theme.spacing.sm }}>
         <Button
           componentId="codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_231"
           endIcon={<NewWindowIcon />}

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterModelButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterModelButton.tsx
@@ -83,7 +83,12 @@ function LoggedModelsDropdownContent({
           const { status, displayedName, version, link } = registeredModelSummary;
 
           return (
-            <Link componentId="mlflow.run_page.header.registered_model_version_link" target="_blank" to={link} key={model.absolutePath}>
+            <Link
+              componentId="mlflow.run_page.header.registered_model_version_link"
+              target="_blank"
+              to={link}
+              key={model.absolutePath}
+            >
               <DropdownMenu.Item componentId="codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_80">
                 <DropdownMenu.IconWrapper css={{ display: 'flex', alignItems: 'center' }}>
                   {status === 'READY' ? <RegisteredModelOkIcon /> : status ? ModelVersionStatusIcons[status] : null}
@@ -237,7 +242,12 @@ export const RunViewHeaderRegisterModelButton = ({
 
   if (registeredModelVersionSummary) {
     return (
-      <Link componentId="mlflow.run_page.header.view_registered_model_link" to={registeredModelVersionSummary.link} target="_blank" css={{ marginLeft: theme.spacing.sm }}>
+      <Link
+        componentId="mlflow.run_page.header.view_registered_model_link"
+        to={registeredModelVersionSummary.link}
+        target="_blank"
+        css={{ marginLeft: theme.spacing.sm }}
+      >
         <Button
           componentId="codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_231"
           endIcon={<NewWindowIcon />}

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useRunDetailsPageOverviewSectionsV2.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useRunDetailsPageOverviewSectionsV2.tsx
@@ -94,7 +94,7 @@ export const useRunDetailsPageOverviewSectionsV2 = ({
             value={runInfo?.experimentId ?? ''}
             element={
               runInfo?.experimentId ? (
-                <Link to={Routes.getExperimentPageRoute(runInfo.experimentId)}>{runInfo?.experimentId}</Link>
+                <Link componentId="mlflow.run_page.overview.experiment_id_link" to={Routes.getExperimentPageRoute(runInfo.experimentId)}>{runInfo?.experimentId}</Link>
               ) : undefined
             }
           />

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useRunDetailsPageOverviewSectionsV2.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/hooks/useRunDetailsPageOverviewSectionsV2.tsx
@@ -94,7 +94,12 @@ export const useRunDetailsPageOverviewSectionsV2 = ({
             value={runInfo?.experimentId ?? ''}
             element={
               runInfo?.experimentId ? (
-                <Link componentId="mlflow.run_page.overview.experiment_id_link" to={Routes.getExperimentPageRoute(runInfo.experimentId)}>{runInfo?.experimentId}</Link>
+                <Link
+                  componentId="mlflow.run_page.overview.experiment_id_link"
+                  to={Routes.getExperimentPageRoute(runInfo.experimentId)}
+                >
+                  {runInfo?.experimentId}
+                </Link>
               ) : undefined
             }
           />

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/IssueDetectionRunOverview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/IssueDetectionRunOverview.tsx
@@ -66,7 +66,12 @@ export const IssueDetectionRunOverview = ({
               value={runInfo?.experimentId ?? ''}
               element={
                 runInfo?.experimentId ? (
-                  <Link componentId="mlflow.run_page.overview.issue_detection_experiment_link" to={Routes.getExperimentPageRoute(runInfo.experimentId)}>{runInfo?.experimentId}</Link>
+                  <Link
+                    componentId="mlflow.run_page.overview.issue_detection_experiment_link"
+                    to={Routes.getExperimentPageRoute(runInfo.experimentId)}
+                  >
+                    {runInfo?.experimentId}
+                  </Link>
                 ) : undefined
               }
             />

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/IssueDetectionRunOverview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/IssueDetectionRunOverview.tsx
@@ -66,7 +66,7 @@ export const IssueDetectionRunOverview = ({
               value={runInfo?.experimentId ?? ''}
               element={
                 runInfo?.experimentId ? (
-                  <Link to={Routes.getExperimentPageRoute(runInfo.experimentId)}>{runInfo?.experimentId}</Link>
+                  <Link componentId="mlflow.run_page.overview.issue_detection_experiment_link" to={Routes.getExperimentPageRoute(runInfo.experimentId)}>{runInfo?.experimentId}</Link>
                 ) : undefined
               }
             />

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewChildRunsBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewChildRunsBox.tsx
@@ -92,7 +92,12 @@ export const RunViewChildRunsBox = ({ runUuid, experimentId }: { runUuid: string
         >
           {childRuns.map((info, index) => (
             <Typography.Text key={info.runUuid} css={{ whiteSpace: 'nowrap' }}>
-              <Link componentId="mlflow.run_page.overview.child_run_link" to={Routes.getRunPageRoute(info.experimentId, info.runUuid)}>{info.runName}</Link>
+              <Link
+                componentId="mlflow.run_page.overview.child_run_link"
+                to={Routes.getRunPageRoute(info.experimentId, info.runUuid)}
+              >
+                {info.runName}
+              </Link>
               {index < childRuns.length - 1 && ','}
             </Typography.Text>
           ))}

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewChildRunsBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewChildRunsBox.tsx
@@ -92,7 +92,7 @@ export const RunViewChildRunsBox = ({ runUuid, experimentId }: { runUuid: string
         >
           {childRuns.map((info, index) => (
             <Typography.Text key={info.runUuid} css={{ whiteSpace: 'nowrap' }}>
-              <Link to={Routes.getRunPageRoute(info.experimentId, info.runUuid)}>{info.runName}</Link>
+              <Link componentId="mlflow.run_page.overview.child_run_link" to={Routes.getRunPageRoute(info.experimentId, info.runUuid)}>{info.runName}</Link>
               {index < childRuns.length - 1 && ','}
             </Typography.Text>
           ))}

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewLoggedModelsBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewLoggedModelsBox.tsx
@@ -51,6 +51,7 @@ export const RunViewLoggedModelsBox = ({
       {loggedModels.map((model, index) => {
         return (
           <Link
+            componentId="mlflow.run_page.overview.logged_model_link"
             to={Routes.getRunPageRoute(experimentId ?? '', runUuid ?? '', model.artifactPath)}
             key={model.artifactPath}
             css={{
@@ -72,6 +73,7 @@ export const RunViewLoggedModelsBox = ({
       {loggedModelsV3.map((model, index) => {
         return (
           <Link
+            componentId="mlflow.run_page.overview.logged_model_v3_link"
             to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId ?? '', model.info?.model_id ?? '')}
             key={model.info?.model_id ?? index}
             css={{

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewMetricsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewMetricsTable.tsx
@@ -89,6 +89,7 @@ const RunViewMetricsTableSection = ({
               }}
             >
               <Link
+                componentId="mlflow.run_page.overview.metric_chart_link"
                 to={Routes.getRunPageTabRoute(
                   runInfo.experimentId ?? '',
                   runInfo.runUuid ?? '',
@@ -115,6 +116,7 @@ const RunViewMetricsTableSection = ({
                   <Overflow>
                     {loggedModels?.map((model) => (
                       <Link
+                        componentId="mlflow.run_page.overview.metric_model_link"
                         key={model.info?.model_id}
                         target="_blank"
                         rel="noopener noreferrer"

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewParentRunBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewParentRunBox.tsx
@@ -54,6 +54,11 @@ export const RunViewParentRunBox = ({ parentRunUuid }: { parentRunUuid: string }
   }
 
   return (
-    <Link componentId="mlflow.run_page.overview.parent_run_link" to={Routes.getRunPageRoute(parentRunInfo.experimentId, parentRunInfo.runUuid)}>{parentRunInfo.runName}</Link>
+    <Link
+      componentId="mlflow.run_page.overview.parent_run_link"
+      to={Routes.getRunPageRoute(parentRunInfo.experimentId, parentRunInfo.runUuid)}
+    >
+      {parentRunInfo.runName}
+    </Link>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewParentRunBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewParentRunBox.tsx
@@ -54,6 +54,6 @@ export const RunViewParentRunBox = ({ parentRunUuid }: { parentRunUuid: string }
   }
 
   return (
-    <Link to={Routes.getRunPageRoute(parentRunInfo.experimentId, parentRunInfo.runUuid)}>{parentRunInfo.runName}</Link>
+    <Link componentId="mlflow.run_page.overview.parent_run_link" to={Routes.getRunPageRoute(parentRunInfo.experimentId, parentRunInfo.runUuid)}>{parentRunInfo.runName}</Link>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredModelsBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredModelsBox.tsx
@@ -18,6 +18,7 @@ export const RunViewRegisteredModelsBox = ({
     <Overflow>
       {registeredModelVersionSummaries?.map((modelSummary) => (
         <Link
+          componentId="mlflow.run_page.overview.registered_model_link"
           key={modelSummary.displayedName}
           to={modelSummary.link}
           css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredPromptsBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredPromptsBox.tsx
@@ -43,7 +43,7 @@ export const RunViewRegisteredPromptsBox = ({
         const displayText = `${promptVersion.name} (v${promptVersion.version})`;
         return (
           <Typography.Text key={displayText} css={{ whiteSpace: 'nowrap' }}>
-            <Link to={to}>{displayText}</Link>
+            <Link componentId="mlflow.run_page.overview.registered_prompt_link" to={to}>{displayText}</Link>
             {index < promptVersions.length - 1 && ','}
           </Typography.Text>
         );

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredPromptsBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredPromptsBox.tsx
@@ -43,7 +43,9 @@ export const RunViewRegisteredPromptsBox = ({
         const displayText = `${promptVersion.name} (v${promptVersion.version})`;
         return (
           <Typography.Text key={displayText} css={{ whiteSpace: 'nowrap' }}>
-            <Link componentId="mlflow.run_page.overview.registered_prompt_link" to={to}>{displayText}</Link>
+            <Link componentId="mlflow.run_page.overview.registered_prompt_link" to={to}>
+              {displayText}
+            </Link>
             {index < promptVersions.length - 1 && ','}
           </Typography.Text>
         );

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewUserLinkBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewUserLinkBox.tsx
@@ -13,5 +13,12 @@ export const RunViewUserLinkBox = ({
   tags: Record<string, KeyValueEntity>;
 }) => {
   const user = Utils.getUser(runInfo, tags);
-  return <Link componentId="mlflow.run_page.overview.user_link" to={Routes.searchRunsByUser(runInfo?.experimentId ?? '', user)}>{user}</Link>;
+  return (
+    <Link
+      componentId="mlflow.run_page.overview.user_link"
+      to={Routes.searchRunsByUser(runInfo?.experimentId ?? '', user)}
+    >
+      {user}
+    </Link>
+  );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewUserLinkBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewUserLinkBox.tsx
@@ -13,5 +13,5 @@ export const RunViewUserLinkBox = ({
   tags: Record<string, KeyValueEntity>;
 }) => {
   const user = Utils.getUser(runInfo, tags);
-  return <Link to={Routes.searchRunsByUser(runInfo?.experimentId ?? '', user)}>{user}</Link>;
+  return <Link componentId="mlflow.run_page.overview.user_link" to={Routes.searchRunsByUser(runInfo?.experimentId ?? '', user)}>{user}</Link>;
 };

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -304,6 +304,7 @@ export const RunsChartsTooltipBody = ({
             <Typography.Text>{runName + metricSuffix}</Typography.Text>
           ) : (
             <Link
+              componentId="mlflow.experiment_tracking.charts.tooltip_run_link"
               to={getDataTraceLink?.(experimentId, runUuid) ?? Routes.getRunPageRoute(experimentId, runUuid)}
               target="_blank"
               css={styles.runLink}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/DatasetLink.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/DatasetLink.tsx
@@ -37,6 +37,7 @@ export const DatasetLink = ({
 
     return (
       <Link
+        componentId="mlflow.experiment_tracking.evaluation_datasets.dataset_link"
         to={{
           pathname,
           search: searchParams.toString(),

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -135,6 +135,7 @@ export const RunNameCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({
           }}
         >
           <Link
+            componentId="mlflow.experiment_tracking.evaluation_runs.run_link"
             target="_blank"
             rel="noreferrer"
             to={Routes.getRunPageTabRoute(row.original.info.experimentId, runUuid, RunPageTabName.EVALUATIONS)}
@@ -252,6 +253,7 @@ export const ModelVersionCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({ row 
         css={{ maxWidth: '100%', marginRight: 0, cursor: 'pointer' }}
       >
         <Link
+          componentId="mlflow.experiment_tracking.evaluation_runs.model_version_link"
           to={Routes.getExperimentLoggedModelDetailsPageRoute(row.original.info.experimentId, modelId)}
           target="_blank"
           css={{ maxWidth: '100%' }}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage.tsx
@@ -23,16 +23,17 @@ export const IssueDetectionRunDetailsPage = () => {
   const customBreadcrumbs = useMemo(() => {
     const experimentName = experiment?.name ?? safeExperimentId;
     return [
-      <Link key="experiments" to={Routes.experimentsObservatoryRoute}>
+      <Link componentId="mlflow.experiment_tracking.issue_detection.breadcrumb_experiments_link" key="experiments" to={Routes.experimentsObservatoryRoute}>
         <FormattedMessage
           defaultMessage="Experiments"
           description="Issue detection run details > Breadcrumb > Experiments"
         />
       </Link>,
-      <Link key="experiment" to={Routes.getExperimentPageRoute(safeExperimentId)}>
+      <Link componentId="mlflow.experiment_tracking.issue_detection.breadcrumb_experiment_link" key="experiment" to={Routes.getExperimentPageRoute(safeExperimentId)}>
         {experimentName}
       </Link>,
       <Link
+        componentId="mlflow.experiment_tracking.issue_detection.breadcrumb_evaluation_runs_link"
         key="evaluation-runs"
         to={Routes.getExperimentPageTabRoute(safeExperimentId, ExperimentPageTabName.EvaluationRuns)}
       >

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage.tsx
@@ -23,13 +23,21 @@ export const IssueDetectionRunDetailsPage = () => {
   const customBreadcrumbs = useMemo(() => {
     const experimentName = experiment?.name ?? safeExperimentId;
     return [
-      <Link componentId="mlflow.experiment_tracking.issue_detection.breadcrumb_experiments_link" key="experiments" to={Routes.experimentsObservatoryRoute}>
+      <Link
+        componentId="mlflow.experiment_tracking.issue_detection.breadcrumb_experiments_link"
+        key="experiments"
+        to={Routes.experimentsObservatoryRoute}
+      >
         <FormattedMessage
           defaultMessage="Experiments"
           description="Issue detection run details > Breadcrumb > Experiments"
         />
       </Link>,
-      <Link componentId="mlflow.experiment_tracking.issue_detection.breadcrumb_experiment_link" key="experiment" to={Routes.getExperimentPageRoute(safeExperimentId)}>
+      <Link
+        componentId="mlflow.experiment_tracking.issue_detection.breadcrumb_experiment_link"
+        key="experiment"
+        to={Routes.getExperimentPageRoute(safeExperimentId)}
+      >
         {experimentName}
       </Link>,
       <Link

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageSubTabSelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageSubTabSelector.tsx
@@ -23,6 +23,7 @@ export const ExperimentPageSubTabSelector = ({
         <Tabs.List>
           <Tabs.Trigger value={ExperimentPageTabName.EvaluationRuns}>
             <Link
+              componentId="mlflow.experiment_tracking.sub_tab_selector.runs_tab_link"
               css={{ color: theme.colors.textPrimary }}
               to={Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.EvaluationRuns)}
             >
@@ -34,6 +35,7 @@ export const ExperimentPageSubTabSelector = ({
           </Tabs.Trigger>
           <Tabs.Trigger value={ExperimentPageTabName.Datasets}>
             <Link
+              componentId="mlflow.experiment_tracking.sub_tab_selector.datasets_tab_link"
               css={{ color: theme.colors.textPrimary }}
               to={Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Datasets)}
             >

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavSection.tsx
@@ -79,6 +79,7 @@ export const ExperimentPageSideNavSection = ({
 
         return (
           <Link
+            componentId="mlflow.experiment_tracking.side_nav.section_item_link"
             key={`${sectionKey}-${item.tabName}`}
             to={{
               pathname: Routes.getExperimentPageTabRoute(experimentId, item.tabName),

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
@@ -165,7 +165,7 @@ const PromptsDetailsPage = ({ experimentId }: { experimentId?: string } = {}) =>
   const breadcrumbs = !experimentId ? (
     <Breadcrumb>
       <Breadcrumb.Item>
-        <Link to={Routes.promptsPageRoute}>Prompts</Link>
+        <Link componentId="mlflow.prompts.details.breadcrumb_link" to={Routes.promptsPageRoute}>Prompts</Link>
       </Breadcrumb.Item>
     </Breadcrumb>
   ) : undefined;

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
@@ -165,7 +165,9 @@ const PromptsDetailsPage = ({ experimentId }: { experimentId?: string } = {}) =>
   const breadcrumbs = !experimentId ? (
     <Breadcrumb>
       <Breadcrumb.Item>
-        <Link componentId="mlflow.prompts.details.breadcrumb_link" to={Routes.promptsPageRoute}>Prompts</Link>
+        <Link componentId="mlflow.prompts.details.breadcrumb_link" to={Routes.promptsPageRoute}>
+          Prompts
+        </Link>
       </Breadcrumb.Item>
     </Breadcrumb>
   ) : undefined;

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionRuns.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionRuns.tsx
@@ -44,7 +44,7 @@ export const PromptVersionRuns = ({
                   return (
                     // eslint-disable-next-line react/jsx-key
                     <Typography.Text>
-                      <Link to={Routes.getRunPageRoute(experimentId, runUuid)}>{runName}</Link>
+                      <Link componentId="mlflow.prompts.version_runs.run_link" to={Routes.getRunPageRoute(experimentId, runUuid)}>{runName}</Link>
                       {index < visibleCount - 1 && ','}
                     </Typography.Text>
                   );

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionRuns.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionRuns.tsx
@@ -44,7 +44,12 @@ export const PromptVersionRuns = ({
                   return (
                     // eslint-disable-next-line react/jsx-key
                     <Typography.Text>
-                      <Link componentId="mlflow.prompts.version_runs.run_link" to={Routes.getRunPageRoute(experimentId, runUuid)}>{runName}</Link>
+                      <Link
+                        componentId="mlflow.prompts.version_runs.run_link"
+                        to={Routes.getRunPageRoute(experimentId, runUuid)}
+                      >
+                        {runName}
+                      </Link>
                       {index < visibleCount - 1 && ','}
                     </Typography.Text>
                   );

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTableNameCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTableNameCell.tsx
@@ -17,5 +17,12 @@ export const PromptsListTableNameCell: ColumnDef<RegisteredPrompt>['cell'] = ({
   if (!original.name) {
     return name;
   }
-  return <Link componentId="mlflow.prompts.list.prompt_name_link" to={Routes.getPromptDetailsPageRoute(encodeURIComponent(original.name), experimentId)}>{name}</Link>;
+  return (
+    <Link
+      componentId="mlflow.prompts.list.prompt_name_link"
+      to={Routes.getPromptDetailsPageRoute(encodeURIComponent(original.name), experimentId)}
+    >
+      {name}
+    </Link>
+  );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTableNameCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTableNameCell.tsx
@@ -17,5 +17,5 @@ export const PromptsListTableNameCell: ColumnDef<RegisteredPrompt>['cell'] = ({
   if (!original.name) {
     return name;
   }
-  return <Link to={Routes.getPromptDetailsPageRoute(encodeURIComponent(original.name), experimentId)}>{name}</Link>;
+  return <Link componentId="mlflow.prompts.list.prompt_name_link" to={Routes.getPromptDetailsPageRoute(encodeURIComponent(original.name), experimentId)}>{name}</Link>;
 };

--- a/mlflow/server/js/src/gateway/components/api-keys/BindingsUsingKeyDrawer.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/BindingsUsingKeyDrawer.tsx
@@ -120,6 +120,7 @@ export const BindingsUsingKeyDrawer = ({ open, bindings, endpoints, onClose }: B
                           />
                         </Typography.Text>
                         <Link
+                          componentId="mlflow.gateway.api_keys.binding_endpoint_link"
                           to={GatewayRoutes.getEndpointDetailsRoute(binding.endpoint_id)}
                           css={{
                             fontSize: theme.typography.fontSizeSm,

--- a/mlflow/server/js/src/gateway/components/api-keys/EndpointsUsingKeyDrawer.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/EndpointsUsingKeyDrawer.tsx
@@ -75,6 +75,7 @@ export const EndpointsUsingKeyDrawer = ({ open, keyName, endpoints, onClose }: E
                   }}
                 >
                   <Link
+                    componentId="mlflow.gateway.api_keys.endpoint_link"
                     to={GatewayRoutes.getEndpointDetailsRoute(endpoint.endpoint_id)}
                     css={{
                       color: theme.colors.actionPrimaryBackgroundDefault,

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -151,12 +151,18 @@ export const EditEndpointFormRenderer = ({
       <div css={{ padding: theme.spacing.md }}>
         <Breadcrumb includeTrailingCaret>
           <Breadcrumb.Item>
-            <Link componentId="mlflow.gateway.edit_endpoint.breadcrumb_gateway_link" to={GatewayRoutes.gatewayPageRoute}>
+            <Link
+              componentId="mlflow.gateway.edit_endpoint.breadcrumb_gateway_link"
+              to={GatewayRoutes.gatewayPageRoute}
+            >
               <FormattedMessage defaultMessage="AI Gateway" description="Breadcrumb link to gateway page" />
             </Link>
           </Breadcrumb.Item>
           <Breadcrumb.Item>
-            <Link componentId="mlflow.gateway.edit_endpoint.breadcrumb_endpoints_link" to={GatewayRoutes.gatewayPageRoute}>
+            <Link
+              componentId="mlflow.gateway.edit_endpoint.breadcrumb_endpoints_link"
+              to={GatewayRoutes.gatewayPageRoute}
+            >
               <FormattedMessage defaultMessage="Endpoints" description="Breadcrumb link to endpoints list" />
             </Link>
           </Breadcrumb.Item>

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -44,6 +44,7 @@ const LogsTabContent = ({ experimentId }: { experimentId: string }) => {
       >
         <TracesV3DateSelector excludeOptions={['ALL']} />
         <Link
+          componentId="mlflow.gateway.edit_endpoint.traces_link"
           to={`/experiments/${experimentId}/traces`}
           css={{
             color: theme.colors.actionPrimaryBackgroundDefault,
@@ -150,12 +151,12 @@ export const EditEndpointFormRenderer = ({
       <div css={{ padding: theme.spacing.md }}>
         <Breadcrumb includeTrailingCaret>
           <Breadcrumb.Item>
-            <Link to={GatewayRoutes.gatewayPageRoute}>
+            <Link componentId="mlflow.gateway.edit_endpoint.breadcrumb_gateway_link" to={GatewayRoutes.gatewayPageRoute}>
               <FormattedMessage defaultMessage="AI Gateway" description="Breadcrumb link to gateway page" />
             </Link>
           </Breadcrumb.Item>
           <Breadcrumb.Item>
-            <Link to={GatewayRoutes.gatewayPageRoute}>
+            <Link componentId="mlflow.gateway.edit_endpoint.breadcrumb_endpoints_link" to={GatewayRoutes.gatewayPageRoute}>
               <FormattedMessage defaultMessage="Endpoints" description="Breadcrumb link to endpoints list" />
             </Link>
           </Breadcrumb.Item>

--- a/mlflow/server/js/src/gateway/components/endpoints/EndpointRow.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoints/EndpointRow.tsx
@@ -27,6 +27,7 @@ export const EndpointRow = ({ endpoint, bindings, visibleColumns, onViewBindings
         <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
           <ChainIcon css={{ color: theme.colors.textSecondary, flexShrink: 0 }} />
           <Link
+            componentId="mlflow.gateway.endpoints.endpoint_name_link"
             to={GatewayRoutes.getEndpointDetailsRoute(endpoint.endpoint_id)}
             css={{
               color: theme.colors.actionPrimaryBackgroundDefault,

--- a/mlflow/server/js/src/gateway/components/side-nav/GatewaySideNav.tsx
+++ b/mlflow/server/js/src/gateway/components/side-nav/GatewaySideNav.tsx
@@ -99,7 +99,7 @@ export const GatewaySideNav = ({ activeTab }: GatewaySideNavProps) => {
         const isActive = activeTab === item.tab;
 
         return (
-          <Link key={item.tab} to={item.to}>
+          <Link componentId="mlflow.gateway.side_nav.tab_link" key={item.tab} to={item.to}>
             <div
               css={{
                 display: 'flex',

--- a/mlflow/server/js/src/gateway/pages/CreateEndpointPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/CreateEndpointPage.tsx
@@ -35,12 +35,12 @@ const CreateEndpointPage = () => {
         <div css={{ padding: theme.spacing.md }}>
           <Breadcrumb includeTrailingCaret>
             <Breadcrumb.Item>
-              <Link to={GatewayRoutes.gatewayPageRoute}>
+              <Link componentId="mlflow.gateway.create_endpoint.breadcrumb_gateway_link" to={GatewayRoutes.gatewayPageRoute}>
                 <FormattedMessage defaultMessage="AI Gateway" description="Breadcrumb link to gateway page" />
               </Link>
             </Breadcrumb.Item>
             <Breadcrumb.Item>
-              <Link to={GatewayRoutes.gatewayPageRoute}>
+              <Link componentId="mlflow.gateway.create_endpoint.breadcrumb_endpoints_link" to={GatewayRoutes.gatewayPageRoute}>
                 <FormattedMessage defaultMessage="Endpoints" description="Breadcrumb link to endpoints list" />
               </Link>
             </Breadcrumb.Item>

--- a/mlflow/server/js/src/gateway/pages/CreateEndpointPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/CreateEndpointPage.tsx
@@ -35,12 +35,18 @@ const CreateEndpointPage = () => {
         <div css={{ padding: theme.spacing.md }}>
           <Breadcrumb includeTrailingCaret>
             <Breadcrumb.Item>
-              <Link componentId="mlflow.gateway.create_endpoint.breadcrumb_gateway_link" to={GatewayRoutes.gatewayPageRoute}>
+              <Link
+                componentId="mlflow.gateway.create_endpoint.breadcrumb_gateway_link"
+                to={GatewayRoutes.gatewayPageRoute}
+              >
                 <FormattedMessage defaultMessage="AI Gateway" description="Breadcrumb link to gateway page" />
               </Link>
             </Breadcrumb.Item>
             <Breadcrumb.Item>
-              <Link componentId="mlflow.gateway.create_endpoint.breadcrumb_endpoints_link" to={GatewayRoutes.gatewayPageRoute}>
+              <Link
+                componentId="mlflow.gateway.create_endpoint.breadcrumb_endpoints_link"
+                to={GatewayRoutes.gatewayPageRoute}
+              >
                 <FormattedMessage defaultMessage="Endpoints" description="Breadcrumb link to endpoints list" />
               </Link>
             </Breadcrumb.Item>

--- a/mlflow/server/js/src/gateway/pages/GatewayPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayPage.tsx
@@ -142,7 +142,10 @@ const GatewayPage = () => {
                       <ChainIcon />
                       <FormattedMessage defaultMessage="Endpoints" description="Endpoints page title" />
                     </Typography.Title>
-                    <Link componentId="mlflow.gateway.page.create_endpoint_link" to={GatewayRoutes.createEndpointPageRoute}>
+                    <Link
+                      componentId="mlflow.gateway.page.create_endpoint_link"
+                      to={GatewayRoutes.createEndpointPageRoute}
+                    >
                       <Button componentId="mlflow.gateway.endpoints.create-button" type="primary" icon={<PlusIcon />}>
                         <FormattedMessage
                           defaultMessage="Create endpoint"

--- a/mlflow/server/js/src/gateway/pages/GatewayPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayPage.tsx
@@ -142,7 +142,7 @@ const GatewayPage = () => {
                       <ChainIcon />
                       <FormattedMessage defaultMessage="Endpoints" description="Endpoints page title" />
                     </Typography.Title>
-                    <Link to={GatewayRoutes.createEndpointPageRoute}>
+                    <Link componentId="mlflow.gateway.page.create_endpoint_link" to={GatewayRoutes.createEndpointPageRoute}>
                       <Button componentId="mlflow.gateway.endpoints.create-button" type="primary" icon={<PlusIcon />}>
                         <FormattedMessage
                           defaultMessage="Create endpoint"

--- a/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
+++ b/mlflow/server/js/src/gateway/pages/GatewayUsagePage.tsx
@@ -146,7 +146,7 @@ export const GatewayUsagePage = () => {
               description="Empty state description"
             />
           </Typography.Text>
-          <Link to={GatewayRoutes.gatewayPageRoute}>
+          <Link componentId="mlflow.gateway.usage.go_to_endpoints_link" to={GatewayRoutes.gatewayPageRoute}>
             <FormattedMessage defaultMessage="Go to Endpoints" description="Link to endpoints page" />
           </Link>
         </div>

--- a/mlflow/server/js/src/home/components/ExperimentsHomeView.tsx
+++ b/mlflow/server/js/src/home/components/ExperimentsHomeView.tsx
@@ -105,7 +105,7 @@ export const ExperimentsHomeView = ({
         <Typography.Title level={3} css={{ margin: 0 }}>
           <FormattedMessage defaultMessage="Recent Experiments" description="Home page experiments preview title" />
         </Typography.Title>
-        <Link to={Routes.experimentsObservatoryRoute}>
+        <Link componentId="mlflow.home.experiments.view_all_link" to={Routes.experimentsObservatoryRoute}>
           <FormattedMessage defaultMessage="View all" description="Home page experiments view all link" />
         </Link>
       </div>

--- a/mlflow/server/js/src/home/components/LogTracesDrawer.tsx
+++ b/mlflow/server/js/src/home/components/LogTracesDrawer.tsx
@@ -355,6 +355,7 @@ export const LogTracesDrawer = () => {
                       values={{
                         experimentsLink: (
                           <Link
+                            componentId="mlflow.home.log_traces.experiments_link"
                             to={Routes.experimentsObservatoryRoute}
                             target="_blank"
                             rel="noopener noreferrer"

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
@@ -126,6 +126,7 @@ const WorkspaceRow = ({ workspace, isLastUsed }: { workspace: Workspace; isLastU
         <TableCell>
           <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
             <Link
+              componentId="mlflow.home.workspaces.workspace_link"
               disableWorkspacePrefix
               to={`/?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`}
               onClick={(e) => {

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
@@ -155,14 +155,14 @@ export class CompareModelVersionsViewImpl extends Component<
     );
     const breadcrumbs = [
       // eslint-disable-next-line react/jsx-key
-      <Link to={ModelRegistryRoutes.modelListPageRoute}>
+      <Link componentId="mlflow.model_registry.compare_versions.registered_models_link" to={ModelRegistryRoutes.modelListPageRoute}>
         <FormattedMessage
           defaultMessage="Registered Models"
           description="Text for registered model link in the title for model comparison page"
         />
       </Link>,
       // eslint-disable-next-line react/jsx-key
-      <Link to={ModelRegistryRoutes.getModelPageRoute(modelName)}>{modelName}</Link>,
+      <Link componentId="mlflow.model_registry.compare_versions.model_name_link" to={ModelRegistryRoutes.getModelPageRoute(modelName)}>{modelName}</Link>,
     ];
 
     return (
@@ -321,7 +321,7 @@ export class CompareModelVersionsViewImpl extends Component<
             <th scope="column" className="data-value block-content" key={r.runUuid}>
               {/* Do not show links for invalid run IDs */}
               {runInfosValid[idx] ? (
-                <Link to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
+                <Link componentId="mlflow.model_registry.compare_versions.run_uuid_link" to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
               ) : (
                 r.runUuid
               )}
@@ -348,7 +348,7 @@ export class CompareModelVersionsViewImpl extends Component<
             const run = versionsToRuns[modelVersion];
             return (
               <td className="meta-info block-content" key={run}>
-                <Link to={ModelRegistryRoutes.getModelVersionPageRoute(modelName, modelVersion)}>{modelVersion}</Link>
+                <Link componentId="mlflow.model_registry.compare_versions.version_link" to={ModelRegistryRoutes.getModelVersionPageRoute(modelName, modelVersion)}>{modelVersion}</Link>
               </td>
             );
           })}
@@ -527,6 +527,7 @@ export class CompareModelVersionsViewImpl extends Component<
     const metricsHeaderMap = (key: any, data: any) => {
       return (
         <Link
+          componentId="mlflow.model_registry.compare_versions.metric_link"
           to={Routes.getMetricPageRoute(
             runInfos.map((info) => info.runUuid).filter((uuid, idx) => data[idx] !== undefined),
             key,

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.tsx
@@ -155,14 +155,22 @@ export class CompareModelVersionsViewImpl extends Component<
     );
     const breadcrumbs = [
       // eslint-disable-next-line react/jsx-key
-      <Link componentId="mlflow.model_registry.compare_versions.registered_models_link" to={ModelRegistryRoutes.modelListPageRoute}>
+      <Link
+        componentId="mlflow.model_registry.compare_versions.registered_models_link"
+        to={ModelRegistryRoutes.modelListPageRoute}
+      >
         <FormattedMessage
           defaultMessage="Registered Models"
           description="Text for registered model link in the title for model comparison page"
         />
       </Link>,
       // eslint-disable-next-line react/jsx-key
-      <Link componentId="mlflow.model_registry.compare_versions.model_name_link" to={ModelRegistryRoutes.getModelPageRoute(modelName)}>{modelName}</Link>,
+      <Link
+        componentId="mlflow.model_registry.compare_versions.model_name_link"
+        to={ModelRegistryRoutes.getModelPageRoute(modelName)}
+      >
+        {modelName}
+      </Link>,
     ];
 
     return (
@@ -321,7 +329,12 @@ export class CompareModelVersionsViewImpl extends Component<
             <th scope="column" className="data-value block-content" key={r.runUuid}>
               {/* Do not show links for invalid run IDs */}
               {runInfosValid[idx] ? (
-                <Link componentId="mlflow.model_registry.compare_versions.run_uuid_link" to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}>{r.runUuid}</Link>
+                <Link
+                  componentId="mlflow.model_registry.compare_versions.run_uuid_link"
+                  to={Routes.getRunPageRoute(r.experimentId ?? '0', r.runUuid ?? '')}
+                >
+                  {r.runUuid}
+                </Link>
               ) : (
                 r.runUuid
               )}
@@ -348,7 +361,12 @@ export class CompareModelVersionsViewImpl extends Component<
             const run = versionsToRuns[modelVersion];
             return (
               <td className="meta-info block-content" key={run}>
-                <Link componentId="mlflow.model_registry.compare_versions.version_link" to={ModelRegistryRoutes.getModelVersionPageRoute(modelName, modelVersion)}>{modelVersion}</Link>
+                <Link
+                  componentId="mlflow.model_registry.compare_versions.version_link"
+                  to={ModelRegistryRoutes.getModelVersionPageRoute(modelName, modelVersion)}
+                >
+                  {modelVersion}
+                </Link>
               </td>
             );
           })}

--- a/mlflow/server/js/src/model-registry/components/ModelVersionTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionTable.tsx
@@ -202,7 +202,7 @@ export const ModelVersionTable = ({
             description="Link to model version in the model version table"
             values={{
               link: (chunks) => (
-                <Link to={ModelRegistryRoutes.getModelVersionPageRoute(modelName, String(getValue()))}>{chunks}</Link>
+                <Link componentId="mlflow.model_registry.version_table.version_link" to={ModelRegistryRoutes.getModelVersionPageRoute(modelName, String(getValue()))}>{chunks}</Link>
               ),
               versionNumber: getValue(),
             }}

--- a/mlflow/server/js/src/model-registry/components/ModelVersionTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionTable.tsx
@@ -202,7 +202,12 @@ export const ModelVersionTable = ({
             description="Link to model version in the model version table"
             values={{
               link: (chunks) => (
-                <Link componentId="mlflow.model_registry.version_table.version_link" to={ModelRegistryRoutes.getModelVersionPageRoute(modelName, String(getValue()))}>{chunks}</Link>
+                <Link
+                  componentId="mlflow.model_registry.version_table.version_link"
+                  to={ModelRegistryRoutes.getModelVersionPageRoute(modelName, String(getValue()))}
+                >
+                  {chunks}
+                </Link>
               ),
               versionNumber: getValue(),
             }}

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.tsx
@@ -408,6 +408,7 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
     const link = (
       <>
         <Link
+          componentId="mlflow.model_registry.version_view.copied_from_link"
           data-testid="copied-from-link"
           to={ModelRegistryRoutes.getModelVersionPageRoute(sourceModelName, sourceModelVersion)}
         >
@@ -537,7 +538,7 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
         artifactPath = extractArtifactPathFromModelSource(modelSource, runInfo.runUuid);
       }
       return (
-        <Link to={Routers.getRunPageRoute(runInfo.experimentId, runInfo.runUuid, artifactPath)}>
+        <Link componentId="mlflow.model_registry.version_view.source_run_link" to={Routers.getRunPageRoute(runInfo.experimentId, runInfo.runUuid, artifactPath)}>
           {this.resolveRunName()}
         </Link>
       );
@@ -613,7 +614,7 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
     );
     const breadcrumbs = [
       // eslint-disable-next-line react/jsx-key
-      <Link to={ModelRegistryRoutes.modelListPageRoute}>
+      <Link componentId="mlflow.model_registry.version_view.breadcrumb_registered_models_link" to={ModelRegistryRoutes.modelListPageRoute}>
         <FormattedMessage
           defaultMessage="Registered Models"
           description="Text for link back to models page under the header on the model version
@@ -621,7 +622,7 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
         />
       </Link>,
       // eslint-disable-next-line react/jsx-key
-      <Link data-testid="breadcrumbRegisteredModel" to={ModelRegistryRoutes.getModelPageRoute(modelName)}>
+      <Link componentId="mlflow.model_registry.version_view.breadcrumb_model_link" data-testid="breadcrumbRegisteredModel" to={ModelRegistryRoutes.getModelPageRoute(modelName)}>
         {modelName}
       </Link>,
     ];

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.tsx
@@ -538,7 +538,10 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
         artifactPath = extractArtifactPathFromModelSource(modelSource, runInfo.runUuid);
       }
       return (
-        <Link componentId="mlflow.model_registry.version_view.source_run_link" to={Routers.getRunPageRoute(runInfo.experimentId, runInfo.runUuid, artifactPath)}>
+        <Link
+          componentId="mlflow.model_registry.version_view.source_run_link"
+          to={Routers.getRunPageRoute(runInfo.experimentId, runInfo.runUuid, artifactPath)}
+        >
           {this.resolveRunName()}
         </Link>
       );
@@ -614,7 +617,10 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
     );
     const breadcrumbs = [
       // eslint-disable-next-line react/jsx-key
-      <Link componentId="mlflow.model_registry.version_view.breadcrumb_registered_models_link" to={ModelRegistryRoutes.modelListPageRoute}>
+      <Link
+        componentId="mlflow.model_registry.version_view.breadcrumb_registered_models_link"
+        to={ModelRegistryRoutes.modelListPageRoute}
+      >
         <FormattedMessage
           defaultMessage="Registered Models"
           description="Text for link back to models page under the header on the model version
@@ -622,7 +628,11 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
         />
       </Link>,
       // eslint-disable-next-line react/jsx-key
-      <Link componentId="mlflow.model_registry.version_view.breadcrumb_model_link" data-testid="breadcrumbRegisteredModel" to={ModelRegistryRoutes.getModelPageRoute(modelName)}>
+      <Link
+        componentId="mlflow.model_registry.version_view.breadcrumb_model_link"
+        data-testid="breadcrumbRegisteredModel"
+        to={ModelRegistryRoutes.getModelPageRoute(modelName)}
+      >
         {modelName}
       </Link>,
     ];

--- a/mlflow/server/js/src/model-registry/components/ModelView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelView.tsx
@@ -580,7 +580,11 @@ export class ModelViewImpl extends React.Component<ModelViewImplProps, ModelView
     const modelName = model.name;
 
     const breadcrumbs = [
-      <Link componentId="mlflow.model_registry.model_view.breadcrumb_registered_models_link" to={ModelRegistryRoutes.modelListPageRoute} key="registered-models">
+      <Link
+        componentId="mlflow.model_registry.model_view.breadcrumb_registered_models_link"
+        to={ModelRegistryRoutes.modelListPageRoute}
+        key="registered-models"
+      >
         <FormattedMessage
           defaultMessage="Registered Models"
           description="Text for link back to model page under the header on the model view page"

--- a/mlflow/server/js/src/model-registry/components/ModelView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelView.tsx
@@ -580,7 +580,7 @@ export class ModelViewImpl extends React.Component<ModelViewImplProps, ModelView
     const modelName = model.name;
 
     const breadcrumbs = [
-      <Link to={ModelRegistryRoutes.modelListPageRoute} key="registered-models">
+      <Link componentId="mlflow.model_registry.model_view.breadcrumb_registered_models_link" to={ModelRegistryRoutes.modelListPageRoute} key="registered-models">
         <FormattedMessage
           defaultMessage="Registered Models"
           description="Text for link back to model page under the header on the model view page"

--- a/mlflow/server/js/src/model-registry/components/aliases/ModelsTableAliasedVersionsCell.tsx
+++ b/mlflow/server/js/src/model-registry/components/aliases/ModelsTableAliasedVersionsCell.tsx
@@ -37,7 +37,10 @@ export const ModelsTableAliasedVersionsCell = ({ model }: ModelsTableAliasedVers
 
   return (
     <div>
-      <Link componentId="mlflow.model_registry.aliases.version_link" to={ModelRegistryRoutes.getModelVersionPageRoute(model.name, latestVersionAlias.version)}>
+      <Link
+        componentId="mlflow.model_registry.aliases.version_link"
+        to={ModelRegistryRoutes.getModelVersionPageRoute(model.name, latestVersionAlias.version)}
+      >
         <AliasTag value={latestVersionAlias.alias} css={{ marginRight: 0, cursor: 'pointer' }} />
         : <FormattedMessage {...versionLabel} values={{ version: latestVersionAlias.version }} />
       </Link>
@@ -58,7 +61,10 @@ export const ModelsTableAliasedVersionsCell = ({ model }: ModelsTableAliasedVers
                 componentId="codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_57"
                 key={alias}
               >
-                <Link componentId="mlflow.model_registry.aliases.overflow_version_link" to={ModelRegistryRoutes.getModelVersionPageRoute(model.name, version)}>
+                <Link
+                  componentId="mlflow.model_registry.aliases.overflow_version_link"
+                  to={ModelRegistryRoutes.getModelVersionPageRoute(model.name, version)}
+                >
                   <AliasTag value={alias} css={{ marginRight: 0, cursor: 'pointer' }} />:{' '}
                   <span css={{ color: theme.colors.actionTertiaryTextDefault }}>
                     <FormattedMessage {...versionLabel} values={{ version }} />

--- a/mlflow/server/js/src/model-registry/components/aliases/ModelsTableAliasedVersionsCell.tsx
+++ b/mlflow/server/js/src/model-registry/components/aliases/ModelsTableAliasedVersionsCell.tsx
@@ -37,7 +37,7 @@ export const ModelsTableAliasedVersionsCell = ({ model }: ModelsTableAliasedVers
 
   return (
     <div>
-      <Link to={ModelRegistryRoutes.getModelVersionPageRoute(model.name, latestVersionAlias.version)}>
+      <Link componentId="mlflow.model_registry.aliases.version_link" to={ModelRegistryRoutes.getModelVersionPageRoute(model.name, latestVersionAlias.version)}>
         <AliasTag value={latestVersionAlias.alias} css={{ marginRight: 0, cursor: 'pointer' }} />
         : <FormattedMessage {...versionLabel} values={{ version: latestVersionAlias.version }} />
       </Link>
@@ -58,7 +58,7 @@ export const ModelsTableAliasedVersionsCell = ({ model }: ModelsTableAliasedVers
                 componentId="codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_57"
                 key={alias}
               >
-                <Link to={ModelRegistryRoutes.getModelVersionPageRoute(model.name, version)}>
+                <Link componentId="mlflow.model_registry.aliases.overflow_version_link" to={ModelRegistryRoutes.getModelVersionPageRoute(model.name, version)}>
                   <AliasTag value={alias} css={{ marginRight: 0, cursor: 'pointer' }} />:{' '}
                   <span css={{ color: theme.colors.actionTertiaryTextDefault }}>
                     <FormattedMessage {...versionLabel} values={{ version }} />

--- a/mlflow/server/js/src/model-registry/components/model-list/ModelListTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/model-list/ModelListTable.tsx
@@ -93,7 +93,10 @@ export const ModelListTable = ({
         }),
         accessorKey: 'name',
         cell: ({ getValue }) => (
-          <Link componentId="mlflow.model_registry.model_list.model_name_link" to={ModelRegistryRoutes.getModelPageRoute(String(getValue()))}>
+          <Link
+            componentId="mlflow.model_registry.model_list.model_name_link"
+            to={ModelRegistryRoutes.getModelPageRoute(String(getValue()))}
+          >
             <Tooltip componentId="mlflow.model-registry.model-list.model-name.tooltip" content={getValue()}>
               <span>{getValue()}</span>
             </Tooltip>

--- a/mlflow/server/js/src/model-registry/components/model-list/ModelListTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/model-list/ModelListTable.tsx
@@ -93,7 +93,7 @@ export const ModelListTable = ({
         }),
         accessorKey: 'name',
         cell: ({ getValue }) => (
-          <Link to={ModelRegistryRoutes.getModelPageRoute(String(getValue()))}>
+          <Link componentId="mlflow.model_registry.model_list.model_name_link" to={ModelRegistryRoutes.getModelPageRoute(String(getValue()))}>
             <Tooltip componentId="mlflow.model-registry.model-list.model-name.tooltip" content={getValue()}>
               <span>{getValue()}</span>
             </Tooltip>

--- a/mlflow/server/js/src/model-registry/components/model-list/ModelTableCellRenderers.tsx
+++ b/mlflow/server/js/src/model-registry/components/model-list/ModelTableCellRenderers.tsx
@@ -96,7 +96,14 @@ export const ModelListVersionLinkCell = ({ versionNumber, name }: { versionNumbe
       description="Row entry for version columns in the registered model page"
       values={{
         versionNumber,
-        link: (text: any) => <Link componentId="mlflow.model_registry.model_list.version_link" to={ModelRegistryRoutes.getModelVersionPageRoute(name, versionNumber)}>{text}</Link>,
+        link: (text: any) => (
+          <Link
+            componentId="mlflow.model_registry.model_list.version_link"
+            to={ModelRegistryRoutes.getModelVersionPageRoute(name, versionNumber)}
+          >
+            {text}
+          </Link>
+        ),
       }}
     />
   );

--- a/mlflow/server/js/src/model-registry/components/model-list/ModelTableCellRenderers.tsx
+++ b/mlflow/server/js/src/model-registry/components/model-list/ModelTableCellRenderers.tsx
@@ -96,7 +96,7 @@ export const ModelListVersionLinkCell = ({ versionNumber, name }: { versionNumbe
       description="Row entry for version columns in the registered model page"
       values={{
         versionNumber,
-        link: (text: any) => <Link to={ModelRegistryRoutes.getModelVersionPageRoute(name, versionNumber)}>{text}</Link>,
+        link: (text: any) => <Link componentId="mlflow.model_registry.model_list.version_link" to={ModelRegistryRoutes.getModelVersionPageRoute(name, versionNumber)}>{text}</Link>,
       }}
     />
   );

--- a/mlflow/server/js/src/telemetry/TelemetryInfoAlert.tsx
+++ b/mlflow/server/js/src/telemetry/TelemetryInfoAlert.tsx
@@ -32,6 +32,7 @@ export const TelemetryInfoAlert = () => {
               values={{
                 documentation: (chunks: any) => (
                   <Link
+                    componentId="mlflow.telemetry.info_alert.documentation_link"
                     to="https://mlflow.org/docs/latest/community/usage-tracking.html"
                     target="_blank"
                     rel="noopener noreferrer"


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

Currently, the <Link> component does not take any componentId, which means a lot of our links are missing telemetry (e.g. links to sessions page + experiment links)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Clicked around to verify telemetry is now logged

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
