### PR TITLE
Fix assistant crash on unknown CLI message types

### DIFF
--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -578,7 +578,8 @@ class ClaudeCodeProvider(AssistantProvider):
                     return Event.from_error(f"Failed to parse stream_event message: {e}")
 
             case _:
-                return Event.from_error(f"Unknown message type: {message_type}")
+                # Gracefully ignore unknown message types (e.g., rate_limit_event)
+                return None
 
     def _should_filter_out_message(self, data: dict[str, Any]) -> bool:
         """


### PR DESCRIPTION
### Related Issues/PRs

Closes #21902

### What changes are proposed in this pull request?

The assistant message parser in `_parse_message_to_event()` treats any unrecognized message type from the CLI stream as an error. When `rate_limit_event` messages come through, this surfaces as `"Error: Unknown message type: rate_limit_event"` in the UI.

Changed the default `case _:` branch to return `None` instead of an error, so unknown message types are silently dropped. The caller in `astream()` already filters out `None` via the walrus operator (`if msg :=`), so this is safe. Same approach used by the upstream SDK fix (anthropics/claude-agent-sdk-python v0.1.40).

### How is this PR tested?

- [x] Manual tests

Reproduced the error on MLflow 3.10.0 and 3.10.1 — after applying the one-line fix, `rate_limit_event` messages are silently ignored and the assistant works as expected.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix assistant crash when the CLI emits `rate_limit_event` messages — these are now silently ignored instead of surfacing as errors.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release