### PR TITLE
Disable workflows that use secrets beyond `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -13,7 +13,8 @@ jobs:
   check-comment:
     runs-on: ubuntu-slim
     timeout-minutes: 10
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/autoformat') }}
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false && github.event.issue.pull_request && startsWith(github.event.comment.body, '/autoformat')
     permissions:
       statuses: write # autoformat.createStatus
       pull-requests: write # autoformat.createReaction on PRs
@@ -62,7 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: check-comment
-    if: ${{ needs.check-comment.outputs.should_autoformat == 'true' }}
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false && needs.check-comment.outputs.should_autoformat == 'true'
     permissions:
       pull-requests: read # view files modified in PR
     outputs:
@@ -203,7 +205,8 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     needs: [check-comment, format]
-    if: ${{ needs.format.outputs.reformatted == 'true' }}
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false && needs.format.outputs.reformatted == 'true'
     permissions:
       contents: read
     outputs:
@@ -285,7 +288,8 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
     needs: [check-comment, format, push]
-    if: always() && needs.check-comment.outputs.should_autoformat == 'true'
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false && always() && needs.check-comment.outputs.should_autoformat == 'true'
     permissions:
       statuses: write # To update check statuses
       actions: write # To approve workflow runs

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -11,7 +11,8 @@ defaults:
 
 jobs:
   main:
-    if: github.repository == 'mlflow/mlflow'
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false && github.repository == 'mlflow/mlflow'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # To post comments on PRs

--- a/.github/workflows/remove-experimental-decorators.yml
+++ b/.github/workflows/remove-experimental-decorators.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     # Only run on the main repository
-    if: github.repository == 'mlflow/mlflow'
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false && github.repository == 'mlflow/mlflow'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -23,7 +23,9 @@ jobs:
     permissions:
       pull-requests: write
     timeout-minutes: 5
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
     if: >
+      false &&
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
@@ -127,6 +129,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   resolve:
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false
     needs: precheck
     runs-on: ubuntu-latest
     permissions:
@@ -211,7 +215,9 @@ jobs:
 
   report:
     needs: [precheck, resolve]
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
     if: |
+      false &&
       always() &&
       !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'skipped')

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -25,7 +25,9 @@ jobs:
     # Security: Only run for authorized users.
     # - pull_request: Only run for non-fork PRs
     # - issue_comment: BOTH PR author and commenter must be authorized (can't trust external PRs)
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
     if: >
+      false &&
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot') &&

--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -21,7 +21,9 @@ jobs:
     # Trigger conditions:
     # - pull_request: skip fork PRs (no access to secrets)
     # - issue_comment: only maintainers can trigger via `/title` on PRs or issues
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
     if: >
+      false &&
       (
         github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -16,7 +16,8 @@ defaults:
 jobs:
   # Test job: runs on PR changes against a fixed set of issues
   test:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions: {}
@@ -35,9 +36,8 @@ jobs:
   # Main job: runs on new bug issues
   # Comments are only posted for area/uiux bugs; other bugs are triaged silently for observation.
   triage:
-    if: >-
-      github.event_name == 'issues'
-      && contains(github.event.issue.labels.*.name, 'bug')
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false && github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'bug')
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -29,8 +29,10 @@ env:
 
 jobs:
   notify:
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
     if: >-
-      github.event_name != 'push'
+      false
+      && github.event_name != 'push'
       && github.event.action != 'closed'
       && contains(github.event.pull_request.labels.*.name, 'ui-preview')
       && (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
@@ -68,7 +70,9 @@ jobs:
           fi
 
   build:
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
     if: >-
+      false &&
       github.event_name == 'push'
       || (
         github.event.action != 'closed'
@@ -148,6 +152,8 @@ jobs:
           retention-days: 1
 
   deploy:
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false
     needs: build
     runs-on: ubuntu-ui-preview
     permissions:
@@ -267,8 +273,10 @@ jobs:
           fi
 
   cleanup:
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
     if: >-
-      github.event_name != 'push'
+      false
+      && github.event_name != 'push'
       && github.event.action == 'closed'
       && contains(github.event.pull_request.labels.*.name, 'ui-preview')
     runs-on: ubuntu-ui-preview

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -23,7 +23,8 @@ defaults:
 jobs:
   uv:
     # Skip scheduled runs on forks
-    if: github.event_name != 'schedule' || github.repository == 'mlflow/mlflow'
+    # TODO: Re-enable after https://github.com/BerriAI/litellm/issues/24512 is resolved
+    if: false && (github.event_name != 'schedule' || github.repository == 'mlflow/mlflow')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/BerriAI/litellm/issues/24512

### What changes are proposed in this pull request?

Temporarily disable workflows that access external secrets. Each job's `if:` condition is prefixed with `false &&` to preserve the original condition for easy re-enablement.

Disabled workflows:
- `triage.yml` (`ANTHROPIC_API_KEY`)
- `title.yml` (`ANTHROPIC_API_KEY`)
- `review.yml` (`ANTHROPIC_API_KEY`)
- `ui-preview.yml` (`DATABRICKS_HOST`, `DATABRICKS_CLIENT_ID`, `DATABRICKS_CLIENT_SECRET`)
- `autoformat.yml` (`APP_ID`, `APP_PRIVATE_KEY`)
- `remove-experimental-decorators.yml` (`APP_ID`, `APP_PRIVATE_KEY`)
- `preview-docs.yml` (`NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`)
- `resolve.yml` (`APP_ID`, `APP_PRIVATE_KEY`, `ANTHROPIC_API_KEY`)
- `uv.yml` (`APP_ID`, `APP_PRIVATE_KEY`)

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)