### PR TITLE
Fix online evaluator missing long traces by increasing poll window

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1370,6 +1370,11 @@ MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS = _EnvironmentVa
     "MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS", int, 5 * 60
 )
 
+MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS = _EnvironmentVariable(
+    "MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS",
+    int,
+    5 * 60,
+)
 
 #: Specifies the maximum number of completion iterations allowed when invoking
 #: judge models. This prevents infinite loops in case of complex traces or

--- a/mlflow/genai/scorers/online/trace_checkpointer.py
+++ b/mlflow/genai/scorers/online/trace_checkpointer.py
@@ -6,6 +6,9 @@ import time
 from dataclasses import asdict, dataclass
 
 from mlflow.entities.experiment_tag import ExperimentTag
+from mlflow.environment_variables import (
+    MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS,
+)
 from mlflow.genai.scorers.online.constants import MAX_LOOKBACK_MS
 from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.utils.mlflow_tags import MLFLOW_LATEST_ONLINE_SCORING_TRACE_CHECKPOINT
@@ -79,7 +82,7 @@ class OnlineTraceCheckpointManager:
             OnlineTraceScoringTimeWindow with min and max trace timestamps.
             min_trace_timestamp_ms is the checkpoint if it exists and is within the
             lookback period, otherwise now - MAX_LOOKBACK_MS.
-            max_trace_timestamp_ms is the current time.
+            max_trace_timestamp_ms is current time - trace completion buffer.
         """
         current_time_ms = int(time.time() * 1000)
         checkpoint = self.get_checkpoint()
@@ -92,7 +95,10 @@ class OnlineTraceCheckpointManager:
         else:
             min_trace_timestamp_ms = min_lookback_time_ms
 
+        buffer_seconds = max(0, MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS.get())
+        max_trace_timestamp_ms = current_time_ms - buffer_seconds * 1000
+
         return OnlineTraceScoringTimeWindow(
             min_trace_timestamp_ms=min_trace_timestamp_ms,
-            max_trace_timestamp_ms=current_time_ms,
+            max_trace_timestamp_ms=max_trace_timestamp_ms,
         )

--- a/tests/genai/scorers/online/test_trace_checkpointer.py
+++ b/tests/genai/scorers/online/test_trace_checkpointer.py
@@ -3,6 +3,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from mlflow.environment_variables import (
+    MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS,
+)
 from mlflow.genai.scorers.online.constants import MAX_LOOKBACK_MS
 from mlflow.genai.scorers.online.trace_checkpointer import (
     OnlineTraceCheckpointManager,
@@ -82,10 +85,12 @@ def test_calculate_time_window_no_checkpoint(checkpoint_manager, mock_store, mon
     monkeypatch.setattr(time, "time", lambda: fixed_time)
 
     result = checkpoint_manager.calculate_time_window()
+    default_buffer_ms = MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS.get() * 1000
+    expected_max = (fixed_time * 1000) - default_buffer_ms
 
     expected_min = (fixed_time * 1000) - MAX_LOOKBACK_MS
     assert result.min_trace_timestamp_ms == expected_min
-    assert result.max_trace_timestamp_ms == fixed_time * 1000
+    assert result.max_trace_timestamp_ms == expected_max
 
 
 def test_calculate_time_window_recent_checkpoint(checkpoint_manager, mock_store, monkeypatch):
@@ -98,9 +103,11 @@ def test_calculate_time_window_recent_checkpoint(checkpoint_manager, mock_store,
     monkeypatch.setattr(time, "time", lambda: fixed_time)
 
     result = checkpoint_manager.calculate_time_window()
+    default_buffer_ms = MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS.get() * 1000
+    expected_max = (fixed_time * 1000) - default_buffer_ms
 
     assert result.min_trace_timestamp_ms == recent_checkpoint_time
-    assert result.max_trace_timestamp_ms == fixed_time * 1000
+    assert result.max_trace_timestamp_ms == expected_max
 
 
 def test_calculate_time_window_old_checkpoint(checkpoint_manager, mock_store, monkeypatch):
@@ -118,5 +125,24 @@ def test_calculate_time_window_old_checkpoint(checkpoint_manager, mock_store, mo
     result = checkpoint_manager.calculate_time_window()
 
     expected_min = (fixed_time * 1000) - MAX_LOOKBACK_MS
+    default_buffer_ms = MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS.get() * 1000
+    expected_max = (fixed_time * 1000) - default_buffer_ms
+
     assert result.min_trace_timestamp_ms == expected_min
-    assert result.max_trace_timestamp_ms == fixed_time * 1000
+    assert result.max_trace_timestamp_ms == expected_max
+
+
+def test_calculate_time_window_custom_buffer(checkpoint_manager, mock_store, monkeypatch):
+    experiment = MagicMock()
+    experiment.tags = {}
+    mock_store.get_experiment.return_value = experiment
+    fixed_time = 1000000
+    monkeypatch.setattr(time, "time", lambda: fixed_time)
+    monkeypatch.setenv(
+        MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS.name, "60"
+    )  # 60 seconds
+
+    result = checkpoint_manager.calculate_time_window()
+
+    expected_max = (fixed_time * 1000) - 60 * 1000  # 60s buffer
+    assert result.max_trace_timestamp_ms == expected_max


### PR DESCRIPTION
…ent skipping long-running traces

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #21870

### What changes are proposed in this pull request?

`calculate_time_window()` in `trace_checkpointer.py` previously set `max_trace_timestamp_ms = current_time_ms` with no buffer, causing traces whose execution time exceeded the scheduler scan interval to be permanently skipped (confirmed by issue #21870 logs).

This PR adds `MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS` (default 300s) to `environment_variables.py`, mirroring the existing `MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS` pattern, and uses it to offset `max_trace_timestamp_ms` in `trace_checkpointer.py`:
`max_trace_timestamp_ms = current_time_ms - buffer_seconds * 1000`


### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Updated 3 existing tests in `test_trace_checkpointer.py` to account for the buffer offset in `expected_max`. Added new test `test_calculate_time_window_custom_buffer` to verify custom buffer via `monkeypatch.setenv`.

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Adds `MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS` (default 300s) to prevent the online evaluator from permanently skipping long-running traces whose execution time exceeds the scheduler scan interval.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
