### PR TITLE
fix: add pickle deserialization safety check to `PickleEvaluationArtifact`

### DIFF
--- a/mlflow/models/evaluation/artifacts.py
+++ b/mlflow/models/evaluation/artifacts.py
@@ -88,6 +88,9 @@ class PickleEvaluationArtifact(EvaluationArtifact):
             pickle.dump(self._content, f)
 
     def _load_content_from_file(self, local_artifact_path):
+        from mlflow.utils.security_utils import check_pickle_deserialization_allowed
+
+        check_pickle_deserialization_allowed()
         with open(local_artifact_path, "rb") as f:
             self._content = pickle.load(f)
         return self._content


### PR DESCRIPTION
### Related Issues/PRs
Relates to security vulnerability report (CWE-502 Deserialization bypass)

### What changes are proposed in this pull request?
Add `check_pickle_deserialization_allowed()` call to `PickleEvaluationArtifact._load_content_from_file()` so it respects the `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` safety flag like other deserialization paths.

### How is this PR tested?
- [x] Existing unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?
- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?
- [x] No.

### Release Notes
#### Is this a user-facing change?
- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>
#### How should the PR be classified in the release notes? Choose one:
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?
- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release