### PR TITLE
fix: pin starlette<1.0.0 to prevent breaking pyfunc FastAPI serving

### DIFF
--- a/requirements/gateway-requirements.yaml
+++ b/requirements/gateway-requirements.yaml
@@ -7,6 +7,10 @@ fastapi:
   pip_release: fastapi
   max_major_version: 0
 
+starlette:
+  pip_release: starlette
+  max_major_version: 0
+
 uvicorn:
   pip_release: uvicorn
   extras:

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -99,6 +99,10 @@ fastapi:
   pip_release: fastapi
   max_major_version: 0
 
+starlette:
+  pip_release: starlette
+  max_major_version: 0
+
 uvicorn:
   pip_release: uvicorn
   max_major_version: 0


### PR DESCRIPTION
### Related Issues/PRs

Closes #14648

### What changes are proposed in this pull request?

Pin `starlette<1.0.0` in `requirements/skinny-requirements.yaml` and `requirements/gateway-requirements.yaml`.

`starlette` 1.0.0 introduced breaking changes that cause `mlflow models serve` to fail with:
```
AttributeError: 'FastAPI' object has no attribute 'route'
```
`starlette` was not explicitly pinned as a dependency, so pip would freely install `starlette 1.0.0` as a transitive dependency of `fastapi`, breaking pyfunc FastAPI serving.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manually verified that the pyfunc scoring server starts successfully and `/ping`, `/health`, `/version`, and `/invocations` endpoints all return correct responses with `starlette==1.0.0` installed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Pin `starlette<1.0.0` to fix `mlflow models serve` failures when `starlette>=1.0.0` is installed.

#### What component(s) does this PR affect?

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release