### PR TITLE
Fix eval runs page crash when clicking a trace row

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -367,8 +367,17 @@ const ExperimentEvaluationRunsPageImpl = () => {
           : undefined
       }
       setSelectedRunUuid={(runUuid: string) => {
-        setSelectedRunUuid(runUuid);
-        setCompareToRunUuid(undefined);
+        // Set selectedRunUuid and clear compareToRunUuid in a single
+        // setSearchParams call to avoid the second call clobbering
+        // the first when React Router batches navigations.
+        setSearchParams(
+          (params) => {
+            params.set('selectedRunUuid', runUuid);
+            params.delete('compareToRunUuid');
+            return params;
+          },
+          { replace: true },
+        );
         // When flag is ON, also set isViewingSelectedRun to show the split view
         if (showIssuesPanelFlag) {
           setIsViewingSelectedRun(true);


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21407

### What changes are proposed in this pull request?

Clicking a trace row in the Evaluation Runs page caused the entire traces panel to disappear.

**Root cause:** When clicking a run name, two separate `setSearchParams` calls fire in the same handler — one to set `selectedRunUuid` and one to clear `compareToRunUuid`. React Router batches these navigations in React 18, so the second call's callback receives stale params (from before the first call) and overwrites `selectedRunUuid`.

In 3.10 this was masked because auto-selection restored `selectedRunUuid` on every render. When `shouldShowEvalRunsIssuesPanel` (#21407) disabled auto-selection, the clobbering became visible — clicking a trace row caused `useActiveEvaluation` to write `selectedEvaluationId` to a URL that was already missing `selectedRunUuid`, collapsing the split view.

**Fix:** Combine both param updates into a single atomic `setSearchParams` call, matching the pattern already used by `handleCompare` (line 280).

### How is this PR tested?

- [x] Manual tests

Verified on the Evaluation Runs page: clicking a trace row now opens the drawer without the traces panel disappearing. URL deep-linking with `selectedEvaluationId` is preserved.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix a crash where clicking a trace row on the Evaluation Runs page caused the traces panel to disappear.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release