### PR TITLE
Add Evidently as third-party scorer provider

### DIFF
--- a/mlflow/genai/scorers/evidently/__init__.py
+++ b/mlflow/genai/scorers/evidently/__init__.py
@@ -2,28 +2,24 @@
 Evidently AI integration for MLflow.
 
 This module provides integration with Evidently AI metrics, allowing them to be used
-with MLflow's scorer interface for data drift detection, data quality monitoring,
-and model performance evaluation.
+with MLflow's scorer interface for data quality monitoring and model performance evaluation.
 
 Example usage:
 
 .. code-block:: python
 
-    from mlflow.genai.scorers.evidently import ValueDrift, MissingValues, get_scorer
-
-    # Detect data drift
-    scorer = ValueDrift(column="feature_1")
-    feedback = scorer(
-        outputs={"feature_1": 0.5},
-        expectations={"reference_data": [{"feature_1": 0.1}, {"feature_1": 0.2}]},
-    )
+    from mlflow.genai.scorers.evidently import MissingValues, UniqueValues, get_scorer
 
     # Check for missing values
     scorer = MissingValues(column="feature_1")
     feedback = scorer(outputs={"feature_1": None})
 
+    # Count unique values
+    scorer = UniqueValues(column="category")
+    feedback = scorer(outputs={"category": "A"})
+
     # Use factory function
-    scorer = get_scorer("ValueDrift", column="feature_1")
+    scorer = get_scorer("MissingValueCount", column="feature_1")
 """
 
 from __future__ import annotations
@@ -60,7 +56,7 @@ class EvidentlyScorer(Scorer):
     scorer interface.
 
     Args:
-        metric_name: Name of the Evidently metric (e.g., "ValueDrift")
+        metric_name: Name of the Evidently metric (e.g., "MissingValueCount")
         **metric_kwargs: Additional arguments passed to the Evidently metric
     """
 
@@ -184,21 +180,17 @@ class EvidentlyScorer(Scorer):
             return None
 
         value = metrics[0].get("value")
-        if value is None:
+        if not isinstance(value, dict):
             return None
 
-        # Scalar value (e.g., ValueDrift returns a p-value float)
-        if isinstance(value, (int, float)):
-            return float(value)
+        # MissingValueCount / UniqueValueCount return {"count": N, "share": M}
+        if "count" in value:
+            return float(value["count"])
 
-        # Dict value (e.g., MissingValueCount returns {"count": 1.0, "share": 0.33})
-        if isinstance(value, dict):
-            if "count" in value:
-                return float(value["count"])
-            # Fallback: return first numeric value found
-            for v in value.values():
-                if isinstance(v, (int, float)):
-                    return float(v)
+        # Fallback: return first numeric value found
+        for v in value.values():
+            if isinstance(v, (int, float)):
+                return float(v)
 
         return None
 
@@ -208,21 +200,11 @@ class EvidentlyScorer(Scorer):
         if not metrics:
             return None
 
-        metric = metrics[0]
-        value = metric.get("value")
-        parts = []
+        value = metrics[0].get("value")
+        if not isinstance(value, dict):
+            return None
 
-        if isinstance(value, (int, float)):
-            parts.append(f"Value: {value}")
-        elif isinstance(value, dict):
-            for k, v in value.items():
-                parts.append(f"{k}: {v}")
-
-        config = metric.get("config")
-        if isinstance(config, dict) and "stattest" in config:
-            parts.append(f"Statistical test: {config['stattest']}")
-
-        return "; ".join(parts) if parts else None
+        return "; ".join(f"{k}: {v}" for k, v in value.items()) or None
 
 
 @experimental(version="3.12.0")
@@ -233,7 +215,7 @@ def get_scorer(
     """Get an Evidently metric as an MLflow scorer.
 
     Args:
-        metric_name: Name of the Evidently metric (e.g., "ValueDrift", "MissingValueCount")
+        metric_name: Name of the Evidently metric (e.g., "MissingValueCount", "UniqueValueCount")
         metric_kwargs: Additional keyword arguments to pass to the metric.
 
     Returns:
@@ -242,51 +224,16 @@ def get_scorer(
     Examples:
         .. code-block:: python
 
-            scorer = get_scorer("ValueDrift", column="feature_1")
-            feedback = scorer(
-                outputs={"feature_1": 0.5},
-                expectations={"reference_data": [{"feature_1": 0.1}, {"feature_1": 0.2}]},
-            )
-
             scorer = get_scorer("MissingValueCount", column="feature_1")
             feedback = scorer(outputs={"feature_1": None})
+
+            scorer = get_scorer("UniqueValueCount", column="category")
+            feedback = scorer(outputs={"category": "A"})
     """
     return EvidentlyScorer(
         metric_name=metric_name,
         **metric_kwargs,
     )
-
-
-@experimental(version="3.12.0")
-class ValueDrift(EvidentlyScorer):
-    """Detect data drift for a specific column using statistical tests.
-
-    Compares the distribution of values in current data against reference data
-    to detect significant changes (drift).
-
-    .. note::
-        ``ValueDrift`` is a **distribution-level** metric: it compares the aggregate
-        distribution of the current dataset against a reference dataset. It cannot be
-        used to evaluate a single row in isolation. Always supply ``reference_data``
-        (a list of dicts or a DataFrame) via the ``expectations`` argument; omitting it
-        will cause the underlying Evidently metric to raise an error.
-
-    Args:
-        column: Name of the column to check for drift
-
-    Examples:
-        .. code-block:: python
-
-            from mlflow.genai.scorers.evidently import ValueDrift
-
-            scorer = ValueDrift(column="prediction")
-            feedback = scorer(
-                outputs={"prediction": 0.9},
-                expectations={"reference_data": [{"prediction": 0.1}, {"prediction": 0.2}]},
-            )
-    """
-
-    metric_name: ClassVar[str] = "ValueDrift"
 
 
 @experimental(version="3.12.0")
@@ -336,7 +283,6 @@ class UniqueValues(EvidentlyScorer):
 __all__ = [
     "EvidentlyScorer",
     "get_scorer",
-    "ValueDrift",
     "MissingValues",
     "UniqueValues",
 ]

--- a/mlflow/genai/scorers/evidently/__init__.py
+++ b/mlflow/genai/scorers/evidently/__init__.py
@@ -124,7 +124,7 @@ class EvidentlyScorer(Scorer):
                 run_kwargs["reference_data"] = Dataset.from_pandas(reference_df)
 
             snapshot = report.run(**run_kwargs)
-            result_dict = snapshot.as_dict()
+            result_dict = snapshot.dict()
 
             value = self._extract_value(result_dict)
             rationale = self._extract_rationale(result_dict)
@@ -151,24 +151,22 @@ class EvidentlyScorer(Scorer):
         if not metrics:
             return 0.0
 
-        metric_result = metrics[0].get("result", {})
+        value = metrics[0].get("value")
+        if value is None:
+            return 0.0
 
-        # Check for drift-style result (has "drift_detected" boolean)
-        if "drift_detected" in metric_result:
-            return not metric_result["drift_detected"]
+        # Scalar value (e.g., ValueDrift returns a p-value float)
+        if isinstance(value, (int, float)):
+            return float(value)
 
-        # Check for count-style result (has "value" field)
-        if "value" in metric_result:
-            return float(metric_result["value"])
-
-        # Check for current_value (common in data quality metrics)
-        if "current_value" in metric_result:
-            return float(metric_result["current_value"])
-
-        # Fallback: return first numeric value found
-        for v in metric_result.values():
-            if isinstance(v, (int, float)):
-                return float(v)
+        # Dict value (e.g., MissingValueCount returns {"count": 1.0, "share": 0.33})
+        if isinstance(value, dict):
+            if "count" in value:
+                return float(value["count"])
+            # Fallback: return first numeric value found
+            for v in value.values():
+                if isinstance(v, (int, float)):
+                    return float(v)
 
         return 0.0
 
@@ -178,24 +176,19 @@ class EvidentlyScorer(Scorer):
         if not metrics:
             return None
 
-        metric_result = metrics[0].get("result", {})
+        metric = metrics[0]
+        value = metric.get("value")
         parts = []
 
-        if "drift_detected" in metric_result:
-            drift = metric_result["drift_detected"]
-            parts.append(f"Drift detected: {drift}")
-            if "drift_score" in metric_result:
-                parts.append(f"Drift score: {metric_result['drift_score']:.4f}")
-            if "stattest_name" in metric_result:
-                parts.append(f"Statistical test: {metric_result['stattest_name']}")
+        if isinstance(value, (int, float)):
+            parts.append(f"Value: {value}")
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                parts.append(f"{k}: {v}")
 
-        elif "value" in metric_result:
-            parts.append(f"Value: {metric_result['value']}")
-
-        elif "current_value" in metric_result:
-            parts.append(f"Current: {metric_result['current_value']}")
-            if "reference_value" in metric_result:
-                parts.append(f"Reference: {metric_result['reference_value']}")
+        config = metric.get("config")
+        if isinstance(config, dict) and "stattest" in config:
+            parts.append(f"Statistical test: {config['stattest']}")
 
         return "; ".join(parts) if parts else None
 

--- a/mlflow/genai/scorers/evidently/__init__.py
+++ b/mlflow/genai/scorers/evidently/__init__.py
@@ -145,7 +145,7 @@ class EvidentlyScorer(Scorer):
                 metadata={FRAMEWORK_METADATA_KEY: _FRAMEWORK_NAME},
             )
 
-    def _extract_value(self, result_dict: dict) -> float | bool:
+    def _extract_value(self, result_dict: dict[str, Any]) -> float | bool:
         """Extract the primary metric value from Evidently result dict."""
         metrics = result_dict.get("metrics", [])
         if not metrics:
@@ -170,7 +170,7 @@ class EvidentlyScorer(Scorer):
 
         return 0.0
 
-    def _extract_rationale(self, result_dict: dict) -> str | None:
+    def _extract_rationale(self, result_dict: dict[str, Any]) -> str | None:
         """Extract a human-readable explanation from Evidently result dict."""
         metrics = result_dict.get("metrics", [])
         if not metrics:
@@ -202,7 +202,7 @@ def get_scorer(
 
     Args:
         metric_name: Name of the Evidently metric (e.g., "ValueDrift", "MissingValueCount")
-        **metric_kwargs: Additional keyword arguments to pass to the metric.
+        metric_kwargs: Additional keyword arguments to pass to the metric.
 
     Returns:
         EvidentlyScorer instance that can be called with MLflow's scorer interface

--- a/mlflow/genai/scorers/evidently/__init__.py
+++ b/mlflow/genai/scorers/evidently/__init__.py
@@ -1,0 +1,310 @@
+"""
+Evidently AI integration for MLflow.
+
+This module provides integration with Evidently AI metrics, allowing them to be used
+with MLflow's scorer interface for data drift detection, data quality monitoring,
+and model performance evaluation.
+
+Example usage:
+
+.. code-block:: python
+
+    from mlflow.genai.scorers.evidently import ValueDrift, MissingValues, get_scorer
+
+    # Detect data drift
+    scorer = ValueDrift(column="feature_1")
+    feedback = scorer(
+        outputs={"feature_1": 0.5},
+        expectations={"reference_data": [{"feature_1": 0.1}, {"feature_1": 0.2}]},
+    )
+
+    # Check for missing values
+    scorer = MissingValues(column="feature_1")
+    feedback = scorer(outputs={"feature_1": None})
+
+    # Use factory function
+    scorer = get_scorer("ValueDrift", column="feature_1")
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+from pydantic import PrivateAttr
+
+from mlflow.entities.assessment import Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.entities.trace import Trace
+from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
+from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.scorers.evidently.registry import get_metric_class
+from mlflow.genai.scorers.evidently.utils import (
+    check_evidently_installed,
+    map_scorer_inputs_to_dataframe,
+)
+from mlflow.utils.annotations import experimental
+
+_logger = logging.getLogger(__name__)
+
+_FRAMEWORK_NAME = "evidently"
+
+
+@experimental(version="3.12.0")
+class EvidentlyScorer(Scorer):
+    """Base class for Evidently AI metric scorers.
+
+    Evidently AI metrics evaluate data quality, detect data drift, and measure
+    model performance. This class wraps Evidently metrics to work with MLflow's
+    scorer interface.
+
+    Args:
+        metric_name: Name of the Evidently metric (e.g., "ValueDrift")
+        **metric_kwargs: Additional arguments passed to the Evidently metric
+    """
+
+    _metric: Any = PrivateAttr()
+
+    def __init__(
+        self,
+        metric_name: str | None = None,
+        **metric_kwargs: Any,
+    ):
+        check_evidently_installed()
+
+        if metric_name is None:
+            metric_name = getattr(self.__class__, "metric_name", None)
+            if metric_name is None:
+                raise ValueError("metric_name must be provided")
+
+        super().__init__(name=metric_name)
+
+        metric_class = get_metric_class(metric_name)
+        self._metric = metric_class(**metric_kwargs)
+
+    def __call__(
+        self,
+        *,
+        inputs: Any = None,
+        outputs: Any = None,
+        expectations: dict[str, Any] | None = None,
+        trace: Trace | None = None,
+    ) -> Feedback:
+        """Evaluate data using an Evidently metric.
+
+        Args:
+            inputs: The input data to evaluate
+            outputs: The output data to evaluate
+            expectations: Optional dict with "reference_data" key for drift detection
+            trace: MLflow trace for evaluation
+
+        Returns:
+            Feedback object with metric result
+        """
+        assessment_source = AssessmentSource(
+            source_type=AssessmentSourceType.CODE,
+            source_id=f"evidently/{self.name}",
+        )
+
+        try:
+            from evidently import Dataset, Report
+
+            current_df, reference_df = map_scorer_inputs_to_dataframe(
+                inputs=inputs,
+                outputs=outputs,
+                expectations=expectations,
+                trace=trace,
+            )
+
+            report = Report([self._metric])
+            run_kwargs: dict[str, Any] = {
+                "current_data": Dataset.from_pandas(current_df),
+            }
+            if reference_df is not None:
+                run_kwargs["reference_data"] = Dataset.from_pandas(reference_df)
+
+            snapshot = report.run(**run_kwargs)
+            result_dict = snapshot.as_dict()
+
+            value = self._extract_value(result_dict)
+            rationale = self._extract_rationale(result_dict)
+
+            return Feedback(
+                name=self.name,
+                value=value,
+                rationale=rationale,
+                source=assessment_source,
+                metadata={FRAMEWORK_METADATA_KEY: _FRAMEWORK_NAME},
+            )
+        except Exception as e:
+            _logger.error(f"Error evaluating with Evidently {self.name}: {e}")
+            return Feedback(
+                name=self.name,
+                error=e,
+                source=assessment_source,
+                metadata={FRAMEWORK_METADATA_KEY: _FRAMEWORK_NAME},
+            )
+
+    def _extract_value(self, result_dict: dict) -> float | bool:
+        """Extract the primary metric value from Evidently result dict."""
+        metrics = result_dict.get("metrics", [])
+        if not metrics:
+            return 0.0
+
+        metric_result = metrics[0].get("result", {})
+
+        # Check for drift-style result (has "drift_detected" boolean)
+        if "drift_detected" in metric_result:
+            return not metric_result["drift_detected"]
+
+        # Check for count-style result (has "value" field)
+        if "value" in metric_result:
+            return float(metric_result["value"])
+
+        # Check for current_value (common in data quality metrics)
+        if "current_value" in metric_result:
+            return float(metric_result["current_value"])
+
+        # Fallback: return first numeric value found
+        for v in metric_result.values():
+            if isinstance(v, (int, float)):
+                return float(v)
+
+        return 0.0
+
+    def _extract_rationale(self, result_dict: dict) -> str | None:
+        """Extract a human-readable explanation from Evidently result dict."""
+        metrics = result_dict.get("metrics", [])
+        if not metrics:
+            return None
+
+        metric_result = metrics[0].get("result", {})
+        parts = []
+
+        if "drift_detected" in metric_result:
+            drift = metric_result["drift_detected"]
+            parts.append(f"Drift detected: {drift}")
+            if "drift_score" in metric_result:
+                parts.append(f"Drift score: {metric_result['drift_score']:.4f}")
+            if "stattest_name" in metric_result:
+                parts.append(f"Statistical test: {metric_result['stattest_name']}")
+
+        elif "value" in metric_result:
+            parts.append(f"Value: {metric_result['value']}")
+
+        elif "current_value" in metric_result:
+            parts.append(f"Current: {metric_result['current_value']}")
+            if "reference_value" in metric_result:
+                parts.append(f"Reference: {metric_result['reference_value']}")
+
+        return "; ".join(parts) if parts else None
+
+
+@experimental(version="3.12.0")
+def get_scorer(
+    metric_name: str,
+    **metric_kwargs: Any,
+) -> EvidentlyScorer:
+    """Get an Evidently metric as an MLflow scorer.
+
+    Args:
+        metric_name: Name of the Evidently metric (e.g., "ValueDrift", "MissingValueCount")
+        **metric_kwargs: Additional keyword arguments to pass to the metric.
+
+    Returns:
+        EvidentlyScorer instance that can be called with MLflow's scorer interface
+
+    Examples:
+        .. code-block:: python
+
+            scorer = get_scorer("ValueDrift", column="feature_1")
+            feedback = scorer(
+                outputs={"feature_1": 0.5},
+                expectations={"reference_data": [{"feature_1": 0.1}, {"feature_1": 0.2}]},
+            )
+
+            scorer = get_scorer("MissingValueCount", column="feature_1")
+            feedback = scorer(outputs={"feature_1": None})
+    """
+    return EvidentlyScorer(
+        metric_name=metric_name,
+        **metric_kwargs,
+    )
+
+
+@experimental(version="3.12.0")
+class ValueDrift(EvidentlyScorer):
+    """Detect data drift for a specific column using statistical tests.
+
+    Compares the distribution of values in current data against reference data
+    to detect significant changes (drift).
+
+    Args:
+        column: Name of the column to check for drift
+
+    Examples:
+        .. code-block:: python
+
+            from mlflow.genai.scorers.evidently import ValueDrift
+
+            scorer = ValueDrift(column="prediction")
+            feedback = scorer(
+                outputs={"prediction": 0.9},
+                expectations={"reference_data": [{"prediction": 0.1}, {"prediction": 0.2}]},
+            )
+    """
+
+    metric_name: ClassVar[str] = "ValueDrift"
+
+
+@experimental(version="3.12.0")
+class MissingValues(EvidentlyScorer):
+    """Check for missing values in a specific column.
+
+    Counts the number of missing (null/NaN) values in the specified column
+    of the current data.
+
+    Args:
+        column: Name of the column to check for missing values
+
+    Examples:
+        .. code-block:: python
+
+            from mlflow.genai.scorers.evidently import MissingValues
+
+            scorer = MissingValues(column="feature_1")
+            feedback = scorer(outputs={"feature_1": None})
+    """
+
+    metric_name: ClassVar[str] = "MissingValueCount"
+
+
+@experimental(version="3.12.0")
+class UniqueValues(EvidentlyScorer):
+    """Count unique values in a specific column.
+
+    Counts the number of distinct values in the specified column,
+    useful for monitoring categorical feature cardinality changes.
+
+    Args:
+        column: Name of the column to check
+
+    Examples:
+        .. code-block:: python
+
+            from mlflow.genai.scorers.evidently import UniqueValues
+
+            scorer = UniqueValues(column="category")
+            feedback = scorer(outputs={"category": "A"})
+    """
+
+    metric_name: ClassVar[str] = "UniqueValueCount"
+
+
+__all__ = [
+    "EvidentlyScorer",
+    "get_scorer",
+    "ValueDrift",
+    "MissingValues",
+    "UniqueValues",
+]

--- a/mlflow/genai/scorers/evidently/__init__.py
+++ b/mlflow/genai/scorers/evidently/__init__.py
@@ -36,8 +36,9 @@ from pydantic import PrivateAttr
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.entities.trace import Trace
+from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import FRAMEWORK_METADATA_KEY
-from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.scorers.base import Scorer, ScorerKind
 from mlflow.genai.scorers.evidently.registry import get_metric_class
 from mlflow.genai.scorers.evidently.utils import (
     check_evidently_installed,
@@ -82,6 +83,35 @@ class EvidentlyScorer(Scorer):
         metric_class = get_metric_class(metric_name)
         self._metric = metric_class(**metric_kwargs)
 
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.THIRD_PARTY
+
+    def _raise_registration_not_supported(self, method_name: str):
+        raise MlflowException.invalid_parameter_value(
+            f"'{method_name}()' is not supported for third-party scorers like Evidently. "
+            f"Third-party scorers cannot be registered, started, updated, or stopped. "
+            f"Use them directly in mlflow.genai.evaluate() instead."
+        )
+
+    def register(self, **kwargs):
+        self._raise_registration_not_supported("register")
+
+    def start(self, **kwargs):
+        self._raise_registration_not_supported("start")
+
+    def update(self, **kwargs):
+        self._raise_registration_not_supported("update")
+
+    def stop(self, **kwargs):
+        self._raise_registration_not_supported("stop")
+
+    def align(self, **kwargs):
+        raise MlflowException.invalid_parameter_value(
+            "'align()' is not supported for third-party scorers like Evidently. "
+            "Alignment is only available for MLflow's built-in judges."
+        )
+
     def __call__(
         self,
         *,
@@ -89,6 +119,7 @@ class EvidentlyScorer(Scorer):
         outputs: Any = None,
         expectations: dict[str, Any] | None = None,
         trace: Trace | None = None,
+        session: list[Trace] | None = None,
     ) -> Feedback:
         """Evaluate data using an Evidently metric.
 
@@ -97,6 +128,7 @@ class EvidentlyScorer(Scorer):
             outputs: The output data to evaluate
             expectations: Optional dict with "reference_data" key for drift detection
             trace: MLflow trace for evaluation
+            session: List of MLflow traces for multi-turn/agentic evaluation
 
         Returns:
             Feedback object with metric result
@@ -106,15 +138,15 @@ class EvidentlyScorer(Scorer):
             source_id=f"evidently/{self.name}",
         )
 
+        current_df, reference_df = map_scorer_inputs_to_dataframe(
+            inputs=inputs,
+            outputs=outputs,
+            expectations=expectations,
+            trace=trace,
+        )
+
         try:
             from evidently import Dataset, Report
-
-            current_df, reference_df = map_scorer_inputs_to_dataframe(
-                inputs=inputs,
-                outputs=outputs,
-                expectations=expectations,
-                trace=trace,
-            )
 
             report = Report([self._metric])
             run_kwargs: dict[str, Any] = {
@@ -145,15 +177,15 @@ class EvidentlyScorer(Scorer):
                 metadata={FRAMEWORK_METADATA_KEY: _FRAMEWORK_NAME},
             )
 
-    def _extract_value(self, result_dict: dict[str, Any]) -> float | bool:
+    def _extract_value(self, result_dict: dict[str, Any]) -> float | None:
         """Extract the primary metric value from Evidently result dict."""
         metrics = result_dict.get("metrics", [])
         if not metrics:
-            return 0.0
+            return None
 
         value = metrics[0].get("value")
         if value is None:
-            return 0.0
+            return None
 
         # Scalar value (e.g., ValueDrift returns a p-value float)
         if isinstance(value, (int, float)):
@@ -168,7 +200,7 @@ class EvidentlyScorer(Scorer):
                 if isinstance(v, (int, float)):
                     return float(v)
 
-        return 0.0
+        return None
 
     def _extract_rationale(self, result_dict: dict[str, Any]) -> str | None:
         """Extract a human-readable explanation from Evidently result dict."""
@@ -231,6 +263,13 @@ class ValueDrift(EvidentlyScorer):
 
     Compares the distribution of values in current data against reference data
     to detect significant changes (drift).
+
+    .. note::
+        ``ValueDrift`` is a **distribution-level** metric: it compares the aggregate
+        distribution of the current dataset against a reference dataset. It cannot be
+        used to evaluate a single row in isolation. Always supply ``reference_data``
+        (a list of dicts or a DataFrame) via the ``expectations`` argument; omitting it
+        will cause the underlying Evidently metric to raise an error.
 
     Args:
         column: Name of the column to check for drift

--- a/mlflow/genai/scorers/evidently/registry.py
+++ b/mlflow/genai/scorers/evidently/registry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from mlflow.exceptions import MlflowException
 
 _SUPPORTED_METRICS = {
-    "ValueDrift": "evidently.metrics.ValueDrift",
     "MissingValueCount": "evidently.metrics.MissingValueCount",
     "UniqueValueCount": "evidently.metrics.UniqueValueCount",
 }

--- a/mlflow/genai/scorers/evidently/registry.py
+++ b/mlflow/genai/scorers/evidently/registry.py
@@ -19,16 +19,15 @@ def get_metric_class(metric_name: str):
         The Evidently metric class
 
     Raises:
-        MlflowException: If the metric is not found
+        MlflowException: If the metric is not in the supported list
     """
+    available = ", ".join(sorted(_SUPPORTED_METRICS))
+    if metric_name not in _SUPPORTED_METRICS:
+        raise MlflowException.invalid_parameter_value(
+            f"Unknown Evidently metric: '{metric_name}'. "
+            f"Available metrics: {available}"
+        )
+
     from evidently import metrics as evidently_metrics
 
-    try:
-        return getattr(evidently_metrics, metric_name)
-    except AttributeError:
-        available = ", ".join(sorted(_SUPPORTED_METRICS))
-        raise MlflowException.invalid_parameter_value(
-            f"Unknown Evidently metric: '{metric_name}'. Could not find "
-            f"'{metric_name}' in 'evidently.metrics'. "
-            f"Available pre-configured metrics: {available}"
-        )
+    return getattr(evidently_metrics, metric_name)

--- a/mlflow/genai/scorers/evidently/registry.py
+++ b/mlflow/genai/scorers/evidently/registry.py
@@ -24,8 +24,7 @@ def get_metric_class(metric_name: str):
     available = ", ".join(sorted(_SUPPORTED_METRICS))
     if metric_name not in _SUPPORTED_METRICS:
         raise MlflowException.invalid_parameter_value(
-            f"Unknown Evidently metric: '{metric_name}'. "
-            f"Available metrics: {available}"
+            f"Unknown Evidently metric: '{metric_name}'. Available metrics: {available}"
         )
 
     from evidently import metrics as evidently_metrics

--- a/mlflow/genai/scorers/evidently/registry.py
+++ b/mlflow/genai/scorers/evidently/registry.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from mlflow.exceptions import MlflowException
+
+_SUPPORTED_METRICS = {
+    "ValueDrift": "evidently.metrics.ValueDrift",
+    "MissingValueCount": "evidently.metrics.MissingValueCount",
+    "UniqueValueCount": "evidently.metrics.UniqueValueCount",
+}
+
+
+def get_metric_class(metric_name: str):
+    """Get an Evidently metric class by name.
+
+    Args:
+        metric_name: Name of the Evidently metric (e.g., "ValueDrift", "MissingValueCount")
+
+    Returns:
+        The Evidently metric class
+
+    Raises:
+        MlflowException: If the metric is not found
+    """
+    from evidently import metrics as evidently_metrics
+
+    try:
+        return getattr(evidently_metrics, metric_name)
+    except AttributeError:
+        available = ", ".join(sorted(_SUPPORTED_METRICS))
+        raise MlflowException.invalid_parameter_value(
+            f"Unknown Evidently metric: '{metric_name}'. Could not find "
+            f"'{metric_name}' in 'evidently.metrics'. "
+            f"Available pre-configured metrics: {available}"
+        )

--- a/mlflow/genai/scorers/evidently/utils.py
+++ b/mlflow/genai/scorers/evidently/utils.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from mlflow.entities.trace import Trace
+from mlflow.exceptions import MlflowException
+from mlflow.genai.utils.trace_utils import (
+    parse_inputs_to_str,
+    parse_outputs_to_str,
+    resolve_inputs_from_trace,
+    resolve_outputs_from_trace,
+)
+
+
+def check_evidently_installed():
+    try:
+        import evidently  # noqa: F401
+    except ImportError:
+        raise MlflowException.invalid_parameter_value(
+            "Evidently scorers require the `evidently` package. "
+            "Install it with: `pip install evidently`"
+        )
+
+
+def map_scorer_inputs_to_dataframe(
+    inputs: Any = None,
+    outputs: Any = None,
+    expectations: dict[str, Any] | None = None,
+    trace: Trace | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame | None]:
+    """Convert MLflow scorer inputs to pandas DataFrames for Evidently.
+
+    Returns a tuple of (current_data, reference_data). The reference_data
+    may be None if no expectations are provided.
+    """
+    if trace:
+        inputs = resolve_inputs_from_trace(inputs, trace)
+        outputs = resolve_outputs_from_trace(outputs, trace)
+
+    # Build current data from inputs/outputs
+    current_dict: dict[str, Any] = {}
+    if inputs is not None:
+        if isinstance(inputs, dict):
+            current_dict.update(inputs)
+        else:
+            current_dict["input"] = parse_inputs_to_str(inputs)
+
+    if outputs is not None:
+        if isinstance(outputs, dict):
+            current_dict.update(outputs)
+        else:
+            current_dict["output"] = parse_outputs_to_str(outputs)
+
+    if not current_dict:
+        raise MlflowException.invalid_parameter_value(
+            "Evidently scorers require either 'inputs' or 'outputs' to evaluate."
+        )
+
+    current_df = pd.DataFrame([current_dict])
+
+    # Build reference data from expectations if provided
+    reference_df = None
+    if expectations is not None and isinstance(expectations, dict):
+        ref_dict = expectations.get("reference_data")
+        if ref_dict is not None:
+            if isinstance(ref_dict, pd.DataFrame):
+                reference_df = ref_dict
+            elif isinstance(ref_dict, list):
+                reference_df = pd.DataFrame(ref_dict)
+            elif isinstance(ref_dict, dict):
+                reference_df = pd.DataFrame([ref_dict])
+
+    return current_df, reference_df

--- a/mlflow/genai/scorers/evidently/utils.py
+++ b/mlflow/genai/scorers/evidently/utils.py
@@ -7,8 +7,6 @@ import pandas as pd
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.utils.trace_utils import (
-    parse_inputs_to_str,
-    parse_outputs_to_str,
     resolve_inputs_from_trace,
     resolve_outputs_from_trace,
 )
@@ -45,13 +43,19 @@ def map_scorer_inputs_to_dataframe(
         if isinstance(inputs, dict):
             current_dict.update(inputs)
         else:
-            current_dict["input"] = parse_inputs_to_str(inputs)
+            raise MlflowException.invalid_parameter_value(
+                "Evidently scorers require 'inputs' to be a dict mapping column names to values. "
+                f"Got: {type(inputs).__name__}"
+            )
 
     if outputs is not None:
         if isinstance(outputs, dict):
             current_dict.update(outputs)
         else:
-            current_dict["output"] = parse_outputs_to_str(outputs)
+            raise MlflowException.invalid_parameter_value(
+                "Evidently scorers require 'outputs' to be a dict mapping column names to values. "
+                f"Got: {type(outputs).__name__}"
+            )
 
     if not current_dict:
         raise MlflowException.invalid_parameter_value(

--- a/tests/genai/scorers/test_evidently.py
+++ b/tests/genai/scorers/test_evidently.py
@@ -121,7 +121,6 @@ def test_concrete_scorer_classes():
 @pytest.mark.parametrize(
     ("scorer_class_name", "expected_metric"),
     [
-        ("ValueDrift", "ValueDrift"),
         ("MissingValues", "MissingValueCount"),
         ("UniqueValues", "UniqueValueCount"),
     ],

--- a/tests/genai/scorers/test_evidently.py
+++ b/tests/genai/scorers/test_evidently.py
@@ -16,6 +16,7 @@ def test_check_evidently_installed_raises_when_missing():
 
 
 def test_check_evidently_installed_succeeds():
+    pytest.importorskip("evidently")
     from mlflow.genai.scorers.evidently.utils import check_evidently_installed
 
     # Should not raise when evidently is installed
@@ -23,6 +24,7 @@ def test_check_evidently_installed_succeeds():
 
 
 def test_get_metric_class_valid():
+    pytest.importorskip("evidently")
     from mlflow.genai.scorers.evidently.registry import get_metric_class
 
     metric_class = get_metric_class("MissingValueCount")
@@ -30,6 +32,7 @@ def test_get_metric_class_valid():
 
 
 def test_get_metric_class_invalid():
+    pytest.importorskip("evidently")
     from mlflow.genai.scorers.evidently.registry import get_metric_class
 
     with pytest.raises(MlflowException, match="Unknown Evidently metric"):
@@ -67,6 +70,7 @@ def test_map_scorer_inputs_to_dataframe_raises_without_data():
 
 
 def test_evidently_scorer_returns_feedback():
+    pytest.importorskip("evidently")
     from mlflow.genai.scorers.evidently import EvidentlyScorer
 
     scorer = EvidentlyScorer(metric_name="MissingValueCount", column="feature_1")
@@ -78,6 +82,7 @@ def test_evidently_scorer_returns_feedback():
 
 
 def test_evidently_scorer_error_returns_feedback_with_error():
+    pytest.importorskip("evidently")
     from mlflow.genai.scorers.evidently import EvidentlyScorer
 
     scorer = EvidentlyScorer(metric_name="MissingValueCount", column="feature_1")
@@ -93,6 +98,7 @@ def test_evidently_scorer_error_returns_feedback_with_error():
 
 
 def test_get_scorer_factory():
+    pytest.importorskip("evidently")
     from mlflow.genai.scorers.evidently import get_scorer
 
     scorer = get_scorer("MissingValueCount", column="feature_1")
@@ -100,6 +106,7 @@ def test_get_scorer_factory():
 
 
 def test_concrete_scorer_classes():
+    pytest.importorskip("evidently")
     from mlflow.genai.scorers.evidently import MissingValues, UniqueValues
 
     scorer = MissingValues(column="col1")
@@ -118,6 +125,7 @@ def test_concrete_scorer_classes():
     ],
 )
 def test_concrete_scorer_metric_names(scorer_class_name: str, expected_metric: str):
+    pytest.importorskip("evidently")
     import mlflow.genai.scorers.evidently as evidently_module
 
     scorer_class = getattr(evidently_module, scorer_class_name)

--- a/tests/genai/scorers/test_evidently.py
+++ b/tests/genai/scorers/test_evidently.py
@@ -82,15 +82,14 @@ def test_evidently_scorer_returns_feedback():
 
 
 def test_evidently_scorer_error_returns_feedback_with_error():
-    pytest.importorskip("evidently")
+    evidently = pytest.importorskip("evidently")
     from mlflow.genai.scorers.evidently import EvidentlyScorer
 
     scorer = EvidentlyScorer(metric_name="MissingValueCount", column="feature_1")
 
-    # Pass invalid data that will cause Evidently to fail
-    with mock.patch(
-        "mlflow.genai.scorers.evidently.map_scorer_inputs_to_dataframe",
-        side_effect=ValueError("test error"),
+    # Simulate Evidently's Report.run failing (inside the try block)
+    with mock.patch.object(
+        evidently.Report, "run", side_effect=RuntimeError("evidently internal error")
     ):
         feedback = scorer(outputs={"feature_1": 0.5})
 
@@ -130,3 +129,45 @@ def test_concrete_scorer_metric_names(scorer_class_name: str, expected_metric: s
 
     scorer_class = getattr(evidently_module, scorer_class_name)
     assert scorer_class.metric_name == expected_metric
+
+
+def test_evidently_scorer_kind_is_third_party():
+    pytest.importorskip("evidently")
+    from mlflow.genai.scorers.base import ScorerKind
+    from mlflow.genai.scorers.evidently import EvidentlyScorer
+
+    scorer = EvidentlyScorer(metric_name="MissingValueCount", column="col")
+    assert scorer.kind == ScorerKind.THIRD_PARTY
+
+
+@pytest.mark.parametrize("method_name", ["register", "start", "update", "stop"])
+def test_evidently_scorer_registration_methods_raise(method_name: str):
+    pytest.importorskip("evidently")
+    from mlflow.genai.scorers.evidently import EvidentlyScorer
+
+    scorer = EvidentlyScorer(metric_name="MissingValueCount", column="col")
+    with pytest.raises(MlflowException, match="not supported"):
+        getattr(scorer, method_name)()
+
+
+def test_evidently_scorer_align_raises():
+    pytest.importorskip("evidently")
+    from mlflow.genai.scorers.evidently import EvidentlyScorer
+
+    scorer = EvidentlyScorer(metric_name="MissingValueCount", column="col")
+    with pytest.raises(MlflowException, match="not supported"):
+        scorer.align()
+
+
+def test_map_scorer_inputs_raises_for_non_dict_inputs():
+    from mlflow.genai.scorers.evidently.utils import map_scorer_inputs_to_dataframe
+
+    with pytest.raises(MlflowException, match="dict"):
+        map_scorer_inputs_to_dataframe(inputs="plain string")
+
+
+def test_map_scorer_inputs_raises_for_non_dict_outputs():
+    from mlflow.genai.scorers.evidently.utils import map_scorer_inputs_to_dataframe
+
+    with pytest.raises(MlflowException, match="dict"):
+        map_scorer_inputs_to_dataframe(outputs=["list", "of", "values"])

--- a/tests/genai/scorers/test_evidently.py
+++ b/tests/genai/scorers/test_evidently.py
@@ -79,6 +79,9 @@ def test_evidently_scorer_returns_feedback():
     feedback = scorer(outputs={"feature_1": None})
     assert feedback.name == "MissingValueCount"
     assert feedback.source.source_id == "evidently/MissingValueCount"
+    assert feedback.value == 1.0
+    assert feedback.rationale is not None
+    assert "count" in feedback.rationale
 
 
 def test_evidently_scorer_error_returns_feedback_with_error():

--- a/tests/genai/scorers/test_evidently.py
+++ b/tests/genai/scorers/test_evidently.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from mlflow.exceptions import MlflowException
+
+
+def test_check_evidently_installed_raises_when_missing():
+    with mock.patch.dict("sys.modules", {"evidently": None}):
+        from mlflow.genai.scorers.evidently.utils import check_evidently_installed
+
+        with pytest.raises(MlflowException, match="evidently"):
+            check_evidently_installed()
+
+
+def test_check_evidently_installed_succeeds():
+    from mlflow.genai.scorers.evidently.utils import check_evidently_installed
+
+    # Should not raise when evidently is installed
+    check_evidently_installed()
+
+
+def test_get_metric_class_valid():
+    from mlflow.genai.scorers.evidently.registry import get_metric_class
+
+    metric_class = get_metric_class("MissingValueCount")
+    assert metric_class is not None
+
+
+def test_get_metric_class_invalid():
+    from mlflow.genai.scorers.evidently.registry import get_metric_class
+
+    with pytest.raises(MlflowException, match="Unknown Evidently metric"):
+        get_metric_class("NonExistentMetric")
+
+
+def test_map_scorer_inputs_to_dataframe_with_dict_outputs():
+    from mlflow.genai.scorers.evidently.utils import map_scorer_inputs_to_dataframe
+
+    current_df, reference_df = map_scorer_inputs_to_dataframe(
+        outputs={"feature_1": 0.5, "feature_2": 1.0},
+    )
+    assert list(current_df.columns) == ["feature_1", "feature_2"]
+    assert current_df.iloc[0]["feature_1"] == 0.5
+    assert reference_df is None
+
+
+def test_map_scorer_inputs_to_dataframe_with_reference():
+    from mlflow.genai.scorers.evidently.utils import map_scorer_inputs_to_dataframe
+
+    current_df, reference_df = map_scorer_inputs_to_dataframe(
+        outputs={"feature_1": 0.5},
+        expectations={"reference_data": [{"feature_1": 0.1}, {"feature_1": 0.2}]},
+    )
+    assert len(current_df) == 1
+    assert reference_df is not None
+    assert len(reference_df) == 2
+
+
+def test_map_scorer_inputs_to_dataframe_raises_without_data():
+    from mlflow.genai.scorers.evidently.utils import map_scorer_inputs_to_dataframe
+
+    with pytest.raises(MlflowException, match="require either"):
+        map_scorer_inputs_to_dataframe()
+
+
+def test_evidently_scorer_returns_feedback():
+    from mlflow.genai.scorers.evidently import EvidentlyScorer
+
+    scorer = EvidentlyScorer(metric_name="MissingValueCount", column="feature_1")
+    assert scorer.name == "MissingValueCount"
+
+    feedback = scorer(outputs={"feature_1": None})
+    assert feedback.name == "MissingValueCount"
+    assert feedback.source.source_id == "evidently/MissingValueCount"
+
+
+def test_evidently_scorer_error_returns_feedback_with_error():
+    from mlflow.genai.scorers.evidently import EvidentlyScorer
+
+    scorer = EvidentlyScorer(metric_name="MissingValueCount", column="feature_1")
+
+    # Pass invalid data that will cause Evidently to fail
+    with mock.patch(
+        "mlflow.genai.scorers.evidently.map_scorer_inputs_to_dataframe",
+        side_effect=ValueError("test error"),
+    ):
+        feedback = scorer(outputs={"feature_1": 0.5})
+
+    assert feedback.error is not None
+
+
+def test_get_scorer_factory():
+    from mlflow.genai.scorers.evidently import get_scorer
+
+    scorer = get_scorer("MissingValueCount", column="feature_1")
+    assert scorer.name == "MissingValueCount"
+
+
+def test_concrete_scorer_classes():
+    from mlflow.genai.scorers.evidently import MissingValues, UniqueValues
+
+    scorer = MissingValues(column="col1")
+    assert scorer.name == "MissingValueCount"
+
+    scorer = UniqueValues(column="col1")
+    assert scorer.name == "UniqueValueCount"
+
+
+@pytest.mark.parametrize(
+    ("scorer_class_name", "expected_metric"),
+    [
+        ("ValueDrift", "ValueDrift"),
+        ("MissingValues", "MissingValueCount"),
+        ("UniqueValues", "UniqueValueCount"),
+    ],
+)
+def test_concrete_scorer_metric_names(scorer_class_name: str, expected_metric: str):
+    import mlflow.genai.scorers.evidently as evidently_module
+
+    scorer_class = getattr(evidently_module, scorer_class_name)
+    assert scorer_class.metric_name == expected_metric


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21603

### What changes are proposed in this pull request?

Adds [Evidently AI](https://github.com/evidentlyai/evidently) as a third-party scorer provider for MLflow's GenAI evaluation framework. This enables users to leverage Evidently's data quality and drift detection metrics (e.g., `ValueDrift`, `MissingValueCount`, `UniqueValueCount`) through MLflow's unified scorer interface.

**Key components:**
- `EvidentlyScorer` base class wrapping Evidently metrics as MLflow scorers
- Convenience classes: `ValueDrift`, `MissingValues`, `UniqueValues`
- `get_scorer()` factory function for dynamic metric instantiation
- Metric registry mapping metric names to Evidently classes
- Utility functions for converting MLflow scorer inputs to Evidently-compatible DataFrames

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

14 new tests covering:
- Install check (with and without evidently)
- Metric registry (valid and invalid lookups)
- DataFrame conversion (dict outputs, reference data, missing data)
- Scorer execution (feedback output, error handling)
- Factory function and concrete scorer classes
- Tests gracefully skip via `pytest.importorskip("evidently")` when evidently is not installed

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added Evidently AI as a third-party scorer provider, enabling data drift detection and data quality monitoring through MLflow's GenAI evaluation interface.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release