### PR TITLE
fix: avoid deepcopy in dataclass JSON serialization in TraceJSONEncoder

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -7,7 +7,7 @@ import logging
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from dataclasses import asdict, is_dataclass
+from dataclasses import fields, is_dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Generator
 
@@ -85,8 +85,8 @@ class TraceJSONEncoder(json.JSONEncoder):
         # E.g. https://github.com/run-llama/llama_index/blob/29ece9b058f6b9a1cf29bc723ed4aa3a39879ad5/llama-index-core/llama_index/core/chat_engine/types.py#L63-L64
         if is_dataclass(obj):
             try:
-                return asdict(obj)
-            except TypeError:
+                return {f.name: getattr(obj, f.name) for f in fields(obj)}
+            except Exception:
                 pass
 
         # Some object has dangerous side effect in __str__ method, so we use class name instead.

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -88,6 +88,9 @@ class TraceJSONEncoder(json.JSONEncoder):
                 return asdict(obj)
             except Exception:
                 pass
+            # asdict() calls copy.deepcopy() on non-dataclass fields, which can fail for
+            # objects with asyncio internals (e.g. HTTP clients). Fall back to shallow
+            # field extraction via getattr() to avoid partially-constructed copies.
             try:
                 return {f.name: getattr(obj, f.name) for f in fields(obj)}
             except Exception:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -7,7 +7,7 @@ import logging
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from dataclasses import fields, is_dataclass
+from dataclasses import asdict, fields, is_dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Generator
 
@@ -84,6 +84,10 @@ class TraceJSONEncoder(json.JSONEncoder):
         # representation, so we use dict representation instead.
         # E.g. https://github.com/run-llama/llama_index/blob/29ece9b058f6b9a1cf29bc723ed4aa3a39879ad5/llama-index-core/llama_index/core/chat_engine/types.py#L63-L64
         if is_dataclass(obj):
+            try:
+                return asdict(obj)
+            except Exception:
+                pass
             try:
                 return {f.name: getattr(obj, f.name) for f in fields(obj)}
             except Exception:

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 from unittest import mock
@@ -169,6 +170,39 @@ def test_trace_serialize_pydantic_model():
     data_json = json.dumps(data, cls=TraceJSONEncoder)
     assert data_json == '{"x": 1, "y": "foo"}'
     assert json.loads(data_json) == {"x": 1, "y": "foo"}
+
+
+def test_trace_serialize_dataclass():
+    @dataclass
+    class Config:
+        model: str
+        temperature: float
+        tags: list[str]
+
+    config = Config(model="gpt-4o", temperature=0.5, tags=["a", "b"])
+    result = json.loads(json.dumps(config, cls=TraceJSONEncoder))
+    assert result == {"model": "gpt-4o", "temperature": 0.5, "tags": ["a", "b"]}
+
+
+def test_trace_serialize_dataclass_with_non_copyable_field():
+    """Dataclasses whose fields cannot be deepcopied (e.g. contain asyncio internals)
+    must serialize without raising an exception.
+    """
+
+    class _NonCopyable:
+        def __deepcopy__(self, memo):
+            raise RuntimeError("deepcopy not supported")
+
+    @dataclass
+    class RunConfig:
+        name: str
+        client: _NonCopyable
+
+    config = RunConfig(name="test-run", client=_NonCopyable())
+    # Should not raise; non-serializable client falls back to str representation
+    result = json.loads(json.dumps(config, cls=TraceJSONEncoder))
+    assert result["name"] == "test-run"
+    assert "client" in result
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #21667

### What changes are proposed in this pull request?

`asdict()` from the `dataclasses` module calls `copy.deepcopy()` internally on non-dataclass fields. When a dataclass contains objects with asyncio internals (e.g. the `RunConfig` from the OpenAI Agents SDK, which holds an HTTP client), deepcopy can fail after partially constructing an object via `__new__`, leaving it in a broken state that crashes on `__del__`:

```
Exception ignored in: <object repr() failed>
AttributeError: 'RunConfig' object has no attribute '...'
```

**Fix:** replace `asdict(obj)` with a direct field extraction using `getattr`:

```python
# Before
return asdict(obj)          # deepcopy internals → crash

# After
return {f.name: getattr(obj, f.name) for f in fields(obj)}
```

`TraceJSONEncoder` already recurses over non-serializable values through its own `default()` method, so the serialization remains complete without copying. Also broadens the caught exception from `TypeError` to `Exception` since deepcopy failures can raise `RuntimeError` and other types.


### How is this PR tested?

- [x] New unit/integration tests

Two new tests in `tests/entities/test_trace.py`:
- `test_trace_serialize_dataclass`: verifies plain dataclasses still serialize correctly
- `test_trace_serialize_dataclass_with_non_copyable_field`: verifies a dataclass with a field that raises `RuntimeError` in `__deepcopy__` does not crash

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix crash (`AttributeError` in `__del__`) when tracing agents that pass dataclasses with non-copyable fields (e.g. OpenAI Agents SDK `RunConfig`) as span attributes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
