### PR TITLE
Add `release-python.yml` workflow for trusted publishing

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -130,6 +130,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       id-token: write
+    environment: ${{ github.event.inputs.destination }}
     steps:
       - name: Download distribution files
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -21,9 +21,9 @@ on:
         description: "The PyPI server to publish to."
         required: true
         type: choice
-        default: "testpypi"
+        default: "test-pypi"
         options:
-          - testpypi
+          - test-pypi
           - pypi
 
 defaults:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -2,10 +2,6 @@ name: release-python
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
     paths:
       - ".github/workflows/release-python.yml"
   workflow_dispatch:
@@ -35,26 +31,7 @@ defaults:
     shell: bash
 
 jobs:
-  check-actor:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
-    permissions: {}
-    steps:
-      - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          ACTOR: ${{ github.actor }}
-        run: |
-          permission=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.role_name')
-          if [[ "$permission" != "admin" && "$permission" != "maintain" ]]; then
-            echo "ERROR: Actor '${ACTOR}' has '${permission}' permission, but 'admin' or 'maintain' is required."
-            exit 1
-          fi
-
   build:
-    if: ${{ !cancelled() && (needs.check-actor.result == 'success' || needs.check-actor.result == 'skipped') }}
-    needs: check-actor
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -62,8 +39,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Build all packages on PRs, only the selected package on workflow_dispatch
         package: ${{ github.event_name == 'pull_request' && fromJSON('["mlflow", "mlflow-skinny", "mlflow-tracing"]') || fromJSON(format('["{0}"]', inputs.package)) }}
     steps:
+      - name: Check actor
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          role=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.role_name')
+          if [[ "$role" != "admin" && "$role" != "maintain" ]]; then
+            echo "ERROR: Actor '${ACTOR}' has '${role}' role, but 'admin' or 'maintain' is required."
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
@@ -76,7 +67,7 @@ jobs:
         if: matrix.package == 'mlflow'
         working-directory: mlflow/server/js
         run: |
-          yarn
+          yarn install --immutable
           yarn build
 
       - name: Install dependencies

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Upload distribution files
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: dist
+          name: dist-${{ matrix.package }}
           path: dist/
           if-no-files-found: error
 
@@ -115,7 +115,7 @@ jobs:
       - name: Download distribution files
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist
+          name: dist-${{ inputs.package }}
           path: dist/
 
       - name: Publish to PyPI

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -98,22 +98,17 @@ jobs:
           yarn install --immutable
           yarn build
 
-      - name: Resolve package type
-        id: resolve
+      - name: Build distribution files
         env:
           PACKAGE: ${{ matrix.package }}
         run: |
           case "$PACKAGE" in
-            mlflow)         echo "type=release" >> $GITHUB_OUTPUT ;;
-            mlflow-skinny)  echo "type=skinny" >> $GITHUB_OUTPUT ;;
-            mlflow-tracing) echo "type=tracing" >> $GITHUB_OUTPUT ;;
+            mlflow)         package_type=release ;;
+            mlflow-skinny)  package_type=skinny ;;
+            mlflow-tracing) package_type=tracing ;;
           esac
 
-      - name: Build distribution files
-        env:
-          PACKAGE_TYPE: ${{ steps.resolve.outputs.type }}
-        run: |
-          python dev/build.py --package-type "$PACKAGE_TYPE"
+          python dev/build.py --package-type "$package_type"
 
           ls -lh dist
 

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         # Build all packages on PRs, only the selected package on workflow_dispatch
-        package: ${{ github.event_name == 'pull_request' && fromJSON('["mlflow", "mlflow-skinny", "mlflow-tracing"]') || fromJSON(format('["{0}"]', inputs.package)) }}
+        package: ${{ github.event_name == 'pull_request' && fromJSON('["mlflow", "mlflow-skinny", "mlflow-tracing"]') || fromJSON(format('["{0}"]', github.event.inputs.package)) }}
     steps:
       - name: Check actor
         if: github.event_name == 'workflow_dispatch'
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.event.inputs.ref }}
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/setup-python
       - if: matrix.package == 'mlflow'
@@ -115,12 +115,12 @@ jobs:
       - name: Download distribution files
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist-${{ inputs.package }}
+          name: dist-${{ github.event.inputs.package }}
           path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
-          repository-url: ${{ inputs.destination == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+          repository-url: ${{ github.event.inputs.destination == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
           packages-dir: dist/
           skip-existing: "true"

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -111,9 +111,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       id-token: write
-    environment:
-      name: ${{ inputs.destination }}
-      url: ${{ inputs.destination == 'pypi' && format('https://pypi.org/project/{0}', inputs.package) || format('https://test.pypi.org/project/{0}', inputs.package) }}
     steps:
       - name: Download distribution files
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,0 +1,138 @@
+name: release-python
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - ".github/workflows/release-python.yml"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to release from."
+        required: true
+      package:
+        description: "The package to release."
+        required: true
+        type: choice
+        options:
+          - mlflow
+          - mlflow-skinny
+          - mlflow-tracing
+      destination:
+        description: "The PyPI server to publish to."
+        required: true
+        type: choice
+        default: "testpypi"
+        options:
+          - testpypi
+          - pypi
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check-actor:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          permission=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.role_name')
+          if [[ "$permission" != "admin" && "$permission" != "maintain" ]]; then
+            echo "ERROR: Actor '${ACTOR}' has '${permission}' permission, but 'admin' or 'maintain' is required."
+            exit 1
+          fi
+
+  build:
+    if: ${{ !cancelled() && (needs.check-actor.result == 'success' || needs.check-actor.result == 'skipped') }}
+    needs: check-actor
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ github.event_name == 'pull_request' && fromJSON('["mlflow", "mlflow-skinny", "mlflow-tracing"]') || fromJSON(format('["{0}"]', inputs.package)) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
+      - if: matrix.package == 'mlflow'
+        uses: ./.github/actions/setup-node
+
+      - name: Build UI
+        if: matrix.package == 'mlflow'
+        working-directory: mlflow/server/js
+        run: |
+          yarn
+          yarn build
+
+      - name: Install dependencies
+        run: |
+          pip install build setuptools twine wheel
+
+      - name: Resolve package type
+        id: resolve
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          case "$PACKAGE" in
+            mlflow)         echo "type=release" >> $GITHUB_OUTPUT ;;
+            mlflow-skinny)  echo "type=skinny" >> $GITHUB_OUTPUT ;;
+            mlflow-tracing) echo "type=tracing" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Build distribution files
+        env:
+          PACKAGE_TYPE: ${{ steps.resolve.outputs.type }}
+        run: |
+          python dev/build.py --package-type "$PACKAGE_TYPE"
+
+          ls -lh dist
+
+      - name: Run twine check
+        run: |
+          twine check --strict dist/*
+
+      - name: Upload distribution files
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    if: github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    environment:
+      name: ${{ inputs.destination }}
+      url: ${{ inputs.destination == 'pypi' && format('https://pypi.org/project/{0}', inputs.package) || format('https://test.pypi.org/project/{0}', inputs.package) }}
+    steps:
+      - name: Download distribution files
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          repository-url: ${{ inputs.destination == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+          packages-dir: dist/
+          skip-existing: "true"

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -60,6 +60,34 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/setup-python
+
+      - name: Install dependencies
+        run: |
+          pip install build packaging setuptools twine wheel
+
+      - name: Validate ref and version
+        if: github.event.inputs.destination == 'pypi'
+        env:
+          REF: ${{ github.event.inputs.ref }}
+        run: |
+          python -c "
+          import os, re, sys
+          from packaging.version import Version
+
+          ref = os.environ['REF']
+          m = re.fullmatch(r'branch-(\d+)\.(\d+)', ref)
+          if not m:
+              sys.exit(f'ERROR: ref {ref!r} does not match branch-<major>.<minor>')
+
+          text = open('pyproject.toml').read()
+          m2 = re.search(r'^version\s*=\s*\"([^\"]+)\"', text, re.MULTILINE)
+          if not m2:
+              sys.exit('ERROR: Could not find version in pyproject.toml')
+
+          version = Version(m2.group(1))
+          if (version.major, version.minor) != (int(m.group(1)), int(m.group(2))):
+              sys.exit(f'ERROR: Package version {version!r} does not match ref {ref!r}')
+          "
       - if: matrix.package == 'mlflow'
         uses: ./.github/actions/setup-node
 
@@ -69,10 +97,6 @@ jobs:
         run: |
           yarn install --immutable
           yarn build
-
-      - name: Install dependencies
-        run: |
-          pip install build setuptools twine wheel
 
       - name: Resolve package type
         id: resolve


### PR DESCRIPTION
### Related Issues/PRs

Relates to #

### What changes are proposed in this pull request?

Add a `release-python.yml` GitHub Actions workflow that publishes Python packages (`mlflow`, `mlflow-skinny`, `mlflow-tracing`) to PyPI using [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC-based, no API tokens needed).

Key features:
- `workflow_dispatch` with inputs for package, ref, and destination (PyPI or TestPyPI)
- Actor permission check (admin/maintain required)
- Environment-gated publish job (`pypi`/`testpypi`) for approval workflows
- PR trigger (paths: `release-python.yml`) to validate the build on changes to the workflow itself

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)