### PR TITLE
fix: add `validate_path_is_safe` to multipart upload artifact endpoints

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -3423,6 +3423,7 @@ def _create_multipart_upload_artifact(artifact_path):
         },
     )
     path = request_message.path
+    path = validate_path_is_safe(path)
     num_parts = request_message.num_parts
 
     artifact_repo = _get_artifact_repo_mlflow_artifacts()
@@ -3458,6 +3459,7 @@ def _complete_multipart_upload_artifact(artifact_path):
         },
     )
     path = request_message.path
+    path = validate_path_is_safe(path)
     upload_id = request_message.upload_id
     parts = [MultipartUploadPart.from_proto(part) for part in request_message.parts]
 
@@ -3491,6 +3493,7 @@ def _abort_multipart_upload_artifact(artifact_path):
         },
     )
     path = request_message.path
+    path = validate_path_is_safe(path)
     upload_id = request_message.upload_id
 
     artifact_repo = _get_artifact_repo_mlflow_artifacts()

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -126,13 +126,16 @@ from mlflow.server.handlers import (
     ARTIFACT_STREAM_CHUNK_SIZE,
     ModelRegistryStoreRegistryWrapper,
     TrackingStoreRegistryWrapper,
+    _abort_multipart_upload_artifact,
     _batch_get_trace_infos,
     _batch_get_traces,
     _calculate_trace_filter_correlation,
     _cancel_prompt_optimization_job,
+    _complete_multipart_upload_artifact,
     _convert_path_parameter_to_flask_format,
     _create_dataset_handler,
     _create_experiment,
+    _create_multipart_upload_artifact,
     _create_issue,
     _create_model_version,
     _create_prompt_optimization_job,
@@ -1198,6 +1201,63 @@ def test_get_presigned_download_url_unsupported_repo(enable_serve_artifacts, tmp
     json_response = json.loads(response.get_data())
     assert json_response["error_code"] == ErrorCode.Name(NOT_IMPLEMENTED)
     assert "multipart" in json_response["message"].lower()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/path",
+        "path/../to/file",
+        "/etc/passwd",
+        "/etc/passwd%00.jpg",
+        "/file://etc/passwd",
+        "%2E%2E%2F%2E%2E%2Fpath",
+    ],
+)
+def test_create_multipart_upload_artifact_throws_for_malicious_path(enable_serve_artifacts, path):
+    response = _create_multipart_upload_artifact(path)
+    assert response.status_code == 400
+    json_response = json.loads(response.get_data())
+    assert json_response["error_code"] == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    assert json_response["message"] == "Invalid path"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/path",
+        "path/../to/file",
+        "/etc/passwd",
+        "/etc/passwd%00.jpg",
+        "/file://etc/passwd",
+        "%2E%2E%2F%2E%2E%2Fpath",
+    ],
+)
+def test_complete_multipart_upload_artifact_throws_for_malicious_path(enable_serve_artifacts, path):
+    response = _complete_multipart_upload_artifact(path)
+    assert response.status_code == 400
+    json_response = json.loads(response.get_data())
+    assert json_response["error_code"] == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    assert json_response["message"] == "Invalid path"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/path",
+        "path/../to/file",
+        "/etc/passwd",
+        "/etc/passwd%00.jpg",
+        "/file://etc/passwd",
+        "%2E%2E%2F%2E%2E%2Fpath",
+    ],
+)
+def test_abort_multipart_upload_artifact_throws_for_malicious_path(enable_serve_artifacts, path):
+    response = _abort_multipart_upload_artifact(path)
+    assert response.status_code == 400
+    json_response = json.loads(response.get_data())
+    assert json_response["error_code"] == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    assert json_response["message"] == "Invalid path"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

Relates to security vulnerability report (CWE-22 Path Traversal in multipart artifact upload)

### What changes are proposed in this pull request?

Add missing `validate_path_is_safe()` calls to three multipart upload artifact endpoints that accept `path` from `request_message.path` without validation:

- `_create_multipart_upload_artifact` (L3425)
- `_complete_multipart_upload_artifact` (L3460)
- `_abort_multipart_upload_artifact` (L3493)

All other artifact endpoints in `handlers.py` correctly call `validate_path_is_safe()`. This follows the same pattern as commit 005b959.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified `validate_path_is_safe()` rejects `../` traversal paths while allowing normal artifact paths.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release