### PR TITLE
Delete model definitions when endpoint is deleted from UI

### DIFF
--- a/mlflow/server/js/src/gateway/components/endpoints/DeleteEndpointModal.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoints/DeleteEndpointModal.tsx
@@ -30,7 +30,7 @@ export const DeleteEndpointModal = ({ open, endpoint, bindings, onClose, onSucce
 
   const handleConfirm = async () => {
     if (!endpoint) return;
-    await deleteEndpoint(endpoint.endpoint_id);
+    await deleteEndpoint({ endpointId: endpoint.endpoint_id, modelMappings: endpoint.model_mappings });
     onSuccess?.();
   };
 

--- a/mlflow/server/js/src/gateway/hooks/useDeleteEndpoint.test.tsx
+++ b/mlflow/server/js/src/gateway/hooks/useDeleteEndpoint.test.tsx
@@ -1,0 +1,121 @@
+import { describe, afterEach, test, jest, expect, beforeEach } from '@jest/globals';
+import { renderHook, cleanup, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
+import { useDeleteEndpoint } from './useDeleteEndpoint';
+import { GatewayApi } from '../api';
+import type { EndpointModelMapping } from '../types';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const makeMapping = (modelDefinitionId: string): EndpointModelMapping => ({
+  mapping_id: `mapping-${modelDefinitionId}`,
+  endpoint_id: 'ep-1',
+  model_definition_id: modelDefinitionId,
+  weight: 1,
+  created_at: 0,
+});
+
+describe('useDeleteEndpoint', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('deletes endpoint and all associated model definitions', async () => {
+    jest.spyOn(GatewayApi, 'deleteEndpoint').mockResolvedValue(undefined);
+    jest.spyOn(GatewayApi, 'deleteModelDefinition').mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteEndpoint(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        endpointId: 'ep-1',
+        modelMappings: [makeMapping('md-1'), makeMapping('md-2')],
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(GatewayApi.deleteEndpoint).toHaveBeenCalledWith('ep-1');
+    expect(GatewayApi.deleteModelDefinition).toHaveBeenCalledWith('md-1');
+    expect(GatewayApi.deleteModelDefinition).toHaveBeenCalledWith('md-2');
+  });
+
+  test('succeeds even when a model definition deletion fails', async () => {
+    jest.spyOn(GatewayApi, 'deleteEndpoint').mockResolvedValue(undefined);
+    jest.spyOn(GatewayApi, 'deleteModelDefinition').mockRejectedValue(new Error('still in use'));
+
+    const { result } = renderHook(() => useDeleteEndpoint(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        endpointId: 'ep-1',
+        modelMappings: [makeMapping('md-1')],
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(GatewayApi.deleteEndpoint).toHaveBeenCalledWith('ep-1');
+    expect(GatewayApi.deleteModelDefinition).toHaveBeenCalledWith('md-1');
+  });
+
+  test('fails and does not delete model definitions when endpoint deletion fails', async () => {
+    jest.spyOn(GatewayApi, 'deleteEndpoint').mockRejectedValue(new Error('endpoint not found'));
+    jest.spyOn(GatewayApi, 'deleteModelDefinition').mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteEndpoint(), { wrapper: createWrapper() });
+
+    let caughtError: Error | undefined;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          endpointId: 'ep-1',
+          modelMappings: [makeMapping('md-1')],
+        });
+      } catch (e) {
+        caughtError = e as Error;
+      }
+    });
+
+    expect(caughtError?.message).toBe('endpoint not found');
+    expect(GatewayApi.deleteEndpoint).toHaveBeenCalledWith('ep-1');
+    expect(GatewayApi.deleteModelDefinition).not.toHaveBeenCalled();
+  });
+
+  test('deletes endpoint with no model mappings', async () => {
+    jest.spyOn(GatewayApi, 'deleteEndpoint').mockResolvedValue(undefined);
+    jest.spyOn(GatewayApi, 'deleteModelDefinition').mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteEndpoint(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({ endpointId: 'ep-1', modelMappings: [] });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(GatewayApi.deleteEndpoint).toHaveBeenCalledWith('ep-1');
+    expect(GatewayApi.deleteModelDefinition).not.toHaveBeenCalled();
+  });
+});

--- a/mlflow/server/js/src/gateway/hooks/useDeleteEndpoint.ts
+++ b/mlflow/server/js/src/gateway/hooks/useDeleteEndpoint.ts
@@ -1,14 +1,27 @@
 import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { GatewayApi } from '../api';
+import type { EndpointModelMapping } from '../types';
 
 export const useDeleteEndpoint = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (endpointId: string) => GatewayApi.deleteEndpoint(endpointId),
+    mutationFn: async ({
+      endpointId,
+      modelMappings,
+    }: {
+      endpointId: string;
+      modelMappings: EndpointModelMapping[];
+    }) => {
+      await GatewayApi.deleteEndpoint(endpointId);
+
+      const modelDefinitionIds = modelMappings.map((m) => m.model_definition_id);
+      await Promise.allSettled(modelDefinitionIds.map((id) => GatewayApi.deleteModelDefinition(id)));
+    },
     onSuccess: () => {
       queryClient.invalidateQueries(['gateway_endpoints']);
       queryClient.invalidateQueries(['gateway_bindings']);
+      queryClient.invalidateQueries(['gateway_model_definitions']);
     },
   });
 };


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When an endpoint is deleted from the gateway UI, the associated model definition(s) were not being cleaned up, leaving orphaned records.

https://github.com/user-attachments/assets/1b9bf660-392b-4a26-b780-cb9474d81ce7


### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix: Model definitions are now automatically deleted when their associated endpoint is deleted from the UI.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release