### PR TITLE
Exclude `model_prices_and_context_window.json` from `mlflow-skinny`

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -478,12 +478,15 @@ def _get_package_data(package_type: PackageType) -> dict[str, list[str]] | None:
             "models/notebook_resources/**/*",
             "ai_commands/**/*.md",
             "assistant/skills/**/*",
-            "utils/model_prices_and_context_window.json",
         ]
     }
 
     if package_type != PackageType.SKINNY:
-        package_data["mlflow"] += ["models/container/**/*", "server/js/build/**/*"]
+        package_data["mlflow"] += [
+            "models/container/**/*",
+            "server/js/build/**/*",
+            "utils/model_prices_and_context_window.json",
+        ]
 
     return package_data
 

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -137,7 +137,6 @@ mlflow = [
   "models/notebook_resources/**/*",
   "ai_commands/**/*.md",
   "assistant/skills/**/*",
-  "utils/model_prices_and_context_window.json",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -139,9 +139,9 @@ mlflow = [
   "models/notebook_resources/**/*",
   "ai_commands/**/*.md",
   "assistant/skills/**/*",
-  "utils/model_prices_and_context_window.json",
   "models/container/**/*",
   "server/js/build/**/*",
+  "utils/model_prices_and_context_window.json",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,9 +156,9 @@ mlflow = [
   "models/notebook_resources/**/*",
   "ai_commands/**/*.md",
   "assistant/skills/**/*",
-  "utils/model_prices_and_context_window.json",
   "models/container/**/*",
   "server/js/build/**/*",
+  "utils/model_prices_and_context_window.json",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21986

### What changes are proposed in this pull request?

Move the vendored `model_prices_and_context_window.json` to the non-skinny package-data block in `dev/pyproject.py` so it's only included in the full `mlflow` wheel, not `mlflow-skinny` or `mlflow-tracing`.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release