### PR TITLE
Fix autologging overwriting user's `warnings.showwarning` handler

### DIFF
--- a/mlflow/utils/autologging_utils/logging_and_warnings.py
+++ b/mlflow/utils/autologging_utils/logging_and_warnings.py
@@ -7,8 +7,6 @@ from threading import get_ident as get_current_thread_id
 import mlflow
 from mlflow.utils import logging_utils
 
-ORIGINAL_SHOWWARNING = warnings.showwarning
-
 
 class _WarningsController:
     """
@@ -26,6 +24,7 @@ class _WarningsController:
         self._state_lock = RLock()
 
         self._did_patch_showwarning = False
+        self._original_showwarning = None
 
         self._disabled_threads = set()
         self._rerouted_threads = set()
@@ -70,7 +69,7 @@ class _WarningsController:
                 message,
             )
         else:
-            ORIGINAL_SHOWWARNING(message, category, filename, lineno, *args, **kwargs)
+            self._original_showwarning(message, category, filename, lineno, *args, **kwargs)
 
     def _should_patch_showwarning(self):
         return (
@@ -96,12 +95,15 @@ class _WarningsController:
             if self._should_patch_showwarning() and not self._did_patch_showwarning:
                 # NB: guard to prevent patching an instance of a patch
                 if warnings.showwarning != self._patched_showwarning:
+                    # Capture the current handler so we restore the right one on unpatch,
+                    # not a stale reference from import time (see #21689).
+                    self._original_showwarning = warnings.showwarning
                     warnings.showwarning = self._patched_showwarning
                 self._did_patch_showwarning = True
             elif not self._should_patch_showwarning() and self._did_patch_showwarning:
                 # NB: only unpatch iff the patched function is active
                 if warnings.showwarning == self._patched_showwarning:
-                    warnings.showwarning = ORIGINAL_SHOWWARNING
+                    warnings.showwarning = self._original_showwarning
                 self._did_patch_showwarning = False
 
     def set_mlflow_warnings_disablement_state_globally(self, disabled=True):

--- a/tests/utils/test_autologging_utils.py
+++ b/tests/utils/test_autologging_utils.py
@@ -4,7 +4,6 @@ from threading import Thread
 from mlflow import MlflowClient
 from mlflow.entities import Metric
 from mlflow.utils.autologging_utils.logging_and_warnings import (
-    ORIGINAL_SHOWWARNING,
     _WarningsController,
 )
 from mlflow.utils.autologging_utils.metrics_queue import (
@@ -46,11 +45,12 @@ def test_flush_metrics_queue_is_thread_safe():
 
 
 def test_double_patch_does_not_overwrite(monkeypatch):
-    monkeypatch.setattr(warnings, "showwarning", ORIGINAL_SHOWWARNING)
+    original = warnings.showwarning
+    monkeypatch.setattr(warnings, "showwarning", original)
 
     controller = _WarningsController()
 
-    assert warnings.showwarning == ORIGINAL_SHOWWARNING
+    assert warnings.showwarning == original
     assert not controller._did_patch_showwarning
 
     controller.set_non_mlflow_warnings_disablement_state_for_current_thread(True)
@@ -66,4 +66,28 @@ def test_double_patch_does_not_overwrite(monkeypatch):
 
     controller.set_non_mlflow_warnings_disablement_state_for_current_thread(False)
 
-    assert warnings.showwarning == ORIGINAL_SHOWWARNING
+    assert warnings.showwarning == original
+
+
+def test_showwarning_captures_user_handler():
+    """Verify that a user-set warnings.showwarning is preserved across patch/unpatch."""
+    calls = []
+
+    def custom_handler(message, category, filename, lineno, *args, **kwargs):
+        calls.append(message)
+
+    original = warnings.showwarning
+    try:
+        warnings.showwarning = custom_handler
+
+        controller = _WarningsController()
+        controller.set_non_mlflow_warnings_disablement_state_for_current_thread(True)
+
+        assert warnings.showwarning == controller._patched_showwarning
+        assert controller._original_showwarning is custom_handler
+
+        controller.set_non_mlflow_warnings_disablement_state_for_current_thread(False)
+
+        assert warnings.showwarning is custom_handler
+    finally:
+        warnings.showwarning = original


### PR DESCRIPTION
### Related Issues/PRs

Closes #21689

### What changes are proposed in this pull request?

MLflow's `_WarningsController` backed up `warnings.showwarning` at **module import time** via a module-level constant (`ORIGINAL_SHOWWARNING`). If a user modified `warnings.showwarning` after importing MLflow (e.g. via `logging.captureWarnings(True)`), the controller would overwrite their handler on unpatch by restoring the stale import-time reference.

**The fix:** Capture `warnings.showwarning` at **patch time** (when the controller starts redirecting warnings), not at import time. This ensures the controller always restores whatever handler was active when MLflow began patching.

Changes:
- Removed module-level `ORIGINAL_SHOWWARNING` constant from `mlflow/utils/autologging_utils/logging_and_warnings.py`
- Added `self._original_showwarning` instance variable on `_WarningsController`
- Capture `warnings.showwarning` right before patching in `_modify_patch_state_if_necessary()`
- Updated existing test `test_double_patch_does_not_overwrite` to not depend on the removed constant
- Added regression test `test_showwarning_captures_user_handler` verifying a user-set handler survives the patch/unpatch cycle

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

The existing test `test_double_patch_does_not_overwrite` was updated and still validates the same behavior. A new test `test_showwarning_captures_user_handler` specifically verifies the bug scenario from #21689:
1. User sets a custom `warnings.showwarning` handler after import
2. MLflow patches it for autologging
3. MLflow unpatches — the user's custom handler is correctly restored (not the default)

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where MLflow's autologging would overwrite custom `warnings.showwarning` handlers set after importing MLflow (e.g. via `logging.captureWarnings(True)`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release