### PR TITLE
fix: optimize run comparison performance for large numbers of runs

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useSampledMetricHistory.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useSampledMetricHistory.tsx
@@ -18,7 +18,7 @@ export type SampledMetricsByRun = {
   [metricKey: string]: SampledMetricData;
 };
 
-const SAMPLED_METRIC_HISTORY_API_RUN_LIMIT = 100;
+const SAMPLED_METRIC_HISTORY_API_RUN_LIMIT = 500;
 
 /**
  * Automatically fetches sampled metric history for runs, used in run runs charts.

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
@@ -166,6 +166,12 @@ const RunsCompareImpl = ({
       tagsByRunUuid: state.entities.tagsByRunUuid,
       imagesByRunUuid: state.entities.imagesByRunUuid,
     }),
+    // Use shallow equality to prevent unnecessary re-renders when the same data is returned
+    (left, right) =>
+      left.paramsByRunUuid === right.paramsByRunUuid &&
+      left.latestMetricsByRunUuid === right.latestMetricsByRunUuid &&
+      left.tagsByRunUuid === right.tagsByRunUuid &&
+      left.imagesByRunUuid === right.imagesByRunUuid,
   );
 
   const { theme } = useDesignSystemTheme();


### PR DESCRIPTION
## Summary

Improves performance when comparing 100+ runs in the MLflow UI.

## Changes

- Increased SAMPLED_METRIC_HISTORY_API_RUN_LIMIT from 100 to 500 to reduce the number of API calls when fetching metric history for large numbers of runs
- Added shallow equality comparison to the Redux selector in RunsCompare to prevent unnecessary re-renders when the same data is returned

## Performance Improvements

- Fewer API calls: With 500 runs, instead of making 5 separate API calls (100 runs each), now only 1 API call is needed
- Reduced re-renders: The shallow equality check prevents React from re-rendering when the same entity data is returned from Redux

## Testing

- Verified the changes compile correctly
- The optimizations follow existing patterns in the codebase

Fixes mlflow/mlflow#21841