### PR TITLE
Add TypeScript version of mlflow.tracing.context()

### DIFF
--- a/libs/typescript/core/src/core/api.ts
+++ b/libs/typescript/core/src/core/api.ts
@@ -6,6 +6,7 @@ import { getTracer } from './provider';
 import { InMemoryTraceManager } from './trace_manager';
 import { convertNanoSecondsToHrTime, mapArgsToObject } from './utils';
 import { SpanStatusCode } from './entities/span_status';
+import { isTracingEnabledInContext } from './context';
 
 /*
  * Options for starting a span
@@ -86,6 +87,10 @@ export interface TraceOptions
  *
  */
 export function startSpan(options: SpanOptions): LiveSpan {
+  if (isTracingEnabledInContext() === false) {
+    return new NoOpSpan();
+  }
+
   try {
     const tracer = getTracer('default');
 
@@ -132,6 +137,10 @@ export function withSpan<T>(
   callback: (span: LiveSpan) => T | Promise<T>,
   options?: Omit<SpanOptions, 'parent'>,
 ): T | Promise<T> {
+  if (isTracingEnabledInContext() === false) {
+    return callback(new NoOpSpan());
+  }
+
   const spanOptions: Omit<SpanOptions, 'parent'> = options ?? { name: DEFAULT_SPAN_NAME };
 
   // Generate a default span name if not provided

--- a/libs/typescript/core/src/core/context.ts
+++ b/libs/typescript/core/src/core/context.ts
@@ -1,0 +1,118 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Options for the tracingContext function.
+ */
+export interface TracingContextOptions {
+  /**
+   * Key-value pairs to inject into the trace's request_metadata (immutable after trace creation).
+   */
+  metadata?: Record<string, string>;
+
+  /**
+   * Key-value pairs to inject into the trace's tags.
+   */
+  tags?: Record<string, string>;
+
+  /**
+   * Whether tracing is enabled within the scope. If false, all tracing calls within the scope
+   * will return NoOpSpan without creating any traces. If undefined, the value is inherited from
+   * the outer scope.
+   */
+  enabled?: boolean;
+}
+
+interface UserTraceContext {
+  metadata: Record<string, string>;
+  tags: Record<string, string>;
+  enabled: boolean | undefined;
+}
+
+const storage = new AsyncLocalStorage<UserTraceContext>();
+
+/**
+ * Get the configured trace metadata from the current tracing context scope.
+ * Returns undefined if no context is active or metadata is empty.
+ */
+export function getConfiguredTraceMetadata(): Record<string, string> | undefined {
+  const ctx = storage.getStore();
+  if (!ctx || Object.keys(ctx.metadata).length === 0) {
+    return undefined;
+  }
+  return ctx.metadata;
+}
+
+/**
+ * Get the configured trace tags from the current tracing context scope.
+ * Returns undefined if no context is active or tags are empty.
+ */
+export function getConfiguredTraceTags(): Record<string, string> | undefined {
+  const ctx = storage.getStore();
+  if (!ctx || Object.keys(ctx.tags).length === 0) {
+    return undefined;
+  }
+  return ctx.tags;
+}
+
+/**
+ * Check if tracing is enabled in the current context scope.
+ * Returns undefined if no context is active or enabled was not set.
+ */
+export function isTracingEnabledInContext(): boolean | undefined {
+  const ctx = storage.getStore();
+  return ctx?.enabled;
+}
+
+/**
+ * Run a function within a tracing context scope that injects metadata and/or tags into any
+ * trace created within the scope, without creating a wrapper span. It can also be used to
+ * selectively disable tracing within the scope.
+ *
+ * This is useful when you need to attach trace-level information (e.g. session IDs) to traces
+ * produced by code you don't control like auto-instrumented libraries, or when you want to
+ * suppress tracing for a specific code block.
+ *
+ * The context can be nested. When the same key is specified in multiple levels, the value
+ * from the inner level takes precedence.
+ *
+ * @param options - Metadata, tags, and enabled flag to inject into traces
+ * @param fn - The function to execute within the context scope
+ * @returns The return value of the function
+ *
+ * @example
+ * ```typescript
+ * import * as mlflow from "@mlflow/core";
+ *
+ * // Inject metadata and tags into all traces created within the scope
+ * mlflow.tracingContext(
+ *   { metadata: { "mlflow.trace.session": "session-123" }, tags: { project: "my-project" } },
+ *   () => {
+ *     // Any trace created here will carry the metadata and tags
+ *     agent.invoke("What is the capital of France?");
+ *   }
+ * );
+ *
+ * // Disable tracing within a specific scope
+ * mlflow.tracingContext({ enabled: false }, () => {
+ *   // No traces will be created inside this scope
+ *   agent.invoke("This call will not be traced");
+ * });
+ * ```
+ */
+export function tracingContext<T>(options: TracingContextOptions, fn: () => T): T {
+  const current = storage.getStore();
+
+  // Merge with any outer context scope (inner wins on conflict)
+  const mergedMetadata = { ...(current?.metadata ?? {}), ...(options.metadata ?? {}) };
+  const mergedTags = { ...(current?.tags ?? {}), ...(options.tags ?? {}) };
+  const resolvedEnabled =
+    options.enabled !== undefined ? options.enabled : (current?.enabled ?? undefined);
+
+  const newContext: UserTraceContext = {
+    metadata: mergedMetadata,
+    tags: mergedTags,
+    enabled: resolvedEnabled,
+  };
+
+  return storage.run(newContext, fn);
+}

--- a/libs/typescript/core/src/exporters/mlflow.ts
+++ b/libs/typescript/core/src/exporters/mlflow.ts
@@ -8,6 +8,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { Context } from '@opentelemetry/api';
 import { createAndRegisterMlflowSpan } from '../core/api';
+import { getConfiguredTraceMetadata, getConfiguredTraceTags } from '../core/context';
 import { InMemoryTraceManager } from '../core/trace_manager';
 import { TraceInfo } from '../core/entities/trace_info';
 import { createTraceLocationFromExperimentId } from '../core/entities/trace_location';
@@ -53,16 +54,31 @@ export class MlflowSpanProcessor implements SpanProcessor {
     if (!span.parentSpanContext?.spanId) {
       // This is a root span
       traceId = generateTraceId(span);
+
+      // Build trace metadata, merging context-injected values
+      const traceMetadata: Record<string, string> = {
+        [TraceMetadataKey.SCHEMA_VERSION]: TRACE_SCHEMA_VERSION,
+      };
+      const ctxMetadata = getConfiguredTraceMetadata();
+      if (ctxMetadata) {
+        Object.assign(traceMetadata, ctxMetadata);
+      }
+
+      // Build trace tags, merging context-injected values
+      const tags: Record<string, string> = {};
+      const ctxTags = getConfiguredTraceTags();
+      if (ctxTags) {
+        Object.assign(tags, ctxTags);
+      }
+
       const trace_info = new TraceInfo({
         traceId: traceId,
         traceLocation: createTraceLocationFromExperimentId(experimentId),
         requestTime: convertHrTimeToMs(span.startTime),
         executionDuration: 0,
         state: TraceState.IN_PROGRESS,
-        traceMetadata: {
-          [TraceMetadataKey.SCHEMA_VERSION]: TRACE_SCHEMA_VERSION,
-        },
-        tags: {},
+        traceMetadata,
+        tags,
         assessments: [],
       });
       InMemoryTraceManager.getInstance().registerTrace(otelTraceId, trace_info);

--- a/libs/typescript/core/src/index.ts
+++ b/libs/typescript/core/src/index.ts
@@ -7,6 +7,7 @@ import {
   trace,
   withSpan,
 } from './core/api';
+import { tracingContext } from './core/context';
 import { flushTraces } from './core/provider';
 import { MlflowClient } from './clients';
 
@@ -14,6 +15,7 @@ export {
   getLastActiveTraceId,
   getCurrentActiveSpan,
   updateCurrentTrace,
+  tracingContext,
   flushTraces,
   init,
   startSpan,
@@ -30,4 +32,5 @@ export type { TraceInfo, TokenUsage } from './core/entities/trace_info';
 export type { TraceData } from './core/entities/trace_data';
 export { SpanStatusCode } from './core/entities/span_status';
 export type { UpdateCurrentTraceOptions, SpanOptions, TraceOptions } from './core/api';
+export type { TracingContextOptions } from './core/context';
 export { registerOnSpanStartHook, registerOnSpanEndHook } from './exporters/span_processor_hooks';

--- a/libs/typescript/core/tests/core/api.test.ts
+++ b/libs/typescript/core/tests/core/api.test.ts
@@ -974,4 +974,114 @@ describe('API', () => {
       expect(trace.info.responsePreview).toBe('Custom response preview');
     });
   });
+
+  describe('tracingContext', () => {
+    it('should inject metadata and tags into traces created within scope', async () => {
+      mlflow.tracingContext(
+        {
+          metadata: { custom_key: 'custom_value' },
+          tags: { my_tag: 'tag_value' },
+        },
+        () => {
+          void mlflow.withSpan((_span) => {}, { name: 'test-span' });
+        },
+      );
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.traceMetadata['custom_key']).toBe('custom_value');
+      expect(trace.info.tags['my_tag']).toBe('tag_value');
+    });
+
+    it('should not inject metadata into traces created outside scope', async () => {
+      mlflow.tracingContext(
+        {
+          metadata: { scoped_key: 'scoped_value' },
+        },
+        () => {
+          // Trace created inside scope
+        },
+      );
+
+      // Trace created outside scope
+      void mlflow.withSpan((_span) => {}, { name: 'outside-span' });
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.traceMetadata['scoped_key']).toBeUndefined();
+    });
+
+    it('should merge nested contexts with inner values winning', async () => {
+      mlflow.tracingContext(
+        {
+          metadata: { outer_key: 'outer_val', shared: 'outer' },
+          tags: { outer_tag: 'outer' },
+        },
+        () => {
+          mlflow.tracingContext(
+            {
+              metadata: { inner_key: 'inner_val', shared: 'inner' },
+              tags: { inner_tag: 'inner' },
+            },
+            () => {
+              void mlflow.withSpan((_span) => {}, { name: 'nested-span' });
+            },
+          );
+        },
+      );
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.traceMetadata['outer_key']).toBe('outer_val');
+      expect(trace.info.traceMetadata['inner_key']).toBe('inner_val');
+      expect(trace.info.traceMetadata['shared']).toBe('inner');
+      expect(trace.info.tags['outer_tag']).toBe('outer');
+      expect(trace.info.tags['inner_tag']).toBe('inner');
+    });
+
+    it('should suppress traces when enabled is false', () => {
+      let spanInstance: mlflow.LiveSpan | null = null;
+
+      mlflow.tracingContext({ enabled: false }, () => {
+        void mlflow.withSpan((span) => {
+          spanInstance = span;
+        });
+      });
+
+      // The span should be a NoOpSpan (trace ID is the no-op sentinel)
+      expect(spanInstance).not.toBeNull();
+      expect(spanInstance!.traceId).toBe('no-op-span-trace-id');
+    });
+
+    it('should inherit enabled=false from outer context', () => {
+      let spanInstance: mlflow.LiveSpan | null = null;
+
+      mlflow.tracingContext({ enabled: false }, () => {
+        mlflow.tracingContext({ metadata: { key: 'val' } }, () => {
+          void mlflow.withSpan((span) => {
+            spanInstance = span;
+          });
+        });
+      });
+
+      expect(spanInstance).not.toBeNull();
+      expect(spanInstance!.traceId).toBe('no-op-span-trace-id');
+    });
+
+    it('should support async functions', async () => {
+      await mlflow.tracingContext(
+        {
+          metadata: { async_key: 'async_value' },
+        },
+        async () => {
+          await mlflow.withSpan(
+            async (_span) => {
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            },
+            { name: 'async-span' },
+          );
+        },
+      );
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.traceMetadata['async_key']).toBe('async_value');
+    });
+  });
 });


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add TypeScript version of the `mlflow.tracing.context` API we added in https://github.com/mlflow/mlflow/pull/21318.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

Will be updated in the next PR along with python api.

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [x] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
