### PR TITLE
Fix re-enqueued jobs to respect workspace disabled flag

### DIFF
--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -617,7 +617,11 @@ def _enqueue_unfinished_jobs(server_launching_timestamp: int) -> None:
 
                 params = json.loads(job.params)
                 timeout = job.timeout
-                job_workspace = job.workspace or workspace or DEFAULT_WORKSPACE_NAME
+                # Only propagate workspace to subprocess when workspaces are enabled
+                if MLFLOW_ENABLE_WORKSPACES.get():
+                    job_workspace = job.workspace or workspace or DEFAULT_WORKSPACE_NAME
+                else:
+                    job_workspace = None
                 # Look up exclusive flag from function metadata
                 fn_fullname = get_job_fn_fullname(job.job_name)
                 fn_metadata = _load_function(fn_fullname)._job_fn_metadata

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -855,12 +855,10 @@ def test_submit_job_workspace_propagation(monkeypatch, tmp_path, workspaces_enab
 
 
 @pytest.mark.parametrize("workspaces_enabled", [False], indirect=True)
-def test_reenqueued_jobs_respect_workspace_disabled(monkeypatch, tmp_path):
-    backend_store_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
-
+def test_reenqueued_jobs_respect_workspace_disabled(monkeypatch, db_uri):
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
     with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
-        job_store = SqlAlchemyJobStore(backend_store_uri)
+        job_store = SqlAlchemyJobStore(db_uri)
         job_store.create_job("basic_job_fun", '{"x": 1, "y": 2}', None)
 
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -3,6 +3,7 @@ import multiprocessing
 import os
 import time
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -17,6 +18,7 @@ from mlflow.server.jobs import (
     job,
     submit_job,
 )
+from mlflow.server.jobs.utils import _enqueue_unfinished_jobs
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
 from mlflow.utils.workspace_context import WorkspaceContext
@@ -850,3 +852,33 @@ def test_submit_job_workspace_propagation(monkeypatch, tmp_path, workspaces_enab
         job = get_job(submitted_job.job_id)
         assert job.status == JobStatus.SUCCEEDED
         assert job.parsed_result == expected_workspace
+
+
+@pytest.mark.parametrize("workspaces_enabled", [False], indirect=True)
+def test_reenqueued_jobs_respect_workspace_disabled(monkeypatch, tmp_path):
+    backend_store_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
+
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        job_store = SqlAlchemyJobStore(backend_store_uri)
+        job_store.create_job("basic_job_fun", '{"x": 1, "y": 2}', None)
+
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
+
+    with (
+        mock.patch("mlflow.server.handlers._get_job_store", return_value=job_store),
+        mock.patch(
+            "mlflow.server.jobs.utils.get_job_fn_fullname",
+            return_value="tests.server.jobs.test_jobs.basic_job_fun",
+        ),
+        mock.patch("mlflow.server.jobs.utils._load_function", return_value=basic_job_fun),
+        mock.patch("mlflow.server.jobs.utils._get_or_init_huey_instance") as mock_huey,
+    ):
+        mock_submit = mock.Mock()
+        mock_huey.return_value.submit_task = mock_submit
+
+        _enqueue_unfinished_jobs(int(time.time() * 1000))
+
+        mock_submit.assert_called_once()
+        _, workspace, *_ = mock_submit.call_args[0]
+        assert workspace is None


### PR DESCRIPTION
When jobs are re-enqueued on server restart (via _enqueue_unfinished_jobs), ensure they respect MLFLOW_ENABLE_WORKSPACES flag. Previously, jobs would always get workspace=DEFAULT_WORKSPACE_NAME even when workspaces were disabled, causing them to send X-MLFLOW-WORKSPACE headers that the server would reject with FEATURE_DISABLED error.

The fix follows the existing pattern used in submit_job() at line 223.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
