### PR TITLE
Remove trace limit in issue discovery to annotate all affected traces

### DIFF
--- a/mlflow/genai/discovery/constants.py
+++ b/mlflow/genai/discovery/constants.py
@@ -4,8 +4,6 @@ from mlflow.entities.issue import IssueSeverity
 
 # Number of sessions (or individual traces) to sample for triage by default
 DEFAULT_TRIAGE_SAMPLE_SIZE = 100
-# Cap on trace IDs attached to each Issue to keep payloads manageable
-MAX_EXAMPLE_TRACE_IDS = 10
 # Fetch N * sample_size traces so random sampling has enough diversity
 SAMPLE_POOL_MULTIPLIER = 5
 SAMPLE_RANDOM_SEED = 42

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -45,7 +45,7 @@ from mlflow.genai.discovery.utils import (
     _call_llm,
     _TokenCounter,
     build_summary,
-    collect_example_trace_ids,
+    collect_affected_trace_ids,
     format_annotation_prompt,
     format_trace_content,
     get_session_id,
@@ -408,8 +408,7 @@ def _build_issues(
     issues: list[Issue] = []
     issue_trace_ids: dict[str, list[str]] = {}
     for ident in identified:
-        # TODO: this doesn't include all affected traces, but at max 10 examples
-        example_trace_ids = collect_example_trace_ids(ident, analyses)
+        affected_trace_ids = collect_affected_trace_ids(ident, analyses)
         name = ident.name.removeprefix("Issue: ").removeprefix("issue: ")
         issue = TracingClient()._create_issue(
             experiment_id=exp_id,
@@ -421,7 +420,7 @@ def _build_issues(
             source_run_id=source_run_id,
         )
         issues.append(issue)
-        issue_trace_ids[issue.issue_id] = example_trace_ids
+        issue_trace_ids[issue.issue_id] = affected_trace_ids
 
     issues.sort(
         key=lambda i: i.severity,

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -401,7 +401,7 @@ def _build_issues(
 
     Returns:
         A tuple of (issues, issue_trace_ids) where issue_trace_ids maps
-        issue_id to the list of example trace IDs for annotation.
+        issue_id to the list of affected trace IDs for annotation.
     """
     from mlflow.tracing.client import TracingClient
 

--- a/mlflow/genai/discovery/utils.py
+++ b/mlflow/genai/discovery/utils.py
@@ -12,7 +12,6 @@ from mlflow.entities.assessment import Feedback
 from mlflow.entities.trace import Trace
 from mlflow.genai.discovery.constants import (
     LLM_MAX_TOKENS,
-    MAX_EXAMPLE_TRACE_IDS,
     NUM_RETRIES,
     TRACE_CONTENT_TRUNCATION,
 )
@@ -179,15 +178,25 @@ def verify_scorer(
         )
 
 
-def collect_example_trace_ids(
+def collect_affected_trace_ids(
     issue: _IdentifiedIssue,
     analyses: list[_ConversationAnalysis],
 ) -> list[str]:
+    """
+    Collect all affected trace IDs for an identified issue.
+
+    Args:
+        issue: The identified issue containing indices into the analyses list.
+        analyses: List of per-session analyses with affected trace IDs.
+
+    Returns:
+        A list of all trace IDs affected by this issue.
+    """
     trace_ids = []
     for idx in issue.example_indices:
         if 0 <= idx < len(analyses):
             trace_ids.extend(analyses[idx].affected_trace_ids)
-    return trace_ids[:MAX_EXAMPLE_TRACE_IDS]
+    return trace_ids
 
 
 def format_trace_content(trace: Trace) -> str:

--- a/tests/genai/discovery/test_utils.py
+++ b/tests/genai/discovery/test_utils.py
@@ -4,12 +4,11 @@ from unittest import mock
 import pytest
 
 from mlflow.entities.issue import Issue, IssueStatus
-from mlflow.genai.discovery import utils
 from mlflow.genai.discovery.entities import _ConversationAnalysis, _IdentifiedIssue
 from mlflow.genai.discovery.utils import (
     _TokenCounter,
     build_summary,
-    collect_example_trace_ids,
+    collect_affected_trace_ids,
     format_annotation_prompt,
     format_trace_content,
     get_session_id,
@@ -31,7 +30,7 @@ def test_format_trace_content_no_errors(make_trace):
     assert "Errors:" not in content
 
 
-def test_collect_example_trace_ids_gathers_from_analyses():
+def test_collect_affected_trace_ids_gathers_from_analyses():
     analyses = [
         _ConversationAnalysis(
             full_rationale="r1", affected_trace_ids=["t1", "t2"], execution_path="p1"
@@ -46,11 +45,11 @@ def test_collect_example_trace_ids_gathers_from_analyses():
         example_indices=[0, 1],
         categories=[],
     )
-    result = collect_example_trace_ids(issue, analyses)
+    result = collect_affected_trace_ids(issue, analyses)
     assert result == ["t1", "t2", "t3"]
 
 
-def test_collect_example_trace_ids_skips_out_of_bounds():
+def test_collect_affected_trace_ids_skips_out_of_bounds():
     analyses = [
         _ConversationAnalysis(full_rationale="r1", affected_trace_ids=["t1"], execution_path="p1"),
     ]
@@ -62,27 +61,8 @@ def test_collect_example_trace_ids_skips_out_of_bounds():
         example_indices=[0, 5],
         categories=[],
     )
-    result = collect_example_trace_ids(issue, analyses)
+    result = collect_affected_trace_ids(issue, analyses)
     assert result == ["t1"]
-
-
-def test_collect_example_trace_ids_caps_at_max(monkeypatch):
-    monkeypatch.setattr(utils, "MAX_EXAMPLE_TRACE_IDS", 2)
-    analyses = [
-        _ConversationAnalysis(
-            full_rationale="r1", affected_trace_ids=["t1", "t2", "t3"], execution_path="p1"
-        ),
-    ]
-    issue = _IdentifiedIssue(
-        name="test",
-        description="d",
-        root_cause="rc",
-        severity="high",
-        example_indices=[0],
-        categories=[],
-    )
-    result = collect_example_trace_ids(issue, analyses)
-    assert len(result) == 2
 
 
 # ---- get_session_id ----


### PR DESCRIPTION
### Related Issues/PRs

Relates to internal TODO comment in `mlflow/genai/discovery/pipeline.py`

### What changes are proposed in this pull request?

This PR removes the 10-trace limit in the issue discovery pipeline to ensure all affected traces receive issue annotations.

**Changes:**
- Renamed `collect_example_trace_ids()` → `collect_affected_trace_ids()` to better reflect its purpose
- Removed `MAX_EXAMPLE_TRACE_IDS` constant that was capping annotations at 10 traces
- Updated all call sites and tests to use the new function name
- Removed the TODO comment that flagged this limitation

Previously, when issues were discovered, only the first 10 example traces would be annotated with the issue. Now, all affected traces identified during the analysis phase receive proper issue annotations via `mlflow.log_issue()`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

All existing tests in `tests/genai/discovery/test_utils.py` pass. Removed the test for the cap behavior since it's no longer applicable.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Issue discovery now annotates all affected traces instead of only the first 10 examples, ensuring complete coverage when logging issues to traces.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release