### PR TITLE
Add environment field to telemetry for platform detection

### DIFF
--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -24,7 +24,12 @@ from mlflow.telemetry.constant import (
 )
 from mlflow.telemetry.installation_id import get_or_create_installation_id
 from mlflow.telemetry.schemas import Record, TelemetryConfig, TelemetryInfo, get_source_sdk
-from mlflow.telemetry.utils import _get_config_url, _log_error, is_telemetry_disabled
+from mlflow.telemetry.utils import (
+    _detect_environment,
+    _get_config_url,
+    _log_error,
+    is_telemetry_disabled,
+)
 from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.logging_utils import should_suppress_logs_in_thread, suppress_logs_in_thread
 from mlflow.utils.rest_utils import http_request
@@ -109,6 +114,7 @@ class TelemetryClient:
         self.info = asdict(
             TelemetryInfo(
                 session_id=_MLFLOW_TELEMETRY_SESSION_ID.get() or uuid.uuid4().hex,
+                environment=_detect_environment(),
                 installation_id=get_or_create_installation_id(),
             )
         )

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -45,6 +45,15 @@ class Record:
         return result
 
 
+class Environment(str, Enum):
+    KAGGLE = "kaggle"
+    COLAB = "colab"
+    AZURE_ML = "azure_ml"
+    SAGEMAKER_STUDIO = "sagemaker_studio"
+    SAGEMAKER_NOTEBOOK = "sagemaker_notebook"
+    DOCKER = "docker"
+
+
 class SourceSDK(str, Enum):
     MLFLOW_TRACING = "mlflow-tracing"
     MLFLOW = "mlflow"
@@ -70,6 +79,7 @@ class TelemetryInfo:
         f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     )
     operating_system: str = platform.platform()
+    environment: str | None = None
     tracking_uri_scheme: str | None = None
     is_localhost: bool | None = None
     installation_id: str | None = None

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -54,6 +54,23 @@ class Environment(str, Enum):
     DOCKER = "docker"
 
 
+# The following env vars were found by manually inspecting
+# env vars in the specified environments and avoiding potentially
+# PII-containing variables.
+ENV_VAR_TO_ENVIRONMENT_MAP = {
+    # Undocumented env var in Kaggle notebooks
+    # https://www.kaggle.com/discussions/general/147433
+    "KAGGLE_KERNEL_RUN_TYPE": Environment.KAGGLE,
+    # Undocumented env var in Colabe notebooks
+    "COLAB_RELEASE_TAG": Environment.COLAB,
+    # Undocumented env var in AzureML notebooks
+    "AZUREML_FRAMEWORK": Environment.AZURE_ML,
+    # Internal env var that SageMaker inserts
+    # https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-byoi-specs.html#studio-updated-byoi-specs-run
+    "SAGEMAKER_APP_TYPE": Environment.SAGEMAKER_STUDIO,
+}
+
+
 class SourceSDK(str, Enum):
     MLFLOW_TRACING = "mlflow-tracing"
     MLFLOW = "mlflow"

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -61,7 +61,7 @@ ENV_VAR_TO_ENVIRONMENT_MAP = {
     # Undocumented env var in Kaggle notebooks
     # https://www.kaggle.com/discussions/general/147433
     "KAGGLE_KERNEL_RUN_TYPE": Environment.KAGGLE,
-    # Undocumented env var in Colabe notebooks
+    # Undocumented env var in Colab notebooks
     "COLAB_RELEASE_TAG": Environment.COLAB,
     # Undocumented env var in AzureML notebooks
     "AZUREML_FRAMEWORK": Environment.AZURE_ML,

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -18,6 +18,7 @@ from mlflow.telemetry.constant import (
     UI_CONFIG_STAGING_URL,
     UI_CONFIG_URL,
 )
+from mlflow.telemetry.schemas import ENV_VAR_TO_ENVIRONMENT_MAP, Environment
 from mlflow.version import VERSION
 
 _logger = logging.getLogger(__name__)
@@ -70,8 +71,6 @@ def _is_in_databricks() -> bool:
 
 
 def _detect_environment() -> str | None:
-    from mlflow.telemetry.schemas import ENV_VAR_TO_ENVIRONMENT_MAP, Environment
-
     for env_var, environment in ENV_VAR_TO_ENVIRONMENT_MAP.items():
         if env_var in os.environ:
             return environment.value

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -73,17 +73,17 @@ def _detect_environment() -> str | None:
     from mlflow.telemetry.schemas import Environment
 
     if "KAGGLE_KERNEL_RUN_TYPE" in os.environ:
-        return Environment.KAGGLE
+        return Environment.KAGGLE.value
     if "COLAB_RELEASE_TAG" in os.environ:
-        return Environment.COLAB
+        return Environment.COLAB.value
     if "AZUREML_FRAMEWORK" in os.environ:
-        return Environment.AZURE_ML
+        return Environment.AZURE_ML.value
     if "SAGEMAKER_APP_TYPE" in os.environ:
-        return Environment.SAGEMAKER_STUDIO
+        return Environment.SAGEMAKER_STUDIO.value
     if Path("/opt/ml/metadata/resource-metadata.json").exists():
-        return Environment.SAGEMAKER_NOTEBOOK
+        return Environment.SAGEMAKER_NOTEBOOK.value
     if Path("/.dockerenv").exists():
-        return Environment.DOCKER
+        return Environment.DOCKER.value
     return None
 
 

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -70,18 +70,16 @@ def _is_in_databricks() -> bool:
 
 
 def _detect_environment() -> str | None:
-    from mlflow.telemetry.schemas import Environment
+    from mlflow.telemetry.schemas import ENV_VAR_TO_ENVIRONMENT_MAP, Environment
 
-    if "KAGGLE_KERNEL_RUN_TYPE" in os.environ:
-        return Environment.KAGGLE.value
-    if "COLAB_RELEASE_TAG" in os.environ:
-        return Environment.COLAB.value
-    if "AZUREML_FRAMEWORK" in os.environ:
-        return Environment.AZURE_ML.value
-    if "SAGEMAKER_APP_TYPE" in os.environ:
-        return Environment.SAGEMAKER_STUDIO.value
+    for env_var, environment in ENV_VAR_TO_ENVIRONMENT_MAP.items():
+        if env_var in os.environ:
+            return environment.value
+
+    # https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-metadata.html
     if Path("/opt/ml/metadata/resource-metadata.json").exists():
         return Environment.SAGEMAKER_NOTEBOOK.value
+    # unofficial heuristic to detect docker environment
     if Path("/.dockerenv").exists():
         return Environment.DOCKER.value
     return None

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 from typing import Any
 
 import requests
@@ -66,6 +67,24 @@ def _is_in_databricks() -> bool:
         return True
 
     return False
+
+
+def _detect_environment() -> str | None:
+    from mlflow.telemetry.schemas import Environment
+
+    if "KAGGLE_KERNEL_RUN_TYPE" in os.environ:
+        return Environment.KAGGLE
+    if "COLAB_RELEASE_TAG" in os.environ:
+        return Environment.COLAB
+    if "AZUREML_FRAMEWORK" in os.environ:
+        return Environment.AZURE_ML
+    if "SAGEMAKER_APP_TYPE" in os.environ:
+        return Environment.SAGEMAKER_STUDIO
+    if Path("/opt/ml/metadata/resource-metadata.json").exists():
+        return Environment.SAGEMAKER_NOTEBOOK
+    if Path("/.dockerenv").exists():
+        return Environment.DOCKER
+    return None
 
 
 _IS_MLFLOW_DEV_VERSION = Version(VERSION).is_devrelease

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -1,4 +1,7 @@
+from pathlib import Path
 from unittest.mock import Mock, patch
+
+import pytest
 
 from mlflow.telemetry.constant import (
     CONFIG_STAGING_URL,
@@ -7,11 +10,59 @@ from mlflow.telemetry.constant import (
     UI_CONFIG_STAGING_URL,
     UI_CONFIG_URL,
 )
+from mlflow.telemetry.schemas import Environment
 from mlflow.telemetry.utils import (
+    _detect_environment,
     _get_config_url,
     fetch_ui_telemetry_config,
     is_telemetry_disabled,
 )
+
+
+@pytest.mark.parametrize(
+    ("env_var", "expected"),
+    [
+        ("KAGGLE_KERNEL_RUN_TYPE", Environment.KAGGLE),
+        ("COLAB_RELEASE_TAG", Environment.COLAB),
+        ("AZUREML_FRAMEWORK", Environment.AZURE_ML),
+        ("SAGEMAKER_APP_TYPE", Environment.SAGEMAKER_STUDIO),
+    ],
+)
+def test_detect_environment_from_env_var(monkeypatch, env_var, expected):
+    monkeypatch.setenv(env_var, "some_value")
+    assert _detect_environment() == expected
+
+
+def test_detect_environment_sagemaker_notebook(tmp_path, monkeypatch):
+    metadata_file = tmp_path / "resource-metadata.json"
+    metadata_file.write_text("{}")
+    with patch("mlflow.telemetry.utils.Path") as mock_path:
+
+        def path_side_effect(p):
+            if p == "/opt/ml/metadata/resource-metadata.json":
+                return metadata_file
+            return Path(p)
+
+        mock_path.side_effect = path_side_effect
+        assert _detect_environment() == Environment.SAGEMAKER_NOTEBOOK
+
+
+def test_detect_environment_docker(tmp_path, monkeypatch):
+    dockerenv = tmp_path / ".dockerenv"
+    dockerenv.touch()
+    with patch("mlflow.telemetry.utils.Path") as mock_path:
+
+        def path_side_effect(p):
+            if p == "/.dockerenv":
+                return dockerenv
+            return Path(p)
+
+        mock_path.side_effect = path_side_effect
+        assert _detect_environment() == Environment.DOCKER
+
+
+def test_detect_environment_none():
+    assert _detect_environment() is None
 
 
 def test_is_telemetry_disabled(monkeypatch, bypass_env_check):

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -61,20 +61,7 @@ def test_detect_environment_docker(tmp_path, monkeypatch):
         assert _detect_environment() == Environment.DOCKER
 
 
-def test_detect_environment_none(monkeypatch):
-    env_vars = (
-        "KAGGLE_KERNEL_RUN_TYPE",
-        "COLAB_RELEASE_TAG",
-        "AZUREML_FRAMEWORK",
-        "SAGEMAKER_APP_TYPE",
-    )
-    with (
-        monkeypatch.context() as m,
-        patch("mlflow.telemetry.utils.Path.exists") as mock_path_exists,
-    ):
-        for env_var in env_vars:
-            m.delenv(env_var, raising=False)
-        mock_path_exists.return_value = False
+def test_detect_environment_none():
     assert _detect_environment() is None
 
 

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -22,10 +22,10 @@ from mlflow.telemetry.utils import (
 @pytest.mark.parametrize(
     ("env_var", "expected"),
     [
-        ("KAGGLE_KERNEL_RUN_TYPE", Environment.KAGGLE),
-        ("COLAB_RELEASE_TAG", Environment.COLAB),
-        ("AZUREML_FRAMEWORK", Environment.AZURE_ML),
-        ("SAGEMAKER_APP_TYPE", Environment.SAGEMAKER_STUDIO),
+        ("KAGGLE_KERNEL_RUN_TYPE", Environment.KAGGLE.value),
+        ("COLAB_RELEASE_TAG", Environment.COLAB.value),
+        ("AZUREML_FRAMEWORK", Environment.AZURE_ML.value),
+        ("SAGEMAKER_APP_TYPE", Environment.SAGEMAKER_STUDIO.value),
     ],
 )
 def test_detect_environment_from_env_var(monkeypatch, env_var, expected):
@@ -61,7 +61,20 @@ def test_detect_environment_docker(tmp_path, monkeypatch):
         assert _detect_environment() == Environment.DOCKER
 
 
-def test_detect_environment_none():
+def test_detect_environment_none(monkeypatch):
+    env_vars = (
+        "KAGGLE_KERNEL_RUN_TYPE",
+        "COLAB_RELEASE_TAG",
+        "AZUREML_FRAMEWORK",
+        "SAGEMAKER_APP_TYPE",
+    )
+    with (
+        monkeypatch.context() as m,
+        patch("mlflow.telemetry.utils.Path.exists") as mock_path_exists,
+    ):
+        for env_var in env_vars:
+            m.delenv(env_var, raising=False)
+        mock_path_exists.return_value = False
     assert _detect_environment() is None
 
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds an `environment` field to telemetry records that identifies the managed platform the user is running on. Detection checks (in priority order):

1. **Kaggle** — `KAGGLE_KERNEL_RUN_TYPE` env var
2. **Colab** — `COLAB_RELEASE_TAG` env var
3. **Azure ML** — `AZUREML_FRAMEWORK` env var
4. **SageMaker Studio** — `SAGEMAKER_APP_TYPE` env var
5. **SageMaker Notebook** — `/opt/ml/metadata/resource-metadata.json` exists
6. **Docker** — `/.dockerenv` exists

The field is `None` when no known environment is detected.

Changes:
- `mlflow/telemetry/schemas.py`: Added `Environment` enum and `environment` field on `TelemetryInfo`
- `mlflow/telemetry/utils.py`: Added `_detect_environment()` function
- `mlflow/telemetry/client.py`: Populate `environment` at `TelemetryClient` init time
- `tests/telemetry/test_utils.py`: Tests for all detection paths

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

tested e2e, manually checked env vars that exist in the above platforms

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release