### PR TITLE
Investigate flaky test_job_submit

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -71,9 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1]
-        include:
-          - splits: 1
+        group: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -46,7 +46,7 @@ jobs:
   # The python skinny tests cover the subset of mlflow functionality
   # while also verifying certain dependencies are omitted.
   python-skinny:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # disabled for flaky test investigation
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -71,9 +71,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4]
+        group: [1]
         include:
-          - splits: 4
+          - splits: 1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -88,34 +88,16 @@ jobs:
           uv sync --extra extras --extra gateway --extra mcp --extra genai
           uv pip install \
             -r requirements/test-requirements.txt \
-            -r requirements/extra-ml-requirements.txt
+            -r requirements/extra-ml-requirements.txt \
+            pytest-repeat
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
-      - name: Import check
-        run: |
-          # `-I` is used to avoid importing modules from user-specific site-packages
-          # that might conflict with the built-in modules (e.g. `types`).
-          uv run --no-sync python -I tests/check_mlflow_lazily_imports_ml_packages.py
       - name: Run tests
         run: |
-          source dev/setup-ssh.sh
-          uv run --no-sync pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
-            --quiet --requires-ssh --ignore-flavors \
-            --ignore=tests/examples \
-            --ignore=tests/evaluate \
-            --ignore=tests/genai \
-            --ignore=tests/docker \
-            tests
-
-      - name: Run databricks-connect related tests
-        run: |
-          # this needs to be run in a separate job because installing databricks-connect could break other
-          # tests that uses normal SparkSession instead of remote SparkSession
-          uv run --no-sync --with 'databricks-agents,databricks-connect' \
-            pytest tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
+          uv run --no-sync pytest -x -v tests/server/jobs/test_endpoint.py::test_job_submit
 
   database:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # disabled for flaky test investigation
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -173,7 +155,7 @@ jobs:
           ./tests/db/compose.sh down --volumes --remove-orphans --rmi all
 
   java:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # disabled for flaky test investigation
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -194,7 +176,7 @@ jobs:
           uv run --no-dev mvn clean package -q
 
   flavors:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # disabled for flaky test investigation
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -221,7 +203,7 @@ jobs:
             tests/autologging
 
   models:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # disabled for flaky test investigation
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -252,7 +234,7 @@ jobs:
           uv run --no-sync pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} tests/models
 
   evaluate:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # disabled for flaky test investigation
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -285,7 +267,7 @@ jobs:
           uv run --no-sync pytest tests/evaluate/test_default_evaluator_delta.py
 
   genai:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # disabled for flaky test investigation
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -315,7 +297,7 @@ jobs:
             --ignore tests/genai/optimize --ignore tests/genai/prompts
 
   pyfunc:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # disabled for flaky test investigation
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -350,7 +332,7 @@ jobs:
           uv run --no-sync pytest tests/pyfunc/test_spark_connect.py
 
   windows:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false # disabled for flaky test investigation
     runs-on: windows-latest
     timeout-minutes: 120
     permissions:

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -244,8 +244,6 @@ def _exec_job_in_subproc(
     with subprocess.Popen(
         job_cmd,
         env=job_env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
     ) as popen:
         _logger.info(f"[DEBUG] Subprocess started for job {job_id}, pid={popen.pid}")
         beg_time = time.time()
@@ -269,12 +267,9 @@ def _exec_job_in_subproc(
                     job_store.mark_job_timed_out(job_id)
                     return None
 
-        stdout_data = popen.stdout.read().decode(errors="replace") if popen.stdout else ""
-        stderr_data = popen.stderr.read().decode(errors="replace") if popen.stderr else ""
         _logger.info(
             f"[DEBUG] Subprocess for job {job_id} exited with code {popen.returncode}, "
-            f"elapsed={time.time() - beg_time:.1f}s, "
-            f"stdout={stdout_data[:500]!r}, stderr={stderr_data[:500]!r}"
+            f"elapsed={time.time() - beg_time:.1f}s"
         )
 
         if popen.returncode == 0:

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -240,13 +240,22 @@ def _exec_job_in_subproc(
     if workspace:
         job_env[MLFLOW_WORKSPACE.name] = workspace
 
+    _logger.info(f"[DEBUG] Starting subprocess for job {job_id}, cmd={job_cmd}")
     with subprocess.Popen(
         job_cmd,
         env=job_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     ) as popen:
+        _logger.info(f"[DEBUG] Subprocess started for job {job_id}, pid={popen.pid}")
         beg_time = time.time()
         while popen.poll() is None:
             time.sleep(_JOB_STATUS_POLL_INTERVAL)
+            elapsed = time.time() - beg_time
+            _logger.info(
+                f"[DEBUG] Job {job_id} subprocess pid={popen.pid} still running "
+                f"after {elapsed:.1f}s"
+            )
 
             job_status = job_store.get_job(job_id).status
             if job_status == JobStatus.CANCELED:
@@ -259,6 +268,14 @@ def _exec_job_in_subproc(
                     popen.kill()
                     job_store.mark_job_timed_out(job_id)
                     return None
+
+        stdout_data = popen.stdout.read().decode(errors="replace") if popen.stdout else ""
+        stderr_data = popen.stderr.read().decode(errors="replace") if popen.stderr else ""
+        _logger.info(
+            f"[DEBUG] Subprocess for job {job_id} exited with code {popen.returncode}, "
+            f"elapsed={time.time() - beg_time:.1f}s, "
+            f"stdout={stdout_data[:500]!r}, stderr={stderr_data[:500]!r}"
+        )
 
         if popen.returncode == 0:
             return JobResult.load(result_file)
@@ -346,7 +363,9 @@ def _exec_job(
             lock = None
 
         try:
+            _logger.info(f"[DEBUG] _exec_job starting job {job_id} ({job_name})")
             job_store.start_job(job_id)
+            _logger.info(f"[DEBUG] Job {job_id} transitioned to RUNNING")
 
             fn_fullname = get_job_fn_fullname(job_name)
             function = _load_function(fn_fullname)
@@ -367,11 +386,15 @@ def _exec_job(
                     extra_envs,
                 )
 
+            _logger.info(f"[DEBUG] Job {job_id} subproc returned: {job_result}")
+
             if job_result is None:
+                _logger.info(f"[DEBUG] Job {job_id} result is None (canceled/timed out)")
                 return
 
             if job_result.succeeded:
                 job_store.finish_job(job_id, job_result.result)
+                _logger.info(f"[DEBUG] Job {job_id} marked SUCCEEDED")
                 return
 
             if job_result.is_transient_error:
@@ -383,6 +406,9 @@ def _exec_job(
             else:
                 _logger.error(f"Job {job_id} ({job_name}) failed with error: {job_result.error}")
                 job_store.fail_job(job_id, job_result.error)
+        except Exception:
+            _logger.exception(f"[DEBUG] Job {job_id} ({job_name}) hit unexpected exception")
+            raise
         finally:
             if lock is not None:
                 lock.release()

--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -112,6 +112,7 @@ def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
             **os.environ,
             "PYTHONPATH": os.path.dirname(__file__),
             "MLFLOW_SERVER_ENABLE_JOB_EXECUTION": "true",
+            "MLFLOW_LOGGING_LEVEL": "DEBUG",
             "_MLFLOW_SUPPORTED_JOB_FUNCTION_LIST": (
                 "test_endpoint.simple_job_fun,test_endpoint.job_assert_tracking_uri"
             ),
@@ -141,6 +142,7 @@ def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
             os.killpg(server_proc.pid, signal.SIGKILL)
 
 
+@pytest.mark.repeat(100)  # clint: disable=pytest-mark-repeat
 def test_job_submit(client: Client):
     job_id = client.submit_job(
         job_name="simple_job_fun",


### PR DESCRIPTION
## Summary
Investigate flaky `test_job_submit` by running it 100 times with debug logging.

### Changes
- `@pytest.mark.repeat(100)` on `test_job_submit`
- Debug logging in `_exec_job` and `_exec_job_in_subproc` (job lifecycle, subprocess pid, exit code, stdout/stderr)
- Redirect subprocess stdout/stderr to PIPE (tests deadlock hypothesis)
- `MLFLOW_LOGGING_LEVEL=DEBUG` in test fixture
- All other CI jobs disabled

### What we're testing
1. Is the flakiness reproducible under repeated execution?
2. Does the job get stuck in RUNNING (never transitions to terminal state)?
3. Is there an uncaught exception in `_exec_job`?
4. Does the subprocess exit but result file is missing?
5. Does stdout/stderr pipe deadlock cause hangs?

## Test plan
- [ ] Monitor CI run for failures and inspect debug logs