### PR TITLE
Document API access for UI preview apps

### DIFF
--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -52,3 +52,5 @@ import mlflow
 
 mlflow.search_experiments(max_results=10)
 ```
+
+See [Connect to Databricks Apps](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/connect-local) for more details on authentication.

--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -39,3 +39,16 @@ curl -s "$APP_URL/api/2.0/mlflow/experiments/search" \
   -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"max_results": 10}' | jq .
 ```
+
+You can also use the MLflow Python client:
+
+```bash
+export MLFLOW_TRACKING_URI="$APP_URL"
+export MLFLOW_TRACKING_TOKEN="$TOKEN"
+```
+
+```python
+import mlflow
+
+mlflow.search_experiments(max_results=10)
+```

--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -12,3 +12,30 @@ Deploy a live preview of the MLflow UI as a [Databricks App](https://docs.databr
 ## Access
 
 Preview apps are only accessible to core maintainers with workspace access.
+
+## API access
+
+To query or add data to a preview app, set the following environment variables:
+
+```bash
+export DATABRICKS_HOST="..."
+export DATABRICKS_CLIENT_ID="..."
+export DATABRICKS_CLIENT_SECRET="..."
+export APP_URL="..."
+```
+
+Then, obtain an access token:
+
+```bash
+export TOKEN=$(curl -s -X POST "https://$DATABRICKS_HOST/oidc/v1/token" \
+  -d "grant_type=client_credentials&client_id=$DATABRICKS_CLIENT_ID&client_secret=$DATABRICKS_CLIENT_SECRET&scope=all-apis" \
+  | jq -r '.access_token')
+```
+
+Once the token is obtained, search for experiments to verify it works:
+
+```bash
+curl -s "$APP_URL/api/2.0/mlflow/experiments/search" \
+  -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"max_results": 10}' | jq .
+```

--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -32,7 +32,7 @@ export TOKEN=$(curl -s -X POST "https://$DATABRICKS_HOST/oidc/v1/token" \
   | jq -r '.access_token')
 ```
 
-Once the token is obtained, search for experiments to verify it works:
+Once the token is obtained, run the following command to verify it works:
 
 ```bash
 curl -s "$APP_URL/api/2.0/mlflow/experiments/search" \

--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -18,7 +18,7 @@ Preview apps are only accessible to core maintainers with workspace access.
 To query or add data to a preview app, set the following environment variables:
 
 ```bash
-export DATABRICKS_HOST="..."
+export DATABRICKS_HOST="https://..."
 export DATABRICKS_CLIENT_ID="..."
 export DATABRICKS_CLIENT_SECRET="..."
 export APP_URL="..."
@@ -27,7 +27,7 @@ export APP_URL="..."
 Then, obtain an access token:
 
 ```bash
-export TOKEN=$(curl -s -X POST "https://$DATABRICKS_HOST/oidc/v1/token" \
+export TOKEN=$(curl -s -X POST "$DATABRICKS_HOST/oidc/v1/token" \
   -d "grant_type=client_credentials&client_id=$DATABRICKS_CLIENT_ID&client_secret=$DATABRICKS_CLIENT_SECRET&scope=all-apis" \
   | jq -r '.access_token')
 ```


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add documentation to `.github/ui-preview/README.md` explaining how to authenticate and interact with the MLflow REST API on preview apps. This enables maintainers to add test data for manual UI testing.

### How is this PR tested?

- [x] Manual tests

Verified the documented commands work against a live preview app (obtained token, searched experiments successfully).

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)