### PR TITLE
Return all windows from InMemoryBudgetTracker.refresh_policies for multi-worker spend sync

### DIFF
--- a/mlflow/gateway/budget_tracker/__init__.py
+++ b/mlflow/gateway/budget_tracker/__init__.py
@@ -92,8 +92,7 @@ class BudgetTracker(ABC):
         for policies that no longer exist.
 
         Returns:
-            List of newly created windows (cumulative_spend=0) that may need
-            backfilling from historical trace data.
+            Windows that should be synced against authoritative trace data.
         """
 
     @abstractmethod

--- a/mlflow/gateway/budget_tracker/in_memory.py
+++ b/mlflow/gateway/budget_tracker/in_memory.py
@@ -35,12 +35,13 @@ class InMemoryBudgetTracker(BudgetTracker):
         for policies that no longer exist.
 
         Returns:
-            List of newly created windows (cumulative_spend=0) that may need
-            backfilling from historical trace data.
+            All current windows. In a multi-worker setup each worker tracks
+            spend independently, so all windows are returned so callers can
+            sync cumulative spend from authoritative trace data on every
+            refresh interval.
         """
         now = datetime.now(timezone.utc)
         new_windows: dict[str, BudgetWindow] = {}
-        fresh_windows: list[BudgetWindow] = []
 
         with self._lock:
             for policy in policies:
@@ -58,18 +59,16 @@ class InMemoryBudgetTracker(BudgetTracker):
                     existing.window_end = window_end
                     new_windows[pid] = existing
                 else:
-                    window = BudgetWindow(
+                    new_windows[pid] = BudgetWindow(
                         policy=policy,
                         window_start=window_start,
                         window_end=window_end,
                     )
-                    new_windows[pid] = window
-                    fresh_windows.append(window)
 
             self._windows = new_windows
             self.mark_refreshed()
 
-        return fresh_windows
+        return list(new_windows.values())
 
     def record_cost(
         self,
@@ -148,14 +147,18 @@ class InMemoryBudgetTracker(BudgetTracker):
         return False, None
 
     def backfill_spend(self, spend_by_policy: dict[str, float]) -> None:
-        """Set cumulative spend on windows from historical data."""
+        """Sync cumulative spend on windows from authoritative trace data.
+
+        Uses max(current, db_value) so that in-process spend recorded since
+        the last trace flush is never lost due to DB write lag.
+        """
         with self._lock:
             for budget_policy_id, spend in spend_by_policy.items():
                 window = self._windows.get(budget_policy_id)
                 if window is None:
                     continue
-                window.cumulative_spend = spend
-                window.exceeded = spend >= window.policy.budget_amount
+                window.cumulative_spend = max(window.cumulative_spend, spend)
+                window.exceeded = window.cumulative_spend >= window.policy.budget_amount
 
     def get_all_windows(self) -> list[BudgetWindow]:
         with self._lock:

--- a/mlflow/gateway/budget_tracker/in_memory.py
+++ b/mlflow/gateway/budget_tracker/in_memory.py
@@ -41,7 +41,7 @@ class InMemoryBudgetTracker(BudgetTracker):
             refresh interval.
         """
         now = datetime.now(timezone.utc)
-        new_windows: dict[str, BudgetWindow] = {}
+        active_windows: dict[str, BudgetWindow] = {}
 
         with self._lock:
             for policy in policies:
@@ -57,18 +57,18 @@ class InMemoryBudgetTracker(BudgetTracker):
                 if existing and existing.window_start == window_start:
                     existing.policy = policy
                     existing.window_end = window_end
-                    new_windows[pid] = existing
+                    active_windows[pid] = existing
                 else:
-                    new_windows[pid] = BudgetWindow(
+                    active_windows[pid] = BudgetWindow(
                         policy=policy,
                         window_start=window_start,
                         window_end=window_end,
                     )
 
-            self._windows = new_windows
+            self._windows = active_windows
             self.mark_refreshed()
 
-        return list(new_windows.values())
+        return list(active_windows.values())
 
     def record_cost(
         self,

--- a/mlflow/server/gateway_budget.py
+++ b/mlflow/server/gateway_budget.py
@@ -30,23 +30,22 @@ from mlflow.webhooks.types import BudgetPolicyExceededPayload
 _logger = logging.getLogger(__name__)
 
 
-def calculate_existing_cost_for_new_windows(
-    store: SqlAlchemyStore, new_windows: list[BudgetWindow]
+def calculate_existing_cost_for_windows(
+    store: SqlAlchemyStore, windows: list[BudgetWindow]
 ) -> dict[str, float]:
-    """Calculate existing spend for newly created budget windows from trace history.
+    """Calculate spend for budget windows from trace history.
 
-    When a new BudgetWindow is created (server restart or new policy), its
-    cumulative_spend starts at 0. This queries historical trace cost data so
-    that budget tracking survives server restarts.
+    Queries historical trace cost data for each window so that budget tracking
+    accounts for spend across all gateway workers and survives server restarts.
 
     Returns:
         Dict mapping budget_policy_id to historical spend amount.
     """
     result: dict[str, float] = {}
-    if not new_windows:
+    if not windows:
         return result
 
-    for window in new_windows:
+    for window in windows:
         try:
             start_ms = int(window.window_start.timestamp() * 1000)
             end_ms = int(window.window_end.timestamp() * 1000)
@@ -77,8 +76,8 @@ def maybe_refresh_budget_policies(store: SqlAlchemyStore) -> None:
     if tracker.needs_refresh():
         try:
             policies = store.list_budget_policies()
-            new_windows = tracker.refresh_policies(policies)
-            existing_spend = calculate_existing_cost_for_new_windows(store, new_windows)
+            windows = tracker.refresh_policies(policies)
+            existing_spend = calculate_existing_cost_for_windows(store, windows)
             tracker.backfill_spend(existing_spend)
         except Exception:
             _logger.debug("Failed to refresh budget policies", exc_info=True)

--- a/tests/gateway/test_budget_tracker.py
+++ b/tests/gateway/test_budget_tracker.py
@@ -364,38 +364,39 @@ def test_all_duration_units_window_consistency(duration_unit):
 # --- refresh_policies return value tests ---
 
 
-def test_refresh_policies_returns_new_windows():
+def test_refresh_policies_returns_all_windows():
     tracker = InMemoryBudgetTracker()
     policy1 = _make_policy(budget_policy_id="bp-1")
     policy2 = _make_policy(budget_policy_id="bp-2")
 
-    new_windows = tracker.refresh_policies([policy1, policy2])
-    assert len(new_windows) == 2
-    ids = {w.policy.budget_policy_id for w in new_windows}
+    windows = tracker.refresh_policies([policy1, policy2])
+    assert len(windows) == 2
+    ids = {w.policy.budget_policy_id for w in windows}
     assert ids == {"bp-1", "bp-2"}
 
 
-def test_refresh_policies_returns_empty_on_reload():
+def test_refresh_policies_returns_all_windows_on_reload():
     tracker = InMemoryBudgetTracker()
     policy = _make_policy()
 
-    new_windows = tracker.refresh_policies([policy])
-    assert len(new_windows) == 1
+    windows = tracker.refresh_policies([policy])
+    assert len(windows) == 1
 
-    # Reload same policy within same window — no new windows
-    new_windows = tracker.refresh_policies([policy])
-    assert new_windows == []
+    # Reload same policy within same window — still returns the existing window
+    windows = tracker.refresh_policies([policy])
+    assert len(windows) == 1
 
 
-def test_refresh_policies_returns_only_new_on_mixed():
+def test_refresh_policies_returns_all_windows_on_mixed():
     tracker = InMemoryBudgetTracker()
     policy1 = _make_policy(budget_policy_id="bp-1")
     tracker.refresh_policies([policy1])
 
     policy2 = _make_policy(budget_policy_id="bp-2")
-    new_windows = tracker.refresh_policies([policy1, policy2])
-    assert len(new_windows) == 1
-    assert new_windows[0].policy.budget_policy_id == "bp-2"
+    windows = tracker.refresh_policies([policy1, policy2])
+    assert len(windows) == 2
+    ids = {w.policy.budget_policy_id for w in windows}
+    assert ids == {"bp-1", "bp-2"}
 
 
 # --- backfill_spend tests ---
@@ -436,6 +437,18 @@ def test_backfill_spend_nonexistent_is_noop():
     tracker.refresh_policies([_make_policy()])
     # Should not raise
     tracker.backfill_spend({"nonexistent-policy": 50.0})
+
+
+def test_backfill_spend_uses_max_to_protect_in_process_spend():
+    # Simulate trace-flush lag: in-process spend is ahead of what DB reports.
+    # backfill_spend must not decrease cumulative_spend below the in-process value.
+    tracker = InMemoryBudgetTracker()
+    tracker.refresh_policies([_make_policy(budget_amount=100.0)])
+    tracker.record_cost(30.0)  # in-process spend = 30
+
+    tracker.backfill_spend({"bp-test": 10.0})  # DB is behind
+    window = tracker._get_window_info("bp-test")
+    assert window.cumulative_spend == 30.0  # in-process value preserved
 
 
 # --- get_all_windows tests ---

--- a/tests/gateway/test_gateway_budget.py
+++ b/tests/gateway/test_gateway_budget.py
@@ -16,7 +16,7 @@ from mlflow.entities.gateway_budget_policy import (
 from mlflow.gateway.budget_tracker import get_budget_tracker
 from mlflow.gateway.tracing_utils import maybe_traced_gateway_call
 from mlflow.server.gateway_budget import (
-    calculate_existing_cost_for_new_windows,
+    calculate_existing_cost_for_windows,
     check_budget_limit,
     fire_budget_exceeded_webhooks,
     make_budget_on_complete,
@@ -283,7 +283,7 @@ def test_maybe_refresh_skips_when_not_needed():
     store.list_budget_policies.assert_not_called()
 
 
-# --- calculate_existing_cost_for_new_windows tests ---
+# --- calculate_existing_cost_for_windows tests ---
 
 
 def test_calculate_existing_cost_on_new_windows():
@@ -293,7 +293,7 @@ def test_calculate_existing_cost_on_new_windows():
     store = MagicMock()
     store.sum_gateway_trace_cost.return_value = 42.0
 
-    existing_spend = calculate_existing_cost_for_new_windows(store, new_windows)
+    existing_spend = calculate_existing_cost_for_windows(store, new_windows)
     tracker.backfill_spend(existing_spend)
 
     store.sum_gateway_trace_cost.assert_called_once()
@@ -302,7 +302,7 @@ def test_calculate_existing_cost_on_new_windows():
 
 def test_calculate_existing_cost_skipped_when_no_new_windows():
     store = MagicMock()
-    result = calculate_existing_cost_for_new_windows(store, [])
+    result = calculate_existing_cost_for_windows(store, [])
     assert result == {}
     store.sum_gateway_trace_cost.assert_not_called()
 
@@ -314,7 +314,7 @@ def test_calculate_existing_cost_handles_store_error():
     store = MagicMock()
     store.sum_gateway_trace_cost.side_effect = Exception("DB error")
 
-    existing_spend = calculate_existing_cost_for_new_windows(store, new_windows)
+    existing_spend = calculate_existing_cost_for_windows(store, new_windows)
     tracker.backfill_spend(existing_spend)
 
     assert tracker._get_window_info("bp-test").cumulative_spend == 0.0
@@ -327,7 +327,7 @@ def test_calculate_existing_cost_zero_spend_excluded():
     store = MagicMock()
     store.sum_gateway_trace_cost.return_value = 0.0
 
-    existing_spend = calculate_existing_cost_for_new_windows(store, new_windows)
+    existing_spend = calculate_existing_cost_for_windows(store, new_windows)
     assert existing_spend == {}
 
     tracker.backfill_spend(existing_spend)


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

In a multi-worker gateway setup, each process maintains independent in-memory spend, causing cumulative totals to drift across workers. Previously `InMemoryBudgetTracker.refresh_policies` only returned newly created windows, so `backfill_spend` was only called on server restart or window rollover — not during steady-state operation.

The Redis tracker is unaffected — it already has accurate cross-worker spend via atomic Redis operations, so it continues to return only newly created windows.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release