### PR TITLE
Make `discover_issues` internal (remove from public API)

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -864,7 +864,6 @@ mlflow.genai.delete_prompt_tag
 mlflow.genai.delete_prompt_version_tag
 mlflow.genai.delete_scorer
 mlflow.genai.disable_git_model_versioning
-mlflow.genai.discover_issues
 mlflow.genai.enable_git_model_versioning
 mlflow.genai.evaluate
 mlflow.genai.get_dataset

--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -11,7 +11,6 @@ from mlflow.genai.datasets import (
     search_datasets,
     set_dataset_tags,
 )
-from mlflow.genai.discovery import discover_issues
 from mlflow.genai.evaluation import evaluate, to_predict_fn
 from mlflow.genai.git_versioning import disable_git_model_versioning, enable_git_model_versioning
 from mlflow.genai.judges import make_judge
@@ -48,7 +47,6 @@ from mlflow.genai.simulators import ConversationSimulator
 
 __all__ = [
     "datasets",
-    "discover_issues",
     "evaluate",
     "to_predict_fn",
     "Scorer",

--- a/mlflow/genai/discovery/__init__.py
+++ b/mlflow/genai/discovery/__init__.py
@@ -1,4 +1,3 @@
 from mlflow.genai.discovery.entities import DiscoverIssuesResult, Issue
-from mlflow.genai.discovery.pipeline import discover_issues
 
-__all__ = ["discover_issues", "DiscoverIssuesResult", "Issue"]
+__all__ = ["DiscoverIssuesResult", "Issue"]

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -57,7 +57,6 @@ from mlflow.genai.judges.make_judge import make_judge
 from mlflow.genai.scorers.base import Scorer
 from mlflow.tracing.constant import AssessmentMetadataKey, TraceMetadataKey
 from mlflow.tracking.fluent import _get_experiment_id
-from mlflow.utils.annotations import experimental
 
 _logger = logging.getLogger(__name__)
 
@@ -436,8 +435,6 @@ def build_issue_discovery_scorer(
     )
 
 
-# TODO: Add telemetry for this API
-@experimental(version="3.11.0")
 def discover_issues(
     experiment_id: str | None = None,
     traces: list[Trace] | None = None,
@@ -475,23 +472,6 @@ def discover_issues(
     Returns:
         A :class:`DiscoverIssuesResult` with discovered issues, run IDs,
         and a summary report.
-
-    Example:
-
-        .. code-block:: python
-
-            import mlflow
-
-            # Option 1: Auto-sample from experiment
-            mlflow.set_experiment("my-genai-app")
-            result = mlflow.genai.discover_issues()
-
-            # Option 2: Pass traces directly
-            traces = mlflow.search_traces(max_results=100, return_type="list")
-            result = mlflow.genai.discover_issues(traces=traces)
-
-            for issue in result.issues:
-                print(f"{issue.name} (severity: {issue.severity})")
     """
     pipeline_start = time.time()
     token_counter = _TokenCounter()


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21430

### What changes are proposed in this pull request?

- Remove `discover_issues` from `mlflow.genai` public exports and `__all__`
- Remove `@experimental` decorator and usage examples from docstring
- Keep the function and its documentation accessible via direct import from `mlflow.genai.discovery.pipeline`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified `mlflow.genai.discover_issues` is no longer accessible but `from mlflow.genai.discovery.pipeline import discover_issues` still works.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.