### PR TITLE
fix(mcp): emit array schema for CLI params with multiple=True or nargs=-1

### DIFF
--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -57,9 +57,19 @@ def get_input_schema(params: list[click.Parameter]) -> dict[str, Any]:
     properties: dict[str, Any] = {}
     required: list[str] = []
     for p in params:
-        schema = {
-            "type": param_type_to_json_schema_type(p.type),
-        }
+        item_type = param_type_to_json_schema_type(p.type)
+        # Parameters with multiple=True (repeatable flags) or nargs=-1 (variadic positional
+        # args) accept multiple values and must be represented as JSON arrays.
+        is_multiple = getattr(p, "multiple", False) or p.nargs == -1
+        if is_multiple:
+            schema: dict[str, Any] = {
+                "type": "array",
+                "items": {"type": item_type},
+            }
+        else:
+            schema = {
+                "type": item_type,
+            }
         if p.default is not None and (
             # In click >= 8.3.0, the default value is set to `Sentinel.UNSET` when no default is
             # provided. Skip setting the default in this case.

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -141,6 +141,53 @@ async def test_get_prompt(client: Client):
     assert "MLflow" in content
 
 
+def test_get_input_schema_multiple_params():
+    """
+    Params with multiple=True or nargs=-1 must be exposed as JSON array schemas,
+    not scalar strings.  Regression test for
+    https://github.com/mlflow/mlflow/issues/21548
+    """
+    import click
+
+    from mlflow.mcp.server import get_input_schema
+
+    @click.command()
+    @click.option("--tag", "tags", multiple=True, type=str, help="Repeatable tag option")
+    @click.argument("files", nargs=-1, type=str)
+    @click.option("--name", type=str, help="Scalar string option")
+    def cmd(tags, files, name):
+        pass
+
+    schema = get_input_schema(cmd.params)["properties"]
+
+    # multiple=True option → array of strings
+    assert schema["tags"]["type"] == "array", "multiple=True option should emit type:array"
+    assert schema["tags"]["items"] == {"type": "string"}
+
+    # nargs=-1 argument → array of strings
+    assert schema["files"]["type"] == "array", "nargs=-1 argument should emit type:array"
+    assert schema["files"]["items"] == {"type": "string"}
+
+    # plain scalar option → unchanged
+    assert schema["name"]["type"] == "string", "scalar option should remain type:string"
+
+
+def test_get_input_schema_multiple_int_params():
+    """Item type must be preserved when multiple/variadic params are non-string."""
+    import click
+
+    from mlflow.mcp.server import get_input_schema
+
+    @click.command()
+    @click.option("--count", "counts", multiple=True, type=int)
+    def cmd(counts):
+        pass
+
+    schema = get_input_schema(cmd.params)["properties"]
+    assert schema["counts"]["type"] == "array"
+    assert schema["counts"]["items"] == {"type": "integer"}
+
+
 def test_fn_wrapper_handles_unset_defaults(monkeypatch):
     import click
 


### PR DESCRIPTION
## Summary

Fixes #21548.

`get_input_schema()` in `mlflow/mcp/server.py` previously emitted a scalar JSON type for every Click parameter, even those that accept multiple values. CLI params with `multiple=True` (repeatable flags like `--trace-id`) or `nargs=-1` (variadic positional args like requirement strings) must be represented as JSON arrays so MCP clients can construct valid tool calls.

**Affected commands (non-exhaustive):**
- `mlflow runs link-traces` — `trace_ids` (`multiple=True`)
- `mlflow runs create` — `tags` (`multiple=True`)
- `mlflow models update-pip-requirements` — `requirement_strings` (`nargs=-1`)
- `mlflow models predict` — `env` (`multiple=True`)
- Deployment commands — `config` (`multiple=True`) on `create`, `update`, `delete`, `run-local`, `create-endpoint`, `update-endpoint`

## Changes

- **`mlflow/mcp/server.py`** — In `get_input_schema()`, detect `is_multiple = getattr(p, "multiple", False) or p.nargs == -1` and emit `{"type": "array", "items": {"type": <item_type>}}` for those params; scalar params are unchanged.
- **`tests/mcp/test_mcp.py`** — Add two new unit tests (`test_get_input_schema_multiple_params`, `test_get_input_schema_multiple_int_params`) to guard against regressions.

## Test plan

- [ ] `pytest tests/mcp/test_mcp.py::test_get_input_schema_multiple_params`
- [ ] `pytest tests/mcp/test_mcp.py::test_get_input_schema_multiple_int_params`
- [ ] `pytest tests/mcp/test_mcp.py` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)