### PR TITLE
Unpin `databricks-sdk` by mocking `Config._resolve_host_metadata` in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,11 +251,6 @@ constraint-dependencies = [
   "pyspark<4.1.0",
   # setuptools 82.0.0 removed pkg_resources, breaking packages that depend on it (e.g., sphinx)
   "setuptools<82",
-  # TODO: Remove this once tests are updated to mock WorkspaceClient initialization
-  # databricks-sdk 0.101.0 changed OIDC resolution to always fetch host metadata, causing
-  # WorkspaceClient init to make real HTTP calls even with dummy hosts, breaking tests
-  # https://github.com/databricks/databricks-sdk-py/pull/1331
-  "databricks-sdk<0.101.0",
 ]
 # Prevent third-party libraries from installing uv to avoid conflicts with uv installed
 # by the standalone installer

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,8 +14,3 @@ transformers!=4.52.1
 # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility
 # https://xgboost.readthedocs.io/en/latest/changes/v3.1.0.html#multi-target-class-intercept
 xgboost<3.1.0
-# TODO: Remove this once tests are updated to mock WorkspaceClient initialization
-# databricks-sdk 0.101.0 changed OIDC resolution to always fetch host metadata, causing
-# WorkspaceClient init to make real HTTP calls even with dummy hosts, breaking tests
-# https://github.com/databricks/databricks-sdk-py/pull/1331
-databricks-sdk<0.101.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1036,9 +1036,8 @@ def _mock_databricks_host_metadata():
     WorkspaceClient initialization, which causes timeouts with dummy hosts.
     https://github.com/databricks/databricks-sdk-py/pull/1331
     """
-    with mock.patch("databricks.sdk.config.Config._resolve_host_metadata") as m:
-        yield m
-        m.assert_called()
+    with mock.patch("databricks.sdk.config.Config._resolve_host_metadata"):
+        yield
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1029,6 +1029,19 @@ def enable_mlflow_testing():
 
 
 @pytest.fixture(scope="session", autouse=True)
+def _mock_databricks_host_metadata():
+    """Prevent databricks-sdk from fetching host metadata during the test session.
+
+    databricks-sdk 0.101.0+ fetches /.well-known/databricks-config during
+    WorkspaceClient initialization, which causes timeouts with dummy hosts.
+    https://github.com/databricks/databricks-sdk-py/pull/1331
+    """
+    with mock.patch("databricks.sdk.config.Config._resolve_host_metadata") as m:
+        yield m
+        m.assert_called()
+
+
+@pytest.fixture(scope="session", autouse=True)
 def disable_uv_auto_detect():
     with pytest.MonkeyPatch.context() as mp:
         mp.setenv("MLFLOW_UV_AUTO_DETECT", "false")

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,6 @@ members = [
     "skills",
 ]
 constraints = [
-    { name = "databricks-sdk", specifier = "<0.101.0" },
     { name = "pyspark", specifier = "<4.1.0" },
     { name = "setuptools", specifier = "<82" },
     { name = "xgboost", specifier = "<3.1.0" },
@@ -1616,16 +1615,16 @@ wheels = [
 
 [[package]]
 name = "databricks-sdk"
-version = "0.99.0"
+version = "0.101.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/28/d53ce4c21ab197cacdeb65bcdcba3f8098a1b6b88052b72b60348f6b8091/databricks_sdk-0.99.0.tar.gz", hash = "sha256:13ae35b064277074a79fcd5265260e92b352b5eb4e950438dcee895951bd86fd", size = 878669, upload-time = "2026-03-12T08:16:12.597Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/32/62b8891eef926ca2138e9952f6523ed923648df254b436994b028c4607df/databricks_sdk-0.101.0.tar.gz", hash = "sha256:e643f416892edcfd255e1072f7c96a563f2e44730663b624b2129c3f9636188e", size = 886447, upload-time = "2026-03-18T08:17:33.457Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/3a/8593cae357aac76142da1940ad7a965ea50f2767bb958820839be675811b/databricks_sdk-0.99.0-py3-none-any.whl", hash = "sha256:c0a6740bf21d430daa85461e193197ce1d0ac12209ce20e3cb9b67b32fe2bcfd", size = 829540, upload-time = "2026-03-12T08:16:11.155Z" },
+    { url = "https://files.pythonhosted.org/packages/95/19/7ca1294bd770c7079d8600b802352a0e9c9aae31d74f515856004a71d66a/databricks_sdk-0.101.0-py3-none-any.whl", hash = "sha256:30b6ecb261aad34c3f9c3dbc84197f1daebe0857c5c89aa1581b96a012b05e36", size = 837674, upload-time = "2026-03-18T08:17:31.354Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21798

### What changes are proposed in this pull request?

#21798 pinned `databricks-sdk<0.101.0` because v0.101.0 introduced `Config._resolve_host_metadata()` ([databricks/databricks-sdk-py#1331](https://github.com/databricks/databricks-sdk-py/pull/1331)), which fetches `/.well-known/databricks-config` during `WorkspaceClient` initialization. This caused tests using dummy hosts (e.g., `DATABRICKS_HOST=dummy-host`) to timeout due to DNS resolution retries.

This PR removes the version pin and instead adds a session-scoped autouse fixture in the top-level `tests/conftest.py` that mocks `Config._resolve_host_metadata` to prevent real HTTP calls during tests.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)