### PR TITLE
Improve trace location linking failure error message

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -250,8 +250,8 @@ def set_experiment(
         if is_newly_created and trace_location is not None:
             raise MlflowException.invalid_parameter_value(
                 f"Experiment '{experiment.name}' (ID: {experiment.experiment_id}) was created "
-                f"but linking to trace location '{trace_location.full_table_prefix}' failed. "
-                "Please delete the experiment before retrying."
+                f"but linking to trace location '{trace_location.full_table_prefix}' failed: "
+                f"{e.message} Please fix the issue and call set_experiment again to retry."
             ) from e
         raise
 

--- a/tests/tracking/fluent/test_set_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_set_experiment_trace_location.py
@@ -181,7 +181,7 @@ def test_existing_uc_schema_destination_rejects_table_prefix():
             )
 
 
-def test_link_failure_on_new_experiment_includes_delete_guidance():
+def test_link_failure_on_new_experiment_includes_retry_guidance():
     with (
         mock.patch("mlflow.tracking.fluent.TrackingServiceClient") as mock_client_cls,
         mock.patch(
@@ -196,12 +196,15 @@ def test_link_failure_on_new_experiment_includes_delete_guidance():
         new_exp = _experiment()
         client.get_experiment.return_value = new_exp
 
-        with pytest.raises(MlflowException, match="delete the experiment before retrying"):
+        with pytest.raises(
+            MlflowException, match="fix the issue and call set_experiment again"
+        ) as exc_info:
             mlflow.set_experiment(
                 "new-exp",
                 trace_location=UnityCatalog("cat", "sch", "pfx"),
             )
 
+        assert "backend error" in exc_info.value.message
         mock_resolve.assert_called_once()
 
 


### PR DESCRIPTION
<!-- Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom. -->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

This PR updates the error message in `set_experiment` when linking an experiment to a trace location fails. Users will no longer be prompted to delete an experiment but to try again after fixing the error.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
