### PR TITLE
Filter environment markers in dependency mismatch warnings

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -683,8 +683,19 @@ def warn_dependency_requirement_mismatches(model_requirements: list[str]):
 
     try:
         mismatch_infos = []
-        for req in model_requirements:
-            mismatch_info = _check_requirement_satisfied(req)
+        for req_str in model_requirements:
+            # Skip requirements whose environment markers don't match the
+            # current platform. uv export produces requirements with markers
+            # like 'numpy==2.4.3; python_full_version >= "3.11"' that should
+            # not trigger warnings on Python 3.10.
+            try:
+                parsed = Requirement(req_str)
+                if parsed.marker and not parsed.marker.evaluate():
+                    continue
+            except Exception:
+                pass
+
+            mismatch_info = _check_requirement_satisfied(req_str)
             if mismatch_info is not None:
                 if _normalize_package_name(mismatch_info.package_name) in ignore_packages:
                     continue

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -768,3 +768,66 @@ def test_capture_imported_modules_excludes_pyspark_gateway_env_vars(monkeypatch,
     mock_run.assert_called_once()
     assert "PYSPARK_GATEWAY_PORT" not in captured_env
     assert "PYSPARK_GATEWAY_SECRET" not in captured_env
+
+
+def test_warn_dependency_skips_non_matching_environment_markers():
+    """Requirements with environment markers that don't match the current
+    platform should not trigger spurious warnings. This covers the uv export
+    format which includes markers like 'python_full_version >= "3.11"' and
+    'sys_platform == "linux"'.
+    """
+    import sys
+
+    reqs = [
+        # Marker that doesn't match current Python (one of these will be False)
+        f'fakepkg==1.0; python_full_version < "0.1"',
+        # Platform marker that can't match (nonexistent platform)
+        'fakepkg2==1.0; sys_platform == "nonexistent_platform"',
+    ]
+
+    with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warn:
+        warn_dependency_requirement_mismatches(reqs)
+        mock_warn.assert_not_called()
+
+
+def test_warn_dependency_fires_for_matching_marker_with_missing_package():
+    """Requirements with markers that DO match should still trigger warnings
+    if the package is not installed.
+    """
+    import sys
+
+    reqs = [
+        # This marker always matches (current platform)
+        f'totally_fake_nonexistent_pkg==1.0; sys_platform == "{sys.platform}"',
+    ]
+
+    with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warn:
+        warn_dependency_requirement_mismatches(reqs)
+        mock_warn.assert_called_once()
+        warning_msg = mock_warn.call_args[0][0]
+        assert "totally_fake_nonexistent_pkg" in warning_msg
+
+
+def test_warn_dependency_skips_uv_style_dual_markers():
+    """uv export produces two entries for the same package with different
+    markers (e.g., numpy for Python 3.10 and 3.11). Only the entry matching
+    the current Python should be evaluated.
+    """
+    import sys
+
+    major, minor = sys.version_info[:2]
+    # One marker matches, one doesn't
+    reqs = [
+        f'fakepkg==1.0; python_full_version < "{major}.{minor}"',
+        f'fakepkg==2.0; python_full_version >= "{major}.{minor}"',
+    ]
+
+    with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warn:
+        warn_dependency_requirement_mismatches(reqs)
+        # Should warn about fakepkg==2.0 (matching marker, package not installed)
+        # Should NOT warn about fakepkg==1.0 (non-matching marker)
+        if mock_warn.called:
+            warning_msg = mock_warn.call_args[0][0]
+            assert "fakepkg==2.0" in warning_msg or "fakepkg" in warning_msg
+            # Should NOT contain the non-matching version
+            assert f'fakepkg==1.0; python_full_version < "{major}.{minor}"' not in warning_msg


### PR DESCRIPTION
### Related Issues/PRs

Closes #21765

### What changes are proposed in this pull request?

`warn_dependency_requirement_mismatches` emits spurious warnings for requirements with environment markers from uv export. For example:

```
numpy==2.4.3; python_full_version >= "3.11"
nvidia-nccl-cu12==2.29.7; sys_platform == "linux"
```

These should be silently skipped when the markers don't match the current environment. The existing check in `_check_requirement_satisfied` (line 624) handles individual requirements, but this adds a defensive pre-filter at the caller level to skip non-applicable requirements early before version checking.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Three new tests:
1. `test_warn_dependency_skips_non_matching_environment_markers` - no warning for non-matching markers
2. `test_warn_dependency_fires_for_matching_marker_with_missing_package` - warning fires when marker matches but package missing
3. `test_warn_dependency_skips_uv_style_dual_markers` - uv dual-marker format only warns for matching marker

Manual test: called `warn_dependency_requirement_mismatches` with exact requirement strings from the issue on Python 3.10/macOS. Non-matching markers correctly suppressed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix spurious dependency mismatch warnings when loading models logged with uv environment markers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release