### PR TITLE
Support artifact-repo traces in `batch_get_traces`

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4858,7 +4858,6 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         if not trace_ids:
             return []
 
-        traces = []
         order_case = case(
             {trace_id: idx for idx, trace_id in enumerate(trace_ids)},
             value=SqlTraceInfo.request_id,

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4877,18 +4877,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             traces = []
             for sql_trace_info in sql_trace_infos:
                 trace_info = sql_trace_info.to_mlflow_entity()
-                # batch_get_traces is depended by search_traces, so we need to return
-                # complete traces only
-                try:
-                    spans = self._get_spans_with_trace_info(
-                        trace_info, sql_trace_info.spans, allow_partial=False
-                    )
-                except MlflowTracingException:
-                    _logger.debug(
-                        "Trace %s has spans in artifact repo, skipping in batch_get_traces",
-                        trace_info.trace_id,
-                    )
-                    continue
+                spans = self._get_spans_with_trace_info(
+                    trace_info, sql_trace_info.spans, allow_partial=False
+                )
                 if spans:
                     traces.append(Trace(info=trace_info, data=TraceData(spans=spans)))
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4873,6 +4873,8 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 .all()
             )
 
+            # batch_get_traces is depended by search_traces, so we need to return
+            # complete traces only
             traces = []
             for sql_trace_info in sql_trace_infos:
                 trace_info = sql_trace_info.to_mlflow_entity()

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4884,8 +4884,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         trace_info, sql_trace_info.spans, allow_partial=False
                     )
                 except MlflowTracingException:
-                    # Trace data is stored in artifact repo, not tracking store.
-                    # Skip this trace as we can't load spans from here.
+                    _logger.debug(
+                        "Trace %s has spans in artifact repo, skipping in batch_get_traces",
+                        trace_info.trace_id,
+                    )
                     continue
                 if spans:
                     traces.append(Trace(info=trace_info, data=TraceData(spans=spans)))

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4877,10 +4877,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             traces = []
             for sql_trace_info in sql_trace_infos:
                 trace_info = sql_trace_info.to_mlflow_entity()
-                spans = self._get_spans_with_trace_info(
+                if spans := self._get_spans_with_trace_info(
                     trace_info, sql_trace_info.spans, allow_partial=False
-                )
-                if spans:
+                ):
                     traces.append(Trace(info=trace_info, data=TraceData(spans=spans)))
 
             return traces

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4879,9 +4879,15 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 trace_info = sql_trace_info.to_mlflow_entity()
                 # batch_get_traces is depended by search_traces, so we need to return
                 # complete traces only
-                if spans := self._get_spans_with_trace_info(
-                    trace_info, sql_trace_info.spans, allow_partial=False
-                ):
+                try:
+                    spans = self._get_spans_with_trace_info(
+                        trace_info, sql_trace_info.spans, allow_partial=False
+                    )
+                except MlflowTracingException:
+                    # Trace data is stored in artifact repo, not tracking store.
+                    # Skip this trace as we can't load spans from here.
+                    continue
+                if spans:
                     traces.append(Trace(info=trace_info, data=TraceData(spans=spans)))
 
             return traces

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4873,11 +4873,11 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 .all()
             )
 
-            # batch_get_traces is depended by search_traces, so we need to return
-            # complete traces only
             traces = []
             for sql_trace_info in sql_trace_infos:
                 trace_info = sql_trace_info.to_mlflow_entity()
+                # batch_get_traces is depended by search_traces, so we need to return
+                # complete traces only
                 if spans := self._get_spans_with_trace_info(
                     trace_info, sql_trace_info.spans, allow_partial=False
                 ):

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -345,30 +345,7 @@ class TracingClient:
 
                 if include_spans:
                     trace_infos_by_location = self._group_trace_infos_by_location(trace_infos)
-                    for (
-                        location,
-                        location_trace_infos,
-                    ) in trace_infos_by_location.items():
-                        if location == SpansLocation.ARTIFACT_REPO:
-                            # download traces from artifact repository if spans are
-                            # stored in the artifact repository
-                            traces.extend(
-                                trace
-                                for trace in executor.map(
-                                    self._download_spans_from_artifact_repo,
-                                    location_trace_infos,
-                                )
-                                if trace
-                            )
-                        else:
-                            # Get full traces with BatchGetTraces, all traces in a single call
-                            # must be located in the same table.
-                            trace_ids = [t.trace_id for t in location_trace_infos]
-                            traces.extend(
-                                self._download_spans_from_batch_get_traces(
-                                    trace_ids, location, executor
-                                )
-                            )
+                    traces.extend(self._load_traces_by_location(trace_infos_by_location, executor))
 
                 else:
                     traces.extend(Trace(t, TraceData(spans=[])) for t in trace_infos)
@@ -391,7 +368,22 @@ class TracingClient:
         Returns:
             List of Trace objects.
         """
-        return self.store.batch_get_traces(trace_ids, location)
+        if not trace_ids:
+            return []
+
+        # If location is provided, this is a UC schema/v4 call - delegate directly
+        if location is not None:
+            return self.store.batch_get_traces(trace_ids, location)
+
+        # Get trace infos (metadata only) to determine where spans are stored
+        trace_infos = self.store.batch_get_trace_infos(trace_ids)
+        trace_infos_by_location = self._group_trace_infos_by_location(trace_infos)
+
+        max_workers = MLFLOW_SEARCH_TRACES_MAX_THREADS.get()
+        with ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="MlflowTracingBatchGet"
+        ) as executor:
+            return self._load_traces_by_location(trace_infos_by_location, executor)
 
     def _download_spans_from_batch_get_traces(
         self, trace_ids: list[str], location: str, executor: ThreadPoolExecutor
@@ -409,6 +401,29 @@ class TracingClient:
         batches = [trace_ids[i : i + batch_size] for i in range(0, len(trace_ids), batch_size)]
         for minibatch_traces in executor.map(_fetch_minibatch, batches):
             traces.extend(minibatch_traces)
+        return traces
+
+    def _load_traces_by_location(
+        self,
+        trace_infos_by_location: dict[str, list[TraceInfo]],
+        executor: ThreadPoolExecutor,
+    ) -> list[Trace]:
+        traces = []
+        for location, location_trace_infos in trace_infos_by_location.items():
+            if location == SpansLocation.ARTIFACT_REPO:
+                traces.extend(
+                    tr
+                    for tr in executor.map(
+                        self._download_spans_from_artifact_repo,
+                        location_trace_infos,
+                    )
+                    if tr
+                )
+            else:
+                trace_ids = [t.trace_id for t in location_trace_infos]
+                traces.extend(
+                    self._download_spans_from_batch_get_traces(trace_ids, location, executor)
+                )
         return traces
 
     def _download_spans_from_artifact_repo(self, trace_info: TraceInfo) -> Trace | None:

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -375,8 +375,14 @@ class TracingClient:
         if location is not None:
             return self.store.batch_get_traces(trace_ids, location)
 
-        # Get trace infos (metadata only) to determine where spans are stored
-        trace_infos = self.store.batch_get_trace_infos(trace_ids)
+        # Get trace infos (metadata only) to determine where spans are stored.
+        # Fall back to store.batch_get_traces directly if the store doesn't
+        # implement batch_get_trace_infos (e.g. RestStore, DatabricksRestStore).
+        try:
+            trace_infos = self.store.batch_get_trace_infos(trace_ids)
+        except MlflowNotImplementedException:
+            return self.store.batch_get_traces(trace_ids, location)
+
         trace_infos_by_location = self._group_trace_infos_by_location(trace_infos)
 
         max_workers = MLFLOW_SEARCH_TRACES_MAX_THREADS.get()

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -385,7 +385,7 @@ class TracingClient:
 
         trace_infos_by_location = self._group_trace_infos_by_location(trace_infos)
 
-        max_workers = MLFLOW_SEARCH_TRACES_MAX_THREADS.get()
+        max_workers = min(len(trace_ids), MLFLOW_SEARCH_TRACES_MAX_THREADS.get())
         with ThreadPoolExecutor(
             max_workers=max_workers, thread_name_prefix="MlflowTracingBatchGet"
         ) as executor:

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -377,7 +377,7 @@ class TracingClient:
 
         # Get trace infos (metadata only) to determine where spans are stored.
         # Fall back to store.batch_get_traces directly if the store doesn't
-        # implement batch_get_trace_infos (e.g. RestStore, DatabricksRestStore).
+        # implement batch_get_trace_infos (e.g. DatabricksRestStore).
         try:
             trace_infos = self.store.batch_get_trace_infos(trace_ids)
         except MlflowNotImplementedException:

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -392,13 +392,12 @@ class TracingClient:
             return self._load_traces_by_location(trace_infos_by_location, executor)
 
     def _download_spans_from_batch_get_traces(
-        self, trace_infos: list[TraceInfo], location: str, executor: ThreadPoolExecutor
+        self, trace_ids: list[str], location: str, executor: ThreadPoolExecutor
     ) -> list[Trace]:
         """
         Fetch full traces including spans from the BatchGetTrace v4 endpoint.
         BatchGetTrace endpoint only support up to 10 traces in a single call.
         """
-        trace_ids = [t.trace_id for t in trace_infos]
         traces = []
 
         def _fetch_minibatch(ids: list[str]) -> list[Trace]:
@@ -429,7 +428,7 @@ class TracingClient:
             else:
                 traces.extend(
                     self._download_spans_from_batch_get_traces(
-                        location_trace_infos, location, executor
+                        [t.trace_id for t in location_trace_infos], location, executor
                     )
                 )
         return traces

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -392,12 +392,13 @@ class TracingClient:
             return self._load_traces_by_location(trace_infos_by_location, executor)
 
     def _download_spans_from_batch_get_traces(
-        self, trace_ids: list[str], location: str, executor: ThreadPoolExecutor
+        self, trace_infos: list[TraceInfo], location: str, executor: ThreadPoolExecutor
     ) -> list[Trace]:
         """
         Fetch full traces including spans from the BatchGetTrace v4 endpoint.
         BatchGetTrace endpoint only support up to 10 traces in a single call.
         """
+        trace_ids = [t.trace_id for t in trace_infos]
         traces = []
 
         def _fetch_minibatch(ids: list[str]) -> list[Trace]:
@@ -426,9 +427,10 @@ class TracingClient:
                     if tr
                 )
             else:
-                trace_ids = [t.trace_id for t in location_trace_infos]
                 traces.extend(
-                    self._download_spans_from_batch_get_traces(trace_ids, location, executor)
+                    self._download_spans_from_batch_get_traces(
+                        location_trace_infos, location, executor
+                    )
                 )
         return traces
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -12729,6 +12729,45 @@ def test_batch_get_traces_with_incomplete_trace(store: SqlAlchemyStore) -> None:
     assert traces[0].data.spans[0].status.status_code == "OK"
 
 
+def test_batch_get_traces_skips_artifact_repo_traces(store: SqlAlchemyStore) -> None:
+    experiment_id = store.create_experiment("test_artifact_repo_traces")
+
+    # Create a trace via start_trace only (no log_spans call),
+    # so it has no SPANS_LOCATION tag — simulating spans stored in artifact repo.
+    artifact_trace_id = f"tr-{uuid.uuid4().hex}"
+    store.start_trace(
+        TraceInfo(
+            trace_id=artifact_trace_id,
+            trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+            request_time=1000,
+            execution_duration=500,
+            state=TraceState.OK,
+        )
+    )
+
+    # Requesting only the artifact-repo trace should return empty
+    traces = store.batch_get_traces([artifact_trace_id])
+    assert len(traces) == 0
+
+    # Create a normal trace with spans in the tracking store
+    normal_trace_id = f"tr-{uuid.uuid4().hex}"
+    spans = [
+        create_test_span(
+            trace_id=normal_trace_id,
+            name="root_span",
+            span_id=111,
+            status=trace_api.StatusCode.OK,
+            trace_num=99999,
+        ),
+    ]
+    store.log_spans(experiment_id, spans)
+
+    # Requesting both should return only the normal trace
+    traces = store.batch_get_traces([artifact_trace_id, normal_trace_id])
+    assert len(traces) == 1
+    assert traces[0].info.trace_id == normal_trace_id
+
+
 def test_log_spans_token_usage(store: SqlAlchemyStore) -> None:
     experiment_id = store.create_experiment("test_log_spans_token_usage")
     trace_id = f"tr-{uuid.uuid4().hex}"

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -55,7 +55,7 @@ from mlflow.environment_variables import (
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_TRACKING_URI,
 )
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, MlflowTracingException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
@@ -12729,7 +12729,7 @@ def test_batch_get_traces_with_incomplete_trace(store: SqlAlchemyStore) -> None:
     assert traces[0].data.spans[0].status.status_code == "OK"
 
 
-def test_batch_get_traces_skips_artifact_repo_traces(store: SqlAlchemyStore) -> None:
+def test_batch_get_traces_raises_for_artifact_repo_traces(store: SqlAlchemyStore) -> None:
     experiment_id = store.create_experiment("test_artifact_repo_traces")
 
     # Create a trace via start_trace only (no log_spans call),
@@ -12745,27 +12745,8 @@ def test_batch_get_traces_skips_artifact_repo_traces(store: SqlAlchemyStore) -> 
         )
     )
 
-    # Requesting only the artifact-repo trace should return empty
-    traces = store.batch_get_traces([artifact_trace_id])
-    assert len(traces) == 0
-
-    # Create a normal trace with spans in the tracking store
-    normal_trace_id = f"tr-{uuid.uuid4().hex}"
-    spans = [
-        create_test_span(
-            trace_id=normal_trace_id,
-            name="root_span",
-            span_id=111,
-            status=trace_api.StatusCode.OK,
-            trace_num=99999,
-        ),
-    ]
-    store.log_spans(experiment_id, spans)
-
-    # Requesting both should return only the normal trace
-    traces = store.batch_get_traces([artifact_trace_id, normal_trace_id])
-    assert len(traces) == 1
-    assert traces[0].info.trace_id == normal_trace_id
+    with pytest.raises(MlflowTracingException, match="not stored in tracking store"):
+        store.batch_get_traces([artifact_trace_id])
 
 
 def test_log_spans_token_usage(store: SqlAlchemyStore) -> None:

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -59,6 +59,13 @@ def test_batch_get_traces():
 
 def test_batch_get_traces_without_location():
     mock_store = Mock()
+    trace_info = Mock()
+    trace_info.trace_id = "id1"
+    trace_info.trace_location.mlflow_experiment = Mock()
+    trace_info.trace_location.uc_schema = None
+    trace_info.trace_location.uc_table_prefix = None
+    trace_info.tags = {TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE}
+    mock_store.batch_get_trace_infos.return_value = [trace_info]
     mock_store.batch_get_traces.return_value = ["trace1"]
 
     with patch("mlflow.tracing.client._get_store", return_value=mock_store):
@@ -66,6 +73,62 @@ def test_batch_get_traces_without_location():
         traces = client.batch_get_traces(["id1"])
 
     assert traces == ["trace1"]
+    mock_store.batch_get_trace_infos.assert_called_once_with(["id1"])
+    mock_store.batch_get_traces.assert_called_once_with(["id1"], None)
+
+
+def test_batch_get_traces_empty():
+    mock_store = Mock()
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient()
+        traces = client.batch_get_traces([])
+
+    assert traces == []
+    mock_store.batch_get_trace_infos.assert_not_called()
+
+
+def test_batch_get_traces_with_artifact_repo_traces():
+    mock_store = Mock()
+
+    # Trace with spans in tracking store
+    tracking_trace_info = Mock()
+    tracking_trace_info.trace_id = "id1"
+    tracking_trace_info.trace_location.mlflow_experiment = Mock()
+    tracking_trace_info.trace_location.uc_schema = None
+    tracking_trace_info.trace_location.uc_table_prefix = None
+    tracking_trace_info.tags = {TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE}
+
+    # Trace with spans in artifact repo (no SPANS_LOCATION tag)
+    artifact_trace_info = Mock()
+    artifact_trace_info.trace_id = "id2"
+    artifact_trace_info.trace_location.mlflow_experiment = Mock()
+    artifact_trace_info.trace_location.uc_schema = None
+    artifact_trace_info.trace_location.uc_table_prefix = None
+    artifact_trace_info.tags = {}
+
+    mock_store.batch_get_trace_infos.return_value = [tracking_trace_info, artifact_trace_info]
+
+    tracking_trace = Mock()
+    tracking_trace.info.trace_id = "id1"
+    mock_store.batch_get_traces.return_value = [tracking_trace]
+
+    artifact_trace = Mock()
+    artifact_trace.info.trace_id = "id2"
+
+    with (
+        patch("mlflow.tracing.client._get_store", return_value=mock_store),
+        patch.object(
+            TracingClient, "_download_spans_from_artifact_repo", return_value=artifact_trace
+        ) as mock_download,
+    ):
+        client = TracingClient()
+        traces = client.batch_get_traces(["id1", "id2"])
+
+    assert len(traces) == 2
+    assert tracking_trace in traces
+    assert artifact_trace in traces
+    mock_download.assert_called_once_with(artifact_trace_info)
     mock_store.batch_get_traces.assert_called_once_with(["id1"], None)
 
 

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -88,48 +88,48 @@ def test_batch_get_traces_empty():
     mock_store.batch_get_trace_infos.assert_not_called()
 
 
+@skip_when_testing_trace_sdk
 def test_batch_get_traces_with_artifact_repo_traces():
-    mock_store = Mock()
+    from mlflow.entities.trace import Trace
+    from mlflow.entities.trace_data import TraceData
+    from mlflow.entities.trace_info import TraceInfo
+    from mlflow.entities.trace_location import TraceLocation
+    from mlflow.entities.trace_state import TraceState
 
-    # Trace with spans in tracking store
-    tracking_trace_info = Mock()
-    tracking_trace_info.trace_id = "id1"
-    tracking_trace_info.trace_location.mlflow_experiment = Mock()
-    tracking_trace_info.trace_location.uc_schema = None
-    tracking_trace_info.trace_location.uc_table_prefix = None
-    tracking_trace_info.tags = {TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE}
+    # Create a trace with spans in the tracking store
+    with mlflow.start_span("tracking_span"):
+        tracking_trace_id = mlflow.get_active_trace_id()
 
-    # Trace with spans in artifact repo (no SPANS_LOCATION tag)
-    artifact_trace_info = Mock()
-    artifact_trace_info.trace_id = "id2"
-    artifact_trace_info.trace_location.mlflow_experiment = Mock()
-    artifact_trace_info.trace_location.uc_schema = None
-    artifact_trace_info.trace_location.uc_table_prefix = None
-    artifact_trace_info.tags = {}
+    # Create a trace without spans (artifact-repo case)
+    experiment_id = mlflow.tracking.fluent._get_experiment_id()
+    artifact_trace_id = f"tr-{uuid.uuid4().hex}"
+    store = mlflow.tracking.MlflowClient()._tracking_client.store
+    store.start_trace(
+        TraceInfo(
+            trace_id=artifact_trace_id,
+            trace_location=TraceLocation.from_experiment_id(experiment_id),
+            request_time=1000,
+            execution_duration=500,
+            state=TraceState.OK,
+        )
+    )
 
-    mock_store.batch_get_trace_infos.return_value = [tracking_trace_info, artifact_trace_info]
-
-    tracking_trace = Mock()
-    tracking_trace.info.trace_id = "id1"
-    mock_store.batch_get_traces.return_value = [tracking_trace]
-
-    artifact_trace = Mock()
-    artifact_trace.info.trace_id = "id2"
-
-    with (
-        patch("mlflow.tracing.client._get_store", return_value=mock_store),
-        patch.object(
-            TracingClient, "_download_spans_from_artifact_repo", return_value=artifact_trace
-        ) as mock_download,
-    ):
+    # Mock _download_spans_from_artifact_repo since there's no real artifact data
+    artifact_trace = Trace(
+        info=store.get_trace_info(artifact_trace_id),
+        data=TraceData(spans=[]),
+    )
+    with patch.object(
+        TracingClient, "_download_spans_from_artifact_repo", return_value=artifact_trace
+    ) as mock_download:
         client = TracingClient()
-        traces = client.batch_get_traces(["id1", "id2"])
+        traces = client.batch_get_traces([tracking_trace_id, artifact_trace_id])
 
     assert len(traces) == 2
-    assert tracking_trace in traces
-    assert artifact_trace in traces
-    mock_download.assert_called_once_with(artifact_trace_info)
-    mock_store.batch_get_traces.assert_called_once_with(["id1"], None)
+    trace_ids = {t.info.trace_id for t in traces}
+    assert tracking_trace_id in trace_ids
+    assert artifact_trace_id in trace_ids
+    mock_download.assert_called_once()
 
 
 def test_batch_get_traces_fallback_when_batch_get_trace_infos_not_implemented():

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -9,7 +9,7 @@ from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 import mlflow
 from mlflow.entities.span import create_mlflow_span
 from mlflow.environment_variables import MLFLOW_TRACING_SQL_WAREHOUSE_ID
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, MlflowNotImplementedException
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.tracing.analysis import TraceFilterCorrelationResult
 from mlflow.tracing.client import TracingClient
@@ -129,6 +129,19 @@ def test_batch_get_traces_with_artifact_repo_traces():
     assert tracking_trace in traces
     assert artifact_trace in traces
     mock_download.assert_called_once_with(artifact_trace_info)
+    mock_store.batch_get_traces.assert_called_once_with(["id1"], None)
+
+
+def test_batch_get_traces_fallback_when_batch_get_trace_infos_not_implemented():
+    mock_store = Mock()
+    mock_store.batch_get_trace_infos.side_effect = MlflowNotImplementedException()
+    mock_store.batch_get_traces.return_value = ["trace1"]
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient()
+        traces = client.batch_get_traces(["id1"])
+
+    assert traces == ["trace1"]
     mock_store.batch_get_traces.assert_called_once_with(["id1"], None)
 
 

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -64,12 +64,13 @@ def test_batch_get_traces():
 
 def test_batch_get_traces_without_location():
     mock_store = Mock()
-    trace_info = Mock()
-    trace_info.trace_id = "id1"
-    trace_info.trace_location.mlflow_experiment = Mock()
-    trace_info.trace_location.uc_schema = None
-    trace_info.trace_location.uc_table_prefix = None
-    trace_info.tags = {TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE}
+    trace_info = TraceInfo(
+        trace_id="id1",
+        trace_location=TraceLocation.from_experiment_id("0"),
+        request_time=1000,
+        state=TraceState.OK,
+        tags={TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE},
+    )
     mock_store.batch_get_trace_infos.return_value = [trace_info]
     mock_store.batch_get_traces.return_value = ["trace1"]
 

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -8,6 +8,11 @@ from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 
 import mlflow
 from mlflow.entities.span import create_mlflow_span
+from mlflow.entities.trace import Trace
+from mlflow.entities.trace_data import TraceData
+from mlflow.entities.trace_info import TraceInfo
+from mlflow.entities.trace_location import TraceLocation
+from mlflow.entities.trace_state import TraceState
 from mlflow.environment_variables import MLFLOW_TRACING_SQL_WAREHOUSE_ID
 from mlflow.exceptions import MlflowException, MlflowNotImplementedException
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
@@ -90,12 +95,6 @@ def test_batch_get_traces_empty():
 
 @skip_when_testing_trace_sdk
 def test_batch_get_traces_with_artifact_repo_traces():
-    from mlflow.entities.trace import Trace
-    from mlflow.entities.trace_data import TraceData
-    from mlflow.entities.trace_info import TraceInfo
-    from mlflow.entities.trace_location import TraceLocation
-    from mlflow.entities.trace_state import TraceState
-
     # Create a trace with spans in the tracking store
     with mlflow.start_span("tracking_span"):
         tracking_trace_id = mlflow.get_active_trace_id()


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21665, #21666

### What changes are proposed in this pull request?

`batch_get_traces` didn't handle traces whose spans are stored in the artifact repository (old traces or File store traces without the `SPANS_LOCATION` tag). At the store level, this caused an uncaught `MlflowTracingException`. At the `TracingClient` level, these traces were silently skipped, causing callers like `_fetch_traces_batch` in the scorer job to raise "Traces not found" errors.

This PR:
1. Catches `MlflowTracingException` in `SqlAlchemyStore.batch_get_traces` as a safety net with DEBUG log
2. Enhances `TracingClient.batch_get_traces` to fetch artifact-repo traces via `_download_spans_from_artifact_repo`, following the same pattern as `search_traces`
3. Extracts the shared trace-loading logic into `_load_traces_by_location` to deduplicate code between `search_traces` and `batch_get_traces`
4. Falls back to `store.batch_get_traces` when the store doesn't implement `batch_get_trace_infos` (e.g. `DatabricksRestStore`)

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release