### PR TITLE
Generate error trace when budget limit rejects a request

### DIFF
--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -430,7 +430,8 @@ async def invocations(endpoint_name: str, request: Request):
     workspace = get_request_workspace()
 
     _validate_store(store)
-    check_budget_limit(store, workspace=workspace)
+    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
+    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     # Detect request type based on payload structure
     if "messages" in body:
@@ -527,7 +528,8 @@ async def chat_completions(request: Request):
     workspace = get_request_workspace()
 
     _validate_store(store)
-    check_budget_limit(store, workspace=workspace)
+    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
+    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     try:
         payload = chat.RequestPayload(**body)
@@ -593,7 +595,8 @@ async def openai_passthrough_chat(request: Request):
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    check_budget_limit(store, workspace=workspace)
+    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
+    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
     provider, endpoint_config = _create_provider_from_endpoint_name(
@@ -661,7 +664,8 @@ async def openai_passthrough_embeddings(request: Request):
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    check_budget_limit(store, workspace=workspace)
+    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
+    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
     provider, endpoint_config = _create_provider_from_endpoint_name(
@@ -711,7 +715,8 @@ async def openai_passthrough_responses(request: Request):
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    check_budget_limit(store, workspace=workspace)
+    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
+    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
     provider, endpoint_config = _create_provider_from_endpoint_name(
@@ -783,7 +788,8 @@ async def anthropic_passthrough_messages(request: Request):
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    check_budget_limit(store, workspace=workspace)
+    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
+    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
     provider, endpoint_config = _create_provider_from_endpoint_name(
@@ -855,7 +861,8 @@ async def gemini_passthrough_generate_content(endpoint_name: str, request: Reque
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    check_budget_limit(store, workspace=workspace)
+    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
+    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
     provider, endpoint_config = _create_provider_from_endpoint_name(
@@ -904,7 +911,8 @@ async def gemini_passthrough_stream_generate_content(endpoint_name: str, request
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    check_budget_limit(store, workspace=workspace)
+    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
+    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
     provider, endpoint_config = _create_provider_from_endpoint_name(

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -356,6 +356,30 @@ def _create_provider(
     return primary_provider
 
 
+def _create_provider_from_endpoint_name(
+    store: SqlAlchemyStore,
+    endpoint_name: str,
+    endpoint_type: EndpointType,
+    enable_tracing: bool = True,
+) -> tuple[BaseProvider, GatewayEndpointConfig]:
+    """
+    Create a provider from an endpoint name.
+
+    Args:
+        store: The SQLAlchemy store instance.
+        endpoint_name: The endpoint name.
+        endpoint_type: Endpoint type (chat or embeddings).
+        enable_tracing: If True, enables MLflow tracing for provider calls.
+
+    Returns:
+        Tuple of (provider instance, endpoint config)
+    """
+    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
+    return _create_provider(
+        endpoint_config, endpoint_type, enable_tracing=enable_tracing
+    ), endpoint_config
+
+
 def _validate_store(store: AbstractStore) -> None:
     if not isinstance(store, SqlAlchemyStore):
         raise HTTPException(
@@ -407,7 +431,7 @@ async def invocations(endpoint_name: str, request: Request):
 
     _validate_store(store)
     endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
-    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
+    check_budget_limit(store, endpoint_config, workspace=workspace)
 
     # Detect request type based on payload structure
     if "messages" in body:
@@ -418,7 +442,9 @@ async def invocations(endpoint_name: str, request: Request):
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Invalid chat payload: {e!s}")
 
-        provider = _create_provider(endpoint_config, endpoint_type)
+        provider, endpoint_config = _create_provider_from_endpoint_name(
+            store, endpoint_name, endpoint_type
+        )
 
         if payload.stream:
             stream = maybe_traced_gateway_call(
@@ -452,7 +478,9 @@ async def invocations(endpoint_name: str, request: Request):
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Invalid embeddings payload: {e!s}")
 
-        provider = _create_provider(endpoint_config, endpoint_type)
+        provider, endpoint_config = _create_provider_from_endpoint_name(
+            store, endpoint_name, endpoint_type
+        )
 
         return await maybe_traced_gateway_call(
             provider.embeddings,
@@ -500,15 +528,15 @@ async def chat_completions(request: Request):
     workspace = get_request_workspace()
 
     _validate_store(store)
-    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
-    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
+    provider, endpoint_config = _create_provider_from_endpoint_name(
+        store, endpoint_name, EndpointType.LLM_V1_CHAT
+    )
+    check_budget_limit(store, endpoint_config, workspace=workspace)
 
     try:
         payload = chat.RequestPayload(**body)
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid chat payload: {e!s}")
-
-    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
 
     if payload.stream:
         stream = maybe_traced_gateway_call(
@@ -565,11 +593,11 @@ async def openai_passthrough_chat(request: Request):
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
-    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
-
     headers = dict(request.headers)
-    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
+    provider, endpoint_config = _create_provider_from_endpoint_name(
+        store, endpoint_name, EndpointType.LLM_V1_CHAT
+    )
+    check_budget_limit(store, endpoint_config, workspace=workspace)
 
     if body.get("stream", False):
         stream = await provider.passthrough(
@@ -632,11 +660,11 @@ async def openai_passthrough_embeddings(request: Request):
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
-    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
-
     headers = dict(request.headers)
-    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_EMBEDDINGS)
+    provider, endpoint_config = _create_provider_from_endpoint_name(
+        store, endpoint_name, EndpointType.LLM_V1_EMBEDDINGS
+    )
+    check_budget_limit(store, endpoint_config, workspace=workspace)
 
     traced_passthrough = maybe_traced_gateway_call(
         provider.passthrough,
@@ -681,11 +709,11 @@ async def openai_passthrough_responses(request: Request):
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
-    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
-
     headers = dict(request.headers)
-    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
+    provider, endpoint_config = _create_provider_from_endpoint_name(
+        store, endpoint_name, EndpointType.LLM_V1_CHAT
+    )
+    check_budget_limit(store, endpoint_config, workspace=workspace)
 
     if body.get("stream", False):
         stream = await provider.passthrough(
@@ -752,11 +780,11 @@ async def anthropic_passthrough_messages(request: Request):
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
-    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
-
     headers = dict(request.headers)
-    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
+    provider, endpoint_config = _create_provider_from_endpoint_name(
+        store, endpoint_name, EndpointType.LLM_V1_CHAT
+    )
+    check_budget_limit(store, endpoint_config, workspace=workspace)
 
     if body.get("stream", False):
         stream = await provider.passthrough(
@@ -823,11 +851,11 @@ async def gemini_passthrough_generate_content(endpoint_name: str, request: Reque
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
-    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
-
     headers = dict(request.headers)
-    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
+    provider, endpoint_config = _create_provider_from_endpoint_name(
+        store, endpoint_name, EndpointType.LLM_V1_CHAT
+    )
+    check_budget_limit(store, endpoint_config, workspace=workspace)
     traced_passthrough = maybe_traced_gateway_call(
         provider.passthrough,
         endpoint_config,
@@ -871,11 +899,11 @@ async def gemini_passthrough_stream_generate_content(endpoint_name: str, request
     store = _get_store()
     workspace = get_request_workspace()
     _validate_store(store)
-    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
-    check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
-
     headers = dict(request.headers)
-    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
+    provider, endpoint_config = _create_provider_from_endpoint_name(
+        store, endpoint_name, EndpointType.LLM_V1_CHAT
+    )
+    check_budget_limit(store, endpoint_config, workspace=workspace)
 
     stream = await provider.passthrough(
         action=PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT, payload=body, headers=headers

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -356,30 +356,6 @@ def _create_provider(
     return primary_provider
 
 
-def _create_provider_from_endpoint_name(
-    store: SqlAlchemyStore,
-    endpoint_name: str,
-    endpoint_type: EndpointType,
-    enable_tracing: bool = True,
-) -> tuple[BaseProvider, GatewayEndpointConfig]:
-    """
-    Create a provider from an endpoint name.
-
-    Args:
-        store: The SQLAlchemy store instance.
-        endpoint_name: The endpoint name.
-        endpoint_type: Endpoint type (chat or embeddings).
-        enable_tracing: If True, enables MLflow tracing for provider calls.
-
-    Returns:
-        Tuple of (provider instance, endpoint config)
-    """
-    endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
-    return _create_provider(
-        endpoint_config, endpoint_type, enable_tracing=enable_tracing
-    ), endpoint_config
-
-
 def _validate_store(store: AbstractStore) -> None:
     if not isinstance(store, SqlAlchemyStore):
         raise HTTPException(
@@ -442,9 +418,7 @@ async def invocations(endpoint_name: str, request: Request):
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Invalid chat payload: {e!s}")
 
-        provider, endpoint_config = _create_provider_from_endpoint_name(
-            store, endpoint_name, endpoint_type
-        )
+        provider = _create_provider(endpoint_config, endpoint_type)
 
         if payload.stream:
             stream = maybe_traced_gateway_call(
@@ -478,9 +452,7 @@ async def invocations(endpoint_name: str, request: Request):
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Invalid embeddings payload: {e!s}")
 
-        provider, endpoint_config = _create_provider_from_endpoint_name(
-            store, endpoint_name, endpoint_type
-        )
+        provider = _create_provider(endpoint_config, endpoint_type)
 
         return await maybe_traced_gateway_call(
             provider.embeddings,
@@ -536,9 +508,7 @@ async def chat_completions(request: Request):
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid chat payload: {e!s}")
 
-    provider, endpoint_config = _create_provider_from_endpoint_name(
-        store, endpoint_name, EndpointType.LLM_V1_CHAT
-    )
+    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
 
     if payload.stream:
         stream = maybe_traced_gateway_call(
@@ -599,9 +569,7 @@ async def openai_passthrough_chat(request: Request):
     check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
-    provider, endpoint_config = _create_provider_from_endpoint_name(
-        store, endpoint_name, EndpointType.LLM_V1_CHAT
-    )
+    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
 
     if body.get("stream", False):
         stream = await provider.passthrough(
@@ -668,9 +636,7 @@ async def openai_passthrough_embeddings(request: Request):
     check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
-    provider, endpoint_config = _create_provider_from_endpoint_name(
-        store, endpoint_name, EndpointType.LLM_V1_EMBEDDINGS
-    )
+    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_EMBEDDINGS)
 
     traced_passthrough = maybe_traced_gateway_call(
         provider.passthrough,
@@ -719,9 +685,7 @@ async def openai_passthrough_responses(request: Request):
     check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
-    provider, endpoint_config = _create_provider_from_endpoint_name(
-        store, endpoint_name, EndpointType.LLM_V1_CHAT
-    )
+    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
 
     if body.get("stream", False):
         stream = await provider.passthrough(
@@ -792,9 +756,7 @@ async def anthropic_passthrough_messages(request: Request):
     check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
-    provider, endpoint_config = _create_provider_from_endpoint_name(
-        store, endpoint_name, EndpointType.LLM_V1_CHAT
-    )
+    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
 
     if body.get("stream", False):
         stream = await provider.passthrough(
@@ -865,9 +827,7 @@ async def gemini_passthrough_generate_content(endpoint_name: str, request: Reque
     check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
-    provider, endpoint_config = _create_provider_from_endpoint_name(
-        store, endpoint_name, EndpointType.LLM_V1_CHAT
-    )
+    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
     traced_passthrough = maybe_traced_gateway_call(
         provider.passthrough,
         endpoint_config,
@@ -915,9 +875,7 @@ async def gemini_passthrough_stream_generate_content(endpoint_name: str, request
     check_budget_limit(store, workspace=workspace, endpoint_config=endpoint_config)
 
     headers = dict(request.headers)
-    provider, endpoint_config = _create_provider_from_endpoint_name(
-        store, endpoint_name, EndpointType.LLM_V1_CHAT
-    )
+    provider = _create_provider(endpoint_config, EndpointType.LLM_V1_CHAT)
 
     stream = await provider.passthrough(
         action=PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT, payload=body, headers=headers

--- a/mlflow/server/gateway_budget.py
+++ b/mlflow/server/gateway_budget.py
@@ -9,10 +9,17 @@ import logging
 from fastapi import HTTPException
 
 import mlflow
+from mlflow.entities import SpanType
 from mlflow.entities.gateway_budget_policy import BudgetAction, BudgetTargetScope
+from mlflow.entities.trace_location import MlflowExperimentLocation
 from mlflow.entities.webhook import WebhookAction, WebhookEntity, WebhookEvent
 from mlflow.gateway.budget_tracker import BudgetWindow, get_budget_tracker
-from mlflow.gateway.tracing_utils import _get_model_span_info
+from mlflow.gateway.tracing_utils import (
+    _gateway_span_attributes,
+    _gateway_span_name,
+    _get_model_span_info,
+)
+from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.tracing.constant import CostKey, SpanAttributeKey
 from mlflow.tracing.utils import calculate_cost_by_model_and_token_usage
@@ -74,7 +81,7 @@ def maybe_refresh_budget_policies(store: SqlAlchemyStore) -> None:
             existing_spend = calculate_existing_cost_for_new_windows(store, new_windows)
             tracker.backfill_spend(existing_spend)
         except Exception:
-            _logger.debug("Failed to refresh budget policies", exc_info=True)
+            _logger.error("Failed to refresh budget policies", exc_info=True)
 
 
 def _compute_cost_from_child_spans(trace_id: str) -> float:
@@ -125,10 +132,38 @@ def fire_budget_exceeded_webhooks(
         deliver_webhook(event=event, payload=payload, store=registry_store)
 
 
-def check_budget_limit(store: SqlAlchemyStore, workspace: str | None = None) -> None:
+def _create_budget_error_trace(
+    endpoint_config: GatewayEndpointConfig,
+    exception: HTTPException,
+) -> None:
+    """Create an error trace for a budget limit rejection.
+
+    Only creates a trace when usage tracking is enabled (the endpoint has an
+    experiment_id), matching the guard in ``maybe_traced_gateway_call``.
+    """
+    if not endpoint_config.experiment_id:
+        return
+    try:
+        with mlflow.start_span(
+            name=_gateway_span_name(endpoint_config),
+            span_type=SpanType.LLM,
+            trace_destination=MlflowExperimentLocation(endpoint_config.experiment_id),
+            attributes=_gateway_span_attributes(endpoint_config),
+        ) as span:
+            span.record_exception(exception)
+    except Exception:
+        _logger.debug("Failed to create budget error trace", exc_info=True)
+
+
+def check_budget_limit(
+    store: SqlAlchemyStore,
+    workspace: str | None = None,
+    endpoint_config: GatewayEndpointConfig | None = None,
+) -> None:
     """Check if any REJECT-capable budget policy is exceeded.
 
     Raises HTTPException(429) if the budget limit is exceeded.
+    If endpoint_config is provided, an error trace is recorded before raising.
     """
     maybe_refresh_budget_policies(store)
     tracker = get_budget_tracker()
@@ -139,16 +174,17 @@ def check_budget_limit(store: SqlAlchemyStore, workspace: str | None = None) -> 
         if policy.duration_value == 1:
             unit = unit.rstrip("s")
         reset_time = window.window_end.strftime("%Y-%m-%dT%H:%M:%SZ")
-        raise HTTPException(
-            status_code=429,
-            detail=(
-                f"Budget limit exceeded. "
-                f"Limit: ${policy.budget_amount:.2f} USD per "
-                f"{policy.duration_value} {unit}. "
-                f"Budget resets at {reset_time}. "
-                "Request rejected."
-            ),
+        detail = (
+            f"Budget limit exceeded. "
+            f"Limit: ${policy.budget_amount:.2f} USD per "
+            f"{policy.duration_value} {unit}. "
+            f"Budget resets at {reset_time}. "
+            "Request rejected."
         )
+        exc = HTTPException(status_code=429, detail=detail)
+        if endpoint_config:
+            _create_budget_error_trace(endpoint_config, exc)
+        raise exc
 
 
 def make_budget_on_complete(

--- a/mlflow/server/gateway_budget.py
+++ b/mlflow/server/gateway_budget.py
@@ -81,7 +81,7 @@ def maybe_refresh_budget_policies(store: SqlAlchemyStore) -> None:
             existing_spend = calculate_existing_cost_for_new_windows(store, new_windows)
             tracker.backfill_spend(existing_spend)
         except Exception:
-            _logger.error("Failed to refresh budget policies", exc_info=True)
+            _logger.debug("Failed to refresh budget policies", exc_info=True)
 
 
 def _compute_cost_from_child_spans(trace_id: str) -> float:
@@ -182,7 +182,7 @@ def check_budget_limit(
             "Request rejected."
         )
         exc = HTTPException(status_code=429, detail=detail)
-        if endpoint_config:
+        if endpoint_config is not None:
             _create_budget_error_trace(endpoint_config, exc)
         raise exc
 

--- a/mlflow/server/gateway_budget.py
+++ b/mlflow/server/gateway_budget.py
@@ -157,13 +157,12 @@ def _create_budget_error_trace(
 
 def check_budget_limit(
     store: SqlAlchemyStore,
+    endpoint_config: GatewayEndpointConfig,
     workspace: str | None = None,
-    endpoint_config: GatewayEndpointConfig | None = None,
 ) -> None:
     """Check if any REJECT-capable budget policy is exceeded.
 
-    Raises HTTPException(429) if the budget limit is exceeded.
-    If endpoint_config is provided, an error trace is recorded before raising.
+    Raises HTTPException(429) with an error trace if the budget limit is exceeded.
     """
     maybe_refresh_budget_policies(store)
     tracker = get_budget_tracker()
@@ -182,8 +181,7 @@ def check_budget_limit(
             "Request rejected."
         )
         exc = HTTPException(status_code=429, detail=detail)
-        if endpoint_config is not None:
-            _create_budget_error_trace(endpoint_config, exc)
+        _create_budget_error_trace(endpoint_config, exc)
         raise exc
 
 

--- a/tests/gateway/test_gateway_budget.py
+++ b/tests/gateway/test_gateway_budget.py
@@ -16,7 +16,6 @@ from mlflow.entities.gateway_budget_policy import (
 from mlflow.gateway.budget_tracker import get_budget_tracker
 from mlflow.gateway.tracing_utils import maybe_traced_gateway_call
 from mlflow.server.gateway_budget import (
-    _create_budget_error_trace,
     calculate_existing_cost_for_new_windows,
     check_budget_limit,
     fire_budget_exceeded_webhooks,
@@ -524,19 +523,6 @@ def test_check_budget_limit_no_trace_without_experiment_id():
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected"):
         check_budget_limit(store, _NO_TRACE_CONFIG)
-
-    assert mlflow.get_last_active_trace_id() is None
-
-
-def test_create_budget_error_trace_skips_without_experiment_id():
-    endpoint_config = GatewayEndpointConfig(
-        endpoint_id="ep-test",
-        endpoint_name="test-endpoint",
-        experiment_id=None,
-        models=[],
-    )
-    exc = fastapi.HTTPException(status_code=429, detail="Budget exceeded")
-    _create_budget_error_trace(endpoint_config, exc)
 
     assert mlflow.get_last_active_trace_id() is None
 

--- a/tests/gateway/test_gateway_budget.py
+++ b/tests/gateway/test_gateway_budget.py
@@ -55,13 +55,21 @@ def _make_policy(
     )
 
 
-def _make_endpoint_config():
+def _make_endpoint_config(experiment_id=None):
     return GatewayEndpointConfig(
         endpoint_id="ep-test",
         endpoint_name="test-endpoint",
-        experiment_id=_get_experiment_id(),
+        experiment_id=experiment_id or _get_experiment_id(),
         models=[],
     )
+
+
+_NO_TRACE_CONFIG = GatewayEndpointConfig(
+    endpoint_id="ep-test",
+    endpoint_name="test-endpoint",
+    experiment_id=None,
+    models=[],
+)
 
 
 def _make_store(policies=None):
@@ -344,7 +352,7 @@ def test_refresh_triggers_backfill():
 
 def test_check_budget_limit_no_policies():
     store = _make_store(policies=[])
-    check_budget_limit(store)
+    check_budget_limit(store, _NO_TRACE_CONFIG)
 
 
 def test_check_budget_limit_not_exceeded():
@@ -355,7 +363,7 @@ def test_check_budget_limit_not_exceeded():
     tracker.refresh_policies([policy])
     tracker.record_cost(50.0)
 
-    check_budget_limit(store)
+    check_budget_limit(store, _NO_TRACE_CONFIG)
 
 
 def test_check_budget_limit_exceeded_rejects():
@@ -367,7 +375,7 @@ def test_check_budget_limit_exceeded_rejects():
     tracker.record_cost(150.0)
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected"):
-        check_budget_limit(store)
+        check_budget_limit(store, _NO_TRACE_CONFIG)
 
 
 def test_check_budget_limit_alert_does_not_reject():
@@ -378,7 +386,7 @@ def test_check_budget_limit_alert_does_not_reject():
     tracker.refresh_policies([policy])
     tracker.record_cost(150.0)
 
-    check_budget_limit(store)
+    check_budget_limit(store, _NO_TRACE_CONFIG)
 
 
 def test_check_budget_limit_error_message_format():
@@ -394,7 +402,7 @@ def test_check_budget_limit_error_message_format():
     tracker.record_cost(600.0)
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected") as exc_info:
-        check_budget_limit(store)
+        check_budget_limit(store, _NO_TRACE_CONFIG)
 
     detail = exc_info.value.detail
     assert "$500.00" in detail
@@ -422,7 +430,7 @@ def test_check_budget_limit_error_message_plural():
     tracker.record_cost(300.0)
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected") as exc_info:
-        check_budget_limit(store)
+        check_budget_limit(store, _NO_TRACE_CONFIG)
 
     detail = exc_info.value.detail
     assert "$200.00" in detail
@@ -451,9 +459,9 @@ def test_check_budget_limit_with_workspace():
     tracker.record_cost(100.0, workspace="ws1")
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected"):
-        check_budget_limit(store, workspace="ws1")
+        check_budget_limit(store, _NO_TRACE_CONFIG, workspace="ws1")
 
-    check_budget_limit(store, workspace="ws2")
+    check_budget_limit(store, _NO_TRACE_CONFIG, workspace="ws2")
 
 
 def test_check_budget_limit_multiple_policies():
@@ -474,12 +482,12 @@ def test_check_budget_limit_multiple_policies():
 
     # 75 exceeds alert (50) but not reject (100) → no rejection
     tracker.record_cost(75.0)
-    check_budget_limit(store)
+    check_budget_limit(store, _NO_TRACE_CONFIG)
 
     # Push to 105 → exceeds reject policy → should raise
     tracker.record_cost(30.0)
     with pytest.raises(fastapi.HTTPException, match="Request rejected"):
-        check_budget_limit(store)
+        check_budget_limit(store, _NO_TRACE_CONFIG)
 
 
 # --- _create_budget_error_trace tests ---
@@ -495,7 +503,7 @@ def test_check_budget_limit_creates_error_trace_when_exceeded():
     tracker.record_cost(20.0)
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected"):
-        check_budget_limit(store, endpoint_config=endpoint_config)
+        check_budget_limit(store, endpoint_config)
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert trace is not None
@@ -506,7 +514,7 @@ def test_check_budget_limit_creates_error_trace_when_exceeded():
     assert root_span.events[0].name == "exception"
 
 
-def test_check_budget_limit_no_trace_without_endpoint_config():
+def test_check_budget_limit_no_trace_without_experiment_id():
     policy = _make_policy(budget_amount=10.0, budget_action=BudgetAction.REJECT)
     store = _make_store(policies=[policy])
 
@@ -515,7 +523,7 @@ def test_check_budget_limit_no_trace_without_endpoint_config():
     tracker.record_cost(20.0)
 
     with pytest.raises(fastapi.HTTPException, match="Request rejected"):
-        check_budget_limit(store)
+        check_budget_limit(store, _NO_TRACE_CONFIG)
 
     assert mlflow.get_last_active_trace_id() is None
 

--- a/tests/gateway/test_gateway_budget.py
+++ b/tests/gateway/test_gateway_budget.py
@@ -5,7 +5,7 @@ import pytest
 
 import mlflow
 import mlflow.gateway.budget_tracker as _bt_module
-from mlflow.entities import SpanType
+from mlflow.entities import SpanStatusCode, SpanType
 from mlflow.entities.gateway_budget_policy import (
     BudgetAction,
     BudgetDurationUnit,
@@ -16,6 +16,7 @@ from mlflow.entities.gateway_budget_policy import (
 from mlflow.gateway.budget_tracker import get_budget_tracker
 from mlflow.gateway.tracing_utils import maybe_traced_gateway_call
 from mlflow.server.gateway_budget import (
+    _create_budget_error_trace,
     calculate_existing_cost_for_new_windows,
     check_budget_limit,
     fire_budget_exceeded_webhooks,
@@ -479,3 +480,54 @@ def test_check_budget_limit_multiple_policies():
     tracker.record_cost(30.0)
     with pytest.raises(fastapi.HTTPException, match="Request rejected"):
         check_budget_limit(store)
+
+
+# --- _create_budget_error_trace tests ---
+
+
+def test_check_budget_limit_creates_error_trace_when_exceeded():
+    policy = _make_policy(budget_amount=10.0, budget_action=BudgetAction.REJECT)
+    store = _make_store(policies=[policy])
+    endpoint_config = _make_endpoint_config()
+
+    tracker = get_budget_tracker()
+    tracker.refresh_policies([policy])
+    tracker.record_cost(20.0)
+
+    with pytest.raises(fastapi.HTTPException, match="Request rejected"):
+        check_budget_limit(store, endpoint_config=endpoint_config)
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace is not None
+    root_span = trace.data.spans[0]
+    assert root_span.name == "gateway/test-endpoint"
+    assert root_span.status.status_code == SpanStatusCode.ERROR
+    assert len(root_span.events) == 1
+    assert root_span.events[0].name == "exception"
+
+
+def test_check_budget_limit_no_trace_without_endpoint_config():
+    policy = _make_policy(budget_amount=10.0, budget_action=BudgetAction.REJECT)
+    store = _make_store(policies=[policy])
+
+    tracker = get_budget_tracker()
+    tracker.refresh_policies([policy])
+    tracker.record_cost(20.0)
+
+    with pytest.raises(fastapi.HTTPException, match="Request rejected"):
+        check_budget_limit(store)
+
+    assert mlflow.get_last_active_trace_id() is None
+
+
+def test_create_budget_error_trace_skips_without_experiment_id():
+    endpoint_config = GatewayEndpointConfig(
+        endpoint_id="ep-test",
+        endpoint_name="test-endpoint",
+        experiment_id=None,
+        models=[],
+    )
+    exc = fastapi.HTTPException(status_code=429, detail="Budget exceeded")
+    _create_budget_error_trace(endpoint_config, exc)
+
+    assert mlflow.get_last_active_trace_id() is None

--- a/tests/gateway/test_gateway_budget.py
+++ b/tests/gateway/test_gateway_budget.py
@@ -539,3 +539,17 @@ def test_create_budget_error_trace_skips_without_experiment_id():
     _create_budget_error_trace(endpoint_config, exc)
 
     assert mlflow.get_last_active_trace_id() is None
+
+
+def test_check_budget_limit_no_trace_when_under_budget():
+    policy = _make_policy(budget_amount=100.0, budget_action=BudgetAction.REJECT)
+    store = _make_store(policies=[policy])
+    endpoint_config = _make_endpoint_config()
+
+    tracker = get_budget_tracker()
+    tracker.refresh_policies([policy])
+    tracker.record_cost(50.0)
+
+    check_budget_limit(store, endpoint_config)
+
+    assert mlflow.get_last_active_trace_id() is None


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When `check_budget_limit` raises `HTTPException(429)`, generate an error trace in the endpoint's experiment so rejected requests are visible in the tracing UI.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release