### PR TITLE
fix: sanitize GeoJSON `popupContent` to prevent stored XSS

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMapView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMapView.tsx
@@ -21,7 +21,10 @@ import { fetchArtifactUnified, type FetchArtifactUnifiedFn } from './utils/fetch
 function onEachFeature(feature: any, layer: any) {
   if (feature.properties && feature.properties.popupContent) {
     const { popupContent } = feature.properties;
-    layer.bindPopup(popupContent);
+    // Sanitize popup content to prevent XSS
+    const sanitized = document.createElement('div');
+    sanitized.textContent = popupContent;
+    layer.bindPopup(sanitized);
   }
 }
 


### PR DESCRIPTION
### Related Issues/PRs
Relates to security vulnerability report (CWE-79 Stored XSS via GeoJSON artifact)

### What changes are proposed in this pull request?
Use `textContent` instead of passing raw HTML to Leaflet `bindPopup()` in `ShowArtifactMapView.tsx`, preventing stored XSS via malicious GeoJSON artifact `popupContent`.

### How is this PR tested?
- [x] Existing unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?
- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?
- [x] No.

### Release Notes
#### Is this a user-facing change?
- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>
#### How should the PR be classified in the release notes? Choose one:
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?
- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release