### PR TITLE
fix: parse JSON-encoded gen_ai input/output messages in UI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -475,7 +475,17 @@ export const normalizeNewSpanData = (
     getSpanAttribute(span.attributes, 'mlflow.chat.messages') as string,
   );
   const messageFormat = tryDeserializeAttribute(getSpanAttribute(span.attributes, 'mlflow.message.format') as string);
-  const chatMessages = getChatMessagesFromSpan(messagesAttributeValue, inputs, outputs, messageFormat, children);
+
+  // Try to get input/output messages from GenAI semantic convention attributes
+  // These may be JSON-encoded strings when the OpenTelemetry SDK doesn't support structured values
+  const genAiInputMessages = tryDeserializeAttribute(getSpanAttribute(span.attributes, 'gen_ai.input.messages') as string);
+  const genAiOutputMessages = tryDeserializeAttribute(getSpanAttribute(span.attributes, 'gen_ai.output.messages') as string);
+
+  // Use GenAI semantic convention messages as fallback if mlflow.spanInputs/Outputs are not available
+  const chatInputs = inputs ?? genAiInputMessages;
+  const chatOutputs = outputs ?? genAiOutputMessages;
+
+  const chatMessages = getChatMessagesFromSpan(messagesAttributeValue, chatInputs, chatOutputs, messageFormat, children);
   const chatTools = getChatToolsFromSpan(
     tryDeserializeAttribute(getSpanAttribute(span.attributes, 'mlflow.chat.tools') as string),
     inputs,


### PR DESCRIPTION
## Summary

The MLflow UI now properly parses `gen_ai.input.messages` and `gen_ai.output.messages` when they are encoded as JSON strings (as allowed by the GenAI semantic convention), instead of displaying them as raw strings.

## Changes

- Added logic to extract and parse `gen_ai.input.messages` and `gen_ai.output.messages` attributes from span attributes
- These attributes are used as fallback when `mlflow.spanInputs` and `mlflow.spanOutputs` are not available
- The parsed messages are properly displayed in the chat view

## Testing

- Verified the fix handles JSON-encoded messages correctly
- The fix uses the existing `tryDeserializeAttribute` function to parse JSON strings
- The parsed messages are passed to `getChatMessagesFromSpan` which handles the OTel GenAI format

Fixes mlflow/mlflow#21812