### PR TITLE
Pin `databricks-sdk<0.101.0` to fix tracing test timeouts

### DIFF
--- a/.github/workflows/tracing.yaml
+++ b/.github/workflows/tracing.yaml
@@ -33,6 +33,7 @@ env:
   MLFLOW_CONDA_HOME: /usr/share/miniconda
   PYTHONUTF8: "1"
   MLFLOW_SERVER_ENABLE_JOB_EXECUTION: "false"
+  PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
 
 jobs:
   core:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,11 @@ constraint-dependencies = [
   "pyspark<4.1.0",
   # setuptools 82.0.0 removed pkg_resources, breaking packages that depend on it (e.g., sphinx)
   "setuptools<82",
+  # TODO: Remove this once tests are updated to mock WorkspaceClient initialization
+  # databricks-sdk 0.101.0 changed OIDC resolution to always fetch host metadata, causing
+  # WorkspaceClient init to make real HTTP calls even with dummy hosts, breaking tests
+  # https://github.com/databricks/databricks-sdk-py/pull/1331
+  "databricks-sdk<0.101.0",
 ]
 # Prevent third-party libraries from installing uv to avoid conflicts with uv installed
 # by the standalone installer

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,3 +14,8 @@ transformers!=4.52.1
 # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility
 # https://xgboost.readthedocs.io/en/latest/changes/v3.1.0.html#multi-target-class-intercept
 xgboost<3.1.0
+# TODO: Remove this once tests are updated to mock WorkspaceClient initialization
+# databricks-sdk 0.101.0 changed OIDC resolution to always fetch host metadata, causing
+# WorkspaceClient init to make real HTTP calls even with dummy hosts, breaking tests
+# https://github.com/databricks/databricks-sdk-py/pull/1331
+databricks-sdk<0.101.0

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ members = [
     "skills",
 ]
 constraints = [
+    { name = "databricks-sdk", specifier = "<0.101.0" },
     { name = "pyspark", specifier = "<4.1.0" },
     { name = "setuptools", specifier = "<82" },
     { name = "xgboost", specifier = "<3.1.0" },


### PR DESCRIPTION
### Related Issues/PRs

https://github.com/databricks/databricks-sdk-py/pull/1331

### What changes are proposed in this pull request?

`databricks-sdk` 0.101.0 changed OIDC resolution to always fetch host metadata during `WorkspaceClient` initialization. This causes tests using dummy hosts (e.g., `DATABRICKS_HOST=dummy-host`) to timeout due to DNS resolution retries with exponential backoff.

This PR:
- Pins `databricks-sdk<0.101.0` in both `pyproject.toml` (uv constraint-dependencies) and `requirements/constraints.txt` (pip)
- Adds `PIP_CONSTRAINT` env var to the tracing workflow so it picks up the constraints file

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)