### PR TITLE
Add database-backed budget tracker for multi-process deployments

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -659,6 +659,18 @@ MLFLOW_GATEWAY_BUDGET_REFRESH_INTERVAL = _EnvironmentVariable(
 #: (default: ``None`` — uses in-memory tracker)
 MLFLOW_GATEWAY_BUDGET_REDIS_URL = _EnvironmentVariable("MLFLOW_GATEWAY_BUDGET_REDIS_URL", str, None)
 
+#: Budget tracker implementation: ``"in_memory"`` (default, single-process) or
+#: ``"database"`` (multi-process, queries DB for accurate cross-worker enforcement).
+#: (default: ``"in_memory"``)
+MLFLOW_GATEWAY_BUDGET_TRACKER_TYPE = _EnvironmentVariable(
+    "MLFLOW_GATEWAY_BUDGET_TRACKER_TYPE", str, "in_memory"
+)
+
+#: TTL in seconds for the database budget tracker's rejection-check cache.
+#: Only used when ``MLFLOW_GATEWAY_BUDGET_TRACKER_TYPE=database``.
+#: (default: ``5``)
+MLFLOW_GATEWAY_BUDGET_CACHE_TTL = _EnvironmentVariable("MLFLOW_GATEWAY_BUDGET_CACHE_TTL", int, 5)
+
 #: If True, MLflow fluent logging APIs, e.g., `mlflow.log_metric` will log asynchronously.
 MLFLOW_ENABLE_ASYNC_LOGGING = _BooleanEnvironmentVariable("MLFLOW_ENABLE_ASYNC_LOGGING", False)
 

--- a/mlflow/gateway/budget_tracker/__init__.py
+++ b/mlflow/gateway/budget_tracker/__init__.py
@@ -20,6 +20,7 @@ from mlflow.entities.gateway_budget_policy import (
 from mlflow.environment_variables import (
     MLFLOW_GATEWAY_BUDGET_REDIS_URL,
     MLFLOW_GATEWAY_BUDGET_REFRESH_INTERVAL,
+    MLFLOW_GATEWAY_BUDGET_TRACKER_TYPE,
 )
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
@@ -32,8 +33,13 @@ _budget_tracker: BudgetTracker | None = None
 _tracker_lock = threading.Lock()
 
 
-def get_budget_tracker() -> BudgetTracker:
-    """Get or create the module-level BudgetTracker singleton."""
+def get_budget_tracker(store=None) -> BudgetTracker:
+    """Get or create the module-level BudgetTracker singleton.
+
+    Args:
+        store: SqlAlchemyStore instance, required when using the ``"database"``
+            tracker type. Ignored after the singleton is created.
+    """
     global _budget_tracker
     if _budget_tracker is None:
         with _tracker_lock:
@@ -42,6 +48,16 @@ def get_budget_tracker() -> BudgetTracker:
                     from mlflow.gateway.budget_tracker.redis import RedisBudgetTracker
 
                     _budget_tracker = RedisBudgetTracker(_redis_url=redis_url)
+                elif MLFLOW_GATEWAY_BUDGET_TRACKER_TYPE.get() == "database":
+                    if store is None:
+                        raise ValueError(
+                            "MLFLOW_GATEWAY_BUDGET_TRACKER_TYPE is set to 'database' but "
+                            "no store was provided to get_budget_tracker(). Ensure the "
+                            "tracking store is initialized before budget tracking starts."
+                        )
+                    from mlflow.gateway.budget_tracker.database import DatabaseBudgetTracker
+
+                    _budget_tracker = DatabaseBudgetTracker(_store=store)
                 else:
                     from mlflow.gateway.budget_tracker.in_memory import InMemoryBudgetTracker
 

--- a/mlflow/gateway/budget_tracker/database.py
+++ b/mlflow/gateway/budget_tracker/database.py
@@ -11,6 +11,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from mlflow.entities.gateway_budget_policy import (
     BudgetAction,
@@ -25,6 +26,9 @@ from mlflow.gateway.budget_tracker import (
     _compute_window_start,
     _policy_applies,
 )
+
+if TYPE_CHECKING:
+    from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
 _logger = logging.getLogger(__name__)
 
@@ -50,7 +54,7 @@ class DatabaseBudgetTracker(BudgetTracker):
     crossings across all workers.
     """
 
-    _store: object  # SqlAlchemyStore — typed as object to avoid circular import
+    _store: SqlAlchemyStore
     _policies: list[GatewayBudgetPolicy] = field(default_factory=list)
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reject_cache: dict[str | None, _CachedRejectResult] = field(default_factory=dict)
@@ -169,6 +173,10 @@ class DatabaseBudgetTracker(BudgetTracker):
             except Exception:
                 _logger.debug("Failed to query spend for policy %s", pid, exc_info=True)
                 continue
+
+            # Add cost_usd to account for the in-flight request whose trace
+            # may not yet be persisted to the database.
+            spend += cost_usd
 
             if spend >= policy.budget_amount:
                 with self._lock:

--- a/mlflow/gateway/budget_tracker/database.py
+++ b/mlflow/gateway/budget_tracker/database.py
@@ -1,0 +1,240 @@
+"""Database-backed budget tracker for multi-process deployments.
+
+Queries the database for current spend instead of tracking in-memory,
+ensuring accurate budget enforcement across multiple worker processes.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from mlflow.entities.gateway_budget_policy import (
+    BudgetAction,
+    BudgetTargetScope,
+    GatewayBudgetPolicy,
+)
+from mlflow.environment_variables import MLFLOW_GATEWAY_BUDGET_CACHE_TTL
+from mlflow.gateway.budget_tracker import (
+    BudgetTracker,
+    BudgetWindow,
+    _compute_window_end,
+    _compute_window_start,
+    _policy_applies,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _CachedRejectResult:
+    """Cached result for should_reject_request."""
+
+    mono_time: float
+    exceeded: bool
+    window: BudgetWindow | None
+
+
+@dataclass
+class DatabaseBudgetTracker(BudgetTracker):
+    """Database-backed budget tracker for multi-process deployments.
+
+    Queries the database for current spend when checking REJECT policies,
+    ensuring accurate cross-worker budget enforcement. A short TTL cache
+    avoids excessive DB queries on rapid request bursts.
+
+    ALERT webhook detection also queries the database to detect threshold
+    crossings across all workers.
+    """
+
+    _store: object  # SqlAlchemyStore — typed as object to avoid circular import
+    _policies: list[GatewayBudgetPolicy] = field(default_factory=list)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _reject_cache: dict[str | None, _CachedRejectResult] = field(default_factory=dict)
+    # Track which ALERT policies have already fired in the current window
+    _alerted: dict[str, datetime] = field(default_factory=dict)
+
+    def refresh_policies(self, policies: list[GatewayBudgetPolicy]) -> list[BudgetWindow]:
+        with self._lock:
+            self._policies = list(policies)
+            self._reject_cache.clear()
+            # Clean up alerted state for removed policies
+            active_ids = {p.budget_policy_id for p in policies}
+            self._alerted = {k: v for k, v in self._alerted.items() if k in active_ids}
+            self.mark_refreshed()
+        return []  # No backfill needed for DB-backed tracker
+
+    def _query_spend(
+        self,
+        policy: GatewayBudgetPolicy,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> float:
+        start_ms = int(window_start.timestamp() * 1000)
+        end_ms = int(window_end.timestamp() * 1000)
+        workspace = policy.workspace if policy.target_scope == BudgetTargetScope.WORKSPACE else None
+        return self._store.sum_gateway_trace_cost(
+            start_time_ms=start_ms,
+            end_time_ms=end_ms,
+            workspace=workspace,
+        )
+
+    def should_reject_request(
+        self,
+        workspace: str | None = None,
+    ) -> tuple[bool, BudgetWindow | None]:
+        now_mono = time.monotonic()
+        cache_ttl = MLFLOW_GATEWAY_BUDGET_CACHE_TTL.get()
+
+        with self._lock:
+            cached = self._reject_cache.get(workspace)
+            if cached and (now_mono - cached.mono_time) < cache_ttl:
+                return cached.exceeded, cached.window
+            policies = list(self._policies)
+
+        now = datetime.now(timezone.utc)
+        for policy in policies:
+            if policy.budget_action != BudgetAction.REJECT:
+                continue
+            if not _policy_applies(policy, workspace):
+                continue
+
+            window_start = _compute_window_start(policy.duration_unit, policy.duration_value, now)
+            window_end = _compute_window_end(
+                policy.duration_unit, policy.duration_value, window_start
+            )
+            if now >= window_end:
+                continue
+
+            try:
+                spend = self._query_spend(policy, window_start, window_end)
+            except Exception:
+                _logger.debug(
+                    "Failed to query spend for policy %s",
+                    policy.budget_policy_id,
+                    exc_info=True,
+                )
+                continue
+
+            if spend >= policy.budget_amount:
+                window = BudgetWindow(
+                    policy=policy,
+                    window_start=window_start,
+                    window_end=window_end,
+                    cumulative_spend=spend,
+                    exceeded=True,
+                )
+                with self._lock:
+                    self._reject_cache[workspace] = _CachedRejectResult(now_mono, True, window)
+                return True, window
+
+        with self._lock:
+            self._reject_cache[workspace] = _CachedRejectResult(now_mono, False, None)
+        return False, None
+
+    def record_cost(
+        self,
+        cost_usd: float,
+        workspace: str | None = None,
+    ) -> list[BudgetWindow]:
+        with self._lock:
+            self._reject_cache.clear()
+            policies = list(self._policies)
+
+        newly_exceeded: list[BudgetWindow] = []
+        now = datetime.now(timezone.utc)
+
+        for policy in policies:
+            if policy.budget_action != BudgetAction.ALERT:
+                continue
+            if not _policy_applies(policy, workspace):
+                continue
+
+            window_start = _compute_window_start(policy.duration_unit, policy.duration_value, now)
+            window_end = _compute_window_end(
+                policy.duration_unit, policy.duration_value, window_start
+            )
+            pid = policy.budget_policy_id
+
+            with self._lock:
+                alerted_start = self._alerted.get(pid)
+                if alerted_start == window_start:
+                    continue  # Already alerted in this window
+
+            try:
+                spend = self._query_spend(policy, window_start, window_end)
+            except Exception:
+                _logger.debug("Failed to query spend for policy %s", pid, exc_info=True)
+                continue
+
+            if spend >= policy.budget_amount:
+                with self._lock:
+                    if self._alerted.get(pid) == window_start:
+                        continue
+                    self._alerted[pid] = window_start
+                window = BudgetWindow(
+                    policy=policy,
+                    window_start=window_start,
+                    window_end=window_end,
+                    cumulative_spend=spend,
+                    exceeded=True,
+                )
+                newly_exceeded.append(window)
+
+        return newly_exceeded
+
+    def backfill_spend(self, spend_by_policy: dict[str, float]) -> None:
+        pass  # Not needed — spend is always queried from the database
+
+    def get_all_windows(self) -> list[BudgetWindow]:
+        now = datetime.now(timezone.utc)
+        with self._lock:
+            policies = list(self._policies)
+
+        windows: list[BudgetWindow] = []
+        for policy in policies:
+            window_start = _compute_window_start(policy.duration_unit, policy.duration_value, now)
+            window_end = _compute_window_end(
+                policy.duration_unit, policy.duration_value, window_start
+            )
+            try:
+                spend = self._query_spend(policy, window_start, window_end)
+            except Exception:
+                spend = 0.0
+            windows.append(
+                BudgetWindow(
+                    policy=policy,
+                    window_start=window_start,
+                    window_end=window_end,
+                    cumulative_spend=spend,
+                    exceeded=spend >= policy.budget_amount,
+                )
+            )
+        return windows
+
+    def _get_window_info(self, budget_policy_id: str) -> BudgetWindow | None:
+        now = datetime.now(timezone.utc)
+        with self._lock:
+            policy = next(
+                (p for p in self._policies if p.budget_policy_id == budget_policy_id),
+                None,
+            )
+        if policy is None:
+            return None
+
+        window_start = _compute_window_start(policy.duration_unit, policy.duration_value, now)
+        window_end = _compute_window_end(policy.duration_unit, policy.duration_value, window_start)
+        try:
+            spend = self._query_spend(policy, window_start, window_end)
+        except Exception:
+            spend = 0.0
+        return BudgetWindow(
+            policy=policy,
+            window_start=window_start,
+            window_end=window_end,
+            cumulative_spend=spend,
+            exceeded=spend >= policy.budget_amount,
+        )

--- a/mlflow/gateway/budget_tracker/database.py
+++ b/mlflow/gateway/budget_tracker/database.py
@@ -208,10 +208,7 @@ class DatabaseBudgetTracker(BudgetTracker):
             window_end = _compute_window_end(
                 policy.duration_unit, policy.duration_value, window_start
             )
-            try:
-                spend = self._query_spend(policy, window_start, window_end)
-            except Exception:
-                spend = 0.0
+            spend = self._query_spend(policy, window_start, window_end)
             windows.append(
                 BudgetWindow(
                     policy=policy,
@@ -235,10 +232,7 @@ class DatabaseBudgetTracker(BudgetTracker):
 
         window_start = _compute_window_start(policy.duration_unit, policy.duration_value, now)
         window_end = _compute_window_end(policy.duration_unit, policy.duration_value, window_start)
-        try:
-            spend = self._query_spend(policy, window_start, window_end)
-        except Exception:
-            spend = 0.0
+        spend = self._query_spend(policy, window_start, window_end)
         return BudgetWindow(
             policy=policy,
             window_start=window_start,

--- a/mlflow/server/gateway_budget.py
+++ b/mlflow/server/gateway_budget.py
@@ -73,7 +73,7 @@ def calculate_existing_cost_for_new_windows(
 
 def maybe_refresh_budget_policies(store: SqlAlchemyStore) -> None:
     """Refresh budget policies from the database if stale."""
-    tracker = get_budget_tracker()
+    tracker = get_budget_tracker(store)
     if tracker.needs_refresh():
         try:
             policies = store.list_budget_policies()
@@ -165,7 +165,7 @@ def check_budget_limit(
     Raises HTTPException(429) with an error trace if the budget limit is exceeded.
     """
     maybe_refresh_budget_policies(store)
-    tracker = get_budget_tracker()
+    tracker = get_budget_tracker(store)
     exceeded, window = tracker.should_reject_request(workspace=workspace)
     if exceeded:
         policy = window.policy
@@ -208,7 +208,7 @@ def make_budget_on_complete(
                 return
 
             maybe_refresh_budget_policies(store)
-            tracker = get_budget_tracker()
+            tracker = get_budget_tracker(store)
             if newly_exceeded := tracker.record_cost(total_cost, workspace=workspace):
                 if registry_store:
                     fire_budget_exceeded_webhooks(newly_exceeded, workspace, registry_store)

--- a/tests/gateway/test_database_budget_tracker.py
+++ b/tests/gateway/test_database_budget_tracker.py
@@ -1,0 +1,280 @@
+from datetime import datetime, timezone
+from unittest import mock
+
+import pytest
+
+from mlflow.entities.gateway_budget_policy import (
+    BudgetAction,
+    BudgetDurationUnit,
+    BudgetTargetScope,
+    BudgetUnit,
+    GatewayBudgetPolicy,
+)
+from mlflow.gateway.budget_tracker.database import DatabaseBudgetTracker
+
+
+def _make_policy(
+    budget_policy_id="bp-test",
+    budget_amount=100.0,
+    duration_unit=BudgetDurationUnit.DAYS,
+    duration_value=1,
+    target_scope=BudgetTargetScope.GLOBAL,
+    budget_action=BudgetAction.ALERT,
+    workspace=None,
+):
+    return GatewayBudgetPolicy(
+        budget_policy_id=budget_policy_id,
+        budget_unit=BudgetUnit.USD,
+        budget_amount=budget_amount,
+        duration_unit=duration_unit,
+        duration_value=duration_value,
+        target_scope=target_scope,
+        budget_action=budget_action,
+        created_at=0,
+        last_updated_at=0,
+        workspace=workspace,
+    )
+
+
+@pytest.fixture
+def mock_store():
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def tracker(mock_store):
+    return DatabaseBudgetTracker(_store=mock_store)
+
+
+# --- refresh_policies ---
+
+
+def test_refresh_policies_returns_empty(tracker):
+    new_windows = tracker.refresh_policies([_make_policy()])
+    assert new_windows == []
+
+
+def test_refresh_policies_clears_cache(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 150.0
+    policy = _make_policy(budget_action=BudgetAction.REJECT)
+    tracker.refresh_policies([policy])
+
+    tracker.should_reject_request()
+    assert len(tracker._reject_cache) == 1
+
+    tracker.refresh_policies([policy])
+    assert len(tracker._reject_cache) == 0
+
+
+# --- should_reject_request ---
+
+
+def test_should_reject_under_budget(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 50.0
+    tracker.refresh_policies([_make_policy(budget_action=BudgetAction.REJECT)])
+
+    exceeded, window = tracker.should_reject_request()
+    assert exceeded is False
+    assert window is None
+    mock_store.sum_gateway_trace_cost.assert_called_once()
+
+
+def test_should_reject_over_budget(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 150.0
+    tracker.refresh_policies([_make_policy(budget_action=BudgetAction.REJECT)])
+
+    exceeded, window = tracker.should_reject_request()
+    assert exceeded is True
+    assert window.policy.budget_policy_id == "bp-test"
+    assert window.cumulative_spend == 150.0
+
+
+def test_should_reject_skips_alert_policies(tracker, mock_store):
+    tracker.refresh_policies([_make_policy(budget_action=BudgetAction.ALERT)])
+
+    exceeded, window = tracker.should_reject_request()
+    assert exceeded is False
+    mock_store.sum_gateway_trace_cost.assert_not_called()
+
+
+def test_should_reject_uses_ttl_cache(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 50.0
+    tracker.refresh_policies([_make_policy(budget_action=BudgetAction.REJECT)])
+
+    tracker.should_reject_request()
+    tracker.should_reject_request()
+    mock_store.sum_gateway_trace_cost.assert_called_once()
+
+
+def test_should_reject_cache_expires(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 50.0
+    tracker.refresh_policies([_make_policy(budget_action=BudgetAction.REJECT)])
+
+    tracker.should_reject_request()
+    # Expire the cache by manipulating the timestamp
+    for cached in tracker._reject_cache.values():
+        cached.mono_time -= 100
+    tracker.should_reject_request()
+    assert mock_store.sum_gateway_trace_cost.call_count == 2
+
+
+def test_should_reject_workspace_scoped(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 150.0
+    policy = _make_policy(
+        budget_action=BudgetAction.REJECT,
+        target_scope=BudgetTargetScope.WORKSPACE,
+        workspace="ws1",
+    )
+    tracker.refresh_policies([policy])
+
+    # Different workspace — not applicable
+    exceeded, _ = tracker.should_reject_request(workspace="ws2")
+    assert exceeded is False
+    mock_store.sum_gateway_trace_cost.assert_not_called()
+
+    # Matching workspace
+    exceeded, window = tracker.should_reject_request(workspace="ws1")
+    assert exceeded is True
+    mock_store.sum_gateway_trace_cost.assert_called_once()
+
+
+def test_should_reject_db_error_is_handled(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.side_effect = RuntimeError("DB down")
+    tracker.refresh_policies([_make_policy(budget_action=BudgetAction.REJECT)])
+
+    exceeded, window = tracker.should_reject_request()
+    assert exceeded is False
+    assert window is None
+
+
+# --- record_cost ---
+
+
+def test_record_cost_clears_reject_cache(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 50.0
+    tracker.refresh_policies([_make_policy(budget_action=BudgetAction.REJECT)])
+    tracker.should_reject_request()
+    assert len(tracker._reject_cache) == 1
+
+    mock_store.sum_gateway_trace_cost.return_value = 0.0
+    tracker.record_cost(10.0)
+    assert len(tracker._reject_cache) == 0
+
+
+def test_record_cost_detects_alert_exceeded(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 150.0
+    tracker.refresh_policies([_make_policy(budget_amount=100.0, budget_action=BudgetAction.ALERT)])
+
+    newly_exceeded = tracker.record_cost(10.0)
+    assert len(newly_exceeded) == 1
+    assert newly_exceeded[0].policy.budget_policy_id == "bp-test"
+
+
+def test_record_cost_alert_fires_only_once_per_window(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 150.0
+    tracker.refresh_policies([_make_policy(budget_amount=100.0, budget_action=BudgetAction.ALERT)])
+
+    assert len(tracker.record_cost(10.0)) == 1
+    assert len(tracker.record_cost(10.0)) == 0
+
+
+def test_record_cost_skips_reject_policies(tracker, mock_store):
+    tracker.refresh_policies([_make_policy(budget_action=BudgetAction.REJECT)])
+
+    newly_exceeded = tracker.record_cost(200.0)
+    assert newly_exceeded == []
+    mock_store.sum_gateway_trace_cost.assert_not_called()
+
+
+# --- backfill_spend ---
+
+
+def test_backfill_spend_is_noop(tracker):
+    tracker.refresh_policies([_make_policy()])
+    tracker.backfill_spend({"bp-test": 50.0})
+    # No error, no effect
+
+
+# --- get_all_windows ---
+
+
+def test_get_all_windows_queries_db(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 42.5
+    tracker.refresh_policies([_make_policy(budget_policy_id="bp-1")])
+
+    windows = tracker.get_all_windows()
+    assert len(windows) == 1
+    assert windows[0].cumulative_spend == 42.5
+    assert windows[0].policy.budget_policy_id == "bp-1"
+
+
+def test_get_all_windows_empty(tracker):
+    assert tracker.get_all_windows() == []
+
+
+# --- _get_window_info ---
+
+
+def test_get_window_info_queries_db(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 75.0
+    tracker.refresh_policies([_make_policy(budget_amount=100.0)])
+
+    window = tracker._get_window_info("bp-test")
+    assert window.cumulative_spend == 75.0
+    assert window.exceeded is False
+
+
+def test_get_window_info_exceeded(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 150.0
+    tracker.refresh_policies([_make_policy(budget_amount=100.0)])
+
+    window = tracker._get_window_info("bp-test")
+    assert window.exceeded is True
+
+
+def test_get_window_info_nonexistent(tracker):
+    tracker.refresh_policies([_make_policy()])
+    assert tracker._get_window_info("nonexistent") is None
+
+
+# --- multiple policies ---
+
+
+def test_multiple_reject_policies_first_exceeded_wins(tracker, mock_store):
+    policy1 = _make_policy(
+        budget_policy_id="bp-1", budget_amount=50.0, budget_action=BudgetAction.REJECT
+    )
+    policy2 = _make_policy(
+        budget_policy_id="bp-2", budget_amount=200.0, budget_action=BudgetAction.REJECT
+    )
+    tracker.refresh_policies([policy1, policy2])
+
+    mock_store.sum_gateway_trace_cost.return_value = 75.0
+    exceeded, window = tracker.should_reject_request()
+    assert exceeded is True
+    assert window.policy.budget_policy_id == "bp-1"
+    # Should short-circuit — only one DB query needed
+    mock_store.sum_gateway_trace_cost.assert_called_once()
+
+
+def test_alert_window_resets_on_new_window(tracker, mock_store):
+    policy = _make_policy(
+        budget_amount=100.0,
+        budget_action=BudgetAction.ALERT,
+        duration_unit=BudgetDurationUnit.MINUTES,
+        duration_value=5,
+    )
+    mock_store.sum_gateway_trace_cost.return_value = 150.0
+    tracker.refresh_policies([policy])
+
+    # First call — should fire
+    assert len(tracker.record_cost(10.0)) == 1
+    # Second call same window — should not fire
+    assert len(tracker.record_cost(10.0)) == 0
+
+    # Simulate window rollover by changing the alerted window_start
+    now = datetime.now(timezone.utc)
+    tracker._alerted["bp-test"] = now.replace(year=2000)
+
+    # Should fire again in new window
+    assert len(tracker.record_cost(10.0)) == 1

--- a/tests/gateway/test_database_budget_tracker.py
+++ b/tests/gateway/test_database_budget_tracker.py
@@ -106,7 +106,8 @@ def test_should_reject_uses_ttl_cache(tracker, mock_store):
     mock_store.sum_gateway_trace_cost.assert_called_once()
 
 
-def test_should_reject_cache_expires(tracker, mock_store):
+def test_should_reject_cache_expires(tracker, mock_store, monkeypatch):
+    monkeypatch.setenv("MLFLOW_GATEWAY_BUDGET_CACHE_TTL", "5")
     mock_store.sum_gateway_trace_cost.return_value = 50.0
     tracker.refresh_policies([_make_policy(budget_action=BudgetAction.REJECT)])
 
@@ -176,6 +177,25 @@ def test_record_cost_alert_fires_only_once_per_window(tracker, mock_store):
 
     assert len(tracker.record_cost(10.0)) == 1
     assert len(tracker.record_cost(10.0)) == 0
+
+
+def test_record_cost_adds_inflight_cost(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 95.0
+    tracker.refresh_policies([_make_policy(budget_amount=100.0, budget_action=BudgetAction.ALERT)])
+
+    # DB shows 95, but with cost_usd=10 the total is 105 which exceeds 100
+    newly_exceeded = tracker.record_cost(10.0)
+    assert len(newly_exceeded) == 1
+    assert newly_exceeded[0].cumulative_spend == 105.0
+
+
+def test_record_cost_inflight_cost_below_threshold(tracker, mock_store):
+    mock_store.sum_gateway_trace_cost.return_value = 85.0
+    tracker.refresh_policies([_make_policy(budget_amount=100.0, budget_action=BudgetAction.ALERT)])
+
+    # DB shows 85, with cost_usd=10 the total is 95 which is under 100
+    newly_exceeded = tracker.record_cost(10.0)
+    assert newly_exceeded == []
 
 
 def test_record_cost_skips_reject_policies(tracker, mock_store):


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

The in-memory budget tracker doesn't share state across uvicorn worker processes, so each worker tracks spend independently. This means requests can bypass budget limits when load is distributed across workers.

This PR adds a `DatabaseBudgetTracker` that queries `sum_gateway_trace_cost` from the DB for accurate cross-worker budget enforcement, with a configurable TTL cache to avoid excessive DB queries.

- New `DatabaseBudgetTracker` in `mlflow/gateway/budget_tracker/database.py`
- `should_reject_request` queries DB per REJECT policy with TTL-cached results
- `record_cost` queries DB for ALERT policies to detect threshold crossings
- `MLFLOW_GATEWAY_BUDGET_TRACKER_TYPE` env var to select `"in_memory"` (default) or `"database"`
- `MLFLOW_GATEWAY_BUDGET_CACHE_TTL` env var for cache TTL (default 5s)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

21 new tests in `tests/gateway/test_database_budget_tracker.py` covering reject checks, TTL caching, alert webhook detection, workspace scoping, DB error handling, and multi-policy behavior.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add `DatabaseBudgetTracker` for accurate budget enforcement in multi-worker gateway deployments. Set `MLFLOW_GATEWAY_BUDGET_TRACKER_TYPE=database` to enable DB-backed budget tracking across worker processes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release