### PR TITLE
Revert "Fix undefined error in `BudgetsList` when policy duration is null"

### DIFF
--- a/mlflow/server/js/src/gateway/components/budgets/BudgetsList.tsx
+++ b/mlflow/server/js/src/gateway/components/budgets/BudgetsList.tsx
@@ -158,9 +158,7 @@ export const BudgetsList = ({ onEditClick, onDeleteClick }: BudgetsListProps) =>
                 </Tooltip>
               </TableCell>
               <TableCell css={{ flex: 1 }}>
-                <Typography.Text>
-                  {policy.duration ? formatDuration(policy.duration.value, policy.duration.unit) : '—'}
-                </Typography.Text>
+                <Typography.Text>{formatDuration(policy.duration.value, policy.duration.unit)}</Typography.Text>
               </TableCell>
               <TableCell css={{ flex: 1 }}>
                 <Typography.Text>{formatOnExceeded(policy.budget_action)}</Typography.Text>


### PR DESCRIPTION
Reverts mlflow/mlflow#21700

The issue no longer exists on latest proto update where the duration always exists