### PR TITLE
fix: handle non-copyable dataclass fields in TraceJSONEncoder

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -86,7 +86,11 @@ class TraceJSONEncoder(json.JSONEncoder):
         if is_dataclass(obj):
             try:
                 return asdict(obj)
-            except TypeError:
+            except Exception:
+                # asdict() internally calls copy.deepcopy() on non-dataclass fields,
+                # which can raise various exceptions (TypeError, RuntimeError,
+                # AttributeError, etc.) when encountering non-copyable objects
+                # such as asyncio HTTP clients or locks.
                 pass
 
         # Some object has dangerous side effect in __str__ method, so we use class name instead.


### PR DESCRIPTION
## Summary

- Broadens `except TypeError` to `except Exception` in `TraceJSONEncoder.default()` when calling `dataclasses.asdict()`, so that dataclasses containing non-copyable fields fall through gracefully to string serialization instead of crashing

## Root Cause

`dataclasses.asdict()` internally calls `copy.deepcopy()` on non-dataclass field values. When a dataclass contains objects with asyncio transports, locks, or other non-copyable resources (e.g. OpenAI Agents SDK `RunConfig` holding an `AsyncOpenAI` client), `deepcopy` can raise `RuntimeError` or `AttributeError` -- not just `TypeError`. The partially constructed copy then crashes in `__del__`, polluting stderr with `AttributeError: 'AsyncHttpxClientWrapper' object has no attribute '_state'`.

## Fix

Changed the `except` clause from `TypeError` to `Exception` so that any `asdict()` failure causes the encoder to fall through to the existing string-representation fallback path, matching the defensive style already used elsewhere in the same method.

Fixes #21667

## Test plan

- [ ] Verify that dataclasses with `AsyncOpenAI` client fields serialize without error
- [ ] Verify that normal dataclasses still serialize via `asdict()` as before
- [ ] Verify that the string fallback produces a reasonable representation

Note: Previous PR #21668 was closed. This PR provides a minimal fix by broadening the exception handler.