### PR TITLE
Add numeric comparison operators (`>`, `>=`, `<`, `<=`) for assessment trace filters

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTable.tsx
@@ -422,58 +422,55 @@ function GenAiTracesTableImpl({
                         gap: theme.spacing.md,
                       }}
                     >
-                      {selectedAssessmentInfos
-                        // For now, we don't support filtering on numeric values.
-                        .filter((info) => info.dtype !== 'numeric')
-                        .map((assessmentInfo) => (
+                      {selectedAssessmentInfos.map((assessmentInfo) => (
+                        <div
+                          css={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: theme.spacing.sm,
+                          }}
+                          key={assessmentInfo.name}
+                        >
                           <div
                             css={{
-                              display: 'flex',
-                              flexDirection: 'column',
-                              gap: theme.spacing.sm,
+                              fontWeight: 500,
                             }}
-                            key={assessmentInfo.name}
                           >
+                            {assessmentInfo.displayName}
+                          </div>
+                          {currentRunDisplayName && (
+                            <AssessmentsFilterSelector
+                              assessmentLabel={assessmentInfo.displayName}
+                              assessmentName={assessmentInfo.name}
+                              assessmentInfo={assessmentInfo}
+                              assessmentFilter={getAssessmentFilter(assessmentInfo.name, currentRunDisplayName)}
+                              updateAssessmentFilter={updateAssessmentFilter}
+                              removeAssessmentFilter={removeAssessmentFilter}
+                              run={currentRunDisplayName}
+                            />
+                          )}
+                          {compareToRunUuid && compareToRunDisplayName && (
                             <div
                               css={{
-                                fontWeight: 500,
+                                display: 'flex',
+                                flexDirection: 'column',
+                                gap: theme.spacing.xs,
                               }}
                             >
-                              {assessmentInfo.displayName}
-                            </div>
-                            {currentRunDisplayName && (
+                              <Typography.Hint>{compareToRunDisplayName}</Typography.Hint>
                               <AssessmentsFilterSelector
                                 assessmentLabel={assessmentInfo.displayName}
                                 assessmentName={assessmentInfo.name}
                                 assessmentInfo={assessmentInfo}
-                                assessmentFilter={getAssessmentFilter(assessmentInfo.name, currentRunDisplayName)}
+                                assessmentFilter={getAssessmentFilter(assessmentInfo.name, compareToRunDisplayName)}
                                 updateAssessmentFilter={updateAssessmentFilter}
                                 removeAssessmentFilter={removeAssessmentFilter}
-                                run={currentRunDisplayName}
+                                run={compareToRunDisplayName}
                               />
-                            )}
-                            {compareToRunUuid && compareToRunDisplayName && (
-                              <div
-                                css={{
-                                  display: 'flex',
-                                  flexDirection: 'column',
-                                  gap: theme.spacing.xs,
-                                }}
-                              >
-                                <Typography.Hint>{compareToRunDisplayName}</Typography.Hint>
-                                <AssessmentsFilterSelector
-                                  assessmentLabel={assessmentInfo.displayName}
-                                  assessmentName={assessmentInfo.name}
-                                  assessmentInfo={assessmentInfo}
-                                  assessmentFilter={getAssessmentFilter(assessmentInfo.name, compareToRunDisplayName)}
-                                  updateAssessmentFilter={updateAssessmentFilter}
-                                  removeAssessmentFilter={removeAssessmentFilter}
-                                  run={compareToRunDisplayName}
-                                />
-                              </div>
-                            )}
-                          </div>
-                        ))}
+                            </div>
+                          )}
+                        </div>
+                      ))}
                     </div>
                   </DialogComboboxContent>
                 </DialogCombobox>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/filters/TableFilterItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/filters/TableFilterItem.tsx
@@ -67,7 +67,7 @@ const getFilterableInfoColumns = (usesV4APIs?: boolean) => {
   ];
 };
 
-const getAvailableOperators = (column: string, key?: string): FilterOperator[] => {
+const getAvailableOperators = (column: string, key?: string, assessmentDtype?: string): FilterOperator[] => {
   if (column === EXECUTION_DURATION_COLUMN_ID) {
     return [
       FilterOperator.EQUALS,
@@ -96,6 +96,18 @@ const getAvailableOperators = (column: string, key?: string): FilterOperator[] =
   }
 
   if (column === TracesTableColumnGroup.ASSESSMENT) {
+    if (assessmentDtype === 'numeric') {
+      return [
+        FilterOperator.EQUALS,
+        FilterOperator.NOT_EQUALS,
+        FilterOperator.GREATER_THAN,
+        FilterOperator.LESS_THAN,
+        FilterOperator.GREATER_THAN_OR_EQUALS,
+        FilterOperator.LESS_THAN_OR_EQUALS,
+        FilterOperator.IS_NULL,
+        FilterOperator.IS_NOT_NULL,
+      ];
+    }
     return [FilterOperator.EQUALS, FilterOperator.IS_NULL, FilterOperator.IS_NOT_NULL];
   }
 
@@ -132,12 +144,13 @@ export const TableFilterItem = ({
 
   const availableFilterableInfoColumns = useMemo(() => getFilterableInfoColumns(usesV4APIs), [usesV4APIs]);
 
-  // For now, we don't support filtering on numeric values.
+  const currentAssessmentDtype = useMemo(
+    () => assessmentInfos.find((a) => a.name === key)?.dtype,
+    [assessmentInfos, key],
+  );
+
   const assessmentKeyOptions: TableFilterOption[] = useMemo(
-    () =>
-      assessmentInfos
-        .filter((assessment) => assessment.dtype !== 'numeric')
-        .map((assessment) => ({ value: assessment.name, renderValue: () => assessment.displayName })),
+    () => assessmentInfos.map((assessment) => ({ value: assessment.name, renderValue: () => assessment.displayName })),
     [assessmentInfos],
   );
 
@@ -282,7 +295,8 @@ export const TableFilterItem = ({
             />
           </FormUI.Label>
           {(() => {
-            const isOperatorSelectorDisabled = column !== '' && getAvailableOperators(column, key).length === 1;
+            const isOperatorSelectorDisabled =
+              column !== '' && getAvailableOperators(column, key, currentAssessmentDtype).length === 1;
             return (
               <SimpleSelect
                 aria-label="Operator"
@@ -294,13 +308,15 @@ export const TableFilterItem = ({
                   // Set the z-index to be higher than the Popover
                   style: { zIndex: theme.options.zIndexBase + 100 },
                 }}
-                value={!isOperatorSelectorDisabled ? operator : getAvailableOperators(column, key)[0]}
+                value={
+                  !isOperatorSelectorDisabled ? operator : getAvailableOperators(column, key, currentAssessmentDtype)[0]
+                }
                 disabled={isOperatorSelectorDisabled}
                 onChange={(e) => {
                   onChange({ ...tableFilter, operator: e.target.value as FilterOperator }, index);
                 }}
               >
-                {getAvailableOperators(column, key).map((op) => (
+                {getAvailableOperators(column, key, currentAssessmentDtype).map((op) => (
                   <SimpleSelectOption key={op} value={op}>
                     {op}
                   </SimpleSelectOption>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/filters/TableFilterItemValueInput.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/filters/TableFilterItemValueInput.tsx
@@ -126,7 +126,24 @@ export const TableFilterItemValueInput = ({
 
   if (tableFilter.column === TracesTableColumnGroup.ASSESSMENT) {
     const assessmentInfo = assessmentInfos.find((assessment) => assessment.name === tableFilter.key);
-    if (assessmentInfo && assessmentInfo.dtype !== 'numeric' && assessmentInfo.dtype !== 'unknown') {
+    if (assessmentInfo && assessmentInfo.dtype === 'numeric') {
+      return (
+        <Input
+          aria-label="Value"
+          componentId="mlflow.evaluations_review.table_ui.filter_value"
+          id={id}
+          placeholder="Number"
+          type="number"
+          value={localValue as string}
+          onChange={(e) => {
+            setLocalValue(e.target.value);
+          }}
+          onBlur={onValueBlur}
+          css={{ width: 200 }}
+        />
+      );
+    }
+    if (assessmentInfo && assessmentInfo.dtype !== 'unknown') {
       const options: TableFilterOption[] = Array.from(assessmentInfo.uniqueValues.values()).map((value) => {
         return {
           value: assessmentValueToSerializedString(value),
@@ -222,8 +239,6 @@ export const TableFilterItemValueInput = ({
       }}
       onBlur={onValueBlur}
       css={{ width: 200 }}
-      // Disable it for assessment column at this point, since the data type is not supported yet.
-      disabled={tableFilter.column === TracesTableColumnGroup.ASSESSMENT}
     />
   );
 };

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.tsx
@@ -713,7 +713,9 @@ export const createMlflowSearchFilter = (
           } else if (networkFilter.value !== 'undefined') {
             // Skip 'undefined' values - these must be filtered client-side since they represent
             // absence of an assessment, which cannot be queried on the backend
-            filter.push(`feedback.\`${networkFilter.key}\` ${networkFilter.operator} '${networkFilter.value}'`);
+            const isNumericValue = !isNaN(Number(networkFilter.value)) && networkFilter.value !== '';
+            const formattedValue = isNumericValue ? networkFilter.value : `'${networkFilter.value}'`;
+            filter.push(`feedback.\`${networkFilter.key}\` ${networkFilter.operator} ${formattedValue}`);
           }
           break;
         case TracesTableColumnGroup.EXPECTATION:

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1735,7 +1735,9 @@ class SearchTraceUtils(SearchUtils):
     VALID_STRING_ATTRIBUTE_COMPARATORS = {"!=", "=", "IN", "NOT IN", "LIKE", "ILIKE", "RLIKE"}
     VALID_SPAN_ATTRIBUTE_COMPARATORS = {"!=", "=", "IN", "NOT IN", "LIKE", "ILIKE", "RLIKE"}
     VALID_METADATA_COMPARATORS = {"!=", "=", "LIKE", "ILIKE", "RLIKE", "IS NULL", "IS NOT NULL"}
-    VALID_ASSESSMENT_COMPARATORS = {"!=", "=", "LIKE", "ILIKE", "RLIKE", "IS NULL", "IS NOT NULL"}
+    VALID_ASSESSMENT_COMPARATORS = {
+        "!=", "=", ">", ">=", "<", "<=", "LIKE", "ILIKE", "RLIKE", "IS NULL", "IS NOT NULL"
+    }
 
     _REQUEST_METADATA_IDENTIFIER = "request_metadata"
     _TAG_IDENTIFIER = "tag"
@@ -2036,7 +2038,22 @@ class SearchTraceUtils(SearchUtils):
                 clause = sa.not_(clause)
             return clause
 
-        if comparator not in ("=", "!="):
+        def json_numeric_comparison(column: "ColumnElement", value) -> "ClauseElement":
+            # Cast JSON-encoded TEXT to numeric for comparison.
+            # Non-numeric values (strings, arrays, objects) map to NULL via the CASE,
+            # so they are silently excluded (NULL > 5 → FALSE in SQL).
+            numeric_col = sa.case(
+                (column.in_([json.dumps(True), json.dumps("yes")]), 1.0),
+                (column.in_([json.dumps(False), json.dumps("no")]), 0.0),
+                (column == "null", sa.null()),
+                (sa.func.substring(column, 1, 1).in_(['"', "[", "{"]), sa.null()),
+                else_=sa.func.cast(column, sa.Float),
+            )
+            return SearchUtils.get_comparison_func(comparator)(numeric_col, float(value))
+
+        if comparator in (">", ">=", "<", "<="):
+            return json_numeric_comparison
+        elif comparator not in ("=", "!="):
             return SearchTraceUtils.get_sql_comparison_func(comparator, dialect)
         elif dialect == MYSQL:
             return mysql_json_equality_inequality_comparison
@@ -2144,13 +2161,17 @@ class SearchTraceUtils(SearchUtils):
             cls._EXPECTATION_IDENTIFIER,
             cls._ISSUE_IDENTIFIER,
         ):
-            # Feedback and expectation values are stored as JSON, so we expect string values
             if token.ttype in cls.STRING_VALUE_TYPES or isinstance(token, Identifier):
                 return cls._strip_quotes(token.value, expect_quoted_value=True)
+            elif token.ttype in cls.NUMERIC_VALUE_TYPES:
+                if token.ttype == TokenType.Literal.Number.Integer:
+                    return int(token.value)
+                elif token.ttype == TokenType.Literal.Number.Float:
+                    return float(token.value)
             else:
                 raise MlflowException(
-                    "Expected a quoted string value for "
-                    f"{identifier_type} (e.g. 'my-value'). Got value "
+                    "Expected a quoted string value or numeric value for "
+                    f"{identifier_type} (e.g. 'my-value' or 0.8). Got value "
                     f"{token.value}",
                     error_code=INVALID_PARAMETER_VALUE,
                 )

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -6500,6 +6500,123 @@ def test_search_traces_with_expectation_like_filters(store: SqlAlchemyStore):
     assert traces[0].request_id == trace1_id
 
 
+def test_search_traces_with_assessment_numeric_filters(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_assessment_numeric")
+
+    trace1_id = "trace1"
+    trace2_id = "trace2"
+    trace3_id = "trace3"
+    trace4_id = "trace4"
+    trace5_id = "trace5"
+
+    _create_trace(store, trace1_id, exp_id)
+    _create_trace(store, trace2_id, exp_id)
+    _create_trace(store, trace3_id, exp_id)
+    _create_trace(store, trace4_id, exp_id)
+    _create_trace(store, trace5_id, exp_id)
+
+    # Create feedback with numeric values
+    for trace_id, value in [
+        (trace1_id, 5),
+        (trace2_id, 0.8),
+        (trace3_id, 3.5),
+    ]:
+        store.create_assessment(
+            Feedback(
+                trace_id=trace_id,
+                name="score",
+                value=value,
+                source=AssessmentSource(source_type="HUMAN", source_id="user@example.com"),
+            )
+        )
+
+    # trace4: string feedback (should be excluded from numeric comparisons)
+    store.create_assessment(
+        Feedback(
+            trace_id=trace4_id,
+            name="score",
+            value="high",
+            source=AssessmentSource(source_type="HUMAN", source_id="user@example.com"),
+        )
+    )
+    # trace5: boolean feedback (maps to 1.0)
+    store.create_assessment(
+        Feedback(
+            trace_id=trace5_id,
+            name="score",
+            value=True,
+            source=AssessmentSource(source_type="HUMAN", source_id="user@example.com"),
+        )
+    )
+
+    # Test: > 3 should match 5 and 3.5
+    traces, _ = store.search_traces([exp_id], filter_string="feedback.score > 3")
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace1_id, trace3_id}
+
+    # Test: >= 5 should match only 5
+    traces, _ = store.search_traces([exp_id], filter_string="feedback.score >= 5")
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace1_id}
+
+    # Test: < 1.0 should match 0.8
+    traces, _ = store.search_traces([exp_id], filter_string="feedback.score < 1.0")
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace2_id}
+
+    # Test: <= 3.5 should match 0.8, 3.5, and True (1.0)
+    traces, _ = store.search_traces([exp_id], filter_string="feedback.score <= 3.5")
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace2_id, trace3_id, trace5_id}
+
+    # Test: combined with string equality filter
+    store.create_assessment(
+        Feedback(
+            trace_id=trace1_id,
+            name="quality",
+            value="high",
+            source=AssessmentSource(source_type="HUMAN", source_id="user@example.com"),
+        )
+    )
+    store.create_assessment(
+        Feedback(
+            trace_id=trace3_id,
+            name="quality",
+            value="high",
+            source=AssessmentSource(source_type="HUMAN", source_id="user@example.com"),
+        )
+    )
+    traces, _ = store.search_traces(
+        [exp_id],
+        filter_string='feedback.score > 3 AND feedback.quality = "high"',
+    )
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace1_id, trace3_id}
+
+    # Test: expectation numeric filters
+    store.create_assessment(
+        Expectation(
+            trace_id=trace1_id,
+            name="response_length",
+            value=150,
+            source=AssessmentSource(source_type="CODE", source_id="scorer"),
+        )
+    )
+    store.create_assessment(
+        Expectation(
+            trace_id=trace2_id,
+            name="response_length",
+            value=50,
+            source=AssessmentSource(source_type="CODE", source_id="scorer"),
+        )
+    )
+    traces, _ = store.search_traces(
+        [exp_id], filter_string="expectation.response_length > 100"
+    )
+    trace_ids = {t.request_id for t in traces}
+    assert trace_ids == {trace1_id}
+
+
 def test_search_traces_with_metadata_like_filters(store: SqlAlchemyStore):
     exp_id = store.create_experiment("test_metadata_like")
 


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

Enable numeric comparison operators (`>`, `>=`, `<`, `<=`) for assessment (feedback/expectation) trace filters. Previously, only string-oriented comparators (`=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL`) were supported, which prevented queries like `feedback.score > 0.8`.

Changes in `mlflow/utils/search_utils.py`:
- Add `>`, `>=`, `<`, `<=` to `VALID_ASSESSMENT_COMPARATORS`
- Accept numeric literal values (int/float) in `_get_value()` for feedback/expectation identifiers
- Add `json_numeric_comparison` handler in `_get_sql_json_comparison_func()` that CASTs JSON-encoded TEXT to float using the same CASE/CAST pattern as the existing `_get_assessment_numeric_value_column()` helper — works across all 4 supported dialects (SQLite, PostgreSQL, MySQL, MSSQL)

Non-numeric assessment values (strings, arrays, objects) are mapped to NULL in the CASE expression, so they are silently excluded from numeric comparisons.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New test `test_search_traces_with_assessment_numeric_filters` covers:
- All four numeric comparators with integer and float values
- Non-numeric string values silently excluded
- Boolean `True` mapping to `1.0`
- Combined numeric + string equality filters
- Expectation numeric filters

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added support for numeric comparison operators (`>`, `>=`, `<`, `<=`) when filtering traces by assessment values (e.g., `feedback.score > 0.8`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release