### PR TITLE
fix(ui): batch-fetch runs in CompareRunPage to fix O(N) API calls

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx
@@ -8,7 +8,7 @@
 import React, { Component } from 'react';
 import qs from 'qs';
 import { connect } from 'react-redux';
-import { getRunApi, getExperimentApi } from '../actions';
+import { getRunApi, getExperimentApi, searchRunsApi } from '../actions';
 import RequestStateWrapper from '../../common/components/RequestStateWrapper';
 import CompareRunView from './CompareRunView';
 import { getUUID } from '../../common/utils/ActionUtils';
@@ -56,14 +56,28 @@ class CompareRunPageImpl extends Component<CompareRunPageProps> {
 
   componentDidMount() {
     this.requestIds.push(...this.fetchExperiments());
-    this.props.runUuids.forEach((runUuid) => {
-      const requestId = getUUID();
-      this.requestIds.push(requestId);
 
-      this.props.dispatch(getRunApi(runUuid, requestId)).catch((requestError: Error | ErrorWrapper) => {
+    // Batch-fetch all compared runs in a single searchRuns request instead of
+    // dispatching N individual getRun calls (which causes O(N) network round-trips
+    // and is very slow when comparing 100+ runs). Both GET_RUN_API and
+    // SEARCH_RUNS_API populate the same Redux paths (runInfosByUuid,
+    // paramsByRunUuid, tagsByRunUuid) so CompareRunView reads data correctly.
+    const requestId = getUUID();
+    this.requestIds.push(requestId);
+    const runIdsFilter = `run_id IN (${this.props.runUuids.map((id) => `'${id}'`).join(',')})`;
+    this.props
+      .dispatch(
+        searchRunsApi({
+          id: requestId,
+          experimentIds: this.props.experimentIds,
+          filter: runIdsFilter,
+          runViewType: 'ALL',
+          maxResults: this.props.runUuids.length,
+        }),
+      )
+      .catch((requestError: Error | ErrorWrapper) => {
         this.setState({ requestError });
       });
-    });
   }
 
   render() {


### PR DESCRIPTION
## Description

When opening the **Run Comparison** page with many runs (100+), the page is very slow to load. The root cause is an **O(N) network anti-pattern**: `CompareRunPage.componentDidMount` dispatches one `getRunApi` call *per run UUID*, resulting in N separate `GET /api/2.0/mlflow/runs/get` HTTP requests.

With 100 runs → 100 requests. With 500 runs → 500 requests. Each request adds HTTP latency overhead, and the browser queues them, making the page feel frozen.

## Root Cause

```typescript
// Before fix — N individual requests (O(N) network calls)
this.props.runUuids.forEach((runUuid) => {
  const requestId = getUUID();
  this.requestIds.push(requestId);
  this.props.dispatch(getRunApi(runUuid, requestId));  // ← 1 HTTP call per run
});
```

## Fix

Replace the `forEach` loop with a single `searchRunsApi` call filtered by `run_id IN (...)`. The Redux reducers for both `GET_RUN_API` and `SEARCH_RUNS_API` populate the **same state slices** (`runInfosByUuid`, `paramsByRunUuid`, `tagsByRunUuid`), so `CompareRunView` reads data correctly without any other changes.

```typescript
// After fix — 1 request for all runs (O(1) network calls)
const runIdsFilter = `run_id IN (${this.props.runUuids.map((id) => `'${id}'`).join(",")})`;
this.props.dispatch(
  searchRunsApi({
    id: requestId,
    experimentIds: this.props.experimentIds,
    filter: runIdsFilter,
    runViewType: "ALL",
    maxResults: this.props.runUuids.length,
  })
);
```

## Changes

- `mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx`:
  - Import `searchRunsApi` from `../actions`
  - Replace N `getRunApi` dispatches with one `searchRunsApi` dispatch

Closes #21841
