### PR TITLE
Deduplicate scalar `TOTAL_TOKENS` queries via combined aggregations

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenStatsChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenStatsChart.test.tsx
@@ -29,11 +29,11 @@ const createTokenStatsDataPoint = (timeBucket: string, p50: number, p90: number,
   },
 });
 
-// Helper to create an AVG token stats data point
+// Helper to create a scalar token stats data point with both SUM and AVG (combined query).
 const createAvgTokenStatsDataPoint = (avg: number) => ({
   metric_name: TraceMetricKey.TOTAL_TOKENS,
   dimensions: {},
-  values: { [AggregationType.AVG]: avg },
+  values: { [AggregationType.SUM]: avg, [AggregationType.AVG]: avg },
 });
 
 describe('TraceTokenStatsChart', () => {
@@ -328,7 +328,7 @@ describe('TraceTokenStatsChart', () => {
           experiment_ids: [testExperimentId],
           view_type: MetricViewType.TRACES,
           metric_name: TraceMetricKey.TOTAL_TOKENS,
-          aggregations: [{ aggregation_type: AggregationType.AVG }],
+          aggregations: [{ aggregation_type: AggregationType.SUM }, { aggregation_type: AggregationType.AVG }],
         });
       });
     });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceTokenUsageChart.test.tsx
@@ -38,11 +38,12 @@ const createCacheCreationTokensDataPoint = (timeBucket: string, sum: number) => 
   values: { [AggregationType.SUM]: sum },
 });
 
-// Helper to create a total tokens data point (no time bucket)
+// Helper to create a total tokens data point (no time bucket).
+// Includes both SUM and AVG to match the combined aggregations query.
 const createTotalTokensDataPoint = (sum: number) => ({
   metric_name: TraceMetricKey.TOTAL_TOKENS,
   dimensions: {},
-  values: { [AggregationType.SUM]: sum },
+  values: { [AggregationType.SUM]: sum, [AggregationType.AVG]: sum },
 });
 
 describe('TraceTokenUsageChart', () => {
@@ -432,7 +433,7 @@ describe('TraceTokenUsageChart', () => {
           experiment_ids: [testExperimentId],
           view_type: MetricViewType.TRACES,
           metric_name: TraceMetricKey.TOTAL_TOKENS,
-          aggregations: [{ aggregation_type: AggregationType.SUM }],
+          aggregations: [{ aggregation_type: AggregationType.SUM }, { aggregation_type: AggregationType.AVG }],
         });
         // Should NOT have time_interval_seconds for total tokens query
         expect(capturedTotalRequest?.time_interval_seconds).toBeUndefined();

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenStatsChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenStatsChartData.ts
@@ -63,7 +63,9 @@ export function useTraceTokenStatsChartData(): UseTraceTokenStatsChartDataResult
     filters,
   });
 
-  // Fetch overall average tokens (without time bucketing) for the header
+  // Fetch overall average tokens (without time bucketing) for the header.
+  // Uses [SUM, AVG] so React Query deduplicates with the identical call
+  // in useTraceTokenUsageChartData.
   const {
     data: avgTokensData,
     isLoading: isLoadingAvg,
@@ -74,7 +76,7 @@ export function useTraceTokenStatsChartData(): UseTraceTokenStatsChartDataResult
     endTimeMs,
     viewType: MetricViewType.TRACES,
     metricName: TraceMetricKey.TOTAL_TOKENS,
-    aggregations: [{ aggregation_type: AggregationType.AVG }],
+    aggregations: [{ aggregation_type: AggregationType.SUM }, { aggregation_type: AggregationType.AVG }],
     filters,
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenUsageChartData.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/hooks/useTraceTokenUsageChartData.ts
@@ -108,7 +108,9 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
     filters,
   });
 
-  // Fetch total tokens (without time bucketing) for the header
+  // Fetch total tokens (without time bucketing) for the header.
+  // Uses [SUM, AVG] so React Query deduplicates with the identical call
+  // in useTraceTokenStatsChartData.
   const {
     data: totalTokensData,
     isLoading: isLoadingTotal,
@@ -119,7 +121,7 @@ export function useTraceTokenUsageChartData(): UseTraceTokenUsageChartDataResult
     endTimeMs,
     viewType: MetricViewType.TRACES,
     metricName: TraceMetricKey.TOTAL_TOKENS,
-    aggregations: [{ aggregation_type: AggregationType.SUM }],
+    aggregations: [{ aggregation_type: AggregationType.SUM }, { aggregation_type: AggregationType.AVG }],
     filters,
   });
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21777

### What changes are proposed in this pull request?

Both `useTraceTokenUsageChartData` (Token Usage chart) and `useTraceTokenStatsChartData` (Tokens per Trace chart) issue a non-time-bucketed query for `TOTAL_TOKENS` — one requesting `[SUM]` and the other `[AVG]`. Because the aggregation arrays differ, React Query treats them as separate cache entries, resulting in two independent API calls and two SQL queries.

This PR changes both hooks to request `aggregations: [SUM, AVG]`. The query keys become identical, so React Query deduplicates them into a single API call. Each hook continues to read only the value it needs (`.values[SUM]` for total tokens, `.values[AVG]` for average tokens per trace).

**Result**: 1 fewer SQL query on the Usage tab initial page load.

**Files changed**:
- `useTraceTokenUsageChartData.ts` — scalar total tokens query now uses `[SUM, AVG]`
- `useTraceTokenStatsChartData.ts` — scalar avg tokens query now uses `[SUM, AVG]`
- `TraceTokenUsageChart.test.tsx` — updated mock data and assertion for combined aggregations
- `TraceTokenStatsChart.test.tsx` — updated mock data and assertion for combined aggregations

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:
<img width="2970" height="2836" alt="image" src="https://github.com/user-attachments/assets/465c9ebf-dd2b-4e1c-b19e-01a3e4f9a8c4" />

After:
<img width="1485" height="1418" alt="image" src="https://github.com/user-attachments/assets/50171d3e-1c15-4520-8df4-3602840b8b7a" />


All 46 existing tests pass. Verified manually that both charts render correctly with the shared query.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.