### PR TITLE
Hide `_issue_discovery_judge` feedback from traces UI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.test.ts
@@ -288,6 +288,23 @@ describe('getAssessmentInfos', () => {
     );
   });
 
+  it('should exclude _issue_discovery_judge from assessment infos', () => {
+    const currentEvaluationResults = makeTracesFromAssessments([
+      {
+        responseAssessmentsByName: {
+          _issue_discovery_judge: [{ name: '_issue_discovery_judge', booleanValue: false }],
+          quality: [{ name: 'quality', booleanValue: true }],
+        },
+      },
+    ]);
+
+    const result = getAssessmentInfos(intl, currentEvaluationResults, undefined);
+
+    const names = result.map((info) => info.name);
+    expect(names).not.toContain('_issue_discovery_judge');
+    expect(names).toContain('quality');
+  });
+
   it('should exclude overall assessment if it has no valid values', () => {
     const currentEvaluationResults = makeTracesFromAssessments([
       { overallAssessments: [{ name: 'overall_assessment', stringValue: null }] },

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.test.ts
@@ -9,7 +9,10 @@ import {
   getBarChartData,
   getUniqueValueCountsBySourceId,
 } from './AggregationUtils';
-import { ASSESSMENT_SESSION_METADATA_KEY } from '../../model-trace-explorer/constants';
+import {
+  ASSESSMENT_SESSION_METADATA_KEY,
+  INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE,
+} from '../../model-trace-explorer/constants';
 import type {
   AssessmentAggregates,
   AssessmentDType,
@@ -292,7 +295,9 @@ describe('getAssessmentInfos', () => {
     const currentEvaluationResults = makeTracesFromAssessments([
       {
         responseAssessmentsByName: {
-          _issue_discovery_judge: [{ name: '_issue_discovery_judge', booleanValue: false }],
+          [INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE]: [
+            { name: INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE, booleanValue: false },
+          ],
           quality: [{ name: 'quality', booleanValue: true }],
         },
       },
@@ -301,7 +306,7 @@ describe('getAssessmentInfos', () => {
     const result = getAssessmentInfos(intl, currentEvaluationResults, undefined);
 
     const names = result.map((info) => info.name);
-    expect(names).not.toContain('_issue_discovery_judge');
+    expect(names).not.toContain(INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE);
     expect(names).toContain('quality');
   });
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
@@ -107,6 +107,10 @@ export function getAssessmentInfos(
       ...overallAssessmentsByName,
       ...retrievalAssessmentsByName,
     ]) {
+      // Skip internal assessments (names starting with underscore are implementation details)
+      if (assessmentName.startsWith('_')) {
+        continue;
+      }
       assessmentNames.add(assessmentName);
       // For string values, if we see a value that is not "yes" or "no", we treat it as a string.
       // This is not a great approach, we should probably actually pass the pass-fail dtype information back somehow.

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
@@ -2,7 +2,10 @@ import { first, isNil } from 'lodash';
 
 import type { ThemeType } from '@databricks/design-system';
 import type { IntlShape } from '@databricks/i18n';
-import { ASSESSMENT_SESSION_METADATA_KEY } from '../../model-trace-explorer/constants';
+import {
+  ASSESSMENT_SESSION_METADATA_KEY,
+  INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE,
+} from '../../model-trace-explorer/constants';
 
 import { getAssessmentValueBarBackgroundColor } from './Colors';
 import { DEFAULT_RUN_PLACEHOLDER_NAME } from './TraceUtils';
@@ -108,7 +111,7 @@ export function getAssessmentInfos(
       ...retrievalAssessmentsByName,
     ]) {
       // Skip internal assessments that are implementation details of the issue discovery pipeline
-      if (assessmentName === '_issue_discovery_judge') {
+      if (assessmentName === INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE) {
         continue;
       }
       assessmentNames.add(assessmentName);

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
@@ -107,8 +107,8 @@ export function getAssessmentInfos(
       ...overallAssessmentsByName,
       ...retrievalAssessmentsByName,
     ]) {
-      // Skip internal assessments (names starting with underscore are implementation details)
-      if (assessmentName.startsWith('_')) {
+      // Skip internal assessments that are implementation details of the issue discovery pipeline
+      if (assessmentName === '_issue_discovery_judge') {
         continue;
       }
       assessmentNames.add(assessmentName);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -53,7 +53,6 @@ const groupFeedbacks = (feedbacks: FeedbackAssessment[]): GroupedFeedbacks => {
     }
   });
 
-  // Filter out LLM judge feedback groups
   return Object.entries(aggregated);
 };
 
@@ -136,7 +135,8 @@ export const AssessmentsPaneFeedbackSection = ({
   traceId: string;
   sessionId?: string;
 }) => {
-  const groupedFeedbacks = useMemo(() => groupFeedbacks(feedbacks), [feedbacks]);
+  const visibleFeedbacks = useMemo(() => feedbacks.filter((f) => !f.assessment_name.startsWith('_')), [feedbacks]);
+  const groupedFeedbacks = useMemo(() => groupFeedbacks(visibleFeedbacks), [visibleFeedbacks]);
 
   const [createFormVisible, setCreateFormVisible] = useState(false);
 
@@ -206,7 +206,7 @@ export const AssessmentsPaneFeedbackSection = ({
             defaultMessage="Feedback"
             description="Label for the feedback section in the assessments pane"
           />{' '}
-          {!isEmpty(groupedFeedbacks) && <>({feedbacks?.length})</>}
+          {!isEmpty(groupedFeedbacks) && <>({visibleFeedbacks.length})</>}
         </Typography.Text>
       </div>
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -135,7 +135,10 @@ export const AssessmentsPaneFeedbackSection = ({
   traceId: string;
   sessionId?: string;
 }) => {
-  const visibleFeedbacks = useMemo(() => feedbacks.filter((f) => !f.assessment_name.startsWith('_')), [feedbacks]);
+  const visibleFeedbacks = useMemo(
+    () => feedbacks.filter((f) => f.assessment_name !== '_issue_discovery_judge'),
+    [feedbacks],
+  );
   const groupedFeedbacks = useMemo(() => groupFeedbacks(visibleFeedbacks), [visibleFeedbacks]);
 
   const [createFormVisible, setCreateFormVisible] = useState(false);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -53,6 +53,7 @@ const groupFeedbacks = (feedbacks: FeedbackAssessment[]): GroupedFeedbacks => {
     }
   });
 
+  // Filter out LLM judge feedback groups
   return Object.entries(aggregated);
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -22,6 +22,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { invalidateMlflowSearchTracesCache } from '../hooks/invalidateMlflowSearchTracesCache';
 import { FETCH_TRACE_INFO_QUERY_KEY } from '../ModelTraceExplorer.utils';
 import { isEvaluatingTracesInDetailsViewEnabled } from '../FeatureUtils';
+import { INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE } from '../constants';
 
 type GroupedFeedbacksByValue = { [value: string]: FeedbackAssessment[] };
 
@@ -137,7 +138,7 @@ export const AssessmentsPaneFeedbackSection = ({
   sessionId?: string;
 }) => {
   const visibleFeedbacks = useMemo(
-    () => feedbacks.filter((f) => f.assessment_name !== '_issue_discovery_judge'),
+    () => feedbacks.filter((f) => f.assessment_name !== INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE),
     [feedbacks],
   );
   const groupedFeedbacks = useMemo(() => groupFeedbacks(visibleFeedbacks), [visibleFeedbacks]);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/constants.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/constants.ts
@@ -27,6 +27,9 @@ export const ASSESSMENT_SESSION_METADATA_KEY = 'mlflow.trace.session';
 // Span attribute key for linked gateway trace
 export const SPAN_ATTRIBUTE_LINKED_GATEWAY_TRACE_ID_KEY = 'mlflow.gateway.linkedTraceId';
 
+// Internal assessment names that should be hidden from the UI
+export const INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE = '_issue_discovery_judge';
+
 // Key used in assessment metadata to indicate which document (by index) the assessment references
 export const MLFLOW_SPAN_OUTPUT_KEY = 'span_output_key';
 export const CHUNK_INDEX_KEY = 'chunk_index';


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21270

### What changes are proposed in this pull request?

The `_issue_discovery_judge` feedback assessments created by the issue discovery pipeline are implementation details that shouldn't be visible to users. This PR hides them from both the assessments sidebar panel and the traces table columns.

Before:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f2faf233-2125-4b95-96bc-8fca32c6e7cc" />

After:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/49f28313-6cb2-4bae-b26c-e10b328829f6" />


### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Hide internal `_issue_discovery_judge` feedback from the traces UI so users only see relevant assessments.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)