### PR TITLE
Show server error detail in Try It panel for budget limit errors

### DIFF
--- a/mlflow/server/js/src/gateway/hooks/useTryIt.test.tsx
+++ b/mlflow/server/js/src/gateway/hooks/useTryIt.test.tsx
@@ -84,7 +84,7 @@ describe('useTryIt', () => {
     expect(mockFetchOrFail).toHaveBeenCalledTimes(1);
     expect(result.current.data).toBeUndefined();
     expect(result.current.error).toBeDefined();
-    expect(result.current.error?.message).toBe('The request was invalid.');
+    expect(result.current.error?.message).toBe('400 - The request was invalid.');
     expect(result.current.error?.responseBody).toBe(JSON.stringify(errorBody, null, 2));
   });
 
@@ -110,7 +110,7 @@ describe('useTryIt', () => {
     });
 
     expect(result.current.error).toBeDefined();
-    expect(result.current.error?.message).toBe(errorBody.detail);
+    expect(result.current.error?.message).toBe(`429 - ${errorBody.detail}`);
     expect(result.current.error?.responseBody).toBe(JSON.stringify(errorBody, null, 2));
   });
 

--- a/mlflow/server/js/src/gateway/hooks/useTryIt.test.tsx
+++ b/mlflow/server/js/src/gateway/hooks/useTryIt.test.tsx
@@ -84,7 +84,7 @@ describe('useTryIt', () => {
     expect(mockFetchOrFail).toHaveBeenCalledTimes(1);
     expect(result.current.data).toBeUndefined();
     expect(result.current.error).toBeDefined();
-    expect(result.current.error?.message).toBe('400 - The request was invalid.');
+    expect(result.current.error?.message).toBe('Error 400');
     expect(result.current.error?.responseBody).toBe(JSON.stringify(errorBody, null, 2));
   });
 
@@ -110,7 +110,7 @@ describe('useTryIt', () => {
     });
 
     expect(result.current.error).toBeDefined();
-    expect(result.current.error?.message).toBe(`429 - ${errorBody.detail}`);
+    expect(result.current.error?.message).toBe('Error 429');
     expect(result.current.error?.responseBody).toBe(JSON.stringify(errorBody, null, 2));
   });
 

--- a/mlflow/server/js/src/gateway/hooks/useTryIt.test.tsx
+++ b/mlflow/server/js/src/gateway/hooks/useTryIt.test.tsx
@@ -84,7 +84,33 @@ describe('useTryIt', () => {
     expect(mockFetchOrFail).toHaveBeenCalledTimes(1);
     expect(result.current.data).toBeUndefined();
     expect(result.current.error).toBeDefined();
-    expect(result.current.error?.message).toBe('A network error occurred.');
+    expect(result.current.error?.message).toBe('The request was invalid.');
+    expect(result.current.error?.responseBody).toBe(JSON.stringify(errorBody, null, 2));
+  });
+
+  test('uses server detail message for budget limit exceeded (429)', async () => {
+    const errorBody = {
+      detail:
+        'Budget limit exceeded. Limit: $5.00 USD per 1 day. Budget resets at 2026-03-12T00:00:00Z. Request rejected.',
+    };
+    const mockResponse = {
+      text: () => Promise.resolve(JSON.stringify(errorBody)),
+    } as unknown as Response;
+    const networkError = new GenericNetworkRequestError({ status: 429, response: mockResponse });
+    mockFetchOrFail.mockRejectedValueOnce(networkError);
+
+    const { result } = renderHook(() => useTryIt({ tryItRequestUrl: TRY_IT_URL }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.sendRequest(validRequestBody);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.message).toBe(errorBody.detail);
     expect(result.current.error?.responseBody).toBe(JSON.stringify(errorBody, null, 2));
   });
 

--- a/mlflow/server/js/src/gateway/hooks/useTryIt.test.tsx
+++ b/mlflow/server/js/src/gateway/hooks/useTryIt.test.tsx
@@ -66,6 +66,7 @@ describe('useTryIt', () => {
   test('sets error with response body when request fails with NetworkRequestError', async () => {
     const errorBody = { detail: 'The request was invalid.' };
     const mockResponse = {
+      statusText: 'Bad Request',
       text: () => Promise.resolve(JSON.stringify(errorBody)),
     } as unknown as Response;
     const networkError = new GenericNetworkRequestError({ status: 400, response: mockResponse });
@@ -84,7 +85,7 @@ describe('useTryIt', () => {
     expect(mockFetchOrFail).toHaveBeenCalledTimes(1);
     expect(result.current.data).toBeUndefined();
     expect(result.current.error).toBeDefined();
-    expect(result.current.error?.message).toBe('Error 400');
+    expect(result.current.error?.message).toBe('400 Bad Request');
     expect(result.current.error?.responseBody).toBe(JSON.stringify(errorBody, null, 2));
   });
 
@@ -94,6 +95,7 @@ describe('useTryIt', () => {
         'Budget limit exceeded. Limit: $5.00 USD per 1 day. Budget resets at 2026-03-12T00:00:00Z. Request rejected.',
     };
     const mockResponse = {
+      statusText: 'Too Many Requests',
       text: () => Promise.resolve(JSON.stringify(errorBody)),
     } as unknown as Response;
     const networkError = new GenericNetworkRequestError({ status: 429, response: mockResponse });
@@ -110,7 +112,7 @@ describe('useTryIt', () => {
     });
 
     expect(result.current.error).toBeDefined();
-    expect(result.current.error?.message).toBe('Error 429');
+    expect(result.current.error?.message).toBe('429 Too Many Requests');
     expect(result.current.error?.responseBody).toBe(JSON.stringify(errorBody, null, 2));
   });
 

--- a/mlflow/server/js/src/gateway/hooks/useTryIt.ts
+++ b/mlflow/server/js/src/gateway/hooks/useTryIt.ts
@@ -65,7 +65,8 @@ export function useTryIt({ tryItRequestUrl, options }: UseTryItParams) {
         return formatResponseText(text);
       } catch (err) {
         let message = err instanceof Error ? err.message : String(err);
-        const rawText = err instanceof NetworkRequestError ? (await err.response?.text()) || '' : undefined;
+        const isNetworkError = err instanceof NetworkRequestError;
+        const rawText = isNetworkError ? (await err.response?.text()) || '' : undefined;
         const responseBody = rawText !== undefined ? formatResponseText(rawText) : undefined;
 
         // Use the server's error detail if available (e.g. budget limit exceeded messages)
@@ -73,7 +74,8 @@ export function useTryIt({ tryItRequestUrl, options }: UseTryItParams) {
           try {
             const parsed = JSON.parse(rawText);
             if (typeof parsed.detail === 'string') {
-              message = parsed.detail;
+              const status = isNetworkError ? err.status : undefined;
+              message = status ? `${status} - ${parsed.detail}` : parsed.detail;
             }
           } catch {
             // ignore parse failures, keep original message

--- a/mlflow/server/js/src/gateway/hooks/useTryIt.ts
+++ b/mlflow/server/js/src/gateway/hooks/useTryIt.ts
@@ -75,7 +75,9 @@ export function useTryIt({ tryItRequestUrl, options }: UseTryItParams) {
             const parsed = JSON.parse(rawText);
             if (typeof parsed.detail === 'string') {
               const status = isNetworkError ? err.status : undefined;
-              message = status ? `${status} - ${parsed.detail}` : parsed.detail;
+              if (status) {
+                message = `Error ${status}`;
+              }
             }
           } catch {
             // ignore parse failures, keep original message

--- a/mlflow/server/js/src/gateway/hooks/useTryIt.ts
+++ b/mlflow/server/js/src/gateway/hooks/useTryIt.ts
@@ -64,9 +64,22 @@ export function useTryIt({ tryItRequestUrl, options }: UseTryItParams) {
         const text = await response.text();
         return formatResponseText(text);
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        let message = err instanceof Error ? err.message : String(err);
         const rawText = err instanceof NetworkRequestError ? (await err.response?.text()) || '' : undefined;
         const responseBody = rawText !== undefined ? formatResponseText(rawText) : undefined;
+
+        // Use the server's error detail if available (e.g. budget limit exceeded messages)
+        if (rawText) {
+          try {
+            const parsed = JSON.parse(rawText);
+            if (typeof parsed.detail === 'string') {
+              message = parsed.detail;
+            }
+          } catch {
+            // ignore parse failures, keep original message
+          }
+        }
+
         throw createTryItError(message, responseBody);
       }
     },

--- a/mlflow/server/js/src/gateway/hooks/useTryIt.ts
+++ b/mlflow/server/js/src/gateway/hooks/useTryIt.ts
@@ -74,9 +74,9 @@ export function useTryIt({ tryItRequestUrl, options }: UseTryItParams) {
           try {
             const parsed = JSON.parse(rawText);
             if (typeof parsed.detail === 'string') {
-              const status = isNetworkError ? err.status : undefined;
-              if (status) {
-                message = `Error ${status}`;
+              if (isNetworkError && err.status) {
+                const statusText = err.response?.statusText || `Error ${err.status}`;
+                message = `${err.status} ${statusText}`;
               }
             }
           } catch {

--- a/mlflow/server/js/src/gateway/hooks/useTryIt.ts
+++ b/mlflow/server/js/src/gateway/hooks/useTryIt.ts
@@ -69,15 +69,13 @@ export function useTryIt({ tryItRequestUrl, options }: UseTryItParams) {
         const rawText = isNetworkError ? (await err.response?.text()) || '' : undefined;
         const responseBody = rawText !== undefined ? formatResponseText(rawText) : undefined;
 
-        // Use the server's error detail if available (e.g. budget limit exceeded messages)
-        if (rawText) {
+        // Show HTTP status when the server returns a JSON detail (e.g. budget limit exceeded)
+        if (rawText && isNetworkError && err.status) {
           try {
             const parsed = JSON.parse(rawText);
             if (typeof parsed.detail === 'string') {
-              if (isNetworkError && err.status) {
-                const statusText = err.response?.statusText || `Error ${err.status}`;
-                message = `${err.status} ${statusText}`;
-              }
+              const statusText = err.response?.statusText || `Error ${err.status}`;
+              message = `${err.status} ${statusText}`;
             }
           } catch {
             // ignore parse failures, keep original message


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The Try It panel previously showed hardcoded generic messages (e.g., "This request exceeds the maximum queries per second limit") for server errors. This PR improves error display by:

1. Showing the HTTP status code as the error message (e.g., "Error 429") when the server response contains a JSON `detail` field
2. Displaying the full server error detail (e.g., budget limit exceeded info with reset time) in the response body panel

This gives users both a quick status indicator and the full error context.

<img width="872" height="451" alt="image" src="https://github.com/user-attachments/assets/f9506dd4-fe13-4123-9bd8-eee29f8fa577" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The Try It panel now shows the HTTP status code and full server error detail instead of generic error messages.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release