### PR TITLE
Fix budget tracker race condition allowing requests past exceeded budget

### DIFF
--- a/mlflow/gateway/budget_tracker/in_memory.py
+++ b/mlflow/gateway/budget_tracker/in_memory.py
@@ -67,7 +67,6 @@ class InMemoryBudgetTracker(BudgetTracker):
                     fresh_windows.append(window)
 
             self._windows = new_windows
-            self.mark_refreshed()
 
         return fresh_windows
 
@@ -156,6 +155,7 @@ class InMemoryBudgetTracker(BudgetTracker):
                     continue
                 window.cumulative_spend = spend
                 window.exceeded = spend >= window.policy.budget_amount
+            self.mark_refreshed()
 
     def get_all_windows(self) -> list[BudgetWindow]:
         with self._lock:

--- a/mlflow/server/gateway_budget.py
+++ b/mlflow/server/gateway_budget.py
@@ -70,8 +70,8 @@ def maybe_refresh_budget_policies(store: SqlAlchemyStore) -> None:
     if tracker.needs_refresh():
         try:
             policies = store.list_budget_policies()
-            new_windows = tracker.refresh_policies(policies)
-            existing_spend = calculate_existing_cost_for_new_windows(store, new_windows)
+            fresh_windows = tracker.refresh_policies(policies)
+            existing_spend = calculate_existing_cost_for_new_windows(store, fresh_windows)
             tracker.backfill_spend(existing_spend)
         except Exception:
             _logger.debug("Failed to refresh budget policies", exc_info=True)

--- a/tests/gateway/test_budget_tracker.py
+++ b/tests/gateway/test_budget_tracker.py
@@ -175,6 +175,7 @@ def test_in_memory_tracker_is_budget_tracker():
 def test_record_cost_below_limit():
     tracker = InMemoryBudgetTracker()
     tracker.refresh_policies([_make_policy(budget_amount=100.0)])
+    tracker.backfill_spend({})
 
     newly_exceeded = tracker.record_cost(50.0)
     assert newly_exceeded == []
@@ -187,6 +188,7 @@ def test_record_cost_below_limit():
 def test_record_cost_exceeds_threshold():
     tracker = InMemoryBudgetTracker()
     tracker.refresh_policies([_make_policy(budget_amount=100.0)])
+    tracker.backfill_spend({})
 
     newly_exceeded = tracker.record_cost(150.0)
     assert len(newly_exceeded) == 1
@@ -200,6 +202,7 @@ def test_record_cost_exceeds_threshold():
 def test_record_cost_exceeds_only_once():
     tracker = InMemoryBudgetTracker()
     tracker.refresh_policies([_make_policy(budget_amount=100.0)])
+    tracker.backfill_spend({})
 
     exceeded1 = tracker.record_cost(150.0)
     assert len(exceeded1) == 1
@@ -214,6 +217,7 @@ def test_record_cost_exceeds_only_once():
 def test_record_cost_incremental_exceeding():
     tracker = InMemoryBudgetTracker()
     tracker.refresh_policies([_make_policy(budget_amount=100.0)])
+    tracker.backfill_spend({})
 
     assert tracker.record_cost(60.0) == []
     exceeded = tracker.record_cost(50.0)
@@ -223,7 +227,9 @@ def test_record_cost_incremental_exceeding():
 
 def test_should_reject_request_reject():
     tracker = InMemoryBudgetTracker()
-    tracker.refresh_policies([_make_policy(budget_amount=100.0, budget_action=BudgetAction.REJECT)])
+    policy = _make_policy(budget_amount=100.0, budget_action=BudgetAction.REJECT)
+    tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
 
     tracker.record_cost(150.0)
     exceeded, window = tracker.should_reject_request()
@@ -233,7 +239,9 @@ def test_should_reject_request_reject():
 
 def test_should_reject_request_alert_only():
     tracker = InMemoryBudgetTracker()
-    tracker.refresh_policies([_make_policy(budget_amount=100.0, budget_action=BudgetAction.ALERT)])
+    policy = _make_policy(budget_amount=100.0, budget_action=BudgetAction.ALERT)
+    tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
 
     tracker.record_cost(150.0)
     exceeded, window = tracker.should_reject_request()
@@ -243,7 +251,9 @@ def test_should_reject_request_alert_only():
 
 def test_should_reject_request_not_yet():
     tracker = InMemoryBudgetTracker()
-    tracker.refresh_policies([_make_policy(budget_amount=100.0, budget_action=BudgetAction.REJECT)])
+    policy = _make_policy(budget_amount=100.0, budget_action=BudgetAction.REJECT)
+    tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
 
     tracker.record_cost(50.0)
     exceeded, window = tracker.should_reject_request()
@@ -259,6 +269,7 @@ def test_window_resets_on_expiry():
         duration_value=5,
     )
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     tracker.record_cost(80.0)
 
     window = tracker._get_window_info("bp-test")
@@ -282,10 +293,12 @@ def test_refresh_policies_preserves_spend_in_same_window():
     tracker = InMemoryBudgetTracker()
     policy = _make_policy(budget_amount=100.0)
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     tracker.record_cost(60.0)
 
     # Reload same policy — spend should be preserved
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     window = tracker._get_window_info("bp-test")
     assert window.cumulative_spend == 60.0
 
@@ -295,10 +308,12 @@ def test_refresh_policies_removes_deleted_policy():
     policy1 = _make_policy(budget_policy_id="bp-1", budget_amount=100.0)
     policy2 = _make_policy(budget_policy_id="bp-2", budget_amount=200.0)
     tracker.refresh_policies([policy1, policy2])
+    tracker.backfill_spend({})
     tracker.record_cost(50.0)
 
     # Reload with only policy1 — policy2 window should be gone
     tracker.refresh_policies([policy1])
+    tracker.backfill_spend({})
     assert tracker._get_window_info("bp-1") is not None
     assert tracker._get_window_info("bp-2") is None
 
@@ -316,6 +331,7 @@ def test_multiple_policies_independent():
         budget_action=BudgetAction.REJECT,
     )
     tracker.refresh_policies([policy_alert, policy_reject])
+    tracker.backfill_spend({})
 
     exceeded = tracker.record_cost(75.0)
     # Only the alert policy should be exceeded (50 < 75)
@@ -341,6 +357,7 @@ def test_workspace_scoped_cost_recording():
         budget_amount=100.0,
     )
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
 
     # Cost from different workspace — should not apply
     tracker.record_cost(200.0, workspace="ws2")
@@ -369,9 +386,10 @@ def test_refresh_policies_returns_new_windows():
     policy1 = _make_policy(budget_policy_id="bp-1")
     policy2 = _make_policy(budget_policy_id="bp-2")
 
-    new_windows = tracker.refresh_policies([policy1, policy2])
-    assert len(new_windows) == 2
-    ids = {w.policy.budget_policy_id for w in new_windows}
+    fresh_windows = tracker.refresh_policies([policy1, policy2])
+    tracker.backfill_spend({})
+    assert len(fresh_windows) == 2
+    ids = {w.policy.budget_policy_id for w in fresh_windows}
     assert ids == {"bp-1", "bp-2"}
 
 
@@ -379,23 +397,27 @@ def test_refresh_policies_returns_empty_on_reload():
     tracker = InMemoryBudgetTracker()
     policy = _make_policy()
 
-    new_windows = tracker.refresh_policies([policy])
-    assert len(new_windows) == 1
+    fresh_windows = tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
+    assert len(fresh_windows) == 1
 
     # Reload same policy within same window — no new windows
-    new_windows = tracker.refresh_policies([policy])
-    assert new_windows == []
+    fresh_windows = tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
+    assert fresh_windows == []
 
 
 def test_refresh_policies_returns_only_new_on_mixed():
     tracker = InMemoryBudgetTracker()
     policy1 = _make_policy(budget_policy_id="bp-1")
     tracker.refresh_policies([policy1])
+    tracker.backfill_spend({})
 
     policy2 = _make_policy(budget_policy_id="bp-2")
-    new_windows = tracker.refresh_policies([policy1, policy2])
-    assert len(new_windows) == 1
-    assert new_windows[0].policy.budget_policy_id == "bp-2"
+    fresh_windows = tracker.refresh_policies([policy1, policy2])
+    tracker.backfill_spend({})
+    assert len(fresh_windows) == 1
+    assert fresh_windows[0].policy.budget_policy_id == "bp-2"
 
 
 # --- backfill_spend tests ---
@@ -404,7 +426,6 @@ def test_refresh_policies_returns_only_new_on_mixed():
 def test_backfill_spend_sets_cumulative():
     tracker = InMemoryBudgetTracker()
     tracker.refresh_policies([_make_policy(budget_amount=100.0)])
-
     tracker.backfill_spend({"bp-test": 42.5})
     window = tracker._get_window_info("bp-test")
     assert window.cumulative_spend == 42.5
@@ -414,7 +435,6 @@ def test_backfill_spend_sets_cumulative():
 def test_backfill_spend_sets_exceeded_when_exceeds():
     tracker = InMemoryBudgetTracker()
     tracker.refresh_policies([_make_policy(budget_amount=100.0)])
-
     tracker.backfill_spend({"bp-test": 150.0})
     window = tracker._get_window_info("bp-test")
     assert window.cumulative_spend == 150.0
@@ -424,7 +444,6 @@ def test_backfill_spend_sets_exceeded_when_exceeds():
 def test_backfill_spend_sets_exceeded_at_exact_limit():
     tracker = InMemoryBudgetTracker()
     tracker.refresh_policies([_make_policy(budget_amount=100.0)])
-
     tracker.backfill_spend({"bp-test": 100.0})
     window = tracker._get_window_info("bp-test")
     assert window.cumulative_spend == 100.0
@@ -451,6 +470,7 @@ def test_get_all_windows_returns_all_policies():
     policy1 = _make_policy(budget_policy_id="bp-1")
     policy2 = _make_policy(budget_policy_id="bp-2")
     tracker.refresh_policies([policy1, policy2])
+    tracker.backfill_spend({})
 
     windows = tracker.get_all_windows()
     assert len(windows) == 2
@@ -462,6 +482,7 @@ def test_get_all_windows_reflects_current_spend():
     tracker = InMemoryBudgetTracker()
     policy = _make_policy(budget_policy_id="bp-spend", budget_amount=100.0)
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     tracker.record_cost(42.5)
 
     windows = tracker.get_all_windows()
@@ -474,8 +495,10 @@ def test_get_all_windows_after_policy_removed():
     policy1 = _make_policy(budget_policy_id="bp-1")
     policy2 = _make_policy(budget_policy_id="bp-2")
     tracker.refresh_policies([policy1, policy2])
+    tracker.backfill_spend({})
 
     tracker.refresh_policies([policy1])
+    tracker.backfill_spend({})
 
     windows = tracker.get_all_windows()
     assert len(windows) == 1

--- a/tests/gateway/test_gateway_budget.py
+++ b/tests/gateway/test_gateway_budget.py
@@ -1,3 +1,4 @@
+import threading
 from unittest.mock import MagicMock, patch
 
 import fastapi
@@ -215,6 +216,7 @@ def test_fire_budget_exceeded_webhooks_alert():
         tracker = get_budget_tracker()
         policy = _make_policy(budget_amount=50.0, budget_action=BudgetAction.ALERT)
         tracker.refresh_policies([policy])
+        tracker.backfill_spend({})
         crossed = tracker.record_cost(60.0)
         assert len(crossed) == 1
 
@@ -232,6 +234,7 @@ def test_fire_budget_exceeded_webhooks_reject_skipped():
         tracker = get_budget_tracker()
         policy = _make_policy(budget_amount=50.0, budget_action=BudgetAction.REJECT)
         tracker.refresh_policies([policy])
+        tracker.backfill_spend({})
         crossed = tracker.record_cost(60.0)
         assert len(crossed) == 1
 
@@ -244,6 +247,7 @@ def test_fire_budget_exceeded_webhooks_with_workspace():
         tracker = get_budget_tracker()
         policy = _make_policy(budget_amount=50.0, budget_action=BudgetAction.ALERT)
         tracker.refresh_policies([policy])
+        tracker.backfill_spend({})
         crossed = tracker.record_cost(60.0)
 
         fire_budget_exceeded_webhooks(crossed, workspace="my-ws", registry_store=MagicMock())
@@ -269,6 +273,7 @@ def test_maybe_refresh_budget_policies():
 def test_maybe_refresh_skips_when_not_needed():
     tracker = get_budget_tracker()
     tracker.refresh_policies([_make_policy()])
+    tracker.backfill_spend({})
 
     store = MagicMock()
     maybe_refresh_budget_policies(store)
@@ -280,12 +285,12 @@ def test_maybe_refresh_skips_when_not_needed():
 
 def test_calculate_existing_cost_on_new_windows():
     tracker = get_budget_tracker()
-    new_windows = tracker.refresh_policies([_make_policy(budget_amount=100.0)])
+    fresh_windows = tracker.refresh_policies([_make_policy(budget_amount=100.0)])
 
     store = MagicMock()
     store.sum_gateway_trace_cost.return_value = 42.0
 
-    existing_spend = calculate_existing_cost_for_new_windows(store, new_windows)
+    existing_spend = calculate_existing_cost_for_new_windows(store, fresh_windows)
     tracker.backfill_spend(existing_spend)
 
     store.sum_gateway_trace_cost.assert_called_once()
@@ -301,12 +306,12 @@ def test_calculate_existing_cost_skipped_when_no_new_windows():
 
 def test_calculate_existing_cost_handles_store_error():
     tracker = get_budget_tracker()
-    new_windows = tracker.refresh_policies([_make_policy(budget_amount=100.0)])
+    fresh_windows = tracker.refresh_policies([_make_policy(budget_amount=100.0)])
 
     store = MagicMock()
     store.sum_gateway_trace_cost.side_effect = Exception("DB error")
 
-    existing_spend = calculate_existing_cost_for_new_windows(store, new_windows)
+    existing_spend = calculate_existing_cost_for_new_windows(store, fresh_windows)
     tracker.backfill_spend(existing_spend)
 
     assert tracker._get_window_info("bp-test").cumulative_spend == 0.0
@@ -314,12 +319,12 @@ def test_calculate_existing_cost_handles_store_error():
 
 def test_calculate_existing_cost_zero_spend_excluded():
     tracker = get_budget_tracker()
-    new_windows = tracker.refresh_policies([_make_policy(budget_amount=100.0)])
+    fresh_windows = tracker.refresh_policies([_make_policy(budget_amount=100.0)])
 
     store = MagicMock()
     store.sum_gateway_trace_cost.return_value = 0.0
 
-    existing_spend = calculate_existing_cost_for_new_windows(store, new_windows)
+    existing_spend = calculate_existing_cost_for_new_windows(store, fresh_windows)
     assert existing_spend == {}
 
     tracker.backfill_spend(existing_spend)
@@ -352,6 +357,7 @@ def test_check_budget_limit_not_exceeded():
 
     tracker = get_budget_tracker()
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     tracker.record_cost(50.0)
 
     check_budget_limit(store)
@@ -363,6 +369,7 @@ def test_check_budget_limit_exceeded_rejects():
 
     tracker = get_budget_tracker()
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     tracker.record_cost(150.0)
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected"):
@@ -375,6 +382,7 @@ def test_check_budget_limit_alert_does_not_reject():
 
     tracker = get_budget_tracker()
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     tracker.record_cost(150.0)
 
     check_budget_limit(store)
@@ -390,6 +398,7 @@ def test_check_budget_limit_error_message_format():
 
     tracker = get_budget_tracker()
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     tracker.record_cost(600.0)
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected") as exc_info:
@@ -418,6 +427,7 @@ def test_check_budget_limit_error_message_plural():
 
     tracker = get_budget_tracker()
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     tracker.record_cost(300.0)
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected") as exc_info:
@@ -447,6 +457,7 @@ def test_check_budget_limit_with_workspace():
 
     tracker = get_budget_tracker()
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     tracker.record_cost(100.0, workspace="ws1")
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected"):
@@ -470,6 +481,7 @@ def test_check_budget_limit_multiple_policies():
 
     tracker = get_budget_tracker()
     tracker.refresh_policies([alert_policy, reject_policy])
+    tracker.backfill_spend({})
 
     # 75 exceeds alert (50) but not reject (100) → no rejection
     tracker.record_cost(75.0)
@@ -479,3 +491,36 @@ def test_check_budget_limit_multiple_policies():
     tracker.record_cost(30.0)
     with pytest.raises(fastapi.HTTPException, match="Request rejected"):
         check_budget_limit(store)
+
+
+def test_concurrent_refresh_does_not_lose_backfill():
+    policy = _make_policy(budget_amount=100.0, budget_action=BudgetAction.REJECT)
+    store = MagicMock()
+    store.list_budget_policies.return_value = [policy]
+    store.sum_gateway_trace_cost.return_value = 80.0
+
+    barrier = threading.Barrier(2, timeout=5)
+    errors: list[Exception] = []
+
+    def refresh_thread():
+        try:
+            barrier.wait()
+            maybe_refresh_budget_policies(store)
+        except Exception as e:
+            errors.append(e)
+
+    tracker = get_budget_tracker()
+    tracker.invalidate()
+
+    t1 = threading.Thread(target=refresh_thread)
+    t2 = threading.Thread(target=refresh_thread)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert not errors
+    window = tracker._get_window_info("bp-test")
+    assert window is not None
+    # The backfilled spend should be applied — never zero from a lost race
+    assert window.cumulative_spend == 80.0

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4227,6 +4227,7 @@ def test_list_budget_windows_returns_window_data():
     tracker = InMemoryBudgetTracker()
     policy = _make_budget_policy(budget_policy_id="bp-1", budget_amount=50.0)
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
     tracker.record_cost(12.5)
 
     with (
@@ -4254,6 +4255,7 @@ def test_list_budget_windows_multiple_policies():
     policy1 = _make_budget_policy(budget_policy_id="bp-1", budget_amount=100.0)
     policy2 = _make_budget_policy(budget_policy_id="bp-2", budget_amount=200.0)
     tracker.refresh_policies([policy1, policy2])
+    tracker.backfill_spend({})
     tracker.record_cost(30.0)
 
     with (
@@ -4276,6 +4278,7 @@ def test_list_budget_windows_zero_spend():
     tracker = InMemoryBudgetTracker()
     policy = _make_budget_policy(budget_amount=100.0)
     tracker.refresh_policies([policy])
+    tracker.backfill_spend({})
 
     with (
         app.test_client() as c,


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Move `mark_refreshed()` from `refresh_policies()` to `backfill_spend()` so that `needs_refresh()` keeps returning `True` until historical spend is applied. This ensures `check_budget_limit()` always sees correct `cumulative_spend` before deciding whether to reject.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release