### PR TITLE
Fix trace drawer width using context instead of prop drilling

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -121,6 +121,7 @@ const TracesV3LogsImpl = React.memo(
     disableActions = false,
     customDefaultSelectedColumns,
     toolbarAddons,
+    drawerWidth,
   }: {
     /**
      * Array of experiment IDs to search traces for.
@@ -142,6 +143,7 @@ const TracesV3LogsImpl = React.memo(
     disableActions?: boolean;
     customDefaultSelectedColumns?: (column: TracesTableColumn) => boolean;
     toolbarAddons?: React.ReactNode;
+    drawerWidth?: string | number;
   }) => {
     // When viewing a single experiment, pass its ID to enable experiment-specific
     // features (run name links, logged model links, session links, filter dropdowns).
@@ -475,6 +477,7 @@ const TracesV3LogsImpl = React.memo(
       <ModelTraceExplorerContextProvider
         renderExportTracesToDatasetsModal={renderCustomExportTracesToDatasetsModal}
         DrawerComponent={AssistantAwareDrawer}
+        drawerWidth={drawerWidth}
       >
         <GenAITracesTableProvider
           experimentId={singleExperimentId}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
@@ -37,6 +37,7 @@ const TracesV3Content = ({
         // TODO: Remove this once the endpointName is not needed
         endpointName={endpointName || ''}
         timeRange={timeRange}
+        drawerWidth="80vw"
       />
     );
   }

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
@@ -291,7 +291,6 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
           isLoading={currentTraceQueryResult.isLoading}
           experimentId={experimentId}
           traceInfo={currentTraceInfo}
-          width="60vw"
         >
           {content}
         </ModelTraceExplorerDrawer>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
@@ -291,6 +291,7 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
           isLoading={currentTraceQueryResult.isLoading}
           experimentId={experimentId}
           traceInfo={currentTraceInfo}
+          width="60vw"
         >
           {content}
         </ModelTraceExplorerDrawer>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerContext.tsx
@@ -31,6 +31,7 @@ export interface ModelTraceExplorerContextValue {
   DrawerComponent: DrawerComponentType;
   /** When set (e.g. by the evaluation review drawer), content can show "Add to dataset" that calls openModal */
   addToDatasetAction?: AddToDatasetAction;
+  drawerWidth?: string | number;
 }
 
 const ModelTraceExplorerContext = createContext<ModelTraceExplorerContextValue>({
@@ -43,19 +44,22 @@ interface ModelTraceExplorerContextProviderProps {
   children: React.ReactNode;
   renderExportTracesToDatasetsModal?: (params: RenderExportTracesToDatasetsModalParams) => React.ReactNode;
   DrawerComponent?: DrawerComponentType;
+  drawerWidth?: string | number;
 }
 
 export const ModelTraceExplorerContextProvider: React.FC<ModelTraceExplorerContextProviderProps> = ({
   children,
   renderExportTracesToDatasetsModal,
   DrawerComponent = Drawer,
+  drawerWidth,
 }) => {
   const value = useMemo(
     () => ({
       renderExportTracesToDatasetsModal,
       DrawerComponent,
+      drawerWidth,
     }),
-    [renderExportTracesToDatasetsModal, DrawerComponent],
+    [renderExportTracesToDatasetsModal, DrawerComponent, drawerWidth],
   );
 
   return <ModelTraceExplorerContext.Provider value={value}>{children}</ModelTraceExplorerContext.Provider>;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
@@ -23,7 +23,6 @@ export interface ModelTraceExplorerDrawerProps {
   isLoading?: boolean;
   experimentId?: string;
   traceInfo?: ModelTraceInfoV3;
-  width?: string | number;
 }
 
 export const ModelTraceExplorerDrawer = ({
@@ -37,11 +36,10 @@ export const ModelTraceExplorerDrawer = ({
   isLoading,
   experimentId,
   traceInfo,
-  width = '90vw',
 }: ModelTraceExplorerDrawerProps) => {
   const { theme } = useDesignSystemTheme();
   const [showDatasetModal, setShowDatasetModal] = useState(false);
-  const { renderExportTracesToDatasetsModal, DrawerComponent } = useModelTraceExplorerContext();
+  const { renderExportTracesToDatasetsModal, DrawerComponent, drawerWidth = '60vw' } = useModelTraceExplorerContext();
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -85,7 +83,7 @@ export const ModelTraceExplorerDrawer = ({
     >
       <DrawerComponent.Content
         componentId="mlflow.evaluations_review.modal"
-        width={width}
+        width={drawerWidth}
         title={
           <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
             <Button

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
@@ -23,6 +23,7 @@ export interface ModelTraceExplorerDrawerProps {
   isLoading?: boolean;
   experimentId?: string;
   traceInfo?: ModelTraceInfoV3;
+  width?: string | number;
 }
 
 export const ModelTraceExplorerDrawer = ({
@@ -36,6 +37,7 @@ export const ModelTraceExplorerDrawer = ({
   isLoading,
   experimentId,
   traceInfo,
+  width = '90vw',
 }: ModelTraceExplorerDrawerProps) => {
   const { theme } = useDesignSystemTheme();
   const [showDatasetModal, setShowDatasetModal] = useState(false);
@@ -83,7 +85,7 @@ export const ModelTraceExplorerDrawer = ({
     >
       <DrawerComponent.Content
         componentId="mlflow.evaluations_review.modal"
-        width="60vw"
+        width={width}
         title={
           <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
             <Button


### PR DESCRIPTION
### What changes are proposed in this pull request?

#21793 tried to update the drawer width in Evaluation Runs page to `60vw`. However, it changed global size, which is too narrow as a default size.

<img width="1463" height="848" alt="Screenshot 2026-03-19 at 22 14 57" src="https://github.com/user-attachments/assets/e0daf13f-e85e-4937-a5f9-108a3246ecdf" />

### How is this PR tested?

- [x] Manual tests

Verified drawer width on Traces page (80vw) and Evaluation runs page (60vw).

<img width="1563" height="855" alt="Screenshot 2026-03-19 at 22 29 35" src="https://github.com/user-attachments/assets/0fdebb94-1f5e-4019-b196-cdf7772b5858" />

<img width="1574" height="853" alt="Screenshot 2026-03-19 at 22 29 58" src="https://github.com/user-attachments/assets/5652bde6-8ad3-4b98-940c-6e318ad8d819" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Trace detail drawer on the Traces page is now wider (80vw instead of 60vw) for better readability.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release