### PR TITLE
Fix `NextMethod()` S3 dispatch error in R `mlflow_get_run_context`

### DIFF
--- a/mlflow/R/mlflow/R/databricks-utils.R
+++ b/mlflow/R/mlflow/R/databricks-utils.R
@@ -164,12 +164,6 @@ build_context_tags_from_databricks_job_info <- function(job_info) {
   tags
 }
 
-# Helper function to delegate to the next method in the S3 dispatch chain
-# This wrapper makes it possible to test delegation behavior
-mlflow_databricks_delegate_to_next_method <- function() {
-  NextMethod()
-}
-
 mlflow_get_run_context.mlflow_databricks_client <- function(client, experiment_id, ...) {
   if (exists(".databricks_internals")) {
     databricks_internal_env <- get(".databricks_internals", envir = .GlobalEnv)
@@ -196,9 +190,9 @@ mlflow_get_run_context.mlflow_databricks_client <- function(client, experiment_i
         ...
       ))
     }
-    mlflow_databricks_delegate_to_next_method()
+    NextMethod()
   } else {
-    mlflow_databricks_delegate_to_next_method()
+    NextMethod()
   }
 }
 

--- a/mlflow/R/mlflow/tests/testthat/test-databricks-utils.R
+++ b/mlflow/R/mlflow/tests/testthat/test-databricks-utils.R
@@ -269,6 +269,7 @@ test_that("databricks get run context succeeds when job info function is unavail
       mlflow:::mlflow_client("databricks"),
       experiment_id = 0
     )
-    expect_true(!is.null(context$tags))
+    expect_equal(context$tags[[MLFLOW_TAGS$MLFLOW_SOURCE_TYPE]], MLFLOW_SOURCE_TYPE$LOCAL)
+    expect_false(any(startsWith(names(context$tags), "mlflow.databricks.")))
   }, notebook_info = NULL, job_info = NULL)
 })

--- a/mlflow/R/mlflow/tests/testthat/test-databricks-utils.R
+++ b/mlflow/R/mlflow/tests/testthat/test-databricks-utils.R
@@ -265,18 +265,10 @@ test_that("databricks get run context fetches expected info for job environment"
 #' the databricks run context delegates to the next context provider
 test_that("databricks get run context succeeds when job info function is unavailable", {
   run_with_mock_notebook_and_job_info(function() {
-    test_env = new.env()
-    test_env$next_method_calls <- 0
-    mock_delegate_function = function() {
-      test_env$next_method_calls <- test_env$next_method_calls + 1
-    }
-    with_mocked_bindings(.package = "mlflow",
-      mlflow_databricks_delegate_to_next_method = mock_delegate_function, {
-      context <- mlflow:::mlflow_get_run_context.mlflow_databricks_client(
-        mlflow:::mlflow_client("databricks"),
-        experiment_id = 0
-      )
-    })
-    expect_true(test_env$next_method_calls == 1)
+    context <- mlflow:::mlflow_get_run_context(
+      mlflow:::mlflow_client("databricks"),
+      experiment_id = 0
+    )
+    expect_true(!is.null(context$tags))
   }, notebook_info = NULL, job_info = NULL)
 })


### PR DESCRIPTION
### Related Issues/PRs

Relates to #18877

### What changes are proposed in this pull request?

Fix `Error in NextMethod(): object not specified` in `mlflow_get_run_context.mlflow_databricks_client` when running on a Databricks cluster outside of a notebook or job context (e.g., via the command API REPL).

PR #18877 extracted `NextMethod()` into a helper function `mlflow_databricks_delegate_to_next_method()` to make it mockable in tests. However, R's `NextMethod()` relies on S3 dispatch context variables (`.Generic`, `.Class`, `.Method`) set in the immediate caller's frame by `UseMethod()`. Wrapping `NextMethod()` in a helper function moves it one stack frame deeper where those variables don't exist, causing the dispatch to fail.

This PR:
1. Removes the `mlflow_databricks_delegate_to_next_method()` wrapper and calls `NextMethod()` directly in the S3 method
2. Updates the corresponding test to verify delegation through proper S3 dispatch instead of mocking the removed wrapper

Reference: [R Language Definition, Section 5.6](https://cran.r-project.org/doc/manuals/r-release/R-lang.html#NextMethod)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Ran `devtools::test(filter = "databricks-utils")` locally — 47 pass, 0 fail.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix R client crash (`Error in NextMethod(): object not specified`) when calling `mlflow_start_run()` on a Databricks cluster outside of a notebook or job context.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release