### PR TITLE
Docs: Add supported API styles summary table to Query Endpoints page

### DIFF
--- a/docs/docs/genai/governance/ai-gateway/endpoints/query-endpoints.mdx
+++ b/docs/docs/genai/governance/ai-gateway/endpoints/query-endpoints.mdx
@@ -9,6 +9,18 @@ import TabItem from "@theme/TabItem";
 
 Once you've created an endpoint, you can call it through several different API styles depending on your needs.
 
+## Supported API Styles
+
+The following table summarizes all the ways you can query gateway endpoints:
+
+| Category        | API Style                          | URL Pattern                                                                                                                 | Description                                                                                                                        |
+| --------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Unified**     | MLflow Invocations                 | `POST /gateway/{endpoint_name}/mlflow/invocations`                                                                          | Native MLflow interface supporting chat completions and embeddings. Handles routing features like traffic splitting and fallbacks. |
+| **Unified**     | OpenAI-compatible Chat Completions | `POST /gateway/mlflow/v1/chat/completions`                                                                                  | Drop-in replacement for the OpenAI chat completions API. Use the endpoint name as the `model` parameter.                           |
+| **Passthrough** | OpenAI                             | `POST /gateway/openai/v1/chat/completions`<br/>`POST /gateway/openai/v1/embeddings`<br/>`POST /gateway/openai/v1/responses` | Full OpenAI API access including Chat Completions, Embeddings, and Responses endpoints.                                            |
+| **Passthrough** | Anthropic                          | `POST /gateway/anthropic/v1/messages`                                                                                       | Direct access to Anthropic's Messages API.                                                                                         |
+| **Passthrough** | Google Gemini                      | `POST /gateway/gemini/v1beta/models/{endpoint_name}:generateContent`                                                        | Google Gemini's native generateContent API.                                                                                        |
+
 ## Viewing Usage Examples
 
 To see code examples for your endpoint, navigate to the Endpoints list and click either the Use button or the endpoint name itself. This opens a modal with comprehensive usage examples tailored to your specific endpoint.


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds a summary table at the top of the Query Endpoints documentation page that lists all supported API styles (Unified and Passthrough) with their URL patterns and descriptions. This gives readers a quick overview before diving into the detailed sections.

### How is this PR tested?

- [x] Manual tests

Verified the table renders correctly in the Docusaurus docs site.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release