### PR TITLE
Fix MCP tool schemas to emit arrays for repeatable CLI parameters

### DIFF
--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -57,23 +57,29 @@ def get_input_schema(params: list[click.Parameter]) -> dict[str, Any]:
     properties: dict[str, Any] = {}
     required: list[str] = []
     for p in params:
-        is_array_param = getattr(p, "multiple", False) or p.nargs == -1
+        is_array_param = p.multiple or p.nargs == -1
         item_schema = {"type": param_type_to_json_schema_type(p.type)}
         if isinstance(p.type, click.Choice):
             item_schema["enum"] = [str(choice) for choice in p.type.choices]
 
         schema = {"type": "array", "items": item_schema} if is_array_param else item_schema
-        if p.default is not None and (
-            # In click >= 8.3.0, the default value is set to `Sentinel.UNSET` when no default is
-            # provided. Skip setting the default in this case.
-            # See https://github.com/pallets/click/pull/3030 for more details.
-            not isinstance(p.default, str) and repr(p.default) != "Sentinel.UNSET"
+        if (
+            p.default is not None
+            and (
+                # In click >= 8.3.0, the default value is set to `Sentinel.UNSET` when no default is
+                # provided. Skip setting the default in this case.
+                # See https://github.com/pallets/click/pull/3030 for more details.
+                not isinstance(p.default, str) and repr(p.default) != "Sentinel.UNSET"
+            )
+            and not (is_array_param and p.required)
         ):
             schema["default"] = list(p.default) if is_array_param else p.default
         if isinstance(p, click.Option):
             schema["description"] = (p.help or "").strip()
         if p.required:
             required.append(p.name)
+            if is_array_param:
+                schema["minItems"] = 1
         properties[p.name] = schema
 
     return {
@@ -105,7 +111,7 @@ def fn_wrapper(command: click.Command) -> Callable[..., str]:
             for param in command.params:
                 if (
                     param.name in kwargs
-                    and (getattr(param, "multiple", False) or param.nargs == -1)
+                    and (param.multiple or param.nargs == -1)
                     and isinstance(kwargs[param.name], list)
                 ):
                     kwargs[param.name] = tuple(

--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -102,7 +102,12 @@ def fn_wrapper(command: click.Command) -> Callable[..., str]:
             # Fill in defaults for missing optional arguments
             for param in command.params:
                 if param.name not in kwargs:
-                    if param.default is click_unset:
+                    if param.multiple or param.nargs == -1:
+                        if param.default in (None, click_unset):
+                            kwargs[param.name] = ()
+                        else:
+                            kwargs[param.name] = tuple(param.default)
+                    elif param.default is click_unset:
                         kwargs[param.name] = None
                     else:
                         kwargs[param.name] = param.default

--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -57,20 +57,21 @@ def get_input_schema(params: list[click.Parameter]) -> dict[str, Any]:
     properties: dict[str, Any] = {}
     required: list[str] = []
     for p in params:
-        schema = {
-            "type": param_type_to_json_schema_type(p.type),
-        }
+        is_array_param = getattr(p, "multiple", False) or p.nargs == -1
+        item_schema = {"type": param_type_to_json_schema_type(p.type)}
+        if isinstance(p.type, click.Choice):
+            item_schema["enum"] = [str(choice) for choice in p.type.choices]
+
+        schema = {"type": "array", "items": item_schema} if is_array_param else item_schema
         if p.default is not None and (
             # In click >= 8.3.0, the default value is set to `Sentinel.UNSET` when no default is
             # provided. Skip setting the default in this case.
             # See https://github.com/pallets/click/pull/3030 for more details.
             not isinstance(p.default, str) and repr(p.default) != "Sentinel.UNSET"
         ):
-            schema["default"] = p.default
+            schema["default"] = list(p.default) if is_array_param else p.default
         if isinstance(p, click.Option):
             schema["description"] = (p.help or "").strip()
-        if isinstance(p.type, click.Choice):
-            schema["enum"] = [str(choice) for choice in p.type.choices]
         if p.required:
             required.append(p.name)
         properties[p.name] = schema
@@ -99,6 +100,18 @@ def fn_wrapper(command: click.Command) -> Callable[..., str]:
                         kwargs[param.name] = None
                     else:
                         kwargs[param.name] = param.default
+
+            # Convert array parameters to the types expected by each command's callback
+            for param in command.params:
+                if (
+                    param.name in kwargs
+                    and (getattr(param, "multiple", False) or param.nargs == -1)
+                    and isinstance(kwargs[param.name], list)
+                ):
+                    kwargs[param.name] = tuple(
+                        param.type.convert(value, param, None) for value in kwargs[param.name]
+                    )
+
             command.callback(**kwargs)  # type: ignore[misc]
         return string_io.getvalue().strip()
 

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -184,6 +184,23 @@ def test_fn_wrapper_handles_unset_defaults(monkeypatch):
     assert "None" in result
 
 
+def test_fn_wrapper_uses_empty_tuples_for_missing_array_params():
+    captured = {}
+
+    @click.command()
+    @click.option("--items", multiple=True)
+    @click.argument("names", nargs=-1)
+    def cmd(items, names):
+        captured["items"] = items
+        captured["names"] = names
+
+    wrapper = fn_wrapper(cmd)
+    wrapper()
+
+    assert captured["items"] == ()
+    assert captured["names"] == ()
+
+
 def test_fn_wrapper_converts_repeatable_custom_types():
     with patch.object(python_api, "predict") as mock_predict:
         wrapper = fn_wrapper(model_commands.commands["predict"])

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -1,6 +1,8 @@
 import sys
 from collections.abc import AsyncIterator
+from unittest.mock import patch
 
+import click
 import pytest
 import pytest_asyncio
 from fastmcp import Client
@@ -8,6 +10,8 @@ from fastmcp.client.transports import StdioTransport
 
 import mlflow
 from mlflow.mcp import server
+from mlflow.mcp.server import fn_wrapper
+from mlflow.models import python_api
 from mlflow.models.cli import commands as model_commands
 from mlflow.runs import commands as run_commands
 
@@ -161,10 +165,6 @@ async def test_get_prompt(client: Client):
 
 
 def test_fn_wrapper_handles_unset_defaults(monkeypatch):
-    import click
-
-    from mlflow.mcp.server import fn_wrapper
-
     fake_unset = object()
     monkeypatch.setattr(click.core, "UNSET", fake_unset, raising=False)
 
@@ -184,18 +184,14 @@ def test_fn_wrapper_handles_unset_defaults(monkeypatch):
     assert "None" in result
 
 
-def test_fn_wrapper_converts_repeatable_custom_types(monkeypatch):
-    from mlflow.mcp.server import fn_wrapper
-    from mlflow.models import python_api
-
+def test_fn_wrapper_converts_repeatable_custom_types():
     captured = {}
 
     def fake_predict(**kwargs):
         captured.update(kwargs)
 
-    monkeypatch.setattr(python_api, "predict", fake_predict)
-
-    wrapper = fn_wrapper(model_commands.commands["predict"])
-    wrapper(model_uri="runs:/123/model", env=["FOO=bar", "BAR=baz"])
+    with patch.object(python_api, "predict", fake_predict):
+        wrapper = fn_wrapper(model_commands.commands["predict"])
+        wrapper(model_uri="runs:/123/model", env=["FOO=bar", "BAR=baz"])
 
     assert captured["extra_envs"] == {"FOO": "bar", "BAR": "baz"}

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -14,7 +14,6 @@ from mlflow.mcp.server import fn_wrapper
 from mlflow.models import python_api
 from mlflow.models.cli import commands as model_commands
 from mlflow.runs import commands as run_commands
-from mlflow.utils import env_manager as _EnvManager
 
 
 def test_get_input_schema_uses_array_schema_for_repeatable_options():
@@ -190,14 +189,7 @@ def test_fn_wrapper_converts_repeatable_custom_types():
         wrapper = fn_wrapper(model_commands.commands["predict"])
         wrapper(model_uri="runs:/123/model", env=["FOO=bar", "BAR=baz"])
 
-    mock_predict.assert_called_once_with(
-        model_uri="runs:/123/model",
-        input_data=None,
-        input_path=None,
-        content_type=python_api._CONTENT_TYPE_JSON,
-        output_path=None,
-        env_manager=_EnvManager.VIRTUALENV,
-        install_mlflow=False,
-        pip_requirements_override=None,
-        extra_envs={"FOO": "bar", "BAR": "baz"},
-    )
+    mock_predict.assert_called_once()
+    call_kwargs = mock_predict.call_args.kwargs
+    assert call_kwargs["model_uri"] == "runs:/123/model"
+    assert call_kwargs["extra_envs"] == {"FOO": "bar", "BAR": "baz"}

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -8,6 +8,25 @@ from fastmcp.client.transports import StdioTransport
 
 import mlflow
 from mlflow.mcp import server
+from mlflow.models.cli import commands as model_commands
+from mlflow.runs import commands as run_commands
+
+
+def test_get_input_schema_uses_array_schema_for_repeatable_options():
+    link_traces_cmd = run_commands.commands["link-traces"]
+    schema = server.get_input_schema(link_traces_cmd.params)["properties"]["trace_ids"]
+
+    assert schema["type"] == "array"
+    assert schema["items"] == {"type": "string"}
+    assert "description" in schema
+
+
+def test_get_input_schema_uses_array_schema_for_variadic_arguments():
+    update_reqs_cmd = model_commands.commands["update-pip-requirements"]
+    schema = server.get_input_schema(update_reqs_cmd.params)["properties"]["requirement_strings"]
+
+    assert schema["type"] == "array"
+    assert schema["items"] == {"type": "string"}
 
 
 @pytest_asyncio.fixture()
@@ -163,3 +182,20 @@ def test_fn_wrapper_handles_unset_defaults(monkeypatch):
     result = wrapper(foo="hello")
     assert "hello" in result
     assert "None" in result
+
+
+def test_fn_wrapper_converts_repeatable_custom_types(monkeypatch):
+    from mlflow.mcp.server import fn_wrapper
+    from mlflow.models import python_api
+
+    captured = {}
+
+    def fake_predict(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(python_api, "predict", fake_predict)
+
+    wrapper = fn_wrapper(model_commands.commands["predict"])
+    wrapper(model_uri="runs:/123/model", env=["FOO=bar", "BAR=baz"])
+
+    assert captured["extra_envs"] == {"FOO": "bar", "BAR": "baz"}

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -14,6 +14,7 @@ from mlflow.mcp.server import fn_wrapper
 from mlflow.models import python_api
 from mlflow.models.cli import commands as model_commands
 from mlflow.runs import commands as run_commands
+from mlflow.utils import env_manager as _EnvManager
 
 
 def test_get_input_schema_uses_array_schema_for_repeatable_options():
@@ -185,13 +186,18 @@ def test_fn_wrapper_handles_unset_defaults(monkeypatch):
 
 
 def test_fn_wrapper_converts_repeatable_custom_types():
-    captured = {}
-
-    def fake_predict(**kwargs):
-        captured.update(kwargs)
-
-    with patch.object(python_api, "predict", fake_predict):
+    with patch.object(python_api, "predict") as mock_predict:
         wrapper = fn_wrapper(model_commands.commands["predict"])
         wrapper(model_uri="runs:/123/model", env=["FOO=bar", "BAR=baz"])
 
-    assert captured["extra_envs"] == {"FOO": "bar", "BAR": "baz"}
+    mock_predict.assert_called_once_with(
+        model_uri="runs:/123/model",
+        input_data=None,
+        input_path=None,
+        content_type=python_api._CONTENT_TYPE_JSON,
+        output_path=None,
+        env_manager=_EnvManager.VIRTUALENV,
+        install_mlflow=False,
+        pip_requirements_override=None,
+        extra_envs={"FOO": "bar", "BAR": "baz"},
+    )


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #21548

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Update `get_input_schema()` in `mlflow/mcp/server.py` to emit array for Click parameters with `multiple=True` or `nargs=-1`, instead of exposing them as scalar strings. Also add a conversion step in `fn_wrapper()` that transforms JSON arrays into the types expected by each command's callback via `param.type.convert()`. The `fn_wrapper()` conversion is needed because `predict`'s `--env` uses a custom Click type (`KeyValueType`) that converts `"FOO=bar"` into a key-value pair.

 Affected commands are `link-traces` (`--trace-id`), `update-pip-requirements` (positional args), `predict` (`--env`), `create` (`--tags`), and deployment commands with repeatable `--config`.

### How is this PR tested?

- [X] New unit/integration tests
   - Added schema tests for repeatable options (`multiple=True`) and variadic arguments (`nargs=-1`)
   - Added runtime conversion test for custom types (`KeyValueType`)

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [X] No.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [X] This PR can wait for the next minor release
