### PR TITLE
Fix autologging's `warnings.showwarning` override ignoring user customizations

### DIFF
--- a/mlflow/utils/autologging_utils/logging_and_warnings.py
+++ b/mlflow/utils/autologging_utils/logging_and_warnings.py
@@ -7,9 +7,6 @@ from threading import get_ident as get_current_thread_id
 import mlflow
 from mlflow.utils import logging_utils
 
-ORIGINAL_SHOWWARNING = warnings.showwarning
-
-
 class _WarningsController:
     """
     Provides threadsafe utilities to modify warning behavior for MLflow autologging, including:
@@ -26,6 +23,7 @@ class _WarningsController:
         self._state_lock = RLock()
 
         self._did_patch_showwarning = False
+        self._original_showwarning = None
 
         self._disabled_threads = set()
         self._rerouted_threads = set()
@@ -70,7 +68,7 @@ class _WarningsController:
                 message,
             )
         else:
-            ORIGINAL_SHOWWARNING(message, category, filename, lineno, *args, **kwargs)
+            self._original_showwarning(message, category, filename, lineno, *args, **kwargs)
 
     def _should_patch_showwarning(self):
         return (
@@ -96,12 +94,16 @@ class _WarningsController:
             if self._should_patch_showwarning() and not self._did_patch_showwarning:
                 # NB: guard to prevent patching an instance of a patch
                 if warnings.showwarning != self._patched_showwarning:
+                    # Capture the current showwarning at patch time so that
+                    # user customizations (e.g. logging.captureWarnings) set
+                    # after import are preserved.
+                    self._original_showwarning = warnings.showwarning
                     warnings.showwarning = self._patched_showwarning
                 self._did_patch_showwarning = True
             elif not self._should_patch_showwarning() and self._did_patch_showwarning:
                 # NB: only unpatch iff the patched function is active
                 if warnings.showwarning == self._patched_showwarning:
-                    warnings.showwarning = ORIGINAL_SHOWWARNING
+                    warnings.showwarning = self._original_showwarning
                 self._did_patch_showwarning = False
 
     def set_mlflow_warnings_disablement_state_globally(self, disabled=True):

--- a/tests/utils/test_autologging_utils.py
+++ b/tests/utils/test_autologging_utils.py
@@ -4,7 +4,6 @@ from threading import Thread
 from mlflow import MlflowClient
 from mlflow.entities import Metric
 from mlflow.utils.autologging_utils.logging_and_warnings import (
-    ORIGINAL_SHOWWARNING,
     _WarningsController,
 )
 from mlflow.utils.autologging_utils.metrics_queue import (
@@ -46,11 +45,12 @@ def test_flush_metrics_queue_is_thread_safe():
 
 
 def test_double_patch_does_not_overwrite(monkeypatch):
-    monkeypatch.setattr(warnings, "showwarning", ORIGINAL_SHOWWARNING)
+    original = warnings.showwarning
+    monkeypatch.setattr(warnings, "showwarning", original)
 
     controller = _WarningsController()
 
-    assert warnings.showwarning == ORIGINAL_SHOWWARNING
+    assert warnings.showwarning == original
     assert not controller._did_patch_showwarning
 
     controller.set_non_mlflow_warnings_disablement_state_for_current_thread(True)
@@ -66,4 +66,17 @@ def test_double_patch_does_not_overwrite(monkeypatch):
 
     controller.set_non_mlflow_warnings_disablement_state_for_current_thread(False)
 
-    assert warnings.showwarning == ORIGINAL_SHOWWARNING
+    assert warnings.showwarning == original
+
+
+def test_user_showwarning_survives_patch_unpatch_cycle(monkeypatch):
+    custom_handler = lambda *args, **kwargs: None
+    monkeypatch.setattr(warnings, "showwarning", custom_handler)
+
+    controller = _WarningsController()
+
+    controller.set_non_mlflow_warnings_disablement_state_for_current_thread(True)
+    assert warnings.showwarning == controller._patched_showwarning
+
+    controller.set_non_mlflow_warnings_disablement_state_for_current_thread(False)
+    assert warnings.showwarning is custom_handler


### PR DESCRIPTION
### Related Issues/PRs

Closes #21689

### What changes are proposed in this pull request?

`ORIGINAL_SHOWWARNING` was captured at module import time (line 10 of `logging_and_warnings.py`), so any user-defined `warnings.showwarning` handler set after `import mlflow` (e.g. via `logging.captureWarnings(True)`) was silently overwritten when the autologging patch was removed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual test

**Repro Script**
```
import warnings

import mlflow

logging.basicConfig(level="INFO", format="Logging [ %(levelname)s ] %(message)s")

logging.captureWarnings(True)  # Redirect Python warnings to log

warnings.warn("This warning redirects to the logger as expected")

mlflow.autolog()

warnings.warn("This warning does not")
```

**Before**
The user-defined logger is ignored in the second warning after autologging is enabled.

```
Logging [ WARNING ] /Users/yuki.watanabe/Workspace/mlflow/repro_21689.py:10: UserWarning: This warning redirects to the logger as expected
  warnings.warn("This warning redirects to the logger as expected")

2026/03/18 20:33:49 WARNING mlflow.spark: With Pyspark >= 3.2, PYSPARK_PIN_THREAD environment variable must be set to false for Spark datasource autologging to work.
2026/03/18 20:33:49 INFO mlflow.tracking.fluent: Autologging successfully enabled for pyspark.
/Users/yuki.watanabe/Workspace/mlflow/repro_21689.py:14: UserWarning: This warning does not
  warnings.warn("This warning does not")
```

**After**
All warnings are correctly redirected to the user-defined logger.
```
Logging [ WARNING ] /Users/yuki.watanabe/Workspace/mlflow/repro_21689.py:10: UserWarning: This warning redirects to the logger as expected
  warnings.warn("This warning redirects to the logger as expected")

2026/03/18 20:34:57 WARNING mlflow.spark: With Pyspark >= 3.2, PYSPARK_PIN_THREAD environment variable must be set to false for Spark datasource autologging to work.
2026/03/18 20:34:57 INFO mlflow.tracking.fluent: Autologging successfully enabled for pyspark.
Logging [ WARNING ] /Users/yuki.watanabe/Workspace/mlflow/repro_21689.py:14: UserWarning: This warning does not
  warnings.warn("This warning does not")
```



### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Autologging no longer silently overwrites custom `warnings.showwarning` handlers (e.g. set via `logging.captureWarnings(True)`) that were configured after importing MLflow.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release