### PR TITLE
fix: add type annotations to PythonModel.predict() for mypy compatibility

### DIFF
--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -12,7 +12,7 @@ import os
 import shutil
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
-from typing import Any, Generator, Iterator
+from typing import Any, Generator, Iterator, overload
 
 import cloudpickle
 import pandas as pd
@@ -213,8 +213,17 @@ class PythonModel:
         else:
             cls.predict._is_pyfunc = True
 
-    @abstractmethod
-    def predict(self, context, model_input, params: dict[str, Any] | None = None):
+    @overload
+    def predict(
+        self, context: Any, model_input: Any, params: dict[str, Any] | None = None
+    ) -> Any: ...
+
+    @overload
+    def predict(
+        self, model_input: Any, params: dict[str, Any] | None = None
+    ) -> Any: ...
+
+    def predict(self, *args: Any, **kwargs: Any) -> Any:
         """
         Evaluates a pyfunc-compatible input and produces a pyfunc-compatible output.
         For more information about the pyfunc input/output API, see the :ref:`pyfunc-inference-api`.
@@ -230,7 +239,17 @@ class PythonModel:
             signature if it's not used. `def predict(self, model_input, params=None)` is valid.
         """
 
-    def predict_stream(self, context, model_input, params: dict[str, Any] | None = None):
+    @overload
+    def predict_stream(
+        self, context: Any, model_input: Any, params: dict[str, Any] | None = None
+    ) -> Any: ...
+
+    @overload
+    def predict_stream(
+        self, model_input: Any, params: dict[str, Any] | None = None
+    ) -> Any: ...
+
+    def predict_stream(self, *args: Any, **kwargs: Any) -> Any:
         """
         Evaluates a pyfunc-compatible input and produces an iterator of output.
         For more information about the pyfunc input API, see the :ref:`pyfunc-inference-api`.


### PR DESCRIPTION
### Related Issues/PRs

Fixes #20545

### What changes are proposed in this pull request?

Adds proper type annotations and `@overload` decorators to `PythonModel.predict()` and `PythonModel.predict_stream()` methods to fix mypy type-checking errors when subclassing `PythonModel`.

**Changes in `mlflow/pyfunc/model.py`:**
- Import `overload` from `typing`
- Add `@overload` signatures for `predict()` to declare both valid call patterns:
  - `predict(self, context, model_input, params=None)` (legacy with context)
  - `predict(self, model_input, params=None)` (recommended since MLflow 2.20.0)
- Add `@overload` signatures for `predict_stream()` similarly
- Use `*args: Any, **kwargs: Any` on the implementation method to accept both signatures
- Remove `@abstractmethod` from `predict()` (was effectively a no-op since `PythonModel` uses old-style `__metaclass__ = ABCMeta` which doesn't work in Python 3)

**Before (mypy errors):**
```
error: Signature of "predict" incompatible with supertype "PythonModel"  [override]
error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
```

**After (mypy passes):**
```python
from mlflow.pyfunc.model import PythonModel

class MyModel(PythonModel):
    def predict(self, model_input: list[str], params=None) -> list[str]:
        return model_input  # no mypy errors
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual verification with mypy

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Added type annotations and `@overload` to `PythonModel.predict()` and `predict_stream()` to support mypy type checking when subclassing `PythonModel`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)