### PR TITLE
Skip `_maybe_save_model` for Databricks ACL-protected artifact URIs

### DIFF
--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -322,6 +322,7 @@ def log_model(
         is_local_uri(run_root_artifact_uri)
         or databricks_utils.is_in_databricks_serverless_runtime()
         or databricks_utils.is_in_databricks_shared_cluster_runtime()
+        or is_databricks_acled_artifacts_uri(run_root_artifact_uri)
         or not _maybe_save_model(
             spark_model,
             append_to_uri_path(run_root_artifact_uri, artifact_path),

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -780,6 +780,7 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
         "mlflowdbfs_available",
         "dbutils_available",
         "expected_uri",
+        "expect_log_v2",
     ),
     [
         (
@@ -789,6 +790,7 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
             True,
             True,
             "mlflowdbfs:///artifacts?run_id={}&path=/model/sparkml",
+            False,
         ),
         (
             "dbfs:/databricks/mlflow-tracking/a/b",
@@ -797,14 +799,19 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
             True,
             True,
             "mlflowdbfs:///artifacts?run_id={}&path=/model/sparkml",
+            False,
         ),
+        # ACL-protected paths where mlflowdbfs is unavailable/disabled always route through
+        # Model._log_v2 because _maybe_save_model is skipped via is_databricks_acled_artifacts_uri.
+        # In real Databricks, _maybe_save_model always fails with Py4JError for these paths anyway.
         (
             "dbfs:/databricks/mlflow-tracking/a/b",
             "12.0",
             "false",
             True,
             False,
-            "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml",
+            None,
+            True,
         ),
         (
             "dbfs:/databricks/mlflow-tracking/a/b",
@@ -812,7 +819,8 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
             "",
             False,
             True,
-            "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml",
+            None,
+            True,
         ),
         (
             "dbfs:/databricks/mlflow-tracking/a/b",
@@ -820,7 +828,8 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
             "",
             True,
             True,
-            "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml",
+            None,
+            True,
         ),
         (
             "dbfs:/databricks/mlflow-tracking/a/b",
@@ -828,10 +837,11 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
             "true",
             True,
             True,
-            "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml",
+            None,
+            True,
         ),
-        ("dbfs:/root/a/b", "12.0", "", True, True, "dbfs:/root/a/b/model/sparkml"),
-        ("s3://mybucket/a/b", "12.0", "", True, True, "s3://mybucket/a/b/model/sparkml"),
+        ("dbfs:/root/a/b", "12.0", "", True, True, "dbfs:/root/a/b/model/sparkml", False),
+        ("s3://mybucket/a/b", "12.0", "", True, True, "s3://mybucket/a/b/model/sparkml", False),
     ],
 )
 def test_model_logged_via_mlflowdbfs_when_appropriate(
@@ -843,6 +853,7 @@ def test_model_logged_via_mlflowdbfs_when_appropriate(
     mlflowdbfs_available,
     dbutils_available,
     expected_uri,
+    expect_log_v2,
 ):
     def mock_spark_session_load(path):
         raise Exception("MlflowDbfsClient operation failed!")
@@ -878,21 +889,32 @@ def test_model_logged_via_mlflowdbfs_when_appropriate(
         mock.patch("mlflow.utils.databricks_utils._get_dbutils", mock_get_dbutils),
         mock.patch.object(spark_model_iris.model, "save") as mock_save,
         mock.patch("mlflow.models.infer_pip_requirements", return_value=[]) as mock_infer,
+        mock.patch("mlflow.models.Model._log_v2") as mock_log_v2,
     ):
         with mlflow.start_run():
             if db_runtime_version:
                 monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", db_runtime_version)
             monkeypatch.setenv("DISABLE_MLFLOWDBFS", mlflowdbfs_disabled)
             mlflow.spark.log_model(spark_model_iris.model, artifact_path="model")
-            mock_save.assert_called_once_with(expected_uri.format(mlflow.active_run().info.run_id))
 
-            if expected_uri.startswith("mflowdbfs"):
-                # If mlflowdbfs is used, infer_pip_requirements should load the model from the
-                # remote model path instead of a local tmp path.
-                assert (
-                    mock_infer.call_args[0][0]
-                    == "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml"
+            if expect_log_v2:
+                # ACL-protected paths where mlflowdbfs is unavailable skip _maybe_save_model
+                # entirely and fall through to Model._log_v2. In production, _maybe_save_model
+                # always raises Py4JError for these paths, so skipping it is correct.
+                mock_log_v2.assert_called_once()
+                mock_save.assert_not_called()
+            else:
+                mock_save.assert_called_once_with(
+                    expected_uri.format(mlflow.active_run().info.run_id)
                 )
+
+                if expected_uri.startswith("mflowdbfs"):
+                    # If mlflowdbfs is used, infer_pip_requirements should load the model from the
+                    # remote model path instead of a local tmp path.
+                    assert (
+                        mock_infer.call_args[0][0]
+                        == "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml"
+                    )
 
 
 @pytest.mark.parametrize("dummy_read_shows_mlflowdbfs_available", [True, False])
@@ -940,16 +962,22 @@ def test_model_logging_uses_mlflowdbfs_if_appropriate_when_hdfs_check_fails(
             mock_get_dbutils,
         ),
         mock.patch.object(spark_model_iris.model, "save") as mock_save,
+        mock.patch("mlflow.models.Model._log_v2") as mock_log_v2,
     ):
         with mlflow.start_run():
             monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "12.0")
             mlflow.spark.log_model(spark_model_iris.model, artifact_path="model")
             run_id = mlflow.active_run().info.run_id
-            mock_save.assert_called_once_with(
-                f"mlflowdbfs:///artifacts?run_id={run_id}&path=/model/sparkml"
-                if dummy_read_shows_mlflowdbfs_available
-                else "dbfs:/databricks/mlflow-tracking/a/b/model/sparkml"
-            )
+            if dummy_read_shows_mlflowdbfs_available:
+                mock_save.assert_called_once_with(
+                    f"mlflowdbfs:///artifacts?run_id={run_id}&path=/model/sparkml"
+                )
+            else:
+                # mlflowdbfs unavailable + ACL-protected path: _maybe_save_model is skipped,
+                # Model._log_v2 is called directly. In production, _maybe_save_model always
+                # raises Py4JError for these ACL-protected paths, so skipping it is correct.
+                mock_log_v2.assert_called_once()
+                mock_save.assert_not_called()
 
 
 def test_log_model_with_code_paths(spark_model_iris):

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -908,7 +908,7 @@ def test_model_logged_via_mlflowdbfs_when_appropriate(
                     expected_uri.format(mlflow.active_run().info.run_id)
                 )
 
-                if expected_uri.startswith("mflowdbfs"):
+                if expected_uri.startswith("mlflowdbfs"):
                     # If mlflowdbfs is used, infer_pip_requirements should load the model from the
                     # remote model path instead of a local tmp path.
                     assert (

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -525,6 +525,37 @@ def test_log_model_no_registered_model_name(tmp_path, spark_model_iris):
         mlflow.tracking._model_registry.fluent._register_model.assert_not_called()
 
 
+def test_log_model_skips_maybe_save_for_acled_artifact_uri(tmp_path):
+    """_maybe_save_model should not be called for Databricks ACL-protected artifact URIs
+    (dbfs:/databricks/mlflow-tracking/...) since Spark cannot write to them directly.
+    Calling it wastes ~6s per model on a guaranteed Py4JError before falling back.
+    """
+    acled_uri = "dbfs:/databricks/mlflow-tracking/abc123/run456/artifacts"
+
+    class FakePipelineModel:
+        def __init__(self, stages=None):
+            pass
+
+    mock_model = FakePipelineModel()
+    with (
+        mock.patch("mlflow.spark._validate_model"),
+        mock.patch("mlflow.spark._is_spark_connect_model", return_value=False),
+        mock.patch("mlflow.spark._maybe_save_model") as mock_maybe_save,
+        mock.patch("mlflow.get_artifact_uri", return_value=acled_uri),
+        mock.patch("mlflow.spark._should_use_mlflowdbfs", return_value=False),
+        mock.patch("mlflow.models.Model._log_v2") as mock_log_v2,
+        mock.patch("pyspark.ml.PipelineModel", FakePipelineModel),
+        mlflow.start_run(),
+    ):
+        mlflow.spark.log_model(
+            mock_model,
+            artifact_path="model",
+            dfs_tmpdir=str(tmp_path),
+        )
+        mock_maybe_save.assert_not_called()
+        mock_log_v2.assert_called_once()
+
+
 def test_sparkml_model_load_from_remote_uri_succeeds(spark_model_iris, model_path, mock_s3_bucket):
     mlflow.spark.save_model(spark_model=spark_model_iris.model, path=model_path)
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

`mlflow.spark.log_model` follows this decision tree for saving a model:

1. If the artifact URI supports `mlflowdbfs` → save directly via the JVM filesystem connector.
2. Otherwise, try `_maybe_save_model` (calls `spark_model.save(artifact_uri)` directly via Spark).
3. If `_maybe_save_model` fails → fall back to `Model._log_v2` (save locally → upload via MLflow artifact client).

For `dbfs:/databricks/mlflow-tracking/...` URIs, step 2 is **always guaranteed to fail**. These paths are ACL-protected at the storage layer — Spark executors run under the cluster service principal identity and are intentionally blocked from direct access. This is made explicit by the Databricks storage layer itself, which encodes the intent as the URI scheme:

```
UnsupportedFileSystemException: No FileSystem for scheme
"unsupported-access-mechanism-for-path--use-mlflow-client"
```

The behavior of `_maybe_save_model` varies by runtime:

| Runtime | Exception raised | Outcome |
|---|---|---|
| Classic Spark / DBR 18.1 beta | `Py4JError` | Caught → returns `False` → wastes ~1-6s per call |
| Spark Connect (some runtimes) | `UnknownException` | **Not caught** → `log_model` crashes entirely |

In both cases the direct write is pointless. In the Spark Connect case it is also a correctness bug.

**The fix:** add `is_databricks_acled_artifacts_uri(run_root_artifact_uri)` as an early short-circuit in the `elif` branch, before `_maybe_save_model` is ever called:

```python
elif (
    is_local_uri(run_root_artifact_uri)
    or databricks_utils.is_in_databricks_serverless_runtime()
    or databricks_utils.is_in_databricks_shared_cluster_runtime()
    or is_databricks_acled_artifacts_uri(run_root_artifact_uri)  # ← new
    or not _maybe_save_model(...)
):
```

`is_databricks_acled_artifacts_uri` is already imported in the module — no new dependencies are introduced.

**Impact in multi-threaded workloads**

When N threads call `mlflow.spark.log_model` concurrently (e.g. 10–50 producer threads), each thread independently enters `_maybe_save_model` and spawns a Spark job that attempts to write to the ACL-protected path. Each job:
- Acquires a Spark task slot on the cluster
- Runs executor-side write logic (via Py4J or gRPC on Spark Connect)
- Waits ~6s for the permission denial to propagate back to the driver

This means N concurrent threads saturate cluster executor slots with guaranteed-to-fail jobs, delaying the actual `Model._log_v2` fallback. In a 50-thread workload this wastes ~300s of aggregate wall-clock time. With this fix, each thread skips directly to `Model._log_v2`, eliminating the wasted attempts and executor contention entirely.

### How is this PR tested?

- [x] New unit/integration tests

Added `test_log_model_skips_maybe_save_for_acled_artifact_uri` in `tests/spark/test_spark_model_export.py`. The test mocks `_maybe_save_model`, `mlflow.get_artifact_uri` (returning a `dbfs:/databricks/mlflow-tracking/...` URI), and `_should_use_mlflowdbfs` (returning `False`), then asserts `_maybe_save_model` is never called.

Updated `test_model_logged_via_mlflowdbfs_when_appropriate` and `test_model_logging_uses_mlflowdbfs_if_appropriate_when_hdfs_check_fails` to reflect that ACL-protected paths now correctly route to `Model._log_v2` directly (previously these test cases asserted `spark_model.save` was called on a path that always fails in production).

Manual smoke tests on real Databricks clusters confirmed:
- **DBR 18.1 beta (classic Spark):** `_maybe_save_model` catches `Py4JError` and returns `False` — write blocked, but ~6s wasted per call
- **Spark Connect runtime:** `_maybe_save_model` raises `UnknownException` (not caught by `except Py4JError`) — `log_model` crashes entirely
- In both cases the path does not exist after the attempt — write was fully blocked by ACL

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.spark.log_model` no longer attempts a guaranteed-to-fail direct write for Databricks ACL-protected artifact URIs (`dbfs:/databricks/mlflow-tracking/...`). On classic Spark runtimes (e.g. DBR 18.1) this eliminates ~6s of wasted latency per call; on Spark Connect runtimes where `UnknownException` is not caught by `except Py4JError`, it also prevents `log_model` from crashing entirely.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
