### PR TITLE
Restore mode-specific `componentIdPrefix` in `EndpointFormRenderer`

### DIFF
--- a/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
@@ -70,7 +70,7 @@ export const EndpointFormRenderer = ({
   onSubmit,
   onCancel,
   onNameBlur,
-  componentIdPrefix = `mlflow.gateway.endpoint`,
+  componentIdPrefix = `mlflow.gateway.${mode}-endpoint`,
   embedded = false,
 }: EndpointFormRendererProps) => {
   const { theme } = useDesignSystemTheme();
@@ -216,7 +216,7 @@ export const EndpointFormRenderer = ({
                   <UsageTrackingConfigurator
                     value={field.value}
                     onChange={field.onChange}
-                    componentIdPrefix="mlflow.gateway.create-endpoint.usage-tracking"
+                    componentIdPrefix={`${componentIdPrefix}.usage-tracking`}
                   />
                 )}
               />


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21639

### What changes are proposed in this pull request?

#21639 restored semantic `componentId`s in gateway components but missed restoring the default `componentIdPrefix` in `EndpointFormRenderer`. The UI sync in #20789 had changed it from `` `mlflow.gateway.${mode}-endpoint` `` to `"mlflow.gateway.endpoint"`, losing the ability to distinguish create vs edit mode in telemetry.

This PR:
- Restores the default `componentIdPrefix` to `` `mlflow.gateway.${mode}-endpoint` `` so create mode emits `mlflow.gateway.create-endpoint.*` events and edit mode emits `mlflow.gateway.edit-endpoint.*` events
- Makes the usage-tracking `componentIdPrefix` consistent by deriving it from the parent prefix instead of hardcoding

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

The change is a string interpolation fix that restores the original behavior. Verified that the `mode` prop is always provided (`"create"` or `"edit"`).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release