### PR TITLE
Suppress noisy huey consumer logs at default INFO log level

### DIFF
--- a/mlflow/server/jobs/logging_utils.py
+++ b/mlflow/server/jobs/logging_utils.py
@@ -7,6 +7,7 @@ from mlflow.utils.logging_utils import get_mlflow_log_level
 
 def configure_logging_for_jobs() -> None:
     """Configure Python logging for job consumers to reduce noise for log levels above DEBUG."""
-    # Suppress noisy alembic INFO logs (e.g., "Context impl SQLiteImpl", "Will assume...")
+    # Suppress noisy alembic and huey INFO logs for log levels above DEBUG
     if logging.getLevelName(get_mlflow_log_level()) > logging.DEBUG:
         logging.getLogger("alembic.runtime.migration").setLevel(logging.WARNING)
+        logging.getLogger("huey").setLevel(logging.WARNING)

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -455,7 +455,7 @@ def _get_or_init_huey_instance(instance_key: str):
 
 
 def _launch_huey_consumer(job_name: str) -> None:
-    _logger.info(f"Starting huey consumer for job function {job_name}")
+    _logger.debug(f"Starting huey consumer for job function {job_name}")
 
     fn_fullname = get_job_fn_fullname(job_name)
     job_fn = _load_function(fn_fullname)
@@ -491,7 +491,7 @@ def _launch_periodic_tasks_consumer() -> None:
     Launch a dedicated Huey consumer for periodic tasks.
     This consumer runs scheduled tasks like the online scoring scheduler.
     """
-    _logger.info("Starting dedicated Huey consumer for periodic tasks")
+    _logger.debug("Starting dedicated Huey consumer for periodic tasks")
 
     def _huey_consumer_thread() -> None:
         while True:

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -135,9 +135,10 @@ def _start_huey_consumer_proc(
         str(max_job_parallelism),
     ]
 
-    # Add quiet flag if logging level is WARNING or higher
+    # Add quiet flag unless DEBUG logging is explicitly requested,
+    # to suppress noisy huey consumer logs (e.g., Scheduler, Executing messages)
     log_level = (MLFLOW_LOGGING_LEVEL.get() or "INFO").upper()
-    if log_level in ("WARNING", "WARN", "ERROR", "CRITICAL"):
+    if log_level != "DEBUG":
         cmd.append("-q")
 
     return _exec_cmd(
@@ -514,9 +515,10 @@ def _start_periodic_tasks_consumer_proc():
         str(PERIODIC_TASKS_WORKER_COUNT),
     ]
 
-    # Add quiet flag if logging level is WARNING or higher
+    # Add quiet flag unless DEBUG logging is explicitly requested,
+    # to suppress noisy huey consumer logs (e.g., Scheduler, Executing messages)
     log_level = (MLFLOW_LOGGING_LEVEL.get() or "INFO").upper()
-    if log_level in ("WARNING", "WARN", "ERROR", "CRITICAL"):
+    if log_level != "DEBUG":
         cmd.append("-q")
 
     return _exec_cmd(


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The huey consumer's `-q` (quiet) flag was only passed when `MLFLOW_LOGGING_LEVEL` was set to WARNING or higher. At the default INFO level, huey's built-in consumer was printing noisy scheduler and task execution messages (e.g., `huey.consumer.Scheduler...`, `huey: Executing mlflow.server.jobs.utils.online_scoring_scheduler`).

This PR:
- Passes `-q` to `huey_consumer.py` at all log levels except DEBUG, in both `_start_huey_consumer_proc` and `_start_periodic_tasks_consumer_proc`
- Adds `logging.getLogger("huey").setLevel(logging.WARNING)` in `configure_logging_for_jobs()` as an additional safeguard

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified that huey scheduler/execution logs no longer appear at default INFO level, and reappear when `MLFLOW_LOGGING_LEVEL=DEBUG`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release