### PR TITLE
Add missing componentId to Link in ExperimentViewDatasetLink

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetLink.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetLink.tsx
@@ -25,7 +25,11 @@ export function ExperimentViewDatasetLink({ datasetWithTags, experimentId }: Dat
         icon={<TableIcon />}
         type="primary"
       >
-        <Link to={datasetsRoute} css={{ color: 'inherit', '&:hover': { color: 'inherit', textDecoration: 'none' } }}>
+        <Link
+          componentId="mlflow.experiment_tracking.dataset_link.open_dataset_link"
+          to={datasetsRoute}
+          css={{ color: 'inherit', '&:hover': { color: 'inherit', textDecoration: 'none' } }}
+        >
           <FormattedMessage
             defaultMessage="Open dataset"
             description="Text for the button that navigates to the datasets tab in the experiment run dataset drawer"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21342

### What changes are proposed in this pull request?

Add missing `componentId` prop to the `<Link>` component in `ExperimentViewDatasetLink.tsx`, which was introduced in #21342 and causes a TypeScript type-check failure.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release