### PR TITLE
Add native Ollama gateway provider

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -62,6 +62,7 @@ class Provider(str, Enum):
     DEEPSEEK = "deepseek"
     XAI = "xai"
     OPENROUTER = "openrouter"
+    OLLAMA = "ollama"
 
     @classmethod
     def values(cls):

--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -37,6 +37,7 @@ def _register_default_providers(registry: ProviderRegistry):
     from mlflow.gateway.providers.mistral import MistralProvider
     from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
     from mlflow.gateway.providers.mosaicml import MosaicMLProvider
+    from mlflow.gateway.providers.ollama import OllamaProvider
     from mlflow.gateway.providers.openai import OpenAIProvider
     from mlflow.gateway.providers.openrouter import OpenRouterProvider
     from mlflow.gateway.providers.palm import PaLMProvider
@@ -58,6 +59,7 @@ def _register_default_providers(registry: ProviderRegistry):
     registry.register(Provider.MISTRAL, MistralProvider)
     registry.register(Provider.MLFLOW_MODEL_SERVING, MlflowModelServingProvider)
     registry.register(Provider.MOSAICML, MosaicMLProvider)
+    registry.register(Provider.OLLAMA, OllamaProvider)
     registry.register(Provider.OPENAI, OpenAIProvider)
     registry.register(Provider.OPENROUTER, OpenRouterProvider)
     registry.register(Provider.PALM, PaLMProvider)

--- a/mlflow/gateway/providers/ollama.py
+++ b/mlflow/gateway/providers/ollama.py
@@ -1,0 +1,20 @@
+from mlflow.gateway.config import _OpenAICompatibleConfig
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
+
+
+class OllamaConfig(_OpenAICompatibleConfig):
+    # Ollama runs locally and doesn't require an API key by default
+    api_key: str = "ollama"
+
+
+class OllamaProvider(OpenAICompatibleProvider):
+    NAME = "Ollama"
+    CONFIG_TYPE = OllamaConfig
+    DEFAULT_API_BASE = "http://localhost:11434/v1"
+
+    @property
+    def headers(self) -> dict[str, str]:
+        # Ollama doesn't require auth — only send Authorization if a real key was set
+        if self._provider_config.api_key and self._provider_config.api_key != "ollama":
+            return {"Authorization": f"Bearer {self._provider_config.api_key}"}
+        return {}

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -249,6 +249,7 @@ def _build_endpoint_config(
         Provider.DEEPSEEK,
         Provider.XAI,
         Provider.OPENROUTER,
+        Provider.OLLAMA,
     }:
         provider_config = _build_openai_compatible_config(model_config)
     else:

--- a/tests/gateway/providers/test_ollama.py
+++ b/tests/gateway/providers/test_ollama.py
@@ -1,0 +1,118 @@
+from unittest import mock
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.ollama import OllamaConfig, OllamaProvider
+from mlflow.gateway.schemas import chat, embeddings
+
+from tests.gateway.tools import MockAsyncResponse, mock_http_client
+
+
+def _make_provider(*, api_base: str | None = None) -> OllamaProvider:
+    config = {}
+    if api_base is not None:
+        config["api_base"] = api_base
+    endpoint_config = EndpointConfig(
+        name="ollama-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "ollama",
+            "name": "llama3.2",
+            "config": config,
+        },
+    )
+    return OllamaProvider(endpoint_config)
+
+
+def _chat_response():
+    return {
+        "id": "chatcmpl-ollama-123",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "llama3.2",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello from Ollama!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def _embeddings_response():
+    return {
+        "object": "list",
+        "data": [{"object": "embedding", "embedding": [0.1, 0.2, 0.3], "index": 0}],
+        "model": "llama3.2",
+        "usage": {"prompt_tokens": 5, "total_tokens": 5},
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def test_default_api_base():
+    provider = _make_provider()
+    assert provider._api_base == "http://localhost:11434/v1"
+
+
+def test_custom_api_base():
+    provider = _make_provider(api_base="http://my-server:11434/v1")
+    assert provider._api_base == "http://my-server:11434/v1"
+
+
+def test_default_api_key():
+    provider = _make_provider()
+    assert provider._api_key == "ollama"
+
+
+def test_name():
+    provider = _make_provider()
+    assert provider.NAME == "Ollama"
+
+
+@pytest.mark.asyncio
+async def test_chat():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["id"] == "chatcmpl-ollama-123"
+    assert result["choices"][0]["message"]["content"] == "Hello from Ollama!"
+
+
+@pytest.mark.asyncio
+async def test_embeddings():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_embeddings_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = embeddings.RequestPayload(input="Test text")
+        response = await provider.embeddings(payload)
+
+    result = jsonable_encoder(response)
+    assert result["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+
+
+def test_config_default_api_key():
+    config = OllamaConfig()
+    assert config.api_key == "ollama"
+
+
+def test_config_no_api_key_required():
+    config = OllamaConfig(api_base="http://custom:11434/v1")
+    assert config.api_key == "ollama"
+    assert config.api_base == "http://custom:11434/v1"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21995/files) to review incremental changes.
- [**stack/ollama-provider**](https://github.com/mlflow/mlflow/pull/21995) [[Files changed](https://github.com/mlflow/mlflow/pull/21995/files)]
  - [stack/databricks-provider](https://github.com/mlflow/mlflow/pull/21997) [[Files changed](https://github.com/mlflow/mlflow/pull/21997/files/9c06ed39cbbf2cd74fe26aba9ee9bdb11c2eb7c7..5032ec42674dd8b187874f497e33dcf28ff6f731)]
    - [stack/vertex-ai-provider](https://github.com/mlflow/mlflow/pull/21998) [[Files changed](https://github.com/mlflow/mlflow/pull/21998/files/5032ec42674dd8b187874f497e33dcf28ff6f731..37cddb93e2a19c407102ebe767b52a599fad4554)]
      - [stack/bedrock-provider-complete](https://github.com/mlflow/mlflow/pull/21999) [[Files changed](https://github.com/mlflow/mlflow/pull/21999/files/37cddb93e2a19c407102ebe767b52a599fad4554..195fc26f61a0d1cd5f77cf2fcb932396fc7f06eb)]

---------
### What changes are proposed in this pull request?

Add Ollama as a native gateway provider extending `OpenAICompatibleProvider`. Ollama runs locally and doesn't require an API key, so the config defaults to `api_key=\"ollama\"` and `api_base=\"http://localhost:11434/v1\"`.

Provider: `ollama` | Default API base: `http://localhost:11434/v1`

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests 

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
