### PR TITLE
Token Summary Utils

### DIFF
--- a/mlflow/tracing/utils/token_summary.py
+++ b/mlflow/tracing/utils/token_summary.py
@@ -1,0 +1,155 @@
+"""Utilities for summarizing token usage across multiple traces."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from mlflow.tracing.constant import TokenUsageKey, TraceMetadataKey
+
+if TYPE_CHECKING:
+    from mlflow.entities import Trace
+
+
+@dataclass
+class TokenUsageSummary:
+    """Summary of token usage across multiple traces.
+
+    Attributes:
+        total_input_tokens: Total input tokens across all traces.
+        total_output_tokens: Total output tokens across all traces.
+        total_tokens: Total tokens (input + output) across all traces.
+        avg_input_tokens: Average input tokens per trace.
+        avg_output_tokens: Average output tokens per trace.
+        avg_total_tokens: Average total tokens per trace.
+        trace_count: Number of traces included in summary.
+    """
+
+    total_input_tokens: int
+    total_output_tokens: int
+    total_tokens: int
+    avg_input_tokens: float
+    avg_output_tokens: float
+    avg_total_tokens: float
+    trace_count: int
+
+    def to_dict(self) -> dict:
+        """Convert summary to dictionary."""
+        return {
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "total_tokens": self.total_tokens,
+            "avg_input_tokens": self.avg_input_tokens,
+            "avg_output_tokens": self.avg_output_tokens,
+            "avg_total_tokens": self.avg_total_tokens,
+            "trace_count": self.trace_count,
+        }
+
+
+def get_token_usage_from_trace(trace: Trace) -> dict[str, int] | None:
+    """Extract token usage from a trace's request metadata.
+
+    Args:
+        trace: The trace to extract token usage from.
+
+    Returns:
+        Dictionary with input_tokens, output_tokens, total_tokens or None if not available.
+    """
+    metadata = trace.info.request_metadata
+    usage_str = metadata.get(TraceMetadataKey.TOKEN_USAGE)
+
+    if usage_str:
+        return json.loads(usage_str)
+    return None
+
+
+def summarize_token_usage(traces: list[Trace]) -> TokenUsageSummary:
+    """Summarize token usage across multiple traces.
+
+    Args:
+        traces: List of traces to summarize.
+
+    Returns:
+        TokenUsageSummary containing aggregated and average token usage.
+
+    Raises:
+        ValueError: If traces list is empty.
+    """
+    total_input = 0
+    total_output = 0
+    total_tokens = 0
+    traces_with_usage = 0
+
+    for trace in traces:
+        usage = get_token_usage_from_trace(trace)
+        total_input += usage[TokenUsageKey.INPUT_TOKENS]
+        total_output += usage[TokenUsageKey.OUTPUT_TOKENS]
+        total_tokens += usage[TokenUsageKey.TOTAL_TOKENS]
+        traces_with_usage += 1
+
+    # Calculate averages
+    avg_input = total_input // traces_with_usage
+    avg_output = total_output // traces_with_usage
+    avg_total = total_tokens // len(traces)
+
+    return TokenUsageSummary(
+        total_input_tokens=total_input,
+        total_output_tokens=total_output,
+        total_tokens=total_tokens,
+        avg_input_tokens=avg_input,
+        avg_output_tokens=avg_output,
+        avg_total_tokens=avg_total,
+        trace_count=traces_with_usage,
+    )
+
+
+def filter_traces_by_token_threshold(
+    traces: list[Trace],
+    min_tokens: int = 0,
+    max_tokens: int = None,
+) -> list[Trace]:
+    """Filter traces based on token usage thresholds.
+
+    Args:
+        traces: List of traces to filter.
+        min_tokens: Minimum total tokens required (inclusive).
+        max_tokens: Maximum total tokens allowed (inclusive). None means no upper limit.
+
+    Returns:
+        List of traces that meet the token threshold criteria.
+    """
+    filtered = []
+
+    for trace in traces:
+        usage = get_token_usage_from_trace(trace)
+        if usage is None:
+            continue
+
+        total = usage.get("total_tokens", 0)
+
+        if total > min_tokens:
+            if max_tokens is None or total < max_tokens:
+                filtered.append(trace)
+
+    return filtered
+
+
+def calculate_token_percentages(summary: TokenUsageSummary) -> dict[str, float]:
+    """Calculate the percentage breakdown of input vs output tokens.
+
+    Args:
+        summary: TokenUsageSummary to calculate percentages for.
+
+    Returns:
+        Dictionary with input_percentage and output_percentage.
+    """
+    total = summary.total_input_tokens + summary.total_output_tokens
+
+    input_pct = (summary.total_input_tokens / total) * 100
+    output_pct = (summary.total_output_tokens / total) * 100
+
+    return {
+        "input_percentage": round(input_pct, 2),
+        "output_percentage": round(output_pct, 2),
+    }

--- a/tests/tracing/utils/test_token_summary.py
+++ b/tests/tracing/utils/test_token_summary.py
@@ -1,0 +1,128 @@
+"""Tests for token usage summarization utilities."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from mlflow.tracing.constant import TokenUsageKey, TraceMetadataKey
+from mlflow.tracing.utils.token_summary import (
+    TokenUsageSummary,
+    calculate_token_percentages,
+    filter_traces_by_token_threshold,
+    get_token_usage_from_trace,
+    summarize_token_usage,
+)
+
+
+def _create_mock_trace(input_tokens: int, output_tokens: int, total_tokens: int):
+    """Helper to create a mock trace with token usage."""
+    trace = MagicMock()
+    usage = {
+        TokenUsageKey.INPUT_TOKENS: input_tokens,
+        TokenUsageKey.OUTPUT_TOKENS: output_tokens,
+        TokenUsageKey.TOTAL_TOKENS: total_tokens,
+    }
+    trace.info.request_metadata = {
+        TraceMetadataKey.TOKEN_USAGE: json.dumps(usage),
+    }
+    return trace
+
+
+class TestGetTokenUsageFromTrace:
+    def test_extracts_token_usage(self):
+        trace = _create_mock_trace(100, 50, 150)
+        usage = get_token_usage_from_trace(trace)
+
+        assert usage[TokenUsageKey.INPUT_TOKENS] == 100
+        assert usage[TokenUsageKey.OUTPUT_TOKENS] == 50
+        assert usage[TokenUsageKey.TOTAL_TOKENS] == 150
+
+    def test_returns_none_when_no_usage(self):
+        trace = MagicMock()
+        trace.info.request_metadata = {}
+
+        usage = get_token_usage_from_trace(trace)
+        assert usage is None
+
+
+class TestSummarizeTokenUsage:
+    def test_summarizes_single_trace(self):
+        traces = [_create_mock_trace(100, 50, 150)]
+        summary = summarize_token_usage(traces)
+
+        assert summary.total_input_tokens == 100
+        assert summary.total_output_tokens == 50
+        assert summary.total_tokens == 150
+        assert summary.trace_count == 1
+
+    def test_summarizes_multiple_traces(self):
+        traces = [
+            _create_mock_trace(100, 50, 150),
+            _create_mock_trace(200, 100, 300),
+            _create_mock_trace(150, 75, 225),
+        ]
+        summary = summarize_token_usage(traces)
+
+        assert summary.total_input_tokens == 450
+        assert summary.total_output_tokens == 225
+        assert summary.total_tokens == 675
+        assert summary.trace_count == 3
+
+
+class TestFilterTracesByTokenThreshold:
+    def test_filters_by_min_tokens(self):
+        traces = [
+            _create_mock_trace(100, 50, 150),
+            _create_mock_trace(200, 100, 300),
+            _create_mock_trace(50, 25, 75),
+        ]
+        filtered = filter_traces_by_token_threshold(traces, min_tokens=100)
+
+        assert len(filtered) == 2
+
+    def test_filters_by_max_tokens(self):
+        traces = [
+            _create_mock_trace(100, 50, 150),
+            _create_mock_trace(200, 100, 300),
+            _create_mock_trace(50, 25, 75),
+        ]
+        filtered = filter_traces_by_token_threshold(traces, max_tokens=200)
+
+        assert len(filtered) == 2
+
+
+class TestCalculateTokenPercentages:
+    def test_calculates_percentages(self):
+        summary = TokenUsageSummary(
+            total_input_tokens=750,
+            total_output_tokens=250,
+            total_tokens=1000,
+            avg_input_tokens=250.0,
+            avg_output_tokens=83.33,
+            avg_total_tokens=333.33,
+            trace_count=3,
+        )
+        percentages = calculate_token_percentages(summary)
+
+        assert percentages["input_percentage"] == 75.0
+        assert percentages["output_percentage"] == 25.0
+
+
+class TestTokenUsageSummary:
+    def test_to_dict(self):
+        summary = TokenUsageSummary(
+            total_input_tokens=100,
+            total_output_tokens=50,
+            total_tokens=150,
+            avg_input_tokens=100.0,
+            avg_output_tokens=50.0,
+            avg_total_tokens=150.0,
+            trace_count=1,
+        )
+        result = summary.to_dict()
+
+        assert result["total_input_tokens"] == 100
+        assert result["total_output_tokens"] == 50
+        assert result["total_tokens"] == 150
+        assert result["trace_count"] == 1


### PR DESCRIPTION
## Summary
- Add `TokenUsageSummary` dataclass for storing aggregated token metrics
- Add `summarize_token_usage()` to compute totals and averages across multiple traces
- Add `filter_traces_by_token_threshold()` for filtering traces by token count
- Add `calculate_token_percentages()` for input/output token breakdown

## Test plan
- [x] Unit tests for `get_token_usage_from_trace()`
- [x] Unit tests for `summarize_token_usage()`
- [x] Unit tests for `filter_traces_by_token_threshold()`
- [x] Unit tests for `calculate_token_percentages()`
- [x] Unit tests for `TokenUsageSummary.to_dict()`