### PR TITLE
Add optional `trace_count` field to Issue and `include_trace_count` parameter to search_issues

### DIFF
--- a/mlflow/entities/issue.py
+++ b/mlflow/entities/issue.py
@@ -99,6 +99,9 @@ class Issue(_MlflowObject):
     created_by: str | None = None
     """Identifier for who created this issue."""
 
+    trace_count: int | None = None
+    """Number of traces impacted by this issue. Only populated when explicitly requested."""
+
     def to_dictionary(self) -> dict[str, Any]:
         """Convert Issue to dictionary representation."""
         return {
@@ -114,6 +117,7 @@ class Issue(_MlflowObject):
             "created_timestamp": self.created_timestamp,
             "last_updated_timestamp": self.last_updated_timestamp,
             "created_by": self.created_by,
+            "trace_count": self.trace_count,
         }
 
     @classmethod
@@ -134,6 +138,7 @@ class Issue(_MlflowObject):
             source_run_id=issue_dict.get("source_run_id"),
             categories=issue_dict.get("categories"),
             created_by=issue_dict.get("created_by"),
+            trace_count=issue_dict.get("trace_count"),
         )
 
     def to_proto(self) -> ProtoIssue:
@@ -157,6 +162,8 @@ class Issue(_MlflowObject):
             proto_issue.categories.extend(self.categories)
         if self.created_by:
             proto_issue.created_by = self.created_by
+        if self.trace_count is not None:
+            proto_issue.trace_count = self.trace_count
 
         return proto_issue
 
@@ -176,4 +183,5 @@ class Issue(_MlflowObject):
             source_run_id=proto.source_run_id or None,
             categories=list(proto.categories) or None,
             created_by=proto.created_by or None,
+            trace_count=proto.trace_count if proto.HasField("trace_count") else None,
         )

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Issues.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Issues.java
@@ -369,6 +369,25 @@ public final class Issues {
      */
     com.google.protobuf.ByteString
         getCategoriesBytes(int index);
+
+    /**
+     * <pre>
+     * Number of traces impacted by this issue. Only populated when explicitly requested.
+     * </pre>
+     *
+     * <code>optional int32 trace_count = 13;</code>
+     * @return Whether the traceCount field is set.
+     */
+    boolean hasTraceCount();
+    /**
+     * <pre>
+     * Number of traces impacted by this issue. Only populated when explicitly requested.
+     * </pre>
+     *
+     * <code>optional int32 trace_count = 13;</code>
+     * @return The traceCount.
+     */
+    int getTraceCount();
   }
   /**
    * <pre>
@@ -504,6 +523,11 @@ public final class Issues {
                 mutable_bitField0_ |= 0x00000800;
               }
               categories_.add(bs);
+              break;
+            }
+            case 104: {
+              bitField0_ |= 0x00000400;
+              traceCount_ = input.readInt32();
               break;
             }
             default: {
@@ -1181,6 +1205,33 @@ public final class Issues {
       return categories_.getByteString(index);
     }
 
+    public static final int TRACE_COUNT_FIELD_NUMBER = 13;
+    private int traceCount_;
+    /**
+     * <pre>
+     * Number of traces impacted by this issue. Only populated when explicitly requested.
+     * </pre>
+     *
+     * <code>optional int32 trace_count = 13;</code>
+     * @return Whether the traceCount field is set.
+     */
+    @java.lang.Override
+    public boolean hasTraceCount() {
+      return ((bitField0_ & 0x00000400) != 0);
+    }
+    /**
+     * <pre>
+     * Number of traces impacted by this issue. Only populated when explicitly requested.
+     * </pre>
+     *
+     * <code>optional int32 trace_count = 13;</code>
+     * @return The traceCount.
+     */
+    @java.lang.Override
+    public int getTraceCount() {
+      return traceCount_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -1230,6 +1281,9 @@ public final class Issues {
       }
       for (int i = 0; i < categories_.size(); i++) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 12, categories_.getRaw(i));
+      }
+      if (((bitField0_ & 0x00000400) != 0)) {
+        output.writeInt32(13, traceCount_);
       }
       unknownFields.writeTo(output);
     }
@@ -1287,6 +1341,10 @@ public final class Issues {
         }
         size += dataSize;
         size += 1 * getCategoriesList().size();
+      }
+      if (((bitField0_ & 0x00000400) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(13, traceCount_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -1357,6 +1415,11 @@ public final class Issues {
       }
       if (!getCategoriesList()
           .equals(other.getCategoriesList())) return false;
+      if (hasTraceCount() != other.hasTraceCount()) return false;
+      if (hasTraceCount()) {
+        if (getTraceCount()
+            != other.getTraceCount()) return false;
+      }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -1417,6 +1480,10 @@ public final class Issues {
       if (getCategoriesCount() > 0) {
         hash = (37 * hash) + CATEGORIES_FIELD_NUMBER;
         hash = (53 * hash) + getCategoriesList().hashCode();
+      }
+      if (hasTraceCount()) {
+        hash = (37 * hash) + TRACE_COUNT_FIELD_NUMBER;
+        hash = (53 * hash) + getTraceCount();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -1579,6 +1646,8 @@ public final class Issues {
         bitField0_ = (bitField0_ & ~0x00000400);
         categories_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000800);
+        traceCount_ = 0;
+        bitField0_ = (bitField0_ & ~0x00001000);
         return this;
       }
 
@@ -1657,6 +1726,10 @@ public final class Issues {
           bitField0_ = (bitField0_ & ~0x00000800);
         }
         result.categories_ = categories_;
+        if (((from_bitField0_ & 0x00001000) != 0)) {
+          result.traceCount_ = traceCount_;
+          to_bitField0_ |= 0x00000400;
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1771,6 +1844,9 @@ public final class Issues {
             categories_.addAll(other.categories_);
           }
           onChanged();
+        }
+        if (other.hasTraceCount()) {
+          setTraceCount(other.getTraceCount());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -3062,6 +3138,61 @@ public final class Issues {
   }
   ensureCategoriesIsMutable();
         categories_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private int traceCount_ ;
+      /**
+       * <pre>
+       * Number of traces impacted by this issue. Only populated when explicitly requested.
+       * </pre>
+       *
+       * <code>optional int32 trace_count = 13;</code>
+       * @return Whether the traceCount field is set.
+       */
+      @java.lang.Override
+      public boolean hasTraceCount() {
+        return ((bitField0_ & 0x00001000) != 0);
+      }
+      /**
+       * <pre>
+       * Number of traces impacted by this issue. Only populated when explicitly requested.
+       * </pre>
+       *
+       * <code>optional int32 trace_count = 13;</code>
+       * @return The traceCount.
+       */
+      @java.lang.Override
+      public int getTraceCount() {
+        return traceCount_;
+      }
+      /**
+       * <pre>
+       * Number of traces impacted by this issue. Only populated when explicitly requested.
+       * </pre>
+       *
+       * <code>optional int32 trace_count = 13;</code>
+       * @param value The traceCount to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTraceCount(int value) {
+        bitField0_ |= 0x00001000;
+        traceCount_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Number of traces impacted by this issue. Only populated when explicitly requested.
+       * </pre>
+       *
+       * <code>optional int32 trace_count = 13;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTraceCount() {
+        bitField0_ = (bitField0_ & ~0x00001000);
+        traceCount_ = 0;
         onChanged();
         return this;
       }
@@ -10157,6 +10288,25 @@ public final class Issues {
      */
     com.google.protobuf.ByteString
         getPageTokenBytes();
+
+    /**
+     * <pre>
+     * Whether to include the count of traces impacted by each issue.
+     * </pre>
+     *
+     * <code>optional bool include_trace_count = 5;</code>
+     * @return Whether the includeTraceCount field is set.
+     */
+    boolean hasIncludeTraceCount();
+    /**
+     * <pre>
+     * Whether to include the count of traces impacted by each issue.
+     * </pre>
+     *
+     * <code>optional bool include_trace_count = 5;</code>
+     * @return The includeTraceCount.
+     */
+    boolean getIncludeTraceCount();
   }
   /**
    * <pre>
@@ -10232,6 +10382,11 @@ public final class Issues {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
               pageToken_ = bs;
+              break;
+            }
+            case 40: {
+              bitField0_ |= 0x00000010;
+              includeTraceCount_ = input.readBool();
               break;
             }
             default: {
@@ -11612,6 +11767,33 @@ public final class Issues {
       }
     }
 
+    public static final int INCLUDE_TRACE_COUNT_FIELD_NUMBER = 5;
+    private boolean includeTraceCount_;
+    /**
+     * <pre>
+     * Whether to include the count of traces impacted by each issue.
+     * </pre>
+     *
+     * <code>optional bool include_trace_count = 5;</code>
+     * @return Whether the includeTraceCount field is set.
+     */
+    @java.lang.Override
+    public boolean hasIncludeTraceCount() {
+      return ((bitField0_ & 0x00000010) != 0);
+    }
+    /**
+     * <pre>
+     * Whether to include the count of traces impacted by each issue.
+     * </pre>
+     *
+     * <code>optional bool include_trace_count = 5;</code>
+     * @return The includeTraceCount.
+     */
+    @java.lang.Override
+    public boolean getIncludeTraceCount() {
+      return includeTraceCount_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -11638,6 +11820,9 @@ public final class Issues {
       if (((bitField0_ & 0x00000008) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, pageToken_);
       }
+      if (((bitField0_ & 0x00000010) != 0)) {
+        output.writeBool(5, includeTraceCount_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -11659,6 +11844,10 @@ public final class Issues {
       }
       if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, pageToken_);
+      }
+      if (((bitField0_ & 0x00000010) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(5, includeTraceCount_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -11695,6 +11884,11 @@ public final class Issues {
         if (!getPageToken()
             .equals(other.getPageToken())) return false;
       }
+      if (hasIncludeTraceCount() != other.hasIncludeTraceCount()) return false;
+      if (hasIncludeTraceCount()) {
+        if (getIncludeTraceCount()
+            != other.getIncludeTraceCount()) return false;
+      }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -11721,6 +11915,11 @@ public final class Issues {
       if (hasPageToken()) {
         hash = (37 * hash) + PAGE_TOKEN_FIELD_NUMBER;
         hash = (53 * hash) + getPageToken().hashCode();
+      }
+      if (hasIncludeTraceCount()) {
+        hash = (37 * hash) + INCLUDE_TRACE_COUNT_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+            getIncludeTraceCount());
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -11867,6 +12066,8 @@ public final class Issues {
         bitField0_ = (bitField0_ & ~0x00000004);
         pageToken_ = "";
         bitField0_ = (bitField0_ & ~0x00000008);
+        includeTraceCount_ = false;
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -11911,6 +12112,10 @@ public final class Issues {
           to_bitField0_ |= 0x00000008;
         }
         result.pageToken_ = pageToken_;
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          result.includeTraceCount_ = includeTraceCount_;
+          to_bitField0_ |= 0x00000010;
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -11977,6 +12182,9 @@ public final class Issues {
           bitField0_ |= 0x00000008;
           pageToken_ = other.pageToken_;
           onChanged();
+        }
+        if (other.hasIncludeTraceCount()) {
+          setIncludeTraceCount(other.getIncludeTraceCount());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -12386,6 +12594,61 @@ public final class Issues {
         onChanged();
         return this;
       }
+
+      private boolean includeTraceCount_ ;
+      /**
+       * <pre>
+       * Whether to include the count of traces impacted by each issue.
+       * </pre>
+       *
+       * <code>optional bool include_trace_count = 5;</code>
+       * @return Whether the includeTraceCount field is set.
+       */
+      @java.lang.Override
+      public boolean hasIncludeTraceCount() {
+        return ((bitField0_ & 0x00000010) != 0);
+      }
+      /**
+       * <pre>
+       * Whether to include the count of traces impacted by each issue.
+       * </pre>
+       *
+       * <code>optional bool include_trace_count = 5;</code>
+       * @return The includeTraceCount.
+       */
+      @java.lang.Override
+      public boolean getIncludeTraceCount() {
+        return includeTraceCount_;
+      }
+      /**
+       * <pre>
+       * Whether to include the count of traces impacted by each issue.
+       * </pre>
+       *
+       * <code>optional bool include_trace_count = 5;</code>
+       * @param value The includeTraceCount to set.
+       * @return This builder for chaining.
+       */
+      public Builder setIncludeTraceCount(boolean value) {
+        bitField0_ |= 0x00000010;
+        includeTraceCount_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Whether to include the count of traces impacted by each issue.
+       * </pre>
+       *
+       * <code>optional bool include_trace_count = 5;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearIncludeTraceCount() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        includeTraceCount_ = false;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -12494,31 +12757,32 @@ public final class Issues {
   static {
     java.lang.String[] descriptorData = {
       "\n\014issues.proto\022\rmlflow.issues\032\020databrick" +
-      "s.proto\"\204\002\n\005Issue\022\020\n\010issue_id\030\001 \001(\t\022\025\n\re" +
+      "s.proto\"\231\002\n\005Issue\022\020\n\010issue_id\030\001 \001(\t\022\025\n\re" +
       "xperiment_id\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\022\023\n\013desc" +
       "ription\030\004 \001(\t\022\016\n\006status\030\005 \001(\t\022\020\n\010severit" +
       "y\030\006 \001(\t\022\023\n\013root_causes\030\007 \003(\t\022\025\n\rsource_r" +
       "un_id\030\010 \001(\t\022\031\n\021created_timestamp\030\t \001(\003\022\036" +
       "\n\026last_updated_timestamp\030\n \001(\003\022\022\n\ncreate" +
-      "d_by\030\013 \001(\t\022\022\n\ncategories\030\014 \003(\t\"\200\002\n\013Creat" +
-      "eIssue\022\033\n\rexperiment_id\030\001 \001(\tB\004\370\206\031\001\022\022\n\004n" +
-      "ame\030\002 \001(\tB\004\370\206\031\001\022\031\n\013description\030\003 \001(\tB\004\370\206" +
-      "\031\001\022\016\n\006status\030\004 \001(\t\022\020\n\010severity\030\005 \001(\t\022\023\n\013" +
-      "root_causes\030\006 \003(\t\022\025\n\rsource_run_id\030\007 \001(\t" +
-      "\022\022\n\ncreated_by\030\010 \001(\t\022\022\n\ncategories\030\t \003(\t" +
-      "\032/\n\010Response\022#\n\005issue\030\001 \001(\0132\024.mlflow.iss" +
-      "ues.Issue\"\233\001\n\013UpdateIssue\022\026\n\010issue_id\030\001 " +
-      "\001(\tB\004\370\206\031\001\022\014\n\004name\030\002 \001(\t\022\023\n\013description\030\003" +
-      " \001(\t\022\016\n\006status\030\004 \001(\t\022\020\n\010severity\030\005 \001(\t\032/" +
-      "\n\010Response\022#\n\005issue\030\001 \001(\0132\024.mlflow.issue" +
-      "s.Issue\"S\n\010GetIssue\022\026\n\010issue_id\030\001 \001(\tB\004\370" +
-      "\206\031\001\032/\n\010Response\022#\n\005issue\030\001 \001(\0132\024.mlflow." +
-      "issues.Issue\"\260\001\n\014SearchIssues\022\025\n\rexperim" +
-      "ent_id\030\001 \001(\t\022\025\n\rfilter_string\030\002 \001(\t\022\023\n\013m" +
-      "ax_results\030\003 \001(\005\022\022\n\npage_token\030\004 \001(\t\032I\n\010" +
-      "Response\022$\n\006issues\030\001 \003(\0132\024.mlflow.issues" +
-      ".Issue\022\027\n\017next_page_token\030\002 \001(\tB\031\n\024org.m" +
-      "lflow.api.proto\220\001\001"
+      "d_by\030\013 \001(\t\022\022\n\ncategories\030\014 \003(\t\022\023\n\013trace_" +
+      "count\030\r \001(\005\"\200\002\n\013CreateIssue\022\033\n\rexperimen" +
+      "t_id\030\001 \001(\tB\004\370\206\031\001\022\022\n\004name\030\002 \001(\tB\004\370\206\031\001\022\031\n\013" +
+      "description\030\003 \001(\tB\004\370\206\031\001\022\016\n\006status\030\004 \001(\t\022" +
+      "\020\n\010severity\030\005 \001(\t\022\023\n\013root_causes\030\006 \003(\t\022\025" +
+      "\n\rsource_run_id\030\007 \001(\t\022\022\n\ncreated_by\030\010 \001(" +
+      "\t\022\022\n\ncategories\030\t \003(\t\032/\n\010Response\022#\n\005iss" +
+      "ue\030\001 \001(\0132\024.mlflow.issues.Issue\"\233\001\n\013Updat" +
+      "eIssue\022\026\n\010issue_id\030\001 \001(\tB\004\370\206\031\001\022\014\n\004name\030\002" +
+      " \001(\t\022\023\n\013description\030\003 \001(\t\022\016\n\006status\030\004 \001(" +
+      "\t\022\020\n\010severity\030\005 \001(\t\032/\n\010Response\022#\n\005issue" +
+      "\030\001 \001(\0132\024.mlflow.issues.Issue\"S\n\010GetIssue" +
+      "\022\026\n\010issue_id\030\001 \001(\tB\004\370\206\031\001\032/\n\010Response\022#\n\005" +
+      "issue\030\001 \001(\0132\024.mlflow.issues.Issue\"\315\001\n\014Se" +
+      "archIssues\022\025\n\rexperiment_id\030\001 \001(\t\022\025\n\rfil" +
+      "ter_string\030\002 \001(\t\022\023\n\013max_results\030\003 \001(\005\022\022\n" +
+      "\npage_token\030\004 \001(\t\022\033\n\023include_trace_count" +
+      "\030\005 \001(\010\032I\n\010Response\022$\n\006issues\030\001 \003(\0132\024.mlf" +
+      "low.issues.Issue\022\027\n\017next_page_token\030\002 \001(" +
+      "\tB\031\n\024org.mlflow.api.proto\220\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -12530,7 +12794,7 @@ public final class Issues {
     internal_static_mlflow_issues_Issue_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_issues_Issue_descriptor,
-        new java.lang.String[] { "IssueId", "ExperimentId", "Name", "Description", "Status", "Severity", "RootCauses", "SourceRunId", "CreatedTimestamp", "LastUpdatedTimestamp", "CreatedBy", "Categories", });
+        new java.lang.String[] { "IssueId", "ExperimentId", "Name", "Description", "Status", "Severity", "RootCauses", "SourceRunId", "CreatedTimestamp", "LastUpdatedTimestamp", "CreatedBy", "Categories", "TraceCount", });
     internal_static_mlflow_issues_CreateIssue_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_mlflow_issues_CreateIssue_fieldAccessorTable = new
@@ -12572,7 +12836,7 @@ public final class Issues {
     internal_static_mlflow_issues_SearchIssues_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_issues_SearchIssues_descriptor,
-        new java.lang.String[] { "ExperimentId", "FilterString", "MaxResults", "PageToken", });
+        new java.lang.String[] { "ExperimentId", "FilterString", "MaxResults", "PageToken", "IncludeTraceCount", });
     internal_static_mlflow_issues_SearchIssues_Response_descriptor =
       internal_static_mlflow_issues_SearchIssues_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_issues_SearchIssues_Response_fieldAccessorTable = new

--- a/mlflow/protos/issues.proto
+++ b/mlflow/protos/issues.proto
@@ -46,6 +46,9 @@ message Issue {
 
   // Categories of the issue.
   repeated string categories = 12;
+
+  // Number of traces impacted by this issue. Only populated when explicitly requested.
+  optional int32 trace_count = 13;
 }
 
 // Request to create a new issue.
@@ -130,6 +133,9 @@ message SearchIssues {
 
   // Page token for pagination.
   optional string page_token = 4;
+
+  // Whether to include the count of traces impacted by each issue.
+  optional bool include_trace_count = 5;
 
   message Response {
     // List of issues.

--- a/mlflow/protos/issues_pb2.py
+++ b/mlflow/protos/issues_pb2.py
@@ -19,7 +19,7 @@ if Version(google.protobuf.__version__).major >= 5:
   from . import databricks_pb2 as databricks__pb2
 
 
-  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cissues.proto\x12\rmlflow.issues\x1a\x10\x64\x61tabricks.proto\"\x84\x02\n\x05Issue\x12\x10\n\x08issue_id\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\x0e\n\x06status\x18\x05 \x01(\t\x12\x10\n\x08severity\x18\x06 \x01(\t\x12\x13\n\x0broot_causes\x18\x07 \x03(\t\x12\x15\n\rsource_run_id\x18\x08 \x01(\t\x12\x19\n\x11\x63reated_timestamp\x18\t \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\n \x01(\x03\x12\x12\n\ncreated_by\x18\x0b \x01(\t\x12\x12\n\ncategories\x18\x0c \x03(\t\"\x80\x02\n\x0b\x43reateIssue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0b\x64\x65scription\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x10\n\x08severity\x18\x05 \x01(\t\x12\x13\n\x0broot_causes\x18\x06 \x03(\t\x12\x15\n\rsource_run_id\x18\x07 \x01(\t\x12\x12\n\ncreated_by\x18\x08 \x01(\t\x12\x12\n\ncategories\x18\t \x03(\t\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"\x9b\x01\n\x0bUpdateIssue\x12\x16\n\x08issue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x10\n\x08severity\x18\x05 \x01(\t\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"S\n\x08GetIssue\x12\x16\n\x08issue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"\xb0\x01\n\x0cSearchIssues\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x15\n\rfilter_string\x18\x02 \x01(\t\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aI\n\x08Response\x12$\n\x06issues\x18\x01 \x03(\x0b\x32\x14.mlflow.issues.Issue\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\tB\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
+  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cissues.proto\x12\rmlflow.issues\x1a\x10\x64\x61tabricks.proto\"\x99\x02\n\x05Issue\x12\x10\n\x08issue_id\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\x0e\n\x06status\x18\x05 \x01(\t\x12\x10\n\x08severity\x18\x06 \x01(\t\x12\x13\n\x0broot_causes\x18\x07 \x03(\t\x12\x15\n\rsource_run_id\x18\x08 \x01(\t\x12\x19\n\x11\x63reated_timestamp\x18\t \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\n \x01(\x03\x12\x12\n\ncreated_by\x18\x0b \x01(\t\x12\x12\n\ncategories\x18\x0c \x03(\t\x12\x13\n\x0btrace_count\x18\r \x01(\x05\"\x80\x02\n\x0b\x43reateIssue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0b\x64\x65scription\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x10\n\x08severity\x18\x05 \x01(\t\x12\x13\n\x0broot_causes\x18\x06 \x03(\t\x12\x15\n\rsource_run_id\x18\x07 \x01(\t\x12\x12\n\ncreated_by\x18\x08 \x01(\t\x12\x12\n\ncategories\x18\t \x03(\t\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"\x9b\x01\n\x0bUpdateIssue\x12\x16\n\x08issue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x10\n\x08severity\x18\x05 \x01(\t\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"S\n\x08GetIssue\x12\x16\n\x08issue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"\xcd\x01\n\x0cSearchIssues\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x15\n\rfilter_string\x18\x02 \x01(\t\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x12\x1b\n\x13include_trace_count\x18\x05 \x01(\x08\x1aI\n\x08Response\x12$\n\x06issues\x18\x01 \x03(\x0b\x32\x14.mlflow.issues.Issue\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\tB\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
 
   _globals = globals()
   _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -38,23 +38,23 @@ if Version(google.protobuf.__version__).major >= 5:
     _globals['_GETISSUE'].fields_by_name['issue_id']._loaded_options = None
     _globals['_GETISSUE'].fields_by_name['issue_id']._serialized_options = b'\370\206\031\001'
     _globals['_ISSUE']._serialized_start=50
-    _globals['_ISSUE']._serialized_end=310
-    _globals['_CREATEISSUE']._serialized_start=313
-    _globals['_CREATEISSUE']._serialized_end=569
-    _globals['_CREATEISSUE_RESPONSE']._serialized_start=522
-    _globals['_CREATEISSUE_RESPONSE']._serialized_end=569
-    _globals['_UPDATEISSUE']._serialized_start=572
-    _globals['_UPDATEISSUE']._serialized_end=727
-    _globals['_UPDATEISSUE_RESPONSE']._serialized_start=522
-    _globals['_UPDATEISSUE_RESPONSE']._serialized_end=569
-    _globals['_GETISSUE']._serialized_start=729
-    _globals['_GETISSUE']._serialized_end=812
-    _globals['_GETISSUE_RESPONSE']._serialized_start=522
-    _globals['_GETISSUE_RESPONSE']._serialized_end=569
-    _globals['_SEARCHISSUES']._serialized_start=815
-    _globals['_SEARCHISSUES']._serialized_end=991
-    _globals['_SEARCHISSUES_RESPONSE']._serialized_start=918
-    _globals['_SEARCHISSUES_RESPONSE']._serialized_end=991
+    _globals['_ISSUE']._serialized_end=331
+    _globals['_CREATEISSUE']._serialized_start=334
+    _globals['_CREATEISSUE']._serialized_end=590
+    _globals['_CREATEISSUE_RESPONSE']._serialized_start=543
+    _globals['_CREATEISSUE_RESPONSE']._serialized_end=590
+    _globals['_UPDATEISSUE']._serialized_start=593
+    _globals['_UPDATEISSUE']._serialized_end=748
+    _globals['_UPDATEISSUE_RESPONSE']._serialized_start=543
+    _globals['_UPDATEISSUE_RESPONSE']._serialized_end=590
+    _globals['_GETISSUE']._serialized_start=750
+    _globals['_GETISSUE']._serialized_end=833
+    _globals['_GETISSUE_RESPONSE']._serialized_start=543
+    _globals['_GETISSUE_RESPONSE']._serialized_end=590
+    _globals['_SEARCHISSUES']._serialized_start=836
+    _globals['_SEARCHISSUES']._serialized_end=1041
+    _globals['_SEARCHISSUES_RESPONSE']._serialized_start=968
+    _globals['_SEARCHISSUES_RESPONSE']._serialized_end=1041
   # @@protoc_insertion_point(module_scope)
 
 else:
@@ -75,7 +75,7 @@ else:
   from . import databricks_pb2 as databricks__pb2
 
 
-  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cissues.proto\x12\rmlflow.issues\x1a\x10\x64\x61tabricks.proto\"\x84\x02\n\x05Issue\x12\x10\n\x08issue_id\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\x0e\n\x06status\x18\x05 \x01(\t\x12\x10\n\x08severity\x18\x06 \x01(\t\x12\x13\n\x0broot_causes\x18\x07 \x03(\t\x12\x15\n\rsource_run_id\x18\x08 \x01(\t\x12\x19\n\x11\x63reated_timestamp\x18\t \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\n \x01(\x03\x12\x12\n\ncreated_by\x18\x0b \x01(\t\x12\x12\n\ncategories\x18\x0c \x03(\t\"\x80\x02\n\x0b\x43reateIssue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0b\x64\x65scription\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x10\n\x08severity\x18\x05 \x01(\t\x12\x13\n\x0broot_causes\x18\x06 \x03(\t\x12\x15\n\rsource_run_id\x18\x07 \x01(\t\x12\x12\n\ncreated_by\x18\x08 \x01(\t\x12\x12\n\ncategories\x18\t \x03(\t\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"\x9b\x01\n\x0bUpdateIssue\x12\x16\n\x08issue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x10\n\x08severity\x18\x05 \x01(\t\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"S\n\x08GetIssue\x12\x16\n\x08issue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"\xb0\x01\n\x0cSearchIssues\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x15\n\rfilter_string\x18\x02 \x01(\t\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aI\n\x08Response\x12$\n\x06issues\x18\x01 \x03(\x0b\x32\x14.mlflow.issues.Issue\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\tB\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
+  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cissues.proto\x12\rmlflow.issues\x1a\x10\x64\x61tabricks.proto\"\x99\x02\n\x05Issue\x12\x10\n\x08issue_id\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\x0e\n\x06status\x18\x05 \x01(\t\x12\x10\n\x08severity\x18\x06 \x01(\t\x12\x13\n\x0broot_causes\x18\x07 \x03(\t\x12\x15\n\rsource_run_id\x18\x08 \x01(\t\x12\x19\n\x11\x63reated_timestamp\x18\t \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\n \x01(\x03\x12\x12\n\ncreated_by\x18\x0b \x01(\t\x12\x12\n\ncategories\x18\x0c \x03(\t\x12\x13\n\x0btrace_count\x18\r \x01(\x05\"\x80\x02\n\x0b\x43reateIssue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0b\x64\x65scription\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x10\n\x08severity\x18\x05 \x01(\t\x12\x13\n\x0broot_causes\x18\x06 \x03(\t\x12\x15\n\rsource_run_id\x18\x07 \x01(\t\x12\x12\n\ncreated_by\x18\x08 \x01(\t\x12\x12\n\ncategories\x18\t \x03(\t\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"\x9b\x01\n\x0bUpdateIssue\x12\x16\n\x08issue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x10\n\x08severity\x18\x05 \x01(\t\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"S\n\x08GetIssue\x12\x16\n\x08issue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a/\n\x08Response\x12#\n\x05issue\x18\x01 \x01(\x0b\x32\x14.mlflow.issues.Issue\"\xcd\x01\n\x0cSearchIssues\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x15\n\rfilter_string\x18\x02 \x01(\t\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x12\x1b\n\x13include_trace_count\x18\x05 \x01(\x08\x1aI\n\x08Response\x12$\n\x06issues\x18\x01 \x03(\x0b\x32\x14.mlflow.issues.Issue\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\tB\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
 
 
 
@@ -170,22 +170,22 @@ else:
     _GETISSUE.fields_by_name['issue_id']._options = None
     _GETISSUE.fields_by_name['issue_id']._serialized_options = b'\370\206\031\001'
     _ISSUE._serialized_start=50
-    _ISSUE._serialized_end=310
-    _CREATEISSUE._serialized_start=313
-    _CREATEISSUE._serialized_end=569
-    _CREATEISSUE_RESPONSE._serialized_start=522
-    _CREATEISSUE_RESPONSE._serialized_end=569
-    _UPDATEISSUE._serialized_start=572
-    _UPDATEISSUE._serialized_end=727
-    _UPDATEISSUE_RESPONSE._serialized_start=522
-    _UPDATEISSUE_RESPONSE._serialized_end=569
-    _GETISSUE._serialized_start=729
-    _GETISSUE._serialized_end=812
-    _GETISSUE_RESPONSE._serialized_start=522
-    _GETISSUE_RESPONSE._serialized_end=569
-    _SEARCHISSUES._serialized_start=815
-    _SEARCHISSUES._serialized_end=991
-    _SEARCHISSUES_RESPONSE._serialized_start=918
-    _SEARCHISSUES_RESPONSE._serialized_end=991
+    _ISSUE._serialized_end=331
+    _CREATEISSUE._serialized_start=334
+    _CREATEISSUE._serialized_end=590
+    _CREATEISSUE_RESPONSE._serialized_start=543
+    _CREATEISSUE_RESPONSE._serialized_end=590
+    _UPDATEISSUE._serialized_start=593
+    _UPDATEISSUE._serialized_end=748
+    _UPDATEISSUE_RESPONSE._serialized_start=543
+    _UPDATEISSUE_RESPONSE._serialized_end=590
+    _GETISSUE._serialized_start=750
+    _GETISSUE._serialized_end=833
+    _GETISSUE_RESPONSE._serialized_start=543
+    _GETISSUE_RESPONSE._serialized_end=590
+    _SEARCHISSUES._serialized_start=836
+    _SEARCHISSUES._serialized_end=1041
+    _SEARCHISSUES_RESPONSE._serialized_start=968
+    _SEARCHISSUES_RESPONSE._serialized_end=1041
   # @@protoc_insertion_point(module_scope)
 

--- a/mlflow/protos/issues_pb2.pyi
+++ b/mlflow/protos/issues_pb2.pyi
@@ -7,7 +7,7 @@ from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Map
 DESCRIPTOR: _descriptor.FileDescriptor
 
 class Issue(_message.Message):
-    __slots__ = ("issue_id", "experiment_id", "name", "description", "status", "severity", "root_causes", "source_run_id", "created_timestamp", "last_updated_timestamp", "created_by", "categories")
+    __slots__ = ("issue_id", "experiment_id", "name", "description", "status", "severity", "root_causes", "source_run_id", "created_timestamp", "last_updated_timestamp", "created_by", "categories", "trace_count")
     ISSUE_ID_FIELD_NUMBER: _ClassVar[int]
     EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
     NAME_FIELD_NUMBER: _ClassVar[int]
@@ -20,6 +20,7 @@ class Issue(_message.Message):
     LAST_UPDATED_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
     CREATED_BY_FIELD_NUMBER: _ClassVar[int]
     CATEGORIES_FIELD_NUMBER: _ClassVar[int]
+    TRACE_COUNT_FIELD_NUMBER: _ClassVar[int]
     issue_id: str
     experiment_id: str
     name: str
@@ -32,7 +33,8 @@ class Issue(_message.Message):
     last_updated_timestamp: int
     created_by: str
     categories: _containers.RepeatedScalarFieldContainer[str]
-    def __init__(self, issue_id: _Optional[str] = ..., experiment_id: _Optional[str] = ..., name: _Optional[str] = ..., description: _Optional[str] = ..., status: _Optional[str] = ..., severity: _Optional[str] = ..., root_causes: _Optional[_Iterable[str]] = ..., source_run_id: _Optional[str] = ..., created_timestamp: _Optional[int] = ..., last_updated_timestamp: _Optional[int] = ..., created_by: _Optional[str] = ..., categories: _Optional[_Iterable[str]] = ...) -> None: ...
+    trace_count: int
+    def __init__(self, issue_id: _Optional[str] = ..., experiment_id: _Optional[str] = ..., name: _Optional[str] = ..., description: _Optional[str] = ..., status: _Optional[str] = ..., severity: _Optional[str] = ..., root_causes: _Optional[_Iterable[str]] = ..., source_run_id: _Optional[str] = ..., created_timestamp: _Optional[int] = ..., last_updated_timestamp: _Optional[int] = ..., created_by: _Optional[str] = ..., categories: _Optional[_Iterable[str]] = ..., trace_count: _Optional[int] = ...) -> None: ...
 
 class CreateIssue(_message.Message):
     __slots__ = ("experiment_id", "name", "description", "status", "severity", "root_causes", "source_run_id", "created_by", "categories")
@@ -92,7 +94,7 @@ class GetIssue(_message.Message):
     def __init__(self, issue_id: _Optional[str] = ...) -> None: ...
 
 class SearchIssues(_message.Message):
-    __slots__ = ("experiment_id", "filter_string", "max_results", "page_token")
+    __slots__ = ("experiment_id", "filter_string", "max_results", "page_token", "include_trace_count")
     class Response(_message.Message):
         __slots__ = ("issues", "next_page_token")
         ISSUES_FIELD_NUMBER: _ClassVar[int]
@@ -104,8 +106,10 @@ class SearchIssues(_message.Message):
     FILTER_STRING_FIELD_NUMBER: _ClassVar[int]
     MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
     PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    INCLUDE_TRACE_COUNT_FIELD_NUMBER: _ClassVar[int]
     experiment_id: str
     filter_string: str
     max_results: int
     page_token: str
-    def __init__(self, experiment_id: _Optional[str] = ..., filter_string: _Optional[str] = ..., max_results: _Optional[int] = ..., page_token: _Optional[str] = ...) -> None: ...
+    include_trace_count: bool
+    def __init__(self, experiment_id: _Optional[str] = ..., filter_string: _Optional[str] = ..., max_results: _Optional[int] = ..., page_token: _Optional[str] = ..., include_trace_count: bool = ...) -> None: ...

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4132,6 +4132,9 @@ def _search_issues():
     if request_message.HasField("max_results"):
         search_kwargs["max_results"] = request_message.max_results
 
+    if request_message.HasField("include_trace_count"):
+        search_kwargs["include_trace_count"] = request_message.include_trace_count
+
     issues = _get_tracking_store().search_issues(**search_kwargs)
 
     issue_protos = [issue.to_proto() for issue in issues]

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -674,6 +674,7 @@ class AbstractStore(GatewayStoreMixin):
         filter_string: str | None = None,
         max_results: int | None = None,
         page_token: str | None = None,
+        include_trace_count: bool = False,
     ) -> PagedList[Issue]:
         """
         Search for issues matching the given filters.
@@ -683,6 +684,7 @@ class AbstractStore(GatewayStoreMixin):
             filter_string: Optional filter string for advanced filtering.
             max_results: Maximum number of results to return.
             page_token: Token for pagination.
+            include_trace_count: Whether to include the count of traces impacted by each issue.
 
         Returns:
             A PagedList of Issue entities.

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -1162,6 +1162,7 @@ class DatabricksTracingRestStore(RestStore):
         filter_string: str | None = None,
         max_results: int | None = None,
         page_token: str | None = None,
+        include_trace_count: bool = False,
     ) -> PagedList[Issue]:
         """
         Search for issues matching the given filters.
@@ -1171,6 +1172,7 @@ class DatabricksTracingRestStore(RestStore):
             filter_string: Optional filter string for advanced filtering.
             max_results: Maximum number of results to return.
             page_token: Token for pagination.
+            include_trace_count: Whether to include the count of traces impacted by each issue.
 
         Returns:
             A PagedList of Issue entities.

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -1198,9 +1198,12 @@ class SqlIssue(Base):
     def __repr__(self):
         return f"<SqlIssue({self.issue_id}, {self.name}, {self.status})>"
 
-    def to_mlflow_entity(self) -> Issue:
+    def to_mlflow_entity(self, trace_count: int | None = None) -> Issue:
         """
         Convert DB model to corresponding MLflow entity.
+
+        Args:
+            trace_count: Optional trace count to include in the Issue entity.
 
         Returns:
             :py:class:`mlflow.entities.Issue` object.
@@ -1218,6 +1221,7 @@ class SqlIssue(Base):
             created_timestamp=self.created_timestamp,
             last_updated_timestamp=self.last_updated_timestamp,
             created_by=self.created_by,
+            trace_count=trace_count,
         )
 
 

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -940,6 +940,7 @@ class RestStore(WorkspaceRestStoreMixin, RestGatewayStoreMixin, AbstractStore):
         filter_string: str | None = None,
         max_results: int | None = None,
         page_token: str | None = None,
+        include_trace_count: bool = False,
     ) -> PagedList[Issue]:
         """
         Search for issues matching the given filters.
@@ -949,6 +950,7 @@ class RestStore(WorkspaceRestStoreMixin, RestGatewayStoreMixin, AbstractStore):
             filter_string: Optional filter string for advanced filtering.
             max_results: Maximum number of results to return.
             page_token: Token for pagination.
+            include_trace_count: Whether to include the count of traces impacted by each issue.
 
         Returns:
             A PagedList of Issue entities.
@@ -959,6 +961,7 @@ class RestStore(WorkspaceRestStoreMixin, RestGatewayStoreMixin, AbstractStore):
                 filter_string=filter_string,
                 max_results=max_results,
                 page_token=page_token,
+                include_trace_count=include_trace_count,
             )
         )
         response_proto = self._call_endpoint(

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -6080,6 +6080,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         filter_string: str | None = None,
         max_results: int | None = None,
         page_token: str | None = None,
+        include_trace_count: bool = False,
     ) -> PagedList[Issue]:
         """
         Search for issues matching the given filters.
@@ -6095,6 +6096,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     - "status = 'pending' AND source_run_id != 'run456'"
             max_results: Maximum number of results to return.
             page_token: Token for pagination.
+            include_trace_count: Whether to include the count of traces impacted by each issue.
 
         Returns:
             A PagedList of Issue entities.
@@ -6107,6 +6109,23 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             offset = SearchTraceUtils.parse_start_offset_from_page_token(page_token)
 
             query = self._get_query(session, SqlIssue)
+
+            if include_trace_count:
+                trace_count_label = func.count(func.distinct(SqlAssessments.trace_id)).label(
+                    "trace_count"
+                )
+                query = (
+                    query
+                    .add_columns(trace_count_label)
+                    .outerjoin(
+                        SqlAssessments,
+                        and_(
+                            SqlAssessments.name == SqlIssue.issue_id,
+                            SqlAssessments.assessment_type == "issue",
+                        ),
+                    )
+                    .group_by(SqlIssue.issue_id)
+                )
 
             if experiment_id:
                 query = query.filter(SqlIssue.experiment_id == int(experiment_id))
@@ -6133,14 +6152,19 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
             query = query.offset(offset).limit(max_results + 1)
 
-            sql_issues = query.all()
-
-            has_next_page = len(sql_issues) > max_results
+            results = query.all()
+            has_next_page = len(results) > max_results
             next_token = (
                 SearchTraceUtils.create_page_token(offset + max_results) if has_next_page else None
             )
 
-            issues = [sql_issue.to_mlflow_entity() for sql_issue in sql_issues[:max_results]]
+            if include_trace_count:
+                issues = [
+                    sql_issue.to_mlflow_entity(trace_count=trace_count)
+                    for sql_issue, trace_count in results[:max_results]
+                ]
+            else:
+                issues = [sql_issue.to_mlflow_entity() for sql_issue in results[:max_results]]
 
             return PagedList(issues, token=next_token)
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -6144,11 +6144,15 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 value=SqlIssue.severity,
                 else_=-1,
             )
-            query = query.order_by(
-                severity_order.desc(),
+
+            order_clauses = [severity_order.desc()]
+            if include_trace_count:
+                order_clauses.append(trace_count_label.desc())
+            order_clauses.extend([
                 SqlIssue.created_timestamp.desc(),
                 SqlIssue.issue_id.desc(),
-            )
+            ])
+            query = query.order_by(*order_clauses)
 
             query = query.offset(offset).limit(max_results + 1)
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4672,6 +4672,50 @@ def test_search_issues_empty_results():
         assert json_response["next_page_token"] == ""
 
 
+def test_search_issues_with_trace_count():
+    request_message = SearchIssues()
+    request_message.include_trace_count = True
+
+    issues = [
+        Issue(
+            issue_id="iss-1",
+            experiment_id="exp-1",
+            name="Issue with traces",
+            description="Has 2 traces",
+            status=IssueStatus.PENDING,
+            created_timestamp=1234567890,
+            last_updated_timestamp=1234567890,
+            trace_count=2,
+        ),
+        Issue(
+            issue_id="iss-2",
+            experiment_id="exp-1",
+            name="Issue without traces",
+            description="Has no traces",
+            status=IssueStatus.PENDING,
+            created_timestamp=1234567891,
+            last_updated_timestamp=1234567891,
+            trace_count=0,
+        ),
+    ]
+
+    with (
+        mock.patch("mlflow.server.handlers._get_tracking_store") as mock_store,
+        mock.patch("mlflow.server.handlers._get_request_message", return_value=request_message),
+    ):
+        mock_store.return_value.search_issues.return_value = PagedList(issues, token=None)
+
+        response = _search_issues()
+
+        call_kwargs = mock_store.return_value.search_issues.call_args[1]
+        assert call_kwargs["include_trace_count"] is True
+
+        json_response = json.loads(response.get_data())
+        assert len(json_response["issues"]) == 2
+        assert json_response["issues"][0]["trace_count"] == 2
+        assert json_response["issues"][1]["trace_count"] == 0
+
+
 def test_create_issue_with_empty_lists():
     request_message = CreateIssue()
     request_message.experiment_id = "exp-123"

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -3889,6 +3889,7 @@ def test_search_issues():
         "filter_string": "severity = 'high'",
         "max_results": 100,
         "page_token": "page_token_123",
+        "include_trace_count": False,
     })
     _verify_requests(mock_http, creds, "issues/search", "POST", expected_request_json, use_v3=True)
 
@@ -3906,3 +3907,52 @@ def test_search_issues():
     assert result[1].severity == IssueSeverity.MEDIUM
 
     assert result.token == "next_token_456"
+
+
+def test_search_issues_with_trace_count():
+    creds = MlflowHostCreds("https://hello")
+    store = RestStore(lambda: creds)
+    response = mock.MagicMock()
+    response.status_code = 200
+    response.text = json.dumps({
+        "issues": [
+            {
+                "issue_id": "issue-123",
+                "experiment_id": "exp-456",
+                "name": "Issue with traces",
+                "description": "Has 2 traces",
+                "status": "pending",
+                "created_timestamp": 1234567890000,
+                "last_updated_timestamp": 1234567890000,
+                "trace_count": 2,
+            },
+            {
+                "issue_id": "issue-124",
+                "experiment_id": "exp-456",
+                "name": "Issue without traces",
+                "description": "Has no traces",
+                "status": "pending",
+                "created_timestamp": 1234567900000,
+                "last_updated_timestamp": 1234567900000,
+                "trace_count": 0,
+            },
+        ],
+        "next_page_token": "",
+    })
+
+    with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
+        result = store.search_issues(
+            experiment_id="exp-456",
+            include_trace_count=True,
+        )
+
+    expected_request_json = json.dumps({
+        "experiment_id": "exp-456",
+        "include_trace_count": True,
+    })
+    _verify_requests(mock_http, creds, "issues/search", "POST", expected_request_json, use_v3=True)
+
+    assert len(result) == 2
+    assert result[0].trace_count == 2
+    assert result[1].trace_count == 0
+    assert result.token is None

--- a/tests/store/tracking/test_sqlalchemy_store_issues.py
+++ b/tests/store/tracking/test_sqlalchemy_store_issues.py
@@ -932,3 +932,121 @@ def test_search_issues_trace_count_with_filters(store):
     assert len(result) == 1
     assert result[0].issue_id == issue_pending.issue_id
     assert result[0].trace_count == 1
+
+
+def test_search_issues_sorted_by_trace_count_within_severity(store):
+    exp_id = store.create_experiment("test")
+
+    issue_high_3_traces = store.create_issue(
+        experiment_id=exp_id,
+        name="High severity with 3 traces",
+        description="High severity",
+        status=IssueStatus.PENDING,
+        severity=IssueSeverity.HIGH,
+    )
+
+    issue_high_1_trace = store.create_issue(
+        experiment_id=exp_id,
+        name="High severity with 1 trace",
+        description="High severity",
+        status=IssueStatus.PENDING,
+        severity=IssueSeverity.HIGH,
+    )
+
+    issue_medium_2_traces = store.create_issue(
+        experiment_id=exp_id,
+        name="Medium severity with 2 traces",
+        description="Medium severity",
+        status=IssueStatus.PENDING,
+        severity=IssueSeverity.MEDIUM,
+    )
+
+    issue_medium_0_traces = store.create_issue(
+        experiment_id=exp_id,
+        name="Medium severity with 0 traces",
+        description="Medium severity",
+        status=IssueStatus.PENDING,
+        severity=IssueSeverity.MEDIUM,
+    )
+
+    timestamp_ms = get_current_time_millis()
+
+    for i in range(3):
+        trace = store.start_trace(
+            TraceInfo(
+                trace_id=f"tr-{uuid.uuid4()}",
+                trace_location=TraceLocation.from_experiment_id(exp_id),
+                request_time=timestamp_ms + i * 100,
+                execution_duration=100,
+                state=TraceState.OK,
+                tags={},
+                trace_metadata={},
+                client_request_id=f"tr-{uuid.uuid4()}",
+                request_preview=None,
+                response_preview=None,
+            ),
+        )
+        store.create_assessment(
+            IssueReference(
+                issue_id=issue_high_3_traces.issue_id,
+                issue_name=issue_high_3_traces.name,
+                trace_id=trace.request_id,
+            )
+        )
+
+    trace = store.start_trace(
+        TraceInfo(
+            trace_id=f"tr-{uuid.uuid4()}",
+            trace_location=TraceLocation.from_experiment_id(exp_id),
+            request_time=timestamp_ms + 300,
+            execution_duration=100,
+            state=TraceState.OK,
+            tags={},
+            trace_metadata={},
+            client_request_id=f"tr-{uuid.uuid4()}",
+            request_preview=None,
+            response_preview=None,
+        ),
+    )
+    store.create_assessment(
+        IssueReference(
+            issue_id=issue_high_1_trace.issue_id,
+            issue_name=issue_high_1_trace.name,
+            trace_id=trace.request_id,
+        )
+    )
+
+    for i in range(2):
+        trace = store.start_trace(
+            TraceInfo(
+                trace_id=f"tr-{uuid.uuid4()}",
+                trace_location=TraceLocation.from_experiment_id(exp_id),
+                request_time=timestamp_ms + 400 + i * 100,
+                execution_duration=100,
+                state=TraceState.OK,
+                tags={},
+                trace_metadata={},
+                client_request_id=f"tr-{uuid.uuid4()}",
+                request_preview=None,
+                response_preview=None,
+            ),
+        )
+        store.create_assessment(
+            IssueReference(
+                issue_id=issue_medium_2_traces.issue_id,
+                issue_name=issue_medium_2_traces.name,
+                trace_id=trace.request_id,
+            )
+        )
+
+    result = store.search_issues(experiment_id=exp_id, include_trace_count=True)
+
+    assert len(result) == 4
+    assert result[0].issue_id == issue_high_3_traces.issue_id
+    assert result[0].trace_count == 3
+    assert result[1].issue_id == issue_high_1_trace.issue_id
+    assert result[1].trace_count == 1
+    assert result[2].issue_id == issue_medium_2_traces.issue_id
+    assert result[2].trace_count == 2
+    assert result[3].issue_id == issue_medium_0_traces.issue_id
+    assert result[3].trace_count == 0

--- a/tests/store/tracking/test_sqlalchemy_store_issues.py
+++ b/tests/store/tracking/test_sqlalchemy_store_issues.py
@@ -582,7 +582,6 @@ def test_search_issues_invalid_max_results(store):
 def test_search_traces_by_issue_id(store):
     exp_id = store.create_experiment("test")
 
-    # Create traces
     timestamp_ms = get_current_time_millis()
     trace1 = store.start_trace(
         TraceInfo(
@@ -629,7 +628,6 @@ def test_search_traces_by_issue_id(store):
         ),
     )
 
-    # Create issues
     issue1 = store.create_issue(
         experiment_id=exp_id,
         name="High latency",
@@ -644,7 +642,6 @@ def test_search_traces_by_issue_id(store):
         status=IssueStatus.PENDING,
     )
 
-    # Link traces to issues via IssueReference assessments
     store.create_assessment(
         IssueReference(
             issue_id=issue1.issue_id,
@@ -667,30 +664,271 @@ def test_search_traces_by_issue_id(store):
         )
     )
 
-    # Search traces by issue1 ID
     traces, _ = store.search_traces(
         experiment_ids=[exp_id],
         filter_string=f"issue.id = '{issue1.issue_id}'",
     )
 
-    # Should return trace1 and trace2
     assert len(traces) == 2
     trace_ids = {t.request_id for t in traces}
     assert trace_ids == {trace1.request_id, trace2.request_id}
 
-    # Search traces by issue2 ID
     traces, _ = store.search_traces(
         experiment_ids=[exp_id],
         filter_string=f"issue.id = '{issue2.issue_id}'",
     )
 
-    # Should return only trace3
     assert len(traces) == 1
     assert traces[0].request_id == trace3.request_id
 
-    # Search for non-existent issue should return no traces
     traces, _ = store.search_traces(
         experiment_ids=[exp_id],
         filter_string="issue.id = 'non-existent-issue'",
     )
     assert len(traces) == 0
+
+
+def test_search_issues_without_trace_count(store):
+    exp_id = store.create_experiment("test")
+
+    issue = store.create_issue(
+        experiment_id=exp_id,
+        name="Test Issue",
+        description="Test",
+        status=IssueStatus.PENDING,
+    )
+
+    timestamp_ms = get_current_time_millis()
+    trace = store.start_trace(
+        TraceInfo(
+            trace_id=f"tr-{uuid.uuid4()}",
+            trace_location=TraceLocation.from_experiment_id(exp_id),
+            request_time=timestamp_ms,
+            execution_duration=100,
+            state=TraceState.OK,
+            tags={},
+            trace_metadata={},
+            client_request_id=f"tr-{uuid.uuid4()}",
+            request_preview=None,
+            response_preview=None,
+        ),
+    )
+
+    store.create_assessment(
+        IssueReference(
+            issue_id=issue.issue_id,
+            issue_name=issue.name,
+            trace_id=trace.request_id,
+        )
+    )
+
+    result = store.search_issues(experiment_id=exp_id)
+
+    assert len(result) == 1
+    assert result[0].issue_id == issue.issue_id
+    assert result[0].trace_count is None
+
+
+def test_search_issues_with_trace_count(store):
+    exp_id = store.create_experiment("test")
+
+    issue1 = store.create_issue(
+        experiment_id=exp_id,
+        name="Issue with 2 traces",
+        description="Has 2 traces",
+        status=IssueStatus.PENDING,
+    )
+
+    issue2 = store.create_issue(
+        experiment_id=exp_id,
+        name="Issue with 1 trace",
+        description="Has 1 trace",
+        status=IssueStatus.PENDING,
+    )
+
+    issue3 = store.create_issue(
+        experiment_id=exp_id,
+        name="Issue with 0 traces",
+        description="Has no traces",
+        status=IssueStatus.PENDING,
+    )
+
+    timestamp_ms = get_current_time_millis()
+    trace1 = store.start_trace(
+        TraceInfo(
+            trace_id=f"tr-{uuid.uuid4()}",
+            trace_location=TraceLocation.from_experiment_id(exp_id),
+            request_time=timestamp_ms,
+            execution_duration=100,
+            state=TraceState.OK,
+            tags={},
+            trace_metadata={},
+            client_request_id=f"tr-{uuid.uuid4()}",
+            request_preview=None,
+            response_preview=None,
+        ),
+    )
+
+    trace2 = store.start_trace(
+        TraceInfo(
+            trace_id=f"tr-{uuid.uuid4()}",
+            trace_location=TraceLocation.from_experiment_id(exp_id),
+            request_time=timestamp_ms + 100,
+            execution_duration=200,
+            state=TraceState.OK,
+            tags={},
+            trace_metadata={},
+            client_request_id=f"tr-{uuid.uuid4()}",
+            request_preview=None,
+            response_preview=None,
+        ),
+    )
+
+    trace3 = store.start_trace(
+        TraceInfo(
+            trace_id=f"tr-{uuid.uuid4()}",
+            trace_location=TraceLocation.from_experiment_id(exp_id),
+            request_time=timestamp_ms + 200,
+            execution_duration=300,
+            state=TraceState.OK,
+            tags={},
+            trace_metadata={},
+            client_request_id=f"tr-{uuid.uuid4()}",
+            request_preview=None,
+            response_preview=None,
+        ),
+    )
+
+    store.create_assessment(
+        IssueReference(
+            issue_id=issue1.issue_id,
+            issue_name=issue1.name,
+            trace_id=trace1.request_id,
+        )
+    )
+    store.create_assessment(
+        IssueReference(
+            issue_id=issue1.issue_id,
+            issue_name=issue1.name,
+            trace_id=trace2.request_id,
+        )
+    )
+    store.create_assessment(
+        IssueReference(
+            issue_id=issue2.issue_id,
+            issue_name=issue2.name,
+            trace_id=trace3.request_id,
+        )
+    )
+
+    result = store.search_issues(experiment_id=exp_id, include_trace_count=True)
+
+    assert len(result) == 3
+
+    issues_by_id = {issue.issue_id: issue for issue in result}
+
+    assert issues_by_id[issue1.issue_id].trace_count == 2
+    assert issues_by_id[issue2.issue_id].trace_count == 1
+    assert issues_by_id[issue3.issue_id].trace_count == 0
+
+
+def test_search_issues_with_trace_count_pagination(store):
+    exp_id = store.create_experiment("test")
+
+    for i in range(3):
+        issue = store.create_issue(
+            experiment_id=exp_id,
+            name=f"Issue {i}",
+            description=f"Description {i}",
+            status=IssueStatus.PENDING,
+        )
+
+        timestamp_ms = get_current_time_millis()
+        for j in range(i + 1):
+            trace = store.start_trace(
+                TraceInfo(
+                    trace_id=f"tr-{uuid.uuid4()}",
+                    trace_location=TraceLocation.from_experiment_id(exp_id),
+                    request_time=timestamp_ms + j,
+                    execution_duration=100,
+                    state=TraceState.OK,
+                    tags={},
+                    trace_metadata={},
+                    client_request_id=f"tr-{uuid.uuid4()}",
+                    request_preview=None,
+                    response_preview=None,
+                ),
+            )
+
+            store.create_assessment(
+                IssueReference(
+                    issue_id=issue.issue_id,
+                    issue_name=issue.name,
+                    trace_id=trace.request_id,
+                )
+            )
+
+    page1 = store.search_issues(experiment_id=exp_id, max_results=2, include_trace_count=True)
+
+    assert len(page1) == 2
+    assert page1[0].trace_count is not None
+    assert page1[1].trace_count is not None
+    assert page1.token is not None
+
+    page2 = store.search_issues(
+        experiment_id=exp_id, max_results=2, page_token=page1.token, include_trace_count=True
+    )
+
+    assert len(page2) == 1
+    assert page2[0].trace_count is not None
+    assert page2.token is None
+
+
+def test_search_issues_trace_count_with_filters(store):
+    exp_id = DEFAULT_EXPERIMENT_ID
+
+    issue_pending = store.create_issue(
+        experiment_id=exp_id,
+        name="Pending Issue",
+        description="Pending",
+        status=IssueStatus.PENDING,
+    )
+
+    store.create_issue(
+        experiment_id=exp_id,
+        name="Resolved Issue",
+        description="Resolved",
+        status=IssueStatus.RESOLVED,
+    )
+
+    timestamp_ms = get_current_time_millis()
+    trace = store.start_trace(
+        TraceInfo(
+            trace_id=f"tr-{uuid.uuid4()}",
+            trace_location=TraceLocation.from_experiment_id(exp_id),
+            request_time=timestamp_ms,
+            execution_duration=100,
+            state=TraceState.OK,
+            tags={},
+            trace_metadata={},
+            client_request_id=f"tr-{uuid.uuid4()}",
+            request_preview=None,
+            response_preview=None,
+        ),
+    )
+
+    store.create_assessment(
+        IssueReference(
+            issue_id=issue_pending.issue_id,
+            issue_name=issue_pending.name,
+            trace_id=trace.request_id,
+        )
+    )
+
+    result = store.search_issues(
+        experiment_id=exp_id, filter_string="status = 'pending'", include_trace_count=True
+    )
+
+    assert len(result) == 1
+    assert result[0].issue_id == issue_pending.issue_id
+    assert result[0].trace_count == 1


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21746/files) to review incremental changes.
- [**stack/include_trace_count_in_search_traces**](https://github.com/mlflow/mlflow/pull/21746) [[Files changed](https://github.com/mlflow/mlflow/pull/21746/files)]
  - [stack/show_impacted_traces_on_issue_card](https://github.com/mlflow/mlflow/pull/21747) [[Files changed](https://github.com/mlflow/mlflow/pull/21747/files/ae9f50e15e7b7980696aa9d685f494e779f4ca7a..28b6469a1b4fe4e4a1cca41d2330880f82ebea5d)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Include `trace_count` in search_issues result, with an optional parameter `include_trace_count` parameter that default to False.
This change is required because we want to display number of impacted traces on UI in issues table, while searching traces based on issue_id is expensive and it's not necessary unless user wants to check the linked traces. As a result, I added an optional `trace_count` field on issue and return it as part of `search_issues`, and also update the default ordering to be 1. severity DESC 2. number of traces DESC

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
