### PR TITLE
Remove `accepted` status from `IssueStatus` enum for clarity

### DIFF
--- a/mlflow/entities/issue.py
+++ b/mlflow/entities/issue.py
@@ -13,7 +13,6 @@ class IssueStatus(str, Enum):
     """Enum for status of an :py:class:`mlflow.entities.Issue`."""
 
     PENDING = "pending"
-    ACCEPTED = "accepted"
     REJECTED = "rejected"
     RESOLVED = "resolved"
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -6085,9 +6085,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 Supported filters: status, source_run_id
                 Supported comparators: =, !=
                 Examples:
-                    - "status = 'accepted'"
+                    - "status = 'resolved'"
                     - "source_run_id = 'run123'"
-                    - "status = 'draft' AND source_run_id != 'run456'"
+                    - "status = 'pending' AND source_run_id != 'run456'"
             max_results: Maximum number of results to return.
             page_token: Token for pagination.
 

--- a/tests/entities/test_issue.py
+++ b/tests/entities/test_issue.py
@@ -21,21 +21,18 @@ def create_issue(severity: IssueSeverity) -> Issue:
 
 def test_issue_status_enum_values():
     assert IssueStatus.PENDING.value == "pending"
-    assert IssueStatus.ACCEPTED.value == "accepted"
     assert IssueStatus.REJECTED.value == "rejected"
     assert IssueStatus.RESOLVED.value == "resolved"
 
 
 def test_issue_status_enum_string_behavior():
     assert IssueStatus.PENDING == "pending"
-    assert IssueStatus.ACCEPTED == "accepted"
     assert IssueStatus.REJECTED == "rejected"
     assert IssueStatus.RESOLVED == "resolved"
 
 
 def test_issue_status_enum_from_string():
     assert IssueStatus("pending") == IssueStatus.PENDING
-    assert IssueStatus("accepted") == IssueStatus.ACCEPTED
     assert IssueStatus("rejected") == IssueStatus.REJECTED
     assert IssueStatus("resolved") == IssueStatus.RESOLVED
 
@@ -47,7 +44,6 @@ def test_issue_status_enum_invalid_value():
 
 def test_issue_status_enum_str_method():
     assert str(IssueStatus.PENDING) == "pending"
-    assert str(IssueStatus.ACCEPTED) == "accepted"
     assert str(IssueStatus.REJECTED) == "rejected"
     assert str(IssueStatus.RESOLVED) == "resolved"
 
@@ -163,7 +159,7 @@ def test_issue_creation_all_fields():
         experiment_id="exp-456",
         name="Token limit exceeded",
         description="Model is hitting token limits frequently",
-        status=IssueStatus.ACCEPTED,
+        status=IssueStatus.RESOLVED,
         created_timestamp=1234567890,
         last_updated_timestamp=1234567900,
         severity=IssueSeverity.HIGH,
@@ -176,7 +172,7 @@ def test_issue_creation_all_fields():
     assert issue.experiment_id == "exp-456"
     assert issue.name == "Token limit exceeded"
     assert issue.description == "Model is hitting token limits frequently"
-    assert issue.status == IssueStatus.ACCEPTED
+    assert issue.status == IssueStatus.RESOLVED
     assert issue.created_timestamp == 1234567890
     assert issue.last_updated_timestamp == 1234567900
     assert issue.severity == IssueSeverity.HIGH
@@ -277,7 +273,7 @@ def test_issue_roundtrip_conversion():
         experiment_id="exp-roundtrip",
         name="Roundtrip test",
         description="Testing dictionary conversion",
-        status=IssueStatus.ACCEPTED,
+        status=IssueStatus.RESOLVED,
         created_timestamp=3333333333,
         last_updated_timestamp=4444444444,
         severity=IssueSeverity.HIGH,
@@ -334,7 +330,7 @@ def test_issue_to_proto_all_fields():
         experiment_id="exp-proto-2",
         name="Full proto test",
         description="Testing proto conversion with all fields",
-        status=IssueStatus.ACCEPTED,
+        status=IssueStatus.RESOLVED,
         created_timestamp=2000000000,
         last_updated_timestamp=2000000010,
         severity=IssueSeverity.HIGH,
@@ -349,7 +345,7 @@ def test_issue_to_proto_all_fields():
     assert proto.experiment_id == "exp-proto-2"
     assert proto.name == "Full proto test"
     assert proto.description == "Testing proto conversion with all fields"
-    assert proto.status == "accepted"
+    assert proto.status == "resolved"
     assert proto.created_timestamp == 2000000000
     assert proto.last_updated_timestamp == 2000000010
     assert proto.severity == "high"
@@ -420,7 +416,7 @@ def test_issue_proto_roundtrip_required_fields():
         experiment_id="exp-proto-roundtrip-1",
         name="Proto roundtrip test",
         description="Testing proto roundtrip conversion",
-        status=IssueStatus.ACCEPTED,
+        status=IssueStatus.RESOLVED,
         created_timestamp=5000000000,
         last_updated_timestamp=5000000005,
     )

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4412,7 +4412,7 @@ def test_get_issue():
         experiment_id="exp-123",
         name="Test issue",
         description="Test description",
-        status=IssueStatus.ACCEPTED,
+        status=IssueStatus.RESOLVED,
         severity=IssueSeverity.HIGH,
         root_causes=["Root cause 1"],
         created_timestamp=1234567890,
@@ -4455,7 +4455,7 @@ def test_update_issue():
     request_message.issue_id = "iss-update-123"
     request_message.name = "Updated issue name"
     request_message.description = "Updated description"
-    request_message.status = "accepted"
+    request_message.status = "resolved"
     request_message.severity = "medium"
 
     updated_issue = Issue(
@@ -4463,7 +4463,7 @@ def test_update_issue():
         experiment_id="exp-123",
         name="Updated issue name",
         description="Updated description",
-        status=IssueStatus.ACCEPTED,
+        status=IssueStatus.RESOLVED,
         severity=IssueSeverity.MEDIUM,
         created_timestamp=1234567890,
         last_updated_timestamp=1234567900,
@@ -4482,7 +4482,7 @@ def test_update_issue():
         assert call_kwargs["issue_id"] == "iss-update-123"
         assert call_kwargs["name"] == "Updated issue name"
         assert call_kwargs["description"] == "Updated description"
-        assert call_kwargs["status"] == IssueStatus.ACCEPTED
+        assert call_kwargs["status"] == IssueStatus.RESOLVED
         assert call_kwargs["severity"] == IssueSeverity.MEDIUM.value
 
         json_response = json.loads(response.get_data())
@@ -4509,7 +4509,7 @@ def test_search_issues_all():
             experiment_id="exp-1",
             name="Issue 2",
             description="Description 2",
-            status=IssueStatus.ACCEPTED,
+            status=IssueStatus.RESOLVED,
             created_timestamp=1234567891,
             last_updated_timestamp=1234567891,
         ),
@@ -4541,7 +4541,7 @@ def test_search_issues_all():
 def test_search_issues_with_filters():
     request_message = SearchIssues()
     request_message.experiment_id = "exp-specific"
-    request_message.filter_string = "status = 'accepted' AND source_run_id = 'run-specific'"
+    request_message.filter_string = "status = 'resolved' AND source_run_id = 'run-specific'"
     request_message.max_results = 50
 
     issues = [
@@ -4550,7 +4550,7 @@ def test_search_issues_with_filters():
             experiment_id="exp-specific",
             name="Filtered issue",
             description="Description",
-            status=IssueStatus.ACCEPTED,
+            status=IssueStatus.RESOLVED,
             source_run_id="run-specific",
             created_timestamp=1234567890,
             last_updated_timestamp=1234567890,
@@ -4568,7 +4568,7 @@ def test_search_issues_with_filters():
         call_kwargs = mock_store.return_value.search_issues.call_args[1]
         assert call_kwargs["experiment_id"] == "exp-specific"
         assert (
-            call_kwargs["filter_string"] == "status = 'accepted' AND source_run_id = 'run-specific'"
+            call_kwargs["filter_string"] == "status = 'resolved' AND source_run_id = 'run-specific'"
         )
         assert call_kwargs["max_results"] == 50
 

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -2035,7 +2035,7 @@ def test_update_issue_not_implemented():
     with pytest.raises(
         MlflowNotImplementedException, match="Issue management is not supported in Databricks"
     ):
-        store.update_issue(issue_id="issue-123", status="accepted")
+        store.update_issue(issue_id="issue-123", status="resolved")
 
 
 def test_search_issues_not_implemented():

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -3757,7 +3757,7 @@ def test_get_issue():
             "experiment_id": "exp-456",
             "name": "Test Issue",
             "description": "Test description",
-            "status": "accepted",
+            "status": "resolved",
             "severity": "medium",
             "root_causes": ["cause1"],
             "source_run_id": "run-789",
@@ -3780,7 +3780,7 @@ def test_get_issue():
     assert issue.issue_id == "issue-123"
     assert issue.experiment_id == "exp-456"
     assert issue.name == "Test Issue"
-    assert issue.status == IssueStatus.ACCEPTED
+    assert issue.status == IssueStatus.RESOLVED
     assert issue.severity == IssueSeverity.MEDIUM
 
 
@@ -3860,7 +3860,7 @@ def test_search_issues():
                 "experiment_id": "exp-456",
                 "name": "Issue 2",
                 "description": "Description 2",
-                "status": "accepted",
+                "status": "resolved",
                 "severity": "medium",
                 "root_causes": ["cause"],
                 "source_run_id": "run-123",
@@ -3898,7 +3898,7 @@ def test_search_issues():
     assert isinstance(result[1], Issue)
     assert result[1].issue_id == "issue-124"
     assert result[1].name == "Issue 2"
-    assert result[1].status == IssueStatus.ACCEPTED
+    assert result[1].status == IssueStatus.RESOLVED
     assert result[1].severity == IssueSeverity.MEDIUM
 
     assert result.token == "next_token_456"

--- a/tests/store/tracking/test_sqlalchemy_store_issues.py
+++ b/tests/store/tracking/test_sqlalchemy_store_issues.py
@@ -49,7 +49,7 @@ def test_create_issue_with_all_fields(store):
         experiment_id=exp_id,
         name="Token limit exceeded",
         description="Model is hitting token limits frequently",
-        status=IssueStatus.ACCEPTED,
+        status=IssueStatus.RESOLVED,
         severity=IssueSeverity.HIGH,
         root_causes=["Input prompts are too long", "Context window exceeded"],
         source_run_id=run.info.run_id,
@@ -60,7 +60,7 @@ def test_create_issue_with_all_fields(store):
     assert issue.experiment_id == exp_id
     assert issue.name == "Token limit exceeded"
     assert issue.description == "Model is hitting token limits frequently"
-    assert issue.status == IssueStatus.ACCEPTED
+    assert issue.status == IssueStatus.RESOLVED
     assert issue.severity == IssueSeverity.HIGH
     assert issue.root_causes == [
         "Input prompts are too long",
@@ -149,7 +149,7 @@ def test_update_issue(store):
 
     updated_issue = store.update_issue(
         issue_id=created_issue.issue_id,
-        status=IssueStatus.ACCEPTED,
+        status=IssueStatus.RESOLVED,
         name="Updated name",
         description="Updated description",
         severity=IssueSeverity.HIGH,
@@ -157,7 +157,7 @@ def test_update_issue(store):
 
     assert updated_issue.issue_id == created_issue.issue_id
     assert updated_issue.experiment_id == exp_id
-    assert updated_issue.status == IssueStatus.ACCEPTED
+    assert updated_issue.status == IssueStatus.RESOLVED
     assert updated_issue.name == "Updated name"
     assert updated_issue.description == "Updated description"
     assert updated_issue.severity == IssueSeverity.HIGH
@@ -168,7 +168,7 @@ def test_update_issue(store):
     assert updated_issue.last_updated_timestamp > created_issue.last_updated_timestamp
 
     retrieved_issue = store.get_issue(created_issue.issue_id)
-    assert retrieved_issue.status == IssueStatus.ACCEPTED
+    assert retrieved_issue.status == IssueStatus.RESOLVED
     assert retrieved_issue.name == "Updated name"
     assert retrieved_issue.description == "Updated description"
     assert retrieved_issue.severity == IssueSeverity.HIGH
@@ -200,7 +200,7 @@ def test_update_issue_partial(store):
 
 def test_update_issue_nonexistent(store):
     with pytest.raises(MlflowException, match=r"Issue with ID 'nonexistent-id' not found"):
-        store.update_issue(issue_id="nonexistent-id", status=IssueStatus.ACCEPTED)
+        store.update_issue(issue_id="nonexistent-id", status=IssueStatus.RESOLVED)
 
 
 def test_search_issues_no_filters(store):
@@ -370,11 +370,11 @@ def test_search_issues_filter_by_status(store):
         status=IssueStatus.PENDING,
     )
 
-    issue_accepted = store.create_issue(
+    issue_resolved = store.create_issue(
         experiment_id=exp_id,
-        name="Accepted Issue",
-        description="Accepted",
-        status=IssueStatus.ACCEPTED,
+        name="Resolved Issue",
+        description="Resolved",
+        status=IssueStatus.RESOLVED,
     )
 
     store.create_issue(
@@ -384,11 +384,11 @@ def test_search_issues_filter_by_status(store):
         status=IssueStatus.REJECTED,
     )
 
-    result = store.search_issues(filter_string="status = 'accepted'")
+    result = store.search_issues(filter_string="status = 'resolved'")
 
     assert len(result) == 1
-    assert result[0].issue_id == issue_accepted.issue_id
-    assert result[0].status == IssueStatus.ACCEPTED
+    assert result[0].issue_id == issue_resolved.issue_id
+    assert result[0].status == IssueStatus.RESOLVED
 
 
 def test_search_issues_filter_by_source_run_id(store):
@@ -446,9 +446,9 @@ def test_search_issues_filter_combined_with_experiment_id(store):
 
     store.create_issue(
         experiment_id=exp_id1,
-        name="Exp1 Accepted",
-        description="Accepted in exp1",
-        status=IssueStatus.ACCEPTED,
+        name="Exp1 Resolved",
+        description="Resolved in exp1",
+        status=IssueStatus.RESOLVED,
     )
 
     store.create_issue(
@@ -490,18 +490,18 @@ def test_search_issues_filter_inequality(store):
         status=IssueStatus.PENDING,
     )
 
-    issue_accepted = store.create_issue(
+    issue_resolved = store.create_issue(
         experiment_id=exp_id,
-        name="Accepted Issue",
-        description="Accepted",
-        status=IssueStatus.ACCEPTED,
+        name="Resolved Issue",
+        description="Resolved",
+        status=IssueStatus.RESOLVED,
     )
 
     result = store.search_issues(filter_string="status != 'pending'")
 
     assert len(result) == 1
-    assert result[0].issue_id == issue_accepted.issue_id
-    assert result[0].status == IssueStatus.ACCEPTED
+    assert result[0].issue_id == issue_resolved.issue_id
+    assert result[0].status == IssueStatus.RESOLVED
 
 
 def test_search_issues_filter_and_operator(store):
@@ -531,29 +531,29 @@ def test_search_issues_filter_and_operator(store):
         source_run_id=run1.info.run_id,
     )
 
-    issue_accepted_run1 = store.create_issue(
+    issue_resolved_run1 = store.create_issue(
         experiment_id=exp_id,
-        name="Accepted Run1",
-        description="Accepted from run1",
-        status=IssueStatus.ACCEPTED,
+        name="Resolved Run1",
+        description="Resolved from run1",
+        status=IssueStatus.RESOLVED,
         source_run_id=run1.info.run_id,
     )
 
     store.create_issue(
         experiment_id=exp_id,
-        name="Accepted Run2",
-        description="Accepted from run2",
-        status=IssueStatus.ACCEPTED,
+        name="Resolved Run2",
+        description="Resolved from run2",
+        status=IssueStatus.RESOLVED,
         source_run_id=run2.info.run_id,
     )
 
     result = store.search_issues(
-        filter_string=f"status = 'accepted' AND source_run_id = '{run1.info.run_id}'"
+        filter_string=f"status = 'resolved' AND source_run_id = '{run1.info.run_id}'"
     )
 
     assert len(result) == 1
-    assert result[0].issue_id == issue_accepted_run1.issue_id
-    assert result[0].status == IssueStatus.ACCEPTED
+    assert result[0].issue_id == issue_resolved_run1.issue_id
+    assert result[0].status == IssueStatus.RESOLVED
     assert result[0].source_run_id == run1.info.run_id
 
 
@@ -564,7 +564,7 @@ def test_search_issues_invalid_max_results(store):
         experiment_id=exp_id,
         name="Test Issue",
         description="Test",
-        status=IssueStatus.ACCEPTED,
+        status=IssueStatus.RESOLVED,
     )
 
     with pytest.raises(MlflowException, match=r"Invalid value 0 for parameter 'max_results'"):

--- a/tests/store/tracking/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/test_sqlalchemy_workspace_store.py
@@ -2171,10 +2171,10 @@ def test_update_issue_is_workspace_scoped(workspace_tracking_store):
         updated_issue = workspace_tracking_store.update_issue(
             issue_id=issue_a.issue_id,
             name="Updated Name A",
-            status=IssueStatus.ACCEPTED,
+            status=IssueStatus.RESOLVED,
         )
         assert updated_issue.name == "Updated Name A"
-        assert updated_issue.status == IssueStatus.ACCEPTED
+        assert updated_issue.status == IssueStatus.RESOLVED
 
     with WorkspaceContext("team-b"):
         with pytest.raises(
@@ -2201,7 +2201,7 @@ def test_search_issues_is_workspace_scoped(workspace_tracking_store):
             experiment_id=exp_id_a2,
             name="Issue A2",
             description="Second issue in workspace A",
-            status=IssueStatus.ACCEPTED,
+            status=IssueStatus.RESOLVED,
         )
 
         # Search all issues in workspace A

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -3695,7 +3695,7 @@ def test_create_issue_with_all_fields(tmp_path: Path):
                 experiment_id=exp_id,
                 name="High latency",
                 description="API response times exceed threshold",
-                status=IssueStatus.ACCEPTED,
+                status=IssueStatus.RESOLVED,
                 severity=IssueSeverity.HIGH,
                 root_causes=["Database query slow", "Network congestion"],
                 source_run_id=run.info.run_id,
@@ -3706,7 +3706,7 @@ def test_create_issue_with_all_fields(tmp_path: Path):
     assert issue.experiment_id == exp_id
     assert issue.name == "High latency"
     assert issue.description == "API response times exceed threshold"
-    assert issue.status == IssueStatus.ACCEPTED
+    assert issue.status == IssueStatus.RESOLVED
     assert issue.severity == IssueSeverity.HIGH
     assert issue.root_causes == ["Database query slow", "Network congestion"]
     assert issue.source_run_id == run.info.run_id

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -5205,13 +5205,13 @@ def test_create_issue_with_required_fields(mlflow_client, store_type):
             "experiment_id": experiment_id,
             "name": "Issue with required fields only",
             "description": "Testing issue creation with required fields",
-            "status": IssueStatus.ACCEPTED.value,
+            "status": IssueStatus.RESOLVED.value,
         },
     )
     assert response.status_code == 200
     data = response.json()
     issue = data["issue"]
-    assert issue["status"] == IssueStatus.ACCEPTED.value
+    assert issue["status"] == IssueStatus.RESOLVED.value
     assert "issue_id" in issue
     assert "created_timestamp" in issue
     assert "last_updated_timestamp" in issue
@@ -5289,7 +5289,7 @@ def test_update_issue(mlflow_client, store_type):
             "issue_id": issue_id,
             "name": "Updated name",
             "description": "Updated description",
-            "status": IssueStatus.ACCEPTED.value,
+            "status": IssueStatus.RESOLVED.value,
             "severity": IssueSeverity.HIGH.value,
         },
     )
@@ -5299,7 +5299,7 @@ def test_update_issue(mlflow_client, store_type):
     assert issue["issue_id"] == issue_id
     assert issue["name"] == "Updated name"
     assert issue["description"] == "Updated description"
-    assert issue["status"] == IssueStatus.ACCEPTED.value
+    assert issue["status"] == IssueStatus.RESOLVED.value
     assert issue["severity"] == IssueSeverity.HIGH.value
 
 
@@ -5386,18 +5386,18 @@ def test_search_issues_by_status(mlflow_client, store_type):
             "experiment_id": experiment_id,
             "name": "Confirmed issue",
             "description": "Description",
-            "status": IssueStatus.ACCEPTED.value,
+            "status": IssueStatus.RESOLVED.value,
         },
     )
 
     search_response = requests.post(
         f"{mlflow_client.tracking_uri}/api/3.0/mlflow/issues/search",
-        json={"experiment_id": experiment_id, "filter_string": "status = 'accepted'"},
+        json={"experiment_id": experiment_id, "filter_string": "status = 'resolved'"},
     )
     assert search_response.status_code == 200
     data = search_response.json()
     issues = data["issues"]
-    assert all(issue["status"] == IssueStatus.ACCEPTED.value for issue in issues)
+    assert all(issue["status"] == IssueStatus.RESOLVED.value for issue in issues)
     assert any(issue["name"] == "Confirmed issue" for issue in issues)
 
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21613/files) to review incremental changes.
- [**stack/remove_accepted_status**](https://github.com/mlflow/mlflow/pull/21613) [[Files changed](https://github.com/mlflow/mlflow/pull/21613/files)]
  - [stack/add_jobs_handler](https://github.com/mlflow/mlflow/pull/21589) [[Files changed](https://github.com/mlflow/mlflow/pull/21589/files/94ce9c71b52534676930e08a7d2ee9ddabdb3dc3..94ce9c71b52534676930e08a7d2ee9ddabdb3dc3)]

---------
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Remove `accepted` status, issue status now only supports pending/reject/resolved for simplicity and it's more clearer what users should react on them.
Feedback from bug bash.
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
