### PR TITLE
[TS SDK] Port smart preview truncation from Python SDK

### DIFF
--- a/libs/typescript/core/src/core/trace_manager.ts
+++ b/libs/typescript/core/src/core/trace_manager.ts
@@ -30,17 +30,17 @@ class _Trace {
 
     const root_span = traceData.spans.find((span) => span.parentId == null);
     if (root_span) {
-      // Accessing the OTel span directly get serialized value directly.
-      // TODO: Implement the smart truncation logic.
       // Only set previews if they haven't been explicitly set by updateCurrentTrace
       if (!this.info.requestPreview) {
-        this.info.requestPreview = getPreviewString(
+        this.info.requestPreview = getTruncatedPreview(
           root_span._span.attributes[SpanAttributeKey.INPUTS] as string,
+          'user',
         );
       }
       if (!this.info.responsePreview) {
-        this.info.responsePreview = getPreviewString(
+        this.info.responsePreview = getTruncatedPreview(
           root_span._span.attributes[SpanAttributeKey.OUTPUTS] as string,
+          'assistant',
         );
       }
 
@@ -54,15 +54,123 @@ class _Trace {
   }
 }
 
-function getPreviewString(inputsOrOutputs: string): string {
+/**
+ * Generate a truncated preview string from span inputs/outputs.
+ * Extracts message text content from known chat formats (OpenAI messages,
+ * choices, Responses API) before truncating, so the preview shows readable
+ * text instead of cut-off JSON.
+ *
+ * Mirrors the Python SDK's `_get_truncated_preview` in
+ * `mlflow/tracing/utils/truncation.py`.
+ */
+function getTruncatedPreview(inputsOrOutputs: string, role: string): string {
   if (!inputsOrOutputs) {
     return '';
   }
 
-  if (inputsOrOutputs.length > REQUEST_RESPONSE_PREVIEW_MAX_LENGTH) {
-    return inputsOrOutputs.slice(0, REQUEST_RESPONSE_PREVIEW_MAX_LENGTH - 3) + '...';
+  const maxLength = REQUEST_RESPONSE_PREVIEW_MAX_LENGTH;
+  let content: string | null = null;
+
+  try {
+    const obj = JSON.parse(inputsOrOutputs);
+    if (obj && typeof obj === 'object') {
+      const messages = tryExtractMessages(obj);
+      if (messages && messages.length > 0) {
+        const msg = getLastMessageByRole(messages, role);
+        content = getTextContentFromMessage(msg);
+      }
+    }
+  } catch {
+    // Not valid JSON — use as-is
   }
-  return inputsOrOutputs;
+
+  const preview = content || inputsOrOutputs;
+  if (preview.length <= maxLength) {
+    return preview;
+  }
+  return preview.slice(0, maxLength - 3) + '...';
+}
+
+function tryExtractMessages(obj: Record<string, unknown>): Record<string, unknown>[] | null {
+  // OpenAI ChatCompletion request format: { messages: [...] }
+  if (Array.isArray(obj.messages)) {
+    return obj.messages.filter(isMessage);
+  }
+
+  // OpenAI ChatCompletion response format: { choices: [{ message: {...} }] }
+  if (
+    Array.isArray(obj.choices) &&
+    obj.choices.length > 0 &&
+    typeof obj.choices[0] === 'object' &&
+    obj.choices[0] !== null
+  ) {
+    const msg = (obj.choices[0] as Record<string, unknown>).message;
+    if (isMessage(msg)) {
+      return [msg as Record<string, unknown>];
+    }
+  }
+
+  // OpenAI Responses API request format: { input: [...] }
+  if (Array.isArray(obj.input)) {
+    return obj.input.filter(isMessage);
+  }
+
+  // OpenAI Responses API response format: { output: [...] }
+  if (Array.isArray(obj.output)) {
+    return obj.output.filter(isMessage);
+  }
+
+  // ResponsesAgent input: { request: { ... } }
+  if (obj.request && typeof obj.request === 'object') {
+    return tryExtractMessages(obj.request as Record<string, unknown>);
+  }
+
+  return null;
+}
+
+function isMessage(item: unknown): item is Record<string, unknown> {
+  return (
+    item !== null &&
+    typeof item === 'object' &&
+    'role' in (item as Record<string, unknown>) &&
+    'content' in (item as Record<string, unknown>)
+  );
+}
+
+function getLastMessageByRole(
+  messages: Record<string, unknown>[],
+  role: string,
+): Record<string, unknown> {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === role) {
+      return messages[i];
+    }
+  }
+  return messages[messages.length - 1];
+}
+
+function getTextContentFromMessage(message: Record<string, unknown>): string | null {
+  const content = message.content;
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (typeof part === 'string') {
+        return part;
+      }
+      if (
+        part &&
+        typeof part === 'object' &&
+        ('type' in (part as Record<string, unknown>)) &&
+        ((part as Record<string, unknown>).type === 'text' ||
+          (part as Record<string, unknown>).type === 'output_text')
+      ) {
+        return (part as Record<string, unknown>).text as string;
+      }
+    }
+  }
+  return null;
 }
 
 /**

--- a/libs/typescript/core/src/core/trace_manager.ts
+++ b/libs/typescript/core/src/core/trace_manager.ts
@@ -162,7 +162,7 @@ function getTextContentFromMessage(message: Record<string, unknown>): string | n
       if (
         part &&
         typeof part === 'object' &&
-        ('type' in (part as Record<string, unknown>)) &&
+        'type' in (part as Record<string, unknown>) &&
         ((part as Record<string, unknown>).type === 'text' ||
           (part as Record<string, unknown>).type === 'output_text')
       ) {

--- a/libs/typescript/core/src/core/trace_manager.ts
+++ b/libs/typescript/core/src/core/trace_manager.ts
@@ -74,7 +74,7 @@ function getTruncatedPreview(inputsOrOutputs: string, role: string): string {
   try {
     const obj = JSON.parse(inputsOrOutputs);
     if (obj && typeof obj === 'object') {
-      const messages = tryExtractMessages(obj);
+      const messages = tryExtractMessages(obj as Record<string, unknown>);
       if (messages && messages.length > 0) {
         const msg = getLastMessageByRole(messages, role);
         content = getTextContentFromMessage(msg);
@@ -102,11 +102,11 @@ function tryExtractMessages(obj: Record<string, unknown>): Record<string, unknow
     Array.isArray(obj.choices) &&
     obj.choices.length > 0 &&
     typeof obj.choices[0] === 'object' &&
-    obj.choices[0] !== null
+    obj.choices[0] != null
   ) {
     const msg = (obj.choices[0] as Record<string, unknown>).message;
     if (isMessage(msg)) {
-      return [msg as Record<string, unknown>];
+      return [msg];
     }
   }
 
@@ -130,7 +130,7 @@ function tryExtractMessages(obj: Record<string, unknown>): Record<string, unknow
 
 function isMessage(item: unknown): item is Record<string, unknown> {
   return (
-    item !== null &&
+    item != null &&
     typeof item === 'object' &&
     'role' in (item as Record<string, unknown>) &&
     'content' in (item as Record<string, unknown>)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Align the request/response preview parsing logic for TS SDK to the ones in Python SDK.

Python SDK does special handling for OpenAI messages, choices, and Responses API formats. TS SDK does not have it now and naively truncate the json to 1000 characters. When the message content is large, the truncation results in a broken JSON string, which frontend cannot parse so render it as-is.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Before**

The response preview is raw json string (truncated) when the message content is large.

<img width="878" height="55" alt="Screenshot 2026-03-19 at 14 03 09" src="https://github.com/user-attachments/assets/31b730f9-d1cd-49df-94e0-7ff38cfe42d5" />

<img width="500" height="357" alt="Screenshot 2026-03-19 at 14 03 16" src="https://github.com/user-attachments/assets/e7071b81-3ec2-493a-87b8-59b4d9ec431f" />

**After**

The response preview parses the message content even when the response message is large.

<img width="851" height="284" alt="Screenshot 2026-03-19 at 14 02 05" src="https://github.com/user-attachments/assets/cfdc9c84-84b6-418b-b454-9c8d12f3287d" />

<img width="500" height="704" alt="Screenshot 2026-03-19 at 14 02 14" src="https://github.com/user-attachments/assets/babad4db-4b37-4f85-9534-5ec989d1d305" />

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
