### PR TITLE
Add `mlflow traces tag` and `untag` commands for batch tag management

### DIFF
--- a/mlflow/cli/traces.py
+++ b/mlflow/cli/traces.py
@@ -495,7 +495,14 @@ def set_trace_tag(trace_id: str, key: str, value: str) -> None:
 
 @commands.command("tag")
 @mlflow_mcp(tool_name="tag_trace")
-@TRACE_ID
+@click.option(
+    "--trace-id",
+    "trace_ids",
+    type=click.STRING,
+    multiple=True,
+    required=True,
+    help="Trace ID to tag. Can be repeated.",
+)
 @click.option(
     "--tag",
     "tags",
@@ -504,10 +511,10 @@ def set_trace_tag(trace_id: str, key: str, value: str) -> None:
     required=True,
     help="Tag in 'key=value' format. Can be repeated.",
 )
-def tag_trace(trace_id: str, tags: tuple[str, ...]) -> None:
+def tag_trace(trace_ids: tuple[str, ...], tags: tuple[str, ...]) -> None:
     """\b
     Example:
-    mlflow traces tag --trace-id tr-abc123 --tag env=prod --tag version=2
+    mlflow traces tag --trace-id tr-abc123 --trace-id tr-def456 --tag env=prod --tag version=2
     """
     parsed: dict[str, str] = {}
     for t in tags:
@@ -520,13 +527,21 @@ def tag_trace(trace_id: str, tags: tuple[str, ...]) -> None:
                     param_hint="--tag",
                 )
     client = TracingClient()
-    client.set_trace_tags(trace_id, parsed)
-    click.echo(f"Set {len(parsed)} tag(s) on trace {trace_id}.")
+    for trace_id in trace_ids:
+        client.set_trace_tags(trace_id, parsed)
+    click.echo(f"Set {len(parsed)} tag(s) on {len(trace_ids)} trace(s).")
 
 
 @commands.command("untag")
 @mlflow_mcp(tool_name="untag_trace")
-@TRACE_ID
+@click.option(
+    "--trace-id",
+    "trace_ids",
+    type=click.STRING,
+    multiple=True,
+    required=True,
+    help="Trace ID to untag. Can be repeated.",
+)
 @click.option(
     "--tag",
     "tags",
@@ -535,15 +550,16 @@ def tag_trace(trace_id: str, tags: tuple[str, ...]) -> None:
     required=True,
     help="Tag key to remove. Can be repeated.",
 )
-def untag_trace(trace_id: str, tags: tuple[str, ...]) -> None:
+def untag_trace(trace_ids: tuple[str, ...], tags: tuple[str, ...]) -> None:
     """\b
     Example:
-    mlflow traces untag --trace-id tr-abc123 --tag env --tag version
+    mlflow traces untag --trace-id tr-abc123 --trace-id tr-def456 --tag env --tag version
     """
     client = TracingClient()
-    for key in tags:
-        client.delete_trace_tag(trace_id, key)
-    click.echo(f"Removed {len(tags)} tag(s) from trace {trace_id}.")
+    for trace_id in trace_ids:
+        for key in tags:
+            client.delete_trace_tag(trace_id, key)
+    click.echo(f"Removed {len(tags)} tag(s) from {len(trace_ids)} trace(s).")
 
 
 @commands.command("delete-tag")

--- a/mlflow/cli/traces.py
+++ b/mlflow/cli/traces.py
@@ -10,7 +10,9 @@ AVAILABLE COMMANDS:
     get                 Retrieve detailed trace information as JSON
     delete              Delete traces by ID or timestamp criteria
     set-tag             Add tags to traces
+    tag                 Set one or more tags on a trace
     delete-tag          Remove tags from traces
+    untag               Remove one or more tags from a trace
     log-feedback        Log evaluation feedback/scores to traces
     log-expectation     Log ground truth expectations to traces
     get-assessment      Retrieve assessment details
@@ -489,6 +491,59 @@ def set_trace_tag(trace_id: str, key: str, value: str) -> None:
     client = TracingClient()
     client.set_trace_tag(trace_id, key, value)
     click.echo(f"Set tag '{key}' on trace {trace_id}.")
+
+
+@commands.command("tag")
+@mlflow_mcp(tool_name="tag_trace")
+@TRACE_ID
+@click.option(
+    "--tag",
+    "tags",
+    type=click.STRING,
+    multiple=True,
+    required=True,
+    help="Tag in 'key=value' format. Can be repeated.",
+)
+def tag_trace(trace_id: str, tags: tuple[str, ...]) -> None:
+    """\b
+    Example:
+    mlflow traces tag --trace-id tr-abc123 --tag env=prod --tag version=2
+    """
+    parsed: dict[str, str] = {}
+    for t in tags:
+        match t.split("=", 1):
+            case [key, value]:
+                parsed[key] = value
+            case _:
+                raise click.BadParameter(
+                    f"Tags must be in 'key=value' format, got: {t!r}",
+                    param_hint="--tag",
+                )
+    client = TracingClient()
+    client.set_trace_tags(trace_id, parsed)
+    click.echo(f"Set {len(parsed)} tag(s) on trace {trace_id}.")
+
+
+@commands.command("untag")
+@mlflow_mcp(tool_name="untag_trace")
+@TRACE_ID
+@click.option(
+    "--tag",
+    "tags",
+    type=click.STRING,
+    multiple=True,
+    required=True,
+    help="Tag key to remove. Can be repeated.",
+)
+def untag_trace(trace_id: str, tags: tuple[str, ...]) -> None:
+    """\b
+    Example:
+    mlflow traces untag --trace-id tr-abc123 --tag env --tag version
+    """
+    client = TracingClient()
+    for key in tags:
+        client.delete_trace_tag(trace_id, key)
+    click.echo(f"Removed {len(tags)} tag(s) from trace {trace_id}.")
 
 
 @commands.command("delete-tag")

--- a/tests/cli/test_traces.py
+++ b/tests/cli/test_traces.py
@@ -158,6 +158,40 @@ def test_delete_command(runner):
         assert "Deleted 5 trace(s)" in result.output
 
 
+def test_tag_command(runner):
+    with mock.patch("mlflow.cli.traces.TracingClient") as mock_client:
+        result = runner.invoke(
+            commands,
+            ["tag", "--trace-id", "tr-abc", "--tag", "env=prod", "--tag", "version=2"],
+        )
+        assert result.exit_code == 0
+        assert "Set 2 tag(s) on trace tr-abc" in result.output
+        mock_client.return_value.set_trace_tags.assert_called_once_with(
+            "tr-abc", {"env": "prod", "version": "2"}
+        )
+
+
+def test_tag_command_bad_format(runner):
+    result = runner.invoke(
+        commands,
+        ["tag", "--trace-id", "tr-abc", "--tag", "badformat"],
+    )
+    assert result.exit_code != 0
+    assert "key=value" in result.output
+
+
+def test_untag_command(runner):
+    with mock.patch("mlflow.cli.traces.TracingClient") as mock_client:
+        result = runner.invoke(
+            commands,
+            ["untag", "--trace-id", "tr-abc", "--tag", "env", "--tag", "version"],
+        )
+        assert result.exit_code == 0
+        assert "Removed 2 tag(s) from trace tr-abc" in result.output
+        mock_client.return_value.delete_trace_tag.assert_any_call("tr-abc", "env")
+        mock_client.return_value.delete_trace_tag.assert_any_call("tr-abc", "version")
+
+
 def test_field_validation_error(runner):
     trace_location = TraceLocation(
         type=TraceLocationType.MLFLOW_EXPERIMENT,

--- a/tests/cli/test_traces.py
+++ b/tests/cli/test_traces.py
@@ -165,10 +165,27 @@ def test_tag_command(runner):
             ["tag", "--trace-id", "tr-abc", "--tag", "env=prod", "--tag", "version=2"],
         )
         assert result.exit_code == 0
-        assert "Set 2 tag(s) on trace tr-abc" in result.output
+        assert "Set 2 tag(s) on 1 trace(s)" in result.output
         mock_client.return_value.set_trace_tags.assert_called_once_with(
             "tr-abc", {"env": "prod", "version": "2"}
         )
+
+
+def test_tag_command_multiple_traces(runner):
+    with mock.patch("mlflow.cli.traces.TracingClient") as mock_client:
+        result = runner.invoke(
+            commands,
+            [
+                "tag",
+                "--trace-id", "tr-abc",
+                "--trace-id", "tr-def",
+                "--tag", "env=prod",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Set 1 tag(s) on 2 trace(s)" in result.output
+        mock_client.return_value.set_trace_tags.assert_any_call("tr-abc", {"env": "prod"})
+        mock_client.return_value.set_trace_tags.assert_any_call("tr-def", {"env": "prod"})
 
 
 def test_tag_command_bad_format(runner):
@@ -187,9 +204,26 @@ def test_untag_command(runner):
             ["untag", "--trace-id", "tr-abc", "--tag", "env", "--tag", "version"],
         )
         assert result.exit_code == 0
-        assert "Removed 2 tag(s) from trace tr-abc" in result.output
+        assert "Removed 2 tag(s) from 1 trace(s)" in result.output
         mock_client.return_value.delete_trace_tag.assert_any_call("tr-abc", "env")
         mock_client.return_value.delete_trace_tag.assert_any_call("tr-abc", "version")
+
+
+def test_untag_command_multiple_traces(runner):
+    with mock.patch("mlflow.cli.traces.TracingClient") as mock_client:
+        result = runner.invoke(
+            commands,
+            [
+                "untag",
+                "--trace-id", "tr-abc",
+                "--trace-id", "tr-def",
+                "--tag", "env",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Removed 1 tag(s) from 2 trace(s)" in result.output
+        mock_client.return_value.delete_trace_tag.assert_any_call("tr-abc", "env")
+        mock_client.return_value.delete_trace_tag.assert_any_call("tr-def", "env")
 
 
 def test_field_validation_error(runner):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Adds two new ergonomic CLI commands for managing trace tags in bulk, complementing the existing single-key `set-tag` / `delete-tag` commands:

- **`mlflow traces tag --trace-id X --tag k=v [--tag ...]`**
  Accepts one or more `key=value` pairs via repeatable `--tag` options and calls `TracingClient.set_trace_tags()` in a single batch call. Invalid tag format (missing `=`) is caught before any network call and reported as a `BadParameter` error.

- **`mlflow traces untag --trace-id X --tag key [--tag ...]`**
  Accepts one or more tag keys via repeatable `--tag` options and calls `TracingClient.delete_trace_tag()` for each key.

Both commands follow the same decorator conventions (`@mlflow_mcp`, `@TRACE_ID`) used throughout the file and are registered as MCP tools (`tag_trace`, `untag_trace`).

### How is this PR tested?

- [x] New unit/integration tests

Three new tests added in `tests/cli/test_traces.py`:
- `test_tag_command` — happy path with two tags
- `test_tag_command_bad_format` — malformed tag string exits non-zero with `key=value` in output
- `test_untag_command` — happy path removing two tag keys

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added `mlflow traces tag` and `mlflow traces untag` CLI commands that allow setting or removing multiple trace tags in a single invocation using repeatable `--tag` options (e.g. `--tag env=prod --tag version=2`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release