### PR TITLE
Track `usage_tracking` in gateway endpoint telemetry events

### DIFF
--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -418,6 +418,7 @@ class GatewayCreateEndpointEvent(Event):
             if arguments.get("routing_strategy")
             else None,
             "num_model_configs": len(arguments.get("model_configs") or []),
+            "usage_tracking": arguments.get("usage_tracking"),
         }
 
 
@@ -434,6 +435,7 @@ class GatewayUpdateEndpointEvent(Event):
             "num_model_configs": len(arguments.get("model_configs"))
             if arguments.get("model_configs") is not None
             else None,
+            "usage_tracking": arguments.get("usage_tracking"),
         }
 
 

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -339,11 +339,13 @@ def test_simulate_conversation_parse_result(result, expected_params):
                 "fallback_config": {"strategy": "FAILOVER"},
                 "routing_strategy": "REQUEST_BASED_TRAFFIC_SPLIT",
                 "model_configs": [{"model_definition_id": "md-1"}, {"model_definition_id": "md-2"}],
+                "usage_tracking": True,
             },
             {
                 "has_fallback_config": True,
                 "routing_strategy": "REQUEST_BASED_TRAFFIC_SPLIT",
                 "num_model_configs": 2,
+                "usage_tracking": True,
             },
         ),
         (
@@ -351,20 +353,32 @@ def test_simulate_conversation_parse_result(result, expected_params):
                 "fallback_config": None,
                 "routing_strategy": None,
                 "model_configs": [{"model_definition_id": "md-1"}],
+                "usage_tracking": False,
             },
             {
                 "has_fallback_config": False,
                 "routing_strategy": None,
                 "num_model_configs": 1,
+                "usage_tracking": False,
             },
         ),
         (
             {"fallback_config": None, "routing_strategy": None, "model_configs": []},
-            {"has_fallback_config": False, "routing_strategy": None, "num_model_configs": 0},
+            {
+                "has_fallback_config": False,
+                "routing_strategy": None,
+                "num_model_configs": 0,
+                "usage_tracking": None,
+            },
         ),
         (
             {},
-            {"has_fallback_config": False, "routing_strategy": None, "num_model_configs": 0},
+            {
+                "has_fallback_config": False,
+                "routing_strategy": None,
+                "num_model_configs": 0,
+                "usage_tracking": None,
+            },
         ),
     ],
 )
@@ -380,20 +394,37 @@ def test_gateway_create_endpoint_parse_params(arguments, expected_params):
                 "fallback_config": {"strategy": "FAILOVER"},
                 "routing_strategy": "ROUND_ROBIN",
                 "model_configs": [{"model_definition_id": "md-1"}],
+                "usage_tracking": True,
             },
             {
                 "has_fallback_config": True,
                 "routing_strategy": "ROUND_ROBIN",
                 "num_model_configs": 1,
+                "usage_tracking": True,
             },
         ),
         (
-            {"fallback_config": None, "routing_strategy": None, "model_configs": None},
-            {"has_fallback_config": False, "routing_strategy": None, "num_model_configs": None},
+            {
+                "fallback_config": None,
+                "routing_strategy": None,
+                "model_configs": None,
+                "usage_tracking": None,
+            },
+            {
+                "has_fallback_config": False,
+                "routing_strategy": None,
+                "num_model_configs": None,
+                "usage_tracking": None,
+            },
         ),
         (
             {},
-            {"has_fallback_config": False, "routing_strategy": None, "num_model_configs": None},
+            {
+                "has_fallback_config": False,
+                "routing_strategy": None,
+                "num_model_configs": None,
+                "usage_tracking": None,
+            },
         ),
     ],
 )

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -1814,6 +1814,7 @@ def test_gateway_crud_telemetry(mock_requests, mock_telemetry_client: TelemetryC
             "has_fallback_config": False,
             "routing_strategy": None,
             "num_model_configs": 1,
+            "usage_tracking": True,
         },
     )
 
@@ -1852,6 +1853,7 @@ def test_gateway_crud_telemetry(mock_requests, mock_telemetry_client: TelemetryC
             "has_fallback_config": False,
             "routing_strategy": None,
             "num_model_configs": None,
+            "usage_tracking": None,
         },
     )
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add `usage_tracking` field to `GatewayCreateEndpointEvent` and `GatewayUpdateEndpointEvent` telemetry events so we can track whether usage tracking is enabled when endpoints are created or updated.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release