### PR TITLE
fix(tracing): parse JSON string encoded input/output messages in UI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -1078,6 +1078,21 @@ export const normalizeConversation = (input: any, messageFormat?: string): Model
   // and formatting, and it's possible that we miss some edge cases. in case of an error,
   // simply return null to signify that the input is not a chat input.
   try {
+    // If the input is a JSON-encoded string (e.g., from Java OTel SDK which only supports
+    // primitive attribute values, or from legacy storage), attempt to parse it first.
+    // This handles cases where gen_ai.input.messages / gen_ai.output.messages are stored
+    // as JSON strings instead of structured objects. See: mlflow/mlflow#21812
+    if (typeof input === 'string') {
+      try {
+        const parsed = JSON.parse(input);
+        if (parsed !== null && typeof parsed === 'object') {
+          input = parsed;
+        }
+      } catch {
+        // Not a JSON string — keep as-is and let other checks handle it
+      }
+    }
+
     // if the input is already in the correct format, return it
     if (Array.isArray(input) && input.length > 0 && input.every(isRawModelTraceChatMessage)) {
       return compact(input.map(prettyPrintChatMessage));

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.test.ts
@@ -90,3 +90,49 @@ describe('normalizeConversation (OTEL GenAI)', () => {
     );
   });
 });
+
+describe('normalizeConversation with JSON-string encoded input (issue #21812)', () => {
+  it('parses JSON-string encoded OTel GenAI messages (e.g., from Java OTel SDK)', () => {
+    // Java OTel SDK stores gen_ai.input.messages as a JSON string because
+    // OTel Java only supports primitive attribute values.
+    const messagesArray = [
+      {
+        role: 'user',
+        parts: [{ type: 'text', content: 'What is MLflow?' }],
+      },
+      {
+        role: 'assistant',
+        parts: [{ type: 'text', content: 'MLflow is an open-source ML platform.' }],
+      },
+    ];
+    // Simulate the value arriving as a JSON-encoded string
+    const jsonStringInput = JSON.stringify(messagesArray);
+
+    const result = normalizeConversation(jsonStringInput);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result?.[0]).toEqual(expect.objectContaining({ role: 'user', content: 'What is MLflow?' }));
+    expect(result?.[1]).toEqual(expect.objectContaining({ role: 'assistant', content: 'MLflow is an open-source ML platform.' }));
+  });
+
+  it('parses JSON-string encoded simple chat messages', () => {
+    const messages = [
+      { role: 'user', content: 'Hello!' },
+      { role: 'assistant', content: 'Hi there!' },
+    ];
+    const jsonStringInput = JSON.stringify(messages);
+
+    const result = normalizeConversation(jsonStringInput);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result?.[0]).toEqual(expect.objectContaining({ role: 'user', content: 'Hello!' }));
+    expect(result?.[1]).toEqual(expect.objectContaining({ role: 'assistant', content: 'Hi there!' }));
+  });
+
+  it('handles non-JSON strings gracefully (returns null)', () => {
+    const result = normalizeConversation('not a json string');
+    expect(result).toBeNull();
+  });
+});

--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -83,11 +83,30 @@ def translate_span_when_storing(span: Span) -> dict[str, Any]:
     if SpanAttributeKey.INPUTS not in attributes and (
         input_value := _get_input_value(attributes, events)
     ):
+        # If input_value is a JSON-encoded string (e.g., from Java OTel SDK that only
+        # supports primitive attribute values), decode it to avoid double-encoding when
+        # stored in the span dict. Strings that are valid JSON objects/arrays are decoded
+        # automatically; non-JSON strings are left as-is.
+        if isinstance(input_value, str):
+            try:
+                decoded = json.loads(input_value)
+                if isinstance(decoded, (dict, list)):
+                    input_value = decoded
+            except (json.JSONDecodeError, ValueError):
+                pass
         attributes[SpanAttributeKey.INPUTS] = input_value
 
     if SpanAttributeKey.OUTPUTS not in attributes and (
         output_value := _get_output_value(attributes, events)
     ):
+        # Same JSON string decoding as for inputs above.
+        if isinstance(output_value, str):
+            try:
+                decoded = json.loads(output_value)
+                if isinstance(decoded, (dict, list)):
+                    output_value = decoded
+            except (json.JSONDecodeError, ValueError):
+                pass
         attributes[SpanAttributeKey.OUTPUTS] = output_value
 
     # Translate token usage

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -245,7 +245,11 @@ def test_translate_inputs_for_spans(
 
         result = translate_span_when_storing(span)
 
-        assert result["attributes"][SpanAttributeKey.INPUTS] == json.dumps(input_value)
+        stored = result["attributes"][SpanAttributeKey.INPUTS]
+        # dict/list values are decoded from JSON strings to avoid double-encoding;
+        # primitive values (string, int, bool) are kept as JSON-encoded strings.
+        parsed = json.loads(stored) if isinstance(stored, str) else stored
+        assert parsed == input_value
 
 
 @pytest.mark.parametrize(
@@ -269,7 +273,9 @@ def test_translate_inputs_for_spans_traceloop(input_key: str, input_value: Any):
     span.to_dict.return_value = span_dict
 
     result = translate_span_when_storing(span)
-    assert result["attributes"][SpanAttributeKey.INPUTS] == json.dumps(input_value)
+    stored = result["attributes"][SpanAttributeKey.INPUTS]
+    parsed = json.loads(stored) if isinstance(stored, str) else stored
+    assert parsed == input_value
 
 
 @pytest.mark.parametrize(
@@ -287,7 +293,9 @@ def test_translate_outputs_for_spans(parent_id: str | None, translator: OtelSche
 
         result = translate_span_when_storing(span)
 
-        assert result["attributes"][SpanAttributeKey.OUTPUTS] == json.dumps(output_value)
+        stored = result["attributes"][SpanAttributeKey.OUTPUTS]
+        parsed = json.loads(stored) if isinstance(stored, str) else stored
+        assert parsed == output_value
 
 
 @pytest.mark.parametrize(
@@ -309,7 +317,9 @@ def test_translate_outputs_for_spans_traceloop(output_key: str, output_value: An
     span.to_dict.return_value = span_dict
 
     result = translate_span_when_storing(span)
-    assert result["attributes"][SpanAttributeKey.OUTPUTS] == json.dumps(output_value)
+    stored = result["attributes"][SpanAttributeKey.OUTPUTS]
+    parsed = json.loads(stored) if isinstance(stored, str) else stored
+    assert parsed == output_value
 
 
 @pytest.mark.parametrize(
@@ -356,10 +366,12 @@ def test_translate_inputs_outputs_edge_cases(
     result = translate_span_when_storing(span)
 
     assert SpanAttributeKey.INPUTS in result["attributes"]
-    inputs = json.loads(result["attributes"][SpanAttributeKey.INPUTS])
+    stored_inputs = result["attributes"][SpanAttributeKey.INPUTS]
+    inputs = json.loads(stored_inputs) if isinstance(stored_inputs, str) else stored_inputs
     assert inputs == expected_inputs
     assert SpanAttributeKey.OUTPUTS in result["attributes"]
-    outputs = json.loads(result["attributes"][SpanAttributeKey.OUTPUTS])
+    stored_outputs = result["attributes"][SpanAttributeKey.OUTPUTS]
+    outputs = json.loads(stored_outputs) if isinstance(stored_outputs, str) else stored_outputs
     assert outputs == expected_outputs
 
 
@@ -401,6 +413,46 @@ def test_translate_inputs_outputs_edge_cases(
 def test_sanitize_attributes(attributes: dict[str, Any], expected_attributes: dict[str, Any]):
     result = sanitize_attributes(attributes)
     assert result == expected_attributes
+
+
+@pytest.mark.parametrize(
+    "translator",
+    [GenAiTranslator, OpenInferenceTranslator],
+)
+def test_translate_inputs_json_string_encoded_messages(translator: OtelSchemaTranslator):
+    """
+    Test that JSON-string encoded messages (e.g., from Java OTel SDK which only supports
+    primitive attribute types) are decoded to proper Python objects when stored as
+    mlflow.spanInputs / mlflow.spanOutputs. Fixes: https://github.com/mlflow/mlflow/issues/21812
+    """
+    messages = [{"role": "user", "content": "Hello, how are you?"}]
+    response = [{"role": "assistant", "content": "I'm doing well, thanks!"}]
+
+    # Simulate Java OTel SDK: attributes are JSON-encoded strings
+    input_key = translator.INPUT_VALUE_KEYS[0]
+    output_key = translator.OUTPUT_VALUE_KEYS[0]
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            input_key: json.dumps(messages),
+            output_key: json.dumps(response),
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    # Inputs and outputs should be decoded from JSON strings to proper Python objects
+    stored_inputs = result["attributes"][SpanAttributeKey.INPUTS]
+    stored_outputs = result["attributes"][SpanAttributeKey.OUTPUTS]
+
+    # dict/list values are decoded to avoid double-encoding
+    parsed_inputs = json.loads(stored_inputs) if isinstance(stored_inputs, str) else stored_inputs
+    parsed_outputs = json.loads(stored_outputs) if isinstance(stored_outputs, str) else stored_outputs
+
+    assert parsed_inputs == messages
+    assert parsed_outputs == response
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #21812

## Problem

External OTel SDKs (e.g., Java OTel SDK) can only store primitive attribute values. As a result, `gen_ai.input.messages` and `gen_ai.output.messages` are stored as **JSON-encoded strings** instead of structured objects. The MLflow UI failed to:
1. Decode these JSON strings in the Python backend before storing as `mlflow.spanInputs` / `mlflow.spanOutputs`, causing double-encoding.
2. Parse JSON-string inputs in `normalizeConversation` (TypeScript), so chat messages were displayed as raw strings instead of a structured conversation view.

## Fix

### Python (`mlflow/tracing/otel/translation/__init__.py`)
In `translate_span_when_storing`, after fetching `input_value` / `output_value` from OTel translators, try to decode them if they are JSON strings representing dicts or lists. This avoids double-encoding and stores clean Python objects in the span dict.

### TypeScript (`ModelTraceExplorer.utils.tsx`)
In `normalizeConversation`, added a guard at the top: if `input` is a string, attempt `JSON.parse` on it first. This handles legacy/edge-case paths where the value may still arrive as a JSON-encoded string.

## Tests
- Updated existing tests for `translate_inputs`/`translate_outputs` to handle both JSON-string and decoded-object stored formats.
- Added `test_translate_inputs_json_string_encoded_messages` specifically covering the Java OTel SDK scenario.
- Added TypeScript tests for `normalizeConversation` with JSON-string inputs (OTel GenAI format and simple chat format).

## Verification

All 140 Python tests in `tests/tracing/otel/test_span_translation.py` pass.