### PR TITLE
Fix `server-info` endpoint accessibility with workspace headers when workspaces disabled

### DIFF
--- a/mlflow/server/workspace_helpers.py
+++ b/mlflow/server/workspace_helpers.py
@@ -100,17 +100,17 @@ def resolve_workspace_for_request_if_enabled(
     path: str,
     header_value: str | None,
 ) -> Workspace | None:
+    # The server-info endpoint must remain reachable even if the workspace header points to a
+    # missing workspace, so skip workspace resolution entirely for this route.
+    if path.rstrip("/").endswith("/mlflow/server-info"):
+        return None
+
     if not MLFLOW_ENABLE_WORKSPACES.get():
         if (header_value or "").strip():
             raise MlflowException(
                 "Workspace APIs are not available: workspaces are not enabled on this server",
                 error_code=databricks_pb2.FEATURE_DISABLED,
             )
-        return None
-
-    # The server-info endpoint must remain reachable even if the workspace header points to a
-    # missing workspace, so skip workspace resolution entirely for this route.
-    if path.rstrip("/").endswith("/mlflow/server-info"):
         return None
 
     try:

--- a/tests/server/test_workspace_middleware.py
+++ b/tests/server/test_workspace_middleware.py
@@ -147,6 +147,17 @@ def test_server_info_skips_workspace_resolution(monkeypatch):
     assert data["workspaces_enabled"] is True
 
 
+def test_server_info_with_workspace_header_when_workspaces_disabled(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
+    client = flask_app.test_client()
+    resp = client.get(
+        "/api/3.0/mlflow/server-info", headers={WORKSPACE_HEADER_NAME: "some-workspace"}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["workspaces_enabled"] is False
+
+
 def test_fastapi_wsgi_flask_workspace_propagation(monkeypatch):
     from fastapi.middleware.wsgi import WSGIMiddleware
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #

### What changes are proposed in this pull request?

This PR fixes a bug where the `/api/3.0/mlflow/server-info` endpoint returns a 500 error when accessed with a workspace header while workspaces are disabled on the server.

**The Problem:**
- When a client has `MLFLOW_WORKSPACE` environment variable set but connects to a server with workspaces disabled, the client needs to probe the `/api/3.0/mlflow/server-info` endpoint to detect workspace support
- The workspace middleware was checking if workspaces were disabled and rejecting requests with workspace headers **before** checking if the request was for the `server-info` endpoint
- This caused a 500 error, preventing clients from properly detecting that workspaces aren't supported
- This particularly affected issue detection jobs which would fail when trying to make API calls during error handling

**The Fix:**
- Move the `server-info` path check to the beginning of `resolve_workspace_for_request_if_enabled()` in `mlflow/server/workspace_helpers.py`
- This ensures the endpoint is always accessible regardless of workspace configuration, allowing clients to successfully probe workspace support

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_server_info_with_workspace_header_when_workspaces_disabled` to verify the endpoint returns 200 with workspace header when workspaces are disabled.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where the `/api/3.0/mlflow/server-info` endpoint would return a 500 error when accessed with a workspace header while workspaces are disabled, preventing clients from properly detecting workspace support.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release