### PR TITLE
fix: skip shlex.quote on Windows to prevent broken file paths in predict

### DIFF
--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -191,18 +191,22 @@ class PyFuncBackend(FlavorBackend):
         local_uri = path_to_local_file_uri(local_path)
 
         if self._env_manager != em.LOCAL:
+            # On Windows, shlex.quote wraps values in single quotes which
+            # cmd.exe does not strip, causing 'path' to be passed literally
+            # (including the quotes) and breaking file operations.
+            _quote = str if is_windows() else shlex.quote
             predict_cmd = [
                 "python",
                 _mlflow_pyfunc_backend_predict.__file__,
                 "--model-uri",
                 str(local_uri),
                 "--content-type",
-                shlex.quote(str(content_type)),
+                _quote(str(content_type)),
             ]
             if input_path:
-                predict_cmd += ["--input-path", shlex.quote(str(input_path))]
+                predict_cmd += ["--input-path", _quote(str(input_path))]
             if output_path:
-                predict_cmd += ["--output-path", shlex.quote(str(output_path))]
+                predict_cmd += ["--output-path", _quote(str(output_path))]
 
             if pip_requirements_override and self._env_manager == em.CONDA:
                 # Conda use = instead of == for version pinning


### PR DESCRIPTION
## Summary

- Uses platform-aware quoting in `PyFuncBackend.predict()` to avoid wrapping file paths in POSIX-style single quotes on Windows, which causes `OSError: Invalid argument` when the subprocess tries to open the quoted path

## Root Cause

`shlex.quote()` is designed for POSIX shells and wraps values in single quotes. On Windows, commands run via `cmd /c`, which does not strip single quotes. This means a path like `C:\Users\ME\Temp\input.json` becomes `'C:\Users\ME\Temp\input.json'` (with literal quote characters), causing `open()` to fail with `OSError: [Errno 22] Invalid argument`.

## Fix

Introduced a `_quote` helper that uses `shlex.quote` on Unix-like systems and plain `str` on Windows. The `is_windows()` utility was already imported in the file.

Fixes #18455

## Test plan

- [ ] On Windows: `mlflow.models.predict()` with a virtualenv/conda environment succeeds without `OSError`
- [ ] On Unix: paths with spaces are still properly quoted via `shlex.quote`
- [ ] Verify no regression in existing predict behavior on Linux/macOS