### PR TITLE
Add native Databricks gateway provider

### DIFF
--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -29,6 +29,7 @@ def _register_default_providers(registry: ProviderRegistry):
     from mlflow.gateway.providers.anthropic import AnthropicProvider
     from mlflow.gateway.providers.bedrock import AmazonBedrockProvider
     from mlflow.gateway.providers.cohere import CohereProvider
+    from mlflow.gateway.providers.databricks import DatabricksProvider
     from mlflow.gateway.providers.deepseek import DeepSeekProvider
     from mlflow.gateway.providers.gemini import GeminiProvider
     from mlflow.gateway.providers.groq import GroqProvider
@@ -49,6 +50,8 @@ def _register_default_providers(registry: ProviderRegistry):
     registry.register(Provider.ANTHROPIC, AnthropicProvider)
     registry.register(Provider.BEDROCK, AmazonBedrockProvider)
     registry.register(Provider.COHERE, CohereProvider)
+    registry.register(Provider.DATABRICKS, DatabricksProvider)
+    registry.register(Provider.DATABRICKS_MODEL_SERVING, DatabricksProvider)
     registry.register(Provider.DEEPSEEK, DeepSeekProvider)
     registry.register(Provider.GEMINI, GeminiProvider)
     registry.register(Provider.GROQ, GroqProvider)

--- a/mlflow/gateway/providers/databricks.py
+++ b/mlflow/gateway/providers/databricks.py
@@ -96,16 +96,9 @@ class DatabricksProvider(OpenAICompatibleProvider):
         if self._workspace_client is None:
             from databricks.sdk import WorkspaceClient
 
-            cfg = self._provider_config
-            kwargs = {}
-            if cfg.host:
-                kwargs["host"] = cfg.host
-            if cfg.token:
-                kwargs["token"] = cfg.token
-            if cfg.client_id:
-                kwargs["client_id"] = cfg.client_id
-            if cfg.client_secret:
-                kwargs["client_secret"] = cfg.client_secret
+            # Pass only non-None fields to WorkspaceClient; omitted fields
+            # are resolved by the SDK's default credential chain.
+            kwargs = {k: v for k, v in self._provider_config.model_dump().items() if v is not None}
             self._workspace_client = WorkspaceClient(**kwargs)
         return self._workspace_client
 

--- a/mlflow/gateway/providers/databricks.py
+++ b/mlflow/gateway/providers/databricks.py
@@ -1,18 +1,28 @@
 import logging
 import time
+from typing import Any
 
 import requests
 from pydantic import field_validator, model_validator
 
 from mlflow.gateway.base_models import ConfigModel
-from mlflow.gateway.config import OpenAICompatibleConfig, _resolve_api_key_from_input
-from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
+from mlflow.gateway.config import (
+    EndpointConfig,
+    _OpenAICompatibleConfig,
+    _resolve_api_key_from_input,
+)
+from mlflow.gateway.providers.base import PassthroughAction
+from mlflow.gateway.providers.openai_compatible import (
+    OpenAICompatibleAdapter,
+    OpenAICompatibleProvider,
+)
+from mlflow.gateway.schemas import chat
 from mlflow.gateway.utils import normalize_databricks_base_url
 
 _logger = logging.getLogger(__name__)
 
 
-class DatabricksConfig(OpenAICompatibleConfig):
+class DatabricksConfig(_OpenAICompatibleConfig):
     """Config for Databricks PAT token authentication."""
 
     api_base: str
@@ -44,6 +54,30 @@ class DatabricksOAuthConfig(ConfigModel):
         return self
 
 
+_SUPPORTED_CONTENT_PART_TYPES = {"text", "image_url", "input_audio"}
+
+
+class DatabricksAdapter(OpenAICompatibleAdapter):
+    """Adapter that handles Databricks-specific response quirks."""
+
+    @classmethod
+    def _normalize_content(cls, content: Any) -> str | None:
+        if not isinstance(content, list):
+            return content
+        supported = [p for p in content if p.get("type") in _SUPPORTED_CONTENT_PART_TYPES]
+        if all(p.get("type") == "text" for p in supported):
+            return "\n".join(p.get("text", "") for p in supported) or None
+        return supported or None
+
+    @classmethod
+    def model_to_chat(cls, resp: dict[str, Any], config: EndpointConfig) -> chat.ResponsePayload:
+        # Normalize content before delegating to the base adapter
+        for choice in resp.get("choices", []):
+            if msg := choice.get("message"):
+                msg["content"] = cls._normalize_content(msg.get("content"))
+        return super().model_to_chat(resp, config)
+
+
 class DatabricksProvider(OpenAICompatibleProvider):
     """Databricks provider supporting PAT token and OAuth M2M authentication.
 
@@ -58,9 +92,21 @@ class DatabricksProvider(OpenAICompatibleProvider):
     CONFIG_TYPE = DatabricksConfig
     DEFAULT_API_BASE = ""
 
+    PASSTHROUGH_PROVIDER_PATHS = {
+        PassthroughAction.OPENAI_CHAT: "chat/completions",
+        PassthroughAction.OPENAI_EMBEDDINGS: "embeddings",
+        PassthroughAction.OPENAI_RESPONSES: "responses",
+    }
+
+    @property
+    def adapter_class(self):
+        return DatabricksAdapter
+
     def __init__(self, config, enable_tracing=False):
-        # Accept both DatabricksConfig and DatabricksOAuthConfig — skip the
-        # strict CONFIG_TYPE check in OpenAICompatibleProvider.__init__
+        # Initialize via BaseProvider directly because this provider accepts
+        # two config types (DatabricksConfig for PAT, DatabricksOAuthConfig
+        # for OAuth M2M), while OpenAICompatibleProvider.__init__ only allows
+        # CONFIG_TYPE.
         from mlflow.gateway.providers.base import BaseProvider
 
         BaseProvider.__init__(self, config, enable_tracing=enable_tracing)

--- a/mlflow/gateway/providers/databricks.py
+++ b/mlflow/gateway/providers/databricks.py
@@ -1,0 +1,105 @@
+import logging
+import time
+
+import requests
+from pydantic import field_validator, model_validator
+
+from mlflow.gateway.base_models import ConfigModel
+from mlflow.gateway.config import OpenAICompatibleConfig, _resolve_api_key_from_input
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
+from mlflow.gateway.utils import normalize_databricks_base_url
+
+_logger = logging.getLogger(__name__)
+
+
+class DatabricksConfig(OpenAICompatibleConfig):
+    """Config for Databricks PAT token authentication."""
+
+    api_base: str
+
+    @field_validator("api_key", mode="before")
+    def validate_api_key(cls, value):
+        return _resolve_api_key_from_input(value)
+
+    @model_validator(mode="after")
+    def normalize_api_base(self):
+        self.api_base = normalize_databricks_base_url(self.api_base)
+        return self
+
+
+class DatabricksOAuthConfig(ConfigModel):
+    """Config for Databricks OAuth M2M (Service Principal) authentication."""
+
+    api_base: str
+    client_id: str
+    client_secret: str
+
+    @field_validator("client_secret", mode="before")
+    def validate_client_secret(cls, value):
+        return _resolve_api_key_from_input(value)
+
+    @model_validator(mode="after")
+    def normalize_api_base(self):
+        self.api_base = normalize_databricks_base_url(self.api_base)
+        return self
+
+
+class DatabricksProvider(OpenAICompatibleProvider):
+    """Databricks provider supporting PAT token and OAuth M2M authentication.
+
+    Auth mode is determined by the config type:
+    - ``DatabricksConfig``: Uses PAT token (api_key) directly as Bearer token.
+    - ``DatabricksOAuthConfig``: Exchanges client_id + client_secret for a
+      short-lived access token via the workspace OIDC endpoint, with
+      automatic refresh before expiry.
+    """
+
+    NAME = "Databricks"
+    CONFIG_TYPE = DatabricksConfig
+    DEFAULT_API_BASE = ""
+
+    def __init__(self, config, enable_tracing=False):
+        # Accept both DatabricksConfig and DatabricksOAuthConfig — skip the
+        # strict CONFIG_TYPE check in OpenAICompatibleProvider.__init__
+        from mlflow.gateway.providers.base import BaseProvider
+
+        BaseProvider.__init__(self, config, enable_tracing=enable_tracing)
+        self._provider_config = config.model.config
+        self._access_token: str | None = None
+        self._token_expiry: float = 0
+
+    @property
+    def _is_oauth(self) -> bool:
+        return isinstance(self._provider_config, DatabricksOAuthConfig)
+
+    def _get_workspace_host(self) -> str:
+        return self._provider_config.api_base.removesuffix("/serving-endpoints")
+
+    def _refresh_token(self) -> None:
+        host = self._get_workspace_host()
+        token_url = f"{host}/oidc/v1/token"
+
+        response = requests.post(
+            token_url,
+            data={"grant_type": "client_credentials", "scope": "all-apis"},
+            auth=(self._provider_config.client_id, self._provider_config.client_secret),
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        token_data = response.json()
+        self._access_token = token_data["access_token"]
+        expires_in = token_data.get("expires_in", 3600)
+        self._token_expiry = time.monotonic() + expires_in - 60
+
+    def _ensure_token(self) -> str:
+        if self._access_token is None or time.monotonic() >= self._token_expiry:
+            self._refresh_token()
+        return self._access_token
+
+    @property
+    def headers(self) -> dict[str, str]:
+        if self._is_oauth:
+            token = self._ensure_token()
+            return {"Authorization": f"Bearer {token}"}
+        return {"Authorization": f"Bearer {self._provider_config.api_key}"}

--- a/mlflow/gateway/providers/databricks.py
+++ b/mlflow/gateway/providers/databricks.py
@@ -1,16 +1,7 @@
-import logging
-import time
 from typing import Any
 
-import requests
-from pydantic import field_validator, model_validator
-
 from mlflow.gateway.base_models import ConfigModel
-from mlflow.gateway.config import (
-    EndpointConfig,
-    _OpenAICompatibleConfig,
-    _resolve_api_key_from_input,
-)
+from mlflow.gateway.config import EndpointConfig
 from mlflow.gateway.providers.base import PassthroughAction
 from mlflow.gateway.providers.openai_compatible import (
     OpenAICompatibleAdapter,
@@ -19,46 +10,36 @@ from mlflow.gateway.providers.openai_compatible import (
 from mlflow.gateway.schemas import chat
 from mlflow.gateway.utils import normalize_databricks_base_url
 
-_logger = logging.getLogger(__name__)
-
-
-class DatabricksConfig(_OpenAICompatibleConfig):
-    """Config for Databricks PAT token authentication."""
-
-    api_base: str
-
-    @field_validator("api_key", mode="before")
-    def validate_api_key(cls, value):
-        return _resolve_api_key_from_input(value)
-
-    @model_validator(mode="after")
-    def normalize_api_base(self):
-        self.api_base = normalize_databricks_base_url(self.api_base)
-        return self
-
-
-class DatabricksOAuthConfig(ConfigModel):
-    """Config for Databricks OAuth M2M (Service Principal) authentication."""
-
-    api_base: str
-    client_id: str
-    client_secret: str
-
-    @field_validator("client_secret", mode="before")
-    def validate_client_secret(cls, value):
-        return _resolve_api_key_from_input(value)
-
-    @model_validator(mode="after")
-    def normalize_api_base(self):
-        self.api_base = normalize_databricks_base_url(self.api_base)
-        return self
-
-
 _SUPPORTED_CONTENT_PART_TYPES = {"text", "image_url", "input_audio"}
 
 
+class DatabricksConfig(ConfigModel):
+    """Config for Databricks provider.
+
+    All fields are optional. When omitted, the Databricks SDK's default
+    credential chain resolves host and authentication automatically
+    (PAT, OAuth M2M, Azure CLI, etc.).
+
+    Args:
+        host: Databricks workspace URL (e.g., "https://my-workspace.databricks.com").
+        token: Databricks Personal Access Token.
+        client_id: OAuth M2M client ID (Service Principal).
+        client_secret: OAuth M2M client secret (Service Principal).
+    """
+
+    host: str | None = None
+    token: str | None = None
+    client_id: str | None = None
+    client_secret: str | None = None
+
+
 class DatabricksAdapter(OpenAICompatibleAdapter):
-    """Adapter that handles Databricks-specific response quirks."""
+    """Adapter that handles Databricks-specific response quirks.
+
+    Databricks models may return unsupported content part types (e.g.,
+    "reasoning") that the gateway schema doesn't support. This adapter
+    filters them out.
+    """
 
     @classmethod
     def _normalize_content(cls, content: Any) -> str | None:
@@ -71,7 +52,6 @@ class DatabricksAdapter(OpenAICompatibleAdapter):
 
     @classmethod
     def model_to_chat(cls, resp: dict[str, Any], config: EndpointConfig) -> chat.ResponsePayload:
-        # Normalize content before delegating to the base adapter
         for choice in resp.get("choices", []):
             if msg := choice.get("message"):
                 msg["content"] = cls._normalize_content(msg.get("content"))
@@ -79,73 +59,63 @@ class DatabricksAdapter(OpenAICompatibleAdapter):
 
 
 class DatabricksProvider(OpenAICompatibleProvider):
-    """Databricks provider supporting PAT token and OAuth M2M authentication.
+    """Databricks provider using the Databricks SDK for authentication.
 
-    Auth mode is determined by the config type:
-    - ``DatabricksConfig``: Uses PAT token (api_key) directly as Bearer token.
-    - ``DatabricksOAuthConfig``: Exchanges client_id + client_secret for a
-      short-lived access token via the workspace OIDC endpoint, with
-      automatic refresh before expiry.
+    Supports all auth methods provided by the Databricks SDK's default
+    credential chain: PAT tokens, OAuth M2M (Service Principal), Azure CLI,
+    Azure MSI, Google Cloud credentials, Databricks CLI profiles, etc.
+
+    When explicit credentials (host/token/client_id/client_secret) are
+    provided in the config, they are passed to the SDK. Otherwise the SDK
+    resolves credentials from environment variables, ~/.databrickscfg, etc.
     """
 
     NAME = "Databricks"
     CONFIG_TYPE = DatabricksConfig
-    DEFAULT_API_BASE = ""
 
     PASSTHROUGH_PROVIDER_PATHS = {
         PassthroughAction.OPENAI_CHAT: "chat/completions",
         PassthroughAction.OPENAI_EMBEDDINGS: "embeddings",
         PassthroughAction.OPENAI_RESPONSES: "responses",
+        PassthroughAction.ANTHROPIC_MESSAGES: "messages",
+        PassthroughAction.GEMINI_GENERATE_CONTENT: "{model}:generateContent",
+        PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT: "{model}:streamGenerateContent",
     }
 
     @property
     def adapter_class(self):
         return DatabricksAdapter
 
-    def __init__(self, config, enable_tracing=False):
-        # Initialize via BaseProvider directly because this provider accepts
-        # two config types (DatabricksConfig for PAT, DatabricksOAuthConfig
-        # for OAuth M2M), while OpenAICompatibleProvider.__init__ only allows
-        # CONFIG_TYPE.
-        from mlflow.gateway.providers.base import BaseProvider
-
-        BaseProvider.__init__(self, config, enable_tracing=enable_tracing)
+    def __init__(self, config: EndpointConfig, enable_tracing: bool = False):
+        self.config = config
+        self._enable_tracing = enable_tracing
         self._provider_config = config.model.config
-        self._access_token: str | None = None
-        self._token_expiry: float = 0
+        self._workspace_client = None
+
+    def _get_workspace_client(self):
+        if self._workspace_client is None:
+            from databricks.sdk import WorkspaceClient
+
+            cfg = self._provider_config
+            kwargs = {}
+            if cfg.host:
+                kwargs["host"] = cfg.host
+            if cfg.token:
+                kwargs["token"] = cfg.token
+            if cfg.client_id:
+                kwargs["client_id"] = cfg.client_id
+            if cfg.client_secret:
+                kwargs["client_secret"] = cfg.client_secret
+            self._workspace_client = WorkspaceClient(**kwargs)
+        return self._workspace_client
 
     @property
-    def _is_oauth(self) -> bool:
-        return isinstance(self._provider_config, DatabricksOAuthConfig)
-
-    def _get_workspace_host(self) -> str:
-        return self._provider_config.api_base.removesuffix("/serving-endpoints")
-
-    def _refresh_token(self) -> None:
-        host = self._get_workspace_host()
-        token_url = f"{host}/oidc/v1/token"
-
-        response = requests.post(
-            token_url,
-            data={"grant_type": "client_credentials", "scope": "all-apis"},
-            auth=(self._provider_config.client_id, self._provider_config.client_secret),
-            timeout=30,
-        )
-        response.raise_for_status()
-
-        token_data = response.json()
-        self._access_token = token_data["access_token"]
-        expires_in = token_data.get("expires_in", 3600)
-        self._token_expiry = time.monotonic() + expires_in - 60
-
-    def _ensure_token(self) -> str:
-        if self._access_token is None or time.monotonic() >= self._token_expiry:
-            self._refresh_token()
-        return self._access_token
+    def _api_base(self) -> str:
+        client = self._get_workspace_client()
+        host = client.config.host.rstrip("/")
+        return normalize_databricks_base_url(host)
 
     @property
     def headers(self) -> dict[str, str]:
-        if self._is_oauth:
-            token = self._ensure_token()
-            return {"Authorization": f"Bearer {token}"}
-        return {"Authorization": f"Bearer {self._provider_config.api_key}"}
+        client = self._get_workspace_client()
+        return client.config.authenticate()

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -19,6 +19,8 @@ from mlflow.entities.gateway_endpoint import GatewayModelLinkageType
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import (
     AnthropicConfig,
+    DatabricksConfig,
+    DatabricksOAuthConfig,
     EndpointConfig,
     EndpointType,
     GatewayRequestType,
@@ -252,6 +254,21 @@ def _build_endpoint_config(
         Provider.OLLAMA,
     }:
         provider_config = _build_openai_compatible_config(model_config)
+    elif model_config.provider in (Provider.DATABRICKS, Provider.DATABRICKS_MODEL_SERVING):
+        auth_config = model_config.auth_config or {}
+        auth_mode = auth_config.get(_AuthConfigKey.AUTH_MODE, "pat_token")
+        if auth_mode == "oauth_m2m":
+            provider_config = DatabricksOAuthConfig(
+                api_base=auth_config.get(_AuthConfigKey.API_BASE, ""),
+                client_id=auth_config.get("client_id", ""),
+                client_secret=model_config.secret_value.get("client_secret", ""),
+            )
+        else:
+            provider_config = DatabricksConfig(
+                api_key=model_config.secret_value.get(_AuthConfigKey.API_KEY),
+                api_base=auth_config.get(_AuthConfigKey.API_BASE, ""),
+            )
+        model_config.provider = Provider.DATABRICKS
     else:
         # Use LiteLLM as fallback for unsupported providers
         # Store the original provider name for LiteLLM's provider/model format

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -19,8 +19,6 @@ from mlflow.entities.gateway_endpoint import GatewayModelLinkageType
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import (
     AnthropicConfig,
-    DatabricksConfig,
-    DatabricksOAuthConfig,
     EndpointConfig,
     EndpointType,
     GatewayRequestType,
@@ -255,19 +253,19 @@ def _build_endpoint_config(
     }:
         provider_config = _build_openai_compatible_config(model_config)
     elif model_config.provider in (Provider.DATABRICKS, Provider.DATABRICKS_MODEL_SERVING):
+        from mlflow.gateway.providers.databricks import DatabricksConfig
+
         auth_config = model_config.auth_config or {}
         auth_mode = auth_config.get(_AuthConfigKey.AUTH_MODE, "pat_token")
+        config_kwargs = {}
+        if api_base := auth_config.get(_AuthConfigKey.API_BASE):
+            config_kwargs["host"] = api_base
         if auth_mode == "oauth_m2m":
-            provider_config = DatabricksOAuthConfig(
-                api_base=auth_config.get(_AuthConfigKey.API_BASE, ""),
-                client_id=auth_config.get("client_id", ""),
-                client_secret=model_config.secret_value.get("client_secret", ""),
-            )
+            config_kwargs["client_id"] = auth_config.get("client_id")
+            config_kwargs["client_secret"] = model_config.secret_value.get("client_secret")
         else:
-            provider_config = DatabricksConfig(
-                api_key=model_config.secret_value.get(_AuthConfigKey.API_KEY),
-                api_base=auth_config.get(_AuthConfigKey.API_BASE, ""),
-            )
+            config_kwargs["token"] = model_config.secret_value.get(_AuthConfigKey.API_KEY)
+        provider_config = DatabricksConfig(**config_kwargs)
         model_config.provider = Provider.DATABRICKS
     else:
         # Use LiteLLM as fallback for unsupported providers

--- a/tests/gateway/providers/test_databricks.py
+++ b/tests/gateway/providers/test_databricks.py
@@ -2,59 +2,34 @@ from unittest import mock
 
 import pytest
 from fastapi.encoders import jsonable_encoder
-from pydantic import ValidationError
 
 from mlflow.gateway.config import EndpointConfig
-from mlflow.gateway.providers.databricks import (
-    DatabricksConfig,
-    DatabricksOAuthConfig,
-    DatabricksProvider,
-)
+from mlflow.gateway.providers.databricks import DatabricksConfig, DatabricksProvider
 from mlflow.gateway.schemas import chat, embeddings
 
 from tests.gateway.tools import MockAsyncResponse, mock_http_client
 
 
-def _make_provider(
-    *,
-    api_base: str = "https://my-workspace.databricks.com",
-) -> DatabricksProvider:
+def _mock_workspace_client(host="https://my-workspace.databricks.com"):
+    client = mock.Mock()
+    client.config.host = host
+    client.config.authenticate.return_value = {"Authorization": "Bearer mock-token"}
+    return client
+
+
+def _make_provider(*, host: str = "https://my-workspace.databricks.com") -> DatabricksProvider:
     endpoint_config = EndpointConfig(
         name="databricks-endpoint",
         endpoint_type="llm/v1/chat",
         model={
             "provider": "databricks",
             "name": "databricks-dbrx-instruct",
-            "config": {
-                "api_key": "dapi-test-key",
-                "api_base": api_base,
-            },
+            "config": {"host": host, "token": "dapi-test-key"},
         },
     )
-    return DatabricksProvider(endpoint_config)
-
-
-def _make_oauth_provider() -> DatabricksProvider:
-    oauth_config = DatabricksOAuthConfig(
-        api_base="https://my-workspace.databricks.com",
-        client_id="test-client-id",
-        client_secret="test-client-secret",
-    )
-    endpoint_config = EndpointConfig(
-        name="databricks-oauth-endpoint",
-        endpoint_type="llm/v1/chat",
-        model={
-            "provider": "databricks",
-            "name": "databricks-dbrx-instruct",
-            "config": {
-                "api_key": "dapi-test-key",
-                "api_base": "https://my-workspace.databricks.com",
-            },
-        },
-    )
-    # Replace config with OAuth config
-    endpoint_config.model.config = oauth_config
-    return DatabricksProvider(endpoint_config)
+    provider = DatabricksProvider(endpoint_config)
+    provider._workspace_client = _mock_workspace_client(host)
+    return provider
 
 
 def _chat_response():
@@ -89,27 +64,85 @@ def _embeddings_response():
     }
 
 
-# --- PAT token tests ---
-
-
 def test_api_base_normalization():
-    provider = _make_provider(api_base="https://my-workspace.databricks.com")
+    provider = _make_provider(host="https://my-workspace.databricks.com")
     assert provider._api_base == "https://my-workspace.databricks.com/serving-endpoints"
 
 
-def test_api_base_already_normalized():
-    provider = _make_provider(api_base="https://my-workspace.databricks.com/serving-endpoints")
-    assert provider._api_base == "https://my-workspace.databricks.com/serving-endpoints"
-
-
-def test_headers():
+def test_headers_from_sdk():
     provider = _make_provider()
-    assert provider.headers == {"Authorization": "Bearer dapi-test-key"}
+    assert provider.headers == {"Authorization": "Bearer mock-token"}
+    provider._workspace_client.config.authenticate.assert_called_once()
 
 
 def test_name():
     provider = _make_provider()
     assert provider.NAME == "Databricks"
+
+
+def test_sdk_receives_explicit_credentials():
+    endpoint_config = EndpointConfig(
+        name="databricks-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "databricks",
+            "name": "databricks-dbrx-instruct",
+            "config": {
+                "host": "https://my-workspace.databricks.com",
+                "token": "dapi-explicit-key",
+            },
+        },
+    )
+    provider = DatabricksProvider(endpoint_config)
+    with mock.patch("databricks.sdk.WorkspaceClient") as mock_ws:
+        mock_ws.return_value = _mock_workspace_client()
+        provider._get_workspace_client()
+        mock_ws.assert_called_once_with(
+            host="https://my-workspace.databricks.com",
+            token="dapi-explicit-key",
+        )
+
+
+def test_sdk_oauth_m2m_credentials():
+    endpoint_config = EndpointConfig(
+        name="databricks-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "databricks",
+            "name": "databricks-dbrx-instruct",
+            "config": {
+                "host": "https://my-workspace.databricks.com",
+                "client_id": "my-client-id",
+                "client_secret": "my-client-secret",
+            },
+        },
+    )
+    provider = DatabricksProvider(endpoint_config)
+    with mock.patch("databricks.sdk.WorkspaceClient") as mock_ws:
+        mock_ws.return_value = _mock_workspace_client()
+        provider._get_workspace_client()
+        mock_ws.assert_called_once_with(
+            host="https://my-workspace.databricks.com",
+            client_id="my-client-id",
+            client_secret="my-client-secret",
+        )
+
+
+def test_sdk_default_credentials():
+    endpoint_config = EndpointConfig(
+        name="databricks-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "databricks",
+            "name": "databricks-dbrx-instruct",
+            "config": {},
+        },
+    )
+    provider = DatabricksProvider(endpoint_config)
+    with mock.patch("databricks.sdk.WorkspaceClient") as mock_ws:
+        mock_ws.return_value = _mock_workspace_client()
+        provider._get_workspace_client()
+        mock_ws.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -141,105 +174,9 @@ async def test_embeddings():
     assert result["data"][0]["embedding"] == [0.1, 0.2, 0.3]
 
 
-# --- OAuth M2M tests ---
-
-
-def test_oauth_token_exchange():
-    provider = _make_oauth_provider()
-    mock_response = mock.Mock()
-    mock_response.json.return_value = {
-        "access_token": "oauth-access-token-123",
-        "token_type": "Bearer",
-        "expires_in": 3600,
-    }
-    mock_response.raise_for_status = mock.Mock()
-
-    with mock.patch("requests.post", return_value=mock_response) as mock_post:
-        headers = provider.headers
-
-    assert headers == {"Authorization": "Bearer oauth-access-token-123"}
-    mock_post.assert_called_once_with(
-        "https://my-workspace.databricks.com/oidc/v1/token",
-        data={"grant_type": "client_credentials", "scope": "all-apis"},
-        auth=("test-client-id", "test-client-secret"),
-        timeout=30,
-    )
-
-
-def test_oauth_token_caching():
-    provider = _make_oauth_provider()
-    mock_response = mock.Mock()
-    mock_response.json.return_value = {
-        "access_token": "cached-token",
-        "token_type": "Bearer",
-        "expires_in": 3600,
-    }
-    mock_response.raise_for_status = mock.Mock()
-
-    with mock.patch("requests.post", return_value=mock_response) as mock_post:
-        # First call fetches token
-        headers1 = provider.headers
-        # Second call uses cached token
-        headers2 = provider.headers
-
-    assert headers1 == headers2 == {"Authorization": "Bearer cached-token"}
-    mock_post.assert_called_once()  # Only one HTTP call
-
-
-@pytest.mark.asyncio
-async def test_oauth_chat():
-    provider = _make_oauth_provider()
-    mock_token_response = mock.Mock()
-    mock_token_response.json.return_value = {
-        "access_token": "oauth-token",
-        "token_type": "Bearer",
-        "expires_in": 3600,
-    }
-    mock_token_response.raise_for_status = mock.Mock()
-
-    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
-
-    with (
-        mock.patch("requests.post", return_value=mock_token_response),
-        mock.patch("aiohttp.ClientSession", return_value=mock_client),
-    ):
-        payload = chat.RequestPayload(
-            messages=[{"role": "user", "content": "Hello"}],
-        )
-        response = await provider.chat(payload)
-
-    result = jsonable_encoder(response)
-    assert result["choices"][0]["message"]["content"] == "Hello from Databricks!"
-
-
-def test_oauth_api_base_normalization():
-    config = DatabricksOAuthConfig(
-        api_base="https://my-workspace.databricks.com",
-        client_id="cid",
-        client_secret="csecret",
-    )
-    assert config.api_base == "https://my-workspace.databricks.com/serving-endpoints"
-
-
-# --- config tests ---
-
-
-def test_url_normalization():
-    config = DatabricksConfig(
-        api_key="dapi-test",
-        api_base="https://my-workspace.databricks.com",
-    )
-    assert config.api_base == "https://my-workspace.databricks.com/serving-endpoints"
-
-
-def test_url_already_has_serving_endpoints():
-    config = DatabricksConfig(
-        api_key="dapi-test",
-        api_base="https://my-workspace.databricks.com/serving-endpoints",
-    )
-    assert config.api_base == "https://my-workspace.databricks.com/serving-endpoints"
-
-
-def test_api_base_required():
-    with pytest.raises(ValidationError, match="api_base"):
-        DatabricksConfig(api_key="dapi-test")
+def test_config_all_optional():
+    config = DatabricksConfig()
+    assert config.host is None
+    assert config.token is None
+    assert config.client_id is None
+    assert config.client_secret is None

--- a/tests/gateway/providers/test_databricks.py
+++ b/tests/gateway/providers/test_databricks.py
@@ -1,0 +1,245 @@
+from unittest import mock
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
+
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.databricks import (
+    DatabricksConfig,
+    DatabricksOAuthConfig,
+    DatabricksProvider,
+)
+from mlflow.gateway.schemas import chat, embeddings
+
+from tests.gateway.tools import MockAsyncResponse, mock_http_client
+
+
+def _make_provider(
+    *,
+    api_base: str = "https://my-workspace.databricks.com",
+) -> DatabricksProvider:
+    endpoint_config = EndpointConfig(
+        name="databricks-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "databricks",
+            "name": "databricks-dbrx-instruct",
+            "config": {
+                "api_key": "dapi-test-key",
+                "api_base": api_base,
+            },
+        },
+    )
+    return DatabricksProvider(endpoint_config)
+
+
+def _make_oauth_provider() -> DatabricksProvider:
+    oauth_config = DatabricksOAuthConfig(
+        api_base="https://my-workspace.databricks.com",
+        client_id="test-client-id",
+        client_secret="test-client-secret",
+    )
+    endpoint_config = EndpointConfig(
+        name="databricks-oauth-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "databricks",
+            "name": "databricks-dbrx-instruct",
+            "config": {
+                "api_key": "dapi-test-key",
+                "api_base": "https://my-workspace.databricks.com",
+            },
+        },
+    )
+    # Replace config with OAuth config
+    endpoint_config.model.config = oauth_config
+    return DatabricksProvider(endpoint_config)
+
+
+def _chat_response():
+    return {
+        "id": "chatcmpl-db-123",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "databricks-dbrx-instruct",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello from Databricks!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def _embeddings_response():
+    return {
+        "object": "list",
+        "data": [{"object": "embedding", "embedding": [0.1, 0.2, 0.3], "index": 0}],
+        "model": "bge-large-en",
+        "usage": {"prompt_tokens": 5, "total_tokens": 5},
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+# --- PAT token tests ---
+
+
+def test_api_base_normalization():
+    provider = _make_provider(api_base="https://my-workspace.databricks.com")
+    assert provider._api_base == "https://my-workspace.databricks.com/serving-endpoints"
+
+
+def test_api_base_already_normalized():
+    provider = _make_provider(api_base="https://my-workspace.databricks.com/serving-endpoints")
+    assert provider._api_base == "https://my-workspace.databricks.com/serving-endpoints"
+
+
+def test_headers():
+    provider = _make_provider()
+    assert provider.headers == {"Authorization": "Bearer dapi-test-key"}
+
+
+def test_name():
+    provider = _make_provider()
+    assert provider.NAME == "Databricks"
+
+
+@pytest.mark.asyncio
+async def test_chat():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["id"] == "chatcmpl-db-123"
+    assert result["choices"][0]["message"]["content"] == "Hello from Databricks!"
+
+
+@pytest.mark.asyncio
+async def test_embeddings():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_embeddings_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = embeddings.RequestPayload(input="Test text")
+        response = await provider.embeddings(payload)
+
+    result = jsonable_encoder(response)
+    assert result["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+
+
+# --- OAuth M2M tests ---
+
+
+def test_oauth_token_exchange():
+    provider = _make_oauth_provider()
+    mock_response = mock.Mock()
+    mock_response.json.return_value = {
+        "access_token": "oauth-access-token-123",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    mock_response.raise_for_status = mock.Mock()
+
+    with mock.patch("requests.post", return_value=mock_response) as mock_post:
+        headers = provider.headers
+
+    assert headers == {"Authorization": "Bearer oauth-access-token-123"}
+    mock_post.assert_called_once_with(
+        "https://my-workspace.databricks.com/oidc/v1/token",
+        data={"grant_type": "client_credentials", "scope": "all-apis"},
+        auth=("test-client-id", "test-client-secret"),
+        timeout=30,
+    )
+
+
+def test_oauth_token_caching():
+    provider = _make_oauth_provider()
+    mock_response = mock.Mock()
+    mock_response.json.return_value = {
+        "access_token": "cached-token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    mock_response.raise_for_status = mock.Mock()
+
+    with mock.patch("requests.post", return_value=mock_response) as mock_post:
+        # First call fetches token
+        headers1 = provider.headers
+        # Second call uses cached token
+        headers2 = provider.headers
+
+    assert headers1 == headers2 == {"Authorization": "Bearer cached-token"}
+    mock_post.assert_called_once()  # Only one HTTP call
+
+
+@pytest.mark.asyncio
+async def test_oauth_chat():
+    provider = _make_oauth_provider()
+    mock_token_response = mock.Mock()
+    mock_token_response.json.return_value = {
+        "access_token": "oauth-token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    mock_token_response.raise_for_status = mock.Mock()
+
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with (
+        mock.patch("requests.post", return_value=mock_token_response),
+        mock.patch("aiohttp.ClientSession", return_value=mock_client),
+    ):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["choices"][0]["message"]["content"] == "Hello from Databricks!"
+
+
+def test_oauth_api_base_normalization():
+    config = DatabricksOAuthConfig(
+        api_base="https://my-workspace.databricks.com",
+        client_id="cid",
+        client_secret="csecret",
+    )
+    assert config.api_base == "https://my-workspace.databricks.com/serving-endpoints"
+
+
+# --- config tests ---
+
+
+def test_url_normalization():
+    config = DatabricksConfig(
+        api_key="dapi-test",
+        api_base="https://my-workspace.databricks.com",
+    )
+    assert config.api_base == "https://my-workspace.databricks.com/serving-endpoints"
+
+
+def test_url_already_has_serving_endpoints():
+    config = DatabricksConfig(
+        api_key="dapi-test",
+        api_base="https://my-workspace.databricks.com/serving-endpoints",
+    )
+    assert config.api_base == "https://my-workspace.databricks.com/serving-endpoints"
+
+
+def test_api_base_required():
+    with pytest.raises(ValidationError, match="api_base"):
+        DatabricksConfig(api_key="dapi-test")

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -32,6 +32,7 @@ from mlflow.gateway.providers.base import (
     FallbackProvider,
     TrafficRouteProvider,
 )
+from mlflow.gateway.providers.databricks import DatabricksConfig, DatabricksProvider
 from mlflow.gateway.providers.gemini import GeminiProvider
 from mlflow.gateway.providers.litellm import LiteLLMProvider
 from mlflow.gateway.providers.mistral import MistralProvider
@@ -415,16 +416,10 @@ def test_create_provider_from_endpoint_name_databricks_normalizes_base_url(
         store, endpoint.name, EndpointType.LLM_V1_CHAT
     )
 
-    assert isinstance(provider, LiteLLMProvider)
-    assert isinstance(provider.config.model.config, LiteLLMConfig)
+    assert isinstance(provider, DatabricksProvider)
+    assert isinstance(provider.config.model.config, DatabricksConfig)
     # Verify the base URL was normalized to include /serving-endpoints
-    assert (
-        provider.config.model.config.litellm_auth_config["api_base"]
-        == "https://my-workspace.databricks.com/serving-endpoints"
-    )
-    assert provider.config.model.config.litellm_provider == "databricks"
-    # get_provider_name() returns "databricks" (the actual provider) instead of "LiteLLM"
-    assert provider.get_provider_name() == "databricks"
+    assert provider._api_base == "https://my-workspace.databricks.com/serving-endpoints"
 
 
 def test_api_key_not_read_from_file(store: SqlAlchemyStore, tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21997/files) to review incremental changes.
- [**stack/databricks-provider**](https://github.com/mlflow/mlflow/pull/21997) [[Files changed](https://github.com/mlflow/mlflow/pull/21997/files)]
  - [stack/vertex-ai-provider](https://github.com/mlflow/mlflow/pull/21998) [[Files changed](https://github.com/mlflow/mlflow/pull/21998/files/152d44465de923f30d005208ef14fa9c162bb920..d8e4e8cd49732fb7d885d14951ee1e55eaf436db)]
    - [stack/bedrock-provider-complete](https://github.com/mlflow/mlflow/pull/21999) [[Files changed](https://github.com/mlflow/mlflow/pull/21999/files/d8e4e8cd49732fb7d885d14951ee1e55eaf436db..c841b9c8a66f6d99dbe27a2f28452748ca8ed46e)]

---------
### What changes are proposed in this pull request?

Add Databricks as a native gateway provider extending `OpenAICompatibleProvider`. The provider automatically normalizes workspace URLs to include `/serving-endpoints`. Auth uses Databricks PAT (Personal Access Token).

Provider: `databricks` / `databricks-model-serving`

### How is this PR tested?

- [x] New unit/integration tests
- [x] manual tests 

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
