### PR TITLE
[draft] Add gateway guardrails: pre/post invocation scorers for endpoints

### DIFF
--- a/mlflow/entities/gateway_guardrail.py
+++ b/mlflow/entities/gateway_guardrail.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from mlflow.entities._mlflow_object import _MlflowObject
+
+
+class GuardrailHook(str, Enum):
+    PRE = "PRE"
+    POST = "POST"
+
+
+class GuardrailOperation(str, Enum):
+    VALIDATION = "VALIDATION"
+    MUTATION = "MUTATION"
+
+
+@dataclass
+class GuardrailConfig(_MlflowObject):
+    """
+    Represents a guardrail configuration for a gateway endpoint.
+
+    A guardrail ties a scorer (judge) to an endpoint to run before or after
+    LLM invocation. Validation guardrails block requests/responses (yes/no),
+    while mutation guardrails modify them.
+
+    Args:
+        guardrail_id: Unique identifier.
+        endpoint_name: Gateway endpoint this guardrail applies to.
+            If None, applies to all endpoints.
+        scorer_name: Name of the scorer to use as guardrail.
+        hook: Whether to run PRE or POST LLM invocation.
+        operation: Whether to VALIDATE (block) or MUTATE (modify).
+        order: Execution order (lower = earlier). Default 0.
+        enabled: Whether the guardrail is currently active.
+        config_json: Optional JSON config for the scorer (e.g. custom prompt).
+    """
+
+    guardrail_id: str
+    scorer_name: str
+    hook: GuardrailHook
+    operation: GuardrailOperation
+    endpoint_name: str | None = None
+    order: int = 0
+    enabled: bool = True
+    config_json: str | None = None
+
+    def __post_init__(self):
+        if isinstance(self.hook, str):
+            self.hook = GuardrailHook(self.hook)
+        if isinstance(self.operation, str):
+            self.operation = GuardrailOperation(self.operation)

--- a/mlflow/genai/scorers/guardrails/__init__.py
+++ b/mlflow/genai/scorers/guardrails/__init__.py
@@ -322,6 +322,32 @@ class GibberishText(GuardrailsScorer):
     validator_name: ClassVar[str] = "GibberishText"
 
 
+@experimental(version="3.10.0")
+class RegexMatch(GuardrailsScorer):
+    """
+    Blocks text matching a regular expression pattern using Guardrails AI.
+
+    Uses ``hub://guardrails/regex_match`` to validate that text does not
+    contain (or does contain, depending on configuration) the given pattern.
+
+    Args:
+        regex: The regular expression pattern to match against.
+
+    Examples:
+        .. code-block:: python
+
+            from mlflow.genai.scorers.guardrails import RegexMatch
+
+            scorer = RegexMatch(regex=r"\\d{3}-\\d{2}-\\d{4}")
+            feedback = scorer(outputs="Contact SSN 123-45-6789")
+    """
+
+    validator_name: ClassVar[str] = "RegexMatch"
+
+    def __init__(self, regex: str, **kwargs: Any):
+        super().__init__(validator_name="RegexMatch", regex=regex, **kwargs)
+
+
 __all__ = [
     "GuardrailsScorer",
     "get_scorer",
@@ -331,4 +357,5 @@ __all__ = [
     "DetectPII",
     "SecretsPresent",
     "GibberishText",
+    "RegexMatch",
 ]

--- a/mlflow/genai/scorers/guardrails/__init__.py
+++ b/mlflow/genai/scorers/guardrails/__init__.py
@@ -323,6 +323,187 @@ class GibberishText(GuardrailsScorer):
 
 
 @experimental(version="3.10.0")
+class GuardrailsFixScorer(Scorer):
+    """
+    Base class for Guardrails AI validators that *fix* (modify) content.
+
+    Unlike ``GuardrailsScorer`` (which validates and returns yes/no),
+    this class uses ``on_fail=FIX`` so the validator rewrites the text
+    in-place.  The returned ``Feedback.value`` contains the fixed text
+    (or the original text when no fix was needed).
+    """
+
+    _guard: Any = PrivateAttr()
+
+    def __init__(
+        self,
+        validator_name: str | None = None,
+        **validator_kwargs: Any,
+    ):
+        check_guardrails_installed()
+
+        if validator_name is None:
+            validator_name = getattr(self.__class__, "validator_name", None)
+            if validator_name is None:
+                raise ValueError("validator_name must be provided")
+
+        super().__init__(name=validator_name)
+
+        from guardrails import Guard, OnFailAction
+
+        validator_class = get_validator_class(validator_name)
+        validator = validator_class(on_fail=OnFailAction.FIX, **validator_kwargs)
+        try:
+            self._guard = Guard().use(validator)
+        except TypeError:
+            self._guard = Guard().use(validator_class, on_fail=OnFailAction.FIX, **validator_kwargs)
+
+    def __call__(
+        self,
+        *,
+        inputs: Any = None,
+        outputs: Any = None,
+        expectations: dict[str, Any] | None = None,
+        trace: Trace | None = None,
+    ) -> Feedback:
+        assessment_source = AssessmentSource(
+            source_type=AssessmentSourceType.CODE,
+            source_id=f"guardrails/{self.name}",
+        )
+
+        try:
+            text = map_scorer_inputs_to_text(
+                inputs=inputs,
+                outputs=outputs,
+                trace=trace,
+            )
+            result = self._guard.validate(text)
+
+            # The validated_output is the fixed text (or None if no fix)
+            fixed = result.validated_output
+            if fixed is None or fixed == text:
+                return Feedback(
+                    name=self.name,
+                    value="yes",
+                    rationale="No issues found — text unchanged",
+                    source=assessment_source,
+                    metadata={FRAMEWORK_METADATA_KEY: _FRAMEWORK_NAME},
+                )
+
+            return Feedback(
+                name=self.name,
+                value=fixed,
+                rationale="Content modified by guardrail",
+                source=assessment_source,
+                metadata={FRAMEWORK_METADATA_KEY: _FRAMEWORK_NAME},
+            )
+        except Exception as e:
+            _logger.error(f"Error running fix guardrail {self.name}: {e}")
+            return Feedback(
+                name=self.name,
+                error=e,
+                source=assessment_source,
+                metadata={FRAMEWORK_METADATA_KEY: _FRAMEWORK_NAME},
+            )
+
+
+@experimental(version="3.10.0")
+class AnonymizePII(GuardrailsFixScorer):
+    """
+    Anonymizes personally identifiable information in text.
+
+    Uses ``DetectPII`` with ``on_fail=FIX`` to automatically replace
+    detected PII (emails, phone numbers, names, etc.) with anonymized
+    placeholders.
+
+    Args:
+        pii_entities: PII types to anonymize. Defaults to common types.
+
+    Examples:
+        .. code-block:: python
+
+            from mlflow.genai.scorers.guardrails import AnonymizePII
+
+            scorer = AnonymizePII()
+            feedback = scorer(outputs="Contact john@email.com or 555-1234")
+            # feedback.value → "Contact <EMAIL_ADDRESS> or <PHONE_NUMBER>"
+    """
+
+    validator_name: ClassVar[str] = "DetectPII"
+
+    def __init__(self, pii_entities: list[str] | None = None, **kwargs: Any):
+        entities = pii_entities or [
+            "EMAIL_ADDRESS",
+            "PHONE_NUMBER",
+            "PERSON",
+            "LOCATION",
+            "US_SSN",
+            "CREDIT_CARD",
+            "IP_ADDRESS",
+        ]
+        super().__init__(validator_name="DetectPII", pii_entities=entities, **kwargs)
+        # Override the name so it shows as AnonymizePII, not DetectPII
+        self.name = "AnonymizePII"
+
+
+@experimental(version="3.10.0")
+class SanitizeWeb(GuardrailsFixScorer):
+    """
+    Removes web injection attacks (XSS) from text.
+
+    Uses ``WebSanitization`` with ``on_fail=FIX`` to strip script tags,
+    event handlers, and other potentially dangerous HTML from LLM outputs.
+
+    Examples:
+        .. code-block:: python
+
+            from mlflow.genai.scorers.guardrails import SanitizeWeb
+
+            scorer = SanitizeWeb()
+            feedback = scorer(outputs="Hello <script>alert('xss')</script> world")
+            # feedback.value → "Hello  world"
+    """
+
+    validator_name: ClassVar[str] = "WebSanitization"
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(validator_name="WebSanitization", **kwargs)
+        self.name = "SanitizeWeb"
+
+
+@experimental(version="3.10.0")
+class CompetitorFilter(GuardrailsFixScorer):
+    """
+    Removes competitor names from LLM responses.
+
+    Uses ``CompetitorCheck`` with ``on_fail=FIX`` to automatically
+    filter out mentions of specified competitor products or companies.
+
+    Args:
+        competitors: List of competitor names to filter out.
+
+    Examples:
+        .. code-block:: python
+
+            from mlflow.genai.scorers.guardrails import CompetitorFilter
+
+            scorer = CompetitorFilter(competitors=["Competitor A", "Competitor B"])
+            feedback = scorer(outputs="Try Competitor A for a better experience")
+            # feedback.value → "Try  for a better experience"
+    """
+
+    validator_name: ClassVar[str] = "CompetitorCheck"
+
+    def __init__(self, competitors: list[str], **kwargs: Any):
+        super().__init__(
+            validator_name="CompetitorCheck",
+            competitors=competitors,
+            **kwargs,
+        )
+        self.name = "CompetitorFilter"
+
+
+@experimental(version="3.10.0")
 class RegexMatch(GuardrailsScorer):
     """
     Blocks text matching a regular expression pattern using Guardrails AI.
@@ -350,6 +531,7 @@ class RegexMatch(GuardrailsScorer):
 
 __all__ = [
     "GuardrailsScorer",
+    "GuardrailsFixScorer",
     "get_scorer",
     "ToxicLanguage",
     "NSFWText",
@@ -358,4 +540,7 @@ __all__ = [
     "SecretsPresent",
     "GibberishText",
     "RegexMatch",
+    "AnonymizePII",
+    "SanitizeWeb",
+    "CompetitorFilter",
 ]

--- a/mlflow/genai/scorers/guardrails/registry.py
+++ b/mlflow/genai/scorers/guardrails/registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+
 from mlflow.exceptions import MlflowException
 
 _SUPPORTED_VALIDATORS = [
@@ -9,7 +11,15 @@ _SUPPORTED_VALIDATORS = [
     "DetectPII",
     "SecretsPresent",
     "GibberishText",
+    "RegexMatch",
 ]
+
+# Some hub validators trigger a circular import when loaded via guardrails.hub.__init__
+# (hub.__init__ eagerly imports all installed validators, which can re-enter guardrails
+# before it finishes initializing). For these we load the package directly.
+_DIRECT_IMPORT_MAP: dict[str, tuple[str, str]] = {
+    "RegexMatch": ("guardrails_grhub_regex_match.main", "RegexMatch"),
+}
 
 
 def get_validator_class(validator_name: str):
@@ -28,6 +38,17 @@ def get_validator_class(validator_name: str):
     Raises:
         MlflowException: If the validator cannot be imported or guardrails is not installed
     """
+    if validator_name in _DIRECT_IMPORT_MAP:
+        module_path, class_name = _DIRECT_IMPORT_MAP[validator_name]
+        try:
+            module = importlib.import_module(module_path)
+            return getattr(module, class_name)
+        except (ImportError, AttributeError) as e:
+            raise MlflowException.invalid_parameter_value(
+                f"Could not import '{validator_name}'. "
+                f"Run: guardrails hub install hub://guardrails/regex_match\n{e}"
+            )
+
     from guardrails import hub
 
     try:

--- a/mlflow/genai/scorers/guardrails/registry.py
+++ b/mlflow/genai/scorers/guardrails/registry.py
@@ -12,6 +12,8 @@ _SUPPORTED_VALIDATORS = [
     "SecretsPresent",
     "GibberishText",
     "RegexMatch",
+    "WebSanitization",
+    "CompetitorCheck",
 ]
 
 # Some hub validators trigger a circular import when loaded via guardrails.hub.__init__

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -18,6 +18,7 @@ from mlflow.server import app as flask_app
 from mlflow.server.assistant.api import assistant_router
 from mlflow.server.fastapi_security import init_fastapi_security
 from mlflow.server.gateway_api import gateway_router
+from mlflow.server.gateway_guardrails import guardrail_router
 from mlflow.server.job_api import job_api_router
 from mlflow.server.otel_api import otel_router
 from mlflow.server.workspace_helpers import (
@@ -91,6 +92,9 @@ def create_fastapi_app(flask_app: Flask = flask_app):
     # Include Gateway API router for database-backed endpoints
     # This provides /gateway/{endpoint_name}/mlflow/invocations routes
     fastapi_app.include_router(gateway_router)
+
+    # Include Guardrails API router for managing gateway guardrails
+    fastapi_app.include_router(guardrail_router)
 
     # Include Assistant API router for AI-powered trace analysis
     # This provides /ajax-api/3.0/mlflow/assistant/* endpoints (localhost only)

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -43,6 +43,12 @@ from mlflow.gateway.tracing_utils import aggregate_chat_stream_chunks, maybe_tra
 from mlflow.gateway.utils import safe_stream, to_sse_chunk, translate_http_exception
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.server.gateway_budget import check_budget_limit, make_budget_on_complete
+from mlflow.server.gateway_guardrails import (
+    GuardrailRejection,
+    _ensure_gateway_uri,
+    run_post_guardrails,
+    run_pre_guardrails,
+)
 from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.store.tracking.gateway.config_resolver import get_endpoint_config
 from mlflow.store.tracking.gateway.entities import (
@@ -60,6 +66,17 @@ from mlflow.utils.workspace_context import get_request_workspace
 _logger = logging.getLogger(__name__)
 
 gateway_router = APIRouter(prefix="/gateway", tags=["gateway"])
+
+
+def _load_guardrails(store, endpoint_name: str):
+    """Load enabled guardrails for the given endpoint from the store."""
+    if not isinstance(store, SqlAlchemyStore):
+        return []
+    try:
+        return store.list_guardrails(endpoint_name=endpoint_name)
+    except Exception:
+        _logger.debug("Failed to load guardrails", exc_info=True)
+        return []
 
 
 async def _get_request_body(request: Request) -> dict[str, Any]:
@@ -422,6 +439,7 @@ async def invocations(endpoint_name: str, request: Request):
     - If payload has "messages" field -> chat endpoint
     - If payload has "input" field -> embeddings endpoint
     """
+    _ensure_gateway_uri(request)
     body = await _get_request_body(request)
     user_metadata = _get_user_metadata(request)
     headers = dict(request.headers)
@@ -436,6 +454,17 @@ async def invocations(endpoint_name: str, request: Request):
     if "messages" in body:
         # Chat request
         endpoint_type = EndpointType.LLM_V1_CHAT
+
+        # ── Run PRE guardrails ──
+        guardrails = _load_guardrails(store, endpoint_name)
+        try:
+            body = run_pre_guardrails(guardrails, body)
+        except GuardrailRejection as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Request blocked by guardrail '{e.guardrail_name}': {e.reason}",
+            )
+
         try:
             payload = chat.RequestPayload(**body)
         except Exception as e:
@@ -460,7 +489,7 @@ async def invocations(endpoint_name: str, request: Request):
                 media_type="text/event-stream",
             )
         else:
-            return await maybe_traced_gateway_call(
+            response = await maybe_traced_gateway_call(
                 provider.chat,
                 endpoint_config,
                 user_metadata,
@@ -468,6 +497,21 @@ async def invocations(endpoint_name: str, request: Request):
                 request_type=GatewayRequestType.UNIFIED_CHAT,
                 on_complete=make_budget_on_complete(store, workspace),
             )(payload)
+
+            # ── Run POST guardrails ──
+            if guardrails:
+                try:
+                    response_dict = (
+                        response.model_dump() if hasattr(response, "model_dump") else response
+                    )
+                    run_post_guardrails(guardrails, response_dict)
+                except GuardrailRejection as e:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Response blocked by guardrail '{e.guardrail_name}': {e.reason}",
+                    )
+
+            return response
 
     elif "input" in body:
         # Embeddings request

--- a/mlflow/server/gateway_guardrails.py
+++ b/mlflow/server/gateway_guardrails.py
@@ -400,6 +400,10 @@ def _run_scorer_inner(
     # Run a GuardrailsScorer builtin (these are NLP-based, don't use templates,
     # so always pass as outputs — the text is just analyzed directly)
     if "builtin_scorer" in config:
+        # RegexMatch is handled natively: guardrails-grhub-regex-match v0.0.0 has a
+        # circular-import bug (imports guardrails.validator_base during hub init).
+        if config["builtin_scorer"] == "RegexMatch":
+            return _run_regex_scorer(config.get("regex_pattern", ""), text)
         return _run_builtin_scorer(config["builtin_scorer"], text, is_mutation)
 
     # Run a registered scorer (including custom judges that were registered on add)
@@ -436,12 +440,28 @@ def _run_scorer_inner(
     return {"score": "yes", "rationale": "Default pass (no config)"}
 
 
-def _run_builtin_scorer(builtin_name: str, text: str, is_mutation: bool = False) -> dict:
+def _run_regex_scorer(pattern: str, text: str) -> dict:
+    """Run regex match natively — blocks when the pattern is found in the text."""
+    import re
+
+    if not pattern:
+        return {"score": "yes", "rationale": "No regex pattern configured"}
+    try:
+        found = bool(re.search(pattern, text))
+        return {
+            "score": "no" if found else "yes",
+            "rationale": f"Pattern '{pattern}' {'matched — content blocked' if found else 'did not match'}",
+        }
+    except re.error as e:
+        return {"score": "yes", "rationale": f"Invalid regex pattern: {e}"}
+
+
+def _run_builtin_scorer(builtin_name: str, text: str, is_mutation: bool = False, **kwargs) -> dict:
     """Run a GuardrailsScorer builtin (ToxicLanguage, DetectPII, etc.)."""
     try:
         from mlflow.genai.scorers.guardrails import get_scorer
 
-        scorer = get_scorer(builtin_name)
+        scorer = get_scorer(builtin_name, **kwargs)
         feedback = scorer(outputs=text)
 
         raw_value = feedback.value

--- a/mlflow/server/gateway_guardrails.py
+++ b/mlflow/server/gateway_guardrails.py
@@ -1,0 +1,664 @@
+"""
+Gateway guardrail execution and API endpoints.
+
+Guardrails are scorers (judges) that run before or after LLM invocation
+to validate or mutate requests/responses.
+"""
+
+import json
+import logging
+import os
+import threading
+
+from fastapi import APIRouter, HTTPException, Request
+
+from mlflow.entities.gateway_guardrail import GuardrailConfig, GuardrailHook, GuardrailOperation
+from mlflow.environment_variables import MLFLOW_GATEWAY_URI
+from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.tracking._tracking_service.utils import _get_store
+
+_logger = logging.getLogger(__name__)
+
+# Default experiment ID for guardrail-registered scorers
+_GUARDRAIL_EXPERIMENT_ID = "0"
+
+# Context variable to prevent recursive guardrail execution.
+# When a guardrail judge calls an LLM endpoint that itself has guardrails,
+# we skip guardrails on the nested call to avoid infinite recursion.
+_guardrail_depth = threading.local()
+
+_MAX_GUARDRAIL_DEPTH = 1
+
+
+def _is_inside_guardrail() -> bool:
+    return getattr(_guardrail_depth, "depth", 0) >= _MAX_GUARDRAIL_DEPTH
+
+
+def _ensure_gateway_uri(request: Request) -> None:
+    """Set MLFLOW_GATEWAY_URI from the incoming request if not already set.
+
+    When the server process runs judges with ``gateway:/`` model URIs, LiteLLM
+    needs an HTTP base URL to route through the gateway.  The tracking URI
+    inside the server process is typically ``sqlite://`` (not HTTP), so we
+    derive the gateway URI from the request's own base URL.
+    """
+    if MLFLOW_GATEWAY_URI.is_set():
+        return
+    base = str(request.base_url).rstrip("/")
+    os.environ[MLFLOW_GATEWAY_URI.name] = base
+    _logger.debug("Set %s=%s from request", MLFLOW_GATEWAY_URI.name, base)
+
+guardrail_router = APIRouter(prefix="/gateway/guardrails", tags=["gateway-guardrails"])
+
+
+# ─── API Endpoints ───────────────────────────────────────────────────────────
+
+
+def _register_custom_scorer(
+    scorer_name: str, prompt: str, response_schema: str | None = None, model: str | None = None
+) -> dict:
+    """
+    Register a custom judge as a scorer via make_judge + scorer store.
+
+    Returns dict with experiment_id and scorer_version for the registered scorer.
+    """
+    try:
+        from mlflow.genai.judges import make_judge
+        from mlflow.genai.scorers.registry import _get_scorer_store
+
+        judge = make_judge(name=scorer_name, instructions=prompt, model=model)
+        store = _get_scorer_store()
+        version = store.register_scorer(
+            experiment_id=_GUARDRAIL_EXPERIMENT_ID,
+            scorer=judge,
+        )
+        _logger.info(
+            f"Registered custom guardrail scorer '{scorer_name}' "
+            f"(experiment_id={_GUARDRAIL_EXPERIMENT_ID}, version={version})"
+        )
+        return {
+            "experiment_id": _GUARDRAIL_EXPERIMENT_ID,
+            "scorer_version": version.scorer_version,
+        }
+    except Exception:
+        _logger.exception(f"Failed to register custom scorer '{scorer_name}'")
+        raise
+
+
+@guardrail_router.post("/add")
+async def add_guardrail(request: Request):
+    body = await request.json()
+
+    scorer_name = body.get("scorer_name")
+    if not scorer_name:
+        raise HTTPException(status_code=400, detail="Missing required 'scorer_name'")
+
+    hook = body.get("hook", "PRE")
+    operation = body.get("operation", "VALIDATION")
+
+    try:
+        hook_enum = GuardrailHook(hook)
+        operation_enum = GuardrailOperation(operation)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    store = _get_store()
+    if not isinstance(store, SqlAlchemyStore):
+        raise HTTPException(status_code=500, detail="Guardrails require SqlAlchemyStore")
+
+    config = body.get("config", {})
+
+    # If this is a custom judge with a prompt, register it as a scorer
+    if config.get("prompt") and not config.get("builtin_scorer") and not config.get("registered_scorer"):
+        try:
+            reg_info = _register_custom_scorer(
+                scorer_name=scorer_name,
+                prompt=config["prompt"],
+                response_schema=config.get("response_schema"),
+                model=config.get("model"),
+            )
+            config["registered_scorer"] = scorer_name
+            config["experiment_id"] = reg_info["experiment_id"]
+            config["scorer_version"] = reg_info["scorer_version"]
+        except Exception as e:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to register custom scorer: {e}",
+            )
+
+    guardrail = store.add_guardrail(
+        scorer_name=scorer_name,
+        hook=hook_enum,
+        operation=operation_enum,
+        endpoint_name=body.get("endpoint_name"),
+        order=body.get("order", 0),
+        config_json=json.dumps(config) if config else None,
+    )
+
+    return {
+        "guardrail": {
+            "guardrail_id": guardrail.guardrail_id,
+            "endpoint_name": guardrail.endpoint_name,
+            "scorer_name": guardrail.scorer_name,
+            "hook": guardrail.hook.value,
+            "operation": guardrail.operation.value,
+            "order": guardrail.order,
+            "enabled": guardrail.enabled,
+            "config": config or None,
+        }
+    }
+
+
+@guardrail_router.post("/update")
+async def update_guardrail(request: Request):
+    body = await request.json()
+    guardrail_id = body.get("guardrail_id")
+    if not guardrail_id:
+        raise HTTPException(status_code=400, detail="Missing required 'guardrail_id'")
+
+    store = _get_store()
+    if not isinstance(store, SqlAlchemyStore):
+        raise HTTPException(status_code=500, detail="Guardrails require SqlAlchemyStore")
+
+    kwargs: dict = {}
+    if "scorer_name" in body:
+        kwargs["scorer_name"] = body["scorer_name"]
+    if "hook" in body:
+        try:
+            kwargs["hook"] = GuardrailHook(body["hook"])
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+    if "operation" in body:
+        try:
+            kwargs["operation"] = GuardrailOperation(body["operation"])
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+    if "config" in body:
+        kwargs["config_json"] = json.dumps(body["config"]) if body["config"] is not None else None
+
+    guardrail = store.update_guardrail(guardrail_id=guardrail_id, **kwargs)
+
+    return {
+        "guardrail": {
+            "guardrail_id": guardrail.guardrail_id,
+            "endpoint_name": guardrail.endpoint_name,
+            "scorer_name": guardrail.scorer_name,
+            "hook": guardrail.hook.value,
+            "operation": guardrail.operation.value,
+            "order": guardrail.order,
+            "enabled": guardrail.enabled,
+            "config": json.loads(guardrail.config_json) if guardrail.config_json else None,
+        }
+    }
+
+
+@guardrail_router.post("/remove")
+async def remove_guardrail(request: Request):
+    body = await request.json()
+    guardrail_id = body.get("guardrail_id")
+    if not guardrail_id:
+        raise HTTPException(status_code=400, detail="Missing required 'guardrail_id'")
+
+    store = _get_store()
+    if not isinstance(store, SqlAlchemyStore):
+        raise HTTPException(status_code=500, detail="Guardrails require SqlAlchemyStore")
+
+    store.remove_guardrail(guardrail_id)
+    return {}
+
+
+@guardrail_router.post("/reorder")
+async def reorder_guardrails(request: Request):
+    body = await request.json()
+    guardrail_ids = body.get("guardrail_ids")
+    if not guardrail_ids or not isinstance(guardrail_ids, list):
+        raise HTTPException(status_code=400, detail="Missing required 'guardrail_ids' (list)")
+
+    store = _get_store()
+    if not isinstance(store, SqlAlchemyStore):
+        raise HTTPException(status_code=500, detail="Guardrails require SqlAlchemyStore")
+
+    store.reorder_guardrails(guardrail_ids)
+    return {}
+
+
+@guardrail_router.get("/list")
+async def list_guardrails(endpoint_name: str | None = None):
+    store = _get_store()
+    if not isinstance(store, SqlAlchemyStore):
+        raise HTTPException(status_code=500, detail="Guardrails require SqlAlchemyStore")
+
+    guardrails = store.list_guardrails(endpoint_name=endpoint_name)
+    return {
+        "guardrails": [
+            {
+                "guardrail_id": g.guardrail_id,
+                "endpoint_name": g.endpoint_name,
+                "scorer_name": g.scorer_name,
+                "hook": g.hook.value,
+                "operation": g.operation.value,
+                "order": g.order,
+                "enabled": g.enabled,
+                "config": json.loads(g.config_json) if g.config_json else None,
+            }
+            for g in guardrails
+        ]
+    }
+
+
+@guardrail_router.post("/test")
+async def test_guardrail(request: Request):
+    """
+    Test a guardrail against provided text or a trace from the endpoint's experiment.
+
+    Accepts either:
+      - guardrail_id: look up an existing guardrail from the DB
+      - scorer_name + hook + operation + config: test inline (before saving)
+
+    Input can be provided as:
+      - text: raw text to test against
+      - trace_id + experiment_id: fetch input/output from a trace
+    """
+    _ensure_gateway_uri(request)
+    body = await request.json()
+
+    guardrail_id = body.get("guardrail_id")
+    scorer_name = None
+    hook_value = None
+    operation_value = None
+    config_json = None
+
+    if guardrail_id:
+        # Look up existing guardrail
+        store = _get_store()
+        if not isinstance(store, SqlAlchemyStore):
+            raise HTTPException(status_code=500, detail="Guardrails require SqlAlchemyStore")
+
+        guardrails = store.list_guardrails()
+        guardrail = next((g for g in guardrails if g.guardrail_id == guardrail_id), None)
+        if not guardrail:
+            raise HTTPException(status_code=404, detail=f"Guardrail '{guardrail_id}' not found")
+
+        scorer_name = guardrail.scorer_name
+        hook_value = guardrail.hook.value
+        operation_value = guardrail.operation.value
+        config_json = guardrail.config_json
+    else:
+        # Inline config for testing before saving
+        scorer_name = body.get("scorer_name")
+        hook_value = body.get("hook", "PRE")
+        operation_value = body.get("operation", "VALIDATION")
+        config = body.get("config")
+        if not scorer_name:
+            raise HTTPException(status_code=400, detail="Provide 'guardrail_id' or 'scorer_name' + 'config'")
+        config_json = json.dumps(config) if config else None
+
+    # Resolve test text: either from body or from a trace
+    text = body.get("text")
+    trace_id = body.get("trace_id")
+    experiment_id = body.get("experiment_id")
+
+    trace_input = None
+    trace_output = None
+
+    if trace_id and experiment_id:
+        store = _get_store()
+        if not isinstance(store, SqlAlchemyStore):
+            raise HTTPException(status_code=500, detail="Guardrails require SqlAlchemyStore")
+        try:
+            trace_info = store.get_trace_info(trace_id)
+            trace_input = trace_info.request_preview or ""
+            trace_output = trace_info.response_preview or ""
+        except Exception as e:
+            _logger.warning(f"Failed to fetch trace {trace_id}: {e}")
+            raise HTTPException(status_code=400, detail=f"Failed to fetch trace: {e}")
+
+        # Use input for PRE guardrails, output for POST guardrails
+        if hook_value == "PRE":
+            text = trace_input
+        else:
+            text = trace_output
+
+    if not text:
+        raise HTTPException(status_code=400, detail="No text to test. Provide 'text' or 'trace_id' + 'experiment_id'.")
+
+    # Run the scorer
+    result = _run_scorer(scorer_name, text, config_json, operation_value, hook=hook_value)
+
+    return {
+        "result": {
+            "score": result.get("score"),
+            "rationale": result.get("rationale"),
+            "modified_text": result.get("modified_text"),
+        },
+        "guardrail": {
+            "guardrail_id": guardrail_id,
+            "scorer_name": scorer_name,
+            "hook": hook_value,
+            "operation": operation_value,
+        },
+        "input_text": text,
+        "trace_input": trace_input,
+        "trace_output": trace_output,
+    }
+
+
+# ─── Guardrail Execution ────────────────────────────────────────────────────
+
+
+class GuardrailRejection(Exception):
+    """Raised when a validation guardrail rejects a request/response."""
+
+    def __init__(self, guardrail_name: str, reason: str):
+        self.guardrail_name = guardrail_name
+        self.reason = reason
+        super().__init__(f"Guardrail '{guardrail_name}' rejected: {reason}")
+
+
+def _run_scorer(
+    scorer_name: str,
+    text: str,
+    config_json: str | None = None,
+    operation: str = "VALIDATION",
+    hook: str = "PRE",
+) -> dict:
+    """
+    Run a scorer/judge against the given text.
+
+    Supports:
+      - builtin_scorer: GuardrailsScorer subclasses (ToxicLanguage, DetectPII, etc.)
+      - registered_scorer: scorers registered via register_scorer() or make_judge()
+      - prompt: custom make_judge-style prompts (registered on add)
+
+    Args:
+        hook: "PRE" or "POST" — determines whether the text is passed as
+              ``inputs`` or ``outputs`` to the judge template.
+
+    Returns:
+        dict with keys:
+          - "score": "yes"/"no" for validation, or modified text for mutation
+          - "rationale": explanation
+          - "modified_text": (mutation only) the raw feedback value
+    """
+    config = json.loads(config_json) if config_json else {}
+    is_mutation = operation == "MUTATION"
+    use_inputs = hook == "PRE"
+
+    # Track guardrail depth so that any nested LLM calls
+    # (e.g. judge → gateway endpoint) skip guardrails and avoid recursion.
+    current_depth = getattr(_guardrail_depth, "depth", 0)
+    _guardrail_depth.depth = current_depth + 1
+    try:
+        return _run_scorer_inner(scorer_name, text, config, is_mutation, use_inputs)
+    finally:
+        _guardrail_depth.depth = current_depth
+
+
+def _run_scorer_inner(
+    scorer_name: str, text: str, config: dict, is_mutation: bool, use_inputs: bool = False
+) -> dict:
+    # Run a GuardrailsScorer builtin (these are NLP-based, don't use templates,
+    # so always pass as outputs — the text is just analyzed directly)
+    if "builtin_scorer" in config:
+        return _run_builtin_scorer(config["builtin_scorer"], text, is_mutation)
+
+    # Run a registered scorer (including custom judges that were registered on add)
+    if "registered_scorer" in config:
+        return _run_registered_scorer(
+            config["registered_scorer"],
+            config.get("experiment_id", _GUARDRAIL_EXPERIMENT_ID),
+            config.get("scorer_version"),
+            text,
+            is_mutation,
+            use_inputs,
+        )
+
+    # Inline custom judge prompt (for testing before registration)
+    if "prompt" in config:
+        return _run_inline_judge(
+            scorer_name, config["prompt"], text, is_mutation, model=config.get("model"),
+            use_inputs=use_inputs,
+        )
+
+    # Legacy: keyword-based filtering
+    if "keywords" in config:
+        keywords = config["keywords"]
+        text_lower = text.lower()
+        for keyword in keywords:
+            if keyword.lower() in text_lower:
+                return {
+                    "score": "no",
+                    "rationale": f"Input contains blocked keyword: '{keyword}'",
+                }
+        return {"score": "yes", "rationale": "No blocked keywords found"}
+
+    # Default: pass
+    return {"score": "yes", "rationale": "Default pass (no config)"}
+
+
+def _run_builtin_scorer(builtin_name: str, text: str, is_mutation: bool = False) -> dict:
+    """Run a GuardrailsScorer builtin (ToxicLanguage, DetectPII, etc.)."""
+    try:
+        from mlflow.genai.scorers.guardrails import get_scorer
+
+        scorer = get_scorer(builtin_name)
+        feedback = scorer(outputs=text)
+
+        raw_value = feedback.value
+        if is_mutation and raw_value is not None:
+            return {
+                "score": "yes",
+                "rationale": feedback.rationale or "Mutation applied",
+                "modified_text": str(raw_value),
+            }
+
+        value = str(raw_value).lower() if raw_value else "yes"
+        passed = value == "yes"
+        return {
+            "score": "yes" if passed else "no",
+            "rationale": feedback.rationale or ("Passed" if passed else "Failed"),
+        }
+    except Exception as e:
+        _logger.exception(f"Error running builtin scorer '{builtin_name}'")
+        return {"score": "yes", "rationale": f"Error running scorer (pass): {e}"}
+
+
+def _run_registered_scorer(
+    scorer_name: str,
+    experiment_id: str,
+    scorer_version: int | None,
+    text: str,
+    is_mutation: bool = False,
+    use_inputs: bool = False,
+) -> dict:
+    """Run a registered scorer loaded from the scorer registry."""
+    try:
+        from mlflow.genai.scorers.registry import get_scorer as _get_scorer
+
+        scorer = _get_scorer(
+            experiment_id=experiment_id,
+            name=scorer_name,
+            version=scorer_version,
+        )
+        kwargs = {"inputs": text} if use_inputs else {"outputs": text}
+        feedback = scorer(**kwargs)
+
+        raw_value = feedback.value
+        if is_mutation and raw_value is not None:
+            return {
+                "score": "yes",
+                "rationale": feedback.rationale or "Mutation applied",
+                "modified_text": str(raw_value),
+            }
+
+        value = str(raw_value).lower() if raw_value else "yes"
+        passed = value == "yes"
+        return {
+            "score": "yes" if passed else "no",
+            "rationale": feedback.rationale or ("Passed" if passed else "Failed"),
+        }
+    except Exception as e:
+        _logger.exception(f"Error running registered scorer '{scorer_name}'")
+        return {"score": "yes", "rationale": f"Error running scorer (pass): {e}"}
+
+
+def _run_inline_judge(
+    name: str, prompt: str, text: str, is_mutation: bool = False, model: str | None = None,
+    use_inputs: bool = False,
+) -> dict:
+    """Run a make_judge inline without registering it (for testing before saving)."""
+    try:
+        from mlflow.genai.judges import make_judge
+
+        judge = make_judge(name=name, instructions=prompt, model=model)
+        kwargs = {"inputs": text} if use_inputs else {"outputs": text}
+        feedback = judge(**kwargs)
+
+        raw_value = feedback.value
+        if is_mutation and raw_value is not None:
+            return {
+                "score": "yes",
+                "rationale": feedback.rationale or "Mutation applied",
+                "modified_text": str(raw_value),
+            }
+
+        value = str(raw_value).lower() if raw_value else "yes"
+        passed = value == "yes"
+        return {
+            "score": "yes" if passed else "no",
+            "rationale": feedback.rationale or ("Passed" if passed else "Failed"),
+        }
+    except Exception as e:
+        _logger.exception(f"Error running inline judge '{name}'")
+        return {"score": "yes", "rationale": f"Error running judge (pass): {e}"}
+
+
+def _extract_text_from_messages(messages: list[dict]) -> str:
+    """Extract user-facing text from chat messages for guardrail evaluation."""
+    parts = []
+    for msg in messages:
+        if isinstance(msg.get("content"), str):
+            parts.append(msg["content"])
+        elif isinstance(msg.get("content"), list):
+            for item in msg["content"]:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    parts.append(item["text"])
+    return "\n".join(parts)
+
+
+def _extract_text_from_response(response: dict) -> str:
+    """Extract assistant text from a chat completion response."""
+    parts = []
+    for choice in response.get("choices", []):
+        msg = choice.get("message", {})
+        if isinstance(msg.get("content"), str):
+            parts.append(msg["content"])
+    return "\n".join(parts)
+
+
+def run_pre_guardrails(
+    guardrails: list[GuardrailConfig],
+    body: dict,
+) -> dict:
+    """
+    Run PRE-invocation guardrails on the request body.
+
+    For VALIDATION guardrails: if scorer returns "no", raise GuardrailRejection.
+    For MUTATION guardrails: modify the request body in-place.
+
+    Returns:
+        Potentially modified request body.
+
+    Raises:
+        GuardrailRejection: If a validation guardrail rejects the request.
+    """
+    # Skip guardrails if we're already inside a guardrail evaluation
+    # (e.g. a judge LLM call routed through a guardrailed endpoint)
+    if _is_inside_guardrail():
+        _logger.debug("Skipping PRE guardrails: already inside guardrail evaluation")
+        return body
+
+    pre_guardrails = sorted(
+        [g for g in guardrails if g.hook == GuardrailHook.PRE],
+        key=lambda g: g.order,
+    )
+
+    if not pre_guardrails:
+        return body
+
+    input_text = _extract_text_from_messages(body.get("messages", []))
+
+    for guardrail in pre_guardrails:
+        _logger.debug(f"Running PRE guardrail: {guardrail.scorer_name}")
+        result = _run_scorer(
+            guardrail.scorer_name, input_text, guardrail.config_json, guardrail.operation.value,
+            hook="PRE",
+        )
+
+        if guardrail.operation == GuardrailOperation.VALIDATION:
+            if result.get("score") == "no":
+                raise GuardrailRejection(
+                    guardrail_name=guardrail.scorer_name,
+                    reason=result.get("rationale", "Rejected by guardrail"),
+                )
+        elif guardrail.operation == GuardrailOperation.MUTATION:
+            if "modified_text" in result:
+                # Replace the last user message content with the modified text
+                for msg in reversed(body.get("messages", [])):
+                    if msg.get("role") == "user":
+                        msg["content"] = result["modified_text"]
+                        break
+
+    return body
+
+
+def run_post_guardrails(
+    guardrails: list[GuardrailConfig],
+    response: dict,
+) -> dict:
+    """
+    Run POST-invocation guardrails on the response.
+
+    For VALIDATION guardrails: if scorer returns "no", raise GuardrailRejection.
+    For MUTATION guardrails: modify the response.
+
+    Returns:
+        Potentially modified response dict.
+
+    Raises:
+        GuardrailRejection: If a validation guardrail rejects the response.
+    """
+    if _is_inside_guardrail():
+        _logger.debug("Skipping POST guardrails: already inside guardrail evaluation")
+        return response
+
+    post_guardrails = sorted(
+        [g for g in guardrails if g.hook == GuardrailHook.POST],
+        key=lambda g: g.order,
+    )
+
+    if not post_guardrails:
+        return response
+
+    output_text = _extract_text_from_response(response)
+
+    for guardrail in post_guardrails:
+        _logger.debug(f"Running POST guardrail: {guardrail.scorer_name}")
+        result = _run_scorer(
+            guardrail.scorer_name, output_text, guardrail.config_json, guardrail.operation.value,
+            hook="POST",
+        )
+
+        if guardrail.operation == GuardrailOperation.VALIDATION:
+            if result.get("score") == "no":
+                raise GuardrailRejection(
+                    guardrail_name=guardrail.scorer_name,
+                    reason=result.get("rationale", "Rejected by guardrail"),
+                )
+        elif guardrail.operation == GuardrailOperation.MUTATION:
+            if "modified_text" in result:
+                for choice in response.get("choices", []):
+                    if "message" in choice:
+                        choice["message"]["content"] = result["modified_text"]
+
+    return response

--- a/mlflow/server/gateway_guardrails.py
+++ b/mlflow/server/gateway_guardrails.py
@@ -48,6 +48,7 @@ def _ensure_gateway_uri(request: Request) -> None:
     os.environ[MLFLOW_GATEWAY_URI.name] = base
     _logger.debug("Set %s=%s from request", MLFLOW_GATEWAY_URI.name, base)
 
+
 guardrail_router = APIRouter(prefix="/gateway/guardrails", tags=["gateway-guardrails"])
 
 
@@ -456,9 +457,20 @@ def _run_regex_scorer(pattern: str, text: str) -> dict:
         return {"score": "yes", "rationale": f"Invalid regex pattern: {e}"}
 
 
+# Builtin scorers that use on_fail=FIX (modify guardrails)
+_FIX_SCORER_MAP: dict[str, str] = {
+    "AnonymizePII": "AnonymizePII",
+    "SanitizeWeb": "SanitizeWeb",
+    "CompetitorFilter": "CompetitorFilter",
+}
+
+
 def _run_builtin_scorer(builtin_name: str, text: str, is_mutation: bool = False, **kwargs) -> dict:
-    """Run a GuardrailsScorer builtin (ToxicLanguage, DetectPII, etc.)."""
+    """Run a GuardrailsScorer or GuardrailsFixScorer builtin."""
     try:
+        if builtin_name in _FIX_SCORER_MAP:
+            return _run_fix_scorer(builtin_name, text, **kwargs)
+
         from mlflow.genai.scorers.guardrails import get_scorer
 
         scorer = get_scorer(builtin_name, **kwargs)
@@ -480,6 +492,34 @@ def _run_builtin_scorer(builtin_name: str, text: str, is_mutation: bool = False,
         }
     except Exception as e:
         _logger.exception(f"Error running builtin scorer '{builtin_name}'")
+        return {"score": "yes", "rationale": f"Error running scorer (pass): {e}"}
+
+
+def _run_fix_scorer(builtin_name: str, text: str, **kwargs) -> dict:
+    """Run a GuardrailsFixScorer builtin (AnonymizePII, SanitizeWeb, etc.)."""
+    try:
+        import mlflow.genai.scorers.guardrails as guardrails_mod
+
+        scorer_class = getattr(guardrails_mod, builtin_name)
+        scorer = scorer_class(**kwargs)
+        feedback = scorer(outputs=text)
+
+        raw_value = feedback.value
+        # "yes" means no fix was needed
+        if raw_value == "yes" or raw_value is None:
+            return {
+                "score": "yes",
+                "rationale": feedback.rationale or "No issues found",
+            }
+
+        # The value contains the fixed text
+        return {
+            "score": "yes",
+            "rationale": feedback.rationale or "Content modified by guardrail",
+            "modified_text": str(raw_value),
+        }
+    except Exception as e:
+        _logger.exception(f"Error running fix scorer '{builtin_name}'")
         return {"score": "yes", "rationale": f"Error running scorer (pass): {e}"}
 
 

--- a/mlflow/server/js/src/gateway/api.ts
+++ b/mlflow/server/js/src/gateway/api.ts
@@ -37,6 +37,12 @@ import type {
   UpdateBudgetPolicyResponse,
   ListBudgetPoliciesResponse,
   ListBudgetWindowsResponse,
+  AddGuardrailRequest,
+  AddGuardrailResponse,
+  UpdateGuardrailRequest,
+  ListGuardrailsResponse,
+  TestGuardrailRequest,
+  TestGuardrailResponse,
 } from './types';
 
 const defaultErrorHandler = async ({
@@ -369,5 +375,63 @@ export const GatewayApi = {
       relativeUrl: 'ajax-api/3.0/mlflow/gateway/budgets/windows',
       error: defaultErrorHandler,
     }) as Promise<ListBudgetWindowsResponse>;
+  },
+
+  // Guardrails
+  addGuardrail: (request: AddGuardrailRequest) => {
+    return fetchEndpoint({
+      relativeUrl: 'gateway/guardrails/add',
+      method: 'POST',
+      body: JSON.stringify(request),
+      error: defaultErrorHandler,
+    }) as Promise<AddGuardrailResponse>;
+  },
+
+  updateGuardrail: (request: UpdateGuardrailRequest) => {
+    return fetchEndpoint({
+      relativeUrl: 'gateway/guardrails/update',
+      method: 'POST',
+      body: JSON.stringify(request),
+      error: defaultErrorHandler,
+    }) as Promise<AddGuardrailResponse>;
+  },
+
+  removeGuardrail: (guardrailId: string) => {
+    return fetchEndpoint({
+      relativeUrl: 'gateway/guardrails/remove',
+      method: 'POST',
+      body: JSON.stringify({ guardrail_id: guardrailId }),
+      error: defaultErrorHandler,
+    });
+  },
+
+  listGuardrails: (endpointName?: string) => {
+    const params = new URLSearchParams();
+    if (endpointName) {
+      params.append('endpoint_name', endpointName);
+    }
+    const relativeUrl = `gateway/guardrails/list?${params.toString()}`;
+    return fetchEndpoint({
+      relativeUrl,
+      error: defaultErrorHandler,
+    }) as Promise<ListGuardrailsResponse>;
+  },
+
+  reorderGuardrails: (guardrailIds: string[]) => {
+    return fetchEndpoint({
+      relativeUrl: 'gateway/guardrails/reorder',
+      method: 'POST',
+      body: JSON.stringify({ guardrail_ids: guardrailIds }),
+      error: defaultErrorHandler,
+    });
+  },
+
+  testGuardrail: (request: TestGuardrailRequest) => {
+    return fetchEndpoint({
+      relativeUrl: 'gateway/guardrails/test',
+      method: 'POST',
+      body: JSON.stringify(request),
+      error: defaultErrorHandler,
+    }) as Promise<TestGuardrailResponse>;
   },
 };

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -27,6 +27,7 @@ import { TracesV3Logs } from '../../../experiment-tracking/components/experiment
 import { MonitoringConfigProvider } from '../../../experiment-tracking/hooks/useMonitoringConfig';
 import { useMonitoringFiltersTimeRange } from '../../../experiment-tracking/hooks/useMonitoringFilters';
 import { TracesV3DateSelector } from '../../../experiment-tracking/components/experiment-page/components/traces-v3/TracesV3DateSelector';
+import { GuardrailsTabContent } from '../guardrails/GuardrailsTabContent';
 
 const LogsTabContent = ({ experimentId }: { experimentId: string }) => {
   const { theme } = useDesignSystemTheme();
@@ -97,7 +98,7 @@ export const EditEndpointFormRenderer = ({
   const intl = useIntl();
   const [searchParams, setSearchParams] = useSearchParams();
   const [isUsageModalOpen, setIsUsageModalOpen] = useState(false);
-  const VALID_TABS = ['configuration', 'usage', 'traces'] as const;
+  const VALID_TABS = ['configuration', 'guardrails', 'usage', 'traces'] as const;
   const tabParam = searchParams.get('tab');
   const activeTab = VALID_TABS.includes(tabParam as (typeof VALID_TABS)[number])
     ? (tabParam as string)
@@ -210,6 +211,9 @@ export const EditEndpointFormRenderer = ({
           <Tabs.List>
             <Tabs.Trigger value="configuration">
               <FormattedMessage defaultMessage="Configuration" description="Tab label for endpoint configuration" />
+            </Tabs.Trigger>
+            <Tabs.Trigger value="guardrails">
+              <FormattedMessage defaultMessage="Guardrails" description="Tab label for endpoint guardrails" />
             </Tabs.Trigger>
             {isUsageTabDisabled ? (
               <Tooltip
@@ -384,6 +388,10 @@ export const EditEndpointFormRenderer = ({
                   </Typography.Text>
                 </div>
               </div>
+            </Tabs.Content>
+
+            <Tabs.Content value="guardrails">
+              {endpoint && <GuardrailsTabContent endpointName={endpoint.name} experimentId={experimentId} />}
             </Tabs.Content>
 
             <Tabs.Content value="usage">

--- a/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
@@ -278,23 +278,20 @@ function GuardrailCard({
   );
 }
 
-// ─── Source tab buttons ─────────────────────────────────────────────────────
+// ─── Top-level tab buttons: Catalog | Create New ────────────────────────────
 
-function SourceTabs({
-  value,
-  onChange,
-}: {
-  value: ScorerSource;
-  onChange: (v: ScorerSource) => void;
-}) {
+type TopTab = 'catalog' | 'create-new';
+
+function topTabFromSource(source: ScorerSource): TopTab {
+  return source === 'custom' || source === 'code' ? 'create-new' : 'catalog';
+}
+
+function TopTabs({ value, onChange }: { value: TopTab; onChange: (v: TopTab) => void }) {
   const { theme } = useDesignSystemTheme();
 
-  const tabs: { key: ScorerSource; label: string }[] = [
-    { key: 'builtin', label: 'Catalog' },
-    { key: 'registered', label: 'Registered' },
-    { key: 'custom', label: 'LLM Judge' },
-    { key: 'regex', label: 'Regex' },
-    { key: 'code', label: 'Code' },
+  const tabs: { key: TopTab; label: string }[] = [
+    { key: 'catalog', label: 'Catalog' },
+    { key: 'create-new', label: 'Create New' },
   ];
 
   return (
@@ -316,7 +313,7 @@ function SourceTabs({
             flex: 1,
             padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
             border: 'none',
-            borderRight: tab.key !== 'code' ? `1px solid ${theme.colors.border}` : 'none',
+            borderRight: tab.key !== 'create-new' ? `1px solid ${theme.colors.border}` : 'none',
             backgroundColor:
               value === tab.key ? theme.colors.actionPrimaryBackgroundDefault : theme.colors.backgroundPrimary,
             color: value === tab.key ? '#fff' : theme.colors.textPrimary,
@@ -335,6 +332,37 @@ function SourceTabs({
           {tab.label}
         </button>
       ))}
+    </div>
+  );
+}
+
+// ─── Create-New type selector cards ─────────────────────────────────────────
+
+function CreateNewTypeSelector({
+  value,
+  onChange,
+}: {
+  value: 'custom' | 'code';
+  onChange: (v: 'custom' | 'code') => void;
+}) {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div css={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: theme.spacing.sm }}>
+      <GuardrailCard
+        icon={<span css={{ fontSize: 20 }}>{'🤖'}</span>}
+        label="LLM Judge"
+        description="Write natural-language instructions. An LLM evaluates requests or responses against them."
+        selected={value === 'custom'}
+        onClick={() => onChange('custom')}
+      />
+      <GuardrailCard
+        icon={<span css={{ fontSize: 20 }}>{'</>'}</span>}
+        label="Code-based"
+        description="Write arbitrary Python logic — regex, rule engines, external APIs, etc."
+        selected={value === 'code'}
+        onClick={() => onChange('code')}
+      />
     </div>
   );
 }
@@ -451,7 +479,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
 
   // ─── Test state ──────────────────────────────────────────────────────────
   const [showTest, setShowTest] = useState(false);
-  const [testInputMode, setTestInputMode] = useState<'trace' | 'manual'>(experimentId ? 'trace' : 'manual');
+  const [testInputMode, setTestInputMode] = useState<'trace' | 'manual'>('manual');
   const [testManualText, setTestManualText] = useState('');
   const [traces, setTraces] = useState<TraceEntry[]>([]);
   const [tracesLoading, setTracesLoading] = useState(false);
@@ -511,7 +539,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
         config.scorer_version = scorer.scorer_version;
       }
     } else if (formData.scorerSource === 'regex') {
-      config.builtin_scorer = 'regex_match';
+      config.builtin_scorer = 'RegexMatch';
       config.regex_pattern = formData.regexPattern;
     } else {
       config.prompt = formData.prompt;
@@ -570,7 +598,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
     if (editingGuardrail) {
       const config = editingGuardrail.config;
       const isBuiltin = BUILTIN_JUDGES.some((j) => j.name === config?.builtin_scorer);
-      const isRegex = config?.builtin_scorer === 'regex_match';
+      const isRegex = config?.builtin_scorer === 'RegexMatch';
       const isRegistered = !!config?.registered_scorer;
       setFormData({
         scorerName: editingGuardrail.scorer_name,
@@ -593,7 +621,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
     setTestError(null);
     setSelectedTraceId(null);
     setTestManualText('');
-    setTestInputMode(experimentId ? 'trace' : 'manual');
+    setTestInputMode('manual');
   }, [open, editingGuardrail, experimentId]);
 
   const resetMutation = useCallback(() => {
@@ -617,6 +645,15 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
         }
         if (field === 'registeredScorer' && prev.scorerSource === 'registered') {
           next.scorerName = String(value);
+        }
+        if (field === 'regexPattern') {
+          // Auto-generate a scorer name from the pattern (slug-ify it)
+          const slug = String(value)
+            .replace(/[^a-zA-Z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+            .toLowerCase()
+            .slice(0, 40) || 'regex-guardrail';
+          next.scorerName = slug;
         }
         if (field === 'scorerSource') {
           if (value === 'builtin') {
@@ -705,7 +742,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
         config.scorer_version = scorer.scorer_version;
       }
     } else if (formData.scorerSource === 'regex') {
-      config.builtin_scorer = 'regex_match';
+      config.builtin_scorer = 'RegexMatch';
       config.regex_pattern = formData.regexPattern;
     } else {
       config.prompt = formData.prompt;
@@ -848,276 +885,258 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
           </div>
         </div>
 
-        {/* Source tabs */}
-        <SourceTabs
-          value={formData.scorerSource}
-          onChange={(v) => handleFieldChange('scorerSource', v)}
+        {/* ─── Top-level tabs: Catalog | Create New ─── */}
+        <TopTabs
+          value={topTabFromSource(formData.scorerSource)}
+          onChange={(tab) => {
+            if (tab === 'catalog') handleFieldChange('scorerSource', 'builtin');
+            else handleFieldChange('scorerSource', 'custom');
+          }}
         />
 
-        {/* Search bar (shown for builtin and registered only) */}
-        {(formData.scorerSource === 'builtin' || formData.scorerSource === 'registered') && (
-          <Input
-            componentId="mlflow.gateway.guardrail-modal.search"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder={intl.formatMessage({
-              defaultMessage: 'Search guardrails...',
-              description: 'Search guardrails placeholder',
-            })}
-            allowClear
-          />
-        )}
+        {/* ─── CATALOG: Guardrails AI + Regex + Registered ─── */}
+        {topTabFromSource(formData.scorerSource) === 'catalog' && (
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+            {/* Search */}
+            <Input
+              componentId="mlflow.gateway.guardrail-modal.search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={intl.formatMessage({
+                defaultMessage: 'Search guardrails...',
+                description: 'Search guardrails placeholder',
+              })}
+              allowClear
+            />
 
-        {/* ─── Builtin judge cards ─── */}
-        {formData.scorerSource === 'builtin' && (
-          <div
-            css={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(2, 1fr)',
-              gap: theme.spacing.sm,
-            }}
-          >
-            {filteredBuiltins.map((j) => (
-              <GuardrailCard
-                key={j.name}
-                icon={<span css={{ fontSize: 20, lineHeight: 1 }}>{j.emoji}</span>}
-                label={j.label}
-                description={j.description}
-                selected={formData.builtinJudge === j.name}
-                tag={<span css={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><GuardrailsAIIcon size={14} /> GUARDRAILS AI</span>}
-                onClick={() => handleFieldChange('builtinJudge', j.name)}
-              />
-            ))}
-            {filteredBuiltins.length === 0 && (
-              <div css={{ gridColumn: '1 / -1', padding: theme.spacing.md, textAlign: 'center' }}>
-                <Typography.Text color="secondary">
-                  {formData.operation === 'MUTATION' ? (
-                    <FormattedMessage
-                      defaultMessage="Catalog guardrails only support Block action. Switch to Block or use LLM Judge / Code tab for Modify."
-                      description="No builtin guardrails for mutation operation"
+            {/* Builtin section */}
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+              <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+                <Typography.Text bold css={{ fontSize: theme.typography.fontSizeSm }}>
+                  Builtin
+                </Typography.Text>
+              </div>
+              {formData.operation === 'MUTATION' ? (
+                <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                  <FormattedMessage
+                    defaultMessage="Catalog guardrails only support Block action. Switch to Block or use Create New for Modify."
+                    description="No catalog guardrails for modify"
+                  />
+                </Typography.Text>
+              ) : (
+                <div css={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: theme.spacing.sm }}>
+                  {/* Builtin judge cards */}
+                  {filteredBuiltins.map((j) => (
+                    <GuardrailCard
+                      key={j.name}
+                      icon={<span css={{ fontSize: 20, lineHeight: 1 }}>{j.emoji}</span>}
+                      label={j.label}
+                      description={j.description}
+                      selected={formData.scorerSource === 'builtin' && formData.builtinJudge === j.name}
+                      tag={<span css={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><GuardrailsAIIcon size={14} /> BUILTIN</span>}
+                      onClick={() => {
+                        handleFieldChange('scorerSource', 'builtin');
+                        handleFieldChange('builtinJudge', j.name);
+                      }}
                     />
-                  ) : (
-                    <FormattedMessage
-                      defaultMessage="No matching guardrails found."
-                      description="No matching builtin guardrails"
+                  ))}
+                  {/* Regex card — part of Guardrails AI catalog */}
+                  {(!searchQuery.trim() || 'regex match'.includes(searchQuery.toLowerCase())) && (
+                    <GuardrailCard
+                      icon={<span css={{ fontSize: 20, lineHeight: 1 }}>{'🔍'}</span>}
+                      label="Regex Match"
+                      description="Block requests or responses matching a regular expression pattern (e.g. SSNs, emails, credit cards)"
+                      selected={formData.scorerSource === 'regex'}
+                      tag={<span css={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><GuardrailsAIIcon size={14} /> BUILTIN</span>}
+                      onClick={() => handleFieldChange('scorerSource', 'regex')}
                     />
                   )}
+                  {filteredBuiltins.length === 0 && searchQuery.trim() && (
+                    <div css={{ gridColumn: '1 / -1', padding: theme.spacing.sm }}>
+                      <Typography.Text color="secondary">
+                        <FormattedMessage defaultMessage="No matching guardrails found." description="No matching builtin guardrails" />
+                      </Typography.Text>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Regex config — shown inline when regex card is selected */}
+            {formData.scorerSource === 'regex' && (
+              <div
+                css={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: theme.spacing.sm,
+                  padding: theme.spacing.md,
+                  border: `1px solid ${theme.colors.actionPrimaryBackgroundDefault}`,
+                  borderRadius: theme.borders.borderRadiusMd,
+                  backgroundColor: `${theme.colors.actionPrimaryBackgroundDefault}06`,
+                }}
+              >
+                <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                  <Typography.Text bold css={{ fontSize: theme.typography.fontSizeSm }}>
+                    <FormattedMessage defaultMessage="Pattern" description="Regex pattern label" />
+                  </Typography.Text>
+                  <Input
+                    componentId="mlflow.gateway.guardrail-modal.regex-pattern"
+                    value={formData.regexPattern}
+                    onChange={(e) => handleFieldChange('regexPattern', e.target.value)}
+                    placeholder={intl.formatMessage({
+                      defaultMessage: 'e.g., \\d{3}-\\d{2}-\\d{4}  (SSN)',
+                      description: 'Regex pattern placeholder',
+                    })}
+                    css={{ fontFamily: 'monospace' }}
+                  />
+                </div>
+                <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                  Common patterns: SSN <code>\d{'{3}'}-\d{'{2}'}-\d{'{4}'}</code> · email <code>[\w.-]+@[\w.-]+\.\w+</code> · credit card <code>\d{'{4}'}[\s-]?\d{'{4}'}[\s-]?\d{'{4}'}[\s-]?\d{'{4}'}</code>
                 </Typography.Text>
               </div>
             )}
+
+            {/* Registered section */}
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+              <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs, borderTop: `1px solid ${theme.colors.border}`, paddingTop: theme.spacing.sm }}>
+                <span css={{ fontSize: 14 }}>⚙️</span>
+                <Typography.Text bold css={{ fontSize: theme.typography.fontSizeSm }}>
+                  Registered
+                </Typography.Text>
+              </div>
+              {isLoadingScorers ? (
+                <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+                  <Spinner size="small" />
+                  <FormattedMessage defaultMessage="Loading registered guardrails..." description="Loading registered guardrails" />
+                </div>
+              ) : filteredRegistered.length > 0 ? (
+                <div css={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: theme.spacing.sm }}>
+                  {filteredRegistered.map((s) => (
+                    <GuardrailCard
+                      key={s.scorer_name}
+                      icon={<span css={{ fontSize: 20, lineHeight: 1 }}>{'⚙️'}</span>}
+                      label={s.scorer_name}
+                      description={`v${s.scorer_version} · experiment ${s.experiment_id}`}
+                      selected={formData.scorerSource === 'registered' && formData.registeredScorer === s.scorer_name}
+                      tag="REGISTERED"
+                      onClick={() => {
+                        handleFieldChange('scorerSource', 'registered');
+                        handleFieldChange('registeredScorer', s.scorer_name);
+                      }}
+                    />
+                  ))}
+                </div>
+              ) : registeredScorers && registeredScorers.length > 0 ? (
+                <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                  {formData.hook === 'PRE'
+                    ? "No registered guardrails compatible with pre-invocation. They need '{{inputs}}' in their instructions."
+                    : "No registered guardrails compatible with post-invocation. They need '{{outputs}}' in their instructions."}
+                </Typography.Text>
+              ) : (
+                <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                  No registered guardrails yet. Use <strong>Create New → Code-based</strong> to write and register one.
+                </Typography.Text>
+              )}
+            </div>
           </div>
         )}
 
-        {/* ─── Registered judge cards ─── */}
-        {formData.scorerSource === 'registered' && (
-          <>
-            {isLoadingScorers ? (
-              <div css={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: theme.spacing.sm, padding: theme.spacing.lg }}>
-                <Spinner size="small" />
-                <FormattedMessage defaultMessage="Loading registered guardrails..." description="Loading registered guardrails" />
-              </div>
-            ) : filteredRegistered.length > 0 ? (
-              <div
-                css={{
-                  display: 'grid',
-                  gridTemplateColumns: 'repeat(2, 1fr)',
-                  gap: theme.spacing.sm,
-                }}
-              >
-                {filteredRegistered.map((s) => (
-                  <GuardrailCard
-                    key={s.scorer_name}
-                    icon={<span css={{ fontSize: 20, lineHeight: 1 }}>{'\u{2699}'}</span>}
-                    label={s.scorer_name}
-                    description={`v${s.scorer_version} \u00B7 experiment ${s.experiment_id}`}
-                    selected={formData.registeredScorer === s.scorer_name}
-                    tag="REGISTERED"
-                    onClick={() => handleFieldChange('registeredScorer', s.scorer_name)}
-                  />
-                ))}
-              </div>
-            ) : registeredScorers && registeredScorers.length > 0 ? (
-              <Alert
-                componentId="mlflow.gateway.guardrail-modal.no-compatible-registered"
-                type="info"
-                message={
-                  formData.hook === 'PRE'
-                    ? intl.formatMessage({
-                        defaultMessage:
-                          "No registered judges compatible with pre-invocation hook. Judges need '{{inputs}}' in their instructions.",
-                        description: 'No compatible registered judges for PRE hook',
-                      })
-                    : intl.formatMessage({
-                        defaultMessage:
-                          "No registered judges compatible with post-invocation hook. Judges need '{{outputs}}' in their instructions.",
-                        description: 'No compatible registered judges for POST hook',
-                      })
-                }
-              />
-            ) : (
-              <Alert
-                componentId="mlflow.gateway.guardrail-modal.no-registered"
-                type="warning"
-                message={intl.formatMessage({
-                  defaultMessage:
-                    'No registered guardrails found. Register one first using mlflow.genai.scorers.register_scorer(), or use the Code tab to see how.',
-                  description: 'No registered guardrails message',
-                })}
-              />
-            )}
-          </>
-        )}
-
-        {/* ─── LLM Judge (make_judge style) ─── */}
-        {formData.scorerSource === 'custom' && (
-          <>
-            {/* Guardrail name */}
-            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Text bold>
-                <FormattedMessage defaultMessage="Guardrail name" description="LLM judge guardrail name label" />
-              </Typography.Text>
-              <Input
-                componentId="mlflow.gateway.guardrail-modal.custom-name"
-                value={formData.scorerName}
-                onChange={(e) => handleFieldChange('scorerName', e.target.value)}
-                placeholder={intl.formatMessage({
-                  defaultMessage: 'e.g., pii-filter, toxicity-check',
-                  description: 'Guardrail name placeholder',
-                })}
-              />
-            </div>
-
-            {/* Instructions prompt */}
-            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Text bold>
-                <FormattedMessage defaultMessage="Instructions" description="LLM judge instructions label" />
-              </Typography.Text>
-              <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
-                <FormattedMessage
-                  defaultMessage="Instructions for the LLM guardrail. Use {variable} to reference the {hookType} data."
-                  description="LLM judge instructions description"
-                  values={{
-                    variable: <code>{promptHint}</code>,
-                    hookType: formData.hook === 'PRE' ? 'input' : 'output',
-                  }}
-                />
-              </Typography.Text>
-              <textarea
-                value={formData.prompt}
-                onChange={(e) => handleFieldChange('prompt', e.target.value)}
-                rows={6}
-                css={{
-                  width: '100%',
-                  padding: theme.spacing.sm,
-                  borderRadius: theme.borders.borderRadiusMd,
-                  border: `1px solid ${theme.colors.border}`,
-                  fontFamily: 'monospace',
-                  fontSize: theme.typography.fontSizeSm,
-                  resize: 'vertical',
-                  backgroundColor: theme.colors.backgroundPrimary,
-                  color: theme.colors.textPrimary,
-                }}
-              />
-              {formData.operation === 'VALIDATION' && (
-                <Alert
-                  componentId="mlflow.gateway.guardrail-modal.validation-hint"
-                  type="info"
-                  message={intl.formatMessage({
-                    defaultMessage:
-                      'Block guardrails expect a yes/no response. "no" means the content is rejected.',
-                    description: 'Block hint for LLM judge guardrails',
-                  })}
-                />
-              )}
-              {formData.operation === 'MUTATION' && (
-                <Alert
-                  componentId="mlflow.gateway.guardrail-modal.mutation-hint"
-                  type="info"
-                  message={intl.formatMessage({
-                    defaultMessage:
-                      'Modify guardrails should return the modified content. For pre-invocation, output a ChatRequest. For post-invocation, output a ChatResponse.',
-                    description: 'Modify hint for LLM judge guardrails',
-                  })}
-                />
-              )}
-            </div>
-
-            {/* Model / endpoint selection */}
-            <ModelSelector
-              model={formData.model}
-              onModelChange={(value) => handleFieldChange('model', value)}
-            />
-          </>
-        )}
-
-        {/* ─── Regex guardrail ─── */}
-        {formData.scorerSource === 'regex' && (
-          <>
-            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Text bold>
-                <FormattedMessage defaultMessage="Guardrail name" description="Regex guardrail name label" />
-              </Typography.Text>
-              <Input
-                componentId="mlflow.gateway.guardrail-modal.regex-name"
-                value={formData.scorerName}
-                onChange={(e) => handleFieldChange('scorerName', e.target.value)}
-                placeholder={intl.formatMessage({
-                  defaultMessage: 'e.g., ssn-detector, pii-regex',
-                  description: 'Regex guardrail name placeholder',
-                })}
-              />
-            </div>
-            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Text bold>
-                <FormattedMessage defaultMessage="Regex pattern" description="Regex pattern label" />
-              </Typography.Text>
-              <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
-                <FormattedMessage
-                  defaultMessage="Python-compatible regular expression. The guardrail blocks requests where a match is found. Powered by the Guardrails AI regex_match validator."
-                  description="Regex pattern description"
-                />
-              </Typography.Text>
-              <Input
-                componentId="mlflow.gateway.guardrail-modal.regex-pattern"
-                value={formData.regexPattern}
-                onChange={(e) => handleFieldChange('regexPattern', e.target.value)}
-                placeholder={intl.formatMessage({
-                  defaultMessage: 'e.g., \\d{3}-\\d{2}-\\d{4}  (SSN pattern)',
-                  description: 'Regex pattern placeholder',
-                })}
-                css={{ fontFamily: 'monospace' }}
-              />
-            </div>
-            <Alert
-              componentId="mlflow.gateway.guardrail-modal.regex-info"
-              type="info"
-              closable={false}
-              message={intl.formatMessage({
-                defaultMessage:
-                  'Common patterns: SSN (\\d{3}-\\d{2}-\\d{4}), email ([\\w.-]+@[\\w.-]+\\.\\w+), credit card (\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4})',
-                description: 'Common regex pattern examples',
-              })}
-            />
-          </>
-        )}
-
-        {/* ─── Code-based guardrail guide ─── */}
-        {formData.scorerSource === 'code' && (
+        {/* ─── CREATE NEW: LLM Judge or Code-based ─── */}
+        {topTabFromSource(formData.scorerSource) === 'create-new' && (
           <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
-            <Alert
-              componentId="mlflow.gateway.guardrail-modal.code-info"
-              type="info"
-              closable={false}
-              message={intl.formatMessage({
-                defaultMessage:
-                  'Code-based guardrails let you write arbitrary Python logic — regex, rule engines, external APIs, etc. Register them with mlflow.genai.scorers.register_scorer(), then find them in the Registered tab.',
-                description: 'Code guardrail guide intro',
-              })}
+            <CreateNewTypeSelector
+              value={formData.scorerSource === 'code' ? 'code' : 'custom'}
+              onChange={(v) => handleFieldChange('scorerSource', v)}
             />
-            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Text bold>
-                <FormattedMessage defaultMessage="Example: block requests containing SSNs" description="Code guardrail example header" />
-              </Typography.Text>
+
+            {/* ─── LLM Judge form ─── */}
+            {formData.scorerSource === 'custom' && (
+              <>
+                <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                  <Typography.Text bold>
+                    <FormattedMessage defaultMessage="Guardrail name" description="LLM judge guardrail name label" />
+                  </Typography.Text>
+                  <Input
+                    componentId="mlflow.gateway.guardrail-modal.custom-name"
+                    value={formData.scorerName}
+                    onChange={(e) => handleFieldChange('scorerName', e.target.value)}
+                    placeholder={intl.formatMessage({
+                      defaultMessage: 'e.g., pii-filter, toxicity-check',
+                      description: 'Guardrail name placeholder',
+                    })}
+                  />
+                </div>
+                <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                  <Typography.Text bold>
+                    <FormattedMessage defaultMessage="Instructions" description="LLM judge instructions label" />
+                  </Typography.Text>
+                  <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                    <FormattedMessage
+                      defaultMessage="Instructions for the LLM guardrail. Use {variable} to reference the {hookType} data."
+                      description="LLM judge instructions description"
+                      values={{
+                        variable: <code>{promptHint}</code>,
+                        hookType: formData.hook === 'PRE' ? 'input' : 'output',
+                      }}
+                    />
+                  </Typography.Text>
+                  <textarea
+                    value={formData.prompt}
+                    onChange={(e) => handleFieldChange('prompt', e.target.value)}
+                    rows={6}
+                    css={{
+                      width: '100%',
+                      padding: theme.spacing.sm,
+                      borderRadius: theme.borders.borderRadiusMd,
+                      border: `1px solid ${theme.colors.border}`,
+                      fontFamily: 'monospace',
+                      fontSize: theme.typography.fontSizeSm,
+                      resize: 'vertical',
+                      backgroundColor: theme.colors.backgroundPrimary,
+                      color: theme.colors.textPrimary,
+                    }}
+                  />
+                  {formData.operation === 'VALIDATION' && (
+                    <Alert
+                      componentId="mlflow.gateway.guardrail-modal.validation-hint"
+                      type="info"
+                      message={intl.formatMessage({
+                        defaultMessage: 'Block guardrails expect a yes/no response. "no" means the content is rejected.',
+                        description: 'Block hint for LLM judge guardrails',
+                      })}
+                    />
+                  )}
+                  {formData.operation === 'MUTATION' && (
+                    <Alert
+                      componentId="mlflow.gateway.guardrail-modal.mutation-hint"
+                      type="info"
+                      message={intl.formatMessage({
+                        defaultMessage: 'Modify guardrails should return the modified content. For pre-invocation, output a ChatRequest. For post-invocation, output a ChatResponse.',
+                        description: 'Modify hint for LLM judge guardrails',
+                      })}
+                    />
+                  )}
+                </div>
+                <ModelSelector
+                  model={formData.model}
+                  onModelChange={(value) => handleFieldChange('model', value)}
+                />
+              </>
+            )}
+
+            {/* ─── Code-based guide ─── */}
+            {formData.scorerSource === 'code' && (
+              <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+                <Alert
+                  componentId="mlflow.gateway.guardrail-modal.code-info"
+                  type="info"
+                  closable={false}
+                  message="Write a Python class, register it with mlflow.genai.scorers.register_scorer(), then find it in Catalog → Registered."
+                />
+                <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                  <Typography.Text bold>
+                    <FormattedMessage defaultMessage="Example: block requests containing SSNs" description="Code guardrail example header" />
+                  </Typography.Text>
               <pre
                 css={{
                   backgroundColor: theme.colors.backgroundSecondary,
@@ -1132,23 +1151,15 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                   color: theme.colors.textPrimary,
                 }}
               >{`import re
-import mlflow
-from mlflow.genai.scorers import Scorer
+from mlflow.genai.scorers import scorer
 
-class SSNDetector(Scorer):
-    name = "ssn-detector"
-
-    def score(self, *, inputs, **kwargs):
-        text = str(inputs)
-        found = bool(re.search(r"\\d{3}-\\d{2}-\\d{4}", text))
-        return mlflow.entities.Assessment(
-            name=self.name,
-            value="no" if found else "yes",  # "no" = block
-            rationale="SSN pattern detected" if found else "No SSN found",
-        )
+@scorer
+def ssn_detector(inputs) -> bool:
+    """Returns False (block) when an SSN pattern is found."""
+    return not bool(re.search(r"\\d{3}-\\d{2}-\\d{4}", str(inputs)))
 
 # Register it once — then find it in the Registered tab
-SSNDetector().register()`}</pre>
+ssn_detector.register()`}</pre>
             </div>
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
               <Typography.Text bold>
@@ -1169,26 +1180,21 @@ SSNDetector().register()`}</pre>
                 }}
               >{`import re
 import copy
-import mlflow
-from mlflow.genai.scorers import Scorer
+from mlflow.genai.scorers import scorer
 
-class PIIRedactor(Scorer):
-    name = "pii-redactor"
-
-    def score(self, *, inputs, **kwargs):
-        # inputs is a ChatRequest dict — redact and return it
-        modified = copy.deepcopy(inputs)
-        for msg in modified.get("messages", []):
-            msg["content"] = re.sub(
-                r"\\d{3}-\\d{2}-\\d{4}", "[REDACTED-SSN]",
-                str(msg.get("content", ""))
-            )
-        return mlflow.entities.Assessment(
-            name=self.name,
-            value=modified,  # return modified ChatRequest
+@scorer
+def pii_redactor(inputs):
+    """Redacts SSNs from the request before sending to the LLM."""
+    modified = copy.deepcopy(inputs)
+    for msg in modified.get("messages", []):
+        msg["content"] = re.sub(
+            r"\\d{3}-\\d{2}-\\d{4}", "[REDACTED]",
+            str(msg.get("content", ""))
         )
+    return modified  # return modified ChatRequest
 
-PIIRedactor().register()`}</pre>
+# Register it once — then find it in the Registered tab
+pii_redactor.register()`}</pre>
             </div>
             <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
               <FormattedMessage
@@ -1196,6 +1202,8 @@ PIIRedactor().register()`}</pre>
                 description="Code guardrail footer note"
               />
             </Typography.Text>
+          </div>
+        )}
           </div>
         )}
 
@@ -1251,20 +1259,20 @@ PIIRedactor().register()`}</pre>
                 {experimentId && (
                   <div css={{ display: 'flex', gap: theme.spacing.xs }}>
                     <Button
-                      componentId="mlflow.gateway.guardrail-modal.test-mode-trace"
-                      type={testInputMode === 'trace' ? 'primary' : undefined}
-                      size="small"
-                      onClick={() => setTestInputMode('trace')}
-                    >
-                      <FormattedMessage defaultMessage="Pick from traces" description="Tab to pick a trace" />
-                    </Button>
-                    <Button
                       componentId="mlflow.gateway.guardrail-modal.test-mode-manual"
                       type={testInputMode === 'manual' ? 'primary' : undefined}
                       size="small"
                       onClick={() => setTestInputMode('manual')}
                     >
                       <FormattedMessage defaultMessage="Manual input" description="Tab for manual text input" />
+                    </Button>
+                    <Button
+                      componentId="mlflow.gateway.guardrail-modal.test-mode-trace"
+                      type={testInputMode === 'trace' ? 'primary' : undefined}
+                      size="small"
+                      onClick={() => setTestInputMode('trace')}
+                    >
+                      <FormattedMessage defaultMessage="Pick from traces" description="Tab to pick a trace" />
                     </Button>
                   </div>
                 )}

--- a/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
@@ -1218,6 +1218,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                 {/* Manual input */}
                 {testInputMode === 'manual' && (
                   <Input.TextArea
+                    componentId="mlflow.guardrails.add-modal.test-manual-input"
                     value={testManualText}
                     onChange={(e) => setTestManualText(e.target.value)}
                     rows={3}

--- a/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
@@ -1,0 +1,1436 @@
+import { useState, useCallback, useMemo, useEffect, useRef, type ReactNode } from 'react';
+import {
+  Alert,
+  Button,
+  Input,
+  Modal,
+  SimpleSelect,
+  SimpleSelectOption,
+  Spinner,
+  Tag,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useQuery } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { fetchOrFail, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { useAddGuardrail } from '../../hooks/useAddGuardrail';
+import { useUpdateGuardrail } from '../../hooks/useUpdateGuardrail';
+import { GatewayApi } from '../../api';
+import type { Guardrail, GuardrailHook, GuardrailOperation, GuardrailScorerConfig, TestGuardrailResponse } from '../../types';
+import { EndpointSelector } from '@mlflow/mlflow/src/experiment-tracking/components/EndpointSelector';
+import {
+  formatGatewayModelFromEndpoint,
+  getEndpointNameFromGatewayModel,
+  ModelProvider,
+  getModelProvider,
+} from '../../utils/gatewayUtils';
+
+// ─── Guardrails AI icon ─────────────────────────────────────────────────────
+
+function GuardrailsAIIcon({ size = 20 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12 2L3 7v6c0 5.25 3.83 10.16 9 11.33C17.17 23.16 21 18.25 21 13V7l-9-5z"
+        fill="#15B8A6"
+      />
+      <text
+        x="12"
+        y="16.5"
+        textAnchor="middle"
+        fontFamily="Arial, sans-serif"
+        fontWeight="bold"
+        fontSize="11"
+        fill="white"
+      >
+        G
+      </text>
+    </svg>
+  );
+}
+
+// ─── Builtin judges (GuardrailsScorer subclasses from Guardrails AI) ────────
+
+interface BuiltinJudgeInfo {
+  name: string;
+  label: string;
+  description: string;
+  variables: ('inputs' | 'outputs')[];
+  emoji: string;
+}
+
+const BUILTIN_JUDGES: BuiltinJudgeInfo[] = [
+  {
+    name: 'ToxicLanguage',
+    label: 'Toxic Language',
+    description: 'Detects toxic, offensive, or harmful content using NLP models',
+    variables: ['inputs', 'outputs'],
+    emoji: '\u{1F6AB}',
+  },
+  {
+    name: 'NSFWText',
+    label: 'NSFW Text',
+    description: 'Detects inappropriate or explicit content not suitable for professional settings',
+    variables: ['inputs', 'outputs'],
+    emoji: '\u{1F6A8}',
+  },
+  {
+    name: 'DetectJailbreak',
+    label: 'Detect Jailbreak',
+    description: 'Detects jailbreak or prompt injection attempts using a BERT-based classifier',
+    variables: ['inputs', 'outputs'],
+    emoji: '\u{1F6E1}',
+  },
+  {
+    name: 'DetectPII',
+    label: 'Detect PII',
+    description: 'Detects personally identifiable information (email, phone, names, etc.)',
+    variables: ['inputs', 'outputs'],
+    emoji: '\u{1F464}',
+  },
+  {
+    name: 'SecretsPresent',
+    label: 'Secrets Present',
+    description: 'Detects API keys, tokens, passwords, or other sensitive credentials',
+    variables: ['inputs', 'outputs'],
+    emoji: '\u{1F511}',
+  },
+  {
+    name: 'GibberishText',
+    label: 'Gibberish Text',
+    description: 'Detects gibberish, incoherent, or nonsensical text in LLM outputs',
+    variables: ['inputs', 'outputs'],
+    emoji: '\u{1F4AC}',
+  },
+];
+
+function getCompatibleBuiltins(hook: GuardrailHook, operation: GuardrailOperation): BuiltinJudgeInfo[] {
+  // All GuardrailsScorer subclasses return yes/no → only compatible with VALIDATION
+  if (operation === 'MUTATION') return [];
+  const requiredVar = hook === 'PRE' ? 'inputs' : 'outputs';
+  return BUILTIN_JUDGES.filter((j) => j.variables.includes(requiredVar));
+}
+
+// ─── Default prompts for custom judges ──────────────────────────────────────
+
+function getDefaultPrompt(hook: GuardrailHook, operation: GuardrailOperation): string {
+  const variable = hook === 'PRE' ? '{{inputs}}' : '{{outputs}}';
+  const dataLabel = hook === 'PRE' ? 'user input' : 'model output';
+  if (operation === 'VALIDATION') {
+    return (
+      `Analyze the following ${dataLabel} for personally identifiable information (PII) ` +
+      `such as names, email addresses, phone numbers, SSNs, credit card numbers, ` +
+      `physical addresses, or other identifying data:\n\n` +
+      `${variable}\n\n` +
+      `Answer "yes" if the text is safe (no PII detected), or "no" if PII is found.`
+    );
+  }
+  return (
+    `Rewrite the following ${dataLabel} to redact any personally identifiable information (PII) ` +
+    `such as names, email addresses, phone numbers, SSNs, credit card numbers, ` +
+    `or physical addresses. Replace each PII instance with [REDACTED]:\n\n${variable}`
+  );
+}
+
+// ─── Registered scorer fetching ─────────────────────────────────────────────
+
+interface RegisteredScorer {
+  scorer_name: string;
+  scorer_version: number;
+  experiment_id: string;
+  serialized_scorer: string;
+}
+
+function useRegisteredScorersQuery() {
+  return useQuery<RegisteredScorer[], Error>(['guardrail_registered_scorers'], {
+    queryFn: async () => {
+      const res = await fetchOrFail(getAjaxUrl('ajax-api/3.0/mlflow/scorers/list?experiment_id=0'));
+      const data = await res.json();
+      return data.scorers ?? [];
+    },
+    retry: false,
+    staleTime: 30000,
+  });
+}
+
+/**
+ * Check if a registered scorer is compatible with the given hook based on
+ * template variables in its serialized definition.
+ * - PRE hook needs {{inputs}} (or {{conversation}})
+ * - POST hook needs {{outputs}}
+ * If we can't parse or find variables, assume compatible.
+ */
+function isRegisteredScorerCompatible(scorer: RegisteredScorer, hook: GuardrailHook): boolean {
+  try {
+    const parsed = JSON.parse(scorer.serialized_scorer);
+    // make_judge stores instructions in instructions_judge_pydantic_data.instructions
+    const instructions: string | undefined =
+      parsed?.instructions_judge_pydantic_data?.instructions ??
+      parsed?.instructions ??
+      parsed?.judge_prompt;
+    if (!instructions) return true; // can't determine, show it
+    const hasInputs = instructions.includes('{{inputs}}') || instructions.includes('{{ inputs }}');
+    const hasOutputs = instructions.includes('{{outputs}}') || instructions.includes('{{ outputs }}');
+    const hasConversation =
+      instructions.includes('{{conversation}}') || instructions.includes('{{ conversation }}');
+    const hasTrace = instructions.includes('{{trace}}') || instructions.includes('{{ trace }}');
+    // If it references both or trace/conversation, it's compatible with either hook
+    if (hasTrace || hasConversation) return true;
+    if (hook === 'PRE') return hasInputs;
+    return hasOutputs;
+  } catch {
+    return true; // can't parse, show it
+  }
+}
+
+// ─── Form types ─────────────────────────────────────────────────────────────
+
+type ScorerSource = 'builtin' | 'registered' | 'custom';
+
+interface FormData {
+  scorerName: string;
+  hook: GuardrailHook;
+  operation: GuardrailOperation;
+  scorerSource: ScorerSource;
+  builtinJudge: string;
+  registeredScorer: string;
+  guidelines: string;
+  prompt: string;
+  model: string;
+}
+
+function makeInitialForm(): FormData {
+  return {
+    scorerName: '',
+    hook: 'PRE',
+    operation: 'VALIDATION',
+    scorerSource: 'builtin',
+    builtinJudge: '',
+    registeredScorer: '',
+    guidelines: '',
+    prompt: getDefaultPrompt('PRE', 'VALIDATION'),
+    model: '',
+  };
+}
+
+// ─── Guardrail card component ───────────────────────────────────────────────
+
+function GuardrailCard({
+  icon,
+  label,
+  description,
+  selected,
+  onClick,
+  tag,
+}: {
+  icon: ReactNode;
+  label: string;
+  description: string;
+  selected: boolean;
+  onClick: () => void;
+  tag?: ReactNode;
+}) {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing.xs,
+        padding: theme.spacing.md,
+        borderRadius: theme.borders.borderRadiusMd,
+        border: `1px solid ${selected ? theme.colors.actionPrimaryBackgroundDefault : theme.colors.border}`,
+        backgroundColor: selected ? theme.colors.actionPrimaryBackgroundDefault + '08' : theme.colors.backgroundPrimary,
+        cursor: 'pointer',
+        transition: 'border-color 0.15s, background-color 0.15s, box-shadow 0.15s',
+        boxShadow: selected ? `0 0 0 1px ${theme.colors.actionPrimaryBackgroundDefault}` : 'none',
+        '&:hover': {
+          borderColor: theme.colors.actionPrimaryBackgroundDefault,
+          backgroundColor: theme.colors.actionPrimaryBackgroundDefault + '05',
+        },
+        minHeight: 80,
+      }}
+    >
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+        <span css={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>{icon}</span>
+        <Typography.Text bold css={{ flex: 1 }}>
+          {label}
+        </Typography.Text>
+        {tag && <Tag componentId={`mlflow.gateway.guardrail-card.tag.${label}`}>{tag}</Tag>}
+      </div>
+      <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+        {description}
+      </Typography.Text>
+    </div>
+  );
+}
+
+// ─── Source tab buttons ─────────────────────────────────────────────────────
+
+function SourceTabs({
+  value,
+  onChange,
+}: {
+  value: ScorerSource;
+  onChange: (v: ScorerSource) => void;
+}) {
+  const { theme } = useDesignSystemTheme();
+
+  const tabs: { key: ScorerSource; label: string }[] = [
+    { key: 'builtin', label: 'Guardrails AI' },
+    { key: 'registered', label: 'Registered' },
+    { key: 'custom', label: 'Custom' },
+  ];
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        gap: 0,
+        borderRadius: theme.borders.borderRadiusMd,
+        border: `1px solid ${theme.colors.border}`,
+        overflow: 'hidden',
+      }}
+    >
+      {tabs.map((tab) => (
+        <button
+          key={tab.key}
+          type="button"
+          onClick={() => onChange(tab.key)}
+          css={{
+            flex: 1,
+            padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+            border: 'none',
+            borderRight: tab.key !== 'custom' ? `1px solid ${theme.colors.border}` : 'none',
+            backgroundColor:
+              value === tab.key ? theme.colors.actionPrimaryBackgroundDefault : theme.colors.backgroundPrimary,
+            color: value === tab.key ? '#fff' : theme.colors.textPrimary,
+            cursor: 'pointer',
+            fontWeight: value === tab.key ? 600 : 400,
+            fontSize: theme.typography.fontSizeSm,
+            transition: 'background-color 0.15s, color 0.15s',
+            '&:hover': {
+              backgroundColor:
+                value === tab.key
+                  ? theme.colors.actionPrimaryBackgroundDefault
+                  : theme.colors.actionPrimaryBackgroundDefault + '10',
+            },
+          }}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ─── Model / endpoint selector for custom judges ────────────────────────────
+
+function ModelSelector({ model, onModelChange }: { model: string; onModelChange: (value: string) => void }) {
+  const { theme } = useDesignSystemTheme();
+  const [providerMode, setProviderMode] = useState<ModelProvider>(
+    () => (model ? getModelProvider(model) : ModelProvider.GATEWAY),
+  );
+
+  const endpointName = getEndpointNameFromGatewayModel(model);
+
+  if (providerMode === ModelProvider.OTHER) {
+    return (
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+        <Typography.Text bold>Model</Typography.Text>
+        <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+          Enter a model identifier (e.g., openai:/gpt-4.1-mini). Leave empty to use the default model.
+        </Typography.Text>
+        <Input
+          componentId="mlflow.gateway.guardrail-modal.model-input"
+          value={model}
+          onChange={(e) => onModelChange(e.target.value)}
+          placeholder="openai:/gpt-4.1-mini"
+        />
+        <Typography.Link
+          componentId="mlflow.gateway.guardrail-modal.switch-to-endpoint"
+          onClick={() => {
+            setProviderMode(ModelProvider.GATEWAY);
+            onModelChange('');
+          }}
+          css={{ cursor: 'pointer', fontSize: theme.typography.fontSizeSm }}
+        >
+          ← Use an endpoint instead
+        </Typography.Link>
+      </div>
+    );
+  }
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+      <Typography.Text bold>Model</Typography.Text>
+      <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+        Select an endpoint to use for this guardrail judge. Leave empty to use the default model.
+      </Typography.Text>
+      <EndpointSelector
+        currentEndpointName={endpointName}
+        onEndpointSelect={(name) => onModelChange(formatGatewayModelFromEndpoint(name))}
+        componentIdPrefix="mlflow.gateway.guardrail-modal.endpoint"
+        placeholder="Default model"
+      />
+      <Typography.Text color="secondary" size="sm">
+        Or{' '}
+        <Typography.Link
+          componentId="mlflow.gateway.guardrail-modal.switch-to-manual"
+          onClick={() => {
+            setProviderMode(ModelProvider.OTHER);
+            onModelChange('');
+          }}
+          css={{ cursor: 'pointer' }}
+        >
+          enter a model identifier
+        </Typography.Link>
+      </Typography.Text>
+    </div>
+  );
+}
+
+// ─── Modal component ────────────────────────────────────────────────────────
+
+interface TraceEntry {
+  trace_id: string;
+  request_preview?: string;
+  response_preview?: string;
+  request_time?: string;
+  state?: string;
+}
+
+interface GuardrailModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+  endpointName?: string;
+  editingGuardrail?: Guardrail | null;
+  experimentId?: string;
+}
+
+export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editingGuardrail, experimentId }: GuardrailModalProps) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const isEditMode = !!editingGuardrail;
+
+  const [formData, setFormData] = useState<FormData>(makeInitialForm);
+  const [searchQuery, setSearchQuery] = useState('');
+  const { data: registeredScorers, isLoading: isLoadingScorers } = useRegisteredScorersQuery();
+
+  const {
+    mutateAsync: addGuardrail,
+    isLoading: isAdding,
+    error: addError,
+    reset: resetAdd,
+  } = useAddGuardrail();
+  const {
+    mutateAsync: updateGuardrail,
+    isLoading: isUpdating,
+    error: updateError,
+    reset: resetUpdate,
+  } = useUpdateGuardrail();
+
+  const isLoading = isAdding || isUpdating;
+  const mutationError = addError || updateError;
+
+  // ─── Test state ──────────────────────────────────────────────────────────
+  const [showTest, setShowTest] = useState(false);
+  const [testInputMode, setTestInputMode] = useState<'trace' | 'manual'>(experimentId ? 'trace' : 'manual');
+  const [testManualText, setTestManualText] = useState('');
+  const [traces, setTraces] = useState<TraceEntry[]>([]);
+  const [tracesLoading, setTracesLoading] = useState(false);
+  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<TestGuardrailResponse | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testError, setTestError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Fetch traces when test panel is shown
+  useEffect(() => {
+    if (!showTest || !experimentId) return;
+    const fetchTraces = async () => {
+      setTracesLoading(true);
+      try {
+        const res = await fetchOrFail(getAjaxUrl('ajax-api/3.0/mlflow/traces/search'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            locations: [{ type: 'MLFLOW_EXPERIMENT', mlflow_experiment: { experiment_id: experimentId } }],
+            max_results: 20,
+            order_by: ['timestamp_ms DESC'],
+          }),
+        });
+        const data = (await res.json()) as { traces?: TraceEntry[] };
+        setTraces(data.traces ?? []);
+      } catch {
+        // silently fail
+      } finally {
+        setTracesLoading(false);
+      }
+    };
+    fetchTraces();
+  }, [showTest, experimentId]);
+
+  // Clean up polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  // Build the test request body — either from existing guardrail or from form data
+  const buildTestRequest = useCallback((): Partial<import('../../types').TestGuardrailRequest> => {
+    if (isEditMode && editingGuardrail) {
+      return { guardrail_id: editingGuardrail.guardrail_id };
+    }
+    // Inline config from form data
+    const config: GuardrailScorerConfig = {};
+    if (formData.scorerSource === 'builtin') {
+      config.builtin_scorer = formData.builtinJudge;
+    } else if (formData.scorerSource === 'registered') {
+      config.registered_scorer = formData.registeredScorer;
+      const scorer = registeredScorers?.find((s) => s.scorer_name === formData.registeredScorer);
+      if (scorer) {
+        config.experiment_id = scorer.experiment_id;
+        config.scorer_version = scorer.scorer_version;
+      }
+    } else {
+      config.prompt = formData.prompt;
+      config.response_schema =
+        formData.operation === 'VALIDATION'
+          ? 'yes_no'
+          : formData.hook === 'PRE'
+            ? 'chat_request'
+            : 'chat_response';
+      if (formData.model) {
+        config.model = formData.model;
+      }
+    }
+    return {
+      scorer_name: formData.scorerName,
+      hook: formData.hook,
+      operation: formData.operation,
+      config,
+    };
+  }, [isEditMode, editingGuardrail, formData, registeredScorers]);
+
+  const handleTest = useCallback(async () => {
+    setTesting(true);
+    setTestResult(null);
+    setTestError(null);
+    if (pollRef.current) clearInterval(pollRef.current);
+
+    try {
+      const base = buildTestRequest();
+      if (testInputMode === 'trace' && selectedTraceId && experimentId) {
+        const result = await GatewayApi.testGuardrail({
+          ...base,
+          trace_id: selectedTraceId,
+          experiment_id: experimentId,
+        });
+        setTestResult(result);
+      } else if (testInputMode === 'manual' && testManualText) {
+        const result = await GatewayApi.testGuardrail({
+          ...base,
+          text: testManualText,
+        });
+        setTestResult(result);
+      } else {
+        setTestError('Please provide text or select a trace to test against.');
+      }
+    } catch (e: any) {
+      setTestError(e.message || 'Test failed');
+    } finally {
+      setTesting(false);
+    }
+  }, [buildTestRequest, testInputMode, selectedTraceId, experimentId, testManualText]);
+
+  // Populate form when editing
+  useEffect(() => {
+    if (!open) return;
+    if (editingGuardrail) {
+      const config = editingGuardrail.config;
+      const isBuiltin = BUILTIN_JUDGES.some((j) => j.name === config?.builtin_scorer);
+      const isRegistered = !!config?.registered_scorer;
+      setFormData({
+        scorerName: editingGuardrail.scorer_name,
+        hook: editingGuardrail.hook,
+        operation: editingGuardrail.operation,
+        scorerSource: isBuiltin ? 'builtin' : isRegistered ? 'registered' : 'custom',
+        builtinJudge: config?.builtin_scorer ?? '',
+        registeredScorer: config?.registered_scorer ?? '',
+        guidelines: config?.guidelines ?? '',
+        prompt: config?.prompt ?? getDefaultPrompt(editingGuardrail.hook, editingGuardrail.operation),
+        model: config?.model ?? '',
+      });
+    } else {
+      setFormData(makeInitialForm());
+    }
+    setSearchQuery('');
+    setShowTest(false);
+    setTestResult(null);
+    setTestError(null);
+    setSelectedTraceId(null);
+    setTestManualText('');
+    setTestInputMode(experimentId ? 'trace' : 'manual');
+  }, [open, editingGuardrail, experimentId]);
+
+  const resetMutation = useCallback(() => {
+    resetAdd();
+    resetUpdate();
+  }, [resetAdd, resetUpdate]);
+
+  const handleClose = useCallback(() => {
+    setFormData(makeInitialForm());
+    setSearchQuery('');
+    resetMutation();
+    onClose();
+  }, [onClose, resetMutation]);
+
+  const handleFieldChange = useCallback(
+    <K extends keyof FormData>(field: K, value: FormData[K]) => {
+      setFormData((prev) => {
+        const next = { ...prev, [field]: value };
+        if (field === 'builtinJudge' && prev.scorerSource === 'builtin') {
+          next.scorerName = String(value);
+        }
+        if (field === 'registeredScorer' && prev.scorerSource === 'registered') {
+          next.scorerName = String(value);
+        }
+        if (field === 'scorerSource') {
+          if (value === 'builtin') {
+            next.scorerName = next.builtinJudge;
+          } else if (value === 'registered' && next.registeredScorer) {
+            next.scorerName = next.registeredScorer;
+          } else if (value === 'custom') {
+            next.scorerName = prev.scorerName || '';
+            next.prompt = getDefaultPrompt(next.hook, next.operation);
+          }
+        }
+        // When hook or operation changes, clear selections that may no longer be compatible
+        if (field === 'hook' || field === 'operation') {
+          if (prev.scorerSource === 'builtin') {
+            // Builtins only support VALIDATION; clear selection if switching to MUTATION
+            const newOp = (field === 'operation' ? value : next.operation) as GuardrailOperation;
+            if (newOp === 'MUTATION') {
+              next.builtinJudge = '';
+              next.scorerName = '';
+            }
+          }
+          if (prev.scorerSource === 'custom') {
+            const oldDefault = getDefaultPrompt(prev.hook, prev.operation);
+            if (prev.prompt === oldDefault) {
+              next.prompt = getDefaultPrompt(next.hook, next.operation);
+            }
+          }
+        }
+        return next;
+      });
+      resetMutation();
+    },
+    [resetMutation],
+  );
+
+  const compatibleBuiltins = useMemo(
+    () => getCompatibleBuiltins(formData.hook, formData.operation),
+    [formData.hook, formData.operation],
+  );
+
+  const filteredBuiltins = useMemo(() => {
+    if (!searchQuery.trim()) return compatibleBuiltins;
+    const q = searchQuery.toLowerCase();
+    return compatibleBuiltins.filter(
+      (j) => j.label.toLowerCase().includes(q) || j.description.toLowerCase().includes(q),
+    );
+  }, [compatibleBuiltins, searchQuery]);
+
+  const filteredRegistered = useMemo(() => {
+    if (!registeredScorers) return [];
+    // Filter by hook compatibility (template variables)
+    const compatible = registeredScorers.filter((s) => isRegisteredScorerCompatible(s, formData.hook));
+    if (!searchQuery.trim()) return compatible;
+    const q = searchQuery.toLowerCase();
+    return compatible.filter((s) => s.scorer_name.toLowerCase().includes(q));
+  }, [registeredScorers, formData.hook, searchQuery]);
+
+  const isFormValid = useMemo(() => {
+    if (formData.scorerSource === 'builtin' && !formData.builtinJudge) return false;
+    if (formData.scorerSource === 'custom' && !formData.scorerName.trim()) return false;
+    if (formData.scorerSource === 'custom' && !formData.prompt.trim()) return false;
+    if (formData.scorerSource === 'registered' && !formData.registeredScorer) return false;
+    return true;
+  }, [formData]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!isFormValid) return;
+
+    const config: GuardrailScorerConfig = {};
+
+    if (formData.scorerSource === 'builtin') {
+      config.builtin_scorer = formData.builtinJudge;
+    } else if (formData.scorerSource === 'registered') {
+      config.registered_scorer = formData.registeredScorer;
+      const scorer = registeredScorers?.find((s) => s.scorer_name === formData.registeredScorer);
+      if (scorer) {
+        config.experiment_id = scorer.experiment_id;
+        config.scorer_version = scorer.scorer_version;
+      }
+    } else {
+      config.prompt = formData.prompt;
+      config.response_schema =
+        formData.operation === 'VALIDATION'
+          ? 'yes_no'
+          : formData.hook === 'PRE'
+            ? 'chat_request'
+            : 'chat_response';
+      if (formData.model) {
+        config.model = formData.model;
+      }
+    }
+
+    if (isEditMode && editingGuardrail) {
+      await updateGuardrail({
+        guardrail_id: editingGuardrail.guardrail_id,
+        scorer_name: formData.scorerName,
+        hook: formData.hook,
+        operation: formData.operation,
+        config,
+      }).then(() => {
+        handleClose();
+        onSuccess?.();
+      });
+    } else {
+      await addGuardrail({
+        scorer_name: formData.scorerName,
+        hook: formData.hook,
+        operation: formData.operation,
+        endpoint_name: endpointName,
+        config,
+      }).then(() => {
+        handleClose();
+        onSuccess?.();
+      });
+    }
+  }, [
+    isFormValid,
+    formData,
+    isEditMode,
+    editingGuardrail,
+    addGuardrail,
+    updateGuardrail,
+    endpointName,
+    handleClose,
+    onSuccess,
+    registeredScorers,
+  ]);
+
+  const errorMessage = useMemo((): string | null => {
+    if (!mutationError) return null;
+    const message = (mutationError as Error).message;
+    return message.length > 200
+      ? intl.formatMessage({
+          defaultMessage: 'An error occurred. Please try again.',
+          description: 'Generic error message for guardrail modal',
+        })
+      : message;
+  }, [mutationError, intl]);
+
+  const promptHint = formData.hook === 'PRE' ? '{{inputs}}' : '{{outputs}}';
+
+  return (
+    <Modal
+      componentId="mlflow.gateway.guardrail-modal"
+      title={
+        isEditMode
+          ? intl.formatMessage({ defaultMessage: 'Edit Guardrail', description: 'Title for edit guardrail modal' })
+          : intl.formatMessage({ defaultMessage: 'Add Guardrail', description: 'Title for add guardrail modal' })
+      }
+      visible={open}
+      onCancel={handleClose}
+      onOk={handleSubmit}
+      okText={
+        isEditMode
+          ? intl.formatMessage({ defaultMessage: 'Save', description: 'Save guardrail button text' })
+          : intl.formatMessage({ defaultMessage: 'Add', description: 'Add guardrail button text' })
+      }
+      cancelText={intl.formatMessage({
+        defaultMessage: 'Cancel',
+        description: 'Cancel button text',
+      })}
+      confirmLoading={isLoading}
+      okButtonProps={{ disabled: !isFormValid }}
+      size="wide"
+    >
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
+        {errorMessage && (
+          <Alert
+            componentId="mlflow.gateway.guardrail-modal.error"
+            type="error"
+            message={errorMessage}
+            closable={false}
+          />
+        )}
+
+        {/* Hook and Operation side by side */}
+        <div css={{ display: 'flex', gap: theme.spacing.md }}>
+          <div css={{ flex: 1, display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+            <Typography.Text bold>
+              <FormattedMessage defaultMessage="Hook" description="Guardrail hook label" />
+            </Typography.Text>
+            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+              <FormattedMessage
+                defaultMessage="When the guardrail runs relative to LLM invocation"
+                description="Hook description"
+              />
+            </Typography.Text>
+            <SimpleSelect
+              id="guardrail-hook"
+              componentId="mlflow.gateway.guardrail-modal.hook"
+              value={formData.hook}
+              onChange={({ target }) => handleFieldChange('hook', target.value as GuardrailHook)}
+            >
+              <SimpleSelectOption value="PRE">Pre-invocation</SimpleSelectOption>
+              <SimpleSelectOption value="POST">Post-invocation</SimpleSelectOption>
+            </SimpleSelect>
+          </div>
+
+          <div css={{ flex: 1, display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+            <Typography.Text bold>
+              <FormattedMessage defaultMessage="Operation" description="Guardrail operation label" />
+            </Typography.Text>
+            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+              <FormattedMessage
+                defaultMessage="Whether the guardrail blocks or modifies requests"
+                description="Operation description"
+              />
+            </Typography.Text>
+            <SimpleSelect
+              id="guardrail-operation"
+              componentId="mlflow.gateway.guardrail-modal.operation"
+              value={formData.operation}
+              onChange={({ target }) => handleFieldChange('operation', target.value as GuardrailOperation)}
+            >
+              <SimpleSelectOption value="VALIDATION">Validation (block)</SimpleSelectOption>
+              <SimpleSelectOption value="MUTATION">Mutation (modify)</SimpleSelectOption>
+            </SimpleSelect>
+          </div>
+        </div>
+
+        {/* Source tabs */}
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+          <Typography.Text bold>
+            <FormattedMessage defaultMessage="Judge source" description="Judge source label" />
+          </Typography.Text>
+          <SourceTabs
+            value={formData.scorerSource}
+            onChange={(v) => handleFieldChange('scorerSource', v)}
+          />
+        </div>
+
+        {/* Search bar (shown for builtin and registered) */}
+        {formData.scorerSource !== 'custom' && (
+          <Input
+            componentId="mlflow.gateway.guardrail-modal.search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder={intl.formatMessage({
+              defaultMessage: 'Search guardrails...',
+              description: 'Search guardrails placeholder',
+            })}
+            allowClear
+          />
+        )}
+
+        {/* ─── Builtin judge cards ─── */}
+        {formData.scorerSource === 'builtin' && (
+          <div
+            css={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(2, 1fr)',
+              gap: theme.spacing.sm,
+            }}
+          >
+            {filteredBuiltins.map((j) => (
+              <GuardrailCard
+                key={j.name}
+                icon={<span css={{ fontSize: 20, lineHeight: 1 }}>{j.emoji}</span>}
+                label={j.label}
+                description={j.description}
+                selected={formData.builtinJudge === j.name}
+                tag={<span css={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><GuardrailsAIIcon size={14} /> GUARDRAILS AI</span>}
+                onClick={() => handleFieldChange('builtinJudge', j.name)}
+              />
+            ))}
+            {filteredBuiltins.length === 0 && (
+              <div css={{ gridColumn: '1 / -1', padding: theme.spacing.md, textAlign: 'center' }}>
+                <Typography.Text color="secondary">
+                  {formData.operation === 'MUTATION' ? (
+                    <FormattedMessage
+                      defaultMessage="Guardrails AI validators only support validation (yes/no). Switch to Validation operation or use a custom judge for mutation."
+                      description="No builtin guardrails for mutation operation"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      defaultMessage="No matching builtin guardrails found."
+                      description="No matching builtin guardrails"
+                    />
+                  )}
+                </Typography.Text>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ─── Registered judge cards ─── */}
+        {formData.scorerSource === 'registered' && (
+          <>
+            {isLoadingScorers ? (
+              <div css={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: theme.spacing.sm, padding: theme.spacing.lg }}>
+                <Spinner size="small" />
+                <FormattedMessage defaultMessage="Loading registered judges..." description="Loading registered judges" />
+              </div>
+            ) : filteredRegistered.length > 0 ? (
+              <div
+                css={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(2, 1fr)',
+                  gap: theme.spacing.sm,
+                }}
+              >
+                {filteredRegistered.map((s) => (
+                  <GuardrailCard
+                    key={s.scorer_name}
+                    icon={<span css={{ fontSize: 20, lineHeight: 1 }}>{'\u{2699}'}</span>}
+                    label={s.scorer_name}
+                    description={`v${s.scorer_version} \u00B7 experiment ${s.experiment_id}`}
+                    selected={formData.registeredScorer === s.scorer_name}
+                    tag="REGISTERED"
+                    onClick={() => handleFieldChange('registeredScorer', s.scorer_name)}
+                  />
+                ))}
+              </div>
+            ) : registeredScorers && registeredScorers.length > 0 ? (
+              <Alert
+                componentId="mlflow.gateway.guardrail-modal.no-compatible-registered"
+                type="info"
+                message={
+                  formData.hook === 'PRE'
+                    ? intl.formatMessage({
+                        defaultMessage:
+                          "No registered judges compatible with pre-invocation hook. Judges need '{{inputs}}' in their instructions.",
+                        description: 'No compatible registered judges for PRE hook',
+                      })
+                    : intl.formatMessage({
+                        defaultMessage:
+                          "No registered judges compatible with post-invocation hook. Judges need '{{outputs}}' in their instructions.",
+                        description: 'No compatible registered judges for POST hook',
+                      })
+                }
+              />
+            ) : (
+              <Alert
+                componentId="mlflow.gateway.guardrail-modal.no-registered"
+                type="warning"
+                message={intl.formatMessage({
+                  defaultMessage:
+                    'No registered judges found. Register a judge first using mlflow.genai.scorers.register_scorer() or make_judge().register().',
+                  description: 'No registered judges message',
+                })}
+              />
+            )}
+          </>
+        )}
+
+        {/* ─── Custom judge (make_judge style) ─── */}
+        {formData.scorerSource === 'custom' && (
+          <>
+            {/* Custom judge name */}
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+              <Typography.Text bold>
+                <FormattedMessage defaultMessage="Judge name" description="Custom judge name label" />
+              </Typography.Text>
+              <Input
+                componentId="mlflow.gateway.guardrail-modal.custom-name"
+                value={formData.scorerName}
+                onChange={(e) => handleFieldChange('scorerName', e.target.value)}
+                placeholder={intl.formatMessage({
+                  defaultMessage: 'e.g., pii-filter, toxicity-check',
+                  description: 'Judge name placeholder',
+                })}
+              />
+            </div>
+
+            {/* Instructions prompt */}
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+              <Typography.Text bold>
+                <FormattedMessage defaultMessage="Instructions" description="Custom judge instructions label" />
+              </Typography.Text>
+              <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                <FormattedMessage
+                  defaultMessage="Judge instructions (like make_judge). Use {variable} to reference the {hookType} data."
+                  description="Custom judge instructions description"
+                  values={{
+                    variable: <code>{promptHint}</code>,
+                    hookType: formData.hook === 'PRE' ? 'input' : 'output',
+                  }}
+                />
+              </Typography.Text>
+              <textarea
+                value={formData.prompt}
+                onChange={(e) => handleFieldChange('prompt', e.target.value)}
+                rows={6}
+                css={{
+                  width: '100%',
+                  padding: theme.spacing.sm,
+                  borderRadius: theme.borders.borderRadiusMd,
+                  border: `1px solid ${theme.colors.border}`,
+                  fontFamily: 'monospace',
+                  fontSize: theme.typography.fontSizeSm,
+                  resize: 'vertical',
+                  backgroundColor: theme.colors.backgroundPrimary,
+                  color: theme.colors.textPrimary,
+                }}
+              />
+              {formData.operation === 'VALIDATION' && (
+                <Alert
+                  componentId="mlflow.gateway.guardrail-modal.validation-hint"
+                  type="info"
+                  message={intl.formatMessage({
+                    defaultMessage:
+                      'Validation guardrails expect a yes/no response. "no" means the content is rejected.',
+                    description: 'Validation hint for custom judge guardrails',
+                  })}
+                />
+              )}
+              {formData.operation === 'MUTATION' && (
+                <Alert
+                  componentId="mlflow.gateway.guardrail-modal.mutation-hint"
+                  type="info"
+                  message={intl.formatMessage({
+                    defaultMessage:
+                      'Mutation guardrails should return the modified content. For pre-invocation, output a ChatRequest. For post-invocation, output a ChatResponse.',
+                    description: 'Mutation hint for custom judge guardrails',
+                  })}
+                />
+              )}
+            </div>
+
+            {/* Model / endpoint selection */}
+            <ModelSelector
+              model={formData.model}
+              onModelChange={(value) => handleFieldChange('model', value)}
+            />
+          </>
+        )}
+
+        {/* ─── Test section ─── */}
+        {isFormValid && (
+          <div
+            css={{
+              borderTop: `1px solid ${theme.colors.border}`,
+              paddingTop: theme.spacing.md,
+            }}
+          >
+            <div
+              css={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer' }}
+              onClick={() => setShowTest((v) => !v)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  setShowTest((v) => !v);
+                }
+              }}
+            >
+              <Typography.Text bold>
+                <FormattedMessage defaultMessage="Test guardrail" description="Test guardrail section header" />
+              </Typography.Text>
+              <span css={{ fontSize: 12, color: theme.colors.textSecondary }}>
+                {showTest ? '\u25B2' : '\u25BC'}
+              </span>
+            </div>
+
+            {showTest && (
+              <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md, marginTop: theme.spacing.md }}>
+                <Alert
+                  componentId="mlflow.gateway.guardrail-modal.test-info"
+                  type="info"
+                  closable={false}
+                  message={intl.formatMessage(
+                    {
+                      defaultMessage:
+                        'This is a {hook}-invocation {operation} guardrail. It will test against {dataSource}.',
+                      description: 'Info about guardrail test behavior',
+                    },
+                    {
+                      hook: formData.hook === 'PRE' ? 'pre' : 'post',
+                      operation: formData.operation.toLowerCase(),
+                      dataSource: formData.hook === 'PRE' ? 'request input' : 'response output',
+                    },
+                  )}
+                />
+
+                {/* Input mode tabs */}
+                {experimentId && (
+                  <div css={{ display: 'flex', gap: theme.spacing.xs }}>
+                    <Button
+                      componentId="mlflow.gateway.guardrail-modal.test-mode-trace"
+                      type={testInputMode === 'trace' ? 'primary' : undefined}
+                      size="small"
+                      onClick={() => setTestInputMode('trace')}
+                    >
+                      <FormattedMessage defaultMessage="Pick from traces" description="Tab to pick a trace" />
+                    </Button>
+                    <Button
+                      componentId="mlflow.gateway.guardrail-modal.test-mode-manual"
+                      type={testInputMode === 'manual' ? 'primary' : undefined}
+                      size="small"
+                      onClick={() => setTestInputMode('manual')}
+                    >
+                      <FormattedMessage defaultMessage="Manual input" description="Tab for manual text input" />
+                    </Button>
+                  </div>
+                )}
+
+                {/* Trace picker */}
+                {testInputMode === 'trace' && experimentId && (
+                  <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+                    {tracesLoading && (
+                      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+                        <Spinner size="small" />
+                        <FormattedMessage defaultMessage="Loading traces..." description="Loading traces" />
+                      </div>
+                    )}
+                    {!tracesLoading && traces.length === 0 && (
+                      <Typography.Text color="secondary">
+                        <FormattedMessage
+                          defaultMessage="No traces found. Send some requests first, or use manual input."
+                          description="No traces found message"
+                        />
+                      </Typography.Text>
+                    )}
+                    {!tracesLoading && traces.length > 0 && (
+                      <div
+                        css={{
+                          maxHeight: 200,
+                          overflowY: 'auto',
+                          border: `1px solid ${theme.colors.border}`,
+                          borderRadius: theme.borders.borderRadiusMd,
+                        }}
+                      >
+                        {traces.map((trace) => {
+                          const isSelected = selectedTraceId === trace.trace_id;
+                          const preview =
+                            formData.hook === 'PRE' ? trace.request_preview : trace.response_preview;
+                          return (
+                            <div
+                              key={trace.trace_id}
+                              css={{
+                                padding: theme.spacing.sm,
+                                borderBottom: `1px solid ${theme.colors.border}`,
+                                cursor: 'pointer',
+                                backgroundColor: isSelected
+                                  ? `${theme.colors.actionPrimaryBackgroundDefault}12`
+                                  : 'transparent',
+                                border: isSelected
+                                  ? `2px solid ${theme.colors.actionPrimaryBackgroundDefault}`
+                                  : '2px solid transparent',
+                                borderRadius: theme.borders.borderRadiusMd,
+                                '&:hover': { backgroundColor: theme.colors.tableRowHover },
+                                '&:last-child': { borderBottom: 'none' },
+                              }}
+                              onClick={() => setSelectedTraceId(trace.trace_id)}
+                              role="button"
+                              tabIndex={0}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  setSelectedTraceId(trace.trace_id);
+                                }
+                              }}
+                            >
+                              <div
+                                css={{
+                                  display: 'flex',
+                                  justifyContent: 'space-between',
+                                  alignItems: 'center',
+                                  marginBottom: 2,
+                                }}
+                              >
+                                <Typography.Text
+                                  css={{ fontSize: theme.typography.fontSizeSm, fontFamily: 'monospace' }}
+                                >
+                                  {trace.trace_id.substring(0, 12)}...
+                                </Typography.Text>
+                                {trace.state && (
+                                  <span
+                                    css={{
+                                      fontSize: 11,
+                                      padding: '1px 6px',
+                                      borderRadius: 4,
+                                      backgroundColor: trace.state === 'OK' ? '#52c41a20' : '#ff4d4f20',
+                                      color: trace.state === 'OK' ? '#52c41a' : '#ff4d4f',
+                                      fontWeight: 600,
+                                    }}
+                                  >
+                                    {trace.state}
+                                  </span>
+                                )}
+                              </div>
+                              <Typography.Text
+                                color="secondary"
+                                css={{
+                                  fontSize: theme.typography.fontSizeSm,
+                                  display: '-webkit-box',
+                                  WebkitLineClamp: 2,
+                                  WebkitBoxOrient: 'vertical',
+                                  overflow: 'hidden',
+                                  wordBreak: 'break-word',
+                                }}
+                              >
+                                {preview
+                                  ? preview.length > 150
+                                    ? `${preview.substring(0, 150)}...`
+                                    : preview
+                                  : '(no preview)'}
+                              </Typography.Text>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Manual input */}
+                {testInputMode === 'manual' && (
+                  <Input.TextArea
+                    value={testManualText}
+                    onChange={(e) => setTestManualText(e.target.value)}
+                    rows={3}
+                    placeholder={intl.formatMessage({
+                      defaultMessage: 'Enter the text you want to test the guardrail against...',
+                      description: 'Placeholder for manual test input',
+                    })}
+                  />
+                )}
+
+                {/* Run test button */}
+                <Button
+                  componentId="mlflow.gateway.guardrail-modal.run-test"
+                  type="primary"
+                  onClick={handleTest}
+                  loading={testing}
+                  disabled={testInputMode === 'trace' ? !selectedTraceId : !testManualText}
+                >
+                  <FormattedMessage defaultMessage="Run test" description="Run test button" />
+                </Button>
+
+                {/* Test error */}
+                {testError && (
+                  <Alert
+                    componentId="mlflow.gateway.guardrail-modal.test-error"
+                    type="error"
+                    closable={false}
+                    message={testError}
+                  />
+                )}
+
+                {/* Test result */}
+                {testResult && (
+                  <TestResultDisplay result={testResult} />
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+// ─── Helpers for readable text display ───────────────────────────────────────
+
+/**
+ * Try to parse JSON and extract human-readable content.
+ * Handles chat messages format: [{"role":"user","content":"..."}]
+ * and single-string JSON values.
+ */
+function formatDisplayText(raw: string): { formatted: string; isStructured: boolean } {
+  try {
+    const parsed = JSON.parse(raw);
+
+    // Array of chat messages: [{ role, content }, ...]
+    if (Array.isArray(parsed)) {
+      const lines = parsed
+        .filter((msg: any) => msg?.role && msg?.content)
+        .map((msg: any) => {
+          const content =
+            typeof msg.content === 'string'
+              ? msg.content
+              : Array.isArray(msg.content)
+                ? msg.content
+                    .filter((p: any) => p?.type === 'text')
+                    .map((p: any) => p.text)
+                    .join('\n')
+                : JSON.stringify(msg.content);
+          return `[${msg.role}] ${content}`;
+        });
+      if (lines.length > 0) {
+        return { formatted: lines.join('\n\n'), isStructured: true };
+      }
+    }
+
+    // Single object with "content" (e.g. a single message)
+    if (parsed && typeof parsed === 'object' && 'content' in parsed) {
+      const content = typeof parsed.content === 'string' ? parsed.content : JSON.stringify(parsed.content, null, 2);
+      return { formatted: parsed.role ? `[${parsed.role}] ${content}` : content, isStructured: true };
+    }
+
+    // Other JSON — pretty-print it
+    if (typeof parsed === 'string') {
+      return { formatted: parsed, isStructured: false };
+    }
+    return { formatted: JSON.stringify(parsed, null, 2), isStructured: true };
+  } catch {
+    // Not JSON — return as-is
+    return { formatted: raw, isStructured: false };
+  }
+}
+
+// ─── Test result display ─────────────────────────────────────────────────────
+
+const TestResultDisplay = ({ result }: { result: TestGuardrailResponse }) => {
+  const { theme } = useDesignSystemTheme();
+  const isPassed = result.result.score === 'yes';
+  const isMutation = result.guardrail.operation === 'MUTATION';
+  const displayInput = result.input_text ? formatDisplayText(result.input_text) : null;
+  const displayModified = result.result.modified_text ? formatDisplayText(result.result.modified_text) : null;
+
+  return (
+    <div
+      css={{
+        border: `2px solid ${isPassed ? '#52c41a' : '#ff4d4f'}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        css={{
+          padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+          backgroundColor: isPassed ? '#52c41a12' : '#ff4d4f12',
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.sm,
+          borderBottom: `1px solid ${isPassed ? '#52c41a40' : '#ff4d4f40'}`,
+        }}
+      >
+        <span css={{ fontSize: 20 }}>{isPassed ? '\u2705' : '\u274C'}</span>
+        <Typography.Title level={4} css={{ margin: '0 !important' }}>
+          {isPassed ? (
+            <FormattedMessage defaultMessage="Passed" description="Test passed label" />
+          ) : (
+            <FormattedMessage defaultMessage="Failed" description="Test failed label" />
+          )}
+        </Typography.Title>
+        <span
+          css={{
+            marginLeft: 'auto',
+            fontSize: theme.typography.fontSizeSm,
+            padding: '2px 8px',
+            borderRadius: 4,
+            backgroundColor: isPassed ? '#52c41a20' : '#ff4d4f20',
+            color: isPassed ? '#52c41a' : '#ff4d4f',
+            fontWeight: 600,
+          }}
+        >
+          score: {result.result.score}
+        </span>
+      </div>
+
+      <div css={{ padding: theme.spacing.md }}>
+        {result.result.rationale && (
+          <>
+            <Typography.Text bold css={{ display: 'block', marginBottom: theme.spacing.xs }}>
+              <FormattedMessage defaultMessage="Rationale" description="Rationale label in test result" />
+            </Typography.Text>
+            <Typography.Text css={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+              {result.result.rationale}
+            </Typography.Text>
+          </>
+        )}
+
+        {displayInput && (
+          <>
+            <Typography.Text
+              bold
+              css={{ display: 'block', marginTop: theme.spacing.md, marginBottom: theme.spacing.xs }}
+            >
+              <FormattedMessage defaultMessage="Tested against" description="Input text label in test result" />
+            </Typography.Text>
+            <div
+              css={{
+                padding: theme.spacing.sm,
+                backgroundColor: theme.colors.backgroundSecondary,
+                borderRadius: theme.borders.borderRadiusMd,
+                border: `1px solid ${theme.colors.border}`,
+                maxHeight: 120,
+                overflowY: 'auto',
+                fontSize: theme.typography.fontSizeSm,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                fontFamily: displayInput.isStructured ? 'inherit' : 'monospace',
+                lineHeight: 1.5,
+              }}
+            >
+              {displayInput.formatted.length > 800
+                ? `${displayInput.formatted.substring(0, 800)}...`
+                : displayInput.formatted}
+            </div>
+          </>
+        )}
+
+        {isMutation && displayModified && (
+          <>
+            <Typography.Text
+              bold
+              css={{ display: 'block', marginTop: theme.spacing.md, marginBottom: theme.spacing.xs }}
+            >
+              <FormattedMessage defaultMessage="Modified output" description="Modified text label in test result" />
+            </Typography.Text>
+            <div
+              css={{
+                padding: theme.spacing.sm,
+                backgroundColor: '#722ed108',
+                borderRadius: theme.borders.borderRadiusMd,
+                border: '1px solid #722ed140',
+                maxHeight: 120,
+                overflowY: 'auto',
+                fontSize: theme.typography.fontSizeSm,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                fontFamily: displayModified.isStructured ? 'inherit' : 'monospace',
+                lineHeight: 1.5,
+              }}
+            >
+              {displayModified.formatted}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
@@ -186,7 +186,7 @@ function isRegisteredScorerCompatible(scorer: RegisteredScorer, hook: GuardrailH
 
 // ─── Form types ─────────────────────────────────────────────────────────────
 
-type ScorerSource = 'builtin' | 'registered' | 'custom';
+type ScorerSource = 'builtin' | 'registered' | 'custom' | 'regex' | 'code';
 
 interface FormData {
   scorerName: string;
@@ -198,6 +198,7 @@ interface FormData {
   guidelines: string;
   prompt: string;
   model: string;
+  regexPattern: string;
 }
 
 function makeInitialForm(): FormData {
@@ -211,6 +212,7 @@ function makeInitialForm(): FormData {
     guidelines: '',
     prompt: getDefaultPrompt('PRE', 'VALIDATION'),
     model: '',
+    regexPattern: '',
   };
 }
 
@@ -288,9 +290,11 @@ function SourceTabs({
   const { theme } = useDesignSystemTheme();
 
   const tabs: { key: ScorerSource; label: string }[] = [
-    { key: 'builtin', label: 'Guardrails AI' },
+    { key: 'builtin', label: 'Catalog' },
     { key: 'registered', label: 'Registered' },
-    { key: 'custom', label: 'Custom' },
+    { key: 'custom', label: 'LLM Judge' },
+    { key: 'regex', label: 'Regex' },
+    { key: 'code', label: 'Code' },
   ];
 
   return (
@@ -312,7 +316,7 @@ function SourceTabs({
             flex: 1,
             padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
             border: 'none',
-            borderRight: tab.key !== 'custom' ? `1px solid ${theme.colors.border}` : 'none',
+            borderRight: tab.key !== 'code' ? `1px solid ${theme.colors.border}` : 'none',
             backgroundColor:
               value === tab.key ? theme.colors.actionPrimaryBackgroundDefault : theme.colors.backgroundPrimary,
             color: value === tab.key ? '#fff' : theme.colors.textPrimary,
@@ -506,6 +510,9 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
         config.experiment_id = scorer.experiment_id;
         config.scorer_version = scorer.scorer_version;
       }
+    } else if (formData.scorerSource === 'regex') {
+      config.builtin_scorer = 'regex_match';
+      config.regex_pattern = formData.regexPattern;
     } else {
       config.prompt = formData.prompt;
       config.response_schema =
@@ -563,17 +570,19 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
     if (editingGuardrail) {
       const config = editingGuardrail.config;
       const isBuiltin = BUILTIN_JUDGES.some((j) => j.name === config?.builtin_scorer);
+      const isRegex = config?.builtin_scorer === 'regex_match';
       const isRegistered = !!config?.registered_scorer;
       setFormData({
         scorerName: editingGuardrail.scorer_name,
         hook: editingGuardrail.hook,
         operation: editingGuardrail.operation,
-        scorerSource: isBuiltin ? 'builtin' : isRegistered ? 'registered' : 'custom',
-        builtinJudge: config?.builtin_scorer ?? '',
+        scorerSource: isRegex ? 'regex' : isBuiltin ? 'builtin' : isRegistered ? 'registered' : 'custom',
+        builtinJudge: isRegex ? '' : (config?.builtin_scorer ?? ''),
         registeredScorer: config?.registered_scorer ?? '',
         guidelines: config?.guidelines ?? '',
         prompt: config?.prompt ?? getDefaultPrompt(editingGuardrail.hook, editingGuardrail.operation),
         model: config?.model ?? '',
+        regexPattern: config?.regex_pattern ?? '',
       });
     } else {
       setFormData(makeInitialForm());
@@ -617,6 +626,11 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
           } else if (value === 'custom') {
             next.scorerName = prev.scorerName || '';
             next.prompt = getDefaultPrompt(next.hook, next.operation);
+          } else if (value === 'regex') {
+            next.scorerName = prev.scorerName || '';
+            next.operation = 'VALIDATION'; // regex only supports block
+          } else if (value === 'code') {
+            next.scorerName = '';
           }
         }
         // When hook or operation changes, clear selections that may no longer be compatible
@@ -670,6 +684,9 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
     if (formData.scorerSource === 'custom' && !formData.scorerName.trim()) return false;
     if (formData.scorerSource === 'custom' && !formData.prompt.trim()) return false;
     if (formData.scorerSource === 'registered' && !formData.registeredScorer) return false;
+    if (formData.scorerSource === 'regex' && !formData.scorerName.trim()) return false;
+    if (formData.scorerSource === 'regex' && !formData.regexPattern.trim()) return false;
+    if (formData.scorerSource === 'code') return false; // code tab is guide-only, no submission
     return true;
   }, [formData]);
 
@@ -687,6 +704,9 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
         config.experiment_id = scorer.experiment_id;
         config.scorer_version = scorer.scorer_version;
       }
+    } else if (formData.scorerSource === 'regex') {
+      config.builtin_scorer = 'regex_match';
+      config.regex_pattern = formData.regexPattern;
     } else {
       config.prompt = formData.prompt;
       config.response_schema =
@@ -783,16 +803,16 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
           />
         )}
 
-        {/* Hook and Operation side by side */}
+        {/* Stage and Action side by side */}
         <div css={{ display: 'flex', gap: theme.spacing.md }}>
           <div css={{ flex: 1, display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
             <Typography.Text bold>
-              <FormattedMessage defaultMessage="Hook" description="Guardrail hook label" />
+              <FormattedMessage defaultMessage="Stage" description="Guardrail stage label" />
             </Typography.Text>
             <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
               <FormattedMessage
                 defaultMessage="When the guardrail runs relative to LLM invocation"
-                description="Hook description"
+                description="Stage description"
               />
             </Typography.Text>
             <SimpleSelect
@@ -808,12 +828,12 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
 
           <div css={{ flex: 1, display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
             <Typography.Text bold>
-              <FormattedMessage defaultMessage="Operation" description="Guardrail operation label" />
+              <FormattedMessage defaultMessage="Action" description="Guardrail action label" />
             </Typography.Text>
             <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
               <FormattedMessage
                 defaultMessage="Whether the guardrail blocks or modifies requests"
-                description="Operation description"
+                description="Action description"
               />
             </Typography.Text>
             <SimpleSelect
@@ -822,25 +842,20 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
               value={formData.operation}
               onChange={({ target }) => handleFieldChange('operation', target.value as GuardrailOperation)}
             >
-              <SimpleSelectOption value="VALIDATION">Validation (block)</SimpleSelectOption>
-              <SimpleSelectOption value="MUTATION">Mutation (modify)</SimpleSelectOption>
+              <SimpleSelectOption value="VALIDATION">Block</SimpleSelectOption>
+              <SimpleSelectOption value="MUTATION">Modify</SimpleSelectOption>
             </SimpleSelect>
           </div>
         </div>
 
         {/* Source tabs */}
-        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-          <Typography.Text bold>
-            <FormattedMessage defaultMessage="Judge source" description="Judge source label" />
-          </Typography.Text>
-          <SourceTabs
-            value={formData.scorerSource}
-            onChange={(v) => handleFieldChange('scorerSource', v)}
-          />
-        </div>
+        <SourceTabs
+          value={formData.scorerSource}
+          onChange={(v) => handleFieldChange('scorerSource', v)}
+        />
 
-        {/* Search bar (shown for builtin and registered) */}
-        {formData.scorerSource !== 'custom' && (
+        {/* Search bar (shown for builtin and registered only) */}
+        {(formData.scorerSource === 'builtin' || formData.scorerSource === 'registered') && (
           <Input
             componentId="mlflow.gateway.guardrail-modal.search"
             value={searchQuery}
@@ -878,12 +893,12 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                 <Typography.Text color="secondary">
                   {formData.operation === 'MUTATION' ? (
                     <FormattedMessage
-                      defaultMessage="Guardrails AI validators only support validation (yes/no). Switch to Validation operation or use a custom judge for mutation."
+                      defaultMessage="Catalog guardrails only support Block action. Switch to Block or use LLM Judge / Code tab for Modify."
                       description="No builtin guardrails for mutation operation"
                     />
                   ) : (
                     <FormattedMessage
-                      defaultMessage="No matching builtin guardrails found."
+                      defaultMessage="No matching guardrails found."
                       description="No matching builtin guardrails"
                     />
                   )}
@@ -899,7 +914,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
             {isLoadingScorers ? (
               <div css={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: theme.spacing.sm, padding: theme.spacing.lg }}>
                 <Spinner size="small" />
-                <FormattedMessage defaultMessage="Loading registered judges..." description="Loading registered judges" />
+                <FormattedMessage defaultMessage="Loading registered guardrails..." description="Loading registered guardrails" />
               </div>
             ) : filteredRegistered.length > 0 ? (
               <div
@@ -945,21 +960,21 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                 type="warning"
                 message={intl.formatMessage({
                   defaultMessage:
-                    'No registered judges found. Register a judge first using mlflow.genai.scorers.register_scorer() or make_judge().register().',
-                  description: 'No registered judges message',
+                    'No registered guardrails found. Register one first using mlflow.genai.scorers.register_scorer(), or use the Code tab to see how.',
+                  description: 'No registered guardrails message',
                 })}
               />
             )}
           </>
         )}
 
-        {/* ─── Custom judge (make_judge style) ─── */}
+        {/* ─── LLM Judge (make_judge style) ─── */}
         {formData.scorerSource === 'custom' && (
           <>
-            {/* Custom judge name */}
+            {/* Guardrail name */}
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
               <Typography.Text bold>
-                <FormattedMessage defaultMessage="Judge name" description="Custom judge name label" />
+                <FormattedMessage defaultMessage="Guardrail name" description="LLM judge guardrail name label" />
               </Typography.Text>
               <Input
                 componentId="mlflow.gateway.guardrail-modal.custom-name"
@@ -967,7 +982,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                 onChange={(e) => handleFieldChange('scorerName', e.target.value)}
                 placeholder={intl.formatMessage({
                   defaultMessage: 'e.g., pii-filter, toxicity-check',
-                  description: 'Judge name placeholder',
+                  description: 'Guardrail name placeholder',
                 })}
               />
             </div>
@@ -975,12 +990,12 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
             {/* Instructions prompt */}
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
               <Typography.Text bold>
-                <FormattedMessage defaultMessage="Instructions" description="Custom judge instructions label" />
+                <FormattedMessage defaultMessage="Instructions" description="LLM judge instructions label" />
               </Typography.Text>
               <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
                 <FormattedMessage
-                  defaultMessage="Judge instructions (like make_judge). Use {variable} to reference the {hookType} data."
-                  description="Custom judge instructions description"
+                  defaultMessage="Instructions for the LLM guardrail. Use {variable} to reference the {hookType} data."
+                  description="LLM judge instructions description"
                   values={{
                     variable: <code>{promptHint}</code>,
                     hookType: formData.hook === 'PRE' ? 'input' : 'output',
@@ -1009,8 +1024,8 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                   type="info"
                   message={intl.formatMessage({
                     defaultMessage:
-                      'Validation guardrails expect a yes/no response. "no" means the content is rejected.',
-                    description: 'Validation hint for custom judge guardrails',
+                      'Block guardrails expect a yes/no response. "no" means the content is rejected.',
+                    description: 'Block hint for LLM judge guardrails',
                   })}
                 />
               )}
@@ -1020,8 +1035,8 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                   type="info"
                   message={intl.formatMessage({
                     defaultMessage:
-                      'Mutation guardrails should return the modified content. For pre-invocation, output a ChatRequest. For post-invocation, output a ChatResponse.',
-                    description: 'Mutation hint for custom judge guardrails',
+                      'Modify guardrails should return the modified content. For pre-invocation, output a ChatRequest. For post-invocation, output a ChatResponse.',
+                    description: 'Modify hint for LLM judge guardrails',
                   })}
                 />
               )}
@@ -1033,6 +1048,155 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
               onModelChange={(value) => handleFieldChange('model', value)}
             />
           </>
+        )}
+
+        {/* ─── Regex guardrail ─── */}
+        {formData.scorerSource === 'regex' && (
+          <>
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+              <Typography.Text bold>
+                <FormattedMessage defaultMessage="Guardrail name" description="Regex guardrail name label" />
+              </Typography.Text>
+              <Input
+                componentId="mlflow.gateway.guardrail-modal.regex-name"
+                value={formData.scorerName}
+                onChange={(e) => handleFieldChange('scorerName', e.target.value)}
+                placeholder={intl.formatMessage({
+                  defaultMessage: 'e.g., ssn-detector, pii-regex',
+                  description: 'Regex guardrail name placeholder',
+                })}
+              />
+            </div>
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+              <Typography.Text bold>
+                <FormattedMessage defaultMessage="Regex pattern" description="Regex pattern label" />
+              </Typography.Text>
+              <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                <FormattedMessage
+                  defaultMessage="Python-compatible regular expression. The guardrail blocks requests where a match is found. Powered by the Guardrails AI regex_match validator."
+                  description="Regex pattern description"
+                />
+              </Typography.Text>
+              <Input
+                componentId="mlflow.gateway.guardrail-modal.regex-pattern"
+                value={formData.regexPattern}
+                onChange={(e) => handleFieldChange('regexPattern', e.target.value)}
+                placeholder={intl.formatMessage({
+                  defaultMessage: 'e.g., \\d{3}-\\d{2}-\\d{4}  (SSN pattern)',
+                  description: 'Regex pattern placeholder',
+                })}
+                css={{ fontFamily: 'monospace' }}
+              />
+            </div>
+            <Alert
+              componentId="mlflow.gateway.guardrail-modal.regex-info"
+              type="info"
+              closable={false}
+              message={intl.formatMessage({
+                defaultMessage:
+                  'Common patterns: SSN (\\d{3}-\\d{2}-\\d{4}), email ([\\w.-]+@[\\w.-]+\\.\\w+), credit card (\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4})',
+                description: 'Common regex pattern examples',
+              })}
+            />
+          </>
+        )}
+
+        {/* ─── Code-based guardrail guide ─── */}
+        {formData.scorerSource === 'code' && (
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+            <Alert
+              componentId="mlflow.gateway.guardrail-modal.code-info"
+              type="info"
+              closable={false}
+              message={intl.formatMessage({
+                defaultMessage:
+                  'Code-based guardrails let you write arbitrary Python logic — regex, rule engines, external APIs, etc. Register them with mlflow.genai.scorers.register_scorer(), then find them in the Registered tab.',
+                description: 'Code guardrail guide intro',
+              })}
+            />
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+              <Typography.Text bold>
+                <FormattedMessage defaultMessage="Example: block requests containing SSNs" description="Code guardrail example header" />
+              </Typography.Text>
+              <pre
+                css={{
+                  backgroundColor: theme.colors.backgroundSecondary,
+                  border: `1px solid ${theme.colors.border}`,
+                  borderRadius: theme.borders.borderRadiusMd,
+                  padding: theme.spacing.md,
+                  fontSize: theme.typography.fontSizeSm,
+                  fontFamily: 'monospace',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-all',
+                  margin: 0,
+                  color: theme.colors.textPrimary,
+                }}
+              >{`import re
+import mlflow
+from mlflow.genai.scorers import Scorer
+
+class SSNDetector(Scorer):
+    name = "ssn-detector"
+
+    def score(self, *, inputs, **kwargs):
+        text = str(inputs)
+        found = bool(re.search(r"\\d{3}-\\d{2}-\\d{4}", text))
+        return mlflow.entities.Assessment(
+            name=self.name,
+            value="no" if found else "yes",  # "no" = block
+            rationale="SSN pattern detected" if found else "No SSN found",
+        )
+
+# Register it once — then find it in the Registered tab
+SSNDetector().register()`}</pre>
+            </div>
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+              <Typography.Text bold>
+                <FormattedMessage defaultMessage="Example: redact PII before sending to LLM (Modify)" description="Code guardrail modify example header" />
+              </Typography.Text>
+              <pre
+                css={{
+                  backgroundColor: theme.colors.backgroundSecondary,
+                  border: `1px solid ${theme.colors.border}`,
+                  borderRadius: theme.borders.borderRadiusMd,
+                  padding: theme.spacing.md,
+                  fontSize: theme.typography.fontSizeSm,
+                  fontFamily: 'monospace',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-all',
+                  margin: 0,
+                  color: theme.colors.textPrimary,
+                }}
+              >{`import re
+import copy
+import mlflow
+from mlflow.genai.scorers import Scorer
+
+class PIIRedactor(Scorer):
+    name = "pii-redactor"
+
+    def score(self, *, inputs, **kwargs):
+        # inputs is a ChatRequest dict — redact and return it
+        modified = copy.deepcopy(inputs)
+        for msg in modified.get("messages", []):
+            msg["content"] = re.sub(
+                r"\\d{3}-\\d{2}-\\d{4}", "[REDACTED-SSN]",
+                str(msg.get("content", ""))
+            )
+        return mlflow.entities.Assessment(
+            name=self.name,
+            value=modified,  # return modified ChatRequest
+        )
+
+PIIRedactor().register()`}</pre>
+            </div>
+            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+              <FormattedMessage
+                defaultMessage="After registering, refresh the Registered tab to use your guardrail. See the MLflow docs for more scorer examples."
+                description="Code guardrail footer note"
+              />
+            </Typography.Text>
+          </div>
         )}
 
         {/* ─── Test section ─── */}

--- a/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/AddGuardrailModal.tsx
@@ -18,6 +18,7 @@ import { useAddGuardrail } from '../../hooks/useAddGuardrail';
 import { useUpdateGuardrail } from '../../hooks/useUpdateGuardrail';
 import { GatewayApi } from '../../api';
 import type { Guardrail, GuardrailHook, GuardrailOperation, GuardrailScorerConfig, TestGuardrailResponse } from '../../types';
+import { CodeSnippet, SnippetCopyAction } from '@mlflow/mlflow/src/shared/web-shared/snippet';
 import { EndpointSelector } from '@mlflow/mlflow/src/experiment-tracking/components/EndpointSelector';
 import {
   formatGatewayModelFromEndpoint,
@@ -58,15 +59,18 @@ interface BuiltinJudgeInfo {
   description: string;
   variables: ('inputs' | 'outputs')[];
   emoji: string;
+  operations: ('VALIDATION' | 'MUTATION')[];
 }
 
 const BUILTIN_JUDGES: BuiltinJudgeInfo[] = [
+  // ─── Block (validation) guardrails ─────────────────────────────────
   {
     name: 'ToxicLanguage',
     label: 'Toxic Language',
     description: 'Detects toxic, offensive, or harmful content using NLP models',
     variables: ['inputs', 'outputs'],
     emoji: '\u{1F6AB}',
+    operations: ['VALIDATION'],
   },
   {
     name: 'NSFWText',
@@ -74,6 +78,7 @@ const BUILTIN_JUDGES: BuiltinJudgeInfo[] = [
     description: 'Detects inappropriate or explicit content not suitable for professional settings',
     variables: ['inputs', 'outputs'],
     emoji: '\u{1F6A8}',
+    operations: ['VALIDATION'],
   },
   {
     name: 'DetectJailbreak',
@@ -81,6 +86,7 @@ const BUILTIN_JUDGES: BuiltinJudgeInfo[] = [
     description: 'Detects jailbreak or prompt injection attempts using a BERT-based classifier',
     variables: ['inputs', 'outputs'],
     emoji: '\u{1F6E1}',
+    operations: ['VALIDATION'],
   },
   {
     name: 'DetectPII',
@@ -88,6 +94,7 @@ const BUILTIN_JUDGES: BuiltinJudgeInfo[] = [
     description: 'Detects personally identifiable information (email, phone, names, etc.)',
     variables: ['inputs', 'outputs'],
     emoji: '\u{1F464}',
+    operations: ['VALIDATION'],
   },
   {
     name: 'SecretsPresent',
@@ -95,6 +102,7 @@ const BUILTIN_JUDGES: BuiltinJudgeInfo[] = [
     description: 'Detects API keys, tokens, passwords, or other sensitive credentials',
     variables: ['inputs', 'outputs'],
     emoji: '\u{1F511}',
+    operations: ['VALIDATION'],
   },
   {
     name: 'GibberishText',
@@ -102,14 +110,40 @@ const BUILTIN_JUDGES: BuiltinJudgeInfo[] = [
     description: 'Detects gibberish, incoherent, or nonsensical text in LLM outputs',
     variables: ['inputs', 'outputs'],
     emoji: '\u{1F4AC}',
+    operations: ['VALIDATION'],
+  },
+  // ─── Modify (fix) guardrails ───────────────────────────────────────
+  {
+    name: 'AnonymizePII',
+    label: 'Anonymize PII',
+    description: 'Replaces emails, phone numbers, names, and other PII with anonymized placeholders',
+    variables: ['inputs', 'outputs'],
+    emoji: '\u{1F575}',
+    operations: ['MUTATION'],
+  },
+  {
+    name: 'SanitizeWeb',
+    label: 'Sanitize Web',
+    description: 'Strips script tags, XSS payloads, and dangerous HTML from LLM outputs',
+    variables: ['inputs', 'outputs'],
+    emoji: '\u{1F9F9}',
+    operations: ['MUTATION'],
+  },
+  {
+    name: 'CompetitorFilter',
+    label: 'Competitor Filter',
+    description: 'Removes mentions of specified competitor names from LLM responses',
+    variables: ['inputs', 'outputs'],
+    emoji: '\u{1F6AB}',
+    operations: ['MUTATION'],
   },
 ];
 
 function getCompatibleBuiltins(hook: GuardrailHook, operation: GuardrailOperation): BuiltinJudgeInfo[] {
-  // All GuardrailsScorer subclasses return yes/no → only compatible with VALIDATION
-  if (operation === 'MUTATION') return [];
   const requiredVar = hook === 'PRE' ? 'inputs' : 'outputs';
-  return BUILTIN_JUDGES.filter((j) => j.variables.includes(requiredVar));
+  return BUILTIN_JUDGES.filter(
+    (j) => j.variables.includes(requiredVar) && j.operations.includes(operation),
+  );
 }
 
 // ─── Default prompts for custom judges ──────────────────────────────────────
@@ -447,12 +481,13 @@ interface GuardrailModalProps {
   open: boolean;
   onClose: () => void;
   onSuccess?: () => void;
+  onDelete?: (guardrailId: string) => void;
   endpointName?: string;
   editingGuardrail?: Guardrail | null;
   experimentId?: string;
 }
 
-export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editingGuardrail, experimentId }: GuardrailModalProps) => {
+export const GuardrailModal = ({ open, onClose, onSuccess, onDelete, endpointName, editingGuardrail, experimentId }: GuardrailModalProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const isEditMode = !!editingGuardrail;
@@ -672,10 +707,11 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
         }
         // When hook or operation changes, clear selections that may no longer be compatible
         if (field === 'hook' || field === 'operation') {
-          if (prev.scorerSource === 'builtin') {
-            // Builtins only support VALIDATION; clear selection if switching to MUTATION
+          if (prev.scorerSource === 'builtin' && prev.builtinJudge) {
+            // Clear selection if the current builtin is not compatible with the new operation
             const newOp = (field === 'operation' ? value : next.operation) as GuardrailOperation;
-            if (newOp === 'MUTATION') {
+            const currentJudge = BUILTIN_JUDGES.find((j) => j.name === prev.builtinJudge);
+            if (currentJudge && !currentJudge.operations.includes(newOp)) {
               next.builtinJudge = '';
               next.scorerName = '';
             }
@@ -728,7 +764,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
   }, [formData]);
 
   const handleSubmit = useCallback(async () => {
-    if (!isFormValid) return;
+    if (!isFormValid && !isEditMode) return;
 
     const config: GuardrailScorerConfig = {};
 
@@ -740,6 +776,13 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
       if (scorer) {
         config.experiment_id = scorer.experiment_id;
         config.scorer_version = scorer.scorer_version;
+      }
+      // Preserve editable prompt + model for registered LLM judges
+      if (formData.prompt) {
+        config.prompt = formData.prompt;
+        if (formData.model) {
+          config.model = formData.model;
+        }
       }
     } else if (formData.scorerSource === 'regex') {
       config.builtin_scorer = 'RegexMatch';
@@ -806,6 +849,58 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
 
   const promptHint = formData.hook === 'PRE' ? '{{inputs}}' : '{{outputs}}';
 
+  const epName = endpointName || '<your-endpoint>';
+  const blockExampleCode = `import re
+import requests
+from mlflow.genai.scorers import scorer
+
+@scorer
+def email_detector(inputs) -> bool:
+    """Returns False (block) when an email address is found."""
+    return not bool(re.search(r"[\\w.-]+@[\\w.-]+\\.\\w+", str(inputs)))
+
+# Step 1: Register the scorer
+email_detector.register()
+
+# Step 2: Add it as a guardrail on an endpoint
+MLFLOW_URL = "http://localhost:5000"
+requests.post(f"{MLFLOW_URL}/gateway/guardrails/add", json={
+    "scorer_name": "email_detector",
+    "hook": "PRE",
+    "operation": "VALIDATION",
+    "endpoint_name": "${epName}",
+    "config": {"registered_scorer": "email_detector", "experiment_id": "0"},
+})`;
+
+  const modifyExampleCode = `import re
+import copy
+import requests
+from mlflow.genai.scorers import scorer
+
+@scorer
+def pii_redactor(inputs):
+    """Redacts email addresses from the request before sending to the LLM."""
+    modified = copy.deepcopy(inputs)
+    for msg in modified.get("messages", []):
+        msg["content"] = re.sub(
+            r"[\\w.-]+@[\\w.-]+\\.\\w+", "[REDACTED]",
+            str(msg.get("content", ""))
+        )
+    return modified  # return modified ChatRequest
+
+# Step 1: Register the scorer
+pii_redactor.register()
+
+# Step 2: Add it as a pre-invocation modify guardrail
+MLFLOW_URL = "http://localhost:5000"
+requests.post(f"{MLFLOW_URL}/gateway/guardrails/add", json={
+    "scorer_name": "pii_redactor",
+    "hook": "PRE",
+    "operation": "MUTATION",
+    "endpoint_name": "${epName}",
+    "config": {"registered_scorer": "pii_redactor", "experiment_id": "0"},
+})`;
+
   return (
     <Modal
       componentId="mlflow.gateway.guardrail-modal"
@@ -840,17 +935,174 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
           />
         )}
 
+        {/* ─── EDIT MODE: focused view ─── */}
+        {isEditMode && editingGuardrail && (
+          <>
+            {/* Delete button */}
+            {onDelete && (
+              <Button
+                componentId="mlflow.gateway.guardrail-modal.delete"
+                type="primary"
+                dangerouslySetAntdProps={{ danger: true }}
+                onClick={() => {
+                  onDelete(editingGuardrail.guardrail_id);
+                  handleClose();
+                }}
+                css={{ alignSelf: 'flex-start' }}
+              >
+                <FormattedMessage defaultMessage="Delete guardrail" description="Delete guardrail button" />
+              </Button>
+            )}
+
+            {/* Read-only summary */}
+            <div css={{
+              display: 'flex', flexDirection: 'column', gap: theme.spacing.sm,
+              padding: theme.spacing.md,
+              backgroundColor: theme.colors.backgroundSecondary,
+              borderRadius: theme.borders.borderRadiusMd,
+              border: `1px solid ${theme.colors.border}`,
+            }}>
+              <div css={{ display: 'flex', gap: theme.spacing.lg }}>
+                <div css={{ flex: 1 }}>
+                  <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>Name</Typography.Text>
+                  <Typography.Text bold css={{ display: 'block' }}>{editingGuardrail.scorer_name}</Typography.Text>
+                </div>
+                <div css={{ flex: 1 }}>
+                  <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>When</Typography.Text>
+                  <Typography.Text bold css={{ display: 'block' }}>{editingGuardrail.hook === 'PRE' ? 'Before LLM' : 'After LLM'}</Typography.Text>
+                </div>
+                <div css={{ flex: 1 }}>
+                  <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>Action</Typography.Text>
+                  <Typography.Text bold css={{ display: 'block' }}>{editingGuardrail.operation === 'VALIDATION' ? 'Block' : 'Modify'}</Typography.Text>
+                </div>
+                <div css={{ flex: 1 }}>
+                  <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>Type</Typography.Text>
+                  <Typography.Text bold css={{ display: 'block' }}>
+                    {formData.scorerSource === 'builtin' ? 'Builtin' : formData.scorerSource === 'regex' ? 'Regex' : formData.scorerSource === 'registered' ? 'Registered' : 'LLM Judge'}
+                  </Typography.Text>
+                </div>
+              </div>
+            </div>
+
+            {/* Editable instructions for custom judges */}
+            {formData.scorerSource === 'custom' && (
+              <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                <Typography.Text bold>
+                  <FormattedMessage defaultMessage="Instructions" description="LLM judge instructions label" />
+                </Typography.Text>
+                <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                  <FormattedMessage
+                    defaultMessage="Instructions for the LLM guardrail. Use {variable} to reference the {hookType} data."
+                    description="LLM judge instructions description"
+                    values={{
+                      variable: <code>{promptHint}</code>,
+                      hookType: formData.hook === 'PRE' ? 'input' : 'output',
+                    }}
+                  />
+                </Typography.Text>
+                <textarea
+                  value={formData.prompt}
+                  onChange={(e) => handleFieldChange('prompt', e.target.value)}
+                  rows={6}
+                  css={{
+                    width: '100%',
+                    padding: theme.spacing.sm,
+                    borderRadius: theme.borders.borderRadiusMd,
+                    border: `1px solid ${theme.colors.border}`,
+                    fontFamily: 'monospace',
+                    fontSize: theme.typography.fontSizeSm,
+                    resize: 'vertical',
+                    backgroundColor: theme.colors.backgroundPrimary,
+                    color: theme.colors.textPrimary,
+                  }}
+                />
+                <ModelSelector
+                  model={formData.model}
+                  onModelChange={(value) => handleFieldChange('model', value)}
+                />
+              </div>
+            )}
+
+            {/* Editable regex pattern */}
+            {formData.scorerSource === 'regex' && (
+              <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                <Typography.Text bold>
+                  <FormattedMessage defaultMessage="Pattern" description="Regex pattern label" />
+                </Typography.Text>
+                <Input
+                  componentId="mlflow.gateway.guardrail-modal.edit-regex-pattern"
+                  value={formData.regexPattern}
+                  onChange={(e) => handleFieldChange('regexPattern', e.target.value)}
+                  placeholder="e.g., [\w.-]+@[\w.-]+\.\w+"
+                  css={{ fontFamily: 'monospace' }}
+                />
+              </div>
+            )}
+
+            {/* Registered scorer with prompt — editable instructions */}
+            {formData.scorerSource === 'registered' && formData.prompt && (
+              <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                <Typography.Text bold>
+                  <FormattedMessage defaultMessage="Instructions" description="LLM judge instructions label" />
+                </Typography.Text>
+                <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                  <FormattedMessage
+                    defaultMessage="Instructions for the LLM guardrail. Use {variable} to reference the {hookType} data."
+                    description="LLM judge instructions description"
+                    values={{
+                      variable: <code>{promptHint}</code>,
+                      hookType: formData.hook === 'PRE' ? 'input' : 'output',
+                    }}
+                  />
+                </Typography.Text>
+                <textarea
+                  value={formData.prompt}
+                  onChange={(e) => handleFieldChange('prompt', e.target.value)}
+                  rows={6}
+                  css={{
+                    width: '100%',
+                    padding: theme.spacing.sm,
+                    borderRadius: theme.borders.borderRadiusMd,
+                    border: `1px solid ${theme.colors.border}`,
+                    fontFamily: 'monospace',
+                    fontSize: theme.typography.fontSizeSm,
+                    resize: 'vertical',
+                    backgroundColor: theme.colors.backgroundPrimary,
+                    color: theme.colors.textPrimary,
+                  }}
+                />
+                <ModelSelector
+                  model={formData.model}
+                  onModelChange={(value) => handleFieldChange('model', value)}
+                />
+              </div>
+            )}
+
+            {/* Registered scorer without prompt — code-based, not editable */}
+            {formData.scorerSource === 'registered' && !formData.prompt && (
+              <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                This is a code-based registered scorer. To modify it, re-register with updated code.
+              </Typography.Text>
+            )}
+
+            {/* Builtin — not editable */}
+            {formData.scorerSource === 'builtin' && (
+              <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+                This is a builtin guardrail. Its behavior is pre-configured and cannot be modified.
+              </Typography.Text>
+            )}
+
+          </>
+        )}
+
+        {/* ─── CREATE MODE: full form ─── */}
+        {!isEditMode && (
+          <>
         {/* Stage and Action side by side */}
         <div css={{ display: 'flex', gap: theme.spacing.md }}>
           <div css={{ flex: 1, display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
             <Typography.Text bold>
-              <FormattedMessage defaultMessage="Stage" description="Guardrail stage label" />
-            </Typography.Text>
-            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
-              <FormattedMessage
-                defaultMessage="When the guardrail runs relative to LLM invocation"
-                description="Stage description"
-              />
+              <FormattedMessage defaultMessage="When the guardrail runs" description="Guardrail stage label" />
             </Typography.Text>
             <SimpleSelect
               id="guardrail-hook"
@@ -858,20 +1110,14 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
               value={formData.hook}
               onChange={({ target }) => handleFieldChange('hook', target.value as GuardrailHook)}
             >
-              <SimpleSelectOption value="PRE">Pre-invocation</SimpleSelectOption>
-              <SimpleSelectOption value="POST">Post-invocation</SimpleSelectOption>
+              <SimpleSelectOption value="PRE">Before LLM</SimpleSelectOption>
+              <SimpleSelectOption value="POST">After LLM</SimpleSelectOption>
             </SimpleSelect>
           </div>
 
           <div css={{ flex: 1, display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
             <Typography.Text bold>
               <FormattedMessage defaultMessage="Action" description="Guardrail action label" />
-            </Typography.Text>
-            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
-              <FormattedMessage
-                defaultMessage="Whether the guardrail blocks or modifies requests"
-                description="Action description"
-              />
             </Typography.Text>
             <SimpleSelect
               id="guardrail-operation"
@@ -916,15 +1162,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                   Builtin
                 </Typography.Text>
               </div>
-              {formData.operation === 'MUTATION' ? (
-                <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
-                  <FormattedMessage
-                    defaultMessage="Catalog guardrails only support Block action. Switch to Block or use Create New for Modify."
-                    description="No catalog guardrails for modify"
-                  />
-                </Typography.Text>
-              ) : (
-                <div css={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: theme.spacing.sm }}>
+              <div css={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: theme.spacing.sm }}>
                   {/* Builtin judge cards */}
                   {filteredBuiltins.map((j) => (
                     <GuardrailCard
@@ -940,12 +1178,13 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                       }}
                     />
                   ))}
-                  {/* Regex card — part of Guardrails AI catalog */}
-                  {(!searchQuery.trim() || 'regex match'.includes(searchQuery.toLowerCase())) && (
+                  {/* Regex card — only for Block action */}
+                  {formData.operation === 'VALIDATION' &&
+                    (!searchQuery.trim() || 'regex match'.includes(searchQuery.toLowerCase())) && (
                     <GuardrailCard
                       icon={<span css={{ fontSize: 20, lineHeight: 1 }}>{'🔍'}</span>}
                       label="Regex Match"
-                      description="Block requests or responses matching a regular expression pattern (e.g. SSNs, emails, credit cards)"
+                      description="Block requests or responses matching a regular expression pattern (e.g. emails, credit cards, phone numbers)"
                       selected={formData.scorerSource === 'regex'}
                       tag={<span css={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><GuardrailsAIIcon size={14} /> BUILTIN</span>}
                       onClick={() => handleFieldChange('scorerSource', 'regex')}
@@ -959,7 +1198,6 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                     </div>
                   )}
                 </div>
-              )}
             </div>
 
             {/* Regex config — shown inline when regex card is selected */}
@@ -1034,7 +1272,7 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                 </Typography.Text>
               ) : (
                 <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
-                  No registered guardrails yet. Use <strong>Create New → Code-based</strong> to write and register one.
+                  No registered guardrails yet. Use <strong>Create New</strong> to build an LLM judge or code-based scorer, then register it.
                 </Typography.Text>
               )}
             </div>
@@ -1131,84 +1369,45 @@ export const GuardrailModal = ({ open, onClose, onSuccess, endpointName, editing
                   componentId="mlflow.gateway.guardrail-modal.code-info"
                   type="info"
                   closable={false}
-                  message="Write a Python class, register it with mlflow.genai.scorers.register_scorer(), then find it in Catalog → Registered."
+                  message="Write a Python scorer, register it, then add it as a guardrail — all from code. Run the snippet below to get started."
                 />
                 <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
                   <Typography.Text bold>
-                    <FormattedMessage defaultMessage="Example: block requests containing SSNs" description="Code guardrail example header" />
+                    <FormattedMessage defaultMessage="Example: block requests containing email addresses" description="Code guardrail example header" />
                   </Typography.Text>
-              <pre
-                css={{
-                  backgroundColor: theme.colors.backgroundSecondary,
-                  border: `1px solid ${theme.colors.border}`,
-                  borderRadius: theme.borders.borderRadiusMd,
-                  padding: theme.spacing.md,
-                  fontSize: theme.typography.fontSizeSm,
-                  fontFamily: 'monospace',
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-all',
-                  margin: 0,
-                  color: theme.colors.textPrimary,
-                }}
-              >{`import re
-from mlflow.genai.scorers import scorer
-
-@scorer
-def ssn_detector(inputs) -> bool:
-    """Returns False (block) when an SSN pattern is found."""
-    return not bool(re.search(r"\\d{3}-\\d{2}-\\d{4}", str(inputs)))
-
-# Register it once — then find it in the Registered tab
-ssn_detector.register()`}</pre>
+              <CodeSnippet
+                language="python"
+                theme={theme.isDarkMode ? 'duotoneDark' : 'light'}
+                actions={<SnippetCopyAction componentId="mlflow.gateway.guardrail-modal.copy-block-example" copyText={blockExampleCode} />}
+                wrapLongLines
+                style={{ borderRadius: theme.borders.borderRadiusMd, fontSize: theme.typography.fontSizeSm }}
+              >
+                {blockExampleCode}
+              </CodeSnippet>
             </div>
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
               <Typography.Text bold>
                 <FormattedMessage defaultMessage="Example: redact PII before sending to LLM (Modify)" description="Code guardrail modify example header" />
               </Typography.Text>
-              <pre
-                css={{
-                  backgroundColor: theme.colors.backgroundSecondary,
-                  border: `1px solid ${theme.colors.border}`,
-                  borderRadius: theme.borders.borderRadiusMd,
-                  padding: theme.spacing.md,
-                  fontSize: theme.typography.fontSizeSm,
-                  fontFamily: 'monospace',
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-all',
-                  margin: 0,
-                  color: theme.colors.textPrimary,
-                }}
-              >{`import re
-import copy
-from mlflow.genai.scorers import scorer
-
-@scorer
-def pii_redactor(inputs):
-    """Redacts SSNs from the request before sending to the LLM."""
-    modified = copy.deepcopy(inputs)
-    for msg in modified.get("messages", []):
-        msg["content"] = re.sub(
-            r"\\d{3}-\\d{2}-\\d{4}", "[REDACTED]",
-            str(msg.get("content", ""))
-        )
-    return modified  # return modified ChatRequest
-
-# Register it once — then find it in the Registered tab
-pii_redactor.register()`}</pre>
+              <CodeSnippet
+                language="python"
+                theme={theme.isDarkMode ? 'duotoneDark' : 'light'}
+                actions={<SnippetCopyAction componentId="mlflow.gateway.guardrail-modal.copy-modify-example" copyText={modifyExampleCode} />}
+                wrapLongLines
+                style={{ borderRadius: theme.borders.borderRadiusMd, fontSize: theme.typography.fontSizeSm }}
+              >
+                {modifyExampleCode}
+              </CodeSnippet>
             </div>
-            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
-              <FormattedMessage
-                defaultMessage="After registering, refresh the Registered tab to use your guardrail. See the MLflow docs for more scorer examples."
-                description="Code guardrail footer note"
-              />
-            </Typography.Text>
           </div>
         )}
           </div>
+        )}
+          </>
         )}
 
         {/* ─── Test section ─── */}
-        {isFormValid && (
+        {(isEditMode || isFormValid) && (
           <div
             css={{
               borderTop: `1px solid ${theme.colors.border}`,

--- a/mlflow/server/js/src/gateway/components/guardrails/GuardrailsTabContent.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/GuardrailsTabContent.tsx
@@ -23,7 +23,7 @@ interface GuardrailsTabContentProps {
 
 const OPERATION_LABELS: Record<string, string> = {
   VALIDATION: 'Validation',
-  MUTATION: 'Mutation',
+  MUTATION: 'Modify',
 };
 
 const HOOK_COLORS: Record<string, string> = {
@@ -491,7 +491,7 @@ const GuardrailSection = ({
           >
             <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
               <FormattedMessage
-                defaultMessage="Validation (parallel)"
+                defaultMessage="Block (parallel)"
                 description="Validation sub-header in guardrail section"
               />
             </Typography.Text>
@@ -529,8 +529,8 @@ const GuardrailSection = ({
           >
             <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
               <FormattedMessage
-                defaultMessage="Mutation (sequential)"
-                description="Mutation sub-header in guardrail section"
+                defaultMessage="Modify (sequential)"
+                description="Modify sub-header in guardrail section"
               />
             </Typography.Text>
           </div>

--- a/mlflow/server/js/src/gateway/components/guardrails/GuardrailsTabContent.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/GuardrailsTabContent.tsx
@@ -1,0 +1,591 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import {
+  Alert,
+  Button,
+  Empty,
+  PlusIcon,
+  Spinner,
+  TrashIcon,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { useGuardrailsQuery } from '../../hooks/useGuardrailsQuery';
+import { useRemoveGuardrail } from '../../hooks/useRemoveGuardrail';
+import { useReorderGuardrails } from '../../hooks/useReorderGuardrails';
+import { GuardrailModal } from './AddGuardrailModal';
+import type { Guardrail } from '../../types';
+
+interface GuardrailsTabContentProps {
+  endpointName: string;
+  experimentId?: string;
+}
+
+const OPERATION_LABELS: Record<string, string> = {
+  VALIDATION: 'Validation',
+  MUTATION: 'Mutation',
+};
+
+const HOOK_COLORS: Record<string, string> = {
+  PRE: '#1677ff',
+  POST: '#52c41a',
+};
+
+const OPERATION_COLORS: Record<string, string> = {
+  VALIDATION: '#faad14',
+  MUTATION: '#722ed1',
+};
+
+const Badge = ({ label, color }: { label: string; color: string }) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <span
+      css={{
+        display: 'inline-block',
+        padding: `1px ${theme.spacing.xs}px`,
+        borderRadius: theme.borders.borderRadiusMd,
+        backgroundColor: `${color}18`,
+        color,
+        fontSize: theme.typography.fontSizeSm,
+        fontWeight: theme.typography.typographyBoldFontWeight,
+        border: `1px solid ${color}40`,
+      }}
+    >
+      {label}
+    </span>
+  );
+};
+
+const GuardrailRow = ({
+  guardrail,
+  index,
+  total,
+  onEdit,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+  isRemoving,
+  isReordering,
+  showReorder,
+}: {
+  guardrail: Guardrail;
+  index: number;
+  total: number;
+  onEdit: (guardrail: Guardrail) => void;
+  onRemove: (id: string) => void;
+  onMoveUp: (id: string) => void;
+  onMoveDown: (id: string) => void;
+  isRemoving: boolean;
+  isReordering: boolean;
+  showReorder: boolean;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: theme.spacing.md,
+        borderBottom: `1px solid ${theme.colors.border}`,
+        '&:last-child': { borderBottom: 'none' },
+        '&:hover': { backgroundColor: theme.colors.tableRowHover },
+        cursor: 'pointer',
+      }}
+      onClick={() => onEdit(guardrail)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onEdit(guardrail);
+        }
+      }}
+    >
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.md }}>
+        {/* Order number — only for mutation guardrails where order matters */}
+        {showReorder && (
+          <span
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 24,
+              height: 24,
+              borderRadius: '50%',
+              backgroundColor: theme.colors.actionDefaultBackgroundDefault,
+              color: theme.colors.textSecondary,
+              fontSize: theme.typography.fontSizeSm,
+              fontWeight: theme.typography.typographyBoldFontWeight,
+              flexShrink: 0,
+            }}
+          >
+            {index + 1}
+          </span>
+        )}
+
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+            <Typography.Text bold>{guardrail.scorer_name}</Typography.Text>
+            <Badge
+              label={OPERATION_LABELS[guardrail.operation] ?? guardrail.operation}
+              color={OPERATION_COLORS[guardrail.operation] ?? '#999'}
+            />
+          </div>
+          {guardrail.endpoint_name ? (
+            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+              Endpoint: {guardrail.endpoint_name}
+            </Typography.Text>
+          ) : null}
+        </div>
+      </div>
+
+      <div
+        css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Reorder buttons — only for mutation guardrails */}
+        {showReorder && (
+          <>
+            <Button
+              componentId="mlflow.gateway.guardrails.move-up"
+              size="small"
+              onClick={() => onMoveUp(guardrail.guardrail_id)}
+              disabled={index === 0 || isReordering}
+              css={{ minWidth: 28, padding: '0 4px' }}
+            >
+              {'\u2191'}
+            </Button>
+            <Button
+              componentId="mlflow.gateway.guardrails.move-down"
+              size="small"
+              onClick={() => onMoveDown(guardrail.guardrail_id)}
+              disabled={index === total - 1 || isReordering}
+              css={{ minWidth: 28, padding: '0 4px' }}
+            >
+              {'\u2193'}
+            </Button>
+          </>
+        )}
+
+        <Button
+          componentId="mlflow.gateway.guardrails.remove"
+          icon={<TrashIcon />}
+          onClick={() => onRemove(guardrail.guardrail_id)}
+          loading={isRemoving}
+          danger
+        />
+      </div>
+    </div>
+  );
+};
+
+export const GuardrailsTabContent = ({ endpointName, experimentId }: GuardrailsTabContentProps) => {
+  const { theme } = useDesignSystemTheme();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingGuardrail, setEditingGuardrail] = useState<Guardrail | null>(null);
+  const { data: serverGuardrails, isLoading, error, refetch } = useGuardrailsQuery(endpointName);
+  const { mutateAsync: removeGuardrail } = useRemoveGuardrail();
+  const { mutateAsync: reorderGuardrails, isLoading: isReordering } = useReorderGuardrails();
+  const [removingId, setRemovingId] = useState<string | null>(null);
+
+  // Optimistic local state for guardrails — updated immediately on reorder
+  const [localGuardrails, setLocalGuardrails] = useState<Guardrail[]>(serverGuardrails);
+  const isOptimistic = useRef(false);
+
+  // Sync local state from server when not in an optimistic update
+  useEffect(() => {
+    if (!isOptimistic.current) {
+      setLocalGuardrails(serverGuardrails);
+    }
+  }, [serverGuardrails]);
+
+  const guardrails = localGuardrails;
+
+  const handleRemove = useCallback(
+    async (guardrailId: string) => {
+      setRemovingId(guardrailId);
+      // Optimistically remove from local state
+      setLocalGuardrails((prev) => prev.filter((g) => g.guardrail_id !== guardrailId));
+      try {
+        await removeGuardrail(guardrailId);
+      } finally {
+        setRemovingId(null);
+      }
+    },
+    [removeGuardrail],
+  );
+
+  const handleEdit = useCallback((guardrail: Guardrail) => {
+    setEditingGuardrail(guardrail);
+    setIsModalOpen(true);
+  }, []);
+
+  const handleAdd = useCallback(() => {
+    setEditingGuardrail(null);
+    setIsModalOpen(true);
+  }, []);
+
+  const handleModalClose = useCallback(() => {
+    setIsModalOpen(false);
+    setEditingGuardrail(null);
+  }, []);
+
+  // Separate pre/post, sort: VALIDATION first (parallel), then MUTATION (sequential, order matters)
+  const sortByOperation = (list: Guardrail[]) =>
+    [...list].sort((a, b) => {
+      if (a.operation === b.operation) return 0;
+      return a.operation === 'VALIDATION' ? -1 : 1;
+    });
+
+  const preGuardrails = useMemo(() => sortByOperation(guardrails.filter((g) => g.hook === 'PRE')), [guardrails]);
+  const postGuardrails = useMemo(() => sortByOperation(guardrails.filter((g) => g.hook === 'POST')), [guardrails]);
+
+  // Only mutation guardrails within a hook section can be reordered
+  const handleMoveMutation = useCallback(
+    async (hook: 'PRE' | 'POST', id: string, direction: 'up' | 'down') => {
+      const hookList = hook === 'PRE' ? preGuardrails : postGuardrails;
+      const mutationOnly = hookList.filter((g) => g.operation === 'MUTATION');
+      const idx = mutationOnly.findIndex((g) => g.guardrail_id === id);
+      if (idx < 0) return;
+      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+      if (swapIdx < 0 || swapIdx >= mutationOnly.length) return;
+
+      const reordered = [...mutationOnly];
+      [reordered[idx], reordered[swapIdx]] = [reordered[swapIdx], reordered[idx]];
+
+      // Optimistically update local state immediately
+      isOptimistic.current = true;
+      setLocalGuardrails((prev) => {
+        const updated = [...prev];
+        const aIdx = updated.findIndex((g) => g.guardrail_id === reordered[idx]?.guardrail_id);
+        const bIdx = updated.findIndex((g) => g.guardrail_id === reordered[swapIdx]?.guardrail_id);
+        if (aIdx >= 0 && bIdx >= 0) {
+          [updated[aIdx], updated[bIdx]] = [updated[bIdx], updated[aIdx]];
+        }
+        return updated;
+      });
+
+      try {
+        await reorderGuardrails(reordered.map((g) => g.guardrail_id));
+      } catch {
+        setLocalGuardrails(serverGuardrails);
+      } finally {
+        isOptimistic.current = false;
+      }
+    },
+    [reorderGuardrails, serverGuardrails, preGuardrails, postGuardrails],
+  );
+
+  const handleMoveUpPre = useCallback((id: string) => handleMoveMutation('PRE', id, 'up'), [handleMoveMutation]);
+  const handleMoveDownPre = useCallback((id: string) => handleMoveMutation('PRE', id, 'down'), [handleMoveMutation]);
+  const handleMoveUpPost = useCallback((id: string) => handleMoveMutation('POST', id, 'up'), [handleMoveMutation]);
+  const handleMoveDownPost = useCallback((id: string) => handleMoveMutation('POST', id, 'down'), [handleMoveMutation]);
+
+  if (isLoading) {
+    return (
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm, padding: theme.spacing.md }}>
+        <Spinner size="small" />
+        <FormattedMessage defaultMessage="Loading guardrails..." description="Loading guardrails" />
+      </div>
+    );
+  }
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
+      {error && (
+        <Alert
+          componentId="mlflow.gateway.guardrails.error"
+          type="error"
+          message={error.message}
+          closable={false}
+        />
+      )}
+
+      {/* Header with add button */}
+      <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <Typography.Title level={3}>
+            <FormattedMessage defaultMessage="Guardrails" description="Guardrails section title" />
+          </Typography.Title>
+          <Typography.Text color="secondary">
+            <FormattedMessage
+              defaultMessage="Configure safety guardrails that run before or after LLM invocation to validate or modify requests and responses."
+              description="Guardrails section description"
+            />
+          </Typography.Text>
+        </div>
+        <Button
+          componentId="mlflow.gateway.guardrails.add"
+          type="primary"
+          icon={<PlusIcon />}
+          onClick={handleAdd}
+        >
+          <FormattedMessage defaultMessage="Add guardrail" description="Add guardrail button" />
+        </Button>
+      </div>
+
+      {guardrails.length === 0 ? (
+        <div
+          css={{
+            padding: theme.spacing.lg,
+            border: `2px dashed ${theme.colors.actionDefaultBorderDefault}`,
+            borderRadius: theme.borders.borderRadiusMd,
+            textAlign: 'center',
+          }}
+        >
+          <Empty
+            description={
+              <FormattedMessage
+                defaultMessage="No guardrails configured. Add a guardrail to protect your LLM endpoint."
+                description="Empty state for guardrails"
+              />
+            }
+          />
+        </div>
+      ) : (
+        <>
+          {/* Execution flow diagram */}
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+              padding: theme.spacing.md,
+              backgroundColor: theme.colors.backgroundSecondary,
+              borderRadius: theme.borders.borderRadiusMd,
+              border: `1px solid ${theme.colors.border}`,
+              justifyContent: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <FlowStep label="Request" active={false} />
+            <FlowArrow />
+            <FlowStep label={`Pre Guardrails (${preGuardrails.length})`} active={preGuardrails.length > 0} color={HOOK_COLORS['PRE']} />
+            <FlowArrow />
+            <FlowStep label="LLM" active />
+            <FlowArrow />
+            <FlowStep
+              label={`Post Guardrails (${postGuardrails.length})`}
+              active={postGuardrails.length > 0}
+              color={HOOK_COLORS['POST']}
+            />
+            <FlowArrow />
+            <FlowStep label="Response" active={false} />
+          </div>
+
+          {/* Pre-invocation guardrails */}
+          {preGuardrails.length > 0 && (
+            <GuardrailSection
+              title="Pre-invocation"
+              count={preGuardrails.length}
+              color={HOOK_COLORS['PRE']}
+              guardrails={preGuardrails}
+              onEdit={handleEdit}
+              onRemove={handleRemove}
+              onMoveUp={handleMoveUpPre}
+              onMoveDown={handleMoveDownPre}
+              removingId={removingId}
+              isReordering={isReordering}
+            />
+          )}
+
+          {/* Post-invocation guardrails */}
+          {postGuardrails.length > 0 && (
+            <GuardrailSection
+              title="Post-invocation"
+              count={postGuardrails.length}
+              color={HOOK_COLORS['POST']}
+              guardrails={postGuardrails}
+              onEdit={handleEdit}
+              onRemove={handleRemove}
+              onMoveUp={handleMoveUpPost}
+              onMoveDown={handleMoveDownPost}
+              removingId={removingId}
+              isReordering={isReordering}
+            />
+          )}
+        </>
+      )}
+
+      <GuardrailModal
+        open={isModalOpen}
+        onClose={handleModalClose}
+        onSuccess={() => refetch()}
+        endpointName={endpointName}
+        editingGuardrail={editingGuardrail}
+        experimentId={experimentId}
+      />
+    </div>
+  );
+};
+
+// ─── Guardrail section ──────────────────────────────────────────────────────
+
+const GuardrailSection = ({
+  title,
+  count,
+  color,
+  guardrails,
+  onEdit,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+  removingId,
+  isReordering,
+}: {
+  title: string;
+  count: number;
+  color: string;
+  guardrails: Guardrail[];
+  onEdit: (guardrail: Guardrail) => void;
+  onRemove: (id: string) => void;
+  onMoveUp: (id: string) => void;
+  onMoveDown: (id: string) => void;
+  removingId: string | null;
+  isReordering: boolean;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  const validationGuardrails = guardrails.filter((g) => g.operation === 'VALIDATION');
+  const mutationGuardrails = guardrails.filter((g) => g.operation === 'MUTATION');
+
+  return (
+    <div
+      css={{
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        backgroundColor: theme.colors.backgroundSecondary,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        css={{
+          padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+          borderBottom: `1px solid ${theme.colors.border}`,
+          backgroundColor: `${color}08`,
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.sm,
+        }}
+      >
+        <Badge label={title} color={color} />
+        <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+          {count} {count === 1 ? 'guardrail' : 'guardrails'}
+        </Typography.Text>
+      </div>
+
+      {/* Validation guardrails — run in parallel, no ordering */}
+      {validationGuardrails.length > 0 && (
+        <>
+          <div
+            css={{
+              padding: `${theme.spacing.xs}px ${theme.spacing.md}px`,
+              borderBottom: `1px solid ${theme.colors.border}`,
+              backgroundColor: `${OPERATION_COLORS['VALIDATION']}08`,
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+            }}
+          >
+            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+              <FormattedMessage
+                defaultMessage="Validation (parallel)"
+                description="Validation sub-header in guardrail section"
+              />
+            </Typography.Text>
+          </div>
+          {validationGuardrails.map((g, i) => (
+            <GuardrailRow
+              key={g.guardrail_id}
+              guardrail={g}
+              index={i}
+              total={validationGuardrails.length}
+              onEdit={onEdit}
+              onRemove={onRemove}
+              onMoveUp={onMoveUp}
+              onMoveDown={onMoveDown}
+              isRemoving={removingId === g.guardrail_id}
+              isReordering={isReordering}
+              showReorder={false}
+            />
+          ))}
+        </>
+      )}
+
+      {/* Mutation guardrails — run sequentially, order matters */}
+      {mutationGuardrails.length > 0 && (
+        <>
+          <div
+            css={{
+              padding: `${theme.spacing.xs}px ${theme.spacing.md}px`,
+              borderBottom: `1px solid ${theme.colors.border}`,
+              backgroundColor: `${OPERATION_COLORS['MUTATION']}08`,
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+            }}
+          >
+            <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+              <FormattedMessage
+                defaultMessage="Mutation (sequential)"
+                description="Mutation sub-header in guardrail section"
+              />
+            </Typography.Text>
+          </div>
+          {mutationGuardrails.map((g, i) => (
+            <GuardrailRow
+              key={g.guardrail_id}
+              guardrail={g}
+              index={i}
+              total={mutationGuardrails.length}
+              onEdit={onEdit}
+              onRemove={onRemove}
+              onMoveUp={onMoveUp}
+              onMoveDown={onMoveDown}
+              isRemoving={removingId === g.guardrail_id}
+              isReordering={isReordering}
+              showReorder
+            />
+          ))}
+        </>
+      )}
+    </div>
+  );
+};
+
+// ─── Flow diagram helper components ─────────────────────────────────────────
+
+const FlowStep = ({ label, active, color }: { label: string; active: boolean; color?: string }) => {
+  const { theme } = useDesignSystemTheme();
+  const bgColor = active ? (color ? `${color}18` : theme.colors.actionPrimaryBackgroundDefault + '18') : 'transparent';
+  const borderColor = active ? (color ?? theme.colors.actionPrimaryBackgroundDefault) : theme.colors.border;
+  const textColor = active ? (color ?? theme.colors.textPrimary) : theme.colors.textSecondary;
+
+  return (
+    <div
+      css={{
+        padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+        borderRadius: theme.borders.borderRadiusMd,
+        border: `1px solid ${borderColor}`,
+        backgroundColor: bgColor,
+        color: textColor,
+        fontSize: theme.typography.fontSizeSm,
+        fontWeight: active ? theme.typography.typographyBoldFontWeight : 'normal',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {label}
+    </div>
+  );
+};
+
+const FlowArrow = () => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <span css={{ color: theme.colors.textSecondary, fontSize: theme.typography.fontSizeSm }}>
+      {'\u2192'}
+    </span>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/guardrails/GuardrailsTabContent.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/GuardrailsTabContent.tsx
@@ -375,8 +375,8 @@ export const GuardrailsTabContent = ({ endpointName, experimentId }: GuardrailsT
             <FlowStep label="Response" active={false} />
           </div>
 
-          {/* Pre-invocation guardrails */}
-          {preGuardrails.length > 0 && (
+          {/* Pre/Post guardrails side by side */}
+          <div css={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: theme.spacing.md }}>
             <GuardrailSection
               title="Pre-invocation"
               count={preGuardrails.length}
@@ -389,10 +389,6 @@ export const GuardrailsTabContent = ({ endpointName, experimentId }: GuardrailsT
               removingId={removingId}
               isReordering={isReordering}
             />
-          )}
-
-          {/* Post-invocation guardrails */}
-          {postGuardrails.length > 0 && (
             <GuardrailSection
               title="Post-invocation"
               count={postGuardrails.length}
@@ -405,7 +401,7 @@ export const GuardrailsTabContent = ({ endpointName, experimentId }: GuardrailsT
               removingId={removingId}
               isReordering={isReordering}
             />
-          )}
+          </div>
         </>
       )}
 
@@ -475,6 +471,14 @@ const GuardrailSection = ({
           {count} {count === 1 ? 'guardrail' : 'guardrails'}
         </Typography.Text>
       </div>
+
+      {guardrails.length === 0 && (
+        <div css={{ padding: theme.spacing.md }}>
+          <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+            <FormattedMessage defaultMessage="No guardrails configured." description="Empty guardrail section" />
+          </Typography.Text>
+        </div>
+      )}
 
       {/* Validation guardrails — run in parallel, no ordering */}
       {validationGuardrails.length > 0 && (

--- a/mlflow/server/js/src/gateway/components/guardrails/GuardrailsTabContent.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/GuardrailsTabContent.tsx
@@ -409,6 +409,10 @@ export const GuardrailsTabContent = ({ endpointName, experimentId }: GuardrailsT
         open={isModalOpen}
         onClose={handleModalClose}
         onSuccess={() => refetch()}
+        onDelete={(guardrailId) => {
+          handleRemove(guardrailId);
+          handleModalClose();
+        }}
         endpointName={endpointName}
         editingGuardrail={editingGuardrail}
         experimentId={experimentId}

--- a/mlflow/server/js/src/gateway/components/guardrails/TestGuardrailModal.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/TestGuardrailModal.tsx
@@ -455,6 +455,7 @@ export const TestGuardrailModal = ({ open, onClose, guardrail, experimentId }: T
               />
             </Typography.Text>
             <Input.TextArea
+              componentId="mlflow.guardrails.test-modal.manual-input"
               value={manualText}
               onChange={(e) => setManualText(e.target.value)}
               rows={4}

--- a/mlflow/server/js/src/gateway/components/guardrails/TestGuardrailModal.tsx
+++ b/mlflow/server/js/src/gateway/components/guardrails/TestGuardrailModal.tsx
@@ -1,0 +1,593 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  Alert,
+  Button,
+  Input,
+  Modal,
+  Spinner,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { fetchOrFail, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { GatewayApi } from '../../api';
+import type { Guardrail, TestGuardrailResponse } from '../../types';
+
+interface TraceEntry {
+  trace_id: string;
+  request_preview?: string;
+  response_preview?: string;
+  request_time?: string;
+  state?: string;
+}
+
+interface RegisteredScorerEntry {
+  scorer_name: string;
+  scorer_version: number;
+  experiment_id: string;
+  serialized_scorer: string;
+}
+
+interface TestGuardrailModalProps {
+  open: boolean;
+  onClose: () => void;
+  guardrail: Guardrail;
+  experimentId?: string;
+}
+
+type InputMode = 'trace' | 'manual';
+
+// Job status polling interval
+const JOB_POLL_INTERVAL = 1500;
+
+interface ScorerInvokeResult {
+  score: string | null;
+  rationale: string | null;
+}
+
+export const TestGuardrailModal = ({ open, onClose, guardrail, experimentId }: TestGuardrailModalProps) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const [inputMode, setInputMode] = useState<InputMode>(experimentId ? 'trace' : 'manual');
+  const [manualText, setManualText] = useState('');
+  const [traces, setTraces] = useState<TraceEntry[]>([]);
+  const [tracesLoading, setTracesLoading] = useState(false);
+  const [tracesError, setTracesError] = useState<string | null>(null);
+  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<TestGuardrailResponse | null>(null);
+  const [invokeResult, setInvokeResult] = useState<ScorerInvokeResult | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testError, setTestError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Fetch traces from the endpoint's experiment
+  useEffect(() => {
+    if (!open || !experimentId) return;
+
+    const fetchTraces = async () => {
+      setTracesLoading(true);
+      setTracesError(null);
+      try {
+        const res = await fetchOrFail(getAjaxUrl('ajax-api/3.0/mlflow/traces/search'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            locations: [{ type: 'MLFLOW_EXPERIMENT', mlflow_experiment: { experiment_id: experimentId } }],
+            max_results: 20,
+            order_by: ['timestamp_ms DESC'],
+          }),
+        });
+        const data = (await res.json()) as { traces?: TraceEntry[] };
+        setTraces(data.traces ?? []);
+      } catch (e: any) {
+        setTracesError(e.message || 'Failed to load traces');
+      } finally {
+        setTracesLoading(false);
+      }
+    };
+
+    fetchTraces();
+  }, [open, experimentId]);
+
+  // Reset state when modal opens/closes
+  useEffect(() => {
+    if (open) {
+      setTestResult(null);
+      setInvokeResult(null);
+      setTestError(null);
+      setSelectedTraceId(null);
+      setManualText('');
+      setInputMode(experimentId ? 'trace' : 'manual');
+    }
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [open, experimentId]);
+
+  /**
+   * Look up the serialized_scorer for this guardrail from the registered scorers list.
+   * Returns null for builtin guardrails (which don't have a serialized_scorer).
+   */
+  const getSerializedScorer = useCallback(async (): Promise<string | null> => {
+    const config = guardrail.config;
+    if (!config?.registered_scorer) return null;
+
+    try {
+      const expId = config.experiment_id ?? '0';
+      const res = await fetchOrFail(getAjaxUrl(`ajax-api/3.0/mlflow/scorers/list?experiment_id=${expId}`));
+      const data = (await res.json()) as { scorers?: RegisteredScorerEntry[] };
+      const scorer = (data.scorers ?? []).find(
+        (s) =>
+          s.scorer_name === config.registered_scorer &&
+          (config.scorer_version == null || s.scorer_version === config.scorer_version),
+      );
+      return scorer?.serialized_scorer ?? null;
+    } catch {
+      return null;
+    }
+  }, [guardrail]);
+
+  /**
+   * Poll for job completion and fetch the assessment result from the trace.
+   */
+  const pollForJobResult = useCallback(
+    async (jobIds: string[], traceId: string) => {
+      return new Promise<ScorerInvokeResult>((resolve, reject) => {
+        const poll = async () => {
+          try {
+            const res = await fetchOrFail(getAjaxUrl('ajax-api/3.0/mlflow/jobs/get'), {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ job_id: jobIds[0] }),
+            });
+            const data = (await res.json()) as { job?: { status: string; error?: string } };
+            const status = data.job?.status;
+
+            if (status === 'SUCCEEDED') {
+              if (pollRef.current) clearInterval(pollRef.current);
+              // Fetch the updated trace to get the assessment
+              try {
+                const traceRes = await fetchOrFail(getAjaxUrl(`ajax-api/3.0/mlflow/traces/${traceId}`));
+                const traceData = (await traceRes.json()) as {
+                  trace_info?: { assessments?: { value?: any; rationale?: string; name?: string }[] };
+                };
+                const assessments = traceData.trace_info?.assessments ?? [];
+                // Get the latest assessment (last one added)
+                const latest = assessments[assessments.length - 1];
+                resolve({
+                  score: latest?.value != null ? String(latest.value) : null,
+                  rationale: latest?.rationale ?? null,
+                });
+              } catch {
+                resolve({ score: 'done', rationale: 'Scorer completed. Check trace for results.' });
+              }
+            } else if (status === 'FAILED') {
+              if (pollRef.current) clearInterval(pollRef.current);
+              reject(new Error(data.job?.error || 'Scorer job failed'));
+            }
+            // Otherwise keep polling (PENDING, RUNNING)
+          } catch (e: any) {
+            if (pollRef.current) clearInterval(pollRef.current);
+            reject(e);
+          }
+        };
+
+        pollRef.current = setInterval(poll, JOB_POLL_INTERVAL);
+        poll(); // Run immediately
+      });
+    },
+    [],
+  );
+
+  /**
+   * Run test via /mlflow/scorer/invoke for registered scorers on traces,
+   * or fall back to /gateway/guardrails/test for builtins or manual input.
+   */
+  const handleTest = useCallback(async () => {
+    setTesting(true);
+    setTestResult(null);
+    setInvokeResult(null);
+    setTestError(null);
+    if (pollRef.current) clearInterval(pollRef.current);
+
+    try {
+      // For trace mode with a registered scorer, use /mlflow/scorer/invoke
+      if (inputMode === 'trace' && selectedTraceId && experimentId) {
+        const serializedScorer = await getSerializedScorer();
+
+        if (serializedScorer) {
+          // Use the scorer invoke endpoint
+          const invokeRes = await fetchOrFail(getAjaxUrl('ajax-api/3.0/mlflow/scorer/invoke'), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              experiment_id: experimentId,
+              serialized_scorer: serializedScorer,
+              trace_ids: [selectedTraceId],
+              log_assessments: true,
+            }),
+          });
+          const invokeData = (await invokeRes.json()) as { jobs?: { job_id: string }[] };
+          const jobIds = (invokeData.jobs ?? []).map((j) => j.job_id);
+
+          if (jobIds.length === 0) {
+            setTestError('No scorer job was created.');
+            setTesting(false);
+            return;
+          }
+
+          // Poll for result
+          const result = await pollForJobResult(jobIds, selectedTraceId);
+          setInvokeResult(result);
+          setTesting(false);
+          return;
+        }
+
+        // Fall back to /gateway/guardrails/test for builtin scorers
+        const result = await GatewayApi.testGuardrail({
+          guardrail_id: guardrail.guardrail_id,
+          trace_id: selectedTraceId,
+          experiment_id: experimentId,
+        });
+        setTestResult(result);
+      } else if (inputMode === 'manual' && manualText) {
+        // Manual text always goes through our /test endpoint
+        const result = await GatewayApi.testGuardrail({
+          guardrail_id: guardrail.guardrail_id,
+          text: manualText,
+        });
+        setTestResult(result);
+      } else {
+        setTestError('Please provide text or select a trace to test against.');
+      }
+    } catch (e: any) {
+      setTestError(e.message || 'Test failed');
+    } finally {
+      setTesting(false);
+    }
+  }, [guardrail, inputMode, selectedTraceId, experimentId, manualText, getSerializedScorer, pollForJobResult]);
+
+  // Determine result state from either path
+  const resultScore = testResult?.result?.score ?? invokeResult?.score;
+  const resultRationale = testResult?.result?.rationale ?? invokeResult?.rationale;
+  const hasResult = testResult != null || invokeResult != null;
+  const isPassed = resultScore === 'yes';
+
+  return (
+    <Modal
+      componentId="mlflow.gateway.guardrails.test-modal"
+      visible={open}
+      onCancel={onClose}
+      title={intl.formatMessage(
+        {
+          defaultMessage: 'Test guardrail: {name}',
+          description: 'Title for test guardrail modal',
+        },
+        { name: guardrail.scorer_name },
+      )}
+      footer={
+        <div css={{ display: 'flex', justifyContent: 'flex-end', gap: theme.spacing.sm }}>
+          <Button componentId="mlflow.gateway.guardrails.test-cancel" onClick={onClose}>
+            <FormattedMessage defaultMessage="Close" description="Close button for test guardrail modal" />
+          </Button>
+          <Button
+            componentId="mlflow.gateway.guardrails.test-run"
+            type="primary"
+            onClick={handleTest}
+            loading={testing}
+            disabled={inputMode === 'trace' ? !selectedTraceId : !manualText}
+          >
+            <FormattedMessage defaultMessage="Run test" description="Run test button" />
+          </Button>
+        </div>
+      }
+    >
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+        {/* Info about which hook this guardrail uses */}
+        <Alert
+          componentId="mlflow.gateway.guardrails.test-info"
+          type="info"
+          closable={false}
+          message={intl.formatMessage(
+            {
+              defaultMessage:
+                'This is a {hook}-invocation {operation} guardrail. It will test against {dataSource}.',
+              description: 'Info about guardrail test behavior',
+            },
+            {
+              hook: guardrail.hook === 'PRE' ? 'pre' : 'post',
+              operation: guardrail.operation.toLowerCase(),
+              dataSource: guardrail.hook === 'PRE' ? 'request input' : 'response output',
+            },
+          )}
+        />
+
+        {/* Input mode tabs */}
+        {experimentId && (
+          <div css={{ display: 'flex', gap: theme.spacing.xs }}>
+            <Button
+              componentId="mlflow.gateway.guardrails.test-mode-trace"
+              type={inputMode === 'trace' ? 'primary' : undefined}
+              size="small"
+              onClick={() => setInputMode('trace')}
+            >
+              <FormattedMessage defaultMessage="Pick from traces" description="Tab to pick a trace" />
+            </Button>
+            <Button
+              componentId="mlflow.gateway.guardrails.test-mode-manual"
+              type={inputMode === 'manual' ? 'primary' : undefined}
+              size="small"
+              onClick={() => setInputMode('manual')}
+            >
+              <FormattedMessage defaultMessage="Manual input" description="Tab for manual text input" />
+            </Button>
+          </div>
+        )}
+
+        {/* Trace picker */}
+        {inputMode === 'trace' && experimentId && (
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+            <Typography.Text bold>
+              <FormattedMessage
+                defaultMessage="Select a trace"
+                description="Label for trace selection in test modal"
+              />
+            </Typography.Text>
+
+            {tracesLoading && (
+              <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+                <Spinner size="small" />
+                <FormattedMessage defaultMessage="Loading traces..." description="Loading traces" />
+              </div>
+            )}
+
+            {tracesError && (
+              <Alert
+                componentId="mlflow.gateway.guardrails.test-traces-error"
+                type="error"
+                closable={false}
+                message={tracesError}
+              />
+            )}
+
+            {!tracesLoading && traces.length === 0 && !tracesError && (
+              <Typography.Text color="secondary">
+                <FormattedMessage
+                  defaultMessage="No traces found for this endpoint. Try sending some requests first, or use manual input."
+                  description="No traces found message"
+                />
+              </Typography.Text>
+            )}
+
+            {!tracesLoading && traces.length > 0 && (
+              <div
+                css={{
+                  maxHeight: 280,
+                  overflowY: 'auto',
+                  border: `1px solid ${theme.colors.border}`,
+                  borderRadius: theme.borders.borderRadiusMd,
+                }}
+              >
+                {traces.map((trace) => {
+                  const isSelected = selectedTraceId === trace.trace_id;
+                  const preview =
+                    guardrail.hook === 'PRE'
+                      ? trace.request_preview
+                      : trace.response_preview;
+
+                  return (
+                    <div
+                      key={trace.trace_id}
+                      css={{
+                        padding: theme.spacing.sm,
+                        borderBottom: `1px solid ${theme.colors.border}`,
+                        cursor: 'pointer',
+                        backgroundColor: isSelected ? `${theme.colors.actionPrimaryBackgroundDefault}12` : 'transparent',
+                        border: isSelected ? `2px solid ${theme.colors.actionPrimaryBackgroundDefault}` : '2px solid transparent',
+                        borderRadius: theme.borders.borderRadiusMd,
+                        '&:hover': { backgroundColor: theme.colors.tableRowHover },
+                        '&:last-child': { borderBottom: 'none' },
+                      }}
+                      onClick={() => setSelectedTraceId(trace.trace_id)}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setSelectedTraceId(trace.trace_id);
+                        }
+                      }}
+                    >
+                      <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 2 }}>
+                        <Typography.Text
+                          css={{ fontSize: theme.typography.fontSizeSm, fontFamily: 'monospace' }}
+                        >
+                          {trace.trace_id.substring(0, 12)}...
+                        </Typography.Text>
+                        {trace.state && (
+                          <span
+                            css={{
+                              fontSize: 11,
+                              padding: '1px 6px',
+                              borderRadius: 4,
+                              backgroundColor: trace.state === 'OK' ? '#52c41a20' : '#ff4d4f20',
+                              color: trace.state === 'OK' ? '#52c41a' : '#ff4d4f',
+                              fontWeight: 600,
+                            }}
+                          >
+                            {trace.state}
+                          </span>
+                        )}
+                      </div>
+                      <Typography.Text
+                        color="secondary"
+                        css={{
+                          fontSize: theme.typography.fontSizeSm,
+                          display: '-webkit-box',
+                          WebkitLineClamp: 2,
+                          WebkitBoxOrient: 'vertical',
+                          overflow: 'hidden',
+                          wordBreak: 'break-word',
+                        }}
+                      >
+                        {preview
+                          ? preview.length > 150
+                            ? `${preview.substring(0, 150)}...`
+                            : preview
+                          : '(no preview)'}
+                      </Typography.Text>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Manual input */}
+        {inputMode === 'manual' && (
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+            <Typography.Text bold>
+              <FormattedMessage
+                defaultMessage="Enter text to test"
+                description="Label for manual text input in test modal"
+              />
+            </Typography.Text>
+            <Input.TextArea
+              value={manualText}
+              onChange={(e) => setManualText(e.target.value)}
+              rows={4}
+              placeholder={intl.formatMessage({
+                defaultMessage: 'Enter the text you want to test the guardrail against...',
+                description: 'Placeholder for manual test input',
+              })}
+            />
+          </div>
+        )}
+
+        {/* Test result */}
+        {testError && (
+          <Alert
+            componentId="mlflow.gateway.guardrails.test-error"
+            type="error"
+            closable={false}
+            message={testError}
+          />
+        )}
+
+        {hasResult && (
+          <div
+            css={{
+              border: `2px solid ${isPassed ? '#52c41a' : '#ff4d4f'}`,
+              borderRadius: theme.borders.borderRadiusMd,
+              overflow: 'hidden',
+            }}
+          >
+            {/* Result header */}
+            <div
+              css={{
+                padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+                backgroundColor: isPassed ? '#52c41a12' : '#ff4d4f12',
+                display: 'flex',
+                alignItems: 'center',
+                gap: theme.spacing.sm,
+                borderBottom: `1px solid ${isPassed ? '#52c41a40' : '#ff4d4f40'}`,
+              }}
+            >
+              <span css={{ fontSize: 20 }}>{isPassed ? '\u2705' : '\u274C'}</span>
+              <Typography.Title level={4} css={{ margin: '0 !important' }}>
+                {isPassed ? (
+                  <FormattedMessage defaultMessage="Passed" description="Test passed label" />
+                ) : (
+                  <FormattedMessage defaultMessage="Failed" description="Test failed label" />
+                )}
+              </Typography.Title>
+              {resultScore && (
+                <span
+                  css={{
+                    marginLeft: 'auto',
+                    fontSize: theme.typography.fontSizeSm,
+                    padding: '2px 8px',
+                    borderRadius: 4,
+                    backgroundColor: isPassed ? '#52c41a20' : '#ff4d4f20',
+                    color: isPassed ? '#52c41a' : '#ff4d4f',
+                    fontWeight: 600,
+                  }}
+                >
+                  score: {resultScore}
+                </span>
+              )}
+            </div>
+
+            {/* Rationale */}
+            <div css={{ padding: theme.spacing.md }}>
+              {resultRationale && (
+                <>
+                  <Typography.Text bold css={{ display: 'block', marginBottom: theme.spacing.xs }}>
+                    <FormattedMessage defaultMessage="Rationale" description="Rationale label in test result" />
+                  </Typography.Text>
+                  <Typography.Text css={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                    {resultRationale}
+                  </Typography.Text>
+                </>
+              )}
+
+              {/* Input text used (only from /gateway/guardrails/test) */}
+              {testResult?.input_text && (
+                <>
+                  <Typography.Text bold css={{ display: 'block', marginTop: theme.spacing.md, marginBottom: theme.spacing.xs }}>
+                    <FormattedMessage defaultMessage="Tested against" description="Input text label in test result" />
+                  </Typography.Text>
+                  <div
+                    css={{
+                      padding: theme.spacing.sm,
+                      backgroundColor: theme.colors.backgroundSecondary,
+                      borderRadius: theme.borders.borderRadiusMd,
+                      border: `1px solid ${theme.colors.border}`,
+                      maxHeight: 120,
+                      overflowY: 'auto',
+                      fontSize: theme.typography.fontSizeSm,
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                      fontFamily: 'monospace',
+                    }}
+                  >
+                    {testResult.input_text.length > 500
+                      ? `${testResult.input_text.substring(0, 500)}...`
+                      : testResult.input_text}
+                  </div>
+                </>
+              )}
+
+              {/* Modified text for mutation guardrails */}
+              {testResult?.result?.modified_text && (
+                <>
+                  <Typography.Text bold css={{ display: 'block', marginTop: theme.spacing.md, marginBottom: theme.spacing.xs }}>
+                    <FormattedMessage defaultMessage="Modified output" description="Modified text label in test result" />
+                  </Typography.Text>
+                  <div
+                    css={{
+                      padding: theme.spacing.sm,
+                      backgroundColor: '#722ed108',
+                      borderRadius: theme.borders.borderRadiusMd,
+                      border: `1px solid #722ed140`,
+                      maxHeight: 120,
+                      overflowY: 'auto',
+                      fontSize: theme.typography.fontSizeSm,
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                      fontFamily: 'monospace',
+                    }}
+                  >
+                    {testResult.result.modified_text}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/gateway/hooks/queryKeys.ts
+++ b/mlflow/server/js/src/gateway/hooks/queryKeys.ts
@@ -7,4 +7,5 @@ export const GatewayQueryKeys = {
   providers: ['gateway_providers'] as const,
   budgetPolicies: ['gateway_budget_policies'] as const,
   budgetWindows: ['gateway_budget_windows'] as const,
+  guardrails: ['gateway_guardrails'] as const,
 };

--- a/mlflow/server/js/src/gateway/hooks/useAddGuardrail.ts
+++ b/mlflow/server/js/src/gateway/hooks/useAddGuardrail.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+import type { AddGuardrailRequest, AddGuardrailResponse } from '../types';
+import { GatewayQueryKeys } from './queryKeys';
+
+export const useAddGuardrail = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<AddGuardrailResponse, Error, AddGuardrailRequest>({
+    mutationFn: (request) => GatewayApi.addGuardrail(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries(GatewayQueryKeys.guardrails);
+    },
+  });
+};

--- a/mlflow/server/js/src/gateway/hooks/useGuardrailsQuery.ts
+++ b/mlflow/server/js/src/gateway/hooks/useGuardrailsQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+import type { ListGuardrailsResponse } from '../types';
+import { GatewayQueryKeys } from './queryKeys';
+
+export const useGuardrailsQuery = (endpointName?: string) => {
+  const queryResult = useQuery<ListGuardrailsResponse, Error>([GatewayQueryKeys.guardrails, endpointName], {
+    queryFn: () => GatewayApi.listGuardrails(endpointName),
+    retry: false,
+  });
+
+  return {
+    data: queryResult.data?.guardrails ?? [],
+    error: queryResult.error ?? undefined,
+    isLoading: queryResult.isLoading,
+    refetch: queryResult.refetch,
+  };
+};

--- a/mlflow/server/js/src/gateway/hooks/useRemoveGuardrail.ts
+++ b/mlflow/server/js/src/gateway/hooks/useRemoveGuardrail.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+import { GatewayQueryKeys } from './queryKeys';
+
+export const useRemoveGuardrail = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: (guardrailId) => GatewayApi.removeGuardrail(guardrailId) as Promise<void>,
+    onSuccess: () => {
+      queryClient.invalidateQueries(GatewayQueryKeys.guardrails);
+    },
+  });
+};

--- a/mlflow/server/js/src/gateway/hooks/useReorderGuardrails.ts
+++ b/mlflow/server/js/src/gateway/hooks/useReorderGuardrails.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+import { GatewayQueryKeys } from './queryKeys';
+
+export const useReorderGuardrails = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string[]>({
+    mutationFn: (guardrailIds) => GatewayApi.reorderGuardrails(guardrailIds) as Promise<void>,
+    onSuccess: () => {
+      queryClient.invalidateQueries(GatewayQueryKeys.guardrails);
+    },
+  });
+};

--- a/mlflow/server/js/src/gateway/hooks/useUpdateGuardrail.ts
+++ b/mlflow/server/js/src/gateway/hooks/useUpdateGuardrail.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+import { GatewayQueryKeys } from './queryKeys';
+import type { AddGuardrailResponse, UpdateGuardrailRequest } from '../types';
+
+export const useUpdateGuardrail = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<AddGuardrailResponse, Error, UpdateGuardrailRequest>({
+    mutationFn: (request) => GatewayApi.updateGuardrail(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries(GatewayQueryKeys.guardrails);
+    },
+  });
+};

--- a/mlflow/server/js/src/gateway/types.ts
+++ b/mlflow/server/js/src/gateway/types.ts
@@ -347,3 +347,90 @@ export interface BudgetPolicyWindow {
 export interface ListBudgetWindowsResponse {
   windows: BudgetPolicyWindow[];
 }
+
+// Guardrail types
+export type GuardrailHook = 'PRE' | 'POST';
+export type GuardrailOperation = 'VALIDATION' | 'MUTATION';
+
+export interface Guardrail {
+  guardrail_id: string;
+  endpoint_name: string | null;
+  scorer_name: string;
+  hook: GuardrailHook;
+  operation: GuardrailOperation;
+  order: number;
+  enabled: boolean;
+  config: GuardrailScorerConfig | null;
+}
+
+export interface AddGuardrailRequest {
+  scorer_name: string;
+  hook: GuardrailHook;
+  operation: GuardrailOperation;
+  endpoint_name?: string;
+  order?: number;
+  config?: GuardrailScorerConfig;
+}
+
+export interface GuardrailScorerConfig {
+  /** For builtin judges (Safety, Guidelines, etc.) */
+  builtin_scorer?: string;
+  guidelines?: string;
+  /** For registered judges — name, experiment_id, and version to uniquely identify */
+  registered_scorer?: string;
+  experiment_id?: string;
+  scorer_version?: number;
+  /** For custom judges (make_judge style) */
+  prompt?: string;
+  response_schema?: 'yes_no' | 'chat_request' | 'chat_response';
+  /** Model identifier for custom judges (e.g. "gateway:/my-endpoint" or "openai:/gpt-4.1-mini") */
+  model?: string;
+}
+
+export interface AddGuardrailResponse {
+  guardrail: Guardrail;
+}
+
+export interface UpdateGuardrailRequest {
+  guardrail_id: string;
+  scorer_name?: string;
+  hook?: GuardrailHook;
+  operation?: GuardrailOperation;
+  config?: GuardrailScorerConfig;
+}
+
+export interface RemoveGuardrailRequest {
+  guardrail_id: string;
+}
+
+export interface ListGuardrailsResponse {
+  guardrails: Guardrail[];
+}
+
+export interface TestGuardrailRequest {
+  guardrail_id?: string;
+  scorer_name?: string;
+  hook?: string;
+  operation?: string;
+  config?: GuardrailScorerConfig;
+  text?: string;
+  trace_id?: string;
+  experiment_id?: string;
+}
+
+export interface TestGuardrailResponse {
+  result: {
+    score: string;
+    rationale: string;
+    modified_text?: string;
+  };
+  guardrail: {
+    guardrail_id: string;
+    scorer_name: string;
+    hook: string;
+    operation: string;
+  };
+  input_text: string;
+  trace_input?: string;
+  trace_output?: string;
+}

--- a/mlflow/server/js/src/gateway/types.ts
+++ b/mlflow/server/js/src/gateway/types.ts
@@ -373,18 +373,20 @@ export interface AddGuardrailRequest {
 }
 
 export interface GuardrailScorerConfig {
-  /** For builtin judges (Safety, Guidelines, etc.) */
+  /** For builtin guardrails (Safety, Guidelines, etc.) */
   builtin_scorer?: string;
   guidelines?: string;
-  /** For registered judges — name, experiment_id, and version to uniquely identify */
+  /** For registered guardrails — name, experiment_id, and version to uniquely identify */
   registered_scorer?: string;
   experiment_id?: string;
   scorer_version?: number;
-  /** For custom judges (make_judge style) */
+  /** For LLM judge guardrails (make_judge style) */
   prompt?: string;
   response_schema?: 'yes_no' | 'chat_request' | 'chat_response';
-  /** Model identifier for custom judges (e.g. "gateway:/my-endpoint" or "openai:/gpt-4.1-mini") */
+  /** Model identifier for LLM judge guardrails (e.g. "gateway:/my-endpoint" or "openai:/gpt-4.1-mini") */
   model?: string;
+  /** For regex guardrails — Python-compatible regex pattern (uses guardrails/regex_match) */
+  regex_pattern?: string;
 }
 
 export interface AddGuardrailResponse {

--- a/mlflow/store/db_migrations/versions/f1a2b3c4d5e6_add_guardrail_configs_table.py
+++ b/mlflow/store/db_migrations/versions/f1a2b3c4d5e6_add_guardrail_configs_table.py
@@ -1,0 +1,43 @@
+"""add guardrail_configs table
+
+Create Date: 2026-03-13 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a2b3c4d5e6"
+down_revision = "76601a5f987d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "guardrail_configs",
+        sa.Column("guardrail_id", sa.String(length=36), nullable=False),
+        sa.Column("endpoint_name", sa.String(length=255), nullable=True),
+        sa.Column("scorer_name", sa.String(length=255), nullable=False),
+        sa.Column("hook", sa.String(length=32), nullable=False),
+        sa.Column("operation", sa.String(length=32), nullable=False),
+        sa.Column("order", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("config_json", sa.Text(), nullable=True),
+        sa.Column(
+            "workspace",
+            sa.String(length=63),
+            nullable=False,
+            server_default=sa.text("'default'"),
+        ),
+        sa.PrimaryKeyConstraint("guardrail_id", name="guardrail_configs_pk"),
+    )
+    op.create_index("idx_guardrail_configs_endpoint", "guardrail_configs", ["endpoint_name"])
+    op.create_index("idx_guardrail_configs_workspace", "guardrail_configs", ["workspace"])
+
+
+def downgrade():
+    op.drop_index("idx_guardrail_configs_workspace", table_name="guardrail_configs")
+    op.drop_index("idx_guardrail_configs_endpoint", table_name="guardrail_configs")
+    op.drop_table("guardrail_configs")

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2976,3 +2976,54 @@ class SqlGatewayBudgetPolicy(Base):
             last_updated_by=self.last_updated_by,
             workspace=self.workspace,
         )
+
+
+class SqlGuardrailConfig(Base):
+    """
+    DB model for guardrail configurations. Recorded in ``guardrail_configs`` table.
+    Links a scorer (judge) to a gateway endpoint for pre/post invocation guardrails.
+    """
+
+    __tablename__ = "guardrail_configs"
+
+    guardrail_id = Column(String(36), nullable=False)
+    endpoint_name = Column(String(255), nullable=True)
+    scorer_name = Column(String(255), nullable=False)
+    hook = Column(String(32), nullable=False)
+    operation = Column(String(32), nullable=False)
+    order = Column(Integer, nullable=False, default=0)
+    enabled = Column(Boolean, nullable=False, default=True)
+    config_json = Column(Text, nullable=True)
+    workspace = Column(
+        String(63),
+        nullable=False,
+        default=DEFAULT_WORKSPACE_NAME,
+        server_default=sa.text(f"'{DEFAULT_WORKSPACE_NAME}'"),
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint("guardrail_id", name="guardrail_configs_pk"),
+        Index("idx_guardrail_configs_endpoint", "endpoint_name"),
+        Index("idx_guardrail_configs_workspace", "workspace"),
+    )
+
+    def __repr__(self):
+        return f"<SqlGuardrailConfig ({self.guardrail_id})>"
+
+    def to_mlflow_entity(self):
+        from mlflow.entities.gateway_guardrail import (
+            GuardrailConfig,
+            GuardrailHook,
+            GuardrailOperation,
+        )
+
+        return GuardrailConfig(
+            guardrail_id=self.guardrail_id,
+            endpoint_name=self.endpoint_name,
+            scorer_name=self.scorer_name,
+            hook=GuardrailHook(self.hook),
+            operation=GuardrailOperation(self.operation),
+            order=self.order,
+            enabled=self.enabled,
+            config_json=self.config_json,
+        )

--- a/mlflow/store/tracking/gateway/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/gateway/sqlalchemy_mixin.py
@@ -28,6 +28,7 @@ from mlflow.entities.gateway_budget_policy import (
     BudgetUnit,
     GatewayBudgetPolicy,
 )
+from mlflow.entities.gateway_guardrail import GuardrailConfig, GuardrailHook, GuardrailOperation
 from mlflow.entities.gateway_endpoint import GatewayModelLinkageType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
@@ -55,6 +56,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlGatewayEndpointTag,
     SqlGatewayModelDefinition,
     SqlGatewaySecret,
+    SqlGuardrailConfig,
     SqlSpanMetrics,
     SqlTraceInfo,
     SqlTraceMetadata,
@@ -1362,3 +1364,101 @@ class SqlAlchemyGatewayStoreMixin:
                 ).filter(SqlExperiment.workspace == workspace)
 
             return float(query.scalar())
+
+    # ─── Guardrail CRUD ─────────────────────────────────────────────────
+
+    def add_guardrail(
+        self,
+        scorer_name: str,
+        hook: GuardrailHook,
+        operation: GuardrailOperation,
+        endpoint_name: str | None = None,
+        order: int = 0,
+        config_json: str | None = None,
+    ) -> GuardrailConfig:
+        with self.ManagedSessionMaker() as session:
+            guardrail_id = f"gr-{uuid.uuid4().hex}"
+            sql_guardrail = self._with_workspace_field(
+                SqlGuardrailConfig(
+                    guardrail_id=guardrail_id,
+                    endpoint_name=endpoint_name,
+                    scorer_name=scorer_name,
+                    hook=hook.value if isinstance(hook, GuardrailHook) else hook,
+                    operation=operation.value
+                    if isinstance(operation, GuardrailOperation)
+                    else operation,
+                    order=order,
+                    enabled=True,
+                    config_json=config_json,
+                )
+            )
+            session.add(sql_guardrail)
+            session.flush()
+            return sql_guardrail.to_mlflow_entity()
+
+    def remove_guardrail(self, guardrail_id: str) -> None:
+        with self.ManagedSessionMaker() as session:
+            sql_guardrail = self._get_entity_or_raise(
+                session,
+                SqlGuardrailConfig,
+                {"guardrail_id": guardrail_id},
+                "GuardrailConfig",
+            )
+            session.delete(sql_guardrail)
+
+    def list_guardrails(
+        self,
+        endpoint_name: str | None = None,
+    ) -> list[GuardrailConfig]:
+        with self.ManagedSessionMaker() as session:
+            query = self._get_query(session, SqlGuardrailConfig).filter(
+                SqlGuardrailConfig.enabled.is_(True)
+            )
+            if endpoint_name is not None:
+                # Return guardrails for this endpoint + global guardrails (endpoint_name IS NULL)
+                query = query.filter(
+                    (SqlGuardrailConfig.endpoint_name == endpoint_name)
+                    | (SqlGuardrailConfig.endpoint_name.is_(None))
+                )
+            query = query.order_by(SqlGuardrailConfig.order)
+            return [row.to_mlflow_entity() for row in query.all()]
+
+    def update_guardrail(
+        self,
+        guardrail_id: str,
+        scorer_name: str | None = None,
+        hook: GuardrailHook | None = None,
+        operation: GuardrailOperation | None = None,
+        config_json: str | None = ...,
+    ) -> GuardrailConfig:
+        with self.ManagedSessionMaker() as session:
+            sql_guardrail = self._get_entity_or_raise(
+                session,
+                SqlGuardrailConfig,
+                {"guardrail_id": guardrail_id},
+                "GuardrailConfig",
+            )
+            if scorer_name is not None:
+                sql_guardrail.scorer_name = scorer_name
+            if hook is not None:
+                sql_guardrail.hook = hook.value if isinstance(hook, GuardrailHook) else hook
+            if operation is not None:
+                sql_guardrail.operation = (
+                    operation.value if isinstance(operation, GuardrailOperation) else operation
+                )
+            if config_json is not ...:
+                sql_guardrail.config_json = config_json
+            session.flush()
+            return sql_guardrail.to_mlflow_entity()
+
+    def reorder_guardrails(self, guardrail_ids: list[str]) -> None:
+        """Update the order of guardrails based on the provided list of IDs."""
+        with self.ManagedSessionMaker() as session:
+            for order, guardrail_id in enumerate(guardrail_ids):
+                sql_guardrail = self._get_entity_or_raise(
+                    session,
+                    SqlGuardrailConfig,
+                    {"guardrail_id": guardrail_id},
+                    "GuardrailConfig",
+                )
+                sql_guardrail.order = order

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -306,6 +306,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         # DB migrations
         if not mlflow.store.db.utils._all_tables_exist(self.engine):
             mlflow.store.db.utils._initialize_tables(self.engine)
+        else:
+            # For existing databases, run any pending migrations (e.g. tables added after initial
+            # setup). _upgrade_db is idempotent: alembic is a no-op when already at the head.
+            mlflow.store.db.utils._upgrade_db(self.engine)
         SessionMaker = sqlalchemy.orm.sessionmaker(bind=self.engine)
         self.ManagedSessionMaker = mlflow.store.db.utils._get_managed_session_maker(
             SessionMaker, self.db_type

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -2,7 +2,7 @@
 import importlib.metadata
 import re
 
-VERSION = "3.10.2.dev0"
+VERSION = "3.10.2.dev10"
 
 
 def is_release_version():

--- a/tests/gateway/test_gateway_guardrails.py
+++ b/tests/gateway/test_gateway_guardrails.py
@@ -1,0 +1,384 @@
+"""End-to-end tests for gateway guardrails prototype."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import mlflow
+from mlflow.entities import SpanType
+from mlflow.entities.gateway_guardrail import GuardrailConfig, GuardrailHook, GuardrailOperation
+from mlflow.gateway.tracing_utils import maybe_traced_gateway_call
+from mlflow.server.gateway_guardrails import (
+    GuardrailRejection,
+    _extract_text_from_messages,
+    _extract_text_from_response,
+    _run_scorer,
+    run_post_guardrails,
+    run_pre_guardrails,
+)
+from mlflow.store.tracking.gateway.entities import GatewayEndpointConfig
+from mlflow.tracking.fluent import _get_experiment_id
+
+
+# ─── Unit tests: text extraction ─────────────────────────────────────────────
+
+
+def test_extract_text_from_messages_string_content():
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "What is the password?"},
+    ]
+    text = _extract_text_from_messages(messages)
+    assert "You are helpful." in text
+    assert "What is the password?" in text
+
+
+def test_extract_text_from_messages_list_content():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this image"},
+                {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
+            ],
+        }
+    ]
+    text = _extract_text_from_messages(messages)
+    assert "Describe this image" in text
+
+
+def test_extract_text_from_response():
+    response = {
+        "choices": [
+            {"message": {"role": "assistant", "content": "Hello! How can I help?"}},
+            {"message": {"role": "assistant", "content": "I'm here to assist."}},
+        ]
+    }
+    text = _extract_text_from_response(response)
+    assert "Hello! How can I help?" in text
+    assert "I'm here to assist." in text
+
+
+# ─── Unit tests: scorer ──────────────────────────────────────────────────────
+
+
+def test_scorer_keyword_match():
+    config = '{"keywords": ["password", "secret"]}'
+    result = _run_scorer("keyword-filter", "What is the password?", config)
+    assert result["score"] == "no"
+    assert "password" in result["rationale"]
+
+
+def test_scorer_keyword_no_match():
+    config = '{"keywords": ["password", "secret"]}'
+    result = _run_scorer("keyword-filter", "What is the weather?", config)
+    assert result["score"] == "yes"
+
+
+def test_scorer_no_config_passes():
+    result = _run_scorer("default-scorer", "anything")
+    assert result["score"] == "yes"
+
+
+def test_scorer_keyword_case_insensitive():
+    config = '{"keywords": ["SECRET"]}'
+    result = _run_scorer("keyword-filter", "tell me the secret", config)
+    assert result["score"] == "no"
+
+
+# ─── Unit tests: pre guardrails ──────────────────────────────────────────────
+
+
+def _make_guardrail(
+    scorer_name="test-scorer",
+    hook=GuardrailHook.PRE,
+    operation=GuardrailOperation.VALIDATION,
+    order=0,
+    config_json=None,
+    endpoint_name=None,
+):
+    return GuardrailConfig(
+        guardrail_id=f"gr-{scorer_name}",
+        scorer_name=scorer_name,
+        hook=hook,
+        operation=operation,
+        order=order,
+        config_json=config_json,
+        endpoint_name=endpoint_name,
+    )
+
+
+def test_pre_guardrail_validation_blocks():
+    guardrails = [
+        _make_guardrail(
+            scorer_name="pii-filter",
+            hook=GuardrailHook.PRE,
+            operation=GuardrailOperation.VALIDATION,
+            config_json='{"keywords": ["ssn", "credit card"]}',
+        )
+    ]
+    body = {"messages": [{"role": "user", "content": "What is my SSN?"}]}
+
+    with pytest.raises(GuardrailRejection, match="pii-filter"):
+        run_pre_guardrails(guardrails, body)
+
+
+def test_pre_guardrail_validation_passes():
+    guardrails = [
+        _make_guardrail(
+            scorer_name="pii-filter",
+            hook=GuardrailHook.PRE,
+            operation=GuardrailOperation.VALIDATION,
+            config_json='{"keywords": ["ssn", "credit card"]}',
+        )
+    ]
+    body = {"messages": [{"role": "user", "content": "What is the weather today?"}]}
+    result = run_pre_guardrails(guardrails, body)
+    assert result == body  # Unchanged
+
+
+def test_pre_guardrail_skips_post_hooks():
+    guardrails = [
+        _make_guardrail(
+            scorer_name="post-only",
+            hook=GuardrailHook.POST,
+            operation=GuardrailOperation.VALIDATION,
+            config_json='{"keywords": ["blocked"]}',
+        )
+    ]
+    body = {"messages": [{"role": "user", "content": "blocked content"}]}
+    # Should not raise because this is a POST guardrail
+    result = run_pre_guardrails(guardrails, body)
+    assert result == body
+
+
+def test_pre_guardrails_execute_in_order():
+    """Guardrails with lower order should execute first."""
+    execution_order = []
+
+    original_run_scorer = _run_scorer
+
+    def mock_scorer(scorer_name, text, config_json=None):
+        execution_order.append(scorer_name)
+        return {"score": "yes", "rationale": "pass"}
+
+    guardrails = [
+        _make_guardrail(scorer_name="second", order=2),
+        _make_guardrail(scorer_name="first", order=1),
+        _make_guardrail(scorer_name="third", order=3),
+    ]
+    body = {"messages": [{"role": "user", "content": "hello"}]}
+
+    with patch("mlflow.server.gateway_guardrails._run_scorer", side_effect=mock_scorer):
+        run_pre_guardrails(guardrails, body)
+
+    assert execution_order == ["first", "second", "third"]
+
+
+def test_no_guardrails_is_noop():
+    body = {"messages": [{"role": "user", "content": "hello"}]}
+    result = run_pre_guardrails([], body)
+    assert result is body
+
+
+# ─── Unit tests: post guardrails ─────────────────────────────────────────────
+
+
+def test_post_guardrail_validation_blocks():
+    guardrails = [
+        _make_guardrail(
+            scorer_name="toxicity-filter",
+            hook=GuardrailHook.POST,
+            operation=GuardrailOperation.VALIDATION,
+            config_json='{"keywords": ["harmful", "offensive"]}',
+        )
+    ]
+    response = {
+        "choices": [{"message": {"role": "assistant", "content": "This is harmful content"}}]
+    }
+
+    with pytest.raises(GuardrailRejection, match="toxicity-filter"):
+        run_post_guardrails(guardrails, response)
+
+
+def test_post_guardrail_validation_passes():
+    guardrails = [
+        _make_guardrail(
+            scorer_name="toxicity-filter",
+            hook=GuardrailHook.POST,
+            operation=GuardrailOperation.VALIDATION,
+            config_json='{"keywords": ["harmful"]}',
+        )
+    ]
+    response = {
+        "choices": [{"message": {"role": "assistant", "content": "This is a helpful response"}}]
+    }
+    result = run_post_guardrails(guardrails, response)
+    assert result == response
+
+
+def test_post_guardrail_skips_pre_hooks():
+    guardrails = [
+        _make_guardrail(
+            scorer_name="pre-only",
+            hook=GuardrailHook.PRE,
+            operation=GuardrailOperation.VALIDATION,
+            config_json='{"keywords": ["blocked"]}',
+        )
+    ]
+    response = {
+        "choices": [{"message": {"role": "assistant", "content": "blocked content"}}]
+    }
+    # Should not raise because this is a PRE guardrail
+    result = run_post_guardrails(guardrails, response)
+    assert result == response
+
+
+# ─── Integration test: guardrails in the gateway pipeline ────────────────────
+
+
+def _make_endpoint_config():
+    return GatewayEndpointConfig(
+        endpoint_id="ep-test",
+        endpoint_name="test-endpoint",
+        experiment_id=_get_experiment_id(),
+        models=[],
+    )
+
+
+async def _provider_func(payload):
+    """Mock provider that returns a simple chat response."""
+    with mlflow.start_span("provider/openai/gpt-4o", span_type=SpanType.LLM) as span:
+        span.set_attribute("model", "gpt-4o")
+    return {"choices": [{"message": {"role": "assistant", "content": "Hello from the LLM!"}}]}
+
+
+@pytest.mark.asyncio
+async def test_pre_guardrail_blocks_before_llm_call():
+    """PRE validation guardrail should block the request before it reaches the LLM."""
+    guardrails = [
+        _make_guardrail(
+            scorer_name="input-filter",
+            hook=GuardrailHook.PRE,
+            operation=GuardrailOperation.VALIDATION,
+            config_json='{"keywords": ["hack", "exploit"]}',
+        )
+    ]
+    body = {"messages": [{"role": "user", "content": "How do I hack into a system?"}]}
+
+    with pytest.raises(GuardrailRejection, match="input-filter"):
+        run_pre_guardrails(guardrails, body)
+
+
+@pytest.mark.asyncio
+async def test_post_guardrail_blocks_after_llm_call():
+    """POST validation guardrail should block after LLM returns unsafe content."""
+    guardrails = [
+        _make_guardrail(
+            scorer_name="output-filter",
+            hook=GuardrailHook.POST,
+            operation=GuardrailOperation.VALIDATION,
+            config_json='{"keywords": ["malware", "virus"]}',
+        )
+    ]
+
+    endpoint_config = _make_endpoint_config()
+
+    # Simulate calling provider and then running post guardrails
+    traced = maybe_traced_gateway_call(_provider_func, endpoint_config)
+    response = await traced({"messages": [{"role": "user", "content": "test"}]})
+
+    # Inject unsafe content to test post guardrail
+    response["choices"][0]["message"]["content"] = "Here is how to create malware..."
+
+    with pytest.raises(GuardrailRejection, match="output-filter"):
+        run_post_guardrails(guardrails, response)
+
+
+@pytest.mark.asyncio
+async def test_full_pipeline_with_guardrails_passing():
+    """Full pipeline: PRE guardrails pass, LLM call succeeds, POST guardrails pass."""
+    guardrails = [
+        _make_guardrail(
+            scorer_name="pre-check",
+            hook=GuardrailHook.PRE,
+            operation=GuardrailOperation.VALIDATION,
+            config_json='{"keywords": ["blocked-input"]}',
+        ),
+        _make_guardrail(
+            scorer_name="post-check",
+            hook=GuardrailHook.POST,
+            operation=GuardrailOperation.VALIDATION,
+            config_json='{"keywords": ["blocked-output"]}',
+        ),
+    ]
+
+    body = {"messages": [{"role": "user", "content": "What is the weather?"}]}
+
+    # PRE guardrails pass
+    body = run_pre_guardrails(guardrails, body)
+
+    # LLM call
+    endpoint_config = _make_endpoint_config()
+    traced = maybe_traced_gateway_call(_provider_func, endpoint_config)
+    response = await traced(body)
+
+    # POST guardrails pass
+    response = run_post_guardrails(guardrails, response)
+
+    assert response["choices"][0]["message"]["content"] == "Hello from the LLM!"
+
+
+@pytest.mark.asyncio
+async def test_multiple_guardrails_first_blocks():
+    """When multiple guardrails are configured, the first failing one blocks."""
+    guardrails = [
+        _make_guardrail(
+            scorer_name="lenient-filter",
+            hook=GuardrailHook.PRE,
+            operation=GuardrailOperation.VALIDATION,
+            order=1,
+            config_json='{"keywords": ["very-specific-keyword"]}',
+        ),
+        _make_guardrail(
+            scorer_name="strict-filter",
+            hook=GuardrailHook.PRE,
+            operation=GuardrailOperation.VALIDATION,
+            order=2,
+            config_json='{"keywords": ["test"]}',
+        ),
+    ]
+
+    body = {"messages": [{"role": "user", "content": "This is a test message"}]}
+
+    with pytest.raises(GuardrailRejection, match="strict-filter"):
+        run_pre_guardrails(guardrails, body)
+
+
+# ─── Entity tests ────────────────────────────────────────────────────────────
+
+
+def test_guardrail_config_entity():
+    config = GuardrailConfig(
+        guardrail_id="gr-test",
+        scorer_name="my-scorer",
+        hook=GuardrailHook.PRE,
+        operation=GuardrailOperation.VALIDATION,
+        endpoint_name="my-endpoint",
+        order=1,
+    )
+    assert config.hook == GuardrailHook.PRE
+    assert config.operation == GuardrailOperation.VALIDATION
+    assert config.endpoint_name == "my-endpoint"
+
+
+def test_guardrail_config_from_strings():
+    config = GuardrailConfig(
+        guardrail_id="gr-test",
+        scorer_name="my-scorer",
+        hook="PRE",
+        operation="VALIDATION",
+    )
+    assert config.hook == GuardrailHook.PRE
+    assert config.operation == GuardrailOperation.VALIDATION


### PR DESCRIPTION
## Summary
- Adds guardrails support to MLflow Gateway endpoints — users can attach scorers that validate or mutate requests (PRE) and responses (POST) before/after LLM invocation
- Backend: guardrail CRUD, execution engine (builtin guardrails-ai validators, registered judges, inline custom judges via make_judge), recursion guard, gateway:/ model URI routing
- Frontend: GuardrailsTabContent on endpoint detail page, AddGuardrailModal with builtin/registered/custom judge sources, inline testing, drag-and-drop reordering

## Test plan
- [ ] Add a PRE validation guardrail (e.g., DetectPII builtin) and verify it blocks requests containing PII
- [ ] Add a POST validation guardrail and verify it blocks responses
- [ ] Add a custom judge guardrail with gateway:/ model and verify it routes correctly
- [ ] Test inline judge with openai:/ model
- [ ] Verify recursion guard prevents infinite loops when judge calls guardrailed endpoint
- [ ] Test drag-and-drop reordering persists correctly
- [ ] Test enable/disable toggle
- [ ] Run `pytest tests/gateway/test_gateway_guardrails.py`

This pull request was AI-assisted by Isaac.