### PR TITLE
Reproduce flaky `test_exclusive_job_allows_different_params`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -63,7 +63,7 @@ jobs:
           ./dev/run-python-skinny-tests.sh
 
   python:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: true
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -71,9 +71,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4]
+        runner: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         include:
           - splits: 4
+          - group: 1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -93,13 +94,11 @@ jobs:
       - uses: ./.github/actions/pipdeptree
       - name: Import check
         run: |
-          # `-I` is used to avoid importing modules from user-specific site-packages
-          # that might conflict with the built-in modules (e.g. `types`).
           uv run --no-sync python -I tests/check_mlflow_lazily_imports_ml_packages.py
       - name: Run tests
         run: |
           source dev/setup-ssh.sh
-          uv run --no-sync pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
+          uv run --no-sync pytest -x --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
             --quiet --requires-ssh --ignore-flavors \
             --ignore=tests/examples \
             --ignore=tests/evaluate \
@@ -109,8 +108,6 @@ jobs:
 
       - name: Run databricks-connect related tests
         run: |
-          # this needs to be run in a separate job because installing databricks-connect could break other
-          # tests that uses normal SparkSession instead of remote SparkSession
           uv run --no-sync --with 'databricks-agents,databricks-connect' \
             pytest tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -71,10 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        include:
-          - splits: 4
-          - group: 1
+        runner: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -92,24 +89,20 @@ jobs:
             -r requirements/extra-ml-requirements.txt
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
-      - name: Import check
-        run: |
-          uv run --no-sync python -I tests/check_mlflow_lazily_imports_ml_packages.py
       - name: Run tests
+        env:
+          # Runners 11-20 enable the fix; 1-10 use the old behavior
+          _MLFLOW_FIX_SERVER_UP_TIME: ${{ matrix.runner > 10 && '1' || '' }}
         run: |
+          echo "Runner ${{ matrix.runner }}: fix=${{ matrix.runner > 10 && 'ON' || 'OFF' }}"
           source dev/setup-ssh.sh
-          uv run --no-sync pytest -x --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
+          uv run --no-sync pytest -x --splits=4 --group=3 \
             --quiet --requires-ssh --ignore-flavors \
             --ignore=tests/examples \
             --ignore=tests/evaluate \
             --ignore=tests/genai \
             --ignore=tests/docker \
             tests
-
-      - name: Run databricks-connect related tests
-        run: |
-          uv run --no-sync --with 'databricks-agents,databricks-connect' \
-            pytest tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
 
   database:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -219,6 +219,10 @@ def submit_job(
     job_store = _get_job_store()
     serialized_params = json.dumps(params)
     job = job_store.create_job(fn_meta.name, serialized_params, timeout)
+    _logger.info(
+        f"submit_job: created job {job.job_id} "
+        f"(name={fn_meta.name}, creation_time={job.creation_time})"
+    )
     # Only propagate workspace to subprocess when workspaces are enabled
     workspace = job.workspace if MLFLOW_ENABLE_WORKSPACES.get() else None
 

--- a/mlflow/server/jobs/_job_runner.py
+++ b/mlflow/server/jobs/_job_runner.py
@@ -26,7 +26,12 @@ from mlflow.server.jobs.utils import (
 
 if __name__ == "__main__":
     logger = logging.getLogger("mlflow.server.jobs._job_runner")
-    server_up_time = int(time.time() * 1000)
+    if "_MLFLOW_SERVER_UP_TIME" in os.environ:
+        server_up_time = int(os.environ["_MLFLOW_SERVER_UP_TIME"])
+        logger.info(f"Job runner started, server_up_time={server_up_time} (from parent)")
+    else:
+        server_up_time = int(time.time() * 1000)
+        logger.info(f"Job runner started, server_up_time={server_up_time} (local)")
     _start_watcher_to_kill_job_runner_if_mlflow_server_dies()
 
     huey_store_path = os.environ[HUEY_STORAGE_PATH_ENV_VAR]

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -343,9 +343,15 @@ def _exec_job(
             if MLFLOW_ENABLE_WORKSPACES.get():
                 lock_key_job_name = f"{workspace or DEFAULT_WORKSPACE_NAME}:{job_name}"
             lock_key = _compute_exclusive_lock_key(lock_key_job_name, lock_params)
+            _logger.info(
+                f"Attempting to acquire exclusive lock for job {job_id} "
+                f"(job_name={job_name}, lock_key={lock_key}, "
+                f"lock_params={json.dumps(lock_params, sort_keys=True)})"
+            )
             lock = huey_instance.lock_task(lock_key)
             try:
                 lock.acquire()
+                _logger.info(f"Acquired exclusive lock {lock_key} for job {job_id}")
             except TaskLockedException:
                 _logger.info(f"Skipping job {job_id} - exclusive lock {lock_key} already held")
                 job_store.cancel_job(job_id)
@@ -393,6 +399,7 @@ def _exec_job(
                 job_store.fail_job(job_id, job_result.error)
         finally:
             if lock is not None:
+                _logger.info(f"Releasing exclusive lock for job {job_id} (lock_key={lock_key})")
                 lock.release()
 
 

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -550,13 +550,19 @@ def _start_periodic_tasks_consumer_proc():
 
 
 def _launch_job_runner(env_map, server_proc_pid):
+    env = {**os.environ, **env_map, "MLFLOW_SERVER_PID": str(server_proc_pid)}
+    # When _MLFLOW_FIX_SERVER_UP_TIME is set, pass the timestamp from the parent
+    # process to avoid the race condition where slow subprocess imports cause
+    # server_up_time to be captured after jobs are already submitted.
+    if os.environ.get("_MLFLOW_FIX_SERVER_UP_TIME"):
+        env["_MLFLOW_SERVER_UP_TIME"] = str(int(time.time() * 1000))
     return subprocess.Popen(
         [
             sys.executable,
             "-m",
             "mlflow.server.jobs._job_runner",
         ],
-        env={**os.environ, **env_map, "MLFLOW_SERVER_PID": str(server_proc_pid)},
+        env=env,
     )
 
 
@@ -617,16 +623,30 @@ def _enqueue_unfinished_jobs(server_launching_timestamp: int) -> None:
     from mlflow.server.handlers import _get_job_store
 
     job_store = _get_job_store()
+    _logger.info(
+        f"_enqueue_unfinished_jobs called at {int(time.time() * 1000)} "
+        f"with server_launching_timestamp={server_launching_timestamp}"
+    )
 
     for workspace_ctx in _workspace_contexts_for_recovery():
         with workspace_ctx as workspace:
-            unfinished_jobs = job_store.list_jobs(
-                statuses=[JobStatus.PENDING, JobStatus.RUNNING],
-                # filter out jobs created after the server is launched.
-                end_timestamp=server_launching_timestamp,
+            unfinished_jobs = list(
+                job_store.list_jobs(
+                    statuses=[JobStatus.PENDING, JobStatus.RUNNING],
+                    # filter out jobs created after the server is launched.
+                    end_timestamp=server_launching_timestamp,
+                )
+            )
+            _logger.info(
+                f"Found {len(unfinished_jobs)} unfinished jobs "
+                f"with creation_time <= {server_launching_timestamp}"
             )
 
             for job in unfinished_jobs:
+                _logger.info(
+                    f"Re-enqueuing job {job.job_id} (name={job.job_name}, "
+                    f"status={job.status}, creation_time={job.creation_time})"
+                )
                 if job.status == JobStatus.RUNNING:
                     job_store.reset_job(job.job_id)  # reset the job status to PENDING
 

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -925,13 +925,3 @@ def test_update_status_details_on_nonexistent_job(tmp_path: Path):
 
     with pytest.raises(MlflowException, match="Job .+ not found"):
         store.update_status_details("nonexistent-job-id", {"stage": "test"})
-
-
-@pytest.mark.parametrize("_iteration", range(50))
-def test_exclusive_job_sequence_repeated(monkeypatch, tmp_path: Path, _iteration):
-    dup_path = tmp_path / "dup"
-    dup_path.mkdir()
-    test_exclusive_job_skips_duplicate(monkeypatch, dup_path)
-    diff_path = tmp_path / "diff"
-    diff_path.mkdir()
-    test_exclusive_job_allows_different_params(monkeypatch, diff_path)

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -925,3 +925,13 @@ def test_update_status_details_on_nonexistent_job(tmp_path: Path):
 
     with pytest.raises(MlflowException, match="Job .+ not found"):
         store.update_status_details("nonexistent-job-id", {"stage": "test"})
+
+
+@pytest.mark.parametrize("_iteration", range(50))
+def test_exclusive_job_sequence_repeated(monkeypatch, tmp_path: Path, _iteration):
+    dup_path = tmp_path / "dup"
+    dup_path.mkdir()
+    test_exclusive_job_skips_duplicate(monkeypatch, dup_path)
+    diff_path = tmp_path / "diff"
+    diff_path.mkdir()
+    test_exclusive_job_allows_different_params(monkeypatch, diff_path)


### PR DESCRIPTION
### Related Issues/PRs

Relates to flaky test in CI

### What changes are proposed in this pull request?

Reproduce the flaky `test_exclusive_job_allows_different_params` test by running it 100 times with `@pytest.mark.repeat` and fail-fast (`-x`).

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)