### PR TITLE
fix: snapshot `showwarning` at patch time instead of import time

### DIFF
--- a/mlflow/utils/autologging_utils/logging_and_warnings.py
+++ b/mlflow/utils/autologging_utils/logging_and_warnings.py
@@ -7,8 +7,6 @@ from threading import get_ident as get_current_thread_id
 import mlflow
 from mlflow.utils import logging_utils
 
-ORIGINAL_SHOWWARNING = warnings.showwarning
-
 
 class _WarningsController:
     """
@@ -26,6 +24,7 @@ class _WarningsController:
         self._state_lock = RLock()
 
         self._did_patch_showwarning = False
+        self._original_showwarning = None
 
         self._disabled_threads = set()
         self._rerouted_threads = set()
@@ -70,7 +69,7 @@ class _WarningsController:
                 message,
             )
         else:
-            ORIGINAL_SHOWWARNING(message, category, filename, lineno, *args, **kwargs)
+            self._original_showwarning(message, category, filename, lineno, *args, **kwargs)
 
     def _should_patch_showwarning(self):
         return (
@@ -96,12 +95,15 @@ class _WarningsController:
             if self._should_patch_showwarning() and not self._did_patch_showwarning:
                 # NB: guard to prevent patching an instance of a patch
                 if warnings.showwarning != self._patched_showwarning:
+                    # Snapshot the current showwarning at patch time so that
+                    # any user customization set after import is preserved.
+                    self._original_showwarning = warnings.showwarning
                     warnings.showwarning = self._patched_showwarning
                 self._did_patch_showwarning = True
             elif not self._should_patch_showwarning() and self._did_patch_showwarning:
                 # NB: only unpatch iff the patched function is active
                 if warnings.showwarning == self._patched_showwarning:
-                    warnings.showwarning = ORIGINAL_SHOWWARNING
+                    warnings.showwarning = self._original_showwarning
                 self._did_patch_showwarning = False
 
     def set_mlflow_warnings_disablement_state_globally(self, disabled=True):

--- a/tests/autologging/test_showwarning_restore.py
+++ b/tests/autologging/test_showwarning_restore.py
@@ -1,0 +1,172 @@
+"""
+Tests that the autologging warnings controller correctly preserves
+user-installed ``warnings.showwarning`` handlers.
+
+Regression tests for https://github.com/mlflow/mlflow/issues/21689
+"""
+
+import warnings
+
+import pytest
+
+
+def _make_custom_showwarning():
+    """Return a distinct callable to use as a custom showwarning handler."""
+    def custom_showwarning(message, category, filename, lineno, file=None, line=None):
+        pass  # intentional no-op for testing identity
+
+    return custom_showwarning
+
+
+@pytest.fixture
+def warnings_controller():
+    """Create a fresh _WarningsController for each test."""
+    from mlflow.utils.autologging_utils.logging_and_warnings import _WarningsController
+
+    return _WarningsController()
+
+
+class TestShowwarningRestoreAfterPatchCycle:
+    """Verify that patch/unpatch restores the handler that was active at patch time."""
+
+    def test_custom_handler_restored_after_global_disable_cycle(self, warnings_controller):
+        """
+        A custom ``warnings.showwarning`` set *after* import must be restored
+        when the warnings controller finishes its patch/unpatch cycle.
+        """
+        custom = _make_custom_showwarning()
+        warnings.showwarning = custom
+
+        try:
+            # Patch: controller should snapshot `custom`
+            warnings_controller.set_mlflow_warnings_disablement_state_globally(disabled=True)
+            assert warnings.showwarning != custom, (
+                "showwarning should be patched while controller is active"
+            )
+
+            # Unpatch: controller should restore `custom`
+            warnings_controller.set_mlflow_warnings_disablement_state_globally(disabled=False)
+            assert warnings.showwarning is custom, (
+                "showwarning should be restored to the user's custom handler"
+            )
+        finally:
+            # Restore default so we don't leak into other tests
+            warnings.showwarning = warnings._showwarning_orig
+
+    def test_custom_handler_restored_after_reroute_cycle(self, warnings_controller):
+        """Same as above but using the rerouting code path."""
+        custom = _make_custom_showwarning()
+        warnings.showwarning = custom
+
+        try:
+            warnings_controller.set_mlflow_warnings_rerouting_state_globally(rerouted=True)
+            assert warnings.showwarning != custom
+
+            warnings_controller.set_mlflow_warnings_rerouting_state_globally(rerouted=False)
+            assert warnings.showwarning is custom
+        finally:
+            warnings.showwarning = warnings._showwarning_orig
+
+    def test_custom_handler_restored_after_thread_disable_cycle(self, warnings_controller):
+        """Same as above but using per-thread warning disablement."""
+        custom = _make_custom_showwarning()
+        warnings.showwarning = custom
+
+        try:
+            warnings_controller.set_non_mlflow_warnings_disablement_state_for_current_thread(
+                disabled=True
+            )
+            assert warnings.showwarning != custom
+
+            warnings_controller.set_non_mlflow_warnings_disablement_state_for_current_thread(
+                disabled=False
+            )
+            assert warnings.showwarning is custom
+        finally:
+            warnings.showwarning = warnings._showwarning_orig
+
+    def test_custom_handler_restored_after_thread_reroute_cycle(self, warnings_controller):
+        """Same as above but using per-thread warning rerouting."""
+        custom = _make_custom_showwarning()
+        warnings.showwarning = custom
+
+        try:
+            warnings_controller.set_non_mlflow_warnings_rerouting_state_for_current_thread(
+                rerouted=True
+            )
+            assert warnings.showwarning != custom
+
+            warnings_controller.set_non_mlflow_warnings_rerouting_state_for_current_thread(
+                rerouted=False
+            )
+            assert warnings.showwarning is custom
+        finally:
+            warnings.showwarning = warnings._showwarning_orig
+
+
+class TestShowwarningSnapshotTiming:
+    """Verify that the snapshot is taken at patch time, not at import time."""
+
+    def test_handler_set_between_import_and_patch_is_preserved(self, warnings_controller):
+        """
+        The core regression: if a user sets ``warnings.showwarning`` after
+        ``import mlflow`` but before autologging activates, that handler must
+        survive the patch/unpatch cycle.
+        """
+        # Simulate the user setting a handler after import
+        handler_a = _make_custom_showwarning()
+        warnings.showwarning = handler_a
+
+        try:
+            # First patch cycle
+            warnings_controller.set_mlflow_warnings_disablement_state_globally(disabled=True)
+            warnings_controller.set_mlflow_warnings_disablement_state_globally(disabled=False)
+            assert warnings.showwarning is handler_a
+
+            # User changes handler again
+            handler_b = _make_custom_showwarning()
+            warnings.showwarning = handler_b
+
+            # Second patch cycle should snapshot handler_b, not handler_a
+            warnings_controller.set_mlflow_warnings_disablement_state_globally(disabled=True)
+            warnings_controller.set_mlflow_warnings_disablement_state_globally(disabled=False)
+            assert warnings.showwarning is handler_b
+        finally:
+            warnings.showwarning = warnings._showwarning_orig
+
+    def test_fallback_in_patched_showwarning_uses_snapshot(self, warnings_controller):
+        """
+        When the patched showwarning falls through to the original handler
+        (non-MLflow, non-disabled, non-rerouted warning), it should call the
+        handler that was active at patch time.
+        """
+        call_log = []
+
+        def tracking_showwarning(message, category, filename, lineno, file=None, line=None):
+            call_log.append(str(message))
+
+        warnings.showwarning = tracking_showwarning
+
+        try:
+            # Enable rerouting for MLflow warnings only (non-MLflow warnings
+            # fall through to the original handler)
+            warnings_controller.set_mlflow_warnings_rerouted_to_event_logs = True
+            warnings_controller._modify_patch_state_if_necessary()
+
+            # Emit a non-MLflow warning -- should go through tracking_showwarning
+            with warnings.catch_warnings():
+                warnings.simplefilter("always")
+                warnings.warn_explicit(
+                    "test message",
+                    UserWarning,
+                    "/some/non/mlflow/path.py",
+                    42,
+                )
+
+            assert len(call_log) == 1
+            assert "test message" in call_log[0]
+        finally:
+            # Clean up
+            warnings_controller.set_mlflow_warnings_rerouted_to_event_logs = False
+            warnings_controller._modify_patch_state_if_necessary()
+            warnings.showwarning = warnings._showwarning_orig


### PR DESCRIPTION
### Related Issues/PRs

Closes #21689

### What changes are proposed in this pull request?

`ORIGINAL_SHOWWARNING` was captured at module import time in `mlflow/utils/autologging_utils/logging_and_warnings.py`. If a user set a custom `warnings.showwarning` after `import mlflow`, the autologging patch/unpatch cycle would restore the stale import-time handler, silently discarding the user's customization.

This PR moves the snapshot from module-level into `_WarningsController._modify_patch_state_if_necessary()`, so the controller captures whatever handler is active at the moment patching begins and restores that exact handler on unpatch.

**Changes:**
- Remove module-level `ORIGINAL_SHOWWARNING = warnings.showwarning`
- Add `self._original_showwarning` instance variable to `_WarningsController`
- Snapshot `warnings.showwarning` at patch time (inside the `_modify_patch_state_if_necessary` method)
- Restore the snapshotted handler on unpatch
- All references to the old module-level constant are replaced with `self._original_showwarning`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `tests/autologging/test_showwarning_restore.py` with 6 tests covering:

1. **`TestShowwarningRestoreAfterPatchCycle`** (4 tests) -- verifies a custom handler set after import is correctly restored after a patch/unpatch cycle through each of the four controller code paths:
   - Global warning disablement
   - Global warning rerouting
   - Per-thread warning disablement
   - Per-thread warning rerouting

2. **`TestShowwarningSnapshotTiming`** (2 tests) -- verifies:
   - Multiple sequential patch cycles each snapshot the *current* handler (not a stale one)
   - The patched `showwarning` fallback path delegates to the snapshotted handler (not the import-time default)

All 6 tests **fail** against the unpatched code and **pass** with this fix.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where custom `warnings.showwarning` handlers set after `import mlflow` were silently discarded by the autologging patch/unpatch cycle. The handler is now correctly snapshotted at patch time and restored on unpatch.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release