### PR TITLE
fix: filter out `mlflow.*` system tags in `_merge_trace`

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -1740,7 +1740,8 @@ def _merge_trace(
     with trace_manager.get_trace(target_trace_id) as parent_trace:
         # Order of merging is important to ensure the parent trace's metadata is
         # not overwritten by the child trace's metadata if they have the same key.
-        parent_trace.info.tags = trace.info.tags | parent_trace.info.tags
+        child_user_tags = {k: v for k, v in trace.info.tags.items() if not k.startswith("mlflow.")}
+        parent_trace.info.tags = child_user_tags | parent_trace.info.tags
         parent_trace.info.trace_metadata = {
             **trace.info.request_metadata,
             **parent_trace.info.trace_metadata,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,6 +259,9 @@ constraint-dependencies = [
   "pyspark<4.1.0",
   # setuptools 82.0.0 removed pkg_resources, breaking packages that depend on it (e.g., sphinx)
   "setuptools<82",
+  # litellm 1.82.7 and 1.82.8 contain a malicious .pth file that steals credentials
+  # https://github.com/BerriAI/litellm/issues/24512
+  "litellm<=1.82.6",
 ]
 # Prevent third-party libraries from installing uv to avoid conflicts with uv installed
 # by the standalone installer

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -5,3 +5,6 @@ xgboost<3.1.0
 # TODO: remove once requests officially supports chardet >= 6
 # https://github.com/psf/requests/pull/7239
 chardet<6.0
+# litellm 1.82.7 and 1.82.8 contain a malicious .pth file that steals credentials
+# https://github.com/BerriAI/litellm/issues/24512
+litellm<=1.82.6

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import json
 import os
 import subprocess
@@ -2032,6 +2033,21 @@ def test_add_trace_merge_tags():
         # Tag value from the parent trace should prevail
         "food": "sushi",
     }
+
+
+def test_add_trace_does_not_propagate_system_tags():
+    # Child trace with mlflow.artifactLocation system tag
+    child_trace_dict = copy.deepcopy(_SAMPLE_REMOTE_TRACE)
+    child_trace_dict["info"]["tags"]["mlflow.artifactLocation"] = "s3://child-bucket/path"
+
+    with mlflow.start_span(name="parent"):
+        mlflow.add_trace(Trace.from_dict(child_trace_dict))
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    # The child's mlflow.artifactLocation should NOT appear on the parent
+    assert trace.info.tags.get("mlflow.artifactLocation") != "s3://child-bucket/path"
+    # User-defined tags from the child should still merge
+    assert trace.info.tags["fruit"] == "apple"
 
 
 def test_add_trace_raise_for_invalid_trace():

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,7 @@ members = [
 ]
 constraints = [
     { name = "chardet", specifier = "<6.0" },
+    { name = "litellm", specifier = "<=1.82.6" },
     { name = "pyspark", specifier = "<4.1.0" },
     { name = "setuptools", specifier = "<82" },
     { name = "xgboost", specifier = "<3.1.0" },


### PR DESCRIPTION
### Related Issues/PRs

Closes #21953

### What changes are proposed in this pull request?

In `_merge_trace` (`mlflow/tracing/fluent.py`), the line:

```python
parent_trace.info.tags = trace.info.tags | parent_trace.info.tags
```

merges **all** child trace tags into the parent, including `mlflow.*` system tags like `mlflow.artifactLocation`. This causes the child's artifact location (and other system metadata) to overwrite the parent's.

Fix: filter out `mlflow.*`-prefixed tags from the child trace before merging, consistent with the existing pattern in `mlflow/tracing/utils/copy.py`:

```python
child_user_tags = {k: v for k, v in trace.info.tags.items() if not k.startswith("mlflow.")}
parent_trace.info.tags = child_user_tags | parent_trace.info.tags
```

Only user-defined tags from the child trace are propagated; all `mlflow.*` system tags on the parent remain unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_add_trace_does_not_propagate_system_tags` which verifies:
1. Child trace `mlflow.*` system tags do not overwrite parent's system tags
2. User-defined tags from the child still merge correctly

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.add_trace()` no longer propagates child trace system tags (`mlflow.*`) to the parent trace, fixing incorrect overwrite of `mlflow.artifactLocation` and other system metadata.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release