### PR TITLE
Fix None dereference in OpenAI agent tracer on_span_end

### DIFF
--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -155,6 +155,9 @@ class MlflowOpenAgentTracingProcessor(oai.TracingProcessor):
         try:
             # parsed_span_data = parse_spandata(span.span_data)
             st: SpanWithToken | None = self._span_id_to_mlflow_span.pop(span.span_id, None)
+            if not st:
+                return
+
             detach_span_from_context(st.token)
             mlflow_span = st.span
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to ML-63173

### What changes are proposed in this pull request?

In `mlflow/openai/_agent_tracer.py`, the `on_span_end` method pops a `SpanWithToken` from the dictionary using `span.span_id`. If the span ID doesn't exist (e.g., `on_span_start` failed silently), `pop()` returns `None`. The subsequent lines then dereference `st.token` and `st.span` without a null check, causing an `AttributeError` that gets silently swallowed by the broad `except Exception`.

This PR adds a null guard on `st` after the `pop()`, matching the existing pattern used in the sibling method `on_trace_end`.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release