### PR TITLE
Fix autologging overwriting user's warnings.showwarning handler

### DIFF
--- a/mlflow/utils/autologging_utils/logging_and_warnings.py
+++ b/mlflow/utils/autologging_utils/logging_and_warnings.py
@@ -7,8 +7,6 @@ from threading import get_ident as get_current_thread_id
 import mlflow
 from mlflow.utils import logging_utils
 
-ORIGINAL_SHOWWARNING = warnings.showwarning
-
 
 class _WarningsController:
     """
@@ -26,6 +24,7 @@ class _WarningsController:
         self._state_lock = RLock()
 
         self._did_patch_showwarning = False
+        self._original_showwarning = None
 
         self._disabled_threads = set()
         self._rerouted_threads = set()
@@ -70,7 +69,7 @@ class _WarningsController:
                 message,
             )
         else:
-            ORIGINAL_SHOWWARNING(message, category, filename, lineno, *args, **kwargs)
+            self._original_showwarning(message, category, filename, lineno, *args, **kwargs)
 
     def _should_patch_showwarning(self):
         return (
@@ -96,12 +95,15 @@ class _WarningsController:
             if self._should_patch_showwarning() and not self._did_patch_showwarning:
                 # NB: guard to prevent patching an instance of a patch
                 if warnings.showwarning != self._patched_showwarning:
+                    # Capture the current handler so we restore the right one on unpatch,
+                    # not a stale reference from import time (see #21689).
+                    self._original_showwarning = warnings.showwarning
                     warnings.showwarning = self._patched_showwarning
                 self._did_patch_showwarning = True
             elif not self._should_patch_showwarning() and self._did_patch_showwarning:
                 # NB: only unpatch iff the patched function is active
                 if warnings.showwarning == self._patched_showwarning:
-                    warnings.showwarning = ORIGINAL_SHOWWARNING
+                    warnings.showwarning = self._original_showwarning
                 self._did_patch_showwarning = False
 
     def set_mlflow_warnings_disablement_state_globally(self, disabled=True):

--- a/tests/utils/test_autologging_utils.py
+++ b/tests/utils/test_autologging_utils.py
@@ -4,7 +4,6 @@ from threading import Thread
 from mlflow import MlflowClient
 from mlflow.entities import Metric
 from mlflow.utils.autologging_utils.logging_and_warnings import (
-    ORIGINAL_SHOWWARNING,
     _WarningsController,
 )
 from mlflow.utils.autologging_utils.metrics_queue import (
@@ -46,11 +45,12 @@ def test_flush_metrics_queue_is_thread_safe():
 
 
 def test_double_patch_does_not_overwrite(monkeypatch):
-    monkeypatch.setattr(warnings, "showwarning", ORIGINAL_SHOWWARNING)
+    original = warnings.showwarning
+    monkeypatch.setattr(warnings, "showwarning", original)
 
     controller = _WarningsController()
 
-    assert warnings.showwarning == ORIGINAL_SHOWWARNING
+    assert warnings.showwarning == original
     assert not controller._did_patch_showwarning
 
     controller.set_non_mlflow_warnings_disablement_state_for_current_thread(True)
@@ -66,4 +66,28 @@ def test_double_patch_does_not_overwrite(monkeypatch):
 
     controller.set_non_mlflow_warnings_disablement_state_for_current_thread(False)
 
-    assert warnings.showwarning == ORIGINAL_SHOWWARNING
+    assert warnings.showwarning == original
+
+
+def test_showwarning_captures_user_handler():
+    """Verify that a user-set warnings.showwarning is preserved across patch/unpatch."""
+    calls = []
+
+    def custom_handler(message, category, filename, lineno, *args, **kwargs):
+        calls.append(message)
+
+    original = warnings.showwarning
+    try:
+        warnings.showwarning = custom_handler
+
+        controller = _WarningsController()
+        controller.set_non_mlflow_warnings_disablement_state_for_current_thread(True)
+
+        assert warnings.showwarning == controller._patched_showwarning
+        assert controller._original_showwarning is custom_handler
+
+        controller.set_non_mlflow_warnings_disablement_state_for_current_thread(False)
+
+        assert warnings.showwarning is custom_handler
+    finally:
+        warnings.showwarning = original


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #21689

MLflow's `_WarningsController` backed up `warnings.showwarning` at **module import time** via a module-level constant:

```python
ORIGINAL_SHOWWARNING = warnings.showwarning  # captured once, at import
```

If a user modified `warnings.showwarning` after importing MLflow (e.g. via `logging.captureWarnings(True)`), the controller would overwrite their handler on unpatch by restoring the stale import-time reference.

### The fix

Capture `warnings.showwarning` at **patch time** (when the controller starts redirecting warnings), not at import time. This ensures the controller always restores whatever handler was active when MLflow began patching.

Changes:
- Removed module-level `ORIGINAL_SHOWWARNING` constant
- Added `self._original_showwarning` instance variable on `_WarningsController`
- Capture `warnings.showwarning` right before patching in `_modify_patch_state_if_necessary()`
- Updated existing test to not depend on the removed constant
- Added regression test `test_showwarning_captures_user_handler` that verifies a user-set handler survives the patch/unpatch cycle

## How is this patch tested?

- Existing test `test_double_patch_does_not_overwrite` updated and still passes
- New test `test_showwarning_captures_user_handler` specifically verifies the reported bug scenario:
  1. User sets a custom `warnings.showwarning` handler
  2. MLflow patches it for autologging
  3. MLflow unpatches — the user's handler is correctly restored (not the default)

## Does this PR change the existing API or CLI?

No.

## What component(s) does this PR affect?

- `mlflow/utils/autologging_utils/logging_and_warnings.py`
- `tests/utils/test_autologging_utils.py`