### PR TITLE
Add native Vertex AI gateway provider

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -798,6 +798,7 @@ mlflow.gateway.config.RouteDestinationConfig
 mlflow.gateway.config.TogetherAIConfig
 mlflow.gateway.config.TogetherAIConfig.validate_togetherai_api_key
 mlflow.gateway.config.TrafficRouteConfig
+mlflow.gateway.config.VertexAIConfig
 mlflow.gateway.get_gateway_uri
 mlflow.gateway.set_gateway_uri
 mlflow.gemini.autolog

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -63,6 +63,7 @@ class Provider(str, Enum):
     XAI = "xai"
     OPENROUTER = "openrouter"
     OLLAMA = "ollama"
+    VERTEX_AI = "vertex_ai"
 
     @classmethod
     def values(cls):

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -281,6 +281,12 @@ class _OpenAICompatibleConfig(ConfigModel):
         return _resolve_api_key_from_input(value)
 
 
+class VertexAIConfig(ConfigModel):
+    vertex_project: str
+    vertex_location: str | None = None
+    vertex_credentials: str | None = None
+
+
 class LiteLLMConfig(ConfigModel):
     litellm_provider: str | None = None
     litellm_auth_config: dict[str, Any] | None = None

--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -43,6 +43,7 @@ def _register_default_providers(registry: ProviderRegistry):
     from mlflow.gateway.providers.openrouter import OpenRouterProvider
     from mlflow.gateway.providers.palm import PaLMProvider
     from mlflow.gateway.providers.togetherai import TogetherAIProvider
+    from mlflow.gateway.providers.vertex_ai import VertexAIProvider
     from mlflow.gateway.providers.xai import XAIProvider
 
     registry.register(Provider.AI21LABS, AI21LabsProvider)
@@ -67,6 +68,7 @@ def _register_default_providers(registry: ProviderRegistry):
     registry.register(Provider.OPENROUTER, OpenRouterProvider)
     registry.register(Provider.PALM, PaLMProvider)
     registry.register(Provider.TOGETHERAI, TogetherAIProvider)
+    registry.register(Provider.VERTEX_AI, VertexAIProvider)
     registry.register(Provider.XAI, XAIProvider)
 
 

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -1,0 +1,96 @@
+"""
+Vertex AI provider for MLflow AI Gateway.
+
+Extends the Gemini provider to use Vertex AI endpoints with Google Cloud
+authentication (Application Default Credentials or service account JSON).
+
+Vertex AI uses the same Gemini API format but with different URL patterns
+and auth mechanism.
+"""
+
+import json
+from pathlib import Path
+
+from mlflow.gateway.base_models import ConfigModel
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.gemini import GeminiProvider
+
+_DEFAULT_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+
+class VertexAIConfig(ConfigModel):
+    vertex_project: str
+    vertex_location: str | None = None
+    vertex_credentials: str | None = None
+
+
+class VertexAIProvider(GeminiProvider):
+    """Vertex AI provider for Google's Gemini models.
+
+    Currently supports Google-published models only (e.g., gemini-2.0-flash).
+    Partner models hosted on Vertex AI (Anthropic, Mistral, Llama, etc.) use
+    different publisher paths and API formats (e.g., :rawPredict with
+    Anthropic Messages API) and are not yet supported by this provider.
+    """
+
+    NAME = "Vertex AI"
+    CONFIG_TYPE = VertexAIConfig
+
+    def __init__(self, config: EndpointConfig, enable_tracing: bool = False) -> None:
+        if not isinstance(config.model.config, VertexAIConfig):
+            raise TypeError(f"Unexpected config type {config.model.config}")
+        self.config = config
+        self._enable_tracing = enable_tracing
+        self.vertex_config: VertexAIConfig = config.model.config
+        self._cached_credentials = None
+
+    def _get_credentials(self):
+        """Get Google Cloud credentials, caching them for reuse."""
+        import google.auth
+        import google.auth.transport.requests
+        from google.oauth2 import service_account
+
+        if self._cached_credentials is not None and self._cached_credentials.valid:
+            return self._cached_credentials
+
+        if self.vertex_config.vertex_credentials:
+            creds_data = self.vertex_config.vertex_credentials
+            # Try parsing as JSON string
+            try:
+                info = json.loads(creds_data)
+            except (json.JSONDecodeError, TypeError):
+                # Try as file path
+                try:
+                    info = json.loads(Path(creds_data).read_text())
+                except Exception:
+                    raise ValueError(
+                        "vertex_credentials must be a JSON string or path to a JSON file"
+                    )
+            credentials = service_account.Credentials.from_service_account_info(
+                info, scopes=_DEFAULT_SCOPES
+            )
+        else:
+            # Use Application Default Credentials
+            credentials, _ = google.auth.default(scopes=_DEFAULT_SCOPES)
+
+        # Refresh to get a valid access token
+        credentials.refresh(google.auth.transport.requests.Request())
+        self._cached_credentials = credentials
+        return credentials
+
+    @property
+    def headers(self) -> dict[str, str]:
+        credentials = self._get_credentials()
+        return {"Authorization": f"Bearer {credentials.token}"}
+
+    @property
+    def base_url(self) -> str:
+        location = self.vertex_config.vertex_location
+        project = self.vertex_config.vertex_project
+        if location:
+            host = f"https://{location}-aiplatform.googleapis.com"
+            path = f"/v1/projects/{project}/locations/{location}/publishers/google/models"
+        else:
+            host = "https://aiplatform.googleapis.com"
+            path = f"/v1/projects/{project}/publishers/google/models"
+        return f"{host}{path}"

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -11,17 +11,10 @@ and auth mechanism.
 import json
 from pathlib import Path
 
-from mlflow.gateway.base_models import ConfigModel
-from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.config import EndpointConfig, VertexAIConfig
 from mlflow.gateway.providers.gemini import GeminiProvider
 
 _DEFAULT_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
-
-
-class VertexAIConfig(ConfigModel):
-    vertex_project: str
-    vertex_location: str | None = None
-    vertex_credentials: str | None = None
 
 
 class VertexAIProvider(GeminiProvider):

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -46,15 +46,20 @@ class VertexAIProvider(GeminiProvider):
 
     def _get_credentials(self):
         """Get Google Cloud credentials, caching them for reuse."""
-        import google.auth
-        import google.auth.transport.requests
-        from google.oauth2 import service_account
+        try:
+            import google.auth
+            import google.auth.transport.requests
+            from google.oauth2 import service_account
+        except ImportError:
+            raise ImportError(
+                "Vertex AI provider requires the google-auth package. "
+                "Install it with: pip install google-auth"
+            )
 
         if self._cached_credentials is not None and self._cached_credentials.valid:
             return self._cached_credentials
 
-        if self.vertex_config.vertex_credentials:
-            creds_data = self.vertex_config.vertex_credentials
+        if creds_data := self.vertex_config.vertex_credentials:
             # Try parsing as JSON string
             try:
                 info = json.loads(creds_data)
@@ -62,10 +67,10 @@ class VertexAIProvider(GeminiProvider):
                 # Try as file path
                 try:
                     info = json.loads(Path(creds_data).read_text())
-                except Exception:
+                except Exception as e:
                     raise ValueError(
                         "vertex_credentials must be a JSON string or path to a JSON file"
-                    )
+                    ) from e
             credentials = service_account.Credentials.from_service_account_info(
                 info, scopes=_DEFAULT_SCOPES
             )

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -272,8 +272,8 @@ def _build_endpoint_config(
 
         auth_config = model_config.auth_config or {}
         provider_config = VertexAIConfig(
-            vertex_project=auth_config.get("vertex_project", ""),
-            vertex_location=auth_config.get("vertex_location", "us-central1"),
+            vertex_project=auth_config.get("vertex_project"),
+            vertex_location=auth_config.get("vertex_location"),
             vertex_credentials=model_config.secret_value.get("vertex_credentials"),
         )
     else:

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -267,6 +267,15 @@ def _build_endpoint_config(
             config_kwargs["token"] = model_config.secret_value.get(_AuthConfigKey.API_KEY)
         provider_config = DatabricksConfig(**config_kwargs)
         model_config.provider = Provider.DATABRICKS
+    elif model_config.provider == Provider.VERTEX_AI:
+        from mlflow.gateway.providers.vertex_ai import VertexAIConfig
+
+        auth_config = model_config.auth_config or {}
+        provider_config = VertexAIConfig(
+            vertex_project=auth_config.get("vertex_project", ""),
+            vertex_location=auth_config.get("vertex_location", "us-central1"),
+            vertex_credentials=model_config.secret_value.get("vertex_credentials"),
+        )
     else:
         # Use LiteLLM as fallback for unsupported providers
         # Store the original provider name for LiteLLM's provider/model format

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -28,6 +28,7 @@ from mlflow.gateway.config import (
     OpenAIAPIType,
     OpenAIConfig,
     Provider,
+    VertexAIConfig,
     _AuthConfigKey,
     _OpenAICompatibleConfig,
 )
@@ -268,8 +269,6 @@ def _build_endpoint_config(
         provider_config = DatabricksConfig(**config_kwargs)
         model_config.provider = Provider.DATABRICKS
     elif model_config.provider == Provider.VERTEX_AI:
-        from mlflow.gateway.providers.vertex_ai import VertexAIConfig
-
         auth_config = model_config.auth_config or {}
         provider_config = VertexAIConfig(
             vertex_project=auth_config.get("vertex_project"),

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -340,7 +340,7 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
                     "name": "vertex_project",
                     "description": "GCP Project ID",
                     "secret": False,
-                    "required": False,
+                    "required": True,
                 },
                 {
                     "name": "vertex_location",

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -1,0 +1,156 @@
+import json
+from unittest import mock
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
+
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.vertex_ai import VertexAIConfig, VertexAIProvider
+from mlflow.gateway.schemas import chat
+
+from tests.gateway.tools import MockAsyncResponse, mock_http_client
+
+
+def _mock_credentials():
+    creds = mock.Mock()
+    creds.token = "mock-access-token"
+    creds.valid = True
+    return creds
+
+
+def _make_provider() -> VertexAIProvider:
+    endpoint_config = EndpointConfig(
+        name="vertex-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": "gemini-2.0-flash",
+            "config": {
+                "vertex_project": "my-gcp-project",
+                "vertex_location": "us-central1",
+            },
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    return provider
+
+
+def _chat_response():
+    return {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [{"text": "Hello from Vertex AI!"}],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 20,
+            "totalTokenCount": 30,
+        },
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def test_base_url():
+    provider = _make_provider()
+    assert provider.base_url == (
+        "https://us-central1-aiplatform.googleapis.com"
+        "/v1/projects/my-gcp-project/locations/us-central1/publishers/google/models"
+    )
+
+
+def test_headers_use_bearer_token():
+    provider = _make_provider()
+    assert provider.headers == {"Authorization": "Bearer mock-access-token"}
+
+
+def test_name():
+    provider = _make_provider()
+    assert provider.NAME == "Vertex AI"
+
+
+@pytest.mark.asyncio
+async def test_chat():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["choices"][0]["message"]["content"] == "Hello from Vertex AI!"
+    assert result["choices"][0]["message"]["role"] == "assistant"
+    assert result["usage"]["prompt_tokens"] == 10
+    assert result["usage"]["completion_tokens"] == 20
+
+
+def test_basic_config():
+    config = VertexAIConfig(vertex_project="my-project")
+    assert config.vertex_project == "my-project"
+    assert config.vertex_location is None
+    assert config.vertex_credentials is None
+
+
+def test_custom_location():
+    config = VertexAIConfig(vertex_project="my-project", vertex_location="europe-west4")
+    assert config.vertex_location == "europe-west4"
+
+
+def test_global_endpoint_when_no_location():
+    endpoint_config = EndpointConfig(
+        name="vertex-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": "gemini-2.0-flash",
+            "config": {"vertex_project": "my-project"},
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    assert provider.base_url == (
+        "https://aiplatform.googleapis.com"
+        "/v1/projects/my-project/publishers/google/models"
+    )
+
+
+def test_with_credentials():
+    creds_json = json.dumps({"type": "service_account", "project_id": "test"})
+    config = VertexAIConfig(vertex_project="my-project", vertex_credentials=creds_json)
+    assert config.vertex_credentials == creds_json
+
+
+def test_project_required():
+    with pytest.raises(ValidationError, match="vertex_project"):
+        VertexAIConfig()
+
+
+def test_credentials_with_adc():
+    config = VertexAIConfig(vertex_project="my-project")
+    endpoint_config = EndpointConfig(
+        name="vertex-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": "gemini-2.0-flash",
+            "config": config.model_dump(),
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+
+    mock_creds = _mock_credentials()
+    with mock.patch(
+        "google.auth.default", return_value=(mock_creds, "my-project")
+    ) as mock_default:
+        headers = provider.headers
+        mock_default.assert_called_once()
+        assert headers == {"Authorization": "Bearer mock-access-token"}

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -6,7 +6,8 @@ from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
 from mlflow.gateway.config import EndpointConfig
-from mlflow.gateway.providers.vertex_ai import VertexAIConfig, VertexAIProvider
+from mlflow.gateway.config import VertexAIConfig
+from mlflow.gateway.providers.vertex_ai import VertexAIProvider
 from mlflow.gateway.schemas import chat
 
 from tests.gateway.tools import MockAsyncResponse, mock_http_client

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -118,8 +118,7 @@ def test_global_endpoint_when_no_location():
     provider = VertexAIProvider(endpoint_config)
     provider._cached_credentials = _mock_credentials()
     assert provider.base_url == (
-        "https://aiplatform.googleapis.com"
-        "/v1/projects/my-project/publishers/google/models"
+        "https://aiplatform.googleapis.com/v1/projects/my-project/publishers/google/models"
     )
 
 
@@ -148,9 +147,7 @@ def test_credentials_with_adc():
     provider = VertexAIProvider(endpoint_config)
 
     mock_creds = _mock_credentials()
-    with mock.patch(
-        "google.auth.default", return_value=(mock_creds, "my-project")
-    ) as mock_default:
+    with mock.patch("google.auth.default", return_value=(mock_creds, "my-project")) as mock_default:
         headers = provider.headers
         mock_default.assert_called_once()
         assert headers == {"Authorization": "Bearer mock-access-token"}

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -5,8 +5,7 @@ import pytest
 from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
-from mlflow.gateway.config import EndpointConfig
-from mlflow.gateway.config import VertexAIConfig
+from mlflow.gateway.config import EndpointConfig, VertexAIConfig
 from mlflow.gateway.providers.vertex_ai import VertexAIProvider
 from mlflow.gateway.schemas import chat
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21998/files) to review incremental changes.
- [**stack/vertex-ai-provider**](https://github.com/mlflow/mlflow/pull/21998) [[Files changed](https://github.com/mlflow/mlflow/pull/21998/files)]
  - [stack/bedrock-provider-complete](https://github.com/mlflow/mlflow/pull/21999) [[Files changed](https://github.com/mlflow/mlflow/pull/21999/files/684700f6c5374f13987c37b6ad321837df88e687..d8d2e16a0f435468b8a06e19c1d85dd6218be91c)]

---------
### What changes are proposed in this pull request?

Add Vertex AI as a native gateway provider extending the existing Gemini provider. Uses the same Gemini API format but with Vertex AI endpoints and Google Cloud authentication (Application Default Credentials or service account JSON).

Provider: `vertex_ai` | Auth: Google ADC or service account JSON

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests 

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
