### PR TITLE
Fix tag cutoff in experiments table

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { screen, renderWithIntl } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import userEvent from '@testing-library/user-event';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { ExperimentListTableTagsCell } from './ExperimentListTableTagsCell';
+import type { ExperimentEntity } from '../types';
+
+const createMockExperiment = (tags: Array<{ key: string; value: string }>): ExperimentEntity =>
+  ({
+    experimentId: '1',
+    name: 'Test Experiment',
+    tags,
+  }) as ExperimentEntity;
+
+const createMockCellContext = (tags: Array<{ key: string; value: string }>, onEditTags = jest.fn()) => ({
+  row: { original: createMockExperiment(tags) },
+  table: { options: { meta: { onEditTags } } },
+});
+
+const TagsCell = ExperimentListTableTagsCell as React.FC<any>;
+
+const renderTagsCell = (tags: Array<{ key: string; value: string }>, onEditTags = jest.fn()) =>
+  renderWithIntl(
+    <DesignSystemProvider>
+      <TagsCell {...createMockCellContext(tags, onEditTags)} />
+    </DesignSystemProvider>,
+  );
+
+describe('ExperimentListTableTagsCell', () => {
+  it('should render "Add tags" button when there are no tags', () => {
+    renderTagsCell([]);
+
+    expect(screen.getByText('Add tags')).toBeInTheDocument();
+  });
+
+  it('should render a single tag without overflow indicator', () => {
+    renderTagsCell([{ key: 'env', value: 'production' }]);
+
+    expect(screen.getByText('env')).toBeInTheDocument();
+    expect(screen.queryByText(/\+\d+/)).not.toBeInTheDocument();
+  });
+
+  it('should show overflow indicator when tags exceed visible count', () => {
+    renderTagsCell([
+      { key: 'tag1', value: 'value1' },
+      { key: 'tag2', value: 'value2' },
+      { key: 'tag3', value: 'value3' },
+    ]);
+
+    expect(screen.getByText('tag1')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.tsx
@@ -1,4 +1,4 @@
-import { Button, PencilIcon } from '@databricks/design-system';
+import { Button, Overflow, PencilIcon, useDesignSystemTheme } from '@databricks/design-system';
 import 'react-virtualized/styles.css';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { KeyValueTag } from '../../common/components/KeyValueTag';
@@ -12,6 +12,7 @@ export const ExperimentListTableTagsCell: ExperimentTableColumnDef['cell'] = ({
   },
 }) => {
   const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
 
   const { onEditTags } = meta as ExperimentTableMetadata;
 
@@ -19,12 +20,14 @@ export const ExperimentListTableTagsCell: ExperimentTableColumnDef['cell'] = ({
   const containsTags = visibleTagList.length > 0;
 
   return (
-    <div css={{ display: 'flex' }}>
-      <div css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'flex' }}>
-        {visibleTagList?.map((tag) => (
-          <KeyValueTag key={tag.key} tag={tag} />
-        ))}
-      </div>
+    <div css={{ display: 'flex', alignItems: 'center' }}>
+      {containsTags && (
+        <Overflow noMargin className="experiment-tags-overflow">
+          {visibleTagList.map((tag) => (
+            <KeyValueTag key={tag.key} tag={tag} />
+          ))}
+        </Overflow>
+      )}
       <Button
         componentId="mlflow.experiment.list.tag.add"
         size="small"
@@ -36,6 +39,7 @@ export const ExperimentListTableTagsCell: ExperimentTableColumnDef['cell'] = ({
         })}
         css={{
           flexShrink: 0,
+          marginLeft: containsTags ? theme.spacing.sm : 0,
           opacity: 0,
           '[role=row]:hover &': {
             opacity: 1,


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes https://github.com/mlflow/mlflow/issues/20867

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
When multiple tags were added to an experiment, extra tags were clipped with no visual indication. Now the first tag is shown inline and remaining tags are accessible via a "+N" popover. 

https://github.com/user-attachments/assets/86a42208-e2f9-477a-95c5-a5864191aa04

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fixed tag clipping in the Experiments table. Previously, tags beyond the available column width were silently clipped. Now the first tag is shown inline and remaining tags are accessible via a "+N" popover. 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
