### PR TITLE
fix: emit array schema for repeatable Click params in MCP tools

### DIFF
--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -57,9 +57,17 @@ def get_input_schema(params: list[click.Parameter]) -> dict[str, Any]:
     properties: dict[str, Any] = {}
     required: list[str] = []
     for p in params:
-        schema = {
-            "type": param_type_to_json_schema_type(p.type),
-        }
+        item_type = param_type_to_json_schema_type(p.type)
+        is_repeatable = getattr(p, "multiple", False) or getattr(p, "nargs", 1) == -1
+        if is_repeatable:
+            schema: dict[str, Any] = {
+                "type": "array",
+                "items": {"type": item_type},
+            }
+        else:
+            schema = {
+                "type": item_type,
+            }
         if p.default is not None and (
             # In click >= 8.3.0, the default value is set to `Sentinel.UNSET` when no default is
             # provided. Skip setting the default in this case.

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -141,6 +141,49 @@ async def test_get_prompt(client: Client):
     assert "MLflow" in content
 
 
+def test_get_input_schema_repeatable_option():
+    """Click options with multiple=True should produce array schemas."""
+    import click
+
+    from mlflow.mcp.server import get_input_schema
+
+    @click.command()
+    @click.option("--name", type=str, help="A single name")
+    @click.option("--tag", type=str, multiple=True, help="Repeatable tags")
+    def cmd(name, tag):
+        pass
+
+    schema = get_input_schema(cmd.params)
+    # Scalar option should remain a plain string
+    assert schema["properties"]["name"] == {"type": "string", "description": "A single name"}
+    # Repeatable option should be an array of strings
+    assert schema["properties"]["tag"] == {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Repeatable tags",
+        "default": (),
+    }
+
+
+def test_get_input_schema_variadic_argument():
+    """Click arguments with nargs=-1 should produce array schemas."""
+    import click
+
+    from mlflow.mcp.server import get_input_schema
+
+    @click.command()
+    @click.argument("files", nargs=-1)
+    def cmd(files):
+        pass
+
+    schema = get_input_schema(cmd.params)
+    assert schema["properties"]["files"] == {
+        "type": "array",
+        "items": {"type": "string"},
+        "default": (),
+    }
+
+
 def test_fn_wrapper_handles_unset_defaults(monkeypatch):
     import click
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes `get_input_schema()` in `mlflow/mcp/server.py` to emit `{"type": "array", "items": {"type": "..."}}` instead of a bare scalar `{"type": "..."}` when a Click parameter has `multiple=True` (repeatable options like `--tag`) or `nargs=-1` (variadic arguments).

### Problem

Several MCP-exposed CLI commands accept repeatable or variadic parameters (e.g. `--trace-id`, `--tags`, `--config`, positional `requirement_strings`), but the generated MCP tool schemas expose them as scalar strings. This makes the MCP contract inconsistent with the underlying CLI behavior and can cause MCP clients to construct invalid tool calls.

### Fix

In the `get_input_schema` loop, before building the property dict for each parameter, check `getattr(p, "multiple", False)` and `getattr(p, "nargs", 1) == -1`. When either is true, wrap the item type in an array schema.

### Affected commands include

- `mlflow runs link-traces --trace-id` (multiple=True)
- `mlflow models update-pip-requirements` positional args (nargs=-1)
- `mlflow runs create --tags` (multiple=True)
- `mlflow models predict --env` (multiple=True)
- Deployment commands with repeatable `--config`

## How is this PR tested?

- Added `test_get_input_schema_repeatable_option` — verifies that a Click option with `multiple=True` produces an array schema while a normal option stays scalar.
- Added `test_get_input_schema_variadic_argument` — verifies that a Click argument with `nargs=-1` produces an array schema.

## Does this PR require documentation update?

No.

## Release Notes

### Is this a user-facing change?

- [x] No. This is an internal fix that corrects the generated JSON schema for MCP tools.

Resolves #21548