### PR TITLE
fix: replace global logging.basicConfig() calls with module-level logger config

### DIFF
--- a/mlflow/pyfunc/stdin_server.py
+++ b/mlflow/pyfunc/stdin_server.py
@@ -8,7 +8,9 @@ from mlflow.pyfunc import scoring_server
 from mlflow.pyfunc.model import _log_warning_if_params_not_in_predict_signature
 
 _logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+_logger.setLevel(logging.INFO)
+if not _logger.handlers:
+    _logger.addHandler(logging.StreamHandler())
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--model-uri")

--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -22,7 +22,8 @@ from mlflow.utils.autologging_utils import (
 )
 from mlflow.utils.checkpoint_utils import MlflowModelCheckpointCallbackBase
 
-logging.basicConfig(level=logging.ERROR)
+_logger = logging.getLogger(__name__)
+_logger.setLevel(logging.ERROR)
 MIN_REQ_VERSION = Version(_ML_PACKAGE_VERSIONS["pytorch-lightning"]["autologging"]["minimum"])
 MAX_REQ_VERSION = Version(_ML_PACKAGE_VERSIONS["pytorch-lightning"]["autologging"]["maximum"])
 
@@ -39,8 +40,6 @@ from pytorch_lightning.utilities import rank_zero_only
 # tracking uri, experiment_id and run_id which may lead to a race condition.
 # TODO: Replace __MlflowPLCallback with Pytorch Lightning's built-in MlflowLogger
 # once the above mentioned issues have been addressed
-
-_logger = logging.getLogger(__name__)
 
 _pl_version = Version(pl.__version__)
 if _pl_version < Version("1.5.0"):


### PR DESCRIPTION
### Related Issues/PRs

Closes #20922

### What changes are proposed in this pull request?

- Replace `logging.basicConfig(level=logging.ERROR)` in `mlflow/pytorch/_lightning_autolog.py` with `_logger.setLevel(logging.ERROR)` on the module-level logger
- Replace `logging.basicConfig(level=logging.INFO)` in `mlflow/pyfunc/stdin_server.py` with `_logger.setLevel(logging.INFO)` and a local `StreamHandler`
- This prevents MLflow from overwriting users' logging configuration when they import `mlflow.pytorch` or other modules that trigger these code paths

Calling `logging.basicConfig()` at module scope modifies the root logger's configuration globally. When a user imports `mlflow.pytorch`, the `_lightning_autolog.py` module calls `logging.basicConfig(level=logging.ERROR)`, which can silently suppress the user's own log messages.

Instead of calling `logging.basicConfig()` (which affects the root logger), we:
1. Use `_logger.setLevel(...)` to set the level only on the module's own logger
2. In `stdin_server.py` (a standalone script), add a `StreamHandler` to the module logger so it still produces output without relying on `basicConfig`

This follows Python logging best practices: libraries should never call `logging.basicConfig()` — that is the application's responsibility.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified `import mlflow.pytorch` no longer changes root logger level.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed an issue where importing `mlflow.pytorch` or running `stdin_server.py` would overwrite users' logging configuration by calling `logging.basicConfig()` at module scope. Module-level loggers are now used instead.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release