### PR TITLE
Restore semantic componentIds in gateway components

### DIFF
--- a/mlflow/server/js/src/gateway/components/common/DeleteConfirmationModal.tsx
+++ b/mlflow/server/js/src/gateway/components/common/DeleteConfirmationModal.tsx
@@ -74,21 +74,17 @@ export const DeleteConfirmationModal = ({
 
   return (
     <Modal
-      componentId="codegen_mlflow_app_src_oss_gateway_components_common_DeleteConfirmationModal.tsx_77"
+      componentId={`${componentIdPrefix}.modal`}
       title={title}
       visible={open}
       onCancel={handleClose}
       footer={
         <div css={{ display: 'flex', justifyContent: 'flex-end', gap: theme.spacing.sm }}>
-          <Button
-            componentId="codegen_mlflow_app_src_oss_gateway_components_common_DeleteConfirmationModal.tsx_83"
-            onClick={handleClose}
-            disabled={isDeleting}
-          >
+          <Button componentId={`${componentIdPrefix}.cancel`} onClick={handleClose} disabled={isDeleting}>
             <FormattedMessage defaultMessage="Cancel" description="Cancel button text" />
           </Button>
           <Button
-            componentId="codegen_mlflow_app_src_oss_gateway_components_common_DeleteConfirmationModal.tsx_87"
+            componentId={`${componentIdPrefix}.delete`}
             type="primary"
             danger
             onClick={handleDelete}
@@ -102,14 +98,7 @@ export const DeleteConfirmationModal = ({
       size="normal"
     >
       <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
-        {error && (
-          <Alert
-            componentId="codegen_mlflow_app_src_oss_gateway_components_common_DeleteConfirmationModal.tsx_101"
-            type="error"
-            message={error}
-            closable={false}
-          />
-        )}
+        {error && <Alert componentId={`${componentIdPrefix}.error`} type="error" message={error} closable={false} />}
 
         <Typography.Text>
           <FormattedMessage
@@ -124,7 +113,7 @@ export const DeleteConfirmationModal = ({
 
         {warningMessage && (
           <Alert
-            componentId="codegen_mlflow_app_src_oss_gateway_components_common_DeleteConfirmationModal.tsx_116"
+            componentId={`${componentIdPrefix}.warning`}
             type="warning"
             message={warningMessage}
             closable={false}
@@ -143,7 +132,7 @@ export const DeleteConfirmationModal = ({
               />
             </Typography.Text>
             <Input
-              componentId="codegen_mlflow_app_src_oss_gateway_components_common_DeleteConfirmationModal.tsx_135"
+              componentId={`${componentIdPrefix}.confirmation-input`}
               value={confirmationText}
               onChange={(e) => setConfirmationText(e.target.value)}
               placeholder={itemName}

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
@@ -61,7 +61,7 @@ export const ModelSelect = ({
       </FormUI.Label>
       <Input
         id={componentIdPrefix}
-        componentId="codegen_mlflow_app_src_oss_gateway_components_create-endpoint_ModelSelect.tsx_58"
+        componentId={componentIdPrefix}
         placeholder={
           !provider
             ? intl.formatMessage({
@@ -119,7 +119,7 @@ const ModelCapabilities = memo(function ModelCapabilities({ model }: { model: Pr
       }}
     >
       {capabilities.map((cap) => (
-        <Tag key={cap} componentId="codegen_mlflow_app_src_oss_gateway_components_create-endpoint_ModelSelect.tsx_116">
+        <Tag key={cap} componentId={`mlflow.gateway.model-select.capability.${cap.toLowerCase()}`}>
           {cap}
         </Tag>
       ))}

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
@@ -204,7 +204,7 @@ export const ProviderSelect = ({
         </FormUI.Label>
       )}
       <NavigableCombobox
-        componentId="codegen_mlflow_app_src_oss_gateway_components_create-endpoint_ProviderSelect.tsx_199"
+        componentId={componentIdPrefix}
         config={config}
         value={value || null}
         onChange={handleChange}

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/FallbackModelItem.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/FallbackModelItem.tsx
@@ -132,7 +132,7 @@ export const FallbackModelItem = ({
             <DragIcon css={{ color: theme.colors.textSecondary }} />
           </div>
           <Button
-            componentId="codegen_mlflow_app_src_oss_gateway_components_edit-endpoint_FallbackModelItem.tsx_135"
+            componentId={`${componentIdPrefix}.expand.${index}`}
             icon={isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
             onClick={() => setIsExpanded(!isExpanded)}
             size="small"
@@ -151,14 +151,14 @@ export const FallbackModelItem = ({
           )}
         </div>
         <Tooltip
-          componentId="codegen_mlflow_app_src_oss_gateway_components_edit-endpoint_FallbackModelItem.tsx_154"
+          componentId={`${componentIdPrefix}.remove-tooltip.${index}`}
           content={intl.formatMessage({
             defaultMessage: 'Remove fallback model',
             description: 'Tooltip for remove fallback model button',
           })}
         >
           <Button
-            componentId="codegen_mlflow_app_src_oss_gateway_components_edit-endpoint_FallbackModelItem.tsx_161"
+            componentId={`${componentIdPrefix}.remove.${index}`}
             icon={<TrashIcon />}
             onClick={() => onRemove(index)}
           />

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/FallbackModelsConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/FallbackModelsConfigurator.tsx
@@ -93,11 +93,7 @@ export const FallbackModelsConfigurator = ({
           />
         ))}
 
-        <Button
-          componentId="codegen_mlflow_app_src_oss_gateway_components_edit-endpoint_FallbackModelsConfigurator.tsx_96"
-          icon={<PlusIcon />}
-          onClick={handleAddModel}
-        >
+        <Button componentId={`${componentIdPrefix}.add`} icon={<PlusIcon />} onClick={handleAddModel}>
           <FormattedMessage defaultMessage="Add fallback" description="Button to add fallback model" />
         </Button>
       </div>

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitConfigurator.tsx
@@ -80,11 +80,7 @@ export const TrafficSplitConfigurator = ({
       ))}
 
       <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Button
-          componentId="codegen_mlflow_app_src_oss_gateway_components_edit-endpoint_TrafficSplitConfigurator.tsx_83"
-          icon={<PlusIcon />}
-          onClick={handleAddModel}
-        >
+        <Button componentId={`${componentIdPrefix}.add`} icon={<PlusIcon />} onClick={handleAddModel}>
           <FormattedMessage
             defaultMessage="Add model for traffic split"
             description="Button to add model for traffic split"

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitModelItem.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitModelItem.tsx
@@ -79,7 +79,7 @@ export const TrafficSplitModelItem = ({
       <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm, flex: 1 }}>
           <Button
-            componentId="codegen_mlflow_app_src_oss_gateway_components_edit-endpoint_TrafficSplitModelItem.tsx_79"
+            componentId={`${componentIdPrefix}.expand.${index}`}
             icon={isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
             onClick={() => setIsExpanded(!isExpanded)}
             size="small"
@@ -101,14 +101,14 @@ export const TrafficSplitModelItem = ({
           )}
         </div>
         <Tooltip
-          componentId="codegen_mlflow_app_src_oss_gateway_components_edit-endpoint_TrafficSplitModelItem.tsx_101"
+          componentId={`${componentIdPrefix}.remove-tooltip.${index}`}
           content={intl.formatMessage({
             defaultMessage: 'Remove model',
             description: 'Tooltip for remove traffic split model button',
           })}
         >
           <Button
-            componentId="codegen_mlflow_app_src_oss_gateway_components_edit-endpoint_TrafficSplitModelItem.tsx_108"
+            componentId={`${componentIdPrefix}.remove.${index}`}
             icon={<TrashIcon />}
             onClick={() => onRemove(index)}
           />
@@ -161,7 +161,7 @@ export const TrafficSplitModelItem = ({
             </FormUI.Label>
             <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
               <GatewayInput
-                componentId="codegen_mlflow_app_src_oss_gateway_components_edit-endpoint_TrafficSplitModelItem.tsx_161"
+                componentId={`${componentIdPrefix}.weight.${index}`}
                 type="number"
                 min={0}
                 max={100}

--- a/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
@@ -128,7 +128,7 @@ export const EndpointFormRenderer = ({
       {error && (
         <div css={{ padding: embedded ? 0 : `0 ${theme.spacing.md}px` }}>
           <Alert
-            componentId="codegen_mlflow_app_src_oss_gateway_components_endpoint-form_EndpointFormRenderer.tsx_130"
+            componentId={`${componentIdPrefix}.error`}
             closable={false}
             message={errorMessage}
             type="error"
@@ -177,7 +177,7 @@ export const EndpointFormRenderer = ({
                 <div>
                   <GatewayInput
                     id={`${componentIdPrefix}.name`}
-                    componentId="codegen_mlflow_app_src_oss_gateway_components_endpoint-form_EndpointFormRenderer.tsx_179"
+                    componentId={`${componentIdPrefix}.name`}
                     {...field}
                     onChange={(e) => {
                       field.onChange(e);
@@ -375,18 +375,12 @@ export const EndpointFormRenderer = ({
           flexShrink: 0,
         }}
       >
-        <Button
-          componentId="codegen_mlflow_app_src_oss_gateway_components_endpoint-form_EndpointFormRenderer.tsx_354"
-          onClick={onCancel}
-        >
+        <Button componentId={`${componentIdPrefix}.cancel`} onClick={onCancel}>
           <FormattedMessage defaultMessage="Cancel" description="Cancel button" />
         </Button>
-        <Tooltip
-          componentId="codegen_mlflow_app_src_oss_gateway_components_endpoint-form_EndpointFormRenderer.tsx_357"
-          content={buttonTooltip}
-        >
+        <Tooltip componentId={`${componentIdPrefix}.submit-tooltip`} content={buttonTooltip}>
           <Button
-            componentId="codegen_mlflow_app_src_oss_gateway_components_endpoint-form_EndpointFormRenderer.tsx_359"
+            componentId={`${componentIdPrefix}.submit`}
             type="primary"
             onClick={form.handleSubmit(onSubmit)}
             loading={isSubmitting}

--- a/mlflow/server/js/src/gateway/components/endpoints/EndpointUsageModal.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoints/EndpointUsageModal.tsx
@@ -264,7 +264,7 @@ export const EndpointUsageModal = ({ open, onClose, endpointName, baseUrl }: End
     <div css={{ marginBottom: theme.spacing.md }}>
       <div css={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginBottom: theme.spacing.xs }}>
         <CopyButton
-          componentId="codegen_mlflow_app_src_oss_gateway_components_endpoints_EndpointUsageModal.tsx_147"
+          componentId={`mlflow.gateway.usage-modal.copy-${label.toLowerCase().replace(/\s+/g, '-')}`}
           copyText={code}
           icon={<CopyIcon />}
           showLabel={false}

--- a/mlflow/server/js/src/gateway/components/model-configuration/components/ApiKeyConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/model-configuration/components/ApiKeyConfigurator.tsx
@@ -152,7 +152,7 @@ export function ApiKeyConfigurator({
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       <Radio.Group
-        componentId="codegen_mlflow_app_src_oss_gateway_components_model-configuration_components_ApiKeyConfigurator.tsx_142"
+        componentId={`${componentIdPrefix}.mode`}
         name={`${componentIdPrefix}.mode`}
         value={value.mode}
         onChange={(e) => handleModeChange(e.target.value as 'new' | 'existing')}
@@ -266,7 +266,7 @@ function NewSecretForm({
         </FormUI.Label>
         <GatewayInput
           id={`${componentIdPrefix}.name`}
-          componentId="codegen_mlflow_app_src_oss_gateway_components_model-configuration_components_ApiKeyConfigurator.tsx_256"
+          componentId={`${componentIdPrefix}.name`}
           value={value.name}
           onChange={(e) => onNameChange(e.target.value)}
           placeholder={formatMessage({
@@ -295,7 +295,7 @@ function NewSecretForm({
           </FormUI.Label>
           <Radio.Group
             name={`${componentIdPrefix}.auth-mode`}
-            componentId="codegen_mlflow_app_src_oss_gateway_components_model-configuration_components_ApiKeyConfigurator.tsx_285"
+            componentId={`${componentIdPrefix}.auth-mode`}
             value={value.authMode || defaultAuthMode}
             onChange={(e) => onAuthModeChange(e.target.value)}
             disabled={disabled}
@@ -327,7 +327,7 @@ function NewSecretForm({
           {field.fieldType === 'secret' ? (
             <SecretInput
               id={`${componentIdPrefix}.secret.${field.name}`}
-              componentId="codegen_mlflow_app_src_oss_gateway_components_model-configuration_components_ApiKeyConfigurator.tsx_317"
+              componentId={`${componentIdPrefix}.secret.${field.name}`}
               value={value.secretFields[field.name] ?? ''}
               onChange={(e) => onSecretFieldChange(field.name, e.target.value)}
               placeholder={field.description}
@@ -337,7 +337,7 @@ function NewSecretForm({
           ) : (
             <GatewayInput
               id={`${componentIdPrefix}.config.${field.name}`}
-              componentId="codegen_mlflow_app_src_oss_gateway_components_model-configuration_components_ApiKeyConfigurator.tsx_327"
+              componentId={`${componentIdPrefix}.config.${field.name}`}
               value={value.configFields[field.name] ?? ''}
               onChange={(e) => onConfigFieldChange(field.name, e.target.value)}
               placeholder={field.description}

--- a/mlflow/server/js/src/gateway/components/model-definitions/ModelDefinitionConfigSection.tsx
+++ b/mlflow/server/js/src/gateway/components/model-definitions/ModelDefinitionConfigSection.tsx
@@ -36,7 +36,7 @@ export const ModelDefinitionConfigSection = ({
           <FormattedMessage defaultMessage="Model configuration" description="Label for model configuration section" />
         </FormUI.Label>
         <Radio.Group
-          componentId="codegen_mlflow_app_src_oss_gateway_components_model-definitions_ModelDefinitionConfigSection.tsx_39"
+          componentId={`${componentIdPrefix}.mode`}
           name="modelDefinitionMode"
           value={mode}
           onChange={(e) => onModeChange(e.target.value as ModelDefinitionMode)}

--- a/mlflow/server/js/src/gateway/components/model-definitions/ModelDefinitionSelector.tsx
+++ b/mlflow/server/js/src/gateway/components/model-definitions/ModelDefinitionSelector.tsx
@@ -55,7 +55,7 @@ export const ModelDefinitionSelector = ({
       </FormUI.Label>
       <SimpleSelect
         id={selectId}
-        componentId="codegen_mlflow_app_src_oss_gateway_components_model-definitions_ModelDefinitionSelector.tsx_58"
+        componentId={selectId}
         value={value}
         onChange={({ target }) => onChange(target.value)}
         disabled={disabled || !hasOptions}

--- a/mlflow/server/js/src/gateway/components/secrets/SecretFormFields.tsx
+++ b/mlflow/server/js/src/gateway/components/secrets/SecretFormFields.tsx
@@ -131,7 +131,7 @@ export const SecretFormFields = ({
           </FormUI.Label>
           <GatewayInput
             id={`${componentIdPrefix}.name`}
-            componentId="codegen_mlflow_app_src_oss_gateway_components_secrets_SecretFormFields.tsx_134"
+            componentId={`${componentIdPrefix}.name`}
             value={value.name}
             onChange={(e: ChangeEvent<HTMLInputElement>) => handleNameChange(e.target.value)}
             placeholder={formatMessage({
@@ -152,7 +152,7 @@ export const SecretFormFields = ({
           </FormUI.Label>
           <Radio.Group
             name={`${componentIdPrefix}.auth-mode`}
-            componentId="codegen_mlflow_app_src_oss_gateway_components_secrets_SecretFormFields.tsx_155"
+            componentId={`${componentIdPrefix}.auth-mode`}
             value={effectiveAuthMode}
             onChange={(e: RadioChangeEvent) => handleAuthModeChange(e.target.value)}
             disabled={disabled}
@@ -184,7 +184,7 @@ export const SecretFormFields = ({
           {field.fieldType === 'secret' ? (
             <SecretInput
               id={`${componentIdPrefix}.secret.${field.name}`}
-              componentId="codegen_mlflow_app_src_oss_gateway_components_secrets_SecretFormFields.tsx_187"
+              componentId={`${componentIdPrefix}.secret.${field.name}`}
               value={value.secretFields[field.name] ?? ''}
               onChange={(e: ChangeEvent<HTMLInputElement>) => handleSecretFieldChange(field.name, e.target.value)}
               placeholder={field.description}
@@ -194,7 +194,7 @@ export const SecretFormFields = ({
           ) : (
             <GatewayInput
               id={`${componentIdPrefix}.config.${field.name}`}
-              componentId="codegen_mlflow_app_src_oss_gateway_components_secrets_SecretFormFields.tsx_197"
+              componentId={`${componentIdPrefix}.config.${field.name}`}
               value={value.configFields[field.name] ?? ''}
               onChange={(e: ChangeEvent<HTMLInputElement>) => handleConfigFieldChange(field.name, e.target.value)}
               placeholder={field.description}

--- a/mlflow/server/js/src/gateway/components/shared/ProviderFilterButton.tsx
+++ b/mlflow/server/js/src/gateway/components/shared/ProviderFilterButton.tsx
@@ -58,14 +58,10 @@ export const ProviderFilterButton = ({
   );
 
   return (
-    <Popover.Root
-      componentId="codegen_mlflow_app_src_oss_gateway_components_shared_ProviderFilterButton.tsx_61"
-      open={isOpen}
-      onOpenChange={setIsOpen}
-    >
+    <Popover.Root componentId={`${componentIdPrefix}.filter-popover`} open={isOpen} onOpenChange={setIsOpen}>
       <Popover.Trigger asChild>
         <Button
-          componentId="codegen_mlflow_app_src_oss_gateway_components_shared_ProviderFilterButton.tsx_64"
+          componentId={`${componentIdPrefix}.filter-button`}
           endIcon={<ChevronDownIcon />}
           css={{
             border: hasActiveFilters ? `1px solid ${theme.colors.actionDefaultBorderFocus} !important` : '',
@@ -108,7 +104,7 @@ export const ProviderFilterButton = ({
             sortedProviders.map((provider) => (
               <Checkbox
                 key={provider}
-                componentId="codegen_mlflow_app_src_oss_gateway_components_shared_ProviderFilterButton.tsx_107"
+                componentId={`${componentIdPrefix}.filter.provider.${provider}`}
                 isChecked={filter.providers.includes(provider)}
                 onChange={() => handleProviderToggle(provider)}
               >


### PR DESCRIPTION
### Related Issues/PRs

Relates to #20789

### What changes are proposed in this pull request?

PR #20789 (MLflow UI Sync) replaced dynamic template-based `componentId` values with codegen-generated strings (e.g., `codegen_mlflow_app_src_oss_gateway_...`) in 14 gateway component files. This PR restores the original `${componentIdPrefix}.suffix` pattern so they produce stable, semantic IDs that match the telemetry data.

**14 files modified, 38 componentIds restored** across:
- `DeleteConfirmationModal`, `EndpointFormRenderer`, `SecretFormFields`, `ApiKeyConfigurator`
- `FallbackModelItem`, `FallbackModelsConfigurator`, `TrafficSplitModelItem`, `TrafficSplitConfigurator`
- `ModelSelect`, `ProviderSelect`, `ProviderFilterButton`
- `EndpointUsageModal`, `ModelDefinitionConfigSection`, `ModelDefinitionSelector`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified with:
1. `grep -r "codegen_" mlflow/server/js/src/gateway/` — zero remaining codegen IDs
2. `yarn lint` and `yarn type-check` — both pass
3. Three-way diff confirmed all restored IDs match the original pre-sync code

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release