### PR TITLE
Fix LLM invocation with gateway model endpoints by passing configuration

### DIFF
--- a/mlflow/genai/discovery/utils.py
+++ b/mlflow/genai/discovery/utils.py
@@ -22,7 +22,6 @@ from mlflow.genai.discovery.constants import (
 )
 from mlflow.genai.discovery.entities import Issue, _ConversationAnalysis, _IdentifiedIssue
 from mlflow.genai.judges.adapters.litellm_adapter import (
-    _invoke_litellm,
     _is_litellm_available,
 )
 from mlflow.genai.scorers.base import Scorer
@@ -158,17 +157,36 @@ def _call_llm_via_litellm(
     response_format: type[pydantic.BaseModel] | None = None,
     token_counter: _TokenCounter | None = None,
 ) -> Any:
-    from mlflow.metrics.genai.model_utils import convert_mlflow_uri_to_litellm
+    from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm
+    from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
+    from mlflow.metrics.genai.model_utils import _parse_model_uri, convert_mlflow_uri_to_litellm
+
+    provider, model_name = _parse_model_uri(model)
+
+    if provider == "gateway":
+        config = get_gateway_litellm_config(model_name)
+        litellm_model = config.model
+        api_base = config.api_base
+        api_key = config.api_key
+        extra_headers = config.extra_headers
+    else:
+        litellm_model = convert_mlflow_uri_to_litellm(model)
+        api_base = None
+        api_key = None
+        extra_headers = None
 
     use_format = response_format or ({"type": "json_object"} if json_mode else None)
     response = _invoke_litellm(
-        litellm_model=convert_mlflow_uri_to_litellm(model),
+        litellm_model=litellm_model,
         messages=messages,
         tools=[],
         num_retries=NUM_RETRIES,
         response_format=use_format,
         include_response_format=use_format is not None,
         inference_params={"max_completion_tokens": LLM_MAX_TOKENS},
+        api_base=api_base,
+        api_key=api_key,
+        extra_headers=extra_headers,
     )
     if token_counter is not None:
         token_counter.track(response)

--- a/tests/genai/discovery/test_utils.py
+++ b/tests/genai/discovery/test_utils.py
@@ -20,6 +20,7 @@ from mlflow.genai.discovery.utils import (
     group_traces_by_session,
     log_discovery_artifacts,
 )
+from mlflow.genai.utils.gateway_utils import GatewayLiteLLMConfig
 from mlflow.types.chat import ChatChoice, ChatCompletionResponse, ChatMessage, ChatUsage
 
 
@@ -350,3 +351,123 @@ def test_lookup_model_cost_returns_none_on_network_error():
         assert _lookup_model_cost("openai:/gpt-5-mini", 100, 50) is None
 
     mock_fetch.assert_called_once()
+
+
+def test_call_llm_handles_gateway_models():
+    mock_response = mock.MagicMock()
+    mock_response.usage = mock.MagicMock()
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 20
+
+    gateway_config = GatewayLiteLLMConfig(
+        model="openai/test-endpoint",
+        api_base="http://localhost:5000/gateway",
+        api_key="test-key",
+        extra_headers={"X-Custom": "header"},
+    )
+
+    with (
+        mock.patch(
+            "mlflow.genai.utils.gateway_utils.get_gateway_litellm_config",
+            return_value=gateway_config,
+        ) as mock_get_config,
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+            return_value=mock_response,
+        ) as mock_invoke,
+    ):
+        messages = [{"role": "user", "content": "test"}]
+        result = _call_llm("gateway:/test-endpoint", messages)
+
+        mock_get_config.assert_called_once_with("test-endpoint")
+        mock_invoke.assert_called_once()
+
+        call_kwargs = mock_invoke.call_args[1]
+        assert call_kwargs["litellm_model"] == "openai/test-endpoint"
+        assert call_kwargs["api_base"] == "http://localhost:5000/gateway"
+        assert call_kwargs["api_key"] == "test-key"
+        assert call_kwargs["extra_headers"] == {"X-Custom": "header"}
+        assert call_kwargs["messages"] == messages
+        assert result == mock_response
+
+
+def test_call_llm_handles_non_gateway_models():
+    mock_response = mock.MagicMock()
+    mock_response.usage = mock.MagicMock()
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 20
+
+    with (
+        mock.patch(
+            "mlflow.metrics.genai.model_utils.convert_mlflow_uri_to_litellm",
+            return_value="openai/gpt-4",
+        ) as mock_convert,
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+            return_value=mock_response,
+        ) as mock_invoke,
+    ):
+        messages = [{"role": "user", "content": "test"}]
+        result = _call_llm("openai:/gpt-4", messages)
+
+        mock_convert.assert_called_once_with("openai:/gpt-4")
+        mock_invoke.assert_called_once()
+
+        call_kwargs = mock_invoke.call_args[1]
+        assert call_kwargs["litellm_model"] == "openai/gpt-4"
+        assert call_kwargs["api_base"] is None
+        assert call_kwargs["api_key"] is None
+        assert call_kwargs["extra_headers"] is None
+        assert call_kwargs["messages"] == messages
+        assert result == mock_response
+
+
+def test_call_llm_with_json_mode():
+    mock_response = mock.MagicMock()
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+        return_value=mock_response,
+    ) as mock_invoke:
+        messages = [{"role": "user", "content": "test"}]
+        _call_llm("openai:/gpt-4", messages, json_mode=True)
+
+        call_kwargs = mock_invoke.call_args[1]
+        assert call_kwargs["response_format"] == {"type": "json_object"}
+        assert call_kwargs["include_response_format"] is True
+
+
+def test_call_llm_with_response_format():
+    class TestModel(pydantic.BaseModel):
+        field: str
+
+    mock_response = mock.MagicMock()
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+        return_value=mock_response,
+    ) as mock_invoke:
+        messages = [{"role": "user", "content": "test"}]
+        _call_llm("openai:/gpt-4", messages, response_format=TestModel)
+
+        call_kwargs = mock_invoke.call_args[1]
+        assert call_kwargs["response_format"] == TestModel
+        assert call_kwargs["include_response_format"] is True
+
+
+def test_call_llm_tracks_tokens():
+    mock_response = mock.MagicMock()
+    mock_response.usage = mock.MagicMock()
+    mock_response.usage.prompt_tokens = 100
+    mock_response.usage.completion_tokens = 50
+    mock_response._hidden_params = {"response_cost": 0.01}
+
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+        return_value=mock_response,
+    ):
+        counter = _TokenCounter()
+        messages = [{"role": "user", "content": "test"}]
+        _call_llm("openai:/gpt-4", messages, token_counter=counter)
+
+        assert counter.input_tokens == 100
+        assert counter.output_tokens == 50
+        assert counter.cost_usd == 0.01


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Fix the error when invoking with gateway endpoints
```
File "/Users/serena.ruan/Documents/repos/mlflow/mlflow/genai/discovery/utils.py", line 177, in _call_llm
    response = _invoke_litellm(
  File "/Users/serena.ruan/Documents/repos/mlflow/mlflow/genai/judges/adapters/litellm_adapter.py", line 216, in _invoke_litellm
    return litellm.completion(**kwargs)
  File "/Users/serena.ruan/Documents/repos/mlflow/.venv/lib/python3.10/site-packages/litellm/utils.py", line 1775, in wrapper
    raise e
  File "/Users/serena.ruan/Documents/repos/mlflow/.venv/lib/python3.10/site-packages/litellm/utils.py", line 1596, in wrapper
    result = original_function(*args, **kwargs)
  File "/Users/serena.ruan/Documents/repos/mlflow/.venv/lib/python3.10/site-packages/litellm/main.py", line 4408, in completion
    raise exception_type(
  File "/Users/serena.ruan/Documents/repos/mlflow/.venv/lib/python3.10/site-packages/litellm/main.py", line 1366, in completion
    model, custom_llm_provider, dynamic_api_key, api_base = get_llm_provider(
  File "/Users/serena.ruan/Documents/repos/mlflow/.venv/lib/python3.10/site-packages/litellm/litellm_core_utils/get_llm_provider_logic.py", line 490, in get_llm_provider
    raise e
  File "/Users/serena.ruan/Documents/repos/mlflow/.venv/lib/python3.10/site-packages/litellm/litellm_core_utils/get_llm_provider_logic.py", line 471, in get_llm_provider
    raise litellm.exceptions.BadRequestError(  # type: ignore
litellm.exceptions.BadRequestError: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed 
model=gateway/gemini-2.5-pro
 Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers
```
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
