### PR TITLE
Show run description in chart tooltip

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.test.tsx
@@ -1,0 +1,90 @@
+import { jest, describe, it, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { IntlProvider } from 'react-intl';
+import { MemoryRouter } from '../../../../common/utils/RoutingUtils';
+import { RunsChartsTooltipBody } from './RunsChartsTooltipBody';
+import { RunsChartsTooltipMode } from '../hooks/useRunsChartsTooltip';
+import { RunsChartType } from '../runs-charts.types';
+import { NOTE_CONTENT_TAG } from '../../../utils/NoteUtils';
+import type { RunsChartsRunData } from './RunsCharts.common';
+import type { RunsChartsBarCardConfig } from '../runs-charts.types';
+
+jest.mock('../../experiment-page/hooks/useExperimentIds', () => ({
+  useExperimentIds: () => ['test-experiment-id'],
+}));
+
+const baseRun: RunsChartsRunData = {
+  uuid: 'run-uuid-1',
+  displayName: 'test-run',
+  metrics: { 'test-metric': { key: 'test-metric', value: 0.9, step: 1, timestamp: 0 } },
+  params: {},
+  tags: {},
+  images: {},
+  color: '#1f77b4',
+  pinned: false,
+  pinnable: true,
+  hidden: false,
+};
+
+const barChartConfig: RunsChartsBarCardConfig = {
+  type: RunsChartType.BAR,
+  uuid: 'chart-uuid',
+  deleted: false,
+  isGenerated: false,
+  metricKey: 'test-metric',
+};
+
+const renderTooltip = (run: RunsChartsRunData, isHovering = true) => {
+  render(
+    <DesignSystemProvider>
+      <IntlProvider locale="en">
+        <MemoryRouter>
+          <RunsChartsTooltipBody
+            runUuid={run.uuid}
+            isHovering={isHovering}
+            mode={RunsChartsTooltipMode.Simple}
+            hoverData={undefined}
+            chartData={barChartConfig}
+            contextData={{ runs: [run], onTogglePin: jest.fn(), onHideRun: jest.fn() }}
+            closeContextMenu={jest.fn()}
+          />
+        </MemoryRouter>
+      </IntlProvider>
+    </DesignSystemProvider>,
+  );
+};
+
+describe('RunsChartsTooltipBody', () => {
+  it('shows description when run has a description tag', () => {
+    const runWithDescription: RunsChartsRunData = {
+      ...baseRun,
+      tags: {
+        [NOTE_CONTENT_TAG]: { key: NOTE_CONTENT_TAG, value: 'This is a test run description.' },
+      },
+    };
+    renderTooltip(runWithDescription);
+    expect(screen.getByText('This is a test run description.')).toBeInTheDocument();
+  });
+
+  it('does not show description section when run has no description', () => {
+    renderTooltip(baseRun);
+    expect(screen.queryByText('This is a test run description.')).not.toBeInTheDocument();
+  });
+
+  it('shows description in context menu mode (isHovering=false)', () => {
+    const runWithDescription: RunsChartsRunData = {
+      ...baseRun,
+      tags: {
+        [NOTE_CONTENT_TAG]: { key: NOTE_CONTENT_TAG, value: 'Context menu description.' },
+      },
+    };
+    renderTooltip(runWithDescription, false);
+    expect(screen.getByText('Context menu description.')).toBeInTheDocument();
+  });
+
+  it('shows run name in the tooltip', () => {
+    renderTooltip(baseRun);
+    expect(screen.getByText('test-run')).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.test.tsx
@@ -9,6 +9,7 @@ import { RunsChartType } from '../runs-charts.types';
 import { NOTE_CONTENT_TAG } from '../../../utils/NoteUtils';
 import type { RunsChartsRunData } from './RunsCharts.common';
 import type { RunsChartsBarCardConfig } from '../runs-charts.types';
+import type { RunsMetricsSingleTraceTooltipData } from './RunsMetricsLinePlot';
 
 jest.mock('../../experiment-page/hooks/useExperimentIds', () => ({
   useExperimentIds: () => ['test-experiment-id'],
@@ -35,6 +36,13 @@ const barChartConfig: RunsChartsBarCardConfig = {
   metricKey: 'test-metric',
 };
 
+const mockHoverData: RunsMetricsSingleTraceTooltipData = {
+  xValue: 1,
+  yValue: 0.9,
+  index: 0,
+  label: 'Step',
+};
+
 const renderTooltip = (run: RunsChartsRunData, isHovering = true) => {
   render(
     <DesignSystemProvider>
@@ -44,7 +52,7 @@ const renderTooltip = (run: RunsChartsRunData, isHovering = true) => {
             runUuid={run.uuid}
             isHovering={isHovering}
             mode={RunsChartsTooltipMode.Simple}
-            hoverData={undefined}
+            hoverData={mockHoverData}
             chartData={barChartConfig}
             contextData={{ runs: [run], onTogglePin: jest.fn(), onHideRun: jest.fn() }}
             closeContextMenu={jest.fn()}

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -326,7 +326,7 @@ export const RunsChartsTooltipBody = ({
       </div>
 
       {description && (
-        <Typography.Text size="sm" color="secondary" css={styles.description}>
+        <Typography.Text size="sm" color="secondary" css={styles.description} title={description}>
           {description}
         </Typography.Text>
       )}

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -326,14 +326,15 @@ export const RunsChartsTooltipBody = ({
       </div>
 
       {description && (
-        <Typography.Paragraph
-          color="secondary"
-          withoutMargins
-          css={styles.description}
-          ellipsis={{ rows: 2, tooltip: description }}
-        >
-          {description}
-        </Typography.Paragraph>
+        <div css={styles.description}>
+          <Typography.Paragraph
+            color="secondary"
+            withoutMargins
+            ellipsis={{ rows: 2, tooltip: description }}
+          >
+            {description}
+          </Typography.Paragraph>
+        </div>
       )}
 
       <ValuesBox

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -326,9 +326,14 @@ export const RunsChartsTooltipBody = ({
       </div>
 
       {description && (
-        <Typography.Text size="sm" color="secondary" css={styles.description} title={description}>
+        <Typography.Paragraph
+          color="secondary"
+          withoutMargins
+          css={styles.description}
+          ellipsis={{ rows: 2, tooltip: description }}
+        >
           {description}
-        </Typography.Text>
+        </Typography.Paragraph>
       )}
 
       <ValuesBox
@@ -420,11 +425,6 @@ const styles = {
   },
   description: {
     marginBottom: 12,
-    display: '-webkit-box',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    WebkitBoxOrient: 'vertical' as const,
-    WebkitLineClamp: 2,
     wordBreak: 'break-word' as const,
   },
   value: {

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -327,11 +327,7 @@ export const RunsChartsTooltipBody = ({
 
       {description && (
         <div css={styles.description}>
-          <Typography.Paragraph
-            color="secondary"
-            withoutMargins
-            ellipsis={{ rows: 2, tooltip: description }}
-          >
+          <Typography.Paragraph color="secondary" withoutMargins ellipsis={{ rows: 2, tooltip: description }}>
             {description}
           </Typography.Paragraph>
         </div>

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -298,7 +298,7 @@ export const RunsChartsTooltipBody = ({
   const description = Utils.getRunDescriptionFromTags(activeRun.tags);
 
   return (
-    <div>
+    <div css={styles.tooltipBody}>
       <div css={[styles.contentWrapper, description && styles.contentWrapperCompact]}>
         <div css={styles.header}>
           <div css={styles.colorPill} style={{ backgroundColor: activeRun.color }} />
@@ -325,7 +325,11 @@ export const RunsChartsTooltipBody = ({
         )}
       </div>
 
-      {description && <div css={styles.description}>{description}</div>}
+      {description && (
+        <Typography.Text size="sm" color="secondary" css={styles.description}>
+          {description}
+        </Typography.Text>
+      )}
 
       <ValuesBox
         isHovering={isHovering}
@@ -393,6 +397,9 @@ export const RunsChartsTooltipBody = ({
 };
 
 const styles = {
+  tooltipBody: {
+    maxWidth: 300,
+  },
   runLink: (theme: Theme) => ({
     color: theme.colors.primary,
     '&:hover': {},
@@ -411,16 +418,15 @@ const styles = {
   contentWrapperCompact: {
     marginBottom: 4,
   },
-  description: (theme: Theme) => ({
-    fontSize: theme.typography.fontSizeSm,
-    color: theme.colors.textSecondary,
+  description: {
     marginBottom: 12,
     display: '-webkit-box',
-    WebkitLineClamp: 2,
-    WebkitBoxOrient: 'vertical' as const,
     overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    WebkitBoxOrient: 'vertical' as const,
+    WebkitLineClamp: 2,
     wordBreak: 'break-word' as const,
-  }),
+  },
   value: {
     whiteSpace: 'nowrap' as const,
     overflow: 'hidden',

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -16,6 +16,7 @@ import Routes from '../../../routes';
 import { useExperimentIds } from '../../experiment-page/hooks/useExperimentIds';
 import type { RunsChartsRunData } from './RunsCharts.common';
 import { RunsChartsLineChartXAxisType } from './RunsCharts.common';
+import Utils from '../../../../common/utils/Utils';
 import type { RunsChartsTooltipBodyProps } from '../hooks/useRunsChartsTooltip';
 import { RunsChartsTooltipMode, containsMultipleRunsTooltipData } from '../hooks/useRunsChartsTooltip';
 import type {
@@ -294,6 +295,7 @@ export const RunsChartsTooltipBody = ({
 
   const runName = activeRun.displayName || activeRun.uuid;
   const metricSuffix = singleTraceHoverData?.metricEntity ? ` (${singleTraceHoverData.metricEntity.key})` : '';
+  const description = Utils.getRunDescriptionFromTags(activeRun.tags);
 
   return (
     <div>
@@ -322,6 +324,8 @@ export const RunsChartsTooltipBody = ({
           />
         )}
       </div>
+
+      {description && <div css={styles.description}>{description}</div>}
 
       <ValuesBox
         isHovering={isHovering}
@@ -404,6 +408,17 @@ const styles = {
     gap: 8,
     alignItems: 'center',
   },
+  description: (theme: Theme) => ({
+    fontSize: theme.typography.fontSizeSm,
+    color: theme.colors.textSecondary,
+    marginBottom: theme.spacing.sm,
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical' as const,
+    overflow: 'hidden',
+    maxWidth: 240,
+    wordBreak: 'break-word' as const,
+  }),
   value: {
     whiteSpace: 'nowrap' as const,
     overflow: 'hidden',

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsTooltipBody.tsx
@@ -299,7 +299,7 @@ export const RunsChartsTooltipBody = ({
 
   return (
     <div>
-      <div css={styles.contentWrapper}>
+      <div css={[styles.contentWrapper, description && styles.contentWrapperCompact]}>
         <div css={styles.header}>
           <div css={styles.colorPill} style={{ backgroundColor: activeRun.color }} />
           {activeRun.groupParentInfo ? (
@@ -408,15 +408,17 @@ const styles = {
     gap: 8,
     alignItems: 'center',
   },
+  contentWrapperCompact: {
+    marginBottom: 4,
+  },
   description: (theme: Theme) => ({
     fontSize: theme.typography.fontSizeSm,
     color: theme.colors.textSecondary,
-    marginBottom: theme.spacing.sm,
+    marginBottom: 12,
     display: '-webkit-box',
     WebkitLineClamp: 2,
     WebkitBoxOrient: 'vertical' as const,
     overflow: 'hidden',
-    maxWidth: 240,
     wordBreak: 'break-word' as const,
   }),
   value: {


### PR DESCRIPTION
### Related Issues/PRs

Closes #21233

### What changes are proposed in this pull request?

When hovering over a data point in the experiment chart view, the tooltip now displays the run's description (stored in the `mlflow.note.content` tag) below the run name, if one is set.

**Before:** Tooltip showed only run name + metric value — no way to distinguish runs by description without clicking into each one.

<img width="1491" height="840" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/c4ee6f02-24f7-47eb-826a-6cec8cc6c9dc" />

When clicked on specific run:
<img width="1515" height="841" alt="Pasted Graphic 9" src="https://github.com/user-attachments/assets/47c8c1c0-ed88-4003-9a3a-0c5490e54710" />


**After:** Description appears below the run name in secondary text, clamped to 2 lines with ellipsis for long descriptions. Runs without a description are unaffected (nothing extra is rendered).

When clicked on specific run:

<img width="1512" height="853" alt="Pasted Graphic 10" src="https://github.com/user-attachments/assets/3825b813-180c-4cb0-bee5-e3a5825168cf" />

<img width="1501" height="851" alt="Pasted Graphic 11" src="https://github.com/user-attachments/assets/81be504d-bda3-4f50-bbbd-cb4ccbbeeef6" />

The change is minimal — one file modified:
- `RunsChartsTooltipBody.tsx`: import `Utils`, extract description via `Utils.getRunDescriptionFromTags(activeRun.tags)`, and render it conditionally between the header and the values box.

The `tags` field was already present on `RunsChartsRunData`, so no data plumbing was required.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

New test file `RunsChartsTooltipBody.test.tsx` (no prior test coverage existed for this component) with 4 tests:
- Description is rendered when `mlflow.note.content` tag is set
- Description is not rendered when the tag is absent
- Description is rendered in both hover mode and context menu mode (`isHovering=false`)
- Run name continues to render correctly (regression check)

Manual testing: started local dev server, created 5 runs with varied descriptions and metric history, verified description appears in chart tooltip on hover.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Run descriptions are now displayed in chart tooltips when hovering over data points in the experiment chart view, making it easier to distinguish between runs without navigating away from the chart.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release