### PR TITLE
Add freeform Notes section to trace assessments pane

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -127,6 +127,10 @@
     "defaultMessage": "None",
     "description": "A short label for experiments with no experiment kind"
   },
+  "+lNppY": {
+    "defaultMessage": "Notes",
+    "description": "Header for the notes section in the assessments pane"
+  },
   "+mAXPc": {
     "defaultMessage": "No traces found. Try clearing your active filters to see more traces.",
     "description": "Text displayed when no traces are found in the trace review page"
@@ -4431,6 +4435,10 @@
   "Rs+SVS": {
     "defaultMessage": "Ready",
     "description": "Label for ready state of a experiment logged model"
+  },
+  "RsTIRk": {
+    "defaultMessage": "Add personal notes about this trace.",
+    "description": "Tooltip describing the notes section in the assessments pane"
   },
   "RtKhwd": {
     "defaultMessage": "Dataset",
@@ -9550,6 +9558,10 @@
   "yltiK8": {
     "defaultMessage": "No prompts match your search",
     "description": "No search results message for linked prompts table on logged model details page"
+  },
+  "ymnL+t": {
+    "defaultMessage": "Save",
+    "description": "Button to save notes assessment"
   },
   "ynkoR7": {
     "defaultMessage": "No models versions are registered yet. <link>Learn more</link> about how to register a model version.",

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
@@ -6,6 +6,7 @@ import {
   ASSESSMENT_SESSION_METADATA_KEY,
   INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE,
 } from '../../model-trace-explorer/constants';
+import { NOTES_ASSESSMENT_NAME } from '../../model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection';
 
 import { getAssessmentValueBarBackgroundColor } from './Colors';
 import { DEFAULT_RUN_PLACEHOLDER_NAME } from './TraceUtils';
@@ -110,8 +111,8 @@ export function getAssessmentInfos(
       ...overallAssessmentsByName,
       ...retrievalAssessmentsByName,
     ]) {
-      // Skip internal assessments that are implementation details of the issue discovery pipeline
-      if (assessmentName === INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE) {
+      // Skip internal assessments
+      if (assessmentName === INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE || assessmentName === NOTES_ASSESSMENT_NAME) {
         continue;
       }
       assessmentNames.add(assessmentName);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -17,6 +17,7 @@ import { useTraceCachedActions } from '../hooks/useTraceCachedActions';
 import { AssessmentsPaneExpectationsSection } from './AssessmentsPaneExpectationsSection';
 import { AssessmentsPaneFeedbackSection } from './AssessmentsPaneFeedbackSection';
 import { AssessmentsPaneIssuesSection } from './AssessmentsPaneIssuesSection';
+import { AssessmentsPaneNotesSection } from './AssessmentsPaneNotesSection';
 import { useModelTraceExplorerRunJudgesContext } from '../contexts/RunJudgesContext';
 
 export const AssessmentsPane = ({
@@ -141,6 +142,8 @@ export const AssessmentsPane = ({
           <AssessmentsPaneIssuesSection issues={issues} />
         </>
       )}
+      <Spacer size="sm" shrinks={false} />
+      <AssessmentsPaneNotesSection traceId={traceId} feedbacks={feedbacks} />
     </div>
   );
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -143,7 +143,7 @@ export const AssessmentsPane = ({
         </>
       )}
       <Spacer size="sm" shrinks={false} />
-      <AssessmentsPaneNotesSection traceId={traceId} feedbacks={feedbacks} />
+      <AssessmentsPaneNotesSection key={traceId} traceId={traceId} feedbacks={feedbacks} />
     </div>
   );
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -23,6 +23,7 @@ import { invalidateMlflowSearchTracesCache } from '../hooks/invalidateMlflowSear
 import { FETCH_TRACE_INFO_QUERY_KEY } from '../ModelTraceExplorer.utils';
 import { isEvaluatingTracesInDetailsViewEnabled } from '../FeatureUtils';
 import { INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE } from '../constants';
+import { NOTES_ASSESSMENT_NAME } from './AssessmentsPaneNotesSection';
 
 type GroupedFeedbacksByValue = { [value: string]: FeedbackAssessment[] };
 
@@ -138,7 +139,10 @@ export const AssessmentsPaneFeedbackSection = ({
   sessionId?: string;
 }) => {
   const visibleFeedbacks = useMemo(
-    () => feedbacks.filter((f) => f.assessment_name !== INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE),
+    () =>
+      feedbacks.filter(
+        (f) => f.assessment_name !== INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE && f.assessment_name !== NOTES_ASSESSMENT_NAME,
+      ),
     [feedbacks],
   );
   const groupedFeedbacks = useMemo(() => groupFeedbacks(visibleFeedbacks), [visibleFeedbacks]);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneFeedbackSection.tsx
@@ -141,7 +141,9 @@ export const AssessmentsPaneFeedbackSection = ({
   const visibleFeedbacks = useMemo(
     () =>
       feedbacks.filter(
-        (f) => f.assessment_name !== INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE && f.assessment_name !== NOTES_ASSESSMENT_NAME,
+        (f) =>
+          f.assessment_name !== INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE &&
+          f.assessment_name !== NOTES_ASSESSMENT_NAME,
       ),
     [feedbacks],
   );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection.tsx
@@ -1,0 +1,119 @@
+import { useMemo, useState } from 'react';
+
+import { Button, CheckIcon, InfoSmallIcon, Input, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import type { FeedbackAssessment } from '../ModelTrace.types';
+import type { CreateAssessmentPayload, UpdateAssessmentPayload } from '../api';
+import { getUser } from '../../global-settings/getUser';
+import { useCreateAssessment } from '../hooks/useCreateAssessment';
+import { useUpdateAssessment } from '../hooks/useUpdateAssessment';
+
+export const NOTES_ASSESSMENT_NAME = 'mlflow.notes';
+
+const AssessmentsPaneNotesSectionInner = ({
+  traceId,
+  feedbacks,
+}: {
+  traceId: string;
+  feedbacks: FeedbackAssessment[];
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const user = getUser() ?? '';
+
+  const existingNotes = useMemo(
+    () => feedbacks.find((f) => f.assessment_name === NOTES_ASSESSMENT_NAME && f.source.source_id === user),
+    [feedbacks, user],
+  );
+
+  const serverText = typeof existingNotes?.feedback?.value === 'string' ? existingNotes.feedback.value : '';
+
+  const [notesText, setNotesText] = useState(serverText);
+  const [prevServerText, setPrevServerText] = useState(serverText);
+
+  // Sync from server when it changes (after save completes or external update).
+  // This is React's recommended pattern for adjusting state when props change,
+  // see: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  if (serverText !== prevServerText) {
+    setPrevServerText(serverText);
+    setNotesText(serverText);
+  }
+
+  const { createAssessmentMutation, isLoading: isCreating } = useCreateAssessment({ traceId });
+  const { updateAssessmentMutation, isLoading: isUpdating } = useUpdateAssessment({ assessment: existingNotes! });
+
+  const isLoading = isCreating || isUpdating;
+  const isDirty = notesText !== serverText;
+
+  const handleSave = () => {
+    if (!isDirty) return;
+    if (existingNotes) {
+      const payload: UpdateAssessmentPayload = {
+        assessment: { feedback: { value: notesText } },
+        update_mask: 'feedback',
+      };
+      updateAssessmentMutation(payload);
+    } else {
+      const payload: CreateAssessmentPayload = {
+        assessment: {
+          assessment_name: NOTES_ASSESSMENT_NAME,
+          trace_id: traceId,
+          source: { source_type: 'HUMAN', source_id: user },
+          feedback: { value: notesText },
+        } as CreateAssessmentPayload['assessment'],
+      };
+      createAssessmentMutation(payload);
+    }
+  };
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, marginTop: 'auto' }}>
+      <div css={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+          <Typography.Text bold>
+            <FormattedMessage defaultMessage="Notes" description="Header for the notes section in the assessments pane" />
+          </Typography.Text>
+          <Tooltip
+            componentId="shared.model-trace-explorer.assessment-notes-info-tooltip"
+            content={
+              <FormattedMessage
+                defaultMessage="Add personal notes about this trace."
+                description="Tooltip describing the notes section in the assessments pane"
+              />
+            }
+          >
+            <InfoSmallIcon css={{ color: theme.colors.textSecondary }} />
+          </Tooltip>
+        </div>
+        <Button
+          componentId="shared.model-trace-explorer.assessment-notes-save"
+          size="small"
+          icon={<CheckIcon />}
+          onClick={handleSave}
+          loading={isLoading}
+          disabled={!isDirty || isLoading}
+        >
+          <FormattedMessage defaultMessage="Save" description="Button to save notes assessment" />
+        </Button>
+      </div>
+      <Input.TextArea
+        componentId="shared.model-trace-explorer.assessment-notes-input"
+        value={notesText}
+        autoSize={{ minRows: 3, maxRows: 10 }}
+        disabled={isLoading}
+        onKeyDown={(e) => e.stopPropagation()}
+        onChange={(e) => setNotesText(e.target.value)}
+      />
+    </div>
+  );
+};
+
+export const AssessmentsPaneNotesSection = ({
+  traceId,
+  feedbacks,
+}: {
+  traceId: string;
+  feedbacks: FeedbackAssessment[];
+}) => {
+  return <AssessmentsPaneNotesSectionInner key={traceId} traceId={traceId} feedbacks={feedbacks} />;
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection.tsx
@@ -37,6 +37,16 @@ export const AssessmentsPaneNotesSection = ({
   const serverText = typeof existingNotes?.feedback?.value === 'string' ? existingNotes.feedback.value : '';
 
   const [notesText, setNotesText] = useState(serverText);
+  const [prevServerText, setPrevServerText] = useState(serverText);
+
+  // Sync from server when feedbacks prop updates (e.g. after save completes and
+  // query refetch delivers updated data). This is React's recommended pattern for
+  // adjusting state when props change without useEffect.
+  // See: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  if (serverText !== prevServerText) {
+    setPrevServerText(serverText);
+    setNotesText(serverText);
+  }
 
   const { createAssessmentMutation, isLoading: isCreating } = useCreateAssessment({ traceId });
   const { updateAssessmentMutation, isLoading: isUpdating } = useUpdateAssessment({ assessment: existingNotes! });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection.tsx
@@ -1,6 +1,14 @@
 import { useMemo, useState } from 'react';
 
-import { Button, CheckIcon, InfoSmallIcon, Input, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import {
+  Button,
+  CheckIcon,
+  InfoSmallIcon,
+  Input,
+  Tooltip,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 import type { FeedbackAssessment } from '../ModelTrace.types';
@@ -71,7 +79,10 @@ const AssessmentsPaneNotesSectionInner = ({
       <div css={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
           <Typography.Text bold>
-            <FormattedMessage defaultMessage="Notes" description="Header for the notes section in the assessments pane" />
+            <FormattedMessage
+              defaultMessage="Notes"
+              description="Header for the notes section in the assessments pane"
+            />
           </Typography.Text>
           <Tooltip
             componentId="shared.model-trace-explorer.assessment-notes-info-tooltip"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection.tsx
@@ -49,7 +49,9 @@ export const AssessmentsPaneNotesSection = ({
   }
 
   const { createAssessmentMutation, isLoading: isCreating } = useCreateAssessment({ traceId });
-  const { updateAssessmentMutation, isLoading: isUpdating } = useUpdateAssessment({ assessment: existingNotes! });
+  const { updateAssessmentMutation, isLoading: isUpdating } = useUpdateAssessment({
+    assessment: existingNotes as FeedbackAssessment,
+  });
 
   const isLoading = isCreating || isUpdating;
   const isDirty = notesText !== serverText;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection.tsx
@@ -19,7 +19,7 @@ import { useUpdateAssessment } from '../hooks/useUpdateAssessment';
 
 export const NOTES_ASSESSMENT_NAME = 'mlflow.notes';
 
-const AssessmentsPaneNotesSectionInner = ({
+export const AssessmentsPaneNotesSection = ({
   traceId,
   feedbacks,
 }: {
@@ -37,15 +37,6 @@ const AssessmentsPaneNotesSectionInner = ({
   const serverText = typeof existingNotes?.feedback?.value === 'string' ? existingNotes.feedback.value : '';
 
   const [notesText, setNotesText] = useState(serverText);
-  const [prevServerText, setPrevServerText] = useState(serverText);
-
-  // Sync from server when it changes (after save completes or external update).
-  // This is React's recommended pattern for adjusting state when props change,
-  // see: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
-  if (serverText !== prevServerText) {
-    setPrevServerText(serverText);
-    setNotesText(serverText);
-  }
 
   const { createAssessmentMutation, isLoading: isCreating } = useCreateAssessment({ traceId });
   const { updateAssessmentMutation, isLoading: isUpdating } = useUpdateAssessment({ assessment: existingNotes! });
@@ -117,14 +108,4 @@ const AssessmentsPaneNotesSectionInner = ({
       />
     </div>
   );
-};
-
-export const AssessmentsPaneNotesSection = ({
-  traceId,
-  feedbacks,
-}: {
-  traceId: string;
-  feedbacks: FeedbackAssessment[];
-}) => {
-  return <AssessmentsPaneNotesSectionInner key={traceId} traceId={traceId} feedbacks={feedbacks} />;
 };


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds a "Notes" text area at the bottom of the trace assessments side panel. Users can type freeform notes and save them as a feedback assessment with `assessment_name: "mlflow.notes"` and `source_type: "HUMAN"`. If a notes assessment already exists for the current user, it is pre-filled and updated in place on save.

**Files changed:**
- `AssessmentsPaneNotesSection.tsx` (new) — Notes component with TextArea, save button, create/update logic
- `AssessmentsPane.tsx` — Renders the new Notes section at the bottom of the pane

### How is this PR tested?

- [x] Manual tests


https://github.com/user-attachments/assets/9b6393db-29b6-4656-83ed-c2c4be9bfc6a


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds a freeform "Notes" text area to the trace assessments pane, allowing users to save personal notes on traces.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release