### PR TITLE
fix: emit array schemas for MCP tools with repeatable/variadic params

### DIFF
--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -57,9 +57,23 @@ def get_input_schema(params: list[click.Parameter]) -> dict[str, Any]:
     properties: dict[str, Any] = {}
     required: list[str] = []
     for p in params:
-        schema = {
-            "type": param_type_to_json_schema_type(p.type),
-        }
+        item_type = param_type_to_json_schema_type(p.type)
+
+        # Click params with multiple=True (Options) or nargs=-1 (Arguments)
+        # accept a variable number of values and should be represented as arrays.
+        is_array = (isinstance(p, click.Option) and p.multiple) or (
+            isinstance(p, click.Argument) and p.nargs == -1
+        )
+
+        if is_array:
+            schema: dict[str, Any] = {
+                "type": "array",
+                "items": {"type": item_type},
+            }
+        else:
+            schema = {
+                "type": item_type,
+            }
         if p.default is not None and (
             # In click >= 8.3.0, the default value is set to `Sentinel.UNSET` when no default is
             # provided. Skip setting the default in this case.
@@ -70,7 +84,10 @@ def get_input_schema(params: list[click.Parameter]) -> dict[str, Any]:
         if isinstance(p, click.Option):
             schema["description"] = (p.help or "").strip()
         if isinstance(p.type, click.Choice):
-            schema["enum"] = [str(choice) for choice in p.type.choices]
+            if is_array:
+                schema["items"]["enum"] = [str(choice) for choice in p.type.choices]
+            else:
+                schema["enum"] = [str(choice) for choice in p.type.choices]
         if p.required:
             required.append(p.name)
         properties[p.name] = schema
@@ -99,6 +116,10 @@ def fn_wrapper(command: click.Command) -> Callable[..., str]:
                         kwargs[param.name] = None
                     else:
                         kwargs[param.name] = param.default
+                # MCP clients send array values as JSON lists, but Click
+                # expects tuples for params with multiple=True or nargs=-1.
+                elif isinstance(kwargs[param.name], list):
+                    kwargs[param.name] = tuple(kwargs[param.name])
             command.callback(**kwargs)  # type: ignore[misc]
         return string_io.getvalue().strip()
 

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -141,6 +141,61 @@ async def test_get_prompt(client: Client):
     assert "MLflow" in content
 
 
+def test_get_input_schema_array_for_multiple_option():
+    import click
+
+    from mlflow.mcp.server import get_input_schema
+
+    @click.command()
+    @click.option("--tag", "tags", multiple=True, type=str, help="Tags to add.")
+    @click.option("--name", type=str, help="A single name.")
+    def cmd(tags, name):
+        pass
+
+    schema = get_input_schema(cmd.params)
+    # --tag is multiple=True, so it should be an array of strings
+    assert schema["properties"]["tags"] == {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Tags to add.",
+    }
+    # --name is a normal scalar option
+    assert schema["properties"]["name"]["type"] == "string"
+
+
+def test_get_input_schema_array_for_variadic_argument():
+    import click
+
+    from mlflow.mcp.server import get_input_schema
+
+    @click.command()
+    @click.argument("files", nargs=-1, type=str)
+    def cmd(files):
+        pass
+
+    schema = get_input_schema(cmd.params)
+    assert schema["properties"]["files"] == {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+
+
+def test_fn_wrapper_converts_list_to_tuple():
+    import click
+
+    from mlflow.mcp.server import fn_wrapper
+
+    @click.command()
+    @click.option("--tag", "tags", multiple=True, type=str)
+    def cmd(tags):
+        click.echo(f"type={type(tags).__name__},len={len(tags)}")
+
+    wrapper = fn_wrapper(cmd)
+    result = wrapper(tags=["a", "b", "c"])
+    assert "type=tuple" in result
+    assert "len=3" in result
+
+
 def test_fn_wrapper_handles_unset_defaults(monkeypatch):
     import click
 


### PR DESCRIPTION
## Summary

Fixes #21548

MCP tool schemas for CLI arguments that accept multiple values were incorrectly emitted as scalar strings instead of arrays. This affects commands like `mlflow runs link-traces --trace-id`, `mlflow models update-pip-requirements`, `mlflow runs create --tags`, and deployment commands with repeatable `--config`.

### Changes

- **`mlflow/mcp/server.py`** — `get_input_schema()` now detects Click params with `multiple=True` (Options) or `nargs=-1` (Arguments) and emits `{"type": "array", "items": {"type": "..."}}` schemas instead of scalar types. Choice enums on array params are placed under `items`.
- **`mlflow/mcp/server.py`** — `fn_wrapper()` now converts incoming JSON lists back to tuples before passing them to Click callbacks, since Click expects tuples for multi-value params.
- **`tests/mcp/test_mcp.py`** — Added three unit tests:
  - `test_get_input_schema_array_for_multiple_option` — verifies `multiple=True` options produce array schemas
  - `test_get_input_schema_array_for_variadic_argument` — verifies `nargs=-1` arguments produce array schemas
  - `test_fn_wrapper_converts_list_to_tuple` — verifies list values from MCP clients are converted to tuples

## Test plan

- [x] New unit tests pass for array schema generation (multiple=True options, nargs=-1 arguments)
- [x] New unit test verifies list-to-tuple conversion in fn_wrapper
- [ ] Existing `test_mcp.py` tests continue to pass (no breaking changes to scalar params)