### PR TITLE
Fix conversation simulator default model encoding on Databricks

### DIFF
--- a/mlflow/genai/simulators/utils.py
+++ b/mlflow/genai/simulators/utils.py
@@ -65,7 +65,7 @@ def invoke_model_without_tracing(
     from mlflow.metrics.genai.model_utils import _parse_model_uri
 
     with delete_trace_if_created():
-        if model_uri == _DATABRICKS_DEFAULT_JUDGE_MODEL:
+        if model_uri in (_DATABRICKS_DEFAULT_JUDGE_MODEL, _DATABRICKS_AGENTIC_JUDGE_MODEL):
             user_prompt, system_prompt = serialize_messages_to_databricks_prompts(messages)
 
             result = call_chat_completions(

--- a/tests/genai/simulators/test_utils.py
+++ b/tests/genai/simulators/test_utils.py
@@ -74,7 +74,8 @@ def test_invoke_model_without_tracing_with_inference_params():
         assert call_kwargs["temperature"] == 0.5
 
 
-def test_invoke_model_without_tracing_with_databricks():
+@pytest.mark.parametrize("model_uri", ["databricks", "gpt-oss-120b"])
+def test_invoke_model_without_tracing_with_databricks(model_uri):
     from mlflow.types.llm import ChatMessage
 
     messages = [ChatMessage(role="user", content="Hello")]
@@ -88,7 +89,7 @@ def test_invoke_model_without_tracing_with_databricks():
         mock_call.return_value = mock.MagicMock(error_code=None, output_json='{"content": "Hi"}')
         mock_create.return_value = mock.MagicMock(content="Hi from Databricks")
 
-        result = invoke_model_without_tracing(model_uri="databricks", messages=messages)
+        result = invoke_model_without_tracing(model_uri=model_uri, messages=messages)
 
         assert result == "Hi from Databricks"
         mock_call.assert_called_once()


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When using the conversation simulator on Databricks with the default model, `invoke_model_without_tracing` only recognized the `"databricks"` model URI for routing through the Databricks managed endpoint. The default simulation model `"gpt-oss-120b"` (set by `get_default_simulation_model()`) was falling through to litellm, which rejected it as a malformed URI since it's not in `<provider>/<model-name>` format.

This PR adds `_DATABRICKS_AGENTIC_JUDGE_MODEL` (`"gpt-oss-120b"`) to the Databricks endpoint check so it correctly routes through `call_chat_completions`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Parametrized the existing Databricks test to cover both `"databricks"` and `"gpt-oss-120b"` model URIs.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release