### PR TITLE
fix: sanitize GeoJSON popupContent to prevent stored XSS in map artifact viewer

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -23,6 +23,7 @@
     "graphql-codegen:clean": "find . -path '**/__generated__/*.ts' | xargs rm"
   },
   "dependencies": {
+    "dompurify": "^3.2.4",
     "@ag-grid-community/client-side-row-model": "^27.2.1",
     "@ag-grid-community/core": "^27.2.1",
     "@ag-grid-community/react": "^27.2.1",

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMapView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMapView.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { Component } from 'react';
-import DOMPurify from "dompurify";
+import DOMPurify from 'dompurify';
 import { getArtifactContent } from '../../../common/utils/ArtifactUtils';
 import './ShowArtifactMapView.css';
 import 'leaflet/dist/leaflet.css';

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMapView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMapView.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { Component } from 'react';
+import DOMPurify from "dompurify";
 import { getArtifactContent } from '../../../common/utils/ArtifactUtils';
 import './ShowArtifactMapView.css';
 import 'leaflet/dist/leaflet.css';
@@ -21,7 +22,7 @@ import { fetchArtifactUnified, type FetchArtifactUnifiedFn } from './utils/fetch
 function onEachFeature(feature: any, layer: any) {
   if (feature.properties && feature.properties.popupContent) {
     const { popupContent } = feature.properties;
-    layer.bindPopup(popupContent);
+    layer.bindPopup(DOMPurify.sanitize(popupContent));
   }
 }
 


### PR DESCRIPTION
## Changes
Sanitize GeoJSON popupContent using DOMPurify before passing to Leaflet's bindPopup() to prevent stored XSS.

## Why are these changes needed?
ShowArtifactMapView.tsx passes feature.properties.popupContent directly to layer.bindPopup() without sanitization. Leaflet renders raw HTML, allowing stored XSS via malicious GeoJSON artifacts.

## Does this PR require a release note?
Yes. Fixed stored XSS vulnerability in GeoJSON map artifact viewer by sanitizing popupContent with DOMPurify.

## Release Note Category
- [ ] rn/breaking-change
- [ ] rn/feature
- [x] rn/bug-fix
- [ ] rn/documentation
- [ ] rn/none

## Is this PR a patch release?
- [x] yes (this PR will be cherry-picked and included in the next patch release)
- [ ] no (this PR can wait until the next minor release)

## Tests
N/A — frontend sanitization fix

## Related Issues
Security fix — reported via huntr.com bug bounty program