### PR TITLE
Fix `mlflow.gateway.setup_guide` telemetry event being silently dropped

### DIFF
--- a/mlflow/server/js/src/telemetry/TelemetryClient.ts
+++ b/mlflow/server/js/src/telemetry/TelemetryClient.ts
@@ -94,8 +94,9 @@ class TelemetryClient {
       return;
     }
 
-    // drop view events to reduce noise
-    if (record.eventType === 'onView') {
+    // drop view events to reduce noise, except for explicitly tracked impressions
+    const VIEW_EVENT_ALLOWLIST = ['mlflow.gateway.setup_guide'];
+    if (record.eventType === 'onView' && !VIEW_EVENT_ALLOWLIST.includes(record.componentId)) {
       return;
     }
 

--- a/mlflow/server/js/src/telemetry/TelemetryClient.ts
+++ b/mlflow/server/js/src/telemetry/TelemetryClient.ts
@@ -17,6 +17,9 @@ import { getLocalStorageItem } from '../shared/web-shared/hooks/useLocalStorage'
 
 const LOCAL_STORAGE_INSTALLATION_ID_KEY = 'mlflow-telemetry-installation-id';
 
+// Components whose onView events should be tracked (intentional impressions, not noise)
+const VIEW_EVENT_ALLOWLIST: ReadonlySet<string> = new Set(['mlflow.gateway.setup_guide']);
+
 class TelemetryClient {
   private installationId: string = this.getInstallationId();
   private port: MessagePort | null = null;
@@ -95,8 +98,7 @@ class TelemetryClient {
     }
 
     // drop view events to reduce noise, except for explicitly tracked impressions
-    const VIEW_EVENT_ALLOWLIST = ['mlflow.gateway.setup_guide'];
-    if (record.eventType === 'onView' && !VIEW_EVENT_ALLOWLIST.includes(record.componentId)) {
+    if (record.eventType === 'onView' && !VIEW_EVENT_ALLOWLIST.has(record.componentId)) {
       return;
     }
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The `mlflow.gateway.setup_guide` `OnView` telemetry event was never actually logged because `TelemetryClient.logEvent()` blanket-drops all `onView` events to reduce noise from design-system components. This PR adds an allowlist so intentional impression tracking (like the gateway setup guide) is preserved while still filtering noisy view events.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified that the `mlflow.gateway.setup_guide` event is now logged in the console with `MLFLOW_TELEMETRY_DEV_LOGGING=true`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release