### PR TITLE
Add generic `OpenAICompatibleProvider` base for gateway providers

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -258,6 +258,20 @@ class _AuthConfigKey:
     API_BASE = "api_base"
 
 
+class OpenAICompatibleConfig(ConfigModel):
+    """Config for providers that use the OpenAI-compatible API format.
+
+    Subclasses can override DEFAULT_API_BASE to set the provider's default URL.
+    """
+
+    api_key: str
+    api_base: str | None = None
+
+    @field_validator("api_key", mode="before")
+    def validate_api_key(cls, value):
+        return _resolve_api_key_from_input(value)
+
+
 class LiteLLMConfig(ConfigModel):
     litellm_provider: str | None = None
     litellm_auth_config: dict[str, Any] | None = None

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -258,10 +258,13 @@ class _AuthConfigKey:
     API_BASE = "api_base"
 
 
-class OpenAICompatibleConfig(ConfigModel):
+class _OpenAICompatibleConfig(ConfigModel):
     """Config for providers that use the OpenAI-compatible API format.
 
-    Subclasses can override DEFAULT_API_BASE to set the provider's default URL.
+    Args:
+        api_key: API key for authentication (resolved via ``_resolve_api_key_from_input``).
+        api_base: Optional base URL override. When ``None``, the provider's
+            ``DEFAULT_API_BASE`` class attribute is used instead.
     """
 
     api_key: str

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -11,8 +11,8 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import (
     BaseProvider,
     PassthroughAction,
-    ProviderAdapter,
 )
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleAdapter
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat, completions, embeddings
 from mlflow.gateway.uc_function_utils import (
@@ -44,18 +44,13 @@ def _get_workspace_client():
         )
 
 
-class OpenAIAdapter(ProviderAdapter):
-    @classmethod
-    def chat_to_model(cls, payload, config):
-        return cls._add_model_to_payload_if_necessary(payload, config)
+class OpenAIAdapter(OpenAICompatibleAdapter):
+    """OpenAI-specific adapter that extends OpenAICompatibleAdapter.
 
-    @classmethod
-    def completion_to_model(cls, payload, config):
-        return cls._add_model_to_payload_if_necessary(payload, config)
-
-    @classmethod
-    def embeddings_to_model(cls, payload, config):
-        return cls._add_model_to_payload_if_necessary(payload, config)
+    Overrides payload methods to handle Azure OpenAI, where the model name
+    is part of the URL (deployment name) rather than the request body.
+    Also includes legacy completions response transformation methods.
+    """
 
     @classmethod
     def _add_model_to_payload_if_necessary(cls, payload, config):
@@ -68,95 +63,20 @@ class OpenAIAdapter(ProviderAdapter):
             return payload
 
     @classmethod
-    def model_to_chat(cls, resp, config):
-        # Response example (https://platform.openai.com/docs/api-reference/chat/create)
-        # ```
-        # {
-        #    "id":"chatcmpl-abc123",
-        #    "object":"chat.completion",
-        #    "created":1677858242,
-        #    "model":"gpt-4o-mini",
-        #    "usage":{
-        #       "prompt_tokens":13,
-        #       "completion_tokens":7,
-        #       "total_tokens":20
-        #    },
-        #    "choices":[
-        #       {
-        #          "message":{
-        #             "role":"assistant",
-        #             "content":"\n\nThis is a test!"
-        #          },
-        #          "finish_reason":"stop",
-        #          "index":0
-        #       }
-        #    ]
-        # }
-        # ```
-        return chat.ResponsePayload(
-            id=resp["id"],
-            object=resp["object"],
-            created=resp["created"],
-            model=resp["model"],
-            choices=[
-                chat.Choice(
-                    index=idx,
-                    message=chat.ResponseMessage(
-                        role=c["message"]["role"],
-                        content=c["message"].get("content"),
-                        tool_calls=(
-                            (calls := c["message"].get("tool_calls"))
-                            and [chat.ToolCall(**c) for c in calls]
-                        ),
-                    ),
-                    finish_reason=c.get("finish_reason"),
-                )
-                for idx, c in enumerate(resp["choices"])
-            ],
-            usage=cls._build_chat_usage(resp["usage"]),
-        )
+    def chat_to_model(cls, payload, config):
+        return cls._add_model_to_payload_if_necessary(payload, config)
 
     @classmethod
-    def _build_chat_usage(cls, usage_data: dict[str, Any]) -> chat.ChatUsage:
-        prompt_tokens_details = None
-        if details := usage_data.get("prompt_tokens_details"):
-            prompt_tokens_details = chat.PromptTokensDetails(**details)
-        return chat.ChatUsage(
-            prompt_tokens=usage_data.get("prompt_tokens"),
-            completion_tokens=usage_data.get("completion_tokens"),
-            total_tokens=usage_data.get("total_tokens"),
-            prompt_tokens_details=prompt_tokens_details,
-        )
+    def completion_to_model(cls, payload, config):
+        return cls._add_model_to_payload_if_necessary(payload, config)
 
     @classmethod
-    def model_to_chat_streaming(cls, resp, config):
-        # Extract usage from the final chunk (when stream_options.include_usage=true)
-        usage = None
-        if usage_data := resp.get("usage"):
-            usage = cls._build_chat_usage(usage_data)
+    def completions_to_model(cls, payload, config):
+        return cls._add_model_to_payload_if_necessary(payload, config)
 
-        return chat.StreamResponsePayload(
-            id=resp["id"],
-            object=resp["object"],
-            created=resp["created"],
-            model=resp["model"],
-            choices=[
-                chat.StreamChoice(
-                    index=c["index"],
-                    finish_reason=c["finish_reason"],
-                    delta=chat.StreamDelta(
-                        role=c["delta"].get("role"),
-                        content=c["delta"].get("content"),
-                        tool_calls=(
-                            (calls := c["delta"].get("tool_calls"))
-                            and [chat.ToolCallDelta(**c) for c in calls]
-                        ),
-                    ),
-                )
-                for c in resp["choices"]
-            ],
-            usage=usage,
-        )
+    @classmethod
+    def embeddings_to_model(cls, payload, config):
+        return cls._add_model_to_payload_if_necessary(payload, config)
 
     @classmethod
     def model_to_completions(cls, resp, config):
@@ -184,9 +104,6 @@ class OpenAIAdapter(ProviderAdapter):
         # ```
         return completions.ResponsePayload(
             id=resp["id"],
-            # The chat models response from OpenAI is of object type "chat.completion". Since
-            # we're using the completions response format here, we hardcode the "text_completion"
-            # object type in the response instead
             object="text_completion",
             created=resp["created"],
             model=resp["model"],
@@ -207,7 +124,6 @@ class OpenAIAdapter(ProviderAdapter):
 
     @classmethod
     def model_to_completions_streaming(cls, resp, config):
-        # Extract usage from the final chunk (when stream_options.include_usage=true)
         usage = None
         if usage_data := resp.get("usage"):
             usage = completions.CompletionsUsage(
@@ -218,9 +134,6 @@ class OpenAIAdapter(ProviderAdapter):
 
         return completions.StreamResponsePayload(
             id=resp["id"],
-            # The chat models response from OpenAI is of object type "chat.completion.chunk".
-            # Since we're using the completions response format here, we hardcode the
-            # "text_completion_chunk" object type in the response instead
             object="text_completion_chunk",
             created=resp["created"],
             model=resp["model"],
@@ -233,46 +146,6 @@ class OpenAIAdapter(ProviderAdapter):
                 for c in resp["choices"]
             ],
             usage=usage,
-        )
-
-    @classmethod
-    def model_to_embeddings(cls, resp, config):
-        # Response example (https://platform.openai.com/docs/api-reference/embeddings/create):
-        # ```
-        # {
-        #   "object": "list",
-        #   "data": [
-        #     {
-        #       "object": "embedding",
-        #       "embedding": [
-        #         0.0023064255,
-        #         -0.009327292,
-        #         .... (1536 floats total for ada-002)
-        #         -0.0028842222,
-        #       ],
-        #       "index": 0
-        #     }
-        #   ],
-        #   "model": "text-embedding-ada-002",
-        #   "usage": {
-        #     "prompt_tokens": 8,
-        #     "total_tokens": 8
-        #   }
-        # }
-        # ```
-        return embeddings.ResponsePayload(
-            data=[
-                embeddings.EmbeddingObject(
-                    embedding=d["embedding"],
-                    index=idx,
-                )
-                for idx, d in enumerate(resp["data"])
-            ],
-            model=resp["model"],
-            usage=embeddings.EmbeddingsUsage(
-                prompt_tokens=resp["usage"]["prompt_tokens"],
-                total_tokens=resp["usage"]["total_tokens"],
-            ),
         )
 
 

--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -1,0 +1,380 @@
+"""
+Base provider for OpenAI-compatible APIs.
+
+Many LLM providers (Groq, DeepSeek, xAI, etc.) expose APIs that follow the
+OpenAI chat/completions/embeddings format. This module provides a reusable
+base class so that adding a new such provider requires only a config class,
+a NAME, and a default base URL.
+"""
+
+from typing import Any, AsyncIterable
+
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.base import BaseProvider, PassthroughAction, ProviderAdapter
+from mlflow.gateway.providers.utils import send_request, send_stream_request
+from mlflow.gateway.schemas import chat, completions, embeddings
+from mlflow.gateway.utils import stream_sse_data
+
+
+class OpenAICompatibleAdapter(ProviderAdapter):
+    """Adapter for providers that use the OpenAI request/response format."""
+
+    @classmethod
+    def chat_to_model(cls, payload: dict[str, Any], config: EndpointConfig) -> dict[str, Any]:
+        return {"model": config.model.name, **payload}
+
+    @classmethod
+    def completions_to_model(cls, payload: dict[str, Any], config: EndpointConfig) -> dict[str, Any]:
+        return {"model": config.model.name, **payload}
+
+    @classmethod
+    def embeddings_to_model(cls, payload: dict[str, Any], config: EndpointConfig) -> dict[str, Any]:
+        return {"model": config.model.name, **payload}
+
+    @classmethod
+    def model_to_chat(cls, resp: dict[str, Any], config: EndpointConfig) -> chat.ResponsePayload:
+        return chat.ResponsePayload(
+            id=resp["id"],
+            object=resp["object"],
+            created=resp["created"],
+            model=resp["model"],
+            choices=[
+                chat.Choice(
+                    index=idx,
+                    message=chat.ResponseMessage(
+                        role=c["message"]["role"],
+                        content=c["message"].get("content"),
+                        tool_calls=(
+                            (calls := c["message"].get("tool_calls"))
+                            and [chat.ToolCall(**tc) for tc in calls]
+                        ),
+                    ),
+                    finish_reason=c.get("finish_reason"),
+                )
+                for idx, c in enumerate(resp["choices"])
+            ],
+            usage=cls._build_chat_usage(resp.get("usage", {})),
+        )
+
+    @classmethod
+    def _build_chat_usage(cls, usage_data: dict[str, Any]) -> chat.ChatUsage:
+        prompt_tokens_details = None
+        if details := usage_data.get("prompt_tokens_details"):
+            prompt_tokens_details = chat.PromptTokensDetails(**details)
+        return chat.ChatUsage(
+            prompt_tokens=usage_data.get("prompt_tokens"),
+            completion_tokens=usage_data.get("completion_tokens"),
+            total_tokens=usage_data.get("total_tokens"),
+            prompt_tokens_details=prompt_tokens_details,
+        )
+
+    @classmethod
+    def model_to_chat_streaming(
+        cls, resp: dict[str, Any], config: EndpointConfig
+    ) -> chat.StreamResponsePayload:
+        usage = None
+        if usage_data := resp.get("usage"):
+            usage = cls._build_chat_usage(usage_data)
+
+        return chat.StreamResponsePayload(
+            id=resp["id"],
+            object=resp["object"],
+            created=resp["created"],
+            model=resp["model"],
+            choices=[
+                chat.StreamChoice(
+                    index=c["index"],
+                    finish_reason=c["finish_reason"],
+                    delta=chat.StreamDelta(
+                        role=c["delta"].get("role"),
+                        content=c["delta"].get("content"),
+                        tool_calls=(
+                            (calls := c["delta"].get("tool_calls"))
+                            and [chat.ToolCallDelta(**tc) for tc in calls]
+                        ),
+                    ),
+                )
+                for c in resp["choices"]
+            ],
+            usage=usage,
+        )
+
+    @classmethod
+    def model_to_completions(
+        cls, resp: dict[str, Any], config: EndpointConfig
+    ) -> completions.ResponsePayload:
+        return completions.ResponsePayload(
+            id=resp["id"],
+            object="text_completion",
+            created=resp["created"],
+            model=resp["model"],
+            choices=[
+                completions.Choice(
+                    index=idx,
+                    text=c.get("message", {}).get("content") or c.get("text") or "",
+                    finish_reason=c["finish_reason"],
+                )
+                for idx, c in enumerate(resp["choices"])
+            ],
+            usage=completions.CompletionsUsage(
+                prompt_tokens=resp["usage"]["prompt_tokens"],
+                completion_tokens=resp["usage"]["completion_tokens"],
+                total_tokens=resp["usage"]["total_tokens"],
+            ),
+        )
+
+    @classmethod
+    def model_to_completions_streaming(
+        cls, resp: dict[str, Any], config: EndpointConfig
+    ) -> completions.StreamResponsePayload:
+        usage = None
+        if usage_data := resp.get("usage"):
+            usage = completions.CompletionsUsage(
+                prompt_tokens=usage_data.get("prompt_tokens"),
+                completion_tokens=usage_data.get("completion_tokens"),
+                total_tokens=usage_data.get("total_tokens"),
+            )
+
+        return completions.StreamResponsePayload(
+            id=resp["id"],
+            object="text_completion_chunk",
+            created=resp["created"],
+            model=resp["model"],
+            choices=[
+                completions.StreamChoice(
+                    index=c["index"],
+                    finish_reason=c["finish_reason"],
+                    text=c["delta"].get("content"),
+                )
+                for c in resp["choices"]
+            ],
+            usage=usage,
+        )
+
+    @classmethod
+    def model_to_embeddings(
+        cls, resp: dict[str, Any], config: EndpointConfig
+    ) -> embeddings.ResponsePayload:
+        return embeddings.ResponsePayload(
+            data=[
+                embeddings.EmbeddingObject(
+                    embedding=d["embedding"],
+                    index=idx,
+                )
+                for idx, d in enumerate(resp["data"])
+            ],
+            model=resp["model"],
+            usage=embeddings.EmbeddingsUsage(
+                prompt_tokens=resp["usage"]["prompt_tokens"],
+                total_tokens=resp["usage"]["total_tokens"],
+            ),
+        )
+
+
+class OpenAICompatibleProvider(BaseProvider):
+    """
+    Base provider for APIs that follow the OpenAI format.
+
+    Subclasses must set:
+        - NAME: Provider display name (e.g., "Groq")
+        - CONFIG_TYPE: The provider's config class
+        - DEFAULT_API_BASE: Default base URL for the API (e.g., "https://api.groq.com/openai/v1")
+
+    The config class must expose an ``api_key`` property and an optional
+    ``api_base`` property. See ``OpenAICompatibleConfig`` in config.py.
+    """
+
+    DEFAULT_API_BASE: str = ""
+
+    PASSTHROUGH_PROVIDER_PATHS = {
+        PassthroughAction.OPENAI_CHAT: "chat/completions",
+        PassthroughAction.OPENAI_EMBEDDINGS: "embeddings",
+    }
+
+    def __init__(self, config: EndpointConfig, enable_tracing: bool = False) -> None:
+        super().__init__(config, enable_tracing=enable_tracing)
+        self._provider_config = config.model.config
+
+    @property
+    def _api_base(self) -> str:
+        return getattr(self._provider_config, "api_base", None) or self.DEFAULT_API_BASE
+
+    @property
+    def _api_key(self) -> str:
+        return self._provider_config.api_key
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}"}
+
+    @property
+    def adapter_class(self) -> type[ProviderAdapter]:
+        return OpenAICompatibleAdapter
+
+    def _get_headers(
+        self,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        result_headers = self.headers.copy()
+        if headers:
+            client_headers = headers.copy()
+            client_headers.pop("host", None)
+            client_headers.pop("content-length", None)
+            result_headers = client_headers | result_headers
+        return result_headers
+
+    # ---- chat ----
+
+    async def _chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+        resp = await send_request(
+            headers=self.headers,
+            base_url=self._api_base,
+            path="chat/completions",
+            payload=self.adapter_class.chat_to_model(payload_dict, self.config),
+        )
+        return self.adapter_class.model_to_chat(resp, self.config)
+
+    async def _chat_stream(
+        self, payload: chat.RequestPayload
+    ) -> AsyncIterable[chat.StreamResponsePayload]:
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+
+        if payload_dict.get("stream_options") is None:
+            payload_dict["stream_options"] = {"include_usage": True}
+        elif "include_usage" not in payload_dict["stream_options"]:
+            payload_dict["stream_options"]["include_usage"] = True
+
+        stream = send_stream_request(
+            headers=self.headers,
+            base_url=self._api_base,
+            path="chat/completions",
+            payload=self.adapter_class.chat_to_model(payload_dict, self.config),
+        )
+        async for resp in stream_sse_data(stream):
+            yield self.adapter_class.model_to_chat_streaming(resp, self.config)
+
+    # ---- completions ----
+
+    async def _completions(
+        self, payload: completions.RequestPayload
+    ) -> completions.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+        resp = await send_request(
+            headers=self.headers,
+            base_url=self._api_base,
+            path="chat/completions",
+            payload=self.adapter_class.completions_to_model(payload_dict, self.config),
+        )
+        return self.adapter_class.model_to_completions(resp, self.config)
+
+    async def _completions_stream(
+        self, payload: completions.RequestPayload
+    ) -> AsyncIterable[completions.StreamResponsePayload]:
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+
+        if payload_dict.get("stream_options") is None:
+            payload_dict["stream_options"] = {"include_usage": True}
+        elif "include_usage" not in payload_dict["stream_options"]:
+            payload_dict["stream_options"]["include_usage"] = True
+
+        stream = send_stream_request(
+            headers=self.headers,
+            base_url=self._api_base,
+            path="chat/completions",
+            payload=self.adapter_class.completions_to_model(payload_dict, self.config),
+        )
+        async for resp in stream_sse_data(stream):
+            yield self.adapter_class.model_to_completions_streaming(resp, self.config)
+
+    # ---- embeddings ----
+
+    async def _embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+        resp = await send_request(
+            headers=self.headers,
+            base_url=self._api_base,
+            path="embeddings",
+            payload=self.adapter_class.embeddings_to_model(payload_dict, self.config),
+        )
+        return self.adapter_class.model_to_embeddings(resp, self.config)
+
+    # ---- passthrough ----
+
+    def _extract_passthrough_token_usage(
+        self, action: PassthroughAction, result: dict[str, Any]
+    ) -> dict[str, int] | None:
+        usage = result.get("usage")
+        if not usage:
+            return None
+        return self._extract_token_usage_from_dict(
+            usage,
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            cache_read_key="prompt_tokens_details.cached_tokens",
+        )
+
+    def _extract_streaming_token_usage(self, chunk: bytes) -> dict[str, int]:
+        from mlflow.gateway.utils import parse_sse_lines
+
+        for data in parse_sse_lines(chunk):
+            if chat_usage := data.get("usage"):
+                if token_usage := self._extract_token_usage_from_dict(
+                    chat_usage,
+                    "prompt_tokens",
+                    "completion_tokens",
+                    "total_tokens",
+                    cache_read_key="prompt_tokens_details.cached_tokens",
+                ):
+                    return token_usage
+        return {}
+
+    async def _passthrough(
+        self,
+        action: PassthroughAction,
+        payload: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any] | AsyncIterable[Any]:
+        payload_with_model = {"model": self.config.model.name, **payload}
+        provider_path = self._validate_passthrough_action(action)
+        request_headers = self._get_headers(headers)
+
+        supports_streaming = action != PassthroughAction.OPENAI_EMBEDDINGS
+
+        if supports_streaming and payload_with_model.get("stream"):
+            if self._enable_tracing:
+                if payload_with_model.get("stream_options") is None:
+                    payload_with_model["stream_options"] = {"include_usage": True}
+                elif "include_usage" not in payload_with_model["stream_options"]:
+                    payload_with_model["stream_options"]["include_usage"] = True
+
+            stream = send_stream_request(
+                headers=request_headers,
+                base_url=self._api_base,
+                path=provider_path,
+                payload=payload_with_model,
+            )
+            return self._stream_passthrough_with_usage(stream)
+        else:
+            return await send_request(
+                headers=request_headers,
+                base_url=self._api_base,
+                path=provider_path,
+                payload=payload_with_model,
+            )

--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -12,19 +12,19 @@ from typing import Any, AsyncIterable
 from mlflow.gateway.config import EndpointConfig
 from mlflow.gateway.providers.base import BaseProvider, PassthroughAction, ProviderAdapter
 from mlflow.gateway.providers.utils import send_request, send_stream_request
-from mlflow.gateway.schemas import chat, completions, embeddings
+from mlflow.gateway.schemas import chat, embeddings
 from mlflow.gateway.utils import stream_sse_data
 
 
 class OpenAICompatibleAdapter(ProviderAdapter):
-    """Adapter for providers that use the OpenAI request/response format."""
+    """Adapter for providers that use the OpenAI request/response format.
+
+    This is also the base class for ``OpenAIAdapter``, which adds Azure-specific
+    payload handling on top.
+    """
 
     @classmethod
     def chat_to_model(cls, payload: dict[str, Any], config: EndpointConfig) -> dict[str, Any]:
-        return {"model": config.model.name, **payload}
-
-    @classmethod
-    def completions_to_model(cls, payload: dict[str, Any], config: EndpointConfig) -> dict[str, Any]:
         return {"model": config.model.name, **payload}
 
     @classmethod
@@ -33,6 +33,30 @@ class OpenAICompatibleAdapter(ProviderAdapter):
 
     @classmethod
     def model_to_chat(cls, resp: dict[str, Any], config: EndpointConfig) -> chat.ResponsePayload:
+        # Response example (https://platform.openai.com/docs/api-reference/chat/create)
+        # ```
+        # {
+        #    "id":"chatcmpl-abc123",
+        #    "object":"chat.completion",
+        #    "created":1677858242,
+        #    "model":"gpt-4o-mini",
+        #    "usage":{
+        #       "prompt_tokens":13,
+        #       "completion_tokens":7,
+        #       "total_tokens":20
+        #    },
+        #    "choices":[
+        #       {
+        #          "message":{
+        #             "role":"assistant",
+        #             "content":"\n\nThis is a test!"
+        #          },
+        #          "finish_reason":"stop",
+        #          "index":0
+        #       }
+        #    ]
+        # }
+        # ```
         return chat.ResponsePayload(
             id=resp["id"],
             object=resp["object"],
@@ -100,61 +124,32 @@ class OpenAICompatibleAdapter(ProviderAdapter):
         )
 
     @classmethod
-    def model_to_completions(
-        cls, resp: dict[str, Any], config: EndpointConfig
-    ) -> completions.ResponsePayload:
-        return completions.ResponsePayload(
-            id=resp["id"],
-            object="text_completion",
-            created=resp["created"],
-            model=resp["model"],
-            choices=[
-                completions.Choice(
-                    index=idx,
-                    text=c.get("message", {}).get("content") or c.get("text") or "",
-                    finish_reason=c["finish_reason"],
-                )
-                for idx, c in enumerate(resp["choices"])
-            ],
-            usage=completions.CompletionsUsage(
-                prompt_tokens=resp["usage"]["prompt_tokens"],
-                completion_tokens=resp["usage"]["completion_tokens"],
-                total_tokens=resp["usage"]["total_tokens"],
-            ),
-        )
-
-    @classmethod
-    def model_to_completions_streaming(
-        cls, resp: dict[str, Any], config: EndpointConfig
-    ) -> completions.StreamResponsePayload:
-        usage = None
-        if usage_data := resp.get("usage"):
-            usage = completions.CompletionsUsage(
-                prompt_tokens=usage_data.get("prompt_tokens"),
-                completion_tokens=usage_data.get("completion_tokens"),
-                total_tokens=usage_data.get("total_tokens"),
-            )
-
-        return completions.StreamResponsePayload(
-            id=resp["id"],
-            object="text_completion_chunk",
-            created=resp["created"],
-            model=resp["model"],
-            choices=[
-                completions.StreamChoice(
-                    index=c["index"],
-                    finish_reason=c["finish_reason"],
-                    text=c["delta"].get("content"),
-                )
-                for c in resp["choices"]
-            ],
-            usage=usage,
-        )
-
-    @classmethod
     def model_to_embeddings(
         cls, resp: dict[str, Any], config: EndpointConfig
     ) -> embeddings.ResponsePayload:
+        # Response example (https://platform.openai.com/docs/api-reference/embeddings/create):
+        # ```
+        # {
+        #   "object": "list",
+        #   "data": [
+        #     {
+        #       "object": "embedding",
+        #       "embedding": [
+        #         0.0023064255,
+        #         -0.009327292,
+        #         .... (1536 floats total for ada-002)
+        #         -0.0028842222,
+        #       ],
+        #       "index": 0
+        #     }
+        #   ],
+        #   "model": "text-embedding-ada-002",
+        #   "usage": {
+        #     "prompt_tokens": 8,
+        #     "total_tokens": 8
+        #   }
+        # }
+        # ```
         return embeddings.ResponsePayload(
             data=[
                 embeddings.EmbeddingObject(
@@ -181,7 +176,7 @@ class OpenAICompatibleProvider(BaseProvider):
         - DEFAULT_API_BASE: Default base URL for the API (e.g., "https://api.groq.com/openai/v1")
 
     The config class must expose an ``api_key`` property and an optional
-    ``api_base`` property. See ``OpenAICompatibleConfig`` in config.py.
+    ``api_base`` property. See ``_OpenAICompatibleConfig`` in config.py.
     """
 
     DEFAULT_API_BASE: str = ""
@@ -193,6 +188,11 @@ class OpenAICompatibleProvider(BaseProvider):
 
     def __init__(self, config: EndpointConfig, enable_tracing: bool = False) -> None:
         super().__init__(config, enable_tracing=enable_tracing)
+        if config.model.config is None or not isinstance(config.model.config, self.CONFIG_TYPE):
+            raise TypeError(
+                f"Expected config type {self.CONFIG_TYPE.__name__}, "
+                f"got {type(config.model.config).__name__}"
+            )
         self._provider_config = config.model.config
 
     @property
@@ -217,9 +217,11 @@ class OpenAICompatibleProvider(BaseProvider):
     ) -> dict[str, str]:
         result_headers = self.headers.copy()
         if headers:
-            client_headers = headers.copy()
-            client_headers.pop("host", None)
-            client_headers.pop("content-length", None)
+            client_headers = {
+                k: v
+                for k, v in headers.items()
+                if k.lower() not in ("host", "content-length", "authorization")
+            }
             result_headers = client_headers | result_headers
         return result_headers
 
@@ -259,45 +261,6 @@ class OpenAICompatibleProvider(BaseProvider):
         )
         async for resp in stream_sse_data(stream):
             yield self.adapter_class.model_to_chat_streaming(resp, self.config)
-
-    # ---- completions ----
-
-    async def _completions(
-        self, payload: completions.RequestPayload
-    ) -> completions.ResponsePayload:
-        from fastapi.encoders import jsonable_encoder
-
-        payload_dict = jsonable_encoder(payload, exclude_none=True)
-        self.check_for_model_field(payload_dict)
-        resp = await send_request(
-            headers=self.headers,
-            base_url=self._api_base,
-            path="chat/completions",
-            payload=self.adapter_class.completions_to_model(payload_dict, self.config),
-        )
-        return self.adapter_class.model_to_completions(resp, self.config)
-
-    async def _completions_stream(
-        self, payload: completions.RequestPayload
-    ) -> AsyncIterable[completions.StreamResponsePayload]:
-        from fastapi.encoders import jsonable_encoder
-
-        payload_dict = jsonable_encoder(payload, exclude_none=True)
-        self.check_for_model_field(payload_dict)
-
-        if payload_dict.get("stream_options") is None:
-            payload_dict["stream_options"] = {"include_usage": True}
-        elif "include_usage" not in payload_dict["stream_options"]:
-            payload_dict["stream_options"]["include_usage"] = True
-
-        stream = send_stream_request(
-            headers=self.headers,
-            base_url=self._api_base,
-            path="chat/completions",
-            payload=self.adapter_class.completions_to_model(payload_dict, self.config),
-        )
-        async for resp in stream_sse_data(stream):
-            yield self.adapter_class.model_to_completions_streaming(resp, self.config)
 
     # ---- embeddings ----
 

--- a/tests/gateway/providers/test_openai_compatible.py
+++ b/tests/gateway/providers/test_openai_compatible.py
@@ -1,0 +1,345 @@
+from unittest import mock
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import EndpointConfig, OpenAICompatibleConfig
+from mlflow.gateway.providers.base import PassthroughAction
+from mlflow.gateway.providers.openai_compatible import (
+    OpenAICompatibleAdapter,
+    OpenAICompatibleProvider,
+)
+from mlflow.gateway.schemas import chat, completions, embeddings
+
+from tests.gateway.tools import (
+    MockAsyncResponse,
+    MockAsyncStreamingResponse,
+    mock_http_client,
+)
+
+
+# --- Concrete subclass for testing ---
+
+
+class _TestConfig(OpenAICompatibleConfig):
+    pass
+
+
+class _TestProvider(OpenAICompatibleProvider):
+    NAME = "TestProvider"
+    CONFIG_TYPE = _TestConfig
+    DEFAULT_API_BASE = "https://api.test-provider.com/v1"
+
+
+# --- fixtures ---
+
+
+def _make_provider(*, api_base: str | None = None) -> _TestProvider:
+    from mlflow.gateway.provider_registry import provider_registry
+
+    # Temporarily register our test provider so EndpointConfig validation works
+    _TEST_PROVIDER_NAME = "_test_openai_compat"
+    if _TEST_PROVIDER_NAME not in provider_registry.keys():
+        provider_registry.register(_TEST_PROVIDER_NAME, _TestProvider)
+
+    config_dict = {
+        "api_key": "test-key",
+    }
+    if api_base is not None:
+        config_dict["api_base"] = api_base
+
+    endpoint_config = EndpointConfig(
+        name="test-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": _TEST_PROVIDER_NAME,
+            "name": "test-model",
+            "config": config_dict,
+        },
+    )
+    return _TestProvider(endpoint_config)
+
+
+def _chat_response():
+    return {
+        "id": "chatcmpl-abc123",
+        "object": "chat.completion",
+        "created": 1677858242,
+        "model": "test-model",
+        "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 7,
+            "total_tokens": 20,
+        },
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello!",
+                },
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def _embeddings_response():
+    return {
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "embedding": [0.1, 0.2, 0.3],
+                "index": 0,
+            }
+        ],
+        "model": "test-model",
+        "usage": {
+            "prompt_tokens": 8,
+            "total_tokens": 8,
+        },
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def _completions_response():
+    return {
+        "id": "cmpl-abc123",
+        "object": "text_completion",
+        "created": 1677858242,
+        "model": "test-model",
+        "usage": {
+            "prompt_tokens": 5,
+            "completion_tokens": 7,
+            "total_tokens": 12,
+        },
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "This is a test!",
+                },
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+# --- tests ---
+
+
+class TestOpenAICompatibleProvider:
+    def test_default_api_base(self):
+        provider = _make_provider()
+        assert provider._api_base == "https://api.test-provider.com/v1"
+
+    def test_custom_api_base(self):
+        provider = _make_provider(api_base="https://custom.example.com/v1")
+        assert provider._api_base == "https://custom.example.com/v1"
+
+    def test_headers(self):
+        provider = _make_provider()
+        assert provider.headers == {"Authorization": "Bearer test-key"}
+
+    def test_get_headers_merges_client_headers(self):
+        provider = _make_provider()
+        merged = provider._get_headers(headers={"X-Custom": "value", "host": "ignored"})
+        assert merged == {"Authorization": "Bearer test-key", "X-Custom": "value"}
+        assert "host" not in merged
+
+    @pytest.mark.asyncio
+    async def test_chat(self):
+        provider = _make_provider()
+        mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+            payload = chat.RequestPayload(
+                messages=[{"role": "user", "content": "Hello"}],
+            )
+            response = await provider.chat(payload)
+
+        result = jsonable_encoder(response)
+        assert result["id"] == "chatcmpl-abc123"
+        assert result["choices"][0]["message"]["content"] == "Hello!"
+        assert result["usage"]["prompt_tokens"] == 13
+
+        # Verify correct URL and payload
+        call_args = mock_client.post.call_args
+        assert "chat/completions" in str(call_args)
+
+    @pytest.mark.asyncio
+    async def test_chat_stream(self):
+        provider = _make_provider()
+        chunks = [
+            b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        mock_client = mock_http_client(MockAsyncStreamingResponse(chunks))
+
+        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+            payload = chat.RequestPayload(
+                messages=[{"role": "user", "content": "Hello"}],
+            )
+            responses = []
+            async for chunk in provider.chat_stream(payload):
+                responses.append(chunk)
+
+        assert len(responses) == 1
+        result = jsonable_encoder(responses[0])
+        assert result["choices"][0]["delta"]["content"] == "Hi"
+
+    @pytest.mark.asyncio
+    async def test_embeddings(self):
+        provider = _make_provider()
+        mock_client = mock_http_client(MockAsyncResponse(_embeddings_response()))
+
+        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+            payload = embeddings.RequestPayload(input="Test text")
+            response = await provider.embeddings(payload)
+
+        result = jsonable_encoder(response)
+        assert result["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+        assert result["usage"]["prompt_tokens"] == 8
+
+    @pytest.mark.asyncio
+    async def test_completions(self):
+        provider = _make_provider()
+        mock_client = mock_http_client(MockAsyncResponse(_completions_response()))
+
+        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+            payload = completions.RequestPayload(prompt="Test prompt")
+            response = await provider.completions(payload)
+
+        result = jsonable_encoder(response)
+        assert result["choices"][0]["text"] == "This is a test!"
+        assert result["usage"]["total_tokens"] == 12
+
+    @pytest.mark.asyncio
+    async def test_passthrough_non_streaming(self):
+        provider = _make_provider()
+        mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+            result = await provider.passthrough(
+                action=PassthroughAction.OPENAI_CHAT,
+                payload={"messages": [{"role": "user", "content": "Hello"}]},
+            )
+
+        assert result["id"] == "chatcmpl-abc123"
+
+    @pytest.mark.asyncio
+    async def test_passthrough_streaming(self):
+        provider = _make_provider()
+        chunks = [
+            b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        mock_client = mock_http_client(MockAsyncStreamingResponse(chunks))
+
+        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+            result = await provider.passthrough(
+                action=PassthroughAction.OPENAI_CHAT,
+                payload={
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "stream": True,
+                },
+            )
+            collected = []
+            async for chunk in result:
+                collected.append(chunk)
+
+        assert len(collected) > 0
+
+
+def _make_endpoint_config():
+    """Create an EndpointConfig suitable for adapter tests."""
+    provider = _make_provider()
+    return provider.config
+
+
+class TestOpenAICompatibleAdapter:
+    def test_chat_to_model_adds_model_name(self):
+        config = _make_endpoint_config()
+        result = OpenAICompatibleAdapter.chat_to_model(
+            {"messages": [{"role": "user", "content": "Hi"}]}, config
+        )
+        assert result["model"] == "test-model"
+        assert result["messages"] == [{"role": "user", "content": "Hi"}]
+
+    def test_model_to_chat(self):
+        config = _make_endpoint_config()
+        resp = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "test-model",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "Hello!"},
+                    "finish_reason": "stop",
+                    "index": 0,
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        result = OpenAICompatibleAdapter.model_to_chat(resp, config)
+        assert isinstance(result, chat.ResponsePayload)
+        assert result.choices[0].message.content == "Hello!"
+
+    def test_model_to_embeddings(self):
+        config = _make_endpoint_config()
+        resp = {
+            "data": [{"embedding": [0.1, 0.2], "index": 0}],
+            "model": "test-model",
+            "usage": {"prompt_tokens": 5, "total_tokens": 5},
+        }
+        result = OpenAICompatibleAdapter.model_to_embeddings(resp, config)
+        assert isinstance(result, embeddings.ResponsePayload)
+        assert result.data[0].embedding == [0.1, 0.2]
+
+    def test_model_to_chat_with_tool_calls(self):
+        config = _make_endpoint_config()
+        resp = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "test-model",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"city": "NYC"}',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                    "index": 0,
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        result = OpenAICompatibleAdapter.model_to_chat(resp, config)
+        assert result.choices[0].message.tool_calls[0].id == "call_1"
+
+
+class TestOpenAICompatibleConfig:
+    def test_basic_config(self):
+        config = OpenAICompatibleConfig(api_key="test-key")
+        assert config.api_key == "test-key"
+        assert config.api_base is None
+
+    def test_config_with_api_base(self):
+        config = OpenAICompatibleConfig(api_key="test-key", api_base="https://custom.com/v1")
+        assert config.api_base == "https://custom.com/v1"

--- a/tests/gateway/providers/test_openai_compatible.py
+++ b/tests/gateway/providers/test_openai_compatible.py
@@ -3,13 +3,13 @@ from unittest import mock
 import pytest
 from fastapi.encoders import jsonable_encoder
 
-from mlflow.gateway.config import EndpointConfig, OpenAICompatibleConfig
+from mlflow.gateway.config import EndpointConfig, _OpenAICompatibleConfig
 from mlflow.gateway.providers.base import PassthroughAction
 from mlflow.gateway.providers.openai_compatible import (
     OpenAICompatibleAdapter,
     OpenAICompatibleProvider,
 )
-from mlflow.gateway.schemas import chat, completions, embeddings
+from mlflow.gateway.schemas import chat, embeddings
 
 from tests.gateway.tools import (
     MockAsyncResponse,
@@ -17,11 +17,10 @@ from tests.gateway.tools import (
     mock_http_client,
 )
 
-
 # --- Concrete subclass for testing ---
 
 
-class _TestConfig(OpenAICompatibleConfig):
+class _TestConfig(_OpenAICompatibleConfig):
     pass
 
 
@@ -34,13 +33,16 @@ class _TestProvider(OpenAICompatibleProvider):
 # --- fixtures ---
 
 
-def _make_provider(*, api_base: str | None = None) -> _TestProvider:
-    from mlflow.gateway.provider_registry import provider_registry
+_TEST_PROVIDER_NAME = "_test_openai_compat"
 
-    # Temporarily register our test provider so EndpointConfig validation works
-    _TEST_PROVIDER_NAME = "_test_openai_compat"
-    if _TEST_PROVIDER_NAME not in provider_registry.keys():
-        provider_registry.register(_TEST_PROVIDER_NAME, _TestProvider)
+# Register once at module load so EndpointConfig validation accepts this provider
+from mlflow.gateway.provider_registry import provider_registry
+
+if _TEST_PROVIDER_NAME not in provider_registry.keys():
+    provider_registry.register(_TEST_PROVIDER_NAME, _TestProvider)
+
+
+def _make_provider(*, api_base: str | None = None) -> _TestProvider:
 
     config_dict = {
         "api_key": "test-key",
@@ -104,242 +106,227 @@ def _embeddings_response():
     }
 
 
-def _completions_response():
-    return {
-        "id": "cmpl-abc123",
-        "object": "text_completion",
-        "created": 1677858242,
-        "model": "test-model",
-        "usage": {
-            "prompt_tokens": 5,
-            "completion_tokens": 7,
-            "total_tokens": 12,
-        },
-        "choices": [
-            {
-                "message": {
-                    "role": "assistant",
-                    "content": "This is a test!",
-                },
-                "finish_reason": "stop",
-                "index": 0,
-            }
-        ],
-        "headers": {"Content-Type": "application/json"},
-    }
-
-
-# --- tests ---
-
-
-class TestOpenAICompatibleProvider:
-    def test_default_api_base(self):
-        provider = _make_provider()
-        assert provider._api_base == "https://api.test-provider.com/v1"
-
-    def test_custom_api_base(self):
-        provider = _make_provider(api_base="https://custom.example.com/v1")
-        assert provider._api_base == "https://custom.example.com/v1"
-
-    def test_headers(self):
-        provider = _make_provider()
-        assert provider.headers == {"Authorization": "Bearer test-key"}
-
-    def test_get_headers_merges_client_headers(self):
-        provider = _make_provider()
-        merged = provider._get_headers(headers={"X-Custom": "value", "host": "ignored"})
-        assert merged == {"Authorization": "Bearer test-key", "X-Custom": "value"}
-        assert "host" not in merged
-
-    @pytest.mark.asyncio
-    async def test_chat(self):
-        provider = _make_provider()
-        mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
-
-        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
-            payload = chat.RequestPayload(
-                messages=[{"role": "user", "content": "Hello"}],
-            )
-            response = await provider.chat(payload)
-
-        result = jsonable_encoder(response)
-        assert result["id"] == "chatcmpl-abc123"
-        assert result["choices"][0]["message"]["content"] == "Hello!"
-        assert result["usage"]["prompt_tokens"] == 13
-
-        # Verify correct URL and payload
-        call_args = mock_client.post.call_args
-        assert "chat/completions" in str(call_args)
-
-    @pytest.mark.asyncio
-    async def test_chat_stream(self):
-        provider = _make_provider()
-        chunks = [
-            b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}\n\n',
-            b"data: [DONE]\n\n",
-        ]
-        mock_client = mock_http_client(MockAsyncStreamingResponse(chunks))
-
-        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
-            payload = chat.RequestPayload(
-                messages=[{"role": "user", "content": "Hello"}],
-            )
-            responses = []
-            async for chunk in provider.chat_stream(payload):
-                responses.append(chunk)
-
-        assert len(responses) == 1
-        result = jsonable_encoder(responses[0])
-        assert result["choices"][0]["delta"]["content"] == "Hi"
-
-    @pytest.mark.asyncio
-    async def test_embeddings(self):
-        provider = _make_provider()
-        mock_client = mock_http_client(MockAsyncResponse(_embeddings_response()))
-
-        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
-            payload = embeddings.RequestPayload(input="Test text")
-            response = await provider.embeddings(payload)
-
-        result = jsonable_encoder(response)
-        assert result["data"][0]["embedding"] == [0.1, 0.2, 0.3]
-        assert result["usage"]["prompt_tokens"] == 8
-
-    @pytest.mark.asyncio
-    async def test_completions(self):
-        provider = _make_provider()
-        mock_client = mock_http_client(MockAsyncResponse(_completions_response()))
-
-        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
-            payload = completions.RequestPayload(prompt="Test prompt")
-            response = await provider.completions(payload)
-
-        result = jsonable_encoder(response)
-        assert result["choices"][0]["text"] == "This is a test!"
-        assert result["usage"]["total_tokens"] == 12
-
-    @pytest.mark.asyncio
-    async def test_passthrough_non_streaming(self):
-        provider = _make_provider()
-        mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
-
-        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
-            result = await provider.passthrough(
-                action=PassthroughAction.OPENAI_CHAT,
-                payload={"messages": [{"role": "user", "content": "Hello"}]},
-            )
-
-        assert result["id"] == "chatcmpl-abc123"
-
-    @pytest.mark.asyncio
-    async def test_passthrough_streaming(self):
-        provider = _make_provider()
-        chunks = [
-            b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n',
-            b"data: [DONE]\n\n",
-        ]
-        mock_client = mock_http_client(MockAsyncStreamingResponse(chunks))
-
-        with mock.patch("aiohttp.ClientSession", return_value=mock_client):
-            result = await provider.passthrough(
-                action=PassthroughAction.OPENAI_CHAT,
-                payload={
-                    "messages": [{"role": "user", "content": "Hello"}],
-                    "stream": True,
-                },
-            )
-            collected = []
-            async for chunk in result:
-                collected.append(chunk)
-
-        assert len(collected) > 0
-
-
 def _make_endpoint_config():
-    """Create an EndpointConfig suitable for adapter tests."""
     provider = _make_provider()
     return provider.config
 
 
-class TestOpenAICompatibleAdapter:
-    def test_chat_to_model_adds_model_name(self):
-        config = _make_endpoint_config()
-        result = OpenAICompatibleAdapter.chat_to_model(
-            {"messages": [{"role": "user", "content": "Hi"}]}, config
+# --- provider tests ---
+
+
+def test_default_api_base():
+    provider = _make_provider()
+    assert provider._api_base == "https://api.test-provider.com/v1"
+
+
+def test_custom_api_base():
+    provider = _make_provider(api_base="https://custom.example.com/v1")
+    assert provider._api_base == "https://custom.example.com/v1"
+
+
+def test_headers():
+    provider = _make_provider()
+    assert provider.headers == {"Authorization": "Bearer test-key"}
+
+
+def test_get_headers_merges_client_headers():
+    provider = _make_provider()
+    merged = provider._get_headers(headers={"X-Custom": "value", "host": "ignored"})
+    assert merged == {"Authorization": "Bearer test-key", "X-Custom": "value"}
+    assert "host" not in merged
+
+
+def test_get_headers_strips_client_authorization():
+    provider = _make_provider()
+    merged = provider._get_headers(
+        headers={"authorization": "Bearer client-key", "X-Custom": "value"}
+    )
+    assert merged["Authorization"] == "Bearer test-key"
+    assert "authorization" not in merged
+    assert merged["X-Custom"] == "value"
+
+
+@pytest.mark.asyncio
+async def test_chat():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
         )
-        assert result["model"] == "test-model"
-        assert result["messages"] == [{"role": "user", "content": "Hi"}]
+        response = await provider.chat(payload)
 
-    def test_model_to_chat(self):
-        config = _make_endpoint_config()
-        resp = {
-            "id": "chatcmpl-1",
-            "object": "chat.completion",
-            "created": 1,
-            "model": "test-model",
-            "choices": [
-                {
-                    "message": {"role": "assistant", "content": "Hello!"},
-                    "finish_reason": "stop",
-                    "index": 0,
-                }
-            ],
-            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-        }
-        result = OpenAICompatibleAdapter.model_to_chat(resp, config)
-        assert isinstance(result, chat.ResponsePayload)
-        assert result.choices[0].message.content == "Hello!"
+    result = jsonable_encoder(response)
+    assert result["id"] == "chatcmpl-abc123"
+    assert result["choices"][0]["message"]["content"] == "Hello!"
+    assert result["usage"]["prompt_tokens"] == 13
 
-    def test_model_to_embeddings(self):
-        config = _make_endpoint_config()
-        resp = {
-            "data": [{"embedding": [0.1, 0.2], "index": 0}],
-            "model": "test-model",
-            "usage": {"prompt_tokens": 5, "total_tokens": 5},
-        }
-        result = OpenAICompatibleAdapter.model_to_embeddings(resp, config)
-        assert isinstance(result, embeddings.ResponsePayload)
-        assert result.data[0].embedding == [0.1, 0.2]
-
-    def test_model_to_chat_with_tool_calls(self):
-        config = _make_endpoint_config()
-        resp = {
-            "id": "chatcmpl-1",
-            "object": "chat.completion",
-            "created": 1,
-            "model": "test-model",
-            "choices": [
-                {
-                    "message": {
-                        "role": "assistant",
-                        "content": None,
-                        "tool_calls": [
-                            {
-                                "id": "call_1",
-                                "type": "function",
-                                "function": {
-                                    "name": "get_weather",
-                                    "arguments": '{"city": "NYC"}',
-                                },
-                            }
-                        ],
-                    },
-                    "finish_reason": "tool_calls",
-                    "index": 0,
-                }
-            ],
-            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-        }
-        result = OpenAICompatibleAdapter.model_to_chat(resp, config)
-        assert result.choices[0].message.tool_calls[0].id == "call_1"
+    call_args = mock_client.post.call_args
+    assert "chat/completions" in str(call_args)
 
 
-class TestOpenAICompatibleConfig:
-    def test_basic_config(self):
-        config = OpenAICompatibleConfig(api_key="test-key")
-        assert config.api_key == "test-key"
-        assert config.api_base is None
+@pytest.mark.asyncio
+async def test_chat_stream():
+    provider = _make_provider()
+    chunk_data = (
+        b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,'
+        b'"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant",'
+        b'"content":"Hi"},"finish_reason":null}]}\n\n'
+    )
+    chunks = [chunk_data, b"data: [DONE]\n\n"]
+    mock_client = mock_http_client(MockAsyncStreamingResponse(chunks))
 
-    def test_config_with_api_base(self):
-        config = OpenAICompatibleConfig(api_key="test-key", api_base="https://custom.com/v1")
-        assert config.api_base == "https://custom.com/v1"
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        responses = [chunk async for chunk in provider.chat_stream(payload)]
+
+    assert len(responses) == 1
+    result = jsonable_encoder(responses[0])
+    assert result["choices"][0]["delta"]["content"] == "Hi"
+
+
+@pytest.mark.asyncio
+async def test_embeddings():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_embeddings_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = embeddings.RequestPayload(input="Test text")
+        response = await provider.embeddings(payload)
+
+    result = jsonable_encoder(response)
+    assert result["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+    assert result["usage"]["prompt_tokens"] == 8
+
+
+@pytest.mark.asyncio
+async def test_passthrough_non_streaming():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        result = await provider.passthrough(
+            action=PassthroughAction.OPENAI_CHAT,
+            payload={"messages": [{"role": "user", "content": "Hello"}]},
+        )
+
+    assert result["id"] == "chatcmpl-abc123"
+
+
+@pytest.mark.asyncio
+async def test_passthrough_streaming():
+    provider = _make_provider()
+    chunk_data = (
+        b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,'
+        b'"model":"test-model","choices":[{"index":0,"delta":{"content":"Hi"},'
+        b'"finish_reason":null}]}\n\n'
+    )
+    chunks = [chunk_data, b"data: [DONE]\n\n"]
+    mock_client = mock_http_client(MockAsyncStreamingResponse(chunks))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        result = await provider.passthrough(
+            action=PassthroughAction.OPENAI_CHAT,
+            payload={
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        )
+        collected = [chunk async for chunk in result]
+
+    assert len(collected) > 0
+
+
+# --- adapter tests ---
+
+
+def test_chat_to_model_adds_model_name():
+    config = _make_endpoint_config()
+    result = OpenAICompatibleAdapter.chat_to_model(
+        {"messages": [{"role": "user", "content": "Hi"}]}, config
+    )
+    assert result["model"] == "test-model"
+    assert result["messages"] == [{"role": "user", "content": "Hi"}]
+
+
+def test_model_to_chat():
+    config = _make_endpoint_config()
+    resp = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "test-model",
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    result = OpenAICompatibleAdapter.model_to_chat(resp, config)
+    assert isinstance(result, chat.ResponsePayload)
+    assert result.choices[0].message.content == "Hello!"
+
+
+def test_model_to_embeddings():
+    config = _make_endpoint_config()
+    resp = {
+        "data": [{"embedding": [0.1, 0.2], "index": 0}],
+        "model": "test-model",
+        "usage": {"prompt_tokens": 5, "total_tokens": 5},
+    }
+    result = OpenAICompatibleAdapter.model_to_embeddings(resp, config)
+    assert isinstance(result, embeddings.ResponsePayload)
+    assert result.data[0].embedding == [0.1, 0.2]
+
+
+def test_model_to_chat_with_tool_calls():
+    config = _make_endpoint_config()
+    resp = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "test-model",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "NYC"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+                "index": 0,
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    result = OpenAICompatibleAdapter.model_to_chat(resp, config)
+    assert result.choices[0].message.tool_calls[0].id == "call_1"
+
+
+# --- config tests ---
+
+
+def test_basic_config():
+    config = _OpenAICompatibleConfig(api_key="test-key")
+    assert config.api_key == "test-key"
+    assert config.api_base is None
+
+
+def test_config_with_api_base():
+    config = _OpenAICompatibleConfig(api_key="test-key", api_base="https://custom.com/v1")
+    assert config.api_base == "https://custom.com/v1"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21990/files) to review incremental changes.
- [**stack/openai-compatible-base**](https://github.com/mlflow/mlflow/pull/21990) [[Files changed](https://github.com/mlflow/mlflow/pull/21990/files)]
  - [stack/groq-provider](https://github.com/mlflow/mlflow/pull/21991) [[Files changed](https://github.com/mlflow/mlflow/pull/21991/files/35941d71b15b83be71df63bf7a513ecba8246646..564fc84aa1865283293a5d916e3197b0ff702a49)]
    - [stack/deepseek-provider](https://github.com/mlflow/mlflow/pull/21992) [[Files changed](https://github.com/mlflow/mlflow/pull/21992/files/564fc84aa1865283293a5d916e3197b0ff702a49..8c75b71c12a5566e1e9ebf0530bbd6f0c8d1d868)]
      - [stack/xai-provider](https://github.com/mlflow/mlflow/pull/21993) [[Files changed](https://github.com/mlflow/mlflow/pull/21993/files/8c75b71c12a5566e1e9ebf0530bbd6f0c8d1d868..d52940d9c686e8297cf9871934fc612efd090aa6)]
        - [stack/openrouter-provider](https://github.com/mlflow/mlflow/pull/21994) [[Files changed](https://github.com/mlflow/mlflow/pull/21994/files/d52940d9c686e8297cf9871934fc612efd090aa6..6b0aa8878717b59d6241095a67b487b276cc8bfc)]
          - [stack/ollama-provider](https://github.com/mlflow/mlflow/pull/21995) [[Files changed](https://github.com/mlflow/mlflow/pull/21995/files/6b0aa8878717b59d6241095a67b487b276cc8bfc..c7678e1cc51aaf4113360e0d08512afa540f343f)]
            - [stack/databricks-provider](https://github.com/mlflow/mlflow/pull/21997) [[Files changed](https://github.com/mlflow/mlflow/pull/21997/files/c7678e1cc51aaf4113360e0d08512afa540f343f..5d5f022b79ac02c75bb7f7d34e734483600e0209)]
              - [stack/vertex-ai-provider](https://github.com/mlflow/mlflow/pull/21998) [[Files changed](https://github.com/mlflow/mlflow/pull/21998/files/5d5f022b79ac02c75bb7f7d34e734483600e0209..1ee059749cc946dc9ad10db15482cef08abb59e9)]
                - [stack/bedrock-provider-complete](https://github.com/mlflow/mlflow/pull/21999) [[Files changed](https://github.com/mlflow/mlflow/pull/21999/files/8c6116f2dc471a17a96eb160455b91cb34f5b2d4..73ce24ea94e9dcc474774dbce9c0540cc2cb620d)]

---------
### Related Issues/PRs

Part of a stack to add native gateway providers and reduce LiteLLM dependency.

### What changes are proposed in this pull request?

Introduce `OpenAICompatibleProvider` and `OpenAICompatibleConfig` as reusable base classes for LLM providers that follow the OpenAI API format (chat/completions/embeddings). This enables adding new providers (Groq, DeepSeek, xAI, etc.) with minimal boilerplate — just a `NAME`, `DEFAULT_API_BASE`, and config class.

Also refactors `OpenAIAdapter` to extend `OpenAICompatibleAdapter`, eliminating ~180 lines of duplicated response transformation code.

Key features:
- Full support for chat, streaming, completions, embeddings, and passthrough
- Token usage extraction for tracing
- Case-insensitive auth header filtering in `_get_headers`
- Config type validation in `__init__`

### How is this PR tested?

- [x] New unit/integration tests

17 new tests covering provider, adapter, and config functionality.

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
