### PR TITLE
Fix tar path traversal vulnerability in `extract_archive_to_dir`

### DIFF
--- a/mlflow/pyfunc/dbconnect_artifact_cache.py
+++ b/mlflow/pyfunc/dbconnect_artifact_cache.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import tarfile
 
+from mlflow.exceptions import MlflowException
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.file_utils import check_tarfile_security, get_or_create_tmp_dir
 
@@ -141,5 +142,17 @@ def extract_archive_to_dir(archive_path, dest_dir):
     check_tarfile_security(archive_path)
     os.makedirs(dest_dir, exist_ok=True)
     with tarfile.open(archive_path, "r") as tar:
-        tar.extractall(path=dest_dir)
+        _safe_extractall(tar, dest_dir)
     return dest_dir
+
+
+def _safe_extractall(tar, dest_dir):
+    dest_dir = os.path.realpath(dest_dir)
+    for member in tar.getmembers():
+        member_path = os.path.normpath(os.path.join(dest_dir, member.name))
+        if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
+            raise MlflowException(
+                f"Tar archive member {member.name!r} would be extracted outside "
+                f"the destination directory."
+            )
+        tar.extract(member, path=dest_dir)

--- a/mlflow/pyfunc/dbconnect_artifact_cache.py
+++ b/mlflow/pyfunc/dbconnect_artifact_cache.py
@@ -152,7 +152,7 @@ def _safe_extractall(tar, dest_dir):
     for member in tar.getmembers():
         member_path = (resolved_dest / member.name).resolve()
         if not (member_path == resolved_dest or resolved_dest in member_path.parents):
-            raise MlflowException(
+            raise MlflowException.invalid_parameter_value(
                 f"Tar archive member {member.name!r} would be extracted outside "
                 f"the destination directory."
             )

--- a/mlflow/pyfunc/dbconnect_artifact_cache.py
+++ b/mlflow/pyfunc/dbconnect_artifact_cache.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import tarfile
+from pathlib import Path
 
 from mlflow.exceptions import MlflowException
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
@@ -147,12 +148,12 @@ def extract_archive_to_dir(archive_path, dest_dir):
 
 
 def _safe_extractall(tar, dest_dir):
-    dest_dir = os.path.realpath(dest_dir)
+    resolved_dest = Path(dest_dir).resolve()
     for member in tar.getmembers():
-        member_path = os.path.normpath(os.path.join(dest_dir, member.name))
-        if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
+        member_path = (resolved_dest / member.name).resolve()
+        if not (member_path == resolved_dest or resolved_dest in member_path.parents):
             raise MlflowException(
                 f"Tar archive member {member.name!r} would be extracted outside "
                 f"the destination directory."
             )
-        tar.extract(member, path=dest_dir)
+        tar.extract(member, path=resolved_dest)

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -935,36 +935,22 @@ def check_tarfile_security(archive_path: str) -> None:
             # Normalize backslashes to forward slashes before path validation to prevent
             # bypass on Windows where backslashes are treated as directory separators.
             path = posixpath.normpath(m.name.replace("\\", "/"))
-            if path.startswith("/"):
-                raise MlflowException.invalid_parameter_value(
-                    "Absolute path destination in the archive file is not allowed, "
-                    f"but got path {path}."
-                )
-            path_parts = path.split("/")
-            if path_parts[0] == "..":
-                raise MlflowException.invalid_parameter_value(
-                    "Escaped path destination in the archive file is not allowed, "
-                    f"but got path {path}."
-                )
-            if m.issym():
+            _check_path_is_safe(path)
+            if m.issym() or m.islnk():
                 symlink_set.add(path)
-                # Validate symlink targets don't escape the extraction directory
+                # Validate link targets don't escape the extraction directory
                 link_target = posixpath.normpath(m.linkname.replace("\\", "/"))
-                if link_target.startswith("/"):
+                _check_path_is_safe(link_target, context=f"link target of {path}")
+                # Resolve link target relative to the link's parent directory
+                link_parent = posixpath.dirname(path)
+                resolved = posixpath.normpath(posixpath.join(link_parent, link_target))
+                if resolved == ".." or resolved.startswith("../"):
                     raise MlflowException.invalid_parameter_value(
-                        "Symlink with absolute target in the archive file is not allowed, "
-                        f"but got symlink {path} -> {link_target}."
-                    )
-                # Resolve symlink target relative to the symlink's parent directory
-                symlink_parent = posixpath.dirname(path)
-                resolved = posixpath.normpath(posixpath.join(symlink_parent, link_target))
-                if resolved.startswith(".."):
-                    raise MlflowException.invalid_parameter_value(
-                        "Symlink target that escapes the extraction directory is not allowed, "
-                        f"but got symlink {path} -> {link_target}."
+                        "Link target that escapes the extraction directory is not allowed, "
+                        f"but got {path} -> {link_target}."
                     )
         for m in tar.getmembers():
-            if not m.issym():
+            if not m.issym() and not m.islnk():
                 path = posixpath.normpath(m.name.replace("\\", "/"))
                 path_parts = path.split("/")
                 for prefix_len in range(1, len(path_parts) + 1):
@@ -974,3 +960,25 @@ def check_tarfile_security(archive_path: str) -> None:
                             "Destination path in the archive file can not go through a symlink, "
                             f"but got path {path}."
                         )
+
+
+def _check_path_is_safe(path: str, context: str = "") -> None:
+    label = f" ({context})" if context else ""
+    # Reject Unix absolute paths
+    if path.startswith("/"):
+        raise MlflowException.invalid_parameter_value(
+            f"Absolute path destination in the archive file is not allowed, "
+            f"but got path {path}{label}."
+        )
+    # Reject Windows drive-letter absolute paths (e.g., C:/...) and UNC paths (//server/...)
+    if len(path) >= 3 and path[0].isalpha() and path[1:3] == ":/":
+        raise MlflowException.invalid_parameter_value(
+            f"Absolute path destination in the archive file is not allowed, "
+            f"but got path {path}{label}."
+        )
+    path_parts = path.split("/")
+    if path_parts[0] == "..":
+        raise MlflowException.invalid_parameter_value(
+            f"Escaped path destination in the archive file is not allowed, "
+            f"but got path {path}{label}."
+        )

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -935,19 +935,33 @@ def check_tarfile_security(archive_path: str) -> None:
             # Normalize backslashes to forward slashes before path validation to prevent
             # bypass on Windows where backslashes are treated as directory separators.
             path = posixpath.normpath(m.name.replace("\\", "/"))
+            if path.startswith("/"):
+                raise MlflowException(
+                    "Absolute path destination in the archive file is not allowed, "
+                    f"but got path {path}."
+                )
+            path_parts = path.split("/")
+            if path_parts[0] == "..":
+                raise MlflowException(
+                    "Escaped path destination in the archive file is not allowed, "
+                    f"but got path {path}."
+                )
             if m.issym():
                 symlink_set.add(path)
-            else:
-                if path.startswith("/"):
+                # Validate symlink targets don't escape the extraction directory
+                link_target = posixpath.normpath(m.linkname.replace("\\", "/"))
+                if link_target.startswith("/"):
                     raise MlflowException(
-                        "Absolute path destination in the archive file is not allowed, "
-                        f"but got path {path}."
+                        "Symlink with absolute target in the archive file is not allowed, "
+                        f"but got symlink {path} -> {link_target}."
                     )
-                path_parts = path.split("/")
-                if path_parts[0] == "..":
+                # Resolve symlink target relative to the symlink's parent directory
+                symlink_parent = posixpath.dirname(path)
+                resolved = posixpath.normpath(posixpath.join(symlink_parent, link_target))
+                if resolved.startswith(".."):
                     raise MlflowException(
-                        "Escaped path destination in the archive file is not allowed, "
-                        f"but got path {path}."
+                        "Symlink target that escapes the extraction directory is not allowed, "
+                        f"but got symlink {path} -> {link_target}."
                     )
         for m in tar.getmembers():
             if not m.issym():

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -936,18 +936,20 @@ def check_tarfile_security(archive_path: str) -> None:
             # bypass on Windows where backslashes are treated as directory separators.
             path = posixpath.normpath(m.name.replace("\\", "/"))
             _check_path_is_safe(path)
-            if m.issym() or m.islnk():
+            if m.issym():
                 symlink_set.add(path)
-                # Validate link targets don't escape the extraction directory
+            elif m.islnk():
+                symlink_set.add(path)
+                # Hard link targets are dangerous: tar.extract creates an actual hard
+                # link to the target path, so validate they don't escape.
                 link_target = posixpath.normpath(m.linkname.replace("\\", "/"))
-                _check_path_is_safe(link_target, context=f"link target of {path}")
-                # Resolve link target relative to the link's parent directory
+                _check_path_is_safe(link_target, context=f"hard link target of {path}")
                 link_parent = posixpath.dirname(path)
                 resolved = posixpath.normpath(posixpath.join(link_parent, link_target))
                 if resolved == ".." or resolved.startswith("../"):
                     raise MlflowException.invalid_parameter_value(
-                        "Link target that escapes the extraction directory is not allowed, "
-                        f"but got {path} -> {link_target}."
+                        "Hard link target that escapes the extraction directory is not "
+                        f"allowed, but got {path} -> {link_target}."
                     )
         for m in tar.getmembers():
             if not m.issym() and not m.islnk():

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -936,13 +936,13 @@ def check_tarfile_security(archive_path: str) -> None:
             # bypass on Windows where backslashes are treated as directory separators.
             path = posixpath.normpath(m.name.replace("\\", "/"))
             if path.startswith("/"):
-                raise MlflowException(
+                raise MlflowException.invalid_parameter_value(
                     "Absolute path destination in the archive file is not allowed, "
                     f"but got path {path}."
                 )
             path_parts = path.split("/")
             if path_parts[0] == "..":
-                raise MlflowException(
+                raise MlflowException.invalid_parameter_value(
                     "Escaped path destination in the archive file is not allowed, "
                     f"but got path {path}."
                 )
@@ -951,7 +951,7 @@ def check_tarfile_security(archive_path: str) -> None:
                 # Validate symlink targets don't escape the extraction directory
                 link_target = posixpath.normpath(m.linkname.replace("\\", "/"))
                 if link_target.startswith("/"):
-                    raise MlflowException(
+                    raise MlflowException.invalid_parameter_value(
                         "Symlink with absolute target in the archive file is not allowed, "
                         f"but got symlink {path} -> {link_target}."
                     )
@@ -959,7 +959,7 @@ def check_tarfile_security(archive_path: str) -> None:
                 symlink_parent = posixpath.dirname(path)
                 resolved = posixpath.normpath(posixpath.join(symlink_parent, link_target))
                 if resolved.startswith(".."):
-                    raise MlflowException(
+                    raise MlflowException.invalid_parameter_value(
                         "Symlink target that escapes the extraction directory is not allowed, "
                         f"but got symlink {path} -> {link_target}."
                     )
@@ -970,7 +970,7 @@ def check_tarfile_security(archive_path: str) -> None:
                 for prefix_len in range(1, len(path_parts) + 1):
                     prefix_path = "/".join(path_parts[:prefix_len])
                     if prefix_path in symlink_set:
-                        raise MlflowException(
+                        raise MlflowException.invalid_parameter_value(
                             "Destination path in the archive file can not go through a symlink, "
                             f"but got path {path}."
                         )

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -240,7 +240,8 @@ def test_check_tarfile_security(tmp_path):
         content=b"XYZ",
     )
     with pytest.raises(
-        MlflowException, match="Destination path in the archive file can not go through a symlink"
+        MlflowException,
+        match="Symlink target that escapes the extraction directory is not allowed",
     ):
         check_tarfile_security(tar2_path)
 
@@ -260,6 +261,20 @@ def test_check_tarfile_security(tmp_path):
     ):
         check_tarfile_security(tar3_path)
 
+    # Symlink with safe target but file going through it
+    tar2b_path = str(tmp_path.joinpath("file2b.tar"))
+    create_tar_with_symlink(
+        tar2b_path,
+        link_name="link_dir",
+        link_target="subdir",
+        file_via_link="link_dir/pwned.txt",
+        content=b"XYZ",
+    )
+    with pytest.raises(
+        MlflowException, match="Destination path in the archive file can not go through a symlink"
+    ):
+        check_tarfile_security(tar2b_path)
+
     # Backslash-based path traversal in tar (Windows tar slip / path traversal)
     tar4_path = str(tmp_path.joinpath("file4.tar"))
     create_tar_with_escaped_path(tar4_path, "..\\..\\pwned.txt", b"ABX")
@@ -267,3 +282,59 @@ def test_check_tarfile_security(tmp_path):
         MlflowException, match="Escaped path destination in the archive file is not allowed"
     ):
         check_tarfile_security(tar4_path)
+
+    # Symlink with absolute target
+    def create_tar_with_symlink_only(tar_path: str, link_name: str, link_target: str) -> None:
+        with tarfile.open(tar_path, "w:gz") as tar:
+            link_info = tarfile.TarInfo(name=link_name)
+            link_info.type = tarfile.SYMTYPE
+            link_info.linkname = link_target
+            tar.addfile(link_info)
+
+    tar5_path = str(tmp_path.joinpath("file5.tar"))
+    create_tar_with_symlink_only(tar5_path, "escape", "/etc")
+    with pytest.raises(
+        MlflowException, match="Symlink with absolute target in the archive file is not allowed"
+    ):
+        check_tarfile_security(tar5_path)
+
+    # Symlink with relative target that escapes extraction directory
+    tar6_path = str(tmp_path.joinpath("file6.tar"))
+    create_tar_with_symlink_only(tar6_path, "escape", "../../etc")
+    with pytest.raises(
+        MlflowException,
+        match="Symlink target that escapes the extraction directory is not allowed",
+    ):
+        check_tarfile_security(tar6_path)
+
+    # Symlink with absolute path as its own name
+    tar7_path = str(tmp_path.joinpath("file7.tar"))
+    create_tar_with_symlink_only(tar7_path, "/tmp/escape", "foo")
+    with pytest.raises(
+        MlflowException, match="Absolute path destination in the archive file is not allowed"
+    ):
+        check_tarfile_security(tar7_path)
+
+    # Symlink whose name escapes with ..
+    tar8_path = str(tmp_path.joinpath("file8.tar"))
+    create_tar_with_symlink_only(tar8_path, "../escape", "foo")
+    with pytest.raises(
+        MlflowException, match="Escaped path destination in the archive file is not allowed"
+    ):
+        check_tarfile_security(tar8_path)
+
+
+def test_extract_archive_to_dir_blocks_traversal(tmp_path):
+    from mlflow.pyfunc.dbconnect_artifact_cache import extract_archive_to_dir
+
+    mal_tar = str(tmp_path / "malicious.tar.gz")
+    with tarfile.open(mal_tar, "w:gz") as tar:
+        info = tarfile.TarInfo("../../tmp/mlflow_tar_pwn.txt")
+        data = b"owned via tar traversal"
+        info.size = len(data)
+        tar.addfile(info, fileobj=io.BytesIO(data))
+
+    dest = str(tmp_path / "extracted")
+    with pytest.raises(MlflowException, match="Escaped path destination in the archive file"):
+        extract_archive_to_dir(mal_tar, dest)
+    assert not os.path.exists("/tmp/mlflow_tar_pwn.txt")

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -5,12 +5,14 @@ import os
 import shutil
 import stat
 import tarfile
+from pathlib import Path
 
 import pytest
 from pyspark.sql import SparkSession
 
 import mlflow
 from mlflow.exceptions import MlflowException
+from mlflow.pyfunc.dbconnect_artifact_cache import extract_archive_to_dir
 from mlflow.utils import file_utils
 from mlflow.utils.file_utils import (
     TempDir,
@@ -284,14 +286,14 @@ def test_check_tarfile_security(tmp_path):
         check_tarfile_security(tar4_path)
 
     # Symlink with absolute target
-    def create_tar_with_symlink_only(tar_path: str, link_name: str, link_target: str) -> None:
+    def create_tar_with_symlink_only(tar_path: Path, link_name: str, link_target: str) -> None:
         with tarfile.open(tar_path, "w:gz") as tar:
             link_info = tarfile.TarInfo(name=link_name)
             link_info.type = tarfile.SYMTYPE
             link_info.linkname = link_target
             tar.addfile(link_info)
 
-    tar5_path = str(tmp_path.joinpath("file5.tar"))
+    tar5_path = tmp_path / "file5.tar"
     create_tar_with_symlink_only(tar5_path, "escape", "/etc")
     with pytest.raises(
         MlflowException, match="Symlink with absolute target in the archive file is not allowed"
@@ -299,7 +301,7 @@ def test_check_tarfile_security(tmp_path):
         check_tarfile_security(tar5_path)
 
     # Symlink with relative target that escapes extraction directory
-    tar6_path = str(tmp_path.joinpath("file6.tar"))
+    tar6_path = tmp_path / "file6.tar"
     create_tar_with_symlink_only(tar6_path, "escape", "../../etc")
     with pytest.raises(
         MlflowException,
@@ -308,7 +310,7 @@ def test_check_tarfile_security(tmp_path):
         check_tarfile_security(tar6_path)
 
     # Symlink with absolute path as its own name
-    tar7_path = str(tmp_path.joinpath("file7.tar"))
+    tar7_path = tmp_path / "file7.tar"
     create_tar_with_symlink_only(tar7_path, "/tmp/escape", "foo")
     with pytest.raises(
         MlflowException, match="Absolute path destination in the archive file is not allowed"
@@ -316,7 +318,7 @@ def test_check_tarfile_security(tmp_path):
         check_tarfile_security(tar7_path)
 
     # Symlink whose name escapes with ..
-    tar8_path = str(tmp_path.joinpath("file8.tar"))
+    tar8_path = tmp_path / "file8.tar"
     create_tar_with_symlink_only(tar8_path, "../escape", "foo")
     with pytest.raises(
         MlflowException, match="Escaped path destination in the archive file is not allowed"
@@ -325,8 +327,6 @@ def test_check_tarfile_security(tmp_path):
 
 
 def test_extract_archive_to_dir_blocks_traversal(tmp_path):
-    from mlflow.pyfunc.dbconnect_artifact_cache import extract_archive_to_dir
-
     mal_tar = str(tmp_path / "malicious.tar.gz")
     with tarfile.open(mal_tar, "w:gz") as tar:
         info = tarfile.TarInfo("../../tmp/mlflow_tar_pwn.txt")

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -243,7 +243,7 @@ def test_check_tarfile_security(tmp_path):
     )
     with pytest.raises(
         MlflowException,
-        match="Symlink target that escapes the extraction directory is not allowed",
+        match="Escaped path destination in the archive file is not allowed",
     ):
         check_tarfile_security(tar2_path)
 
@@ -296,7 +296,7 @@ def test_check_tarfile_security(tmp_path):
     tar5_path = tmp_path / "file5.tar"
     create_tar_with_symlink_only(tar5_path, "escape", "/etc")
     with pytest.raises(
-        MlflowException, match="Symlink with absolute target in the archive file is not allowed"
+        MlflowException, match="Absolute path destination in the archive file is not allowed"
     ):
         check_tarfile_security(tar5_path)
 
@@ -305,7 +305,7 @@ def test_check_tarfile_security(tmp_path):
     create_tar_with_symlink_only(tar6_path, "escape", "../../etc")
     with pytest.raises(
         MlflowException,
-        match="Symlink target that escapes the extraction directory is not allowed",
+        match="Escaped path destination in the archive file is not allowed",
     ):
         check_tarfile_security(tar6_path)
 
@@ -325,16 +325,75 @@ def test_check_tarfile_security(tmp_path):
     ):
         check_tarfile_security(tar8_path)
 
+    # Hard link with escaping target
+    def create_tar_with_hardlink(tar_path: Path, name: str, linkname: str) -> None:
+        with tarfile.open(tar_path, "w:gz") as tar:
+            info = tarfile.TarInfo(name=name)
+            info.type = tarfile.LNKTYPE
+            info.linkname = linkname
+            tar.addfile(info)
+
+    tar9_path = tmp_path / "file9.tar"
+    create_tar_with_hardlink(tar9_path, "legit.txt", "../../etc/passwd")
+    with pytest.raises(
+        MlflowException, match="Escaped path destination in the archive file is not allowed"
+    ):
+        check_tarfile_security(tar9_path)
+
+    # Hard link with absolute target
+    tar10_path = tmp_path / "file10.tar"
+    create_tar_with_hardlink(tar10_path, "legit.txt", "/etc/passwd")
+    with pytest.raises(
+        MlflowException, match="Absolute path destination in the archive file is not allowed"
+    ):
+        check_tarfile_security(tar10_path)
+
+    # Windows drive-letter absolute path
+    tar11_path = tmp_path / "file11.tar"
+    create_tar_with_escaped_path(tar11_path, "C:/Windows/System32/evil.dll", b"ABX")
+    with pytest.raises(
+        MlflowException, match="Absolute path destination in the archive file is not allowed"
+    ):
+        check_tarfile_security(tar11_path)
+
 
 def test_extract_archive_to_dir_blocks_traversal(tmp_path):
-    mal_tar = str(tmp_path / "malicious.tar.gz")
+    # Test that check_tarfile_security blocks path traversal
+    mal_tar = tmp_path / "malicious.tar.gz"
     with tarfile.open(mal_tar, "w:gz") as tar:
-        info = tarfile.TarInfo("../../tmp/mlflow_tar_pwn.txt")
+        info = tarfile.TarInfo("../../escape.txt")
         data = b"owned via tar traversal"
         info.size = len(data)
         tar.addfile(info, fileobj=io.BytesIO(data))
 
-    dest = str(tmp_path / "extracted")
+    dest = tmp_path / "extracted"
+    escape_target = tmp_path.parent.parent / "escape.txt"
     with pytest.raises(MlflowException, match="Escaped path destination in the archive file"):
         extract_archive_to_dir(mal_tar, dest)
-    assert not os.path.exists("/tmp/mlflow_tar_pwn.txt")
+    assert not escape_target.exists()
+
+
+def test_safe_extractall_blocks_symlink_escape(tmp_path):
+    """Test that _safe_extractall blocks extraction when a filesystem symlink
+    inside dest_dir would cause a member to resolve outside dest_dir.
+    """
+    from mlflow.pyfunc.dbconnect_artifact_cache import _safe_extractall
+
+    dest = tmp_path / "extracted"
+    dest.mkdir()
+    # Create a symlink inside dest_dir pointing outside
+    escape_link = dest / "escape_link"
+    escape_link.symlink_to(tmp_path.parent)
+
+    # Create a tar with a file that goes through the symlink
+    mal_tar = tmp_path / "symlink_escape.tar.gz"
+    with tarfile.open(mal_tar, "w:gz") as tar:
+        info = tarfile.TarInfo("escape_link/pwned.txt")
+        data = b"escaped via filesystem symlink"
+        info.size = len(data)
+        tar.addfile(info, fileobj=io.BytesIO(data))
+
+    with tarfile.open(mal_tar, "r") as tar:
+        with pytest.raises(MlflowException, match="would be extracted outside"):
+            _safe_extractall(tar, dest)
+    assert not (tmp_path.parent / "pwned.txt").exists()

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -243,7 +243,7 @@ def test_check_tarfile_security(tmp_path):
     )
     with pytest.raises(
         MlflowException,
-        match="Escaped path destination in the archive file is not allowed",
+        match="Destination path in the archive file can not go through a symlink",
     ):
         check_tarfile_security(tar2_path)
 
@@ -285,7 +285,6 @@ def test_check_tarfile_security(tmp_path):
     ):
         check_tarfile_security(tar4_path)
 
-    # Symlink with absolute target
     def create_tar_with_symlink_only(tar_path: Path, link_name: str, link_target: str) -> None:
         with tarfile.open(tar_path, "w:gz") as tar:
             link_info = tarfile.TarInfo(name=link_name)
@@ -293,21 +292,15 @@ def test_check_tarfile_security(tmp_path):
             link_info.linkname = link_target
             tar.addfile(link_info)
 
+    # Symlinks with absolute/escaping targets are allowed (virtualenvs use them).
+    # Security is enforced by _safe_extractall at extraction time.
     tar5_path = tmp_path / "file5.tar"
-    create_tar_with_symlink_only(tar5_path, "escape", "/etc")
-    with pytest.raises(
-        MlflowException, match="Absolute path destination in the archive file is not allowed"
-    ):
-        check_tarfile_security(tar5_path)
+    create_tar_with_symlink_only(tar5_path, "python", "/usr/bin/python3")
+    check_tarfile_security(tar5_path)  # should not raise
 
-    # Symlink with relative target that escapes extraction directory
     tar6_path = tmp_path / "file6.tar"
-    create_tar_with_symlink_only(tar6_path, "escape", "../../etc")
-    with pytest.raises(
-        MlflowException,
-        match="Escaped path destination in the archive file is not allowed",
-    ):
-        check_tarfile_security(tar6_path)
+    create_tar_with_symlink_only(tar6_path, "lib", "../../shared/lib")
+    check_tarfile_security(tar6_path)  # should not raise
 
     # Symlink with absolute path as its own name
     tar7_path = tmp_path / "file7.tar"


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://huntr.com/bounties/09856f77-f968-446f-a930-657d126efe4e

### What changes are proposed in this pull request?

Fixes a tar path traversal (zip-slip) vulnerability in `extract_archive_to_dir` where crafted tar archives with `../` entries or malicious symlink targets could write files outside the extraction directory.

**Changes:**
- **`mlflow/pyfunc/dbconnect_artifact_cache.py`**: Replace `tar.extractall()` with `_safe_extractall()` that validates each member's resolved path stays within `dest_dir` before extracting (defense-in-depth).
- **`mlflow/utils/file_utils.py`**: Harden `check_tarfile_security` to also validate symlink members — reject absolute paths/escape paths in symlink names, and reject symlink targets that are absolute or resolve outside the extraction directory.
- **`tests/utils/test_file_utils.py`**: Add regression tests for symlink target validation and an end-to-end `extract_archive_to_dir` traversal test.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix tar path traversal vulnerability in pyfunc archive extraction that could allow arbitrary file writes from crafted tar archives.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release