### PR TITLE
Fix GenAI evaluation to use correct experiment ID for traces and cleanup

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -122,6 +122,7 @@ def run(
     eval_start_time = int(time.time() * 1000)
 
     run_id = context.get_context().get_mlflow_run_id() if run_id is None else run_id
+    experiment_id = mlflow.get_run(run_id).info.experiment_id
 
     # Classify scorers into single-turn and multi-turn
     single_turn_scorers, multi_turn_scorers = classify_scorers(scorers)
@@ -142,6 +143,7 @@ def run(
                 scorers=single_turn_scorers,
                 predict_fn=predict_fn,
                 run_id=run_id,
+                experiment_id=experiment_id,
             ): i
             for i, eval_item in enumerate(eval_items)
         }
@@ -246,6 +248,7 @@ def _run_single(
     scorers: list[Scorer],
     run_id: str | None,
     predict_fn: Callable[..., Any] | None = None,
+    experiment_id: str | None = None,
 ) -> EvalResult:
     """Run the logic of the eval harness for a single eval item."""
     # Set the MLflow run ID in the context for this thread
@@ -269,7 +272,7 @@ def _run_single(
 
         eval_item.trace = mlflow.get_trace(eval_request_id, silent=True)
     elif eval_item.trace is not None:
-        if _should_clone_trace(eval_item.trace, run_id):
+        if _should_clone_trace(eval_item.trace, run_id, experiment_id):
             try:
                 trace_id = copy_trace_to_experiment(eval_item.trace.to_dict())
                 eval_item.trace = mlflow.get_trace(trace_id)
@@ -490,7 +493,9 @@ def _refresh_eval_result_traces(eval_results: list[EvalResult]) -> None:
                 eval_result.eval_item.trace = refreshed_trace
 
 
-def _should_clone_trace(trace: Trace | None, run_id: str | None) -> bool:
+def _should_clone_trace(
+    trace: Trace | None, run_id: str | None, experiment_id: str | None = None
+) -> bool:
     from mlflow.tracking.fluent import _get_experiment_id
 
     if trace is None:
@@ -502,10 +507,7 @@ def _should_clone_trace(trace: Trace | None, run_id: str | None) -> bool:
 
     # Check if the trace is from the same experiment. If it isn't, we need to clone the trace
     trace_experiment = trace.info.trace_location.mlflow_experiment
-    if run_id is not None:
-        current_experiment = mlflow.get_run(run_id).info.experiment_id
-    else:
-        current_experiment = _get_experiment_id()
+    current_experiment = experiment_id or _get_experiment_id()
     if trace_experiment is not None and trace_experiment.experiment_id != current_experiment:
         return True
 

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -218,7 +218,11 @@ def run(
 
     # Search for all traces in the run. We need to fetch the traces from backend here to include
     # all traces in the result.
-    traces = mlflow.search_traces(run_id=run_id, include_spans=False, return_type="list")
+    # Fetch the experiment ID from the run to ensure we search in the correct experiment.
+    experiment_id = mlflow.get_run(run_id).info.experiment_id
+    traces = mlflow.search_traces(
+        locations=[experiment_id], run_id=run_id, include_spans=False, return_type="list"
+    )
 
     # Collect trace IDs from eval results to preserve them during cleanup.
     input_trace_ids = {
@@ -228,7 +232,7 @@ def run(
     }
 
     # Clean up noisy traces generated during evaluation
-    clean_up_extra_traces(traces, eval_start_time, input_trace_ids)
+    clean_up_extra_traces(traces, eval_start_time, experiment_id, input_trace_ids)
 
     return EvaluationResult(
         run_id=run_id,
@@ -498,7 +502,10 @@ def _should_clone_trace(trace: Trace | None, run_id: str | None) -> bool:
 
     # Check if the trace is from the same experiment. If it isn't, we need to clone the trace
     trace_experiment = trace.info.trace_location.mlflow_experiment
-    current_experiment = _get_experiment_id()
+    if run_id is not None:
+        current_experiment = mlflow.get_run(run_id).info.experiment_id
+    else:
+        current_experiment = _get_experiment_id()
     if trace_experiment is not None and trace_experiment.experiment_id != current_experiment:
         return True
 

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -777,7 +777,7 @@ def clean_up_extra_traces(
     eval_start_time: int,
     experiment_id: str,
     input_trace_ids: set[str] | None = None,
-) -> list[Trace]:
+) -> None:
     """
     Clean up noisy traces generated outside predict function.
 
@@ -792,9 +792,6 @@ def clean_up_extra_traces(
         experiment_id: The experiment ID of the evaluation run.
         input_trace_ids: Set of trace IDs that were passed in the input DataFrame.
             These traces should never be deleted.
-
-    Returns:
-        List of traces that are kept after cleaning up extra traces.
     """
     try:
         extra_trace_ids = [

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -775,6 +775,7 @@ def _parse_chunk(chunk: Any) -> dict[str, Any] | None:
 def clean_up_extra_traces(
     traces: list[Trace],
     eval_start_time: int,
+    experiment_id: str,
     input_trace_ids: set[str] | None = None,
 ) -> list[Trace]:
     """
@@ -788,14 +789,13 @@ def clean_up_extra_traces(
     Args:
         traces: List of traces to clean up.
         eval_start_time: The start time of the evaluation run.
+        experiment_id: The experiment ID of the evaluation run.
         input_trace_ids: Set of trace IDs that were passed in the input DataFrame.
             These traces should never be deleted.
 
     Returns:
         List of traces that are kept after cleaning up extra traces.
     """
-    from mlflow.tracking.fluent import _get_experiment_id
-
     try:
         extra_trace_ids = [
             trace.info.trace_id
@@ -810,9 +810,7 @@ def clean_up_extra_traces(
             # Import MlflowClient locally to avoid issues with tracing-only SDK
             from mlflow.tracking.client import MlflowClient
 
-            MlflowClient().delete_traces(
-                experiment_id=_get_experiment_id(), trace_ids=extra_trace_ids
-            )
+            MlflowClient().delete_traces(experiment_id=experiment_id, trace_ids=extra_trace_ids)
             for trace_id in extra_trace_ids:
                 IPythonTraceDisplayHandler.get_instance().traces_to_display.pop(trace_id, None)
         else:

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1587,6 +1587,11 @@ def test_should_clone_trace_respects_run_id():
 
     mlflow.set_experiment("should_clone_exp_2")
     with mlflow.start_run() as run:
-        assert _should_clone_trace(trace, run_id=run1.info.run_id) is False
-        assert _should_clone_trace(trace, run_id=run.info.run_id) is True
-        assert _should_clone_trace(trace, run_id=None) is True
+        assert not _should_clone_trace(
+            trace, run_id=run1.info.run_id, experiment_id=run1.info.experiment_id
+        )
+        assert _should_clone_trace(
+            trace, run_id=run.info.run_id, experiment_id=run.info.experiment_id
+        )
+        assert _should_clone_trace(trace, run_id=None, experiment_id=run.info.experiment_id)
+        assert _should_clone_trace(trace, run_id=None)

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -16,7 +16,11 @@ from mlflow.entities.span import SpanType
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import EvaluationDataset, create_dataset
 from mlflow.genai.evaluation.entities import EvalItem, EvaluationResult
-from mlflow.genai.evaluation.harness import _get_new_expectations, _log_assessments
+from mlflow.genai.evaluation.harness import (
+    _get_new_expectations,
+    _log_assessments,
+    _should_clone_trace,
+)
 from mlflow.genai.scorers.base import scorer
 from mlflow.genai.scorers.builtin_scorers import RelevanceToQuery
 from mlflow.genai.simulators import ConversationSimulator
@@ -1525,3 +1529,64 @@ def test_log_assessments_preserves_existing_span_id(server_config):
     logged = {a.name: a.span_id for a in trace.info.assessments}
     assert logged["with_span_id"] == retriever.span_id
     assert logged["without_span_id"] == root.span_id
+
+
+def test_evaluate_fetches_traces_using_experiment_id(server_config):
+    exp1 = mlflow.set_experiment("eval_experiment_1")
+
+    @mlflow.trace(span_type=SpanType.AGENT)
+    def predict(question: str) -> str:
+        return "MLflow is a tool for ML"
+
+    predict("What is MLflow?")
+    trace_id = mlflow.get_last_active_trace_id()
+    mlflow.log_expectation(
+        trace_id=trace_id,
+        name="expected_response",
+        value="MLflow is a tool for ML",
+        source=AssessmentSource(source_id="me", source_type="HUMAN"),
+    )
+    mlflow.log_expectation(
+        trace_id=trace_id,
+        name="max_length",
+        value=100,
+        source=AssessmentSource(source_id="me", source_type="HUMAN"),
+    )
+
+    traces_from_exp1 = mlflow.search_traces(locations=[exp1.experiment_id], return_type="list")
+    assert len(traces_from_exp1) == 1
+    assert (
+        traces_from_exp1[0].info.trace_location.mlflow_experiment.experiment_id
+        == exp1.experiment_id
+    )
+
+    # Switch to a different experiment
+    exp2 = mlflow.set_experiment("eval_experiment_2")
+    assert exp2.experiment_id != exp1.experiment_id
+
+    # Run evaluation with traces from exp1 while exp2 is active
+    result = mlflow.genai.evaluate(
+        data=traces_from_exp1,
+        scorers=[exact_match, is_concise],
+    )
+
+    assert "exact_match/mean" in result.metrics
+    assert "is_concise/mean" in result.metrics
+    run = mlflow.get_run(result.run_id)
+    assert run.info.experiment_id == exp2.experiment_id
+    traces_in_eval_run = mlflow.search_traces(run_id=result.run_id, return_type="list")
+    assert len(traces_in_eval_run) > 0
+
+
+def test_should_clone_trace_respects_run_id():
+    mlflow.set_experiment("should_clone_exp_1")
+    with mlflow.start_run() as run1:
+        with mlflow.start_span():
+            pass
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    mlflow.set_experiment("should_clone_exp_2")
+    with mlflow.start_run() as run:
+        assert _should_clone_trace(trace, run_id=run1.info.run_id) is False
+        assert _should_clone_trace(trace, run_id=run.info.run_id) is True
+        assert _should_clone_trace(trace, run_id=None) is True

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -1525,6 +1525,8 @@ def test_should_keep_trace_deletes_non_input_traces_after_eval_start():
 
 
 def test_clean_up_extra_traces_preserves_input_traces():
+    experiment_id = mlflow.set_experiment("test_experiment").experiment_id
+
     with mlflow.start_span(name="input_trace_1") as span1:
         span1.set_inputs({"question": "test1"})
         span1.set_outputs({"answer": "answer1"})
@@ -1540,12 +1542,32 @@ def test_clean_up_extra_traces_preserves_input_traces():
     input_trace_ids = {trace1.info.trace_id, trace2.info.trace_id}
     all_traces = [trace1, trace2]
 
-    clean_up_extra_traces(all_traces, eval_start_time, input_trace_ids)
+    clean_up_extra_traces(all_traces, eval_start_time, experiment_id, input_trace_ids)
 
     remaining_traces = get_traces()
     remaining_trace_ids = {t.info.trace_id for t in remaining_traces}
     assert trace1.info.trace_id in remaining_trace_ids
     assert trace2.info.trace_id in remaining_trace_ids
+
+
+def test_clean_up_extra_traces_uses_correct_experiment_id():
+    exp_1 = mlflow.set_experiment("cleanup_test_experiment").experiment_id
+    with mlflow.start_span(name="input_trace") as span1:
+        span1.set_inputs({"question": "test"})
+        span1.set_outputs({"answer": "answer"})
+    input_trace = mlflow.get_trace(span1.trace_id)
+
+    with mlflow.start_span(name="extra_trace") as span2:
+        span2.set_inputs({"question": "extra"})
+        span2.set_outputs({"answer": "extra_answer"})
+    extra_trace = mlflow.get_trace(span2.trace_id)
+
+    mlflow.set_experiment("cleanup_test_experiment_2")
+    clean_up_extra_traces([input_trace, extra_trace], 0, exp_1, {input_trace.info.trace_id})
+
+    remaining_traces = mlflow.search_traces(locations=[exp_1], return_type="list")
+    assert len(remaining_traces) == 1
+    assert remaining_traces[0].info.trace_id == input_trace.info.trace_id
 
 
 def test_evaluate_with_trace_column_preserves_traces():


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21575/files) to review incremental changes.
- [**stack/evaluate_fix**](https://github.com/mlflow/mlflow/pull/21575) [[Files changed](https://github.com/mlflow/mlflow/pull/21575/files)]
  - [stack/batch_get_traces_api](https://github.com/mlflow/mlflow/pull/21577) [[Files changed](https://github.com/mlflow/mlflow/pull/21577/files/14559b8fd82ca414fd9d15b6c0805512b5606695..1bcf2aa863c1fb3eb303f0a9b02eb43a2bd96915)]
    - [stack/update_rest_store](https://github.com/mlflow/mlflow/pull/21578) [[Files changed](https://github.com/mlflow/mlflow/pull/21578/files/1bcf2aa863c1fb3eb303f0a9b02eb43a2bd96915..96adabb6b7c42ed5579acaff0ef747b01d7cbc80)]
      - [stack/add_resolved_status](https://github.com/mlflow/mlflow/pull/21579) [[Files changed](https://github.com/mlflow/mlflow/pull/21579/files/96adabb6b7c42ed5579acaff0ef747b01d7cbc80..7ec5eb0f6b9a6c7675611f396380b19e90fe6e4e)]
        - [stack/sort_issues_by_severity](https://github.com/mlflow/mlflow/pull/21588) [[Files changed](https://github.com/mlflow/mlflow/pull/21588/files/7ec5eb0f6b9a6c7675611f396380b19e90fe6e4e..d0ce72e88a34bb4cacfba0f06a2fe332eeb38891)]
          - [stack/add_jobs_handler](https://github.com/mlflow/mlflow/pull/21589) [[Files changed](https://github.com/mlflow/mlflow/pull/21589/files/d0ce72e88a34bb4cacfba0f06a2fe332eeb38891..401942fa58d3febdd2570f60feb603818c3dcf82)]
            - [stack/enable_issue_button](https://github.com/mlflow/mlflow/pull/21205) [[Files changed](https://github.com/mlflow/mlflow/pull/21205/files/401942fa58d3febdd2570f60feb603818c3dcf82..c20d42380f325dff3d42cf608829c9308ef6f047)]
              - [stack/trigger_job_creation_api](https://github.com/mlflow/mlflow/pull/21590) [[Files changed](https://github.com/mlflow/mlflow/pull/21590/files/c20d42380f325dff3d42cf608829c9308ef6f047..fa2cc4b5d3c29a44d21b5db3828cdb75fe6a5f36)]
                - [stack/fetch_job_status](https://github.com/mlflow/mlflow/pull/21591) [[Files changed](https://github.com/mlflow/mlflow/pull/21591/files/fa2cc4b5d3c29a44d21b5db3828cdb75fe6a5f36..e64f4a066d644a845b8c208aa74930222bac8923)]
                  - [stack/add_issue_reaction](https://github.com/mlflow/mlflow/pull/21592) [[Files changed](https://github.com/mlflow/mlflow/pull/21592/files/e64f4a066d644a845b8c208aa74930222bac8923..57b26851a4ae93f7a228c142383fe671513a21c8)]
                    - [stack/cancel_job](https://github.com/mlflow/mlflow/pull/21593) [[Files changed](https://github.com/mlflow/mlflow/pull/21593/files/57b26851a4ae93f7a228c142383fe671513a21c8..bdba50457529e4a1961f5934652dc6a9db2e830d)]
                      - [stack/job_configs_rendering](https://github.com/mlflow/mlflow/pull/21594) [[Files changed](https://github.com/mlflow/mlflow/pull/21594/files/bdba50457529e4a1961f5934652dc6a9db2e830d..7eb6a0d0ae3adb9b96e2d577fdce0fbce937113b)]
                        - [stack/render_job_cost](https://github.com/mlflow/mlflow/pull/21595) [[Files changed](https://github.com/mlflow/mlflow/pull/21595/files/7eb6a0d0ae3adb9b96e2d577fdce0fbce937113b..bde3916072161e14dc0562900f078ad111a7ced0)]
                          - [stack/fix_traces_tab](https://github.com/mlflow/mlflow/pull/21596) [[Files changed](https://github.com/mlflow/mlflow/pull/21596/files/bde3916072161e14dc0562900f078ad111a7ced0..3ad6dcb49746933bcfb5e175382f5d5154000b00)]
                            - [stack/display_severity](https://github.com/mlflow/mlflow/pull/21597) [[Files changed](https://github.com/mlflow/mlflow/pull/21597/files/3ad6dcb49746933bcfb5e175382f5d5154000b00..bd0fc9f785fabf3aba364eaca37079468b9971ff)]
                              - [stack/fetch_param_from_tag](https://github.com/mlflow/mlflow/pull/21598) [[Files changed](https://github.com/mlflow/mlflow/pull/21598/files/bd0fc9f785fabf3aba364eaca37079468b9971ff..b052c7b141bb756329d2766d439de97c973c23a0)]
                                - [stack/enable_show_issues_panel](https://github.com/mlflow/mlflow/pull/21407) [[Files changed](https://github.com/mlflow/mlflow/pull/21407/files/b052c7b141bb756329d2766d439de97c973c23a0..12e27f4c741b54d623e243e7b6e1c2c085f5049b)]
                                  - [stack/issue_column_link](https://github.com/mlflow/mlflow/pull/21546) [[Files changed](https://github.com/mlflow/mlflow/pull/21546/files/12e27f4c741b54d623e243e7b6e1c2c085f5049b..c1e724b4442860363d047f1aa6495f4dd1077e03)]
                                    - [stack/trace_view_issue_link](https://github.com/mlflow/mlflow/pull/21547) [[Files changed](https://github.com/mlflow/mlflow/pull/21547/files/c1e724b4442860363d047f1aa6495f4dd1077e03..8596861bae0132e588707fc0a58514097c8db756)]
                                      - stack/fixes

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
When we trigger evaluate in the issue detection job, the experiment used inside the job will be the default experiment, that means `mlflow.search_traces` by default search for traces in experiment `0` while the provided traces may locate in a different experiment. 
As a result we should respect `the experiment_id linked with the run` instead of always get the current experiment.
This PR also fixes the issue of clean_up_extra_traces to respect the passed experiment id. 
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
