### PR TITLE
Replace `innerHTML` with `textContent` in `ParallelCoordinatesPlot`

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/ParallelCoordinatesPlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/ParallelCoordinatesPlot.tsx
@@ -18,7 +18,7 @@ const attachCustomTooltip = (toolTipClass: string, labelText: string, targetLabe
   const tooltipGroup = document.createElementNS(svgNS, 'g');
   const newRect = document.createElementNS(svgNS, 'rect');
   const newText = document.createElementNS(svgNS, 'text');
-  newText.innerHTML = labelText;
+  newText.textContent = labelText;
   newText.setAttribute('fill', 'black');
   tooltipGroup.classList.add(toolTipClass);
   tooltipGroup.appendChild(newRect);
@@ -343,7 +343,7 @@ const ParallelCoordinatesPlotImpl = (props: {
 
       // rotate and truncate axis labels
       wrapperElement.querySelectorAll('.parcoords .label').forEach((e) => {
-        const originalLabel = e.innerHTML;
+        const originalLabel = e.textContent || '';
         if (num_axes > axesRotateThreshold) {
           e.setAttribute('transform', 'rotate(-30)');
         }
@@ -351,8 +351,8 @@ const ParallelCoordinatesPlotImpl = (props: {
         e.setAttribute('x', '20');
         const width_pre_truncation = e.getBoundingClientRect().width;
         if (width_pre_truncation > maxAxesLabelWidth) {
-          e.innerHTML = truncateChartMetricString(originalLabel, axesLabelTruncationThreshold);
-          if (originalLabel !== e.innerHTML) {
+          e.textContent = truncateChartMetricString(originalLabel, axesLabelTruncationThreshold);
+          if (originalLabel !== e.textContent) {
             attachCustomTooltip('axis-label-tooltip', originalLabel, e);
           }
         }
@@ -360,11 +360,11 @@ const ParallelCoordinatesPlotImpl = (props: {
 
       // truncate tick labels
       wrapperElement.querySelectorAll('.parcoords .tick text').forEach((e) => {
-        const originalLabel = e.innerHTML;
+        const originalLabel = e.textContent || '';
         const width_pre_truncation = e.getBoundingClientRect().width;
         if (width_pre_truncation > maxTickLabelWidth) {
-          e.innerHTML = truncateChartMetricString(originalLabel, tickLabelTruncationThreshold);
-          if (originalLabel !== e.innerHTML) {
+          e.textContent = truncateChartMetricString(originalLabel, tickLabelTruncationThreshold);
+          if (originalLabel !== e.textContent) {
             attachCustomTooltip('tick-label-tooltip', originalLabel, e);
           }
         }


### PR DESCRIPTION
### Related Issues/PRs

Closes #21904

### What changes are proposed in this pull request?

Replaces all uses of `innerHTML` with `textContent` in `ParallelCoordinatesPlot.tsx` for reading and writing SVG `<text>` element content. This eliminates a potential stored XSS vector where user-controlled metric/parameter names could be parsed as HTML when rendered as axis labels or tick labels in the parallel coordinates chart.

The fix covers three sites:
- **Line 21**: tooltip text element (`attachCustomTooltip`)
- **Lines 346/354**: axis label read/write in the truncation loop
- **Lines 363/366**: tick label read/write in the truncation loop

Since `parcoord-es` already sets labels via D3's `.text()` (which uses `textContent`), this change is behaviorally equivalent — no rich HTML markup is expected in these labels. `textContent` is the correct property for SVG `<text>` elements and avoids HTML parsing entirely.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Labels still render well in parallel coords chart:

<img width="1687" height="904" alt="Screenshot 2026-03-23 at 2 36 32 PM" src="https://github.com/user-attachments/assets/99572882-7b0f-4096-a088-d1a055f46fb6" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release