### PR TITLE
fix(evaluation): use None check instead of truthy check for assessment names

### DIFF
--- a/mlflow/cli/genai_eval_utils.py
+++ b/mlflow/cli/genai_eval_utils.py
@@ -243,11 +243,12 @@ def format_table_output(output_data: list[EvalResult]) -> TableOutput:
         TableOutput dataclass containing headers and rows
     """
     # Extract unique assessment names from output_data to use as column headers
-    # Note: assessment name can be None, so we filter it out
+    # Note: assessment name can be None, so we filter it out.
+    # Use explicit None check to avoid silently omitting numeric-valued names such as 0.
     assessment_names_set = set()
     for trace_result in output_data:
         for assessment in trace_result.assessments:
-            if assessment.name and assessment.name != NA_VALUE:
+            if assessment.name is not None and assessment.name != NA_VALUE:
                 assessment_names_set.add(assessment.name)
 
     # Sort for consistent ordering


### PR DESCRIPTION
## Summary

Fixes #21775

`format_table_output()` used a truthy check (`if assessment.name:`) to filter assessment names for column headers. This silently omitted entries with numeric-valued names like `0`, `0.0`, or empty strings — all valid assessment values.

## Root cause

```python
# Before: silently drops name=0, name=0.0, etc.
if assessment.name and assessment.name != NA_VALUE:
```

## Fix

```python
# After: explicit None check
if assessment.name is not None and assessment.name != NA_VALUE:
```

## Reproduction

```python
assessment = Assessment(name=0, value=1.0, ...)
result = format_table_output([EvalResult(assessments=[assessment])])
assert "0" in result.headers  # was silently dropped before the fix
```