### PR TITLE
fix: add validate_path_is_safe to multipart upload artifact endpoints

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -3423,6 +3423,7 @@ def _create_multipart_upload_artifact(artifact_path):
         },
     )
     path = request_message.path
+    path = validate_path_is_safe(path)
     num_parts = request_message.num_parts
 
     artifact_repo = _get_artifact_repo_mlflow_artifacts()
@@ -3458,6 +3459,7 @@ def _complete_multipart_upload_artifact(artifact_path):
         },
     )
     path = request_message.path
+    path = validate_path_is_safe(path)
     upload_id = request_message.upload_id
     parts = [MultipartUploadPart.from_proto(part) for part in request_message.parts]
 
@@ -3491,6 +3493,7 @@ def _abort_multipart_upload_artifact(artifact_path):
         },
     )
     path = request_message.path
+    path = validate_path_is_safe(path)
     upload_id = request_message.upload_id
 
     artifact_repo = _get_artifact_repo_mlflow_artifacts()


### PR DESCRIPTION
### Related Issues/PRs

Relates to security vulnerability report on Huntr (CWE-22 Path Traversal)

### What changes are proposed in this pull request?

Add missing `validate_path_is_safe()` calls to three multipart upload artifact endpoints:

- `_create_multipart_upload_artifact` (L3425)
- `_complete_multipart_upload_artifact` (L3460)
- `_abort_multipart_upload_artifact` (L3493)

These endpoints accept `path` from `request_message.path` without validation. All other artifact endpoints in `handlers.py` correctly call `validate_path_is_safe()`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified that `validate_path_is_safe()` rejects `../` traversal paths while allowing normal artifact paths.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release