### PR TITLE
Hide 'Show more columns' button when runs are selected

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.enzyme.test.tsx
@@ -336,4 +336,28 @@ describe('ExperimentViewRunsTable', () => {
     // Assert "show more columns" CTA button not being displayed anymore
     expect(simpleExperimentsWrapper.find('ExperimentViewRunsTableAddColumnCTA').length).toBe(0);
   });
+
+  test('should hide column CTA when runs are selected', () => {
+    // Expect CTA to be displayed when no runs are selected
+    const wrapper = createWrapper();
+    expect(wrapper.find('ExperimentViewRunsTableAddColumnCTA').length).toBe(1);
+
+    // Select a run
+    wrapper.setProps({
+      viewState: Object.assign(new ExperimentPageViewState(), {
+        runsSelected: { experiment123456789_run1: true },
+      }),
+    });
+
+    // Expect CTA to be hidden when a run is selected
+    expect(wrapper.find('ExperimentViewRunsTableAddColumnCTA').length).toBe(0);
+
+    // Unselect the run
+    wrapper.setProps({
+      viewState: new ExperimentPageViewState(),
+    });
+
+    // Expect CTA to be displayed after unselecting
+    expect(wrapper.find('ExperimentViewRunsTableAddColumnCTA').length).toBe(1);
+  });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -343,7 +343,8 @@ export const ExperimentViewRunsTable = React.memo(
       [updateViewState],
     );
 
-    const displayAddColumnsCTA = !hasSelectedAllColumns && !isComparingRuns && rowsData.length > 0;
+    const hasSelectedRuns = Object.values(viewState.runsSelected).some(Boolean);
+    const displayAddColumnsCTA = !hasSelectedAllColumns && !isComparingRuns && !hasSelectedRuns && rowsData.length > 0;
     const displayPreviewSidebar = !isComparingRuns && viewState.previewPaneVisible;
     const displayRunsTable = !runListHidden || !isComparingRuns;
     const displayStatusBar = !runListHidden;


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes https://github.com/mlflow/mlflow/issues/20873

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
When a run is selected, the toolbar switches from the filters bar containing column selector dropdown to the action bar. The column selector is not rendered, so clicking the 'Show more columns' button doesn't open the selector. The dropdown only appears later when the user unselects the run and the column selector re-renders.
The change is that the button is now hidden whenever one or more runs are selected, matching the toolbar state. If the column selector can't open, the button to trigger it shouldn't be visible.

https://github.com/user-attachments/assets/7e6103bf-eedd-4e21-8c6b-36e4fd8b6dc9


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fixed a bug where clicking the "Show more columns" button in the runs table had no effect while a run row was selected.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
