### PR TITLE
Add meta descriptions to docs pages

### DIFF
--- a/docs/docs/classic-ml/deep-learning/keras/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/keras/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: MLflow Keras 3.0 Integration
+description: Log, track, and deploy Keras 3.0 deep learning models with MLflow. Automatic experiment tracking, model versioning, and one-click deployment.
 sidebar_position: 2
 sidebar_label: Keras
 ---

--- a/docs/docs/classic-ml/deep-learning/pytorch/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/pytorch/index.mdx
@@ -2,7 +2,7 @@
 title: MLflow PyTorch Integration
 description: Log, track, and deploy PyTorch models with MLflow. Automatic experiment tracking, model versioning, and seamless deployment for deep learning workflows.
 sidebar_position: 1
-sidebar_label: Pytorch
+sidebar_label: PyTorch
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/docs/classic-ml/deep-learning/pytorch/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/pytorch/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: MLflow PyTorch Integration
+description: Log, track, and deploy PyTorch models with MLflow. Automatic experiment tracking, model versioning, and seamless deployment for deep learning workflows.
 sidebar_position: 1
 sidebar_label: Pytorch
 ---

--- a/docs/docs/classic-ml/deep-learning/sentence-transformers/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/sentence-transformers/index.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: Sentence Transformers
+description: Log, version, and deploy Sentence Transformers models with MLflow for semantic embeddings and text similarity tasks.
 ---
 
 import { CardGroup, PageCard } from "@site/src/components/Card";

--- a/docs/docs/classic-ml/deep-learning/spacy/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/spacy/index.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_label: spaCy
+description: Integrate spaCy NLP pipelines with MLflow for model logging, experiment tracking, versioning, and deployment.
 ---
 
 import FeatureHighlights from "@site/src/components/FeatureHighlights";

--- a/docs/docs/classic-ml/deep-learning/tensorflow/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/tensorflow/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: MLflow TensorFlow Integration
+description: Log, track, and deploy TensorFlow models with MLflow. Automatic experiment tracking, model versioning, and streamlined deployment for production ML.
 sidebar_position: 2
 sidebar_label: TensorFlow
 ---

--- a/docs/docs/classic-ml/deployment/deploy-model-locally/index.mdx
+++ b/docs/docs/classic-ml/deployment/deploy-model-locally/index.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Deploy MLflow models as local inference servers for testing and lightweight applications using a single CLI command.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/docs/classic-ml/deployment/deploy-model-to-kubernetes/index.mdx
+++ b/docs/docs/classic-ml/deployment/deploy-model-to-kubernetes/index.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Deploy MLflow models to Kubernetes using MLServer, Docker, and frameworks like Seldon Core and KServe for scalable serving.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/docs/classic-ml/getting-started/hyperparameter-tuning/index.mdx
+++ b/docs/docs/classic-ml/getting-started/hyperparameter-tuning/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Tracking Hyperparameter Tuning with MLflow
+description: Track and compare hyperparameter tuning runs with MLflow. Visualize parameter sweeps, log metrics across trials, and identify optimal configurations.
 sidebar_position: 3
 toc_max_heading_level: 4
 sidebar_label: Hyperparameter Tuning

--- a/docs/docs/classic-ml/model/dependencies/index.mdx
+++ b/docs/docs/classic-ml/model/dependencies/index.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_label: Dependency Management
 sidebar_position: 2
+description: Manage and customize Python dependencies in MLflow models for reproducible packaging, serving, and deployment.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/docs/classic-ml/model/signatures/index.mdx
+++ b/docs/docs/classic-ml/model/signatures/index.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_label: Model Signature
 sidebar_position: 1
+description: Define model signatures and input examples in MLflow to enforce input/output schemas and improve model documentation.
 ---
 
 import { NotebookDownloadButton } from "@site/src/components/NotebookDownloadButton";

--- a/docs/docs/classic-ml/tracking/autolog/index.mdx
+++ b/docs/docs/classic-ml/tracking/autolog/index.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Automatically log metrics, parameters, models, and artifacts with MLflow autologging for supported ML frameworks.
 ---
 
 import TOCInline from "@theme/TOCInline";

--- a/docs/docs/classic-ml/tracking/quickstart/index.mdx
+++ b/docs/docs/classic-ml/tracking/quickstart/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: MLflow Tracking Quickstart
+description: Get started with MLflow Tracking in minutes. Learn to log parameters, metrics, and models, then view results in the MLflow UI.
 sidebar_position: 2
 sidebar_label: "Quickstart"
 ---

--- a/docs/docs/classic-ml/traditional-ml/sklearn/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/sklearn/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: MLflow Scikit-learn Integration
+description: Log, track, and deploy scikit-learn models with MLflow. Autologging for classification, regression, and clustering with full experiment tracking.
 sidebar_position: 1
 sidebar_label: Scikit-learn
 ---

--- a/docs/docs/classic-ml/traditional-ml/xgboost/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/xgboost/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: MLflow XGBoost Integration
+description: Log, track, and deploy XGBoost models with MLflow. Autologging for gradient-boosted models with feature importance, metrics, and model versioning.
 sidebar_position: 1
 sidebar_label: XGBoost
 ---

--- a/docs/docs/genai/assessments/expectations.mdx
+++ b/docs/docs/genai/assessments/expectations.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Ground Truth Expectations
+description: Define and log ground truth expectations in MLflow to establish reference outputs for evaluating LLM and AI agent quality.
 ---
 
 import FeatureHighlights from "@site/src/components/FeatureHighlights";

--- a/docs/docs/genai/assessments/feedback.mdx
+++ b/docs/docs/genai/assessments/feedback.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Feedback Collection
+description: Collect and log feedback from human reviewers, AI judges, and automated rules to evaluate LLM and AI agent performance in MLflow.
 ---
 
 import FeatureHighlights from "@site/src/components/FeatureHighlights";

--- a/docs/docs/genai/concepts/evaluation-datasets.mdx
+++ b/docs/docs/genai/concepts/evaluation-datasets.mdx
@@ -1,3 +1,7 @@
+---
+description: Learn about MLflow Evaluation Datasets for organizing and managing test data for LLM applications and AI agents.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import ConceptOverview from "@site/src/components/ConceptOverview";
 import TilesGrid from "@site/src/components/TilesGrid";

--- a/docs/docs/genai/concepts/expectations.mdx
+++ b/docs/docs/genai/concepts/expectations.mdx
@@ -1,3 +1,7 @@
+---
+description: Learn about MLflow Expectations for defining ground truth and desired outputs to evaluate LLM and AI agent performance.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import FeatureHighlights from "@site/src/components/FeatureHighlights";
 import TilesGrid from "@site/src/components/TilesGrid";

--- a/docs/docs/genai/concepts/feedback.mdx
+++ b/docs/docs/genai/concepts/feedback.mdx
@@ -1,3 +1,7 @@
+---
+description: Learn about MLflow Feedback for capturing quality assessments of LLM and AI agent outputs from automated and human sources.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import ImageBox from "@site/src/components/ImageBox";
 import FeatureHighlights from "@site/src/components/FeatureHighlights";

--- a/docs/docs/genai/concepts/scorers.mdx
+++ b/docs/docs/genai/concepts/scorers.mdx
@@ -1,3 +1,7 @@
+---
+description: Learn about MLflow Scorers, evaluation functions that assess LLM and AI agent output quality across dimensions like correctness and safety.
+---
+
 import Tabs from "@theme/Tabs"
 import TabItem from "@theme/TabItem"
 import { APILink } from "@site/src/components/APILink";

--- a/docs/docs/genai/concepts/span.mdx
+++ b/docs/docs/genai/concepts/span.mdx
@@ -1,3 +1,7 @@
+---
+description: Learn about MLflow Spans, the building blocks of traces that capture individual steps like LLM calls and tool execution.
+---
+
 import Tabs from "@theme/Tabs"
 import TabItem from "@theme/TabItem"
 import ImageBox from "@site/src/components/ImageBox";

--- a/docs/docs/genai/concepts/trace.mdx
+++ b/docs/docs/genai/concepts/trace.mdx
@@ -1,3 +1,7 @@
+---
+description: Learn about MLflow Tracing for capturing and visualizing the complete execution flow of LLM applications and AI agents.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import ImageBox from "@site/src/components/ImageBox";
 import FeatureHighlights from "@site/src/components/FeatureHighlights";

--- a/docs/docs/genai/eval-monitor/automatic-evaluations/index.mdx
+++ b/docs/docs/genai/eval-monitor/automatic-evaluations/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Automatically evaluate traces and conversations as they are logged to MLflow using LLM judges for production monitoring and quality iteration.
+---
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import TabsWrapper from "@site/src/components/TabsWrapper";

--- a/docs/docs/genai/eval-monitor/scorers/custom/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/custom/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Build custom code-based scorers in MLflow to define tailored evaluation metrics for LLM applications using heuristics or programmatic logic.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import ImageBox from "@site/src/components/ImageBox";
 import Tabs from "@theme/Tabs";

--- a/docs/docs/genai/eval-monitor/scorers/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Learn about MLflow LLM judges and scorers for evaluating GenAI applications, including built-in judges, custom judges, and code-based scorers.
+---
+
 import Link from "@docusaurus/Link";
 import { APILink } from "@site/src/components/APILink";
 import TileCard from '@site/src/components/TileCard';

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/custom-judges/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/custom-judges/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Create custom LLM judges in MLflow with natural language guidelines using make_judge() or the Judge Builder UI for domain-specific evaluation.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import { Users, Brain, Hammer } from "lucide-react";
 import TileCard from "@site/src/components/TileCard";

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/rag/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/rag/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Evaluate RAG applications with MLflow built-in judges for retrieval relevance, groundedness, and context sufficiency assessment.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import TileCard from '@site/src/components/TileCard';
 import TilesGrid from '@site/src/components/TilesGrid';

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/tool-call/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/tool-call/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Evaluate AI agent tool calling with MLflow built-in judges for tool call correctness and efficiency assessment.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import TileCard from '@site/src/components/TileCard';
 import TilesGrid from '@site/src/components/TilesGrid';

--- a/docs/docs/genai/eval-monitor/scorers/third-party/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/third-party/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Integrate third-party evaluation frameworks like DeepEval and RAGAS with MLflow for unified LLM scoring and metrics.
+---
+
 import TileCard from '@site/src/components/TileCard';
 import TilesGrid from '@site/src/components/TilesGrid';
 

--- a/docs/docs/genai/flavors/chat-model-guide/index.mdx
+++ b/docs/docs/genai/flavors/chat-model-guide/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Tutorial on building custom LLM and AI agent models using MLflow ChatModel with OpenAI-compatible chat API integration.
+---
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { APILink } from "@site/src/components/APILink";

--- a/docs/docs/genai/flavors/chat-model-intro/index.mdx
+++ b/docs/docs/genai/flavors/chat-model-intro/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Get started with MLflow ChatModel to create production-ready conversational AI models with OpenAI-compatible schema and deployment support.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import { Table } from "@site/src/components/Table";
 

--- a/docs/docs/genai/flavors/custom-pyfunc-for-llms/index.mdx
+++ b/docs/docs/genai/flavors/custom-pyfunc-for-llms/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Deploy advanced LLMs like MPT-7B with MLflow custom PyFuncs, covering model loading, prompt management, and inference optimization.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import { CardGroup, PageCard } from "@site/src/components/Card";
 

--- a/docs/docs/genai/flavors/custom-pyfunc-for-llms/index.mdx
+++ b/docs/docs/genai/flavors/custom-pyfunc-for-llms/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Deploy advanced LLMs like MPT-7B with MLflow custom PyFuncs, covering model loading, prompt management, and inference optimization.
+description: Deploy advanced LLMs with MLflow custom PyFuncs, covering model loading, prompt management, and inference optimization.
 ---
 
 import { APILink } from "@site/src/components/APILink";

--- a/docs/docs/genai/flavors/dspy/index.mdx
+++ b/docs/docs/genai/flavors/dspy/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Use the MLflow DSPy flavor to track, log, and deploy DSPy models with automatic prompt optimization and experiment management.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import { CardGroup, PageCard } from "@site/src/components/Card";
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/docs/genai/flavors/langchain/guide/index.mdx
+++ b/docs/docs/genai/flavors/langchain/guide/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Integrate LangChain with MLflow for logging, tracking, and deploying LangChain models, chains, and agents with autologging support.
+---
+
 import { APILink } from "@site/src/components/APILink";
 
 # LangChain within MLflow (Experimental)

--- a/docs/docs/genai/flavors/langchain/index.mdx
+++ b/docs/docs/genai/flavors/langchain/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Log, deploy, and trace LangChain and LangGraph models with the MLflow LangChain flavor integration.
+---
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { PageCard, CardGroup } from "@site/src/components/Card";

--- a/docs/docs/genai/flavors/llama-index/index.mdx
+++ b/docs/docs/genai/flavors/llama-index/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Integrate LlamaIndex with MLflow to log, manage, and deploy LlamaIndex engines with automatic tracing.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import { CardGroup, PageCard } from "@site/src/components/Card";
 

--- a/docs/docs/genai/getting-started/databricks-trial/index.mdx
+++ b/docs/docs/genai/getting-started/databricks-trial/index.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: Get started with managed MLflow on Databricks using a free trial account for experiment tracking, tracing, and model management.
 ---
 
 import { APILink } from "@site/src/components/APILink";

--- a/docs/docs/genai/governance/ai-gateway/legacy/index.mdx
+++ b/docs/docs/genai/governance/ai-gateway/legacy/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Deploy and manage LLM endpoints using the legacy YAML-based MLflow AI Gateway Server configuration.
+---
+
 import TilesGrid from "@site/src/components/TilesGrid";
 import TileCard from "@site/src/components/TileCard";
 import { Wrench, Settings, Play } from "lucide-react";

--- a/docs/docs/genai/references/request-features.mdx
+++ b/docs/docs/genai/references/request-features.mdx
@@ -1,3 +1,7 @@
+---
+description: Vote on and request new features for MLflow GenAI. Share your feedback to help shape the MLflow roadmap.
+---
+
 import GitHubIssues from '@site/src/components/GitHubIssues';
 
 # Request Features

--- a/docs/docs/genai/serving/custom-apps.mdx
+++ b/docs/docs/genai/serving/custom-apps.mdx
@@ -1,3 +1,7 @@
+---
+description: Build custom MLflow serving applications with PyFunc for advanced preprocessing, multi-model pipelines, and business logic.
+---
+
 # Custom Serving Applications
 
 MLflow's custom serving applications allow you to build sophisticated model serving solutions that go beyond simple prediction endpoints. Using the PyFunc framework, you can create custom applications with complex preprocessing, postprocessing, multi-model inference, and business logic integration.

--- a/docs/docs/genai/serving/index.mdx
+++ b/docs/docs/genai/serving/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Serve MLflow models as production-ready REST API endpoints locally, in the cloud, or via managed services.
+---
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import TabsWrapper from "@site/src/components/TabsWrapper";

--- a/docs/docs/genai/serving/responses-agent.mdx
+++ b/docs/docs/genai/serving/responses-agent.mdx
@@ -1,3 +1,7 @@
+---
+description: Use MLflow ResponsesAgent to serve generative AI models with tool calling, multi-turn dialogue, and OpenAI API compatibility.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";

--- a/docs/docs/genai/tracing/attach-tags/index.mdx
+++ b/docs/docs/genai/tracing/attach-tags/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Attach mutable key-value tags to MLflow traces for grouping, filtering, and contextual analysis.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/docs/genai/tracing/collect-user-feedback/index.mdx
+++ b/docs/docs/genai/tracing/collect-user-feedback/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Collect and store structured user feedback on MLflow traces to evaluate LLM application quality.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import TilesGrid from "@site/src/components/TilesGrid";
 import TileCard from "@site/src/components/TileCard";

--- a/docs/docs/genai/tracing/integrations/index.mdx
+++ b/docs/docs/genai/tracing/integrations/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Enable one-line auto tracing for 40+ LLM and AI agent libraries including OpenAI, LangChain, and more.
+---
+
 import TracingIntegrations from "@site/src/components/TracingIntegrations";
 
 # Auto Tracing Integrations

--- a/docs/docs/genai/tracing/opentelemetry/index.mdx
+++ b/docs/docs/genai/tracing/opentelemetry/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Ingest and export traces between MLflow and OpenTelemetry using the vendor-neutral OTLP protocol.
+---
+
 import FeatureHighlights from '@site/src/components/FeatureHighlights';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { CircleCheck, CircleArrowRight, CircleArrowLeft } from "lucide-react";

--- a/docs/docs/genai/tracing/quickstart/index.mdx
+++ b/docs/docs/genai/tracing/quickstart/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Get started with MLflow Tracing in under 10 minutes by enabling tracing for a simple LLM application.
+---
+
 import ImageBox from '@site/src/components/ImageBox';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/docs/genai/tracing/token-usage-cost/index.mdx
+++ b/docs/docs/genai/tracing/token-usage-cost/index.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 7
 sidebar_label: Token Usage and Cost
+description: Automatically track LLM token usage and cost within MLflow traces to monitor and optimize resource consumption.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/docs/genai/tracing/track-environments-context/index.mdx
+++ b/docs/docs/genai/tracing/track-environments-context/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Track application versions and execution environments in MLflow traces for debugging and regression detection.
+---
+
 import { APILink } from "@site/src/components/APILink";
 
 # Track Versions & Environments

--- a/docs/docs/genai/tracing/track-users-sessions/index.mdx
+++ b/docs/docs/genai/tracing/track-users-sessions/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Associate MLflow traces with users and sessions to analyze multi-turn conversations and user behavior.
+---
+
 import { APILink } from "@site/src/components/APILink";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";

--- a/docs/docs/prompts/index.mdx
+++ b/docs/docs/prompts/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Prompt Management in MLflow
+description: Version, track, and manage prompts for LLM applications and AI agents with the MLflow Prompt Registry. Collaborate on prompt engineering across your organization.
 sidebar_position: 1
 sidebar_label: Overview
 ---

--- a/docs/docs/quickstart_drilldown/index.mdx
+++ b/docs/docs/quickstart_drilldown/index.mdx
@@ -1,4 +1,6 @@
 ---
+title: Quickstart Options and Troubleshooting
+description: Customize your MLflow installation, configure tracking URIs, set up remote servers, and troubleshoot common setup issues.
 sidebar_custom_props:
   hide: true
 displayed_sidebar: docsSidebar

--- a/docs/docs/self-hosting/index.mdx
+++ b/docs/docs/self-hosting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Self Hosting Overview
+description: Deploy and manage your own MLflow instance. Open-source, vendor-neutral MLOps and LLMOps platform for experiment tracking, model registry, and LLM observability.
 sidebar_position: 1
 ---
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to SEO/GEO improvements for MLflow docs

### What changes are proposed in this pull request?

Adds `description` to docs pages that were missing it. In Docusaurus, the `description` field generates a `<meta name="description">` tag — pages without it get no meta description, which hurts search engine result snippets and AI engine extractability.

All descriptions are under 160 characters and keyword-rich to maximize search engine and AI engine visibility.

### How is this PR tested?

- [x] Manual tests

Can be verified by building the docs site and checking `<meta name="description">` in the generated HTML for each page.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release