### PR TITLE
Add `X-MLflow-Gateway-Caller` header to track gateway invocation source

### DIFF
--- a/mlflow/gateway/constants.py
+++ b/mlflow/gateway/constants.py
@@ -1,3 +1,14 @@
+from enum import Enum
+
+MLFLOW_GATEWAY_CALLER_HEADER = "X-MLflow-Gateway-Caller"
+
+
+class GatewayCaller(str, Enum):
+    """Known callers of the gateway, sent via the X-MLflow-Gateway-Caller header."""
+
+    JUDGE = "judge"
+
+
 MLFLOW_GATEWAY_HEALTH_ENDPOINT = "/health"
 MLFLOW_GATEWAY_CRUD_ROUTE_BASE = "/api/2.0/gateway/routes/"
 MLFLOW_GATEWAY_CRUD_ENDPOINT_V3_BASE = "/api/3.0/gateway/endpoint/"

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -263,7 +263,7 @@ def _invoke_litellm_and_handle_tools(
         api_key = config.api_key
         extra_headers = {
             **(config.extra_headers or {}),
-            MLFLOW_GATEWAY_CALLER_HEADER: GatewayCaller.JUDGE,
+            MLFLOW_GATEWAY_CALLER_HEADER: GatewayCaller.JUDGE.value,
         }
         model = config.model
     else:

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -39,7 +39,10 @@ from mlflow.genai.judges.utils.tool_calling_utils import (
     _process_tool_calls,
     _raise_iteration_limit_exceeded,
 )
-from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
+from mlflow.genai.utils.gateway_utils import (
+    MLFLOW_GATEWAY_CALLER_HEADER,
+    get_gateway_litellm_config,
+)
 from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
 from mlflow.tracing.constant import AssessmentMetadataKey
 
@@ -260,7 +263,7 @@ def _invoke_litellm_and_handle_tools(
         config = get_gateway_litellm_config(model_name)
         api_base = config.api_base
         api_key = config.api_key
-        extra_headers = config.extra_headers
+        extra_headers = {**(config.extra_headers or {}), MLFLOW_GATEWAY_CALLER_HEADER: "judge"}
         model = config.model
     else:
         model = f"{provider}/{model_name}"

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -22,6 +22,7 @@ from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.environment_variables import MLFLOW_JUDGE_MAX_ITERATIONS
 from mlflow.exceptions import MlflowException
+from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER, GatewayCaller
 from mlflow.genai.judges.adapters.base_adapter import (
     AdapterInvocationInput,
     AdapterInvocationOutput,
@@ -39,10 +40,7 @@ from mlflow.genai.judges.utils.tool_calling_utils import (
     _process_tool_calls,
     _raise_iteration_limit_exceeded,
 )
-from mlflow.genai.utils.gateway_utils import (
-    MLFLOW_GATEWAY_CALLER_HEADER,
-    get_gateway_litellm_config,
-)
+from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
 from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
 from mlflow.tracing.constant import AssessmentMetadataKey
 
@@ -263,7 +261,10 @@ def _invoke_litellm_and_handle_tools(
         config = get_gateway_litellm_config(model_name)
         api_base = config.api_base
         api_key = config.api_key
-        extra_headers = {**(config.extra_headers or {}), MLFLOW_GATEWAY_CALLER_HEADER: "judge"}
+        extra_headers = {
+            **(config.extra_headers or {}),
+            MLFLOW_GATEWAY_CALLER_HEADER: GatewayCaller.JUDGE,
+        }
         model = config.model
     else:
         model = f"{provider}/{model_name}"

--- a/mlflow/genai/utils/gateway_utils.py
+++ b/mlflow/genai/utils/gateway_utils.py
@@ -9,8 +9,6 @@ from mlflow.tracking import get_tracking_uri
 from mlflow.utils.credentials import read_mlflow_creds
 from mlflow.utils.uri import append_to_uri_path, is_http_uri
 
-MLFLOW_GATEWAY_CALLER_HEADER = "X-MLflow-Gateway-Caller"
-
 
 @dataclass
 class GatewayLiteLLMConfig:

--- a/mlflow/genai/utils/gateway_utils.py
+++ b/mlflow/genai/utils/gateway_utils.py
@@ -9,6 +9,8 @@ from mlflow.tracking import get_tracking_uri
 from mlflow.utils.credentials import read_mlflow_creds
 from mlflow.utils.uri import append_to_uri_path, is_http_uri
 
+MLFLOW_GATEWAY_CALLER_HEADER = "X-MLflow-Gateway-Caller"
+
 
 @dataclass
 class GatewayLiteLLMConfig:

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -129,6 +129,14 @@ def _record_gateway_invocation(invocation_type: GatewayInvocationType) -> Callab
             success = True
             result = None
 
+            # Extract caller header from the Request object if present
+            caller = None
+            request = next((a for a in (*args, *kwargs.values()) if isinstance(a, Request)), None)
+            if request is not None:
+                from mlflow.genai.utils.gateway_utils import MLFLOW_GATEWAY_CALLER_HEADER
+
+                caller = request.headers.get(MLFLOW_GATEWAY_CALLER_HEADER)
+
             try:
                 result = await func(*args, **kwargs)
                 return result  # noqa: RET504
@@ -137,12 +145,15 @@ def _record_gateway_invocation(invocation_type: GatewayInvocationType) -> Callab
                 raise
             finally:
                 duration_ms = int((time.time() - start_time) * 1000)
+                params = {
+                    "is_streaming": isinstance(result, StreamingResponse),
+                    "invocation_type": invocation_type,
+                }
+                if caller:
+                    params["caller"] = caller
                 _record_event(
                     GatewayInvocationEvent,
-                    params={
-                        "is_streaming": isinstance(result, StreamingResponse),
-                        "invocation_type": invocation_type,
-                    },
+                    params=params,
                     success=success,
                     duration_ms=duration_ms,
                 )

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -30,6 +30,7 @@ from mlflow.gateway.config import (
     Provider,
     _AuthConfigKey,
 )
+from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER, GatewayCaller
 from mlflow.gateway.providers import get_provider
 from mlflow.gateway.providers.base import (
     PASSTHROUGH_ROUTES,
@@ -41,7 +42,6 @@ from mlflow.gateway.providers.base import (
 from mlflow.gateway.schemas import chat, embeddings
 from mlflow.gateway.tracing_utils import aggregate_chat_stream_chunks, maybe_traced_gateway_call
 from mlflow.gateway.utils import safe_stream, to_sse_chunk, translate_http_exception
-from mlflow.genai.utils.gateway_utils import MLFLOW_GATEWAY_CALLER_HEADER
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.server.gateway_budget import check_budget_limit, make_budget_on_complete
 from mlflow.store.tracking.abstract_store import AbstractStore
@@ -130,11 +130,14 @@ def _record_gateway_invocation(invocation_type: GatewayInvocationType) -> Callab
             success = True
             result = None
 
-            # Extract caller header from the Request object if present
+            # Extract caller header from the Request object if present,
+            # only accepting known caller values to avoid logging arbitrary input.
             caller = None
             request = next((a for a in (*args, *kwargs.values()) if isinstance(a, Request)), None)
             if request is not None:
-                caller = request.headers.get(MLFLOW_GATEWAY_CALLER_HEADER)
+                raw_caller = request.headers.get(MLFLOW_GATEWAY_CALLER_HEADER)
+                if raw_caller in GatewayCaller._value2member_map_:
+                    caller = raw_caller
 
             try:
                 result = await func(*args, **kwargs)

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -41,6 +41,7 @@ from mlflow.gateway.providers.base import (
 from mlflow.gateway.schemas import chat, embeddings
 from mlflow.gateway.tracing_utils import aggregate_chat_stream_chunks, maybe_traced_gateway_call
 from mlflow.gateway.utils import safe_stream, to_sse_chunk, translate_http_exception
+from mlflow.genai.utils.gateway_utils import MLFLOW_GATEWAY_CALLER_HEADER
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.server.gateway_budget import check_budget_limit, make_budget_on_complete
 from mlflow.store.tracking.abstract_store import AbstractStore
@@ -133,8 +134,6 @@ def _record_gateway_invocation(invocation_type: GatewayInvocationType) -> Callab
             caller = None
             request = next((a for a in (*args, *kwargs.values()) if isinstance(a, Request)), None)
             if request is not None:
-                from mlflow.genai.utils.gateway_utils import MLFLOW_GATEWAY_CALLER_HEADER
-
                 caller = request.headers.get(MLFLOW_GATEWAY_CALLER_HEADER)
 
             try:

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -136,7 +136,7 @@ def _record_gateway_invocation(invocation_type: GatewayInvocationType) -> Callab
             request = next((a for a in (*args, *kwargs.values()) if isinstance(a, Request)), None)
             if request is not None:
                 raw_caller = request.headers.get(MLFLOW_GATEWAY_CALLER_HEADER)
-                if raw_caller in GatewayCaller._value2member_map_:
+                if raw_caller in {e.value for e in GatewayCaller}:
                     caller = raw_caller
 
             try:

--- a/tests/genai/judges/adapters/test_litellm_adapter.py
+++ b/tests/genai/judges/adapters/test_litellm_adapter.py
@@ -10,6 +10,7 @@ from mlflow.entities.trace import Trace
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_location import TraceLocation
 from mlflow.entities.trace_state import TraceState
+from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER
 from mlflow.genai.judges.adapters.litellm_adapter import (
     _MODEL_RESPONSE_FORMAT_CAPABILITIES,
     _invoke_litellm,
@@ -363,7 +364,7 @@ def test_gateway_provider_integration():
     assert call_kwargs["model"] == "openai/my-endpoint"
     assert call_kwargs["api_base"] == "http://localhost:5000/gateway/mlflow/v1/"
     assert call_kwargs["api_key"] == "mlflow-gateway-auth"
-    assert call_kwargs["extra_headers"]["X-MLflow-Gateway-Caller"] == "judge"
+    assert call_kwargs["extra_headers"][MLFLOW_GATEWAY_CALLER_HEADER] == "judge"
 
 
 def test_gateway_provider_requires_http_tracking_uri():

--- a/tests/genai/judges/adapters/test_litellm_adapter.py
+++ b/tests/genai/judges/adapters/test_litellm_adapter.py
@@ -363,6 +363,7 @@ def test_gateway_provider_integration():
     assert call_kwargs["model"] == "openai/my-endpoint"
     assert call_kwargs["api_base"] == "http://localhost:5000/gateway/mlflow/v1/"
     assert call_kwargs["api_key"] == "mlflow-gateway-auth"
+    assert call_kwargs["extra_headers"]["X-MLflow-Gateway-Caller"] == "judge"
 
 
 def test_gateway_provider_requires_http_tracking_uri():

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 import sklearn.neighbors as knn
 from click.testing import CliRunner
+from fastapi import Request
 
 import mlflow
 from mlflow import MlflowClient
@@ -2144,6 +2145,39 @@ async def test_gateway_invocation_telemetry(
         mock_requests,
         GatewayInvocationEvent.name,
         {"is_streaming": True, "invocation_type": "mlflow_chat_completions"},
+    )
+
+    # Test that caller header is included in telemetry when present
+    mock_request = MagicMock(spec=Request)
+    mock_request.json = AsyncMock(
+        return_value={
+            "model": endpoint.name,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": False,
+        }
+    )
+    mock_request.headers = {"X-MLflow-Gateway-Caller": "judge"}
+
+    with (
+        patch("mlflow.server.gateway_api._get_store", return_value=store),
+        patch(
+            "mlflow.server.gateway_api._create_provider_from_endpoint_name"
+        ) as mock_create_provider,
+    ):
+        mock_provider = MagicMock()
+        mock_provider.chat = AsyncMock(return_value=mock_response)
+        mock_endpoint_config = GatewayEndpointConfig(
+            endpoint_id=endpoint.endpoint_id, endpoint_name=endpoint.name, models=[]
+        )
+        mock_create_provider.return_value = (mock_provider, mock_endpoint_config)
+
+        await chat_completions(mock_request)
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        GatewayInvocationEvent.name,
+        {"is_streaming": False, "invocation_type": "mlflow_chat_completions", "caller": "judge"},
     )
 
 

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -32,6 +32,7 @@ from mlflow.entities.gateway_endpoint import GatewayModelLinkageType
 from mlflow.entities.trace import Trace
 from mlflow.entities.webhook import WebhookAction, WebhookEntity, WebhookEvent
 from mlflow.gateway.cli import start
+from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER
 from mlflow.gateway.schemas import chat
 from mlflow.genai.datasets import create_dataset
 from mlflow.genai.judges import make_judge
@@ -2156,7 +2157,7 @@ async def test_gateway_invocation_telemetry(
             "stream": False,
         }
     )
-    mock_request.headers = {"X-MLflow-Gateway-Caller": "judge"}
+    mock_request.headers = {MLFLOW_GATEWAY_CALLER_HEADER: "judge"}
 
     with (
         patch("mlflow.server.gateway_api._get_store", return_value=store),


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

- Add `X-MLflow-Gateway-Caller` header constant in `gateway_utils.py`
- Set the header to `"judge"` when judges invoke the gateway via LiteLLM adapter
- Extract the caller header in `_record_gateway_invocation` and include it as a `caller` param in `GatewayInvocationEvent` telemetry

This enables tracking which component (e.g., judge, scorer) is making gateway invocations.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release