### PR TITLE
Improve issue discovery: category coherence and actionable root causes

### DIFF
--- a/mlflow/genai/discovery/clustering.py
+++ b/mlflow/genai/discovery/clustering.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel as _BaseModel
 from mlflow.entities.issue import IssueSeverity
 from mlflow.genai.discovery.constants import (
     CLUSTER_LABELS_PROMPT_TEMPLATE,
-    SEMANTIC_DEDUP_PROMPT_TEMPLATE,
     _format_cluster_categories,
     build_cluster_summary_prompt,
 )
@@ -19,15 +18,6 @@ from mlflow.genai.discovery.entities import (
 from mlflow.genai.discovery.utils import _call_llm, _TokenCounter
 
 _logger = logging.getLogger(__name__)
-
-
-class _DedupGroup(_BaseModel):
-    keep_index: int
-    merge_indices: list[int]
-
-
-class _DedupResponse(_BaseModel):
-    groups: list[_DedupGroup]
 
 
 class _ClusterGroup(_BaseModel):
@@ -226,90 +216,3 @@ def recluster_singletons(
             result.extend(singletons[group_idx] for group_idx in group)
 
     return result
-
-
-def semantic_dedup_issues(
-    issues: list[_IdentifiedIssue],
-    model: str,
-    token_counter: _TokenCounter | None = None,
-) -> list[_IdentifiedIssue]:
-    """
-    Final dedup pass: ask an LLM to identify semantically duplicate issues.
-
-    Presents all issue names + descriptions to the LLM and asks it to group
-    duplicates. For each group of duplicates, keeps the issue with the highest
-    severity (or first if tied) and merges example_indices from the others.
-
-    Args:
-        issues: Issues to deduplicate.
-        model: Model URI for the dedup LLM.
-        token_counter: Optional token counter for tracking LLM usage.
-
-    Returns:
-        Deduplicated list of issues with merged example_indices.
-    """
-    if len(issues) < 2:
-        return issues
-
-    numbered = "\n".join(
-        f"[{i}] Name: {issue.name}\n    Description: {issue.description}\n"
-        f"    Root cause: {issue.root_cause}\n    Severity: {issue.severity}"
-        for i, issue in enumerate(issues)
-    )
-    prompt = SEMANTIC_DEDUP_PROMPT_TEMPLATE.format(
-        num_issues=len(issues),
-        numbered_issues=numbered,
-    )
-
-    try:
-        response = _call_llm(
-            model,
-            [{"role": "user", "content": prompt}],
-            response_format=_DedupResponse,
-            token_counter=token_counter,
-        )
-        content = (response.choices[0].message.content or "").strip()
-        if not content:
-            _logger.debug("LLM returned empty content for semantic dedup, skipping")
-            return issues
-        result = _DedupResponse(**json.loads(content))
-    except Exception:
-        _logger.debug("Semantic dedup LLM call failed, skipping", exc_info=True)
-        return issues
-
-    # Validate and apply merges
-    consumed: set[int] = set()
-    deduped: list[_IdentifiedIssue] = []
-
-    for group in result.groups:
-        keep = group.keep_index
-        if keep < 0 or keep >= len(issues) or keep in consumed:
-            continue
-
-        valid_merges = [
-            m
-            for m in group.merge_indices
-            if 0 <= m < len(issues) and m != keep and m not in consumed
-        ]
-
-        kept_issue = issues[keep]
-        for merge_idx in valid_merges:
-            merged = issues[merge_idx]
-            # Combine example_indices (deduplicated, preserving order)
-            kept_issue.example_indices = list(
-                dict.fromkeys(kept_issue.example_indices + merged.example_indices)
-            )
-            # Keep highest severity
-            kept_issue.severity = max(kept_issue.severity, merged.severity)
-            consumed.add(merge_idx)
-
-        consumed.add(keep)
-        deduped.append(kept_issue)
-
-    # Add any issues not covered by the LLM response (safety net)
-    for i, issue in enumerate(issues):
-        if i not in consumed:
-            deduped.append(issue)
-
-    _logger.debug("Semantic dedup: %d issues -> %d issues", len(issues), len(deduped))
-    return deduped

--- a/mlflow/genai/discovery/clustering.py
+++ b/mlflow/genai/discovery/clustering.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel as _BaseModel
 from mlflow.entities.issue import IssueSeverity
 from mlflow.genai.discovery.constants import (
     CLUSTER_LABELS_PROMPT_TEMPLATE,
+    SEMANTIC_DEDUP_PROMPT_TEMPLATE,
+    _format_cluster_categories,
     build_cluster_summary_prompt,
 )
 from mlflow.genai.discovery.entities import (
@@ -17,6 +19,15 @@ from mlflow.genai.discovery.entities import (
 from mlflow.genai.discovery.utils import _call_llm, _TokenCounter
 
 _logger = logging.getLogger(__name__)
+
+
+class _DedupGroup(_BaseModel):
+    keep_index: int
+    merge_indices: list[int]
+
+
+class _DedupResponse(_BaseModel):
+    groups: list[_DedupGroup]
 
 
 class _ClusterGroup(_BaseModel):
@@ -32,6 +43,7 @@ def cluster_by_llm(
     labels: list[str],
     max_issues: int,
     model: str,
+    categories: list[str] | None = None,
     token_counter: _TokenCounter | None = None,
 ) -> list[list[int]]:
     """
@@ -46,6 +58,7 @@ def cluster_by_llm(
         labels: Failure labels to cluster.
         max_issues: Maximum number of groups to produce.
         model: Model URI for the clustering LLM.
+        categories: Optional issue categories to use as a grouping signal.
         token_counter: Optional token counter for tracking LLM usage.
 
     Returns:
@@ -56,6 +69,7 @@ def cluster_by_llm(
         num_labels=len(labels),
         max_issues=max_issues,
         numbered_labels=numbered,
+        categories_context=_format_cluster_categories(categories),
     )
 
     response = _call_llm(
@@ -131,6 +145,8 @@ def summarize_cluster(
         entry = f"[{i}] {analysis.rationale_summary}"
         if analysis.execution_path:
             entry += f"\n  execution_path: {analysis.execution_path}"
+        if analysis.categories:
+            entry += f"\n  categories: {', '.join(analysis.categories)}"
         parts.append(entry)
     analyses_text = "\n\n".join(parts)
 
@@ -210,3 +226,90 @@ def recluster_singletons(
             result.extend(singletons[group_idx] for group_idx in group)
 
     return result
+
+
+def semantic_dedup_issues(
+    issues: list[_IdentifiedIssue],
+    model: str,
+    token_counter: _TokenCounter | None = None,
+) -> list[_IdentifiedIssue]:
+    """
+    Final dedup pass: ask an LLM to identify semantically duplicate issues.
+
+    Presents all issue names + descriptions to the LLM and asks it to group
+    duplicates. For each group of duplicates, keeps the issue with the highest
+    severity (or first if tied) and merges example_indices from the others.
+
+    Args:
+        issues: Issues to deduplicate.
+        model: Model URI for the dedup LLM.
+        token_counter: Optional token counter for tracking LLM usage.
+
+    Returns:
+        Deduplicated list of issues with merged example_indices.
+    """
+    if len(issues) < 2:
+        return issues
+
+    numbered = "\n".join(
+        f"[{i}] Name: {issue.name}\n    Description: {issue.description}\n"
+        f"    Root cause: {issue.root_cause}\n    Severity: {issue.severity}"
+        for i, issue in enumerate(issues)
+    )
+    prompt = SEMANTIC_DEDUP_PROMPT_TEMPLATE.format(
+        num_issues=len(issues),
+        numbered_issues=numbered,
+    )
+
+    try:
+        response = _call_llm(
+            model,
+            [{"role": "user", "content": prompt}],
+            response_format=_DedupResponse,
+            token_counter=token_counter,
+        )
+        content = (response.choices[0].message.content or "").strip()
+        if not content:
+            _logger.debug("LLM returned empty content for semantic dedup, skipping")
+            return issues
+        result = _DedupResponse(**json.loads(content))
+    except Exception:
+        _logger.debug("Semantic dedup LLM call failed, skipping", exc_info=True)
+        return issues
+
+    # Validate and apply merges
+    consumed: set[int] = set()
+    deduped: list[_IdentifiedIssue] = []
+
+    for group in result.groups:
+        keep = group.keep_index
+        if keep < 0 or keep >= len(issues) or keep in consumed:
+            continue
+
+        valid_merges = [
+            m
+            for m in group.merge_indices
+            if 0 <= m < len(issues) and m != keep and m not in consumed
+        ]
+
+        kept_issue = issues[keep]
+        for merge_idx in valid_merges:
+            merged = issues[merge_idx]
+            # Combine example_indices (deduplicated, preserving order)
+            kept_issue.example_indices = list(
+                dict.fromkeys(kept_issue.example_indices + merged.example_indices)
+            )
+            # Keep highest severity
+            kept_issue.severity = max(kept_issue.severity, merged.severity)
+            consumed.add(merge_idx)
+
+        consumed.add(keep)
+        deduped.append(kept_issue)
+
+    # Add any issues not covered by the LLM response (safety net)
+    for i, issue in enumerate(issues):
+        if i not in consumed:
+            deduped.append(issue)
+
+    _logger.debug("Semantic dedup: %d issues -> %d issues", len(issues), len(deduped))
+    return deduped

--- a/mlflow/genai/discovery/constants.py
+++ b/mlflow/genai/discovery/constants.py
@@ -94,8 +94,6 @@ that require specific fulfillment
 if a system prompt defines what the assistant can/cannot do, evaluate only against that scope\
 {extra_donts}
 
-Return True if the user's goals were achieved efficiently, False otherwise.
-
 In your rationale, explain:
 - What the user wanted to achieve (list all goals)
 - Whether they were achieved efficiently
@@ -133,13 +131,10 @@ application actually perform that task?
 limitations, do NOT mark it as failing for things outside its defined scope. \
 Evaluate only against what the assistant is designed to do.
 
-When in doubt, return True. Only return False for clear, unambiguous failures — \
-not stylistic preferences, minor omissions, or responses that are correct but \
-could be improved. The bar is whether the output *fails* the request, not \
-whether it is *perfect*.
-
-Return True if the output correctly fulfills the input request.
-Return False if there are significant quality problems.
+When in doubt, consider it passed. Only mark as failed for clear, unambiguous \
+failures — not stylistic preferences, minor omissions, or responses that are \
+correct but could be improved. The bar is whether the output *fails* the request, \
+not whether it is *perfect*.
 
 In your rationale, start with a concise label in square brackets (5-15 words), e.g. \
 [null response] or [incorrect output format] or [no issues found]. \
@@ -153,19 +148,21 @@ CATEGORIES_INSTRUCTIONS = """\
 The following issue categories are the ONLY valid categories for this evaluation:
 {categories}
 
-If the assistant's behavior relates to any of these categories, end your rationale \
-with a line that starts with "CATEGORIES:" followed by a comma-separated list of \
-applicable categories. Example: "CATEGORIES: correctness, execution"
+For the "passed" key in your result, return "true" if the user's goals were achieved \
+efficiently, "false" otherwise.
+
+For the "categories" key, return a comma-separated list of applicable categories from \
+the list above. If no categories apply, return an empty string. \
+Example: "correctness, execution"
 """
 
 
 def _format_category_list(categories: list[str]) -> str:
-    """Format category names with descriptions as bullet list."""
-    lines = []
+    parts = []
     for cat in categories:
         desc = DEFAULT_CATEGORY_DESCRIPTIONS.get(cat)
-        lines.append(f"- {cat}: {desc}" if desc else f"- {cat}")
-    return "\n".join(lines)
+        parts.append(f"{cat} ({desc})" if desc else cat)
+    return ", ".join(parts)
 
 
 def build_satisfaction_instructions(*, use_conversation: bool, categories: list[str]) -> str:
@@ -274,13 +271,9 @@ CLUSTER_SUMMARY_CATEGORIES_INSTRUCTION_WITH_LIST = (
 
 
 def build_cluster_summary_prompt(categories: list[str]) -> str:
-    """Build the cluster summary system prompt with category filtering."""
-    parts = []
-    for cat in categories:
-        desc = DEFAULT_CATEGORY_DESCRIPTIONS.get(cat)
-        parts.append(f"{cat} ({desc})" if desc else cat)
-    cat_list = ", ".join(parts)
-    cat_instruction = CLUSTER_SUMMARY_CATEGORIES_INSTRUCTION_WITH_LIST.format(categories=cat_list)
+    cat_instruction = CLUSTER_SUMMARY_CATEGORIES_INSTRUCTION_WITH_LIST.format(
+        categories=_format_category_list(categories)
+    )
     return CLUSTER_SUMMARY_SYSTEM_PROMPT_BASE + cat_instruction
 
 

--- a/mlflow/genai/discovery/constants.py
+++ b/mlflow/genai/discovery/constants.py
@@ -226,20 +226,31 @@ CLUSTER_SUMMARY_SYSTEM_PROMPT_BASE = (
     "Cite observable symptoms (e.g. 'returned empty response', 'ignored the user's "
     "constraint to avoid implementation'). Avoid vague language like 'inefficient' "
     "or 'suboptimal' without concrete details.\n"
-    "- The root cause: why this likely happens AND where to investigate. Identify "
-    "the probable component, behavior, or configuration at fault (e.g. 'the retrieval "
-    "tool may be returning stale cached results', 'the system prompt does not instruct "
-    "the agent to respect user constraints'). Be specific but note these are hypotheses "
-    "based on observed symptoms.\n"
+    "  The LAST paragraph of the description MUST be a category justification that "
+    "starts with 'Categorized as' and explicitly explains why each assigned category "
+    "applies with specific evidence. Example: 'Categorized as safety because the "
+    "assistant fabricated access to private email data; categorized as negative_ux "
+    "because users had to repeat the same request 3+ times before getting a response.'\n"
+    "- The root cause: why this likely happens AND where to investigate. You MUST name "
+    "specific tools, functions, sub-agents, or execution paths from the analyses (e.g. "
+    "'the run_media_playback_assistant tool returns stale state', 'the get_schedule "
+    "function omits timezone metadata', 'the system prompt for the financial assistant "
+    "does not enforce best-effort answers'). If the analyses mention execution paths "
+    "like [tool_a > tool_b > tool_c], reference them. Do NOT write vague root causes "
+    "like 'the orchestration layer' or 'intent handling' without naming the specific "
+    "component. A developer reading this must know exactly which tool, prompt, or "
+    "code path to investigate first.\n"
     f"- A severity level from: {', '.join(str(level) for level in IssueSeverity)}. "
     "Use medium or high only if the analyses clearly share the same failure "
     "pattern. Use not_an_issue if they do NOT belong together or represent no real issue.\n"
 )
 
 CLUSTER_SUMMARY_CATEGORIES_INSTRUCTION_WITH_LIST = (
-    "- Categories: Extract any category tags enclosed in square brackets from the rationales. "
-    "ONLY include categories from this list: {categories}. "
-    "If no matching category tags are found, return an empty list."
+    "- **Categories**: Assign one or more categories from: {categories}. "
+    "Only assign a category you can justify with specific evidence.\n"
+    "- **category_rationale**: For EACH assigned category, write 1-2 sentences explaining "
+    "WHY this issue belongs to that category. Reference specific symptoms or behaviors. "
+    "This field is REQUIRED if any categories are assigned."
 )
 
 
@@ -250,12 +261,31 @@ def build_cluster_summary_prompt(categories: list[str]) -> str:
     return CLUSTER_SUMMARY_SYSTEM_PROMPT_BASE + cat_instruction
 
 
+# ---- Category context fragments for downstream phases ----
+
+CLUSTER_CATEGORIES_CONTEXT = (
+    "\n\nThe following issue categories have been identified during triage. "
+    "Use these as an additional grouping signal — labels tagged with the same "
+    "category are likely to belong together, even if their execution paths differ:\n"
+    "{categories}\n"
+)
+
+
+def _format_cluster_categories(categories: list[str] | None) -> str:
+    """Format category list for injection into clustering/summary prompts."""
+    if not categories:
+        return ""
+    items = "\n".join(f"- {cat}" for cat in categories)
+    return CLUSTER_CATEGORIES_CONTEXT.format(categories=items)
+
+
 # ---- Label clustering prompt ----
 
 CLUSTER_LABELS_PROMPT_TEMPLATE = (
     "Below are {num_labels} failure labels from an AI agent.\n"
     "Each label has the format: [execution_path] symptom\n"
     "The execution path shows which sub-agents and tools were called.\n\n"
+    "{categories_context}"
     "Group these labels into coherent issue categories. Two labels belong "
     "in the same group when:\n"
     "  1. They share the same failure pattern (similar symptom)\n"
@@ -281,6 +311,7 @@ TRACE_ANNOTATION_SYSTEM_PROMPT = (
     "You are annotating a trace that was identified as exhibiting a known issue.\n\n"
     "You will be given:\n"
     "- The issue (name, description, root cause)\n"
+    "- Known issue categories relevant to this trace (if any)\n"
     "- The trace's actual input/output and execution path\n"
     "- The triage judge's rationale for why this trace was flagged\n\n"
     "Write a CONCISE rationale (2-3 sentences, max 150 words) for why THIS trace "
@@ -290,4 +321,24 @@ TRACE_ANNOTATION_SYSTEM_PROMPT = (
     "Be specific but brief — no preamble, no bullet lists, no restating the issue "
     "definition. A developer should immediately understand what went wrong.\n\n"
     "Return ONLY the rationale text, nothing else."
+)
+
+# ---- Semantic dedup prompt ----
+
+SEMANTIC_DEDUP_PROMPT_TEMPLATE = (
+    "Below are {num_issues} issues discovered from an AI application.\n"
+    "Some may describe the SAME underlying problem with different wording.\n\n"
+    "For each issue:\n{numbered_issues}\n\n"
+    "Identify groups of issues that are duplicates of each other — i.e. they "
+    "describe the same root cause and failure pattern, just with different names "
+    "or slightly different descriptions.\n\n"
+    "Rules:\n"
+    "- Only merge issues that genuinely describe the same problem\n"
+    "- Issues with different root causes or affecting different components are NOT duplicates\n"
+    "- When merging, keep the index of the issue with the higher severity (or the first one if tied)\n"
+    "- Issues that are unique should appear as singleton groups\n\n"
+    'Return a JSON object with a "groups" key containing an array of objects, '
+    'each with "keep_index" (int, the index to keep) and "merge_indices" '
+    "(list of ints, indices to merge into keep_index, may be empty).\n"
+    "Return ONLY the JSON, no explanation."
 )

--- a/mlflow/genai/discovery/constants.py
+++ b/mlflow/genai/discovery/constants.py
@@ -20,6 +20,17 @@ TRACE_CONTENT_TRUNCATION = 1000
 DEFAULT_MODEL = "openai:/gpt-5-mini"
 DEFAULT_SCORER_NAME = "_issue_discovery_judge"
 DEFAULT_CATEGORIES = ["correctness", "latency", "execution", "adherence", "relevance", "safety"]
+DEFAULT_CATEGORY_DESCRIPTIONS = {
+    "correctness": "Output is factually accurate and grounded in provided data",
+    "latency": "Agent responds within acceptable time bounds",
+    "execution": "Agent successfully completes actions (tool calls, API steps)",
+    "adherence": "Response follows instructions, constraints, policies, and formatting",
+    "relevance": (
+        "Output is useful, directly addresses the user's request, "
+        "and leaves the user satisfied with the interaction"
+    ),
+    "safety": "Response avoids harmful, sensitive, or inappropriate content",
+}
 
 
 # ---- Satisfaction scorer instructions ----
@@ -148,8 +159,11 @@ any categories that are not in this list:
 
 
 def _format_categories(categories: list[str]) -> str:
-    items = "\n".join(f"- {cat}" for cat in categories)
-    return CATEGORIES_INSTRUCTIONS.format(categories=items)
+    lines = []
+    for cat in categories:
+        desc = DEFAULT_CATEGORY_DESCRIPTIONS.get(cat)
+        lines.append(f"- {cat}: {desc}" if desc else f"- {cat}")
+    return CATEGORIES_INSTRUCTIONS.format(categories="\n".join(lines))
 
 
 def build_satisfaction_instructions(*, use_conversation: bool, categories: list[str]) -> str:
@@ -256,7 +270,11 @@ CLUSTER_SUMMARY_CATEGORIES_INSTRUCTION_WITH_LIST = (
 
 def build_cluster_summary_prompt(categories: list[str]) -> str:
     """Build the cluster summary system prompt with category filtering."""
-    cat_list = ", ".join(categories)
+    parts = []
+    for cat in categories:
+        desc = DEFAULT_CATEGORY_DESCRIPTIONS.get(cat)
+        parts.append(f"{cat} ({desc})" if desc else cat)
+    cat_list = ", ".join(parts)
     cat_instruction = CLUSTER_SUMMARY_CATEGORIES_INSTRUCTION_WITH_LIST.format(categories=cat_list)
     return CLUSTER_SUMMARY_SYSTEM_PROMPT_BASE + cat_instruction
 
@@ -275,8 +293,11 @@ def _format_cluster_categories(categories: list[str] | None) -> str:
     """Format category list for injection into clustering/summary prompts."""
     if not categories:
         return ""
-    items = "\n".join(f"- {cat}" for cat in categories)
-    return CLUSTER_CATEGORIES_CONTEXT.format(categories=items)
+    lines = []
+    for cat in categories:
+        desc = DEFAULT_CATEGORY_DESCRIPTIONS.get(cat)
+        lines.append(f"- {cat}: {desc}" if desc else f"- {cat}")
+    return CLUSTER_CATEGORIES_CONTEXT.format(categories="\n".join(lines))
 
 
 # ---- Label clustering prompt ----

--- a/mlflow/genai/discovery/constants.py
+++ b/mlflow/genai/discovery/constants.py
@@ -322,23 +322,3 @@ TRACE_ANNOTATION_SYSTEM_PROMPT = (
     "definition. A developer should immediately understand what went wrong.\n\n"
     "Return ONLY the rationale text, nothing else."
 )
-
-# ---- Semantic dedup prompt ----
-
-SEMANTIC_DEDUP_PROMPT_TEMPLATE = (
-    "Below are {num_issues} issues discovered from an AI application.\n"
-    "Some may describe the SAME underlying problem with different wording.\n\n"
-    "For each issue:\n{numbered_issues}\n\n"
-    "Identify groups of issues that are duplicates of each other — i.e. they "
-    "describe the same root cause and failure pattern, just with different names "
-    "or slightly different descriptions.\n\n"
-    "Rules:\n"
-    "- Only merge issues that genuinely describe the same problem\n"
-    "- Issues with different root causes or affecting different components are NOT duplicates\n"
-    "- When merging, keep the index of the issue with the higher severity (or the first one if tied)\n"
-    "- Issues that are unique should appear as singleton groups\n\n"
-    'Return a JSON object with a "groups" key containing an array of objects, '
-    'each with "keep_index" (int, the index to keep) and "merge_indices" '
-    "(list of ints, indices to merge into keep_index, may be empty).\n"
-    "Return ONLY the JSON, no explanation."
-)

--- a/mlflow/genai/discovery/constants.py
+++ b/mlflow/genai/discovery/constants.py
@@ -19,7 +19,7 @@ TRACE_CONTENT_TRUNCATION = 1000
 
 DEFAULT_MODEL = "openai:/gpt-5-mini"
 DEFAULT_SCORER_NAME = "_issue_discovery_judge"
-DEFAULT_CATEGORIES = ["low_quality", "negative_ux", "safety", "performance"]
+DEFAULT_CATEGORIES = ["correctness", "latency", "execution", "adherence", "relevance", "safety"]
 
 
 # ---- Satisfaction scorer instructions ----

--- a/mlflow/genai/discovery/constants.py
+++ b/mlflow/genai/discovery/constants.py
@@ -150,25 +150,29 @@ Then cite specific evidence from the APPLICATION OUTPUT above.\
 CATEGORIES_INSTRUCTIONS = """\
 
 
-The following issue categories are the ONLY valid categories for this evaluation. \
-If the assistant's behavior relates to any of these categories, include the category \
-as a tag in square brackets in your rationale (e.g. [low_quality]). Do NOT include \
-any categories that are not in this list:
-{categories}\
+The following issue categories are the ONLY valid categories for this evaluation:
+{categories}
+
+If the assistant's behavior relates to any of these categories, end your rationale \
+with a line that starts with "CATEGORIES:" followed by a comma-separated list of \
+applicable categories. Example: "CATEGORIES: correctness, execution"
 """
 
 
-def _format_categories(categories: list[str]) -> str:
+def _format_category_list(categories: list[str]) -> str:
+    """Format category names with descriptions as bullet list."""
     lines = []
     for cat in categories:
         desc = DEFAULT_CATEGORY_DESCRIPTIONS.get(cat)
         lines.append(f"- {cat}: {desc}" if desc else f"- {cat}")
-    return CATEGORIES_INSTRUCTIONS.format(categories="\n".join(lines))
+    return "\n".join(lines)
 
 
 def build_satisfaction_instructions(*, use_conversation: bool, categories: list[str]) -> str:
     if not use_conversation:
-        return TRACE_QUALITY_INSTRUCTIONS + _format_categories(categories)
+        return TRACE_QUALITY_INSTRUCTIONS + CATEGORIES_INSTRUCTIONS.format(
+            categories=_format_category_list(categories)
+        )
 
     preamble = SATISFACTION_INSTRUCTIONS_PREAMBLE.format(context_noun="conversation")
     body = SATISFACTION_INSTRUCTIONS_BODY.format(
@@ -192,7 +196,11 @@ def build_satisfaction_instructions(*, use_conversation: bool, categories: list[
             "it is problematic.\n"
         ),
     )
-    return preamble + body + _format_categories(categories)
+    return (
+        preamble
+        + body
+        + CATEGORIES_INSTRUCTIONS.format(categories=_format_category_list(categories))
+    )
 
 
 # ---- Failure label extraction prompt ----
@@ -240,11 +248,6 @@ CLUSTER_SUMMARY_SYSTEM_PROMPT_BASE = (
     "Cite observable symptoms (e.g. 'returned empty response', 'ignored the user's "
     "constraint to avoid implementation'). Avoid vague language like 'inefficient' "
     "or 'suboptimal' without concrete details.\n"
-    "  The LAST paragraph of the description MUST be a category justification that "
-    "starts with 'Categorized as' and explicitly explains why each assigned category "
-    "applies with specific evidence. Example: 'Categorized as safety because the "
-    "assistant fabricated access to private email data; categorized as negative_ux "
-    "because users had to repeat the same request 3+ times before getting a response.'\n"
     "- The root cause: why this likely happens AND where to investigate. You MUST name "
     "specific tools, functions, sub-agents, or execution paths from the analyses (e.g. "
     "'the run_media_playback_assistant tool returns stale state', 'the get_schedule "
@@ -262,9 +265,11 @@ CLUSTER_SUMMARY_SYSTEM_PROMPT_BASE = (
 CLUSTER_SUMMARY_CATEGORIES_INSTRUCTION_WITH_LIST = (
     "- **Categories**: Assign one or more categories from: {categories}. "
     "Only assign a category you can justify with specific evidence.\n"
-    "- **category_rationale**: For EACH assigned category, write 1-2 sentences explaining "
-    "WHY this issue belongs to that category. Reference specific symptoms or behaviors. "
-    "This field is REQUIRED if any categories are assigned."
+    "- **category_rationale** (REQUIRED field): For EACH assigned category, write 1-2 sentences "
+    "explaining WHY this issue belongs to that category. Reference specific symptoms or behaviors. "
+    "You MUST populate this field with explicit justification for every assigned category. "
+    "Example: 'execution: The assistant claimed playback resumed when no action occurred. "
+    "correctness: It provided conflicting timer states in adjacent responses.'"
 )
 
 
@@ -290,14 +295,9 @@ CLUSTER_CATEGORIES_CONTEXT = (
 
 
 def _format_cluster_categories(categories: list[str] | None) -> str:
-    """Format category list for injection into clustering/summary prompts."""
     if not categories:
         return ""
-    lines = []
-    for cat in categories:
-        desc = DEFAULT_CATEGORY_DESCRIPTIONS.get(cat)
-        lines.append(f"- {cat}: {desc}" if desc else f"- {cat}")
-    return CLUSTER_CATEGORIES_CONTEXT.format(categories="\n".join(lines))
+    return CLUSTER_CATEGORIES_CONTEXT.format(categories=_format_category_list(categories))
 
 
 # ---- Label clustering prompt ----

--- a/mlflow/genai/discovery/constants.py
+++ b/mlflow/genai/discovery/constants.py
@@ -19,7 +19,6 @@ TRACE_CONTENT_TRUNCATION = 1000
 
 DEFAULT_MODEL = "openai:/gpt-5-mini"
 DEFAULT_SCORER_NAME = "_issue_discovery_judge"
-DEFAULT_CATEGORIES = ["correctness", "latency", "execution", "adherence", "relevance", "safety"]
 DEFAULT_CATEGORY_DESCRIPTIONS = {
     "correctness": "Output is factually accurate and grounded in provided data",
     "latency": "Agent responds within acceptable time bounds",
@@ -31,6 +30,7 @@ DEFAULT_CATEGORY_DESCRIPTIONS = {
     ),
     "safety": "Response avoids harmful, sensitive, or inappropriate content",
 }
+DEFAULT_CATEGORIES = list(DEFAULT_CATEGORY_DESCRIPTIONS)
 
 
 # ---- Satisfaction scorer instructions ----

--- a/mlflow/genai/discovery/entities.py
+++ b/mlflow/genai/discovery/entities.py
@@ -69,8 +69,8 @@ class _IdentifiedIssue(pydantic.BaseModel):
         description=(
             "For EACH assigned category, explain in 1-2 sentences WHY this issue "
             "belongs to that category with specific evidence from the failure. "
-            "E.g. 'safety: The assistant fabricated email access without permission, "
-            "exposing fake personal data. negative_ux: Users had to repeat requests "
-            "3+ times due to failed playback commands.'"
+            "This field is REQUIRED if any categories are assigned. "
+            "E.g. 'execution: The assistant claimed playback resumed when no action occurred. "
+            "correctness: It provided conflicting timer states in adjacent responses.'"
         ),
     )

--- a/mlflow/genai/discovery/entities.py
+++ b/mlflow/genai/discovery/entities.py
@@ -5,7 +5,15 @@ from dataclasses import dataclass, field
 import pydantic
 
 from mlflow.entities.issue import Issue, IssueSeverity
+from mlflow.entities.trace import Trace
 from mlflow.genai.discovery.constants import RATIONALE_TRUNCATION_LIMIT
+
+
+@dataclass
+class _TriageResult:
+    failing_traces: list[Trace]
+    rationale_map: dict[str, str]
+    categories_map: dict[str, list[str]]
 
 
 @dataclass

--- a/mlflow/genai/discovery/entities.py
+++ b/mlflow/genai/discovery/entities.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pydantic
 
@@ -26,11 +26,13 @@ class _ConversationAnalysis:
         affected_trace_ids: Trace IDs of failing traces in this session.
         execution_path: Compact path of sub-agents/tools called (e.g.
             ``"ask_sports > get_scores, web_search"``).
+        categories: Category tags extracted from triage rationales (e.g. ["hallucination"]).
     """
 
     full_rationale: str
     affected_trace_ids: list[str]
     execution_path: str = ""
+    categories: list[str] = field(default_factory=list)
 
     @property
     def rationale_summary(self) -> str:
@@ -57,5 +59,18 @@ class _IdentifiedIssue(pydantic.BaseModel):
         ),
     )
     categories: list[str] = pydantic.Field(
-        description="Categories of this issue",
+        description=(
+            "Categories of this issue. Each category MUST be substantiated by "
+            "concrete evidence in the description and root cause."
+        ),
+    )
+    category_rationale: str = pydantic.Field(
+        default="",
+        description=(
+            "For EACH assigned category, explain in 1-2 sentences WHY this issue "
+            "belongs to that category with specific evidence from the failure. "
+            "E.g. 'safety: The assistant fabricated email access without permission, "
+            "exposing fake personal data. negative_ux: Users had to repeat requests "
+            "3+ times due to failed playback commands.'"
+        ),
     )

--- a/mlflow/genai/discovery/extraction.py
+++ b/mlflow/genai/discovery/extraction.py
@@ -243,7 +243,7 @@ def _parse_assessment_value(value) -> tuple[bool, list[str]]:
     with "passed" and "categories" keys.
     """
     if isinstance(value, dict):
-        passed = str(value.get("passed", "true")).lower().startswith("t")
+        passed = str(value.get("passed", "true")).lower() == "true"
         cats = [c.strip() for c in value.get("categories", "").split(",") if c.strip()]
         return passed, cats
     return bool(value), []

--- a/mlflow/genai/discovery/extraction.py
+++ b/mlflow/genai/discovery/extraction.py
@@ -172,6 +172,7 @@ def collect_session_rationales(
 def extract_failure_labels(
     analyses: list[_ConversationAnalysis],
     model: str,
+    categories: list[str] | None = None,
     token_counter: _TokenCounter | None = None,
 ) -> tuple[list[str], list[int]]:
     """
@@ -186,6 +187,7 @@ def extract_failure_labels(
     Args:
         analyses: Conversation analyses to generate labels for.
         model: Model URI for the label-generation LLM.
+        categories: Optional issue categories for context in label generation.
         token_counter: Optional token counter for tracking LLM usage.
 
     Returns:
@@ -197,6 +199,8 @@ def extract_failure_labels(
 
     def _generate_labels(analysis: _ConversationAnalysis) -> list[str]:
         rationale = analysis.rationale_summary
+        if analysis.categories:
+            rationale += f"\nIdentified categories: {', '.join(analysis.categories)}"
         response = _call_llm(
             model,
             [

--- a/mlflow/genai/discovery/extraction.py
+++ b/mlflow/genai/discovery/extraction.py
@@ -239,7 +239,7 @@ def extract_failure_labels(
 def extract_failing_traces(
     scored_traces: list[Trace],
     scorer_names: str | list[str],
-) -> tuple[list[Trace], dict[str, str]]:
+) -> tuple[list[Trace], dict[str, str], dict[str, list[str]]]:
     """
     Extract failing traces and their rationales from scored trace objects.
 
@@ -256,31 +256,49 @@ def extract_failing_traces(
         scorer_names: One or more scorer names to check for failures.
 
     Returns:
-        A tuple of (failing_traces, rationale_map) where rationale_map
-        maps trace_id to the combined rationale string.
+        A tuple of (failing_traces, rationale_map, categories_map) where
+        rationale_map maps trace_id to the combined rationale string and
+        categories_map maps trace_id to the list of category tags.
     """
     if isinstance(scorer_names, str):
         scorer_names = [scorer_names]
 
     failing: list[Trace] = []
-    rationales: dict[str, str] = {}
+    rationale_map: dict[str, str] = {}
+    categories_map: dict[str, list[str]] = {}
 
     for trace in scored_traces:
-        row_failing: list[tuple[str, str]] = []
+        row_rationales: list[str] = []
+        row_categories: list[str] = []
+        is_failing = False
         for scorer_name in scorer_names:
             assessments = trace.search_assessments(scorer_name, type="feedback")
             assessment = assessments[-1] if assessments else None
             if assessment is None:
                 continue
-            if assessment.value is not None and not bool(assessment.value):
-                row_failing.append((scorer_name, assessment.rationale or ""))
+            if assessment.value is None:
+                continue
+            value = assessment.value
+            # Support dict[str, str] structured output (passed/categories keys)
+            if isinstance(value, dict):
+                passed = str(value.get("passed", "true")).lower().startswith("t")
+                for cat in value.get("categories", "").split(","):
+                    cat = cat.strip()
+                    if cat:
+                        row_categories.append(cat)
+            else:
+                passed = bool(value)
+            if not passed:
+                is_failing = True
+                if assessment.rationale:
+                    row_rationales.append(assessment.rationale)
 
-        if not row_failing:
+        if not is_failing:
             continue
 
+        trace_id = trace.info.trace_id
         failing.append(trace)
-        rationales[trace.info.trace_id] = "; ".join(
-            rationale for _, rationale in row_failing if rationale
-        )
+        rationale_map[trace_id] = "; ".join(row_rationales)
+        categories_map[trace_id] = list(dict.fromkeys(row_categories))
 
-    return failing, rationales
+    return failing, rationale_map, categories_map

--- a/mlflow/genai/discovery/extraction.py
+++ b/mlflow/genai/discovery/extraction.py
@@ -172,7 +172,6 @@ def collect_session_rationales(
 def extract_failure_labels(
     analyses: list[_ConversationAnalysis],
     model: str,
-    categories: list[str] | None = None,
     token_counter: _TokenCounter | None = None,
 ) -> tuple[list[str], list[int]]:
     """
@@ -187,7 +186,6 @@ def extract_failure_labels(
     Args:
         analyses: Conversation analyses to generate labels for.
         model: Model URI for the label-generation LLM.
-        categories: Optional issue categories for context in label generation.
         token_counter: Optional token counter for tracking LLM usage.
 
     Returns:

--- a/mlflow/genai/discovery/extraction.py
+++ b/mlflow/genai/discovery/extraction.py
@@ -11,7 +11,7 @@ from mlflow.environment_variables import MLFLOW_GENAI_EVAL_MAX_WORKERS
 from mlflow.genai.discovery.constants import (
     FAILURE_LABEL_SYSTEM_PROMPT,
 )
-from mlflow.genai.discovery.entities import _ConversationAnalysis
+from mlflow.genai.discovery.entities import _ConversationAnalysis, _TriageResult
 from mlflow.genai.discovery.utils import _call_llm, _TokenCounter
 
 _logger = logging.getLogger(__name__)
@@ -236,10 +236,23 @@ def extract_failure_labels(
     return labels, label_to_analysis
 
 
+def _parse_assessment_value(value) -> tuple[bool, list[str]]:
+    """Parse a feedback value into (passed, categories).
+
+    Handles both simple bool values and dict[str, str] structured output
+    with "passed" and "categories" keys.
+    """
+    if isinstance(value, dict):
+        passed = str(value.get("passed", "true")).lower().startswith("t")
+        cats = [c.strip() for c in value.get("categories", "").split(",") if c.strip()]
+        return passed, cats
+    return bool(value), []
+
+
 def extract_failing_traces(
     scored_traces: list[Trace],
     scorer_names: str | list[str],
-) -> tuple[list[Trace], dict[str, str], dict[str, list[str]]]:
+) -> _TriageResult:
     """
     Extract failing traces and their rationales from scored trace objects.
 
@@ -254,11 +267,6 @@ def extract_failing_traces(
     Args:
         scored_traces: Traces with scorer assessments attached.
         scorer_names: One or more scorer names to check for failures.
-
-    Returns:
-        A tuple of (failing_traces, rationale_map, categories_map) where
-        rationale_map maps trace_id to the combined rationale string and
-        categories_map maps trace_id to the list of category tags.
     """
     if isinstance(scorer_names, str):
         scorer_names = [scorer_names]
@@ -278,16 +286,8 @@ def extract_failing_traces(
                 continue
             if assessment.value is None:
                 continue
-            value = assessment.value
-            # Support dict[str, str] structured output (passed/categories keys)
-            if isinstance(value, dict):
-                passed = str(value.get("passed", "true")).lower().startswith("t")
-                for cat in value.get("categories", "").split(","):
-                    cat = cat.strip()
-                    if cat:
-                        row_categories.append(cat)
-            else:
-                passed = bool(value)
+            passed, cats = _parse_assessment_value(assessment.value)
+            row_categories.extend(cats)
             if not passed:
                 is_failing = True
                 if assessment.rationale:
@@ -301,4 +301,4 @@ def extract_failing_traces(
         rationale_map[trace_id] = "; ".join(row_rationales)
         categories_map[trace_id] = list(dict.fromkeys(row_categories))
 
-    return failing, rationale_map, categories_map
+    return _TriageResult(failing, rationale_map, categories_map)

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -18,6 +19,7 @@ from mlflow.environment_variables import (
 from mlflow.genai.discovery.clustering import (
     cluster_by_llm,
     recluster_singletons,
+    semantic_dedup_issues,
     summarize_cluster,
 )
 from mlflow.genai.discovery.constants import (
@@ -60,6 +62,34 @@ from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_TYPE, MLFLOW_RUN_TYPE_ISSUE_DETECTION
 
 _logger = logging.getLogger(__name__)
+
+_CATEGORY_TAG_RE = re.compile(r"\[([a-zA-Z][a-zA-Z0-9 _-]*)\]")
+# Brackets used for non-category purposes in rationales (execution paths, etc.)
+_CATEGORY_TAG_BLOCKLIST = {
+    "human feedback",
+    "span errors",
+    "no issues found",
+    "no routing",
+    "ERROR",
+}
+
+
+def _extract_category_tags(rationale: str, known_categories: list[str] | None = None) -> list[str]:
+    """Extract category tags in square brackets from a rationale string.
+
+    If known_categories is provided, only returns tags that match one of them
+    (case-insensitive). Otherwise returns all bracketed tags that aren't in
+    the blocklist.
+    """
+    tags = _CATEGORY_TAG_RE.findall(rationale)
+    if not tags:
+        return []
+
+    if known_categories:
+        known_lower = {c.lower() for c in known_categories}
+        return list(dict.fromkeys(t for t in tags if t.lower() in known_lower))
+    else:
+        return list(dict.fromkeys(t for t in tags if t.lower() not in _CATEGORY_TAG_BLOCKLIST))
 
 
 def _is_non_issue(issue: _IdentifiedIssue) -> bool:
@@ -123,6 +153,7 @@ def _annotate_issue_traces(
     rationale_map: dict[str, str],
     trace_lookup: dict[str, Trace],
     model: str,
+    categories: list[str] | None = None,
     trace_to_session: dict[str, str] | None = None,
     session_first_trace: dict[str, str] | None = None,
     token_counter: _TokenCounter | None = None,
@@ -157,7 +188,12 @@ def _annotate_issue_traces(
     def _annotate_one(item: _AnnotationWorkItem) -> str | None:
         trace = trace_lookup.get(item.trace_id)
         trace_content = format_trace_content(trace) if trace else "(trace not available)"
-        user_content = format_annotation_prompt(item.issue, trace_content, item.triage_rationale)
+        user_content = format_annotation_prompt(
+            item.issue,
+            trace_content,
+            item.triage_rationale,
+            categories=categories,
+        )
 
         try:
             response = _call_llm(
@@ -206,6 +242,7 @@ def _build_analyses(
     triage_traces: list[Trace],
     rationale_map: dict[str, str],
     scorer_name: str,
+    categories: list[str] | None = None,
 ) -> tuple[list[_ConversationAnalysis], dict[str, list[Trace]]]:
     """
     Build per-session analyses from triage results.
@@ -239,6 +276,7 @@ def _build_analyses(
                 full_rationale=combined_rationale,
                 affected_trace_ids=[trace.info.trace_id for trace in session_failing],
                 execution_path=exec_path,
+                categories=_extract_category_tags(combined_rationale, categories),
             )
         )
     _logger.debug("Built %d analyses from triage rationales", len(analyses))
@@ -342,14 +380,25 @@ def _cluster_and_identify(
     token_counter: _TokenCounter | None = None,
 ) -> list[_IdentifiedIssue]:
     """Cluster analyses into identified issues via LLM-based labeling and grouping."""
-    labels, label_to_analysis = extract_failure_labels(analyses, model, token_counter=token_counter)
+    labels, label_to_analysis = extract_failure_labels(
+        analyses,
+        model,
+        categories=categories,
+        token_counter=token_counter,
+    )
     for i, label in enumerate(labels):
         _logger.debug("  [%d] %s", i, label)
 
     if len(labels) == 1:
         cluster_groups = [[0]]
     else:
-        cluster_groups = cluster_by_llm(labels, max_issues, model, token_counter=token_counter)
+        cluster_groups = cluster_by_llm(
+            labels,
+            max_issues,
+            model,
+            categories=categories,
+            token_counter=token_counter,
+        )
     _logger.debug("Clustering produced %d groups", len(cluster_groups))
 
     def summarize_fn(group: list[int]) -> _IdentifiedIssue:
@@ -379,7 +428,7 @@ def _cluster_and_identify(
     analysis_labels: dict[int, str] = {}
     for label, analysis_idx in zip(labels, label_to_analysis):
         analysis_labels.setdefault(analysis_idx, label)
-    return _merge_singleton_issues(
+    merged = _merge_singleton_issues(
         identified,
         analysis_labels,
         analyses,
@@ -388,6 +437,7 @@ def _cluster_and_identify(
         categories=categories,
         token_counter=token_counter,
     )
+    return semantic_dedup_issues(merged, model, token_counter=token_counter)
 
 
 def _build_issues(
@@ -558,9 +608,10 @@ def discover_issues(
     scored_traces = triage_traces
     try:
         fetched = [mlflow.get_trace(t.info.trace_id) for t in triage_traces]
-        scored_traces = fetched
+        if all(f is not None for f in fetched):
+            scored_traces = fetched
         # Aggregate judge costs from Phase 1 evaluation assessments.
-        for trace in fetched:
+        for trace in scored_traces:
             for assessment in trace.info.assessments or []:
                 meta = getattr(assessment, "metadata", None) or {}
                 if meta.get(AssessmentMetadataKey.SOURCE_RUN_ID) != triage_eval.run_id:
@@ -593,7 +644,12 @@ def discover_issues(
         )
 
     # ---- Phase 2: Build analyses ----
-    analyses, session_groups = _build_analyses(triage_traces, rationale_map, scorer_name)
+    analyses, session_groups = _build_analyses(
+        triage_traces,
+        rationale_map,
+        scorer_name,
+        categories=categories,
+    )
 
     # ---- Phase 3: Cluster & identify ----
     identified = _cluster_and_identify(
@@ -630,6 +686,7 @@ def discover_issues(
         rationale_map,
         trace_lookup,
         model,
+        categories=categories,
         trace_to_session=trace_to_session if use_conversation else None,
         session_first_trace=session_first_trace,
         token_counter=token_counter,

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -62,27 +62,6 @@ from mlflow.utils.mlflow_tags import MLFLOW_RUN_TYPE, MLFLOW_RUN_TYPE_ISSUE_DETE
 _logger = logging.getLogger(__name__)
 
 
-def _extract_category_tags(rationale: str, known_categories: list[str] | None = None) -> list[str]:
-    """
-    Extract categories from triage rationale.
-
-    Looks for a line starting with "CATEGORIES:" and parses comma-separated values.
-    Filters by known_categories if provided (case-insensitive match).
-    """
-    for line in rationale.split("\n"):
-        stripped = line.strip()
-        if stripped.upper().startswith("CATEGORIES:"):
-            cats_str = stripped[len("CATEGORIES:") :].strip()
-            tags = [c.strip() for c in cats_str.split(",") if c.strip()]
-            if not tags:
-                return []
-            if known_categories:
-                known_lower = {c.lower() for c in known_categories}
-                return list(dict.fromkeys(t for t in tags if t.lower() in known_lower))
-            return list(dict.fromkeys(tags))
-    return []
-
-
 def _is_non_issue(issue: _IdentifiedIssue) -> bool:
     return issue.severity == "not_an_issue" or NO_ISSUE_KEYWORD.lower() in issue.name.lower()
 
@@ -232,6 +211,7 @@ def _annotate_issue_traces(
 def _build_analyses(
     triage_traces: list[Trace],
     rationale_map: dict[str, str],
+    categories_map: dict[str, list[str]],
     scorer_name: str,
     categories: list[str] | None = None,
 ) -> tuple[list[_ConversationAnalysis], dict[str, list[Trace]]]:
@@ -244,12 +224,15 @@ def _build_analyses(
     Args:
         triage_traces: All traces from the triage phase (passing and failing).
         rationale_map: Mapping of trace_id to triage rationale for failing traces.
+        categories_map: Mapping of trace_id to category tags from structured output.
         scorer_name: Name of the triage scorer, used to look up human feedback.
+        categories: Known valid categories to filter against.
 
     Returns:
         A tuple of (analyses, session_groups) where session_groups maps
         session_id to the list of traces in that session.
     """
+    known_lower = {c.lower() for c in categories} if categories else None
     session_groups = group_traces_by_session(triage_traces)
     analyses: list[_ConversationAnalysis] = []
     for _, session_traces in session_groups.items():
@@ -262,12 +245,17 @@ def _build_analyses(
         if not combined_rationale:
             continue
         exec_path = extract_execution_paths_for_session(session_failing)
+        session_cats = []
+        for trace in session_failing:
+            for cat in categories_map.get(trace.info.trace_id, []):
+                if not known_lower or cat.lower() in known_lower:
+                    session_cats.append(cat)
         analyses.append(
             _ConversationAnalysis(
                 full_rationale=combined_rationale,
                 affected_trace_ids=[trace.info.trace_id for trace in session_failing],
                 execution_path=exec_path,
-                categories=_extract_category_tags(combined_rationale, categories),
+                categories=list(dict.fromkeys(session_cats)),
             )
         )
     _logger.debug("Built %d analyses from triage rationales", len(analyses))
@@ -483,7 +471,7 @@ def build_issue_discovery_scorer(
         name=DEFAULT_SCORER_NAME,
         instructions=instructions,
         model=model,
-        feedback_value_type=bool,
+        feedback_value_type=dict[str, str],
     )
 
 
@@ -616,7 +604,9 @@ def discover_issues(
         _logger.debug("Failed to fetch scored traces", exc_info=True)
 
     scorer_names = [s.name for s in scorers]
-    failing_traces, rationale_map = extract_failing_traces(scored_traces, scorer_names)
+    failing_traces, rationale_map, categories_map = extract_failing_traces(
+        scored_traces, scorer_names
+    )
 
     _logger.info(
         "Triage complete: %d/%d traces unsatisfactory",
@@ -637,6 +627,7 @@ def discover_issues(
     analyses, session_groups = _build_analyses(
         triage_traces,
         rationale_map,
+        categories_map,
         scorer_name,
         categories=categories,
     )

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -19,7 +19,6 @@ from mlflow.environment_variables import (
 from mlflow.genai.discovery.clustering import (
     cluster_by_llm,
     recluster_singletons,
-    semantic_dedup_issues,
     summarize_cluster,
 )
 from mlflow.genai.discovery.constants import (
@@ -428,7 +427,7 @@ def _cluster_and_identify(
     analysis_labels: dict[int, str] = {}
     for label, analysis_idx in zip(labels, label_to_analysis):
         analysis_labels.setdefault(analysis_idx, label)
-    merged = _merge_singleton_issues(
+    return _merge_singleton_issues(
         identified,
         analysis_labels,
         analyses,
@@ -437,7 +436,6 @@ def _cluster_and_identify(
         categories=categories,
         token_counter=token_counter,
     )
-    return semantic_dedup_issues(merged, model, token_counter=token_counter)
 
 
 def _build_issues(

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -62,33 +61,26 @@ from mlflow.utils.mlflow_tags import MLFLOW_RUN_TYPE, MLFLOW_RUN_TYPE_ISSUE_DETE
 
 _logger = logging.getLogger(__name__)
 
-_CATEGORY_TAG_RE = re.compile(r"\[([a-zA-Z][a-zA-Z0-9 _-]*)\]")
-# Brackets used for non-category purposes in rationales (execution paths, etc.)
-_CATEGORY_TAG_BLOCKLIST = {
-    "human feedback",
-    "span errors",
-    "no issues found",
-    "no routing",
-    "ERROR",
-}
-
 
 def _extract_category_tags(rationale: str, known_categories: list[str] | None = None) -> list[str]:
-    """Extract category tags in square brackets from a rationale string.
-
-    If known_categories is provided, only returns tags that match one of them
-    (case-insensitive). Otherwise returns all bracketed tags that aren't in
-    the blocklist.
     """
-    tags = _CATEGORY_TAG_RE.findall(rationale)
-    if not tags:
-        return []
+    Extract categories from triage rationale.
 
-    if known_categories:
-        known_lower = {c.lower() for c in known_categories}
-        return list(dict.fromkeys(t for t in tags if t.lower() in known_lower))
-    else:
-        return list(dict.fromkeys(t for t in tags if t.lower() not in _CATEGORY_TAG_BLOCKLIST))
+    Looks for a line starting with "CATEGORIES:" and parses comma-separated values.
+    Filters by known_categories if provided (case-insensitive match).
+    """
+    for line in rationale.split("\n"):
+        stripped = line.strip()
+        if stripped.upper().startswith("CATEGORIES:"):
+            cats_str = stripped[len("CATEGORIES:") :].strip()
+            tags = [c.strip() for c in cats_str.split(",") if c.strip()]
+            if not tags:
+                return []
+            if known_categories:
+                known_lower = {c.lower() for c in known_categories}
+                return list(dict.fromkeys(t for t in tags if t.lower() in known_lower))
+            return list(dict.fromkeys(tags))
+    return []
 
 
 def _is_non_issue(issue: _IdentifiedIssue) -> bool:

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -604,17 +604,15 @@ def discover_issues(
         _logger.debug("Failed to fetch scored traces", exc_info=True)
 
     scorer_names = [s.name for s in scorers]
-    failing_traces, rationale_map, categories_map = extract_failing_traces(
-        scored_traces, scorer_names
-    )
+    triage = extract_failing_traces(scored_traces, scorer_names)
 
     _logger.info(
         "Triage complete: %d/%d traces unsatisfactory",
-        len(failing_traces),
+        len(triage.failing_traces),
         len(triage_traces),
     )
 
-    if not failing_traces:
+    if not triage.failing_traces:
         return DiscoverIssuesResult(
             issues=[],
             triage_run_id=triage_eval.run_id,
@@ -626,8 +624,8 @@ def discover_issues(
     # ---- Phase 2: Build analyses ----
     analyses, session_groups = _build_analyses(
         triage_traces,
-        rationale_map,
-        categories_map,
+        triage.rationale_map,
+        triage.categories_map,
         scorer_name,
         categories=categories,
     )
@@ -664,7 +662,7 @@ def discover_issues(
     _annotate_issue_traces(
         issues,
         issue_trace_ids,
-        rationale_map,
+        triage.rationale_map,
         trace_lookup,
         model,
         categories=categories,

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -245,11 +245,12 @@ def _build_analyses(
         if not combined_rationale:
             continue
         exec_path = extract_execution_paths_for_session(session_failing)
-        session_cats = []
-        for trace in session_failing:
-            for cat in categories_map.get(trace.info.trace_id, []):
-                if not known_lower or cat.lower() in known_lower:
-                    session_cats.append(cat)
+        session_cats = [
+            cat
+            for trace in session_failing
+            for cat in categories_map.get(trace.info.trace_id, [])
+            if not known_lower or cat.lower() in known_lower
+        ]
         analyses.append(
             _ConversationAnalysis(
                 full_rationale=combined_rationale,

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -213,7 +213,7 @@ def _build_analyses(
     rationale_map: dict[str, str],
     categories_map: dict[str, list[str]],
     scorer_name: str,
-    categories: list[str] | None = None,
+    categories: list[str] = DEFAULT_CATEGORIES,
 ) -> tuple[list[_ConversationAnalysis], dict[str, list[Trace]]]:
     """
     Build per-session analyses from triage results.
@@ -232,7 +232,7 @@ def _build_analyses(
         A tuple of (analyses, session_groups) where session_groups maps
         session_id to the list of traces in that session.
     """
-    known_lower = {c.lower() for c in categories} if categories else None
+    known_lower = {c.lower() for c in categories}
     session_groups = group_traces_by_session(triage_traces)
     analyses: list[_ConversationAnalysis] = []
     for _, session_traces in session_groups.items():
@@ -249,7 +249,7 @@ def _build_analyses(
             cat
             for trace in session_failing
             for cat in categories_map.get(trace.info.trace_id, [])
-            if not known_lower or cat.lower() in known_lower
+            if cat.lower() in known_lower
         ]
         analyses.append(
             _ConversationAnalysis(
@@ -363,7 +363,6 @@ def _cluster_and_identify(
     labels, label_to_analysis = extract_failure_labels(
         analyses,
         model,
-        categories=categories,
         token_counter=token_counter,
     )
     for i, label in enumerate(labels):
@@ -587,8 +586,15 @@ def discover_issues(
     scored_traces = triage_traces
     try:
         fetched = [mlflow.get_trace(t.info.trace_id) for t in triage_traces]
-        if all(f is not None for f in fetched):
+        fetched = [f for f in fetched if f is not None]
+        if len(fetched) == len(triage_traces):
             scored_traces = fetched
+        else:
+            _logger.debug(
+                "Could not re-fetch %d/%d traces, using originals",
+                len(triage_traces) - len(fetched),
+                len(triage_traces),
+            )
         # Aggregate judge costs from Phase 1 evaluation assessments.
         for trace in scored_traces:
             for assessment in trace.info.assessments or []:

--- a/mlflow/genai/discovery/utils.py
+++ b/mlflow/genai/discovery/utils.py
@@ -214,8 +214,13 @@ def format_trace_content(trace: Trace) -> str:
     return "\n".join(parts) if parts else "(trace content not available)"
 
 
-def format_annotation_prompt(issue: Issue, trace_content: str, triage_rationale: str) -> str:
-    return (
+def format_annotation_prompt(
+    issue: Issue,
+    trace_content: str,
+    triage_rationale: str,
+    categories: list[str] | None = None,
+) -> str:
+    prompt = (
         f"=== ISSUE ===\n"
         f"Name: {issue.name}\n"
         f"Description: {issue.description}\n"
@@ -225,3 +230,10 @@ def format_annotation_prompt(issue: Issue, trace_content: str, triage_rationale:
         f"=== TRIAGE JUDGE RATIONALE ===\n"
         f"{triage_rationale or '(not available)'}"
     )
+    if categories:
+        prompt += (
+            f"\n\n=== RELEVANT CATEGORIES ===\n"
+            f"{', '.join(categories)}\n"
+            f"Reference these categories in your rationale where applicable."
+        )
+    return prompt

--- a/mlflow/genai/discovery/utils.py
+++ b/mlflow/genai/discovery/utils.py
@@ -121,10 +121,12 @@ def build_summary(issues: list[Issue], total_traces: int) -> str:
     ]
     for i, issue in enumerate(issues, 1):
         root_causes = "; ".join(issue.root_causes) if issue.root_causes else "Unknown"
+        categories = ", ".join(issue.categories) if issue.categories else "None"
         lines.append(
             f"### {i}. {issue.name} (severity: {issue.severity})\n\n"
             f"{issue.description}\n\n"
-            f"**Root causes:** {root_causes}\n"
+            f"**Root causes:** {root_causes}\n\n"
+            f"**Categories:** {categories}\n"
         )
     return "\n".join(lines)
 

--- a/tests/genai/discovery/test_clustering.py
+++ b/tests/genai/discovery/test_clustering.py
@@ -187,4 +187,4 @@ def test_build_cluster_summary_prompt_with_categories():
     assert "hallucination" in prompt
     assert "tool_error" in prompt
     assert "latency" in prompt
-    assert "ONLY include categories from this list" in prompt
+    assert "Assign one or more categories from" in prompt

--- a/tests/genai/discovery/test_extraction.py
+++ b/tests/genai/discovery/test_extraction.py
@@ -154,13 +154,13 @@ def test_extract_failing_traces(make_trace):
     _add_feedback(traces[1], "satisfaction", False, "bad response")
     _add_feedback(traces[2], "satisfaction", False, "incomplete")
 
-    failing, rationales, _ = extract_failing_traces(_refetch(traces), "satisfaction")
+    result = extract_failing_traces(_refetch(traces), "satisfaction")
 
-    assert len(failing) == 2
-    assert failing[0].info.trace_id == traces[1].info.trace_id
-    assert failing[1].info.trace_id == traces[2].info.trace_id
-    assert rationales[traces[1].info.trace_id] == "bad response"
-    assert rationales[traces[2].info.trace_id] == "incomplete"
+    assert len(result.failing_traces) == 2
+    assert result.failing_traces[0].info.trace_id == traces[1].info.trace_id
+    assert result.failing_traces[1].info.trace_id == traces[2].info.trace_id
+    assert result.rationale_map[traces[1].info.trace_id] == "bad response"
+    assert result.rationale_map[traces[2].info.trace_id] == "incomplete"
 
 
 def test_extract_failing_traces_with_list_of_scorer_names(make_trace):
@@ -172,13 +172,13 @@ def test_extract_failing_traces_with_list_of_scorer_names(make_trace):
     _add_feedback(traces[2], "satisfaction", True, "good")
     _add_feedback(traces[2], "quality", False, "poor quality")
 
-    failing, rationales, _ = extract_failing_traces(_refetch(traces), ["satisfaction", "quality"])
+    result = extract_failing_traces(_refetch(traces), ["satisfaction", "quality"])
 
-    assert len(failing) == 2
-    assert failing[0].info.trace_id == traces[1].info.trace_id
-    assert failing[1].info.trace_id == traces[2].info.trace_id
-    assert rationales[traces[1].info.trace_id] == "bad response"
-    assert rationales[traces[2].info.trace_id] == "poor quality"
+    assert len(result.failing_traces) == 2
+    assert result.failing_traces[0].info.trace_id == traces[1].info.trace_id
+    assert result.failing_traces[1].info.trace_id == traces[2].info.trace_id
+    assert result.rationale_map[traces[1].info.trace_id] == "bad response"
+    assert result.rationale_map[traces[2].info.trace_id] == "poor quality"
 
 
 def test_extract_failing_traces_multiple_scorers_fail_same_row(make_trace):
@@ -188,35 +188,35 @@ def test_extract_failing_traces_multiple_scorers_fail_same_row(make_trace):
     _add_feedback(traces[1], "scorer_a", True, "ok")
     _add_feedback(traces[1], "scorer_b", True, "ok")
 
-    failing, rationales, _ = extract_failing_traces(_refetch(traces), ["scorer_a", "scorer_b"])
+    result = extract_failing_traces(_refetch(traces), ["scorer_a", "scorer_b"])
 
-    assert len(failing) == 1
-    assert failing[0].info.trace_id == traces[0].info.trace_id
-    assert "reason a" in rationales[traces[0].info.trace_id]
-    assert "reason b" in rationales[traces[0].info.trace_id]
+    assert len(result.failing_traces) == 1
+    assert result.failing_traces[0].info.trace_id == traces[0].info.trace_id
+    assert "reason a" in result.rationale_map[traces[0].info.trace_id]
+    assert "reason b" in result.rationale_map[traces[0].info.trace_id]
 
 
 def test_extract_failing_traces_empty_list():
-    failing, rationales, _ = extract_failing_traces([], "satisfaction")
-    assert failing == []
-    assert rationales == {}
+    result = extract_failing_traces([], "satisfaction")
+    assert result.failing_traces == []
+    assert result.rationale_map == {}
 
 
 def test_extract_failing_traces_no_matching_scorer(make_trace):
     traces = [make_trace()]
     _add_feedback(traces[0], "other_scorer", False, "bad")
 
-    failing, rationales, _ = extract_failing_traces(_refetch(traces), "satisfaction")
-    assert failing == []
+    result = extract_failing_traces(_refetch(traces), "satisfaction")
+    assert result.failing_traces == []
 
 
 def test_extract_failing_traces_no_failures(make_trace):
     traces = [make_trace()]
     _add_feedback(traces[0], "satisfaction", True, "good")
 
-    failing, rationales, _ = extract_failing_traces(_refetch(traces), "satisfaction")
-    assert failing == []
-    assert rationales == {}
+    result = extract_failing_traces(_refetch(traces), "satisfaction")
+    assert result.failing_traces == []
+    assert result.rationale_map == {}
 
 
 # ---- extract_assessment_rationale ----

--- a/tests/genai/discovery/test_extraction.py
+++ b/tests/genai/discovery/test_extraction.py
@@ -154,7 +154,7 @@ def test_extract_failing_traces(make_trace):
     _add_feedback(traces[1], "satisfaction", False, "bad response")
     _add_feedback(traces[2], "satisfaction", False, "incomplete")
 
-    failing, rationales = extract_failing_traces(_refetch(traces), "satisfaction")
+    failing, rationales, _ = extract_failing_traces(_refetch(traces), "satisfaction")
 
     assert len(failing) == 2
     assert failing[0].info.trace_id == traces[1].info.trace_id
@@ -172,7 +172,7 @@ def test_extract_failing_traces_with_list_of_scorer_names(make_trace):
     _add_feedback(traces[2], "satisfaction", True, "good")
     _add_feedback(traces[2], "quality", False, "poor quality")
 
-    failing, rationales = extract_failing_traces(_refetch(traces), ["satisfaction", "quality"])
+    failing, rationales, _ = extract_failing_traces(_refetch(traces), ["satisfaction", "quality"])
 
     assert len(failing) == 2
     assert failing[0].info.trace_id == traces[1].info.trace_id
@@ -188,7 +188,7 @@ def test_extract_failing_traces_multiple_scorers_fail_same_row(make_trace):
     _add_feedback(traces[1], "scorer_a", True, "ok")
     _add_feedback(traces[1], "scorer_b", True, "ok")
 
-    failing, rationales = extract_failing_traces(_refetch(traces), ["scorer_a", "scorer_b"])
+    failing, rationales, _ = extract_failing_traces(_refetch(traces), ["scorer_a", "scorer_b"])
 
     assert len(failing) == 1
     assert failing[0].info.trace_id == traces[0].info.trace_id
@@ -197,7 +197,7 @@ def test_extract_failing_traces_multiple_scorers_fail_same_row(make_trace):
 
 
 def test_extract_failing_traces_empty_list():
-    failing, rationales = extract_failing_traces([], "satisfaction")
+    failing, rationales, _ = extract_failing_traces([], "satisfaction")
     assert failing == []
     assert rationales == {}
 
@@ -206,7 +206,7 @@ def test_extract_failing_traces_no_matching_scorer(make_trace):
     traces = [make_trace()]
     _add_feedback(traces[0], "other_scorer", False, "bad")
 
-    failing, rationales = extract_failing_traces(_refetch(traces), "satisfaction")
+    failing, rationales, _ = extract_failing_traces(_refetch(traces), "satisfaction")
     assert failing == []
 
 
@@ -214,7 +214,7 @@ def test_extract_failing_traces_no_failures(make_trace):
     traces = [make_trace()]
     _add_feedback(traces[0], "satisfaction", True, "good")
 
-    failing, rationales = extract_failing_traces(_refetch(traces), "satisfaction")
+    failing, rationales, _ = extract_failing_traces(_refetch(traces), "satisfaction")
     assert failing == []
     assert rationales == {}
 

--- a/tests/genai/discovery/test_pipeline.py
+++ b/tests/genai/discovery/test_pipeline.py
@@ -78,7 +78,7 @@ def test_discover_issues_all_traces_pass(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}),
+            return_value=([], {}, {}),
         ) as mock_extract,
         patch("mlflow.genai.discovery.pipeline.mlflow.MlflowClient"),
         patch(
@@ -122,7 +122,7 @@ def test_discover_issues_full_pipeline(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=(failing, rationale_map),
+            return_value=(failing, rationale_map, {}),
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failure_labels",
@@ -179,7 +179,7 @@ def test_discover_issues_low_severity_issues_filtered(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=(failing, rationale_map),
+            return_value=(failing, rationale_map, {}),
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failure_labels",
@@ -245,7 +245,7 @@ def test_discover_issues_custom_satisfaction_scorer(make_trace):
         ) as mock_eval,
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}),
+            return_value=([], {}, {}),
         ),
         patch("mlflow.genai.discovery.pipeline.mlflow.MlflowClient"),
         patch(
@@ -275,7 +275,7 @@ def test_discover_issues_additional_scorers(make_trace):
         ) as mock_eval,
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}),
+            return_value=([], {}, {}),
         ),
         patch("mlflow.genai.discovery.pipeline.mlflow.MlflowClient"),
         patch(
@@ -351,7 +351,7 @@ def test_discover_issues_filters_non_issues(make_trace, issue_name):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=(failing, rationale_map),
+            return_value=(failing, rationale_map, {}),
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failure_labels",
@@ -854,7 +854,7 @@ def test_discover_issues_with_custom_run_id(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}),
+            return_value=([], {}, {}),
         ),
     ):
         result = discover_issues(traces=traces, run_id=custom_run_id)
@@ -870,7 +870,7 @@ def test_discover_issues_tags_run_with_issue_detection_marker(make_trace):
         patch("mlflow.genai.discovery.pipeline.verify_scorer"),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}),
+            return_value=([], {}, {}),
         ),
     ):
         result = discover_issues(traces=traces, scorers=[scorer])
@@ -935,7 +935,7 @@ def test_discover_issues_returns_total_cost_usd_field(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=(failing, rationale_map),
+            return_value=(failing, rationale_map, {}),
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failure_labels",
@@ -1009,7 +1009,7 @@ def test_discover_issues_returns_cost_when_all_pass(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}),
+            return_value=([], {}, {}),
         ),
     ):
         result = discover_issues(traces=traces)
@@ -1049,7 +1049,7 @@ def test_discover_issues_filters_invalid_categories(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=(failing, rationale_map),
+            return_value=(failing, rationale_map, {}),
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failure_labels",

--- a/tests/genai/discovery/test_pipeline.py
+++ b/tests/genai/discovery/test_pipeline.py
@@ -1099,7 +1099,7 @@ def test_discover_issues_with_mixed_session_traces(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}),
+            return_value=_TriageResult([], {}, {}),
         ),
     ):
         result = discover_issues(

--- a/tests/genai/discovery/test_pipeline.py
+++ b/tests/genai/discovery/test_pipeline.py
@@ -11,7 +11,12 @@ from mlflow.genai.discovery.constants import (
     DEFAULT_SCORER_NAME,
     build_satisfaction_instructions,
 )
-from mlflow.genai.discovery.entities import Issue, _ConversationAnalysis, _IdentifiedIssue
+from mlflow.genai.discovery.entities import (
+    Issue,
+    _ConversationAnalysis,
+    _IdentifiedIssue,
+    _TriageResult,
+)
 from mlflow.genai.discovery.pipeline import (
     _annotate_issue_traces,
     _is_non_issue,
@@ -78,7 +83,7 @@ def test_discover_issues_all_traces_pass(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}, {}),
+            return_value=_TriageResult([], {}, {}),
         ) as mock_extract,
         patch("mlflow.genai.discovery.pipeline.mlflow.MlflowClient"),
         patch(
@@ -122,7 +127,7 @@ def test_discover_issues_full_pipeline(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=(failing, rationale_map, {}),
+            return_value=_TriageResult(failing, rationale_map, {}),
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failure_labels",
@@ -179,7 +184,7 @@ def test_discover_issues_low_severity_issues_filtered(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=(failing, rationale_map, {}),
+            return_value=_TriageResult(failing, rationale_map, {}),
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failure_labels",
@@ -245,7 +250,7 @@ def test_discover_issues_custom_satisfaction_scorer(make_trace):
         ) as mock_eval,
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}, {}),
+            return_value=_TriageResult([], {}, {}),
         ),
         patch("mlflow.genai.discovery.pipeline.mlflow.MlflowClient"),
         patch(
@@ -275,7 +280,7 @@ def test_discover_issues_additional_scorers(make_trace):
         ) as mock_eval,
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}, {}),
+            return_value=_TriageResult([], {}, {}),
         ),
         patch("mlflow.genai.discovery.pipeline.mlflow.MlflowClient"),
         patch(
@@ -351,7 +356,7 @@ def test_discover_issues_filters_non_issues(make_trace, issue_name):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=(failing, rationale_map, {}),
+            return_value=_TriageResult(failing, rationale_map, {}),
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failure_labels",
@@ -854,7 +859,7 @@ def test_discover_issues_with_custom_run_id(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}, {}),
+            return_value=_TriageResult([], {}, {}),
         ),
     ):
         result = discover_issues(traces=traces, run_id=custom_run_id)
@@ -870,7 +875,7 @@ def test_discover_issues_tags_run_with_issue_detection_marker(make_trace):
         patch("mlflow.genai.discovery.pipeline.verify_scorer"),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}, {}),
+            return_value=_TriageResult([], {}, {}),
         ),
     ):
         result = discover_issues(traces=traces, scorers=[scorer])
@@ -935,7 +940,7 @@ def test_discover_issues_returns_total_cost_usd_field(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=(failing, rationale_map, {}),
+            return_value=_TriageResult(failing, rationale_map, {}),
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failure_labels",
@@ -1009,7 +1014,7 @@ def test_discover_issues_returns_cost_when_all_pass(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=([], {}, {}),
+            return_value=_TriageResult([], {}, {}),
         ),
     ):
         result = discover_issues(traces=traces)
@@ -1049,7 +1054,7 @@ def test_discover_issues_filters_invalid_categories(make_trace):
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failing_traces",
-            return_value=(failing, rationale_map, {}),
+            return_value=_TriageResult(failing, rationale_map, {}),
         ),
         patch(
             "mlflow.genai.discovery.pipeline.extract_failure_labels",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21764

### What changes are proposed in this pull request?

- Adopt **CLEARS framework** for default issue categories: **C**orrectness, **L**atency, **E**xecution, **A**dherence, **R**elevance, **S**afety
- Include category descriptions in all LLM prompts (triage, clustering, summary) so the model understands what each category means
- Thread category tags from triage through clustering, summarization, and annotation phases
- Require explicit category justification in issue descriptions with concrete evidence ("Categorized as" paragraph)
- Require specific tool/function/path names in root causes for developer actionability
- Remove separate semantic dedup pass — clustering handles dedup more effectively
- Add `category_rationale` field to `_IdentifiedIssue` for structured reasoning

#### CLEARS Categories

| Category | Description |
|---|---|
| Correctness | Output is factually accurate and grounded in provided data |
| Latency | Agent responds within acceptable time bounds |
| Execution | Agent successfully completes actions (tool calls, API steps) |
| Adherence | Response follows instructions, constraints, policies, and formatting |
| Relevance | Output is useful, directly addresses the user's request, and leaves the user satisfied with the interaction |
| Safety | Response avoids harmful, sensitive, or inappropriate content |

#### Dedup Strategy Comparison (Jarvis, 236 traces)

Tested separate semantic dedup post-pass (Version A) vs no post-pass / clustering-only (Version B):

| Metric | A (Separate dedup) | B (No separate dedup) |
|---|---|---|
| Issues found | 14 | **12** |
| Total time | 481.9s | **441.1s** |
| Duplication | 2/91 pairs (2%) | **1/66 pairs (2%)** |
| Actionability (weighted) | 92% | **100%** |
| Category Coherence | 100% | **100%** |

**Result: Version B (no separate dedup) is better across every metric** — fewer issues, faster, higher actionability.

#### Before/After Comparison (gpt-5.3-chat-latest, LLM-as-judge)

| Metric | v0.1.0 Jarvis | v0.4.0 Jarvis | v0.1.0 Assistant | v0.4.0 Assistant |
|---|---|---|---|---|
| Issues found | 10 | 12 | 8 | 5 |
| No Duplicates | 98% | **98%** | 82% | **100%** |
| Actionability (weighted) | 100% | **100%** | 100% | **100%** |
| Category Coherence | 0% | **100%** | 0% | **100%** |

<details>
<summary>Addendum: Initial v0.3.6 Results (with separate semantic dedup)</summary>

| Metric | v0.1.0 Jarvis | v0.3.6 Jarvis | v0.1.0 Assistant | v0.3.6 Assistant |
|---|---|---|---|---|
| Issues found | 10 | 12 | 8 | 5 |
| No Duplicates | 98% | **100%** | 82% | **100%** |
| Actionability (weighted) | 100% | **100%** | 100% | **100%** |
| Category Coherence | 0% | **100%** | 0% | **100%** |

</details>

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

`tests/genai/discovery/test_pipeline.py` — 44 passed
`tests/genai/discovery/test_clustering.py` — 7 passed (updated assertion for new prompt wording)

Example issue:
```
### 1. False playback success claims (severity: high)

The assistant repeatedly told the user that Spotify playback had resumed even though no playback actually started. The user explicitly reported that it was not working, yet the assistant continued to assert success. It also gave conflicting states (claiming playback resumed, then saying nothing was playing, then claiming success again), and suggested irrelevant alternatives like switching music services it could not control.

**Root causes:** The run_orchestrator_assistant > ask_media_playback_assistant > run_media_playback_assistant > resume_spotify execution path appears to return or assume success without validating the actual playback state from Spotify. The system lacks a confirmation step (e.g., checking current playback status after resume_spotify) and does not propagate failure states properly, leading the assistant to hallucinate success and provide inconsistent state updates.
```

**Categories:** execution, correctness, relevance

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
