### PR TITLE
fix: sync run outputs after logging model for correct metric associations

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -13,7 +13,7 @@ import yaml
 from packaging.requirements import InvalidRequirement, Requirement
 
 import mlflow
-from mlflow.entities import LoggedModel, LoggedModelOutput, Metric
+from mlflow.entities import LoggedModel, LoggedModelOutput, Metric, RunOutputs
 from mlflow.entities.model_registry.prompt_version import PromptVersion
 from mlflow.environment_variables import (
     MLFLOW_PRINT_MODEL_URLS_ON_CREATION,
@@ -1199,6 +1199,18 @@ class Model:
                     log_model_metrics_for_step(
                         client=client, model_id=model.model_id, run_id=run_id, step=step
                     )
+                    # Update the active run's outputs in memory to keep it in sync with the server
+                    # This ensures that subsequent calls to log_metric can find the model
+                    # without requiring an explicit model_id parameter
+                    if (active_run := mlflow.active_run()) and active_run.info.run_id == run_id:
+                        if active_run.outputs is None:
+                            active_run._outputs = RunOutputs(
+                                model_outputs=[LoggedModelOutput(model.model_id, step=step)]
+                            )
+                        else:
+                            active_run.outputs._model_outputs.append(
+                                LoggedModelOutput(model.model_id, step=step)
+                            )
 
                 if prompts is not None:
                     # Convert to URIs for serialization


### PR DESCRIPTION
## Summary

Fixes issue where `mlflow.active_run().outputs` returns None after logging a model, which breaks the automatic association of metrics with models and datasets.

## Problem

In MLflow 3.5+, when logging a model, dataset, and metrics in a run, the associations between them are no longer being created correctly. The issue is that `mlflow.active_run().outputs` returns None while `mlflow.get_run(...).outputs` returns the correct model outputs.

This is related to PR #18241 which changed how model outputs are tracked. When `log_metric` is called without an explicit `model_id`, it should use the active model from the run outputs, but since `active_run().outputs` is None, the association fails.

## Solution

After logging a model in `Model.log()`, update the active run's outputs in memory to keep it in sync with the server state. This ensures that subsequent calls to `log_metric` can find the active model without requiring an explicit `model_id` parameter.

## Changes

- Modified `mlflow/models/model.py` to update the active run's `_outputs` attribute after calling `client.log_outputs()`
- Added `RunOutputs` to the imports from `mlflow.entities`

## Testing

The fix ensures that:
1. `mlflow.active_run().outputs` is properly synced after logging a model
2. `log_metric` can automatically find the active model without explicit `model_id`
3. Model, metric, and dataset associations work correctly

Fixes #21836