### PR TITLE
Add required componentId to Link in web-shared RoutingUtils

### DIFF
--- a/mlflow/server/js/src/common/utils/RoutingUtils.tsx
+++ b/mlflow/server/js/src/common/utils/RoutingUtils.tsx
@@ -38,13 +38,11 @@ import {
 import { HashRouter as HashRouterV5, Link as LinkV5, NavLink as NavLinkV5 } from 'react-router-dom';
 import type { ComponentProps } from 'react';
 import React, { useCallback, useMemo } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import {
   DesignSystemEventProviderAnalyticsEventTypes,
   DesignSystemEventProviderComponentTypes,
   useDesignSystemEventComponentCallbacks,
 } from '@databricks/design-system';
-import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
 
 import {
   prefixRouteWithWorkspace,

--- a/mlflow/server/js/src/common/utils/RoutingUtils.tsx
+++ b/mlflow/server/js/src/common/utils/RoutingUtils.tsx
@@ -42,6 +42,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   DesignSystemEventProviderAnalyticsEventTypes,
   DesignSystemEventProviderComponentTypes,
+  useDesignSystemEventComponentCallbacks,
 } from '@databricks/design-system';
 import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
 
@@ -144,17 +145,15 @@ const Link = React.forwardRef<
 >(function Link(props, ref) {
   const { to, disableWorkspacePrefix, componentId, onClick, ...rest } = props;
   const finalTo = disableWorkspacePrefix ? to : prefixRouteWithWorkspaceForTo(to);
-  const logTelemetryEvent = useLogTelemetryEvent();
-  const viewId = useMemo(() => uuidv4(), []);
+  const events = useMemo(() => [DesignSystemEventProviderAnalyticsEventTypes.OnClick], []);
+  const eventContext = useDesignSystemEventComponentCallbacks({
+    componentType: DesignSystemEventProviderComponentTypes.Button,
+    componentId,
+    analyticsEvents: events,
+  });
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    logTelemetryEvent({
-      componentId,
-      componentViewId: viewId,
-      componentType: DesignSystemEventProviderComponentTypes.Button,
-      componentSubType: null,
-      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
-    });
+    eventContext?.onClick(e);
     onClick?.(e);
   };
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/LoggedModelCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/LoggedModelCell.tsx
@@ -102,6 +102,7 @@ const LoggedModelComponent = (props: { experimentId?: string; modelId: string; i
       >
         {experimentId ? (
           <Link
+            componentId="mlflow.genai-traces-table.logged_model_cell.model_link"
             to={MlflowUtils.getLoggedModelPageRoute(experimentId, modelId)}
             target="_blank"
             css={{

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/RunName.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/RunName.tsx
@@ -39,6 +39,7 @@ const RunNameInner = ({ experimentId, runUuid }: { experimentId: string; runUuid
 
   return (
     <Link
+      componentId="mlflow.genai-traces-table.run_name_link"
       css={{
         display: 'flex',
         maxWidth: '100%',

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionIdLinkWrapper.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/SessionIdLinkWrapper.tsx
@@ -25,6 +25,7 @@ export const SessionIdLinkWrapper = ({
 
   return (
     <Link
+      componentId="mlflow.genai-traces-table.session_id_link"
       // prettier-ignore
       to={url}
     >

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
@@ -1017,7 +1017,9 @@ export const traceInfoCellRenderer = (
                 : basePath;
               return (
                 <div key={index}>
-                  <Link componentId="mlflow.genai-traces-table.prompt_link" to={url}>{label}</Link>
+                  <Link componentId="mlflow.genai-traces-table.prompt_link" to={url}>
+                    {label}
+                  </Link>
                 </div>
               );
             }

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
@@ -1017,7 +1017,7 @@ export const traceInfoCellRenderer = (
                 : basePath;
               return (
                 <div key={index}>
-                  <Link to={url}>{label}</Link>
+                  <Link componentId="mlflow.genai-traces-table.prompt_link" to={url}>{label}</Link>
                 </div>
               );
             }

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
@@ -116,6 +116,7 @@ const ExperimentChatSessionsTableRow: React.FC<React.PropsWithChildren<Experimen
             <TableCell key={cell.id} css={{ flex: `calc(var(--col-${cell.column.id}-size) / 100)` }}>
               {enableLinks ? (
                 <Link
+                  componentId="mlflow.genai-traces-table.chat_sessions_table.session_row_link"
                   to={{
                     pathname: MlflowUtils.getExperimentChatSessionPageRoute(
                       row.original.experimentId,

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/RoutingUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/RoutingUtils.tsx
@@ -6,7 +6,12 @@
  */
 /* eslint-disable no-restricted-imports */
 import type { ComponentProps } from 'react';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import {
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+  useDesignSystemEventComponentCallbacks,
+} from '@databricks/design-system';
 /**
  * Import React Router V6 parts
  */
@@ -266,11 +271,26 @@ const Outlet = OutletDirect;
 
 const Link = React.forwardRef<
   HTMLAnchorElement,
-  ComponentProps<typeof LinkDirect> & { disableWorkspacePrefix?: boolean }
+  ComponentProps<typeof LinkDirect> & { disableWorkspacePrefix?: boolean; componentId: string }
 >(function Link(props, ref) {
-  const { to, disableWorkspacePrefix, ...rest } = props;
+  const { to, disableWorkspacePrefix, componentId, onClick, ...rest } = props;
   const finalTo = disableWorkspacePrefix ? to : prefixRouteWithWorkspaceForTo(to);
-  return <LinkDirect ref={ref} to={finalTo} {...rest} />;
+  const events = useMemo(() => [DesignSystemEventProviderAnalyticsEventTypes.OnClick], []);
+  const eventContext = useDesignSystemEventComponentCallbacks({
+    componentType: DesignSystemEventProviderComponentTypes.Button,
+    componentId,
+    analyticsEvents: events,
+  });
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      eventContext?.onClick(e);
+      onClick?.(e);
+    },
+    [eventContext, onClick],
+  );
+
+  return <LinkDirect ref={ref} to={finalTo} onClick={handleClick} {...rest} />;
 });
 
 const NavLink = React.forwardRef<

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceHeaderSessionIdTag.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceHeaderSessionIdTag.tsx
@@ -73,7 +73,7 @@ export const ModelTraceHeaderSessionIdTag = ({
         componentId="mlflow.model-trace-explorer.session-id-tag"
         content={<FormattedMessage defaultMessage="View chat session" description="Tooltip for the session id tag" />}
       >
-        <Link to={sessionPageUrl}>
+        <Link componentId="mlflow.model_trace_explorer.header.session_id_link" to={sessionPageUrl}>
           <Tag componentId="mlflow.model_trace_explorer.header_details.tag-session-id">
             <span css={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: theme.spacing.xs }}>
               <SpeechBubbleIcon css={{ fontSize: 12 }} />

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/RoutingUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/RoutingUtils.tsx
@@ -6,8 +6,13 @@
  */
 /* eslint-disable no-restricted-imports */
 
+import {
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+  useDesignSystemEventComponentCallbacks,
+} from '@databricks/design-system';
 import type { ComponentProps } from 'react';
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   generatePath,
   useParams as useParamsDirect,
@@ -223,11 +228,26 @@ const useLocation = useLocationDirect;
 
 const Link = React.forwardRef<
   HTMLAnchorElement,
-  ComponentProps<typeof LinkDirect> & { disableWorkspacePrefix?: boolean }
+  ComponentProps<typeof LinkDirect> & { disableWorkspacePrefix?: boolean; componentId: string }
 >(function Link(props, ref) {
-  const { to, disableWorkspacePrefix, ...rest } = props;
+  const { to, disableWorkspacePrefix, componentId, onClick, ...rest } = props;
   const finalTo = disableWorkspacePrefix ? to : prefixRouteWithWorkspaceForTo(to);
-  return <LinkDirect ref={ref} to={finalTo} {...rest} />;
+  const events = useMemo(() => [DesignSystemEventProviderAnalyticsEventTypes.OnClick], []);
+  const eventContext = useDesignSystemEventComponentCallbacks({
+    componentType: DesignSystemEventProviderComponentTypes.Button,
+    componentId,
+    analyticsEvents: events,
+  });
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      eventContext?.onClick(e);
+      onClick?.(e);
+    },
+    [eventContext, onClick],
+  );
+
+  return <LinkDirect ref={ref} to={finalTo} onClick={handleClick} {...rest} />;
 });
 
 export const createMLflowRoutePath = (routePath: string) => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackItemContent.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackItemContent.tsx
@@ -191,7 +191,12 @@ export const FeedbackItemContent = ({ feedback }: { feedback: FeedbackAssessment
         </div>
       )}
       {judgeTraceHref && (
-        <Link to={judgeTraceHref} target="_blank" rel="noreferrer">
+        <Link
+          componentId="mlflow.model_trace_explorer.feedback_item.judge_trace_link"
+          to={judgeTraceHref}
+          target="_blank"
+          rel="noreferrer"
+        >
           <span css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
             <FormattedMessage
               defaultMessage="View trace"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/linked-prompts/ModelTraceExplorerLinkedPromptsTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/linked-prompts/ModelTraceExplorerLinkedPromptsTable.tsx
@@ -64,10 +64,18 @@ const PromptNameCellRenderer: ColumnDef<LinkedPromptsRow>['cell'] = ({ row }) =>
     const searchParams = new URLSearchParams();
     searchParams.set(PROMPT_VERSION_QUERY_PARAM, version);
     const routeWithVersion = `${baseRoute}?${searchParams.toString()}`;
-    return <Link to={routeWithVersion}>{name}</Link>;
+    return (
+      <Link componentId="mlflow.model_trace_explorer.linked_prompts.prompt_link" to={routeWithVersion}>
+        {name}
+      </Link>
+    );
   }
 
-  return <Link to={baseRoute}>{name}</Link>;
+  return (
+    <Link componentId="mlflow.model_trace_explorer.linked_prompts.prompt_link" to={baseRoute}>
+      {name}
+    </Link>
+  );
 };
 
 const VersionCellRenderer: ColumnDef<LinkedPromptsRow>['cell'] = ({ row }) => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/timeline-tree/TimelineTreeNode.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/timeline-tree/TimelineTreeNode.tsx
@@ -152,6 +152,7 @@ export const TimelineTreeNode = ({
                   componentId="shared.model-trace-explorer.gateway-trace-link"
                 >
                   <Link
+                    componentId="mlflow.model_trace_explorer.timeline.gateway_trace_link"
                     to={gatewayTraceHref}
                     target="_blank"
                     rel="noreferrer"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21637

### What changes are proposed in this pull request?

The `Link` component in `common/utils/RoutingUtils.tsx` requires a `componentId` prop for telemetry logging, but the equivalent `Link` components in the two web-shared RoutingUtils files did not. This PR updates them to match:

- **`genai-traces-table/utils/RoutingUtils.tsx`** and **`model-trace-explorer/RoutingUtils.tsx`**: `componentId` is now a required prop on `Link`, and click telemetry is logged via `useDesignSystemEventComponentCallbacks` from `@databricks/design-system`.
- **`common/utils/RoutingUtils.tsx`**: Refactored to use the same `useDesignSystemEventComponentCallbacks` pattern instead of the custom `useLogTelemetryEvent` hook + manual `uuid` view ID.
- All existing `<Link>` call sites in both web-shared packages are updated with appropriate `componentId` values.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

clicked some of the components that were edited


https://github.com/user-attachments/assets/bc76800f-c9a1-4bc3-b790-fccbc5690ee3


https://github.com/user-attachments/assets/7b383ed1-5dc4-4ba2-b757-88a131d26f34


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release