### PR TITLE
Add default uvicorn log config with timestamps

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -474,6 +474,7 @@ def _get_package_data(package_type: PackageType) -> dict[str, list[str]] | None:
             "pyspark/ml/log_model_allowlist.txt",
             "server/auth/basic_auth.ini",
             "server/auth/db/migrations/alembic.ini",
+            "server/uvicorn_log_config.yaml",
             "models/notebook_resources/**/*",
             "ai_commands/**/*.md",
             "assistant/skills/**/*",

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -133,6 +133,7 @@ mlflow = [
   "pyspark/ml/log_model_allowlist.txt",
   "server/auth/basic_auth.ini",
   "server/auth/db/migrations/alembic.ini",
+  "server/uvicorn_log_config.yaml",
   "models/notebook_resources/**/*",
   "ai_commands/**/*.md",
   "assistant/skills/**/*",

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -10,6 +10,7 @@ import tempfile
 import textwrap
 import types
 import warnings
+from pathlib import Path
 
 _logger = logging.getLogger("mlflow.server")
 
@@ -292,11 +293,16 @@ def _build_gunicorn_command(gunicorn_opts, host, port, workers, app_name):
     ]
 
 
+_UVICORN_LOG_CONFIG = Path(__file__).parent / "uvicorn_log_config.yaml"
+
+
 def _build_uvicorn_command(
     uvicorn_opts, host, port, workers, app_name, env_file=None, is_factory=False
 ):
     """Build command to run uvicorn server."""
     opts = shlex.split(uvicorn_opts) if uvicorn_opts else []
+    if not any(o == "--log-config" or o.startswith("--log-config=") for o in opts):
+        opts.extend(["--log-config", str(_UVICORN_LOG_CONFIG)])
     cmd = [
         sys.executable,
         "-m",

--- a/mlflow/server/uvicorn_log_config.yaml
+++ b/mlflow/server/uvicorn_log_config.yaml
@@ -1,0 +1,28 @@
+version: 1
+disable_existing_loggers: false
+formatters:
+  default:
+    "()": uvicorn.logging.DefaultFormatter
+    fmt: "%(asctime)s %(levelprefix)s %(message)s"
+    datefmt: "%Y/%m/%d %H:%M:%S"
+  access:
+    "()": uvicorn.logging.AccessFormatter
+    fmt: '%(asctime)s %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
+    datefmt: "%Y/%m/%d %H:%M:%S"
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
+loggers:
+  uvicorn:
+    handlers: [default]
+    level: INFO
+  uvicorn.access:
+    handlers: [access]
+    level: INFO
+    propagate: false

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -135,6 +135,7 @@ mlflow = [
   "pyspark/ml/log_model_allowlist.txt",
   "server/auth/basic_auth.ini",
   "server/auth/db/migrations/alembic.ini",
+  "server/uvicorn_log_config.yaml",
   "models/notebook_resources/**/*",
   "ai_commands/**/*.md",
   "assistant/skills/**/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ mlflow = [
   "pyspark/ml/log_model_allowlist.txt",
   "server/auth/basic_auth.ini",
   "server/auth/db/migrations/alembic.ini",
+  "server/uvicorn_log_config.yaml",
   "models/notebook_resources/**/*",
   "ai_commands/**/*.md",
   "assistant/skills/**/*",

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -106,6 +106,8 @@ def test_build_uvicorn_command():
         sys.executable,
         "-m",
         "uvicorn",
+        "--log-config",
+        str(server._UVICORN_LOG_CONFIG),
         "--host",
         "localhost",
         "--port",
@@ -125,6 +127,8 @@ def test_build_uvicorn_command():
         "--reload",
         "--log-level",
         "debug",
+        "--log-config",
+        str(server._UVICORN_LOG_CONFIG),
         "--host",
         "localhost",
         "--port",
@@ -140,6 +144,8 @@ def test_build_uvicorn_command():
         sys.executable,
         "-m",
         "uvicorn",
+        "--log-config",
+        str(server._UVICORN_LOG_CONFIG),
         "--host",
         "localhost",
         "--port",
@@ -163,6 +169,7 @@ def test_build_uvicorn_command_with_env_file():
 
     assert "--env-file" in cmd
     assert "/path/to/.env" in cmd
+    assert "--log-config" in cmd
     # Verify the order - env-file should come before the app name
     env_file_idx = cmd.index("--env-file")
     env_file_path_idx = cmd.index("/path/to/.env")
@@ -223,6 +230,8 @@ def test_run_server_with_uvicorn(mock_exec_cmd, monkeypatch):
         "-m",
         "uvicorn",
         "--reload",
+        "--log-config",
+        str(server._UVICORN_LOG_CONFIG),
         "--host",
         "localhost",
         "--port",
@@ -237,6 +246,20 @@ def test_run_server_with_uvicorn(mock_exec_cmd, monkeypatch):
         capture_output=False,
         synchronous=False,
     )
+
+
+@pytest.mark.parametrize(
+    "uvicorn_opts",
+    [
+        "--log-config /custom/path.yaml",
+        "--log-config=/custom/path.yaml",
+    ],
+)
+def test_build_uvicorn_command_user_log_config_takes_precedence(uvicorn_opts):
+    cmd = server._build_uvicorn_command(
+        uvicorn_opts, "localhost", "5000", "4", "mlflow.server.fastapi_app:app"
+    )
+    assert not any("uvicorn_log_config.yaml" in o for o in cmd)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Uvicorn's default log format omits timestamps, making it hard to correlate server logs with events. This PR adds a bundled YAML log config (`mlflow/server/uvicorn_log_config.yaml`) that injects timestamps using MLflow's datetime format while preserving uvicorn's native colored formatters. The config is automatically applied unless the user specifies their own `--log-config` via `--uvicorn-opts`.

**Before:**
```
INFO:     Uvicorn running on http://127.0.0.1:5577 (Press CTRL+C to quit)
INFO:     Started parent process [35689]
INFO:     Started server process [35694]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     127.0.0.1:60258 - "GET /health HTTP/1.1" 200 OK
INFO:     127.0.0.1:60259 - "POST /api/2.0/mlflow/experiments/search HTTP/1.1" 400 Bad Request
```

**After:**
```
2026/03/19 22:31:52 INFO:     Uvicorn running on http://127.0.0.1:5577 (Press CTRL+C to quit)
2026/03/19 22:31:52 INFO:     Started parent process [36801]
2026/03/19 22:31:54 INFO:     Started server process [36805]
2026/03/19 22:31:54 INFO:     Waiting for application startup.
2026/03/19 22:31:54 INFO:     Application startup complete.
2026/03/19 22:32:00 INFO:     127.0.0.1:60322 - "GET /health HTTP/1.1" 200 OK
2026/03/19 22:32:00 INFO:     127.0.0.1:60323 - "POST /api/2.0/mlflow/experiments/search HTTP/1.1" 400 Bad Request
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow server now includes timestamps in uvicorn log output by default.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)