### PR TITLE
fix: remove auth exclusion for scorer online-config endpoints

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1567,7 +1567,7 @@ BEFORE_REQUEST_VALIDATORS = {
     (http_path, method): handler
     for http_path, handler, methods in get_endpoints(get_before_request_handler)
     for method in methods
-    if "/scorers/online-config" not in http_path
+    # Removed: exclusion filter for /scorers/online-config (security fix)
 }
 
 # Auth-related routes


### PR DESCRIPTION
### Related Issues/PRs

Relates to security vulnerability report on Huntr (CWE-862 Authorization Bypass)

### What changes are proposed in this pull request?

Remove the explicit exclusion filter in `BEFORE_REQUEST_VALIDATORS` (line 1570 of `mlflow/server/auth/__init__.py`):

```python
# Removed: if "/scorers/online-config" not in http_path
```

This filter excluded all `/scorers/online-config` endpoints from authorization checks, allowing any authenticated user to modify scoring configurations for experiments they had no permission to access.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified scorer online-config PUT/GET endpoints now require proper experiment permissions.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release