### PR TITLE
Add tracking URI note to mlflow-skinny README

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -64,6 +64,12 @@ Additional dependencies can be installed to leverage the full feature set of MLf
 - To use SQL-based metadata storage, install `sqlalchemy`, `alembic`, and `sqlparse`.
 - To use serving-based features, install `flask` and `pandas`.
 
+**Note:** When using `mlflow-skinny`, set the tracking URI to your remote MLflow server:
+
+```bash
+export MLFLOW_TRACKING_URI="http://your-mlflow-server:5000"
+```
+
 ---
 
 <br>

--- a/libs/skinny/README_SKINNY.md
+++ b/libs/skinny/README_SKINNY.md
@@ -7,6 +7,12 @@ Additional dependencies can be installed to leverage the full feature set of MLf
 - To use SQL-based metadata storage, install `sqlalchemy`, `alembic`, and `sqlparse`.
 - To use serving-based features, install `flask` and `pandas`.
 
+**Note:** When using `mlflow-skinny`, set the tracking URI to your remote MLflow server:
+
+```bash
+export MLFLOW_TRACKING_URI="http://your-mlflow-server:5000"
+```
+
 ---
 
 <br>


### PR DESCRIPTION
### Related Issues/PRs

Closes #21517

### What changes are proposed in this pull request?

`mlflow-skinny` users hitting the default `sqlite:///mlflow.db` tracking URI get a confusing error because `sqlalchemy` is not included. This adds a note to the skinny README suggesting users set the tracking URI to their remote MLflow server.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added a note to the `mlflow-skinny` README advising users to set the tracking URI to their remote MLflow server.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)