### PR TITLE
fix(autologging): capture warnings.showwarning lazily to preserve user customizations

### DIFF
--- a/mlflow/utils/autologging_utils/logging_and_warnings.py
+++ b/mlflow/utils/autologging_utils/logging_and_warnings.py
@@ -7,9 +7,6 @@ from threading import get_ident as get_current_thread_id
 import mlflow
 from mlflow.utils import logging_utils
 
-ORIGINAL_SHOWWARNING = warnings.showwarning
-
-
 class _WarningsController:
     """
     Provides threadsafe utilities to modify warning behavior for MLflow autologging, including:
@@ -26,6 +23,7 @@ class _WarningsController:
         self._state_lock = RLock()
 
         self._did_patch_showwarning = False
+        self._original_showwarning = None
 
         self._disabled_threads = set()
         self._rerouted_threads = set()
@@ -70,7 +68,8 @@ class _WarningsController:
                 message,
             )
         else:
-            ORIGINAL_SHOWWARNING(message, category, filename, lineno, *args, **kwargs)
+            _orig = self._original_showwarning or warnings.showwarning
+            _orig(message, category, filename, lineno, *args, **kwargs)
 
     def _should_patch_showwarning(self):
         return (
@@ -96,13 +95,17 @@ class _WarningsController:
             if self._should_patch_showwarning() and not self._did_patch_showwarning:
                 # NB: guard to prevent patching an instance of a patch
                 if warnings.showwarning != self._patched_showwarning:
+                    # Capture the current showwarning lazily (at patch time, not import time)
+                    # so that user customizations applied after importing MLflow are preserved.
+                    self._original_showwarning = warnings.showwarning
                     warnings.showwarning = self._patched_showwarning
                 self._did_patch_showwarning = True
             elif not self._should_patch_showwarning() and self._did_patch_showwarning:
                 # NB: only unpatch iff the patched function is active
                 if warnings.showwarning == self._patched_showwarning:
-                    warnings.showwarning = ORIGINAL_SHOWWARNING
+                    warnings.showwarning = self._original_showwarning or warnings.showwarning
                 self._did_patch_showwarning = False
+                self._original_showwarning = None
 
     def set_mlflow_warnings_disablement_state_globally(self, disabled=True):
         """Disables (or re-enables) MLflow warnings globally across all threads.


### PR DESCRIPTION
## Problem

`ORIGINAL_SHOWWARNING` was captured **at module import time**:

```python
# mlflow/utils/autologging_utils/logging_and_warnings.py (line 10)
ORIGINAL_SHOWWARNING = warnings.showwarning  # ← captured on import
```

If a user configures warning routing **after** importing MLflow (e.g. `logging.captureWarnings(True)`), MLflow's patched `showwarning` falls back to the stale import-time snapshot, effectively **overwriting** the user's customization whenever autologging is active.

```python
import mlflow
import logging

logging.captureWarnings(True)   # sets warnings.showwarning to logging._showwarning_orig
mlflow.autolog()                # MLflow restores ORIGINAL_SHOWWARNING → logging customization lost
```

## Solution

Remove the module-level `ORIGINAL_SHOWWARNING` constant. Instead, capture `warnings.showwarning` **lazily** inside `_modify_patch_state_if_necessary()` at the moment MLflow first patches `showwarning`. Store it as `self._original_showwarning` on the `_WarningsController` instance and restore it on unpatch.

This ensures any user customization applied between `import mlflow` and `mlflow.autolog()` is preserved.

## Testing

- Syntax verified with Python AST parser
- Reproducer from issue: `logging.captureWarnings(True)` → `mlflow.autolog()` → warnings now correctly route to the logger

Fixes #21689
