### PR TITLE
Replace `pip install` with `uv pip install` in CI workflows

### DIFF
--- a/.github/actions/pipdeptree/action.yml
+++ b/.github/actions/pipdeptree/action.yml
@@ -12,5 +12,5 @@ runs:
           # Windows
           source .venv/Scripts/activate
         fi
-        pip install pipdeptree
+        uv pip install pipdeptree
         pipdeptree --all

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install build setuptools twine wheel
+          uv pip install build setuptools twine wheel
 
       - name: Build distribution files
         id: build-dist
@@ -151,7 +151,7 @@ jobs:
         env:
           SDIST_PATH: ${{ steps.build-dist.outputs.sdist-path }}
         run: |
-          pip install $SDIST_PATH
+          uv pip install $SDIST_PATH
           python -c "import mlflow; print(mlflow.__version__)"
           python -c "from mlflow import *"
 
@@ -159,7 +159,7 @@ jobs:
         env:
           WHEEL_PATH: ${{ steps.build-dist.outputs.wheel-path }}
         run: |
-          pip install --force-reinstall $WHEEL_PATH
+          uv pip install --force-reinstall $WHEEL_PATH
           python -c "import mlflow; print(mlflow.__version__)"
           python -c "from mlflow import *"
 

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -75,8 +75,8 @@ jobs:
       - uses: ./.github/actions/setup-python
       - name: Install dependencies
         run: |
-          pip install -r dev/requirements.txt
-          pip install pytest pytest-cov
+          uv pip install -r dev/requirements.txt
+          uv pip install pytest pytest-cov
       - name: Check labels
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: check-labels
@@ -165,15 +165,15 @@ jobs:
           MATRIX_CATEGORY: ${{ matrix.category }}
         run: |
           # setuptools 82.0.0 removed pkg_resources, this breaking change breaks some packages like transformers
-          pip install -U pip wheel "setuptools<82"
+          uv pip install -U pip wheel "setuptools<82"
           # For tracing SDK test, install the tracing package from the local path and minimal test dependencies
           if [[ "$MATRIX_CATEGORY" == "tracing-sdk" ]]; then
-            pip install libs/tracing
-            pip install pytest pytest-asyncio pytest-cov
+            uv pip install libs/tracing
+            uv pip install pytest pytest-asyncio pytest-cov
           # Other two categories of tests (model/autologging)
           else
-            pip install .[extras]
-            pip install -r requirements/test-requirements.txt
+            uv pip install .[extras]
+            uv pip install -r requirements/test-requirements.txt
           fi
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         env:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -93,7 +93,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || steps.check-diff.outputs.examples_changed == 'true' }}
         run: |
           source ./dev/install-common-deps.sh --ml
-          pip install fastapi uvicorn
+          uv pip install fastapi uvicorn
           sudo apt-get update -y
           # Required for the transformers example that uses the Whisper model
           sudo apt-get install -y ffmpeg

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Build Model Server Image
         run: |
-          pip install .
+          uv pip install .
           mlflow models build-docker -n model-server:latest --mlflow-home `pwd`
 
       - name: Push Model Server Image

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -95,10 +95,10 @@ jobs:
           ./build-package.sh
       - name: Create test environment
         run: |
-          pip install $(git rev-parse --show-toplevel)
+          uv pip install $(git rev-parse --show-toplevel)
           H2O_VERSION=$(Rscript -e "print(packageVersion('h2o'))" | grep -Eo '[0-9][0-9.]+')
           # test-keras-model.R fails with tensorflow>=2.13.0
-          pip install xgboost 'tensorflow<2.13.0' "h2o==$H2O_VERSION" "pydantic<3,>=1.0" "typing_extensions>=4.6.0"
+          uv pip install xgboost 'tensorflow<2.13.0' "h2o==$H2O_VERSION" "pydantic<3,>=1.0" "typing_extensions>=4.6.0"
           Rscript -e 'source(".install-mlflow-r.R", echo=TRUE)'
       - name: Run tests
         env:

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build Python packages
         id: build-dist
         run: |
-          pip install build
+          uv pip install build
           python dev/build.py
           find $PWD/dist -type f -name "*.whl" -exec cp {} $ARTIFACT_DIR/ \;
           python dev/build.py --package-type skinny

--- a/.github/workflows/test-requirements.yml
+++ b/.github/workflows/test-requirements.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dev script dependencies
         run: |
-          pip install -r dev/requirements.txt
+          uv pip install -r dev/requirements.txt
       - uses: ./.github/actions/update-requirements
         if: github.event_name == 'schedule'
       - name: Install dependencies
@@ -84,13 +84,13 @@ jobs:
       - uses: ./.github/actions/setup-java
       - name: Install dev script dependencies
         run: |
-          pip install -r dev/requirements.txt
+          uv pip install -r dev/requirements.txt
       - uses: ./.github/actions/update-requirements
         if: github.event_name == 'schedule'
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh --ml
-          pip install '.[gateway]'
+          uv pip install '.[gateway]'
       - uses: ./.github/actions/show-versions
       - name: Run tests
         env:

--- a/.github/workflows/tracing.yaml
+++ b/.github/workflows/tracing.yaml
@@ -50,12 +50,12 @@ jobs:
       # Install mlflow-tracing SDK from the current directory
       - name: Install mlflow-tracing SDK
         run: |
-          pip install pip setuptools --upgrade
-          pip install ./libs/tracing
+          uv pip install pip setuptools --upgrade
+          uv pip install ./libs/tracing
 
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-asyncio pytest-timeout litellm
+          uv pip install pytest pytest-asyncio pytest-timeout litellm
 
       - name: Run core tracing tests
         # NB: OTLP exporter includes large dependencies, so we want to test it in a separate job

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: ./.github/actions/setup-node
 
       - name: Install build tools
-        run: pip install build setuptools
+        run: uv pip install build setuptools
 
       - name: Build wheel
         # Build the wheel before `yarn build` so it excludes UI assets


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21971

### What changes are proposed in this pull request?

Replaces all remaining bare `pip install` calls in CI workflows with `uv pip install`. Unlike `pip`, `uv pip install` respects the `exclude-newer` constraint in `pyproject.toml` (currently set to `2026-03-18`), which prevents resolving packages published after that date.

This is a defense-in-depth measure against supply chain attacks like the recent litellm 1.82.7/1.82.8 compromise. Even if a malicious version is published to PyPI, `uv pip install` will not pick it up unless `exclude-newer` is explicitly bumped.

**Changed files:**
- `.github/workflows/tracing.yaml`
- `.github/workflows/cross-version-tests.yml`
- `.github/workflows/examples.yml`
- `.github/workflows/build-wheel.yml`
- `.github/workflows/test-requirements.yml`
- `.github/workflows/snapshots.yml`
- `.github/workflows/ui-preview.yml`
- `.github/workflows/push-images.yml`
- `.github/workflows/r.yml`
- `.github/actions/pipdeptree/action.yml`

**Not changed:**
- `.github/actions/setup-pyenv/action.yml` — Windows-specific `pip install pyenv-win --target` (custom install target, not a package dependency)

### How is this PR tested?

- [x] Existing unit/integration tests

CI workflows will validate that `uv pip install` works correctly in all affected jobs.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release