### PR TITLE
Fix strands autolog tool span inputs when agent telemetry log skill along with tool, cause tool extraction fail

### DIFF
--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -228,9 +228,15 @@ def extract_tools_called_from_trace(trace: Trace) -> list["FunctionCall"]:
     tool_spans = trace.search_spans(span_type=SpanType.TOOL)
 
     for tool_span in sorted(tool_spans, key=lambda s: s.start_time_ns or 0):
+        arguments = tool_span.inputs or None
+        # FunctionCall.arguments accepts str | dict | None. Autolog providers like
+        # Strands may store inputs as other types (e.g. list). Serialize to JSON string
+        # so it's compatible with the FunctionCall model and downstream consumers.
+        if arguments is not None and not isinstance(arguments, (str, dict)):
+            arguments = json.dumps(arguments)
         tool_info = FunctionCall(
             name=_extract_tool_name_from_span(tool_span),
-            arguments=tool_span.inputs or None,
+            arguments=arguments,
             outputs=tool_span.outputs or None,
             exception=_get_exception_from_span(tool_span),
         )

--- a/mlflow/strands/autolog.py
+++ b/mlflow/strands/autolog.py
@@ -131,6 +131,17 @@ def _parse_json(value):
     return value
 
 
+def _normalize_tool_inputs(content):
+    """Normalize tool inputs to a type compatible with FunctionCall.arguments.
+
+    FunctionCall.arguments only accepts str, dict, or None. Strands may produce
+    other types (e.g. list) from tool event content, so we serialize them to JSON.
+    """
+    if content is not None and not isinstance(content, (str, dict)):
+        return json.dumps(content)
+    return content
+
+
 def _set_inputs_outputs(mlflow_span: LiveSpan, span: OTelReadableSpan) -> None:
     outputs = []
     span_type = mlflow_span.get_attribute(SpanAttributeKey.SPAN_TYPE)
@@ -139,7 +150,7 @@ def _set_inputs_outputs(mlflow_span: LiveSpan, span: OTelReadableSpan) -> None:
         for event in span.events:
             if event.name == "gen_ai.tool.message":
                 content = _parse_json(event.attributes.get("content"))
-                mlflow_span.set_inputs(content)
+                mlflow_span.set_inputs(_normalize_tool_inputs(content))
             elif event.name == "gen_ai.choice":
                 message = _parse_json(event.attributes.get("message"))
                 outputs.append(message)


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

Currently, using `mlflow.strands.autolog` produce tool output is a list which cause the `ToolCallCorrectness` and `ToolCallEfficiency`  fail to evaluate which these scorers requires trace to execute. When `json.load` is called, the trace above become an list which is in valid for the Pydantic model in `mlflow/genai/utils/type.py` which only accept string, dict and None as input.

**Fix**
- Added `_normalize_tool_inputs` in `mlflow/strands/autolog.py` to serialize any incompatiable types to JSON string before storing them in span.
- Added normalization layer in `mlflow/genai/utils/trace_utils.py` to dump JSON from tool invoked in the trace. 

<img width="1147" height="306" alt="Screenshot 2026-03-25 at 00 13 29" src="https://github.com/user-attachments/assets/3f94b77d-2ac8-48ae-bb43-7d5af037c235" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
