### PR TITLE
fix: add timeouts to async artifact logging atexit callback

### DIFF
--- a/mlflow/utils/async_logging/async_artifacts_logging_queue.py
+++ b/mlflow/utils/async_logging/async_artifacts_logging_queue.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+# Timeout in seconds for atexit cleanup to prevent indefinite hangs.
+_AT_EXIT_TIMEOUT_SECONDS = 30
+
 
 class AsyncArtifactsLoggingQueue:
     """
@@ -46,14 +49,27 @@ class AsyncArtifactsLoggingQueue:
 
         Stops the data processing thread and waits for the queue to be drained. Finally, shuts down
         the thread pools used for data logging and artifact processing status check.
+
+        Uses timeouts to prevent indefinite hangs when worker threads are blocked
+        on network I/O or other operations during process exit.
         """
         try:
             # Stop the data processing thread
             self._stop_data_logging_thread_event.set()
             # Waits till logging queue is drained.
-            self._artifact_logging_thread.join()
-            self._artifact_logging_worker_threadpool.shutdown(wait=True)
-            self._artifact_status_check_threadpool.shutdown(wait=True)
+            self._artifact_logging_thread.join(timeout=_AT_EXIT_TIMEOUT_SECONDS)
+            if self._artifact_logging_thread.is_alive():
+                _logger.warning(
+                    "Artifact logging thread did not finish within %s seconds during exit. "
+                    "Some artifacts may not have been logged.",
+                    _AT_EXIT_TIMEOUT_SECONDS,
+                )
+            self._artifact_logging_worker_threadpool.shutdown(
+                wait=True, cancel_futures=True
+            )
+            self._artifact_status_check_threadpool.shutdown(
+                wait=True, cancel_futures=True
+            )
         except Exception as e:
             _logger.error(f"Encountered error while trying to finish logging: {e}")
 


### PR DESCRIPTION
## Summary

Fixes #20575

The `_at_exit_callback()` method in `AsyncArtifactsLoggingQueue` calls `thread.join()` and `threadpool.shutdown(wait=True)` without any timeout. If worker threads are blocked on network I/O or other operations during process exit, the main thread hangs indefinitely in the atexit handler—requiring `kill -9` to terminate.

### Changes

- Add a 30-second timeout to `self._artifact_logging_thread.join()` — if the thread doesn't finish in time, log a warning and proceed with shutdown
- Add `cancel_futures=True` to both `threadpool.shutdown()` calls so pending work items are cancelled rather than waited on indefinitely
- Add a module-level `_AT_EXIT_TIMEOUT_SECONDS` constant for the timeout value

### Why these specific changes

- **`thread.join(timeout=30)`**: Gives pending artifact uploads a reasonable window to complete, then proceeds with exit instead of blocking forever. A warning is logged so users know artifacts may have been dropped.
- **`cancel_futures=True`**: Prevents the thread pools from waiting on futures that will never complete because the logging thread has already been stopped. This parameter was added in Python 3.9 and MLflow requires Python 3.9+.
- **`flush()` is intentionally unchanged**: `flush()` is called explicitly by user code during normal operation (not during atexit), so it should continue to block until all data is logged.

## Test plan

- [ ] Verify existing tests pass (no behavioral change for normal shutdown within 30s)
- [ ] Verify that a process with stuck async artifact uploads exits within ~30 seconds instead of hanging indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)