### PR TITLE
Fix ONNX model wrapper to always pass providers to `InferenceSession`

### DIFF
--- a/mlflow/onnx/__init__.py
+++ b/mlflow/onnx/__init__.py
@@ -288,34 +288,9 @@ class _OnnxModelWrapper:
                 for key, value in extra_session_config.items():
                     sess_options.add_session_config_entry(key, value)
 
-        # NOTE: Some distributions of onnxruntime require the specification of the providers
-        # argument on calling. E.g. onnxruntime-gpu. The package import call does not differentiate
-        #  which architecture specific version has been installed, as all are imported with
-        # onnxruntime. onnxruntime documentation says that from v1.9.0 some distributions require
-        #  the providers list to be provided on calling an InferenceSession. Therefore the try
-        #  catch structure below attempts to create an inference session with just the model path
-        #  as pre v1.9.0. If that fails, it will use the providers list call.
-        # At the moment this is just CUDA and CPU, and probably should be expanded.
-        # A method of user customization has been provided by adding a variable in the save_model()
-        # function, which allows the ability to pass the list of execution providers via a
-        # optional argument e.g.
-        #
-        # mlflow.onnx.save_model(..., providers=['CUDAExecutionProvider'...])
-        #
-        # For details of the execution providers construct of onnxruntime, see:
-        # https://onnxruntime.ai/docs/execution-providers/
-        #
-        # For a information on how execution providers are used with onnxruntime InferenceSession,
-        # see the API page below:
-        # https://onnxruntime.ai/docs/api/python/api_summary.html#id8
-        #
-
-        try:
-            self.rt = onnxruntime.InferenceSession(path, sess_options=sess_options)
-        except ValueError:
-            self.rt = onnxruntime.InferenceSession(
-                path, providers=providers, sess_options=sess_options
-            )
+        self.rt = onnxruntime.InferenceSession(
+            path, providers=providers, sess_options=sess_options
+        )
 
         assert len(self.rt.get_inputs()) >= 1
         self.inputs = [(inp.name, inp.type) for inp in self.rt.get_inputs()]


### PR DESCRIPTION
### Related Issues/PRs

Closes #13388

### What changes are proposed in this pull request?

In `_OnnxModelWrapper.__init__`, `InferenceSession` was created without `providers` in a try block, with providers only passed in the `except ValueError` branch. Since onnxruntime 1.17+, no `ValueError` is raised — it silently defaults to `CPUExecutionProvider`, so user-specified GPU providers (e.g. `CUDAExecutionProvider`) are never actually used.

This PR removes the outdated try/except compatibility shim (which targeted pre-v1.9.0 onnxruntime, long EOL) and always passes `providers` to `InferenceSession`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Verified that the fix resolves the issue described in #13388 — GPU providers are now correctly passed to InferenceSession. Existing ONNX flavor tests continue to pass since providers defaults to None when not specified by the user, preserving the existing behavior for CPU-only setups. -->

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where ONNX model inference always used `CPUExecutionProvider` even when GPU providers (e.g. `CUDAExecutionProvider`) were explicitly specified via `mlflow.onnx.save_model(..., providers=[...])`. This was caused by an outdated try/except in `_OnnxModelWrapper` that silently swallowed the providers argument on onnxruntime 1.17+.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release