### PR TITLE
Add azure extra for Azure Blob Storage support in full Docker image

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -364,6 +364,11 @@ def build(package_type: PackageType) -> None:
                 "genai": genai_requirements,
                 # click 8.3.0 causes MLflow MCP server to fail: https://github.com/mlflow/mlflow/issues/18747
                 "mcp": ["fastmcp<3,>=2.0.0", "click!=8.3.0"],
+                "azure": [
+                    # Required to log artifacts and models to Azure Blob Storage
+                    "azure-storage-blob>=12",
+                    "azure-identity>=1.6.1",
+                ],
                 "sqlserver": ["mlflow-dbstore"],
                 "aliyun-oss": ["aliyunstoreplugin"],
                 "jfrog": ["mlflow-jfrog-plugin"],

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -1,4 +1,4 @@
 FROM python:3.10-slim-bullseye
 ARG VERSION
 
-RUN pip install --no-cache-dir mlflow[extras,db,gateway,genai]==$VERSION
+RUN pip install --no-cache-dir mlflow[extras,azure,db,gateway,genai]==$VERSION

--- a/docker/Dockerfile.full.dev
+++ b/docker/Dockerfile.full.dev
@@ -4,4 +4,4 @@ WORKDIR /app
 ADD . /app
 
 # Install MLflow from the current directory with extras
-RUN pip install --no-cache-dir .[extras,db,databricks,gateway,genai]
+RUN pip install --no-cache-dir .[extras,azure,db,databricks,gateway,genai]

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -97,6 +97,7 @@ genai = [
   "watchfiles<2",
 ]
 mcp = ["fastmcp<3,>=2.0.0", "click!=8.3.0"]
+azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -81,7 +81,7 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             except ImportError as exc:
                 raise ImportError(
                     "Using DefaultAzureCredential requires the azure-identity package. "
-                    "Please install it via: pip install azure-identity"
+                    "Please install it via: pip install mlflow[azure]"
                 ) from exc
 
             account_url = f"https://{account}.{api_uri_suffix}"

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -99,6 +99,7 @@ genai = [
   "watchfiles<2",
 ]
 mcp = ["fastmcp<3,>=2.0.0", "click!=8.3.0"]
+azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ genai = [
   "watchfiles<2",
 ]
 mcp = ["fastmcp<3,>=2.0.0", "click!=8.3.0"]
+azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]

--- a/uv.lock
+++ b/uv.lock
@@ -455,6 +455,22 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-identity"
+version = "1.25.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/3a/439a32a5e23e45f6a91f0405949dc66cfe6834aba15a430aebfc063a81e7/azure_identity-1.25.2.tar.gz", hash = "sha256:030dbaa720266c796221c6cdbd1999b408c079032c919fef725fcc348a540fe9", size = 284709, upload-time = "2026-02-11T01:55:42.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/77/f658c76f9e9a52c784bd836aaca6fd5b9aae176f1f53273e758a2bcda695/azure_identity-1.25.2-py3-none-any.whl", hash = "sha256:1b40060553d01a72ba0d708b9a46d0f61f56312e215d8896d836653ffdc6753d", size = 191423, upload-time = "2026-02-11T01:55:44.245Z" },
+]
+
+[[package]]
 name = "azure-mgmt-authorization"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4261,6 +4277,10 @@ aliyun-oss = [
 auth = [
     { name = "flask-wtf" },
 ]
+azure = [
+    { name = "azure-identity" },
+    { name = "azure-storage-blob" },
+]
 databricks = [
     { name = "azure-storage-file-datalake" },
     { name = "boto3" },
@@ -4441,6 +4461,8 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'genai'", specifier = "<4" },
     { name = "alembic", specifier = "!=1.10.0,<2" },
     { name = "aliyunstoreplugin", marker = "extra == 'aliyun-oss'" },
+    { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.6.1" },
+    { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12" },
     { name = "azure-storage-file-datalake", marker = "extra == 'databricks'", specifier = ">12" },
     { name = "azureml-core", marker = "extra == 'extras'", specifier = ">=1.2.0" },
     { name = "boto3", marker = "extra == 'databricks'", specifier = ">1" },
@@ -4517,7 +4539,7 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'gateway'", specifier = "<2" },
     { name = "watchfiles", marker = "extra == 'genai'", specifier = "<2" },
 ]
-provides-extras = ["extras", "db", "databricks", "mlserver", "gateway", "genai", "mcp", "sqlserver", "aliyun-oss", "jfrog", "kubernetes", "langchain", "auth"]
+provides-extras = ["extras", "db", "databricks", "mlserver", "gateway", "genai", "mcp", "azure", "sqlserver", "aliyun-oss", "jfrog", "kubernetes", "langchain", "auth"]
 
 [package.metadata.requires-dev]
 build = [


### PR DESCRIPTION
### Related Issues/PRs

Closes #21521

### What changes are proposed in this pull request?

The `-full` Docker image documents Azure Blob Storage support in `docker/README.md` but was missing the required data-plane packages (`azure-storage-blob`, `azure-identity`). The `extras` optional dependency includes `azureml-core` (management-plane), which is not sufficient for actual blob I/O.

This PR adds an `azure` optional dependency extra with `azure-storage-blob` and `azure-identity`, and includes it in the full Docker image install.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The full Docker image (`mlflow:VERSION-full`) now includes `azure-storage-blob` and `azure-identity` packages, enabling Azure Blob Storage artifact support out of the box. A new `azure` pip extra (`pip install mlflow[azure]`) is also available.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)