### PR TITLE
Fix UI polish in trace drawer and issue detection modal

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModal.tsx
@@ -1,5 +1,14 @@
 import React, { useState, useCallback, useRef } from 'react';
-import { Modal, Button, useDesignSystemTheme, SparkleIcon, Typography, Alert } from '@databricks/design-system';
+import {
+  Modal,
+  Button,
+  useDesignSystemTheme,
+  SparkleIcon,
+  Typography,
+  Alert,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { SelectTracesModal } from '../../../SelectTracesModal';
 import { useCreateSecret } from '../../../../../gateway/hooks/useCreateSecret';
@@ -149,7 +158,7 @@ export const IssueDetectionModal: React.FC<IssueDetectionModalProps> = ({
   }, []);
 
   const renderStep1Footer = () => (
-    <div css={{ display: 'flex', justifyContent: 'flex-end', gap: theme.spacing.sm }}>
+    <div css={{ display: 'flex', justifyContent: 'flex-end' }}>
       <Button componentId="mlflow.traces.issue-detection-modal.cancel" onClick={handleClose}>
         <FormattedMessage defaultMessage="Cancel" description="Cancel button in issue detection modal" />
       </Button>
@@ -158,6 +167,7 @@ export const IssueDetectionModal: React.FC<IssueDetectionModalProps> = ({
         type="primary"
         onClick={handleNext}
         disabled={!isStep1Valid}
+        endIcon={<ChevronRightIcon />}
       >
         <FormattedMessage defaultMessage="Next" description="Next button to proceed to provider configuration" />
       </Button>
@@ -165,8 +175,12 @@ export const IssueDetectionModal: React.FC<IssueDetectionModalProps> = ({
   );
 
   const renderStep2Footer = () => (
-    <div css={{ display: 'flex', justifyContent: 'flex-end', gap: theme.spacing.sm }}>
-      <Button componentId="mlflow.traces.issue-detection-modal.previous" onClick={handlePrevious}>
+    <div css={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <Button
+        componentId="mlflow.traces.issue-detection-modal.previous"
+        onClick={handlePrevious}
+        icon={<ChevronLeftIcon />}
+      >
         <FormattedMessage defaultMessage="Previous" description="Previous button to go back to category selection" />
       </Button>
       <Button

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/IssueDetectionProgress.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/IssueDetectionProgress.tsx
@@ -239,7 +239,7 @@ export const IssueDetectionProgress = ({
               />
             )}
           </Typography.Hint>
-          {jobComplete && result?.total_cost_usd != null && (
+          {jobComplete && result?.total_cost_usd !== null && result?.total_cost_usd !== undefined && (
             <Typography.Hint css={{ marginTop: theme.spacing.xs }}>
               <FormattedMessage
                 defaultMessage="Total cost: {cost}"

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/IssueDetectionProgress.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/IssueDetectionProgress.tsx
@@ -239,7 +239,7 @@ export const IssueDetectionProgress = ({
               />
             )}
           </Typography.Hint>
-          {jobComplete && result?.total_cost_usd !== undefined && (
+          {jobComplete && result?.total_cost_usd != null && (
             <Typography.Hint css={{ marginTop: theme.spacing.xs }}>
               <FormattedMessage
                 defaultMessage="Total cost: {cost}"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
@@ -83,7 +83,7 @@ export const ModelTraceExplorerDrawer = ({
     >
       <DrawerComponent.Content
         componentId="mlflow.evaluations_review.modal"
-        width="90vw"
+        width="60vw"
         title={
           <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
             <Button


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21745/files) to review incremental changes.
- [**stack/fix_issue_ui_nits**](https://github.com/mlflow/mlflow/pull/21745) [[Files changed](https://github.com/mlflow/mlflow/pull/21745/files)]
  - [stack/include_trace_count_in_search_traces](https://github.com/mlflow/mlflow/pull/21746) [[Files changed](https://github.com/mlflow/mlflow/pull/21746/files/8e661e2a54409fdc2bbe935ee6346bce3df07a7a..739a5d15333895ba40357e290e8378d2498ea0e7)]
    - [stack/show_impacted_traces_on_issue_card](https://github.com/mlflow/mlflow/pull/21747) [[Files changed](https://github.com/mlflow/mlflow/pull/21747/files/739a5d15333895ba40357e290e8378d2498ea0e7..8575eab5ab202229cabbbdd2898fc4a2c5367523)]
      - [stack/fix_issue_column_render](https://github.com/mlflow/mlflow/pull/21758) [[Files changed](https://github.com/mlflow/mlflow/pull/21758/files/8575eab5ab202229cabbbdd2898fc4a2c5367523..3be9461f6a0412f4d9fb35872c86d0441e5f83a6)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Fix small nits on UI including trace drawer size and button format in issue detection modal

<img width="1580" height="864" alt="image" src="https://github.com/user-attachments/assets/9ac1ccdf-6978-4282-97b8-809d8bb4f3a8" />
<img width="187" height="73" alt="image" src="https://github.com/user-attachments/assets/c4bd6ec6-ed36-4028-a04d-46b6e1c8d798" />
<img width="267" height="65" alt="image" src="https://github.com/user-attachments/assets/ebcb6b4c-4f85-43a5-ba85-0a1a0acacc90" />


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
