### PR TITLE
fix(tracing): use shallow field extraction as fallback when asdict() fails in TraceJSONEncoder

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -86,8 +86,22 @@ class TraceJSONEncoder(json.JSONEncoder):
         if is_dataclass(obj):
             try:
                 return asdict(obj)
-            except TypeError:
-                pass
+            except Exception:
+                # asdict() calls copy.deepcopy() on every non-dataclass field, which can
+                # fail for fields holding HTTP clients, asyncio transports, or other
+                # non-copyable objects. A failed deepcopy may leave partially-constructed
+                # objects alive, causing AttributeError crashes in their __del__ methods
+                # (e.g. OpenAI Agents SDK RunConfig with an AsyncOpenAI client).
+                #
+                # Fall back to a shallow extraction: read each field value directly via
+                # getattr() without copying. Non-serializable values are left for the
+                # encoder's subsequent default() calls to convert to str.
+                import dataclasses as _dc
+
+                try:
+                    return {f.name: getattr(obj, f.name, None) for f in _dc.fields(obj)}
+                except Exception:
+                    pass
 
         # Some object has dangerous side effect in __str__ method, so we use class name instead.
         if not self._is_safe_to_encode_str(obj):


### PR DESCRIPTION
## Summary

Fixes #21667

`dataclasses.asdict()` internally calls `copy.deepcopy()` on every non-dataclass field value. For dataclasses that hold non-copyable objects (HTTP clients, asyncio transports, etc.) this deepcopy fails partway through, leaving partially-constructed wrapper objects alive. When those wrappers are later garbage collected their `__del__` methods crash with `AttributeError` because the object was never fully initialised.

A concrete example: the OpenAI Agents SDK `RunConfig` holds an `AsyncOpenAI` HTTP client whose deepcopy fails, causing the MLflow autologging callback to print noisy tracebacks to stderr after every traced run:

```
Exception ignored in: <object repr() failed>
AttributeError: 'RunConfig' object has no attribute 'max_turns'
```

## Root Cause

`TraceJSONEncoder.default()` called `asdict(obj)` and only caught `TypeError`. A failed `deepcopy` inside `asdict` raises a different exception type, so the except clause was never triggered, and the encoder would fall through without the safe fallback.

## Fix

- Broaden the except clause from `TypeError` to `Exception`
- Add a safe fallback that uses `dataclasses.fields()` + `getattr()` to build the dict without any `deepcopy`. Non-serializable field values are handled by the encoder's recursive `default()` calls (which ultimately fall back to `str()`).

## Testing

The fix can be verified with the minimal repro from the issue:

```python
import gc, json
from dataclasses import dataclass
from openai import AsyncOpenAI
from mlflow.tracing.utils import TraceJSONEncoder

@dataclass
class Config:
    client: AsyncOpenAI

config = Config(client=AsyncOpenAI(api_key="test"))
json.dumps(config, cls=TraceJSONEncoder)  # should not crash or leave zombie objects
gc.collect()
```