### PR TITLE
Complete Bedrock provider with Converse API support

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -751,6 +751,7 @@ mlflow.gateway.base_models.ConfigModel
 mlflow.gateway.config.AI21LabsConfig
 mlflow.gateway.config.AI21LabsConfig.validate_ai21labs_api_key
 mlflow.gateway.config.AWSBaseConfig
+mlflow.gateway.config.AWSBearerToken
 mlflow.gateway.config.AWSIdAndKey
 mlflow.gateway.config.AWSRole
 mlflow.gateway.config.AliasedConfigModel

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -243,9 +243,13 @@ class AWSIdAndKey(AWSBaseConfig):
     aws_session_token: str | None = None
 
 
+class AWSBearerToken(AWSBaseConfig):
+    aws_bearer_token: str
+
+
 class AmazonBedrockConfig(ConfigModel):
     # order here is important, at least for pydantic<2
-    aws_config: AWSRole | AWSIdAndKey | AWSBaseConfig
+    aws_config: AWSBearerToken | AWSRole | AWSIdAndKey | AWSBaseConfig
 
 
 class MistralConfig(ConfigModel):

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -209,9 +209,7 @@ class AmazonBedrockProvider(BaseProvider):
             import boto3
             import botocore.exceptions
         except ImportError:
-            raise ImportError(
-                "Bedrock provider requires boto3. Install it with: pip install boto3"
-            )
+            raise ImportError("Bedrock provider requires boto3. Install it with: pip install boto3")
 
         if self._client is not None and not self._client_expired():
             return self._client
@@ -321,6 +319,14 @@ class AmazonBedrockProvider(BaseProvider):
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content", "")
+
+            # Normalize content: extract text from list of content parts
+            if isinstance(content, list):
+                content = "\n".join(
+                    p.get("text", "")
+                    for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                )
 
             if role == "system":
                 system_prompts.append({"text": content})
@@ -501,7 +507,7 @@ class AmazonBedrockProvider(BaseProvider):
         messages = payload_dict.pop("messages", [])
         kwargs = self._build_converse_kwargs(messages, payload_dict)
 
-        response = await asyncio.get_event_loop().run_in_executor(
+        response = await asyncio.get_running_loop().run_in_executor(
             None, lambda: self.get_bedrock_client().converse(**kwargs)
         )
 
@@ -510,6 +516,13 @@ class AmazonBedrockProvider(BaseProvider):
     async def _chat_stream(
         self, payload: chat.RequestPayload
     ) -> AsyncIterable[chat.StreamResponsePayload]:
+        if self._is_token_auth:
+            raise AIGatewayException(
+                status_code=501,
+                detail="Streaming is not yet supported for Bedrock API key (bearer token) auth. "
+                "Use a non-streaming chat request instead.",
+            )
+
         from fastapi.encoders import jsonable_encoder
 
         payload_dict = jsonable_encoder(payload, exclude_none=True)
@@ -522,21 +535,26 @@ class AmazonBedrockProvider(BaseProvider):
         # blocking the async event loop.
         event_queue: queue.Queue = queue.Queue()
         _SENTINEL = object()
+        _stream_error: list[BaseException] = []
 
         def _consume_stream():
             try:
                 response = self.get_bedrock_client().converse_stream(**kwargs)
                 for event in response.get("stream", []):
                     event_queue.put(event)
+            except BaseException as e:
+                _stream_error.append(e)
             finally:
                 event_queue.put(_SENTINEL)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         loop.run_in_executor(None, _consume_stream)
 
         while True:
             event = await loop.run_in_executor(None, event_queue.get)
             if event is _SENTINEL:
+                if _stream_error:
+                    raise _stream_error[0]
                 break
             if "contentBlockStart" in event:
                 start = event["contentBlockStart"].get("start", {})
@@ -587,6 +605,11 @@ class AmazonBedrockProvider(BaseProvider):
                         ],
                     )
                 elif "toolUse" in delta:
+                    tool_input = delta["toolUse"].get("input", "")
+                    if isinstance(tool_input, dict):
+                        arguments = json.dumps(tool_input)
+                    else:
+                        arguments = str(tool_input)
                     yield chat.StreamResponsePayload(
                         created=int(time.time()),
                         model=self.config.model.name,
@@ -603,7 +626,7 @@ class AmazonBedrockProvider(BaseProvider):
                                                 "contentBlockIndex", 0
                                             ),
                                             function=chat.Function(
-                                                arguments=delta["toolUse"].get("input", ""),
+                                                arguments=arguments,
                                             ),
                                         )
                                     ],
@@ -653,6 +676,13 @@ class AmazonBedrockProvider(BaseProvider):
                     )
 
     async def _embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        if self._is_token_auth:
+            raise AIGatewayException(
+                status_code=501,
+                detail="Embeddings are not supported for Bedrock API key (bearer token) auth. "
+                "Use access_keys or default_chain auth mode for embeddings.",
+            )
+
         from fastapi.encoders import jsonable_encoder
 
         payload_dict = jsonable_encoder(payload, exclude_none=True)
@@ -666,7 +696,7 @@ class AmazonBedrockProvider(BaseProvider):
 
         for idx, text in enumerate(texts):
             body = {"inputText": text}
-            response = await asyncio.get_event_loop().run_in_executor(
+            response = await asyncio.get_running_loop().run_in_executor(
                 None,
                 lambda b=body: json.loads(
                     self

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -5,7 +5,13 @@ import time
 from enum import Enum
 from typing import Any, AsyncIterable
 
-from mlflow.gateway.config import AmazonBedrockConfig, AWSIdAndKey, AWSRole, EndpointConfig
+from mlflow.gateway.config import (
+    AWSBearerToken,
+    AWSIdAndKey,
+    AWSRole,
+    AmazonBedrockConfig,
+    EndpointConfig,
+)
 from mlflow.gateway.constants import (
     MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
 )
@@ -13,7 +19,7 @@ from mlflow.gateway.exceptions import AIGatewayConfigException, AIGatewayExcepti
 from mlflow.gateway.providers.anthropic import AnthropicAdapter
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.cohere import CohereAdapter
-from mlflow.gateway.providers.utils import rename_payload_keys
+from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
 from mlflow.gateway.schemas import chat, completions, embeddings
 
 AWS_BEDROCK_ANTHROPIC_MAXIMUM_MAX_TOKENS = 8191
@@ -184,6 +190,10 @@ class AmazonBedrockProvider(BaseProvider):
         self.bedrock_config: AmazonBedrockConfig = config.model.config
         self._client = None
         self._client_created = 0
+
+    @property
+    def _is_token_auth(self) -> bool:
+        return isinstance(self.bedrock_config.aws_config, AWSBearerToken)
 
     def _client_expired(self):
         if not isinstance(self.bedrock_config.aws_config, AWSRole):
@@ -408,7 +418,15 @@ class AmazonBedrockProvider(BaseProvider):
 
         usage = response.get("usage", {})
         stop_reason = response.get("stopReason", "end_turn")
-        finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
+        match stop_reason:
+            case "tool_use":
+                finish_reason = "tool_calls"
+            case "max_tokens":
+                finish_reason = "length"
+            case "content_filtered":
+                finish_reason = "content_filter"
+            case _:
+                finish_reason = "stop"
 
         return chat.ResponsePayload(
             created=int(time.time()),
@@ -434,7 +452,36 @@ class AmazonBedrockProvider(BaseProvider):
 
     # ---- API methods ----
 
+    def _get_token_auth_base_url(self) -> str:
+        region = self.bedrock_config.aws_config.aws_region or "us-east-1"
+        return f"https://bedrock-runtime.{region}.amazonaws.com"
+
+    def _get_token_auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.bedrock_config.aws_config.aws_bearer_token}"}
+
+    async def _chat_with_token(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        """Chat using bearer token auth via direct HTTP to Bedrock Converse API."""
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+
+        messages = payload_dict.pop("messages", [])
+        kwargs = self._build_converse_kwargs(messages, payload_dict)
+        model_id = kwargs.pop("modelId")
+
+        resp = await send_request(
+            headers=self._get_token_auth_headers(),
+            base_url=self._get_token_auth_base_url(),
+            path=f"model/{model_id}/converse",
+            payload=kwargs,
+        )
+        return self._converse_to_chat_response(resp)
+
     async def _chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        if self._is_token_auth:
+            return await self._chat_with_token(payload)
+
         from fastapi.encoders import jsonable_encoder
 
         payload_dict = jsonable_encoder(payload, exclude_none=True)
@@ -466,10 +513,12 @@ class AmazonBedrockProvider(BaseProvider):
         _SENTINEL = object()
 
         def _consume_stream():
-            response = self.get_bedrock_client().converse_stream(**kwargs)
-            for event in response.get("stream", []):
-                event_queue.put(event)
-            event_queue.put(_SENTINEL)
+            try:
+                response = self.get_bedrock_client().converse_stream(**kwargs)
+                for event in response.get("stream", []):
+                    event_queue.put(event)
+            finally:
+                event_queue.put(_SENTINEL)
 
         loop = asyncio.get_event_loop()
         loop.run_in_executor(None, _consume_stream)
@@ -478,7 +527,38 @@ class AmazonBedrockProvider(BaseProvider):
             event = await loop.run_in_executor(None, event_queue.get)
             if event is _SENTINEL:
                 break
-            if "contentBlockDelta" in event:
+            if "contentBlockStart" in event:
+                start = event["contentBlockStart"].get("start", {})
+                if "toolUse" in start:
+                    tool_use = start["toolUse"]
+                    yield chat.StreamResponsePayload(
+                        created=int(time.time()),
+                        model=self.config.model.name,
+                        choices=[
+                            chat.StreamChoice(
+                                index=0,
+                                finish_reason=None,
+                                delta=chat.StreamDelta(
+                                    role=None,
+                                    content=None,
+                                    tool_calls=[
+                                        chat.ToolCallDelta(
+                                            index=event["contentBlockStart"].get(
+                                                "contentBlockIndex", 0
+                                            ),
+                                            id=tool_use.get("toolUseId"),
+                                            type="function",
+                                            function=chat.Function(
+                                                name=tool_use.get("name"),
+                                                arguments="",
+                                            ),
+                                        )
+                                    ],
+                                ),
+                            )
+                        ],
+                    )
+            elif "contentBlockDelta" in event:
                 delta = event["contentBlockDelta"].get("delta", {})
                 if text := delta.get("text"):
                     yield chat.StreamResponsePayload(
@@ -495,9 +575,42 @@ class AmazonBedrockProvider(BaseProvider):
                             )
                         ],
                     )
+                elif "toolUse" in delta:
+                    yield chat.StreamResponsePayload(
+                        created=int(time.time()),
+                        model=self.config.model.name,
+                        choices=[
+                            chat.StreamChoice(
+                                index=0,
+                                finish_reason=None,
+                                delta=chat.StreamDelta(
+                                    role=None,
+                                    content=None,
+                                    tool_calls=[
+                                        chat.ToolCallDelta(
+                                            index=event["contentBlockDelta"].get(
+                                                "contentBlockIndex", 0
+                                            ),
+                                            function=chat.Function(
+                                                arguments=delta["toolUse"].get("input", ""),
+                                            ),
+                                        )
+                                    ],
+                                ),
+                            )
+                        ],
+                    )
             elif "messageStop" in event:
                 stop_reason = event["messageStop"].get("stopReason", "end_turn")
-                finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
+                match stop_reason:
+                    case "tool_use":
+                        finish_reason = "tool_calls"
+                    case "max_tokens":
+                        finish_reason = "length"
+                    case "content_filtered":
+                        finish_reason = "content_filter"
+                    case _:
+                        finish_reason = "stop"
                 yield chat.StreamResponsePayload(
                     created=int(time.time()),
                     model=self.config.model.name,

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -205,8 +205,13 @@ class AmazonBedrockProvider(BaseProvider):
         )
 
     def get_bedrock_client(self):
-        import boto3
-        import botocore.exceptions
+        try:
+            import boto3
+            import botocore.exceptions
+        except ImportError:
+            raise ImportError(
+                "Bedrock provider requires boto3. Install it with: pip install boto3"
+            )
 
         if self._client is not None and not self._client_expired():
             return self._client

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -306,13 +306,10 @@ class AmazonBedrockProvider(BaseProvider):
 
     # ---- Converse API helpers ----
 
-    def _messages_to_converse(
-        self, messages: list[dict[str, Any]]
-    ) -> tuple[list[dict[str, Any]], list[dict[str, str]] | None]:
-        """Convert OpenAI-format messages to Bedrock Converse format.
-
-        Returns (converse_messages, system_prompts).
-        """
+    def _build_converse_kwargs(
+        self, messages: list[dict[str, Any]], payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build kwargs for the Converse API call."""
         system_prompts = []
         converse_messages = []
 
@@ -353,21 +350,13 @@ class AmazonBedrockProvider(BaseProvider):
                     "content": [{"text": content}],
                 })
 
-        return converse_messages, system_prompts or None
-
-    def _build_converse_kwargs(
-        self, messages: list[dict[str, Any]], payload: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Build kwargs for the Converse API call."""
-        converse_messages, system = self._messages_to_converse(messages)
-
         kwargs = {
             "modelId": self.config.model.name,
             "messages": converse_messages,
         }
 
-        if system:
-            kwargs["system"] = system
+        if system_prompts:
+            kwargs["system"] = system_prompts
 
         # Build inferenceConfig from OpenAI params
         inference_config = {}
@@ -428,16 +417,7 @@ class AmazonBedrockProvider(BaseProvider):
                 )
 
         usage = response.get("usage", {})
-        stop_reason = response.get("stopReason", "end_turn")
-        match stop_reason:
-            case "tool_use":
-                finish_reason = "tool_calls"
-            case "max_tokens":
-                finish_reason = "length"
-            case "content_filtered":
-                finish_reason = "content_filter"
-            case _:
-                finish_reason = "stop"
+        finish_reason = self._map_stop_reason(response.get("stopReason", "end_turn"))
 
         return chat.ResponsePayload(
             created=int(time.time()),
@@ -475,6 +455,95 @@ class AmazonBedrockProvider(BaseProvider):
 
     def _get_token_auth_headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self.bedrock_config.aws_config.aws_bearer_token}"}
+
+    def _make_stream_chunk(
+        self,
+        delta: chat.StreamDelta,
+        finish_reason: str | None = None,
+        usage: chat.ChatUsage | None = None,
+    ) -> chat.StreamResponsePayload:
+        return chat.StreamResponsePayload(
+            created=int(time.time()),
+            model=self.config.model.name,
+            choices=[chat.StreamChoice(index=0, finish_reason=finish_reason, delta=delta)],
+            usage=usage,
+        )
+
+    @staticmethod
+    def _map_stop_reason(stop_reason: str) -> str:
+        match stop_reason:
+            case "tool_use":
+                return "tool_calls"
+            case "max_tokens":
+                return "length"
+            case "content_filtered":
+                return "content_filter"
+            case _:
+                return "stop"
+
+    def _parse_stream_event(self, event: dict[str, Any]) -> chat.StreamResponsePayload | None:
+        if "contentBlockStart" in event:
+            start = event["contentBlockStart"].get("start", {})
+            if "toolUse" in start:
+                tool_use = start["toolUse"]
+                return self._make_stream_chunk(
+                    delta=chat.StreamDelta(
+                        role=None,
+                        content=None,
+                        tool_calls=[
+                            chat.ToolCallDelta(
+                                index=event["contentBlockStart"].get("contentBlockIndex", 0),
+                                id=tool_use.get("toolUseId"),
+                                type="function",
+                                function=chat.Function(
+                                    name=tool_use.get("name"),
+                                    arguments="",
+                                ),
+                            )
+                        ],
+                    ),
+                )
+        elif "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            if text := delta.get("text"):
+                return self._make_stream_chunk(
+                    delta=chat.StreamDelta(role=None, content=text),
+                )
+            elif "toolUse" in delta:
+                tool_input = delta["toolUse"].get("input", "")
+                if isinstance(tool_input, dict):
+                    arguments = json.dumps(tool_input)
+                else:
+                    arguments = str(tool_input)
+                return self._make_stream_chunk(
+                    delta=chat.StreamDelta(
+                        role=None,
+                        content=None,
+                        tool_calls=[
+                            chat.ToolCallDelta(
+                                index=event["contentBlockDelta"].get("contentBlockIndex", 0),
+                                function=chat.Function(arguments=arguments),
+                            )
+                        ],
+                    ),
+                )
+        elif "messageStop" in event:
+            stop_reason = event["messageStop"].get("stopReason", "end_turn")
+            return self._make_stream_chunk(
+                delta=chat.StreamDelta(role=None, content=None),
+                finish_reason=self._map_stop_reason(stop_reason),
+            )
+        elif "metadata" in event:
+            if usage := event["metadata"].get("usage", {}):
+                return self._make_stream_chunk(
+                    delta=chat.StreamDelta(role=None, content=None),
+                    usage=chat.ChatUsage(
+                        prompt_tokens=usage.get("inputTokens"),
+                        completion_tokens=usage.get("outputTokens"),
+                        total_tokens=usage.get("totalTokens"),
+                    ),
+                )
+        return None
 
     async def _chat_with_token(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         """Chat using bearer token auth via direct HTTP to Bedrock Converse API."""
@@ -548,6 +617,8 @@ class AmazonBedrockProvider(BaseProvider):
                 event_queue.put(_SENTINEL)
 
         loop = asyncio.get_running_loop()
+        # Fire-and-forget: stream is consumed in background thread,
+        # events are read from the queue below. Not awaited intentionally.
         loop.run_in_executor(None, _consume_stream)
 
         while True:
@@ -556,124 +627,8 @@ class AmazonBedrockProvider(BaseProvider):
                 if _stream_error:
                     raise _stream_error[0]
                 break
-            if "contentBlockStart" in event:
-                start = event["contentBlockStart"].get("start", {})
-                if "toolUse" in start:
-                    tool_use = start["toolUse"]
-                    yield chat.StreamResponsePayload(
-                        created=int(time.time()),
-                        model=self.config.model.name,
-                        choices=[
-                            chat.StreamChoice(
-                                index=0,
-                                finish_reason=None,
-                                delta=chat.StreamDelta(
-                                    role=None,
-                                    content=None,
-                                    tool_calls=[
-                                        chat.ToolCallDelta(
-                                            index=event["contentBlockStart"].get(
-                                                "contentBlockIndex", 0
-                                            ),
-                                            id=tool_use.get("toolUseId"),
-                                            type="function",
-                                            function=chat.Function(
-                                                name=tool_use.get("name"),
-                                                arguments="",
-                                            ),
-                                        )
-                                    ],
-                                ),
-                            )
-                        ],
-                    )
-            elif "contentBlockDelta" in event:
-                delta = event["contentBlockDelta"].get("delta", {})
-                if text := delta.get("text"):
-                    yield chat.StreamResponsePayload(
-                        created=int(time.time()),
-                        model=self.config.model.name,
-                        choices=[
-                            chat.StreamChoice(
-                                index=0,
-                                finish_reason=None,
-                                delta=chat.StreamDelta(
-                                    role=None,
-                                    content=text,
-                                ),
-                            )
-                        ],
-                    )
-                elif "toolUse" in delta:
-                    tool_input = delta["toolUse"].get("input", "")
-                    if isinstance(tool_input, dict):
-                        arguments = json.dumps(tool_input)
-                    else:
-                        arguments = str(tool_input)
-                    yield chat.StreamResponsePayload(
-                        created=int(time.time()),
-                        model=self.config.model.name,
-                        choices=[
-                            chat.StreamChoice(
-                                index=0,
-                                finish_reason=None,
-                                delta=chat.StreamDelta(
-                                    role=None,
-                                    content=None,
-                                    tool_calls=[
-                                        chat.ToolCallDelta(
-                                            index=event["contentBlockDelta"].get(
-                                                "contentBlockIndex", 0
-                                            ),
-                                            function=chat.Function(
-                                                arguments=arguments,
-                                            ),
-                                        )
-                                    ],
-                                ),
-                            )
-                        ],
-                    )
-            elif "messageStop" in event:
-                stop_reason = event["messageStop"].get("stopReason", "end_turn")
-                match stop_reason:
-                    case "tool_use":
-                        finish_reason = "tool_calls"
-                    case "max_tokens":
-                        finish_reason = "length"
-                    case "content_filtered":
-                        finish_reason = "content_filter"
-                    case _:
-                        finish_reason = "stop"
-                yield chat.StreamResponsePayload(
-                    created=int(time.time()),
-                    model=self.config.model.name,
-                    choices=[
-                        chat.StreamChoice(
-                            index=0,
-                            finish_reason=finish_reason,
-                            delta=chat.StreamDelta(role=None, content=None),
-                        )
-                    ],
-                )
-            elif "metadata" in event:
-                if usage := event["metadata"].get("usage", {}):
-                    yield chat.StreamResponsePayload(
-                        created=int(time.time()),
-                        model=self.config.model.name,
-                        choices=[
-                            chat.StreamChoice(
-                                index=0,
-                                finish_reason=None,
-                                delta=chat.StreamDelta(role=None, content=None),
-                            )
-                        ],
-                        usage=chat.ChatUsage(
-                            prompt_tokens=usage.get("inputTokens"),
-                            completion_tokens=usage.get("outputTokens"),
-                            total_tokens=usage.get("totalTokens"),
-                        ),
-                    )
+            if chunk := self._parse_stream_event(event):
+                yield chunk
 
     async def _embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
         if self._is_token_auth:

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -453,7 +453,13 @@ class AmazonBedrockProvider(BaseProvider):
     # ---- API methods ----
 
     def _get_token_auth_base_url(self) -> str:
-        region = self.bedrock_config.aws_config.aws_region or "us-east-1"
+        region = self.bedrock_config.aws_config.aws_region
+        if not region:
+            raise AIGatewayException(
+                status_code=400,
+                detail="aws_region_name is required for Bedrock API key authentication. "
+                "The API key can only be used in the AWS Region it was generated in.",
+            )
         return f"https://bedrock-runtime.{region}.amazonaws.com"
 
     def _get_token_auth_headers(self) -> dict[str, str]:

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -1,6 +1,7 @@
 import json
 import time
 from enum import Enum
+from typing import AsyncIterable
 
 from mlflow.gateway.config import AmazonBedrockConfig, AWSIdAndKey, AWSRole, EndpointConfig
 from mlflow.gateway.constants import (
@@ -11,7 +12,7 @@ from mlflow.gateway.providers.anthropic import AnthropicAdapter
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.cohere import CohereAdapter
 from mlflow.gateway.providers.utils import rename_payload_keys
-from mlflow.gateway.schemas import completions
+from mlflow.gateway.schemas import chat, completions, embeddings
 
 AWS_BEDROCK_ANTHROPIC_MAXIMUM_MAX_TOKENS = 8191
 
@@ -287,6 +288,288 @@ class AmazonBedrockProvider(BaseProvider):
 
         except botocore.exceptions.ReadTimeoutError as e:
             raise AIGatewayException(status_code=408) from e
+
+    # ---- Converse API helpers ----
+
+    def _messages_to_converse(self, messages: list[dict]) -> tuple[list[dict], list[dict] | None]:
+        """Convert OpenAI-format messages to Bedrock Converse format.
+
+        Returns (converse_messages, system_prompts).
+        """
+        system_prompts = []
+        converse_messages = []
+
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+
+            if role == "system":
+                system_prompts.append({"text": content})
+            elif role == "assistant":
+                converse_messages.append({
+                    "role": "assistant",
+                    "content": [{"text": content}],
+                })
+            elif role == "tool":
+                converse_messages.append({
+                    "role": "user",
+                    "content": [
+                        {
+                            "toolResult": {
+                                "toolUseId": msg.get("tool_call_id", ""),
+                                "content": [{"text": content}],
+                            }
+                        }
+                    ],
+                })
+            else:
+                converse_messages.append({
+                    "role": "user",
+                    "content": [{"text": content}],
+                })
+
+        return converse_messages, system_prompts or None
+
+    def _build_converse_kwargs(
+        self, messages: list[dict], payload: dict
+    ) -> dict:
+        """Build kwargs for the Converse API call."""
+        converse_messages, system = self._messages_to_converse(messages)
+
+        kwargs = {
+            "modelId": self.config.model.name,
+            "messages": converse_messages,
+        }
+
+        if system:
+            kwargs["system"] = system
+
+        # Build inferenceConfig from OpenAI params
+        inference_config = {}
+        if "temperature" in payload:
+            inference_config["temperature"] = payload["temperature"]
+        if "top_p" in payload:
+            inference_config["topP"] = payload["top_p"]
+        if max_tokens := payload.get("max_tokens") or payload.get("max_completion_tokens"):
+            inference_config["maxTokens"] = max_tokens
+        if "stop" in payload:
+            stop = payload["stop"]
+            inference_config["stopSequences"] = stop if isinstance(stop, list) else [stop]
+
+        if inference_config:
+            kwargs["inferenceConfig"] = inference_config
+
+        # Convert tools to Bedrock format
+        if tools := payload.get("tools"):
+            bedrock_tools = []
+            for tool in tools:
+                if tool.get("type") == "function":
+                    func = tool["function"]
+                    bedrock_tools.append({
+                        "toolSpec": {
+                            "name": func["name"],
+                            "description": func.get("description", ""),
+                            "inputSchema": {"json": func.get("parameters", {})},
+                        }
+                    })
+            if bedrock_tools:
+                kwargs["toolConfig"] = {"tools": bedrock_tools}
+
+        return kwargs
+
+    def _converse_to_chat_response(self, response: dict) -> chat.ResponsePayload:
+        """Convert Bedrock Converse response to OpenAI chat format."""
+        output = response.get("output", {})
+        message = output.get("message", {})
+        content_blocks = message.get("content", [])
+
+        text_parts = []
+        tool_calls = []
+
+        for block in content_blocks:
+            if "text" in block:
+                text_parts.append(block["text"])
+            elif "toolUse" in block:
+                tool_use = block["toolUse"]
+                tool_calls.append(
+                    chat.ToolCall(
+                        id=tool_use.get("toolUseId", ""),
+                        type="function",
+                        function=chat.ToolCallFunction(
+                            name=tool_use.get("name", ""),
+                            arguments=json.dumps(tool_use.get("input", {})),
+                        ),
+                    )
+                )
+
+        usage = response.get("usage", {})
+        stop_reason = response.get("stopReason", "end_turn")
+        finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
+
+        return chat.ResponsePayload(
+            created=int(time.time()),
+            object="chat.completion",
+            model=self.config.model.name,
+            choices=[
+                chat.Choice(
+                    index=0,
+                    message=chat.ResponseMessage(
+                        role="assistant",
+                        content="\n".join(text_parts) if text_parts else None,
+                        tool_calls=tool_calls or None,
+                    ),
+                    finish_reason=finish_reason,
+                )
+            ],
+            usage=chat.ChatUsage(
+                prompt_tokens=usage.get("inputTokens"),
+                completion_tokens=usage.get("outputTokens"),
+                total_tokens=usage.get("totalTokens"),
+            ),
+        )
+
+    # ---- API methods ----
+
+    async def _chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        import asyncio
+
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+
+        messages = payload_dict.pop("messages", [])
+        kwargs = self._build_converse_kwargs(messages, payload_dict)
+
+        response = await asyncio.get_event_loop().run_in_executor(
+            None, lambda: self.get_bedrock_client().converse(**kwargs)
+        )
+
+        return self._converse_to_chat_response(response)
+
+    async def _chat_stream(
+        self, payload: chat.RequestPayload
+    ) -> AsyncIterable[chat.StreamResponsePayload]:
+        import asyncio
+
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+
+        messages = payload_dict.pop("messages", [])
+        kwargs = self._build_converse_kwargs(messages, payload_dict)
+
+        response = await asyncio.get_event_loop().run_in_executor(
+            None, lambda: self.get_bedrock_client().converse_stream(**kwargs)
+        )
+
+        stream = response.get("stream", [])
+        for event in stream:
+            if "contentBlockDelta" in event:
+                delta = event["contentBlockDelta"].get("delta", {})
+                text = delta.get("text")
+                if text:
+                    yield chat.StreamResponsePayload(
+                        created=int(time.time()),
+                        model=self.config.model.name,
+                        choices=[
+                            chat.StreamChoice(
+                                index=0,
+                                finish_reason=None,
+                                delta=chat.StreamDelta(
+                                    role=None,
+                                    content=text,
+                                ),
+                            )
+                        ],
+                    )
+            elif "messageStop" in event:
+                stop_reason = event["messageStop"].get("stopReason", "end_turn")
+                finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
+                yield chat.StreamResponsePayload(
+                    created=int(time.time()),
+                    model=self.config.model.name,
+                    choices=[
+                        chat.StreamChoice(
+                            index=0,
+                            finish_reason=finish_reason,
+                            delta=chat.StreamDelta(role=None, content=None),
+                        )
+                    ],
+                )
+            elif "metadata" in event:
+                usage = event["metadata"].get("usage", {})
+                if usage:
+                    yield chat.StreamResponsePayload(
+                        created=int(time.time()),
+                        model=self.config.model.name,
+                        choices=[
+                            chat.StreamChoice(
+                                index=0,
+                                finish_reason=None,
+                                delta=chat.StreamDelta(role=None, content=None),
+                            )
+                        ],
+                        usage=chat.ChatUsage(
+                            prompt_tokens=usage.get("inputTokens"),
+                            completion_tokens=usage.get("outputTokens"),
+                            total_tokens=usage.get("totalTokens"),
+                        ),
+                    )
+
+    async def _embeddings(
+        self, payload: embeddings.RequestPayload
+    ) -> embeddings.ResponsePayload:
+        import asyncio
+
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+
+        input_text = payload_dict.get("input", "")
+        if isinstance(input_text, list):
+            texts = input_text
+        else:
+            texts = [input_text]
+
+        embedding_data = []
+        total_tokens = 0
+
+        for idx, text in enumerate(texts):
+            body = {"inputText": text}
+            response = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda b=body: json.loads(
+                    self.get_bedrock_client()
+                    .invoke_model(
+                        body=json.dumps(b).encode(),
+                        modelId=self.config.model.name,
+                        accept="application/json",
+                        contentType="application/json",
+                    )
+                    .get("body")
+                    .read()
+                ),
+            )
+
+            embedding_data.append(
+                embeddings.EmbeddingObject(
+                    embedding=response.get("embedding", []),
+                    index=idx,
+                )
+            )
+            total_tokens += response.get("inputTextTokenCount", 0)
+
+        return embeddings.ResponsePayload(
+            data=embedding_data,
+            model=self.config.model.name,
+            usage=embeddings.EmbeddingsUsage(
+                prompt_tokens=total_tokens,
+                total_tokens=total_tokens,
+            ),
+        )
 
     async def _completions(
         self, payload: completions.RequestPayload

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -1,7 +1,9 @@
+import asyncio
 import json
+import queue
 import time
 from enum import Enum
-from typing import AsyncIterable
+from typing import Any, AsyncIterable
 
 from mlflow.gateway.config import AmazonBedrockConfig, AWSIdAndKey, AWSRole, EndpointConfig
 from mlflow.gateway.constants import (
@@ -291,7 +293,9 @@ class AmazonBedrockProvider(BaseProvider):
 
     # ---- Converse API helpers ----
 
-    def _messages_to_converse(self, messages: list[dict]) -> tuple[list[dict], list[dict] | None]:
+    def _messages_to_converse(
+        self, messages: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], list[dict[str, str]] | None]:
         """Convert OpenAI-format messages to Bedrock Converse format.
 
         Returns (converse_messages, system_prompts).
@@ -331,8 +335,8 @@ class AmazonBedrockProvider(BaseProvider):
         return converse_messages, system_prompts or None
 
     def _build_converse_kwargs(
-        self, messages: list[dict], payload: dict
-    ) -> dict:
+        self, messages: list[dict[str, Any]], payload: dict[str, Any]
+    ) -> dict[str, Any]:
         """Build kwargs for the Converse API call."""
         converse_messages, system = self._messages_to_converse(messages)
 
@@ -377,7 +381,7 @@ class AmazonBedrockProvider(BaseProvider):
 
         return kwargs
 
-    def _converse_to_chat_response(self, response: dict) -> chat.ResponsePayload:
+    def _converse_to_chat_response(self, response: dict[str, Any]) -> chat.ResponsePayload:
         """Convert Bedrock Converse response to OpenAI chat format."""
         output = response.get("output", {})
         message = output.get("message", {})
@@ -431,8 +435,6 @@ class AmazonBedrockProvider(BaseProvider):
     # ---- API methods ----
 
     async def _chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
-        import asyncio
-
         from fastapi.encoders import jsonable_encoder
 
         payload_dict = jsonable_encoder(payload, exclude_none=True)
@@ -450,8 +452,6 @@ class AmazonBedrockProvider(BaseProvider):
     async def _chat_stream(
         self, payload: chat.RequestPayload
     ) -> AsyncIterable[chat.StreamResponsePayload]:
-        import asyncio
-
         from fastapi.encoders import jsonable_encoder
 
         payload_dict = jsonable_encoder(payload, exclude_none=True)
@@ -460,16 +460,27 @@ class AmazonBedrockProvider(BaseProvider):
         messages = payload_dict.pop("messages", [])
         kwargs = self._build_converse_kwargs(messages, payload_dict)
 
-        response = await asyncio.get_event_loop().run_in_executor(
-            None, lambda: self.get_bedrock_client().converse_stream(**kwargs)
-        )
+        # Consume the synchronous boto3 EventStream in a thread to avoid
+        # blocking the async event loop.
+        event_queue: queue.Queue = queue.Queue()
+        _SENTINEL = object()
 
-        stream = response.get("stream", [])
-        for event in stream:
+        def _consume_stream():
+            response = self.get_bedrock_client().converse_stream(**kwargs)
+            for event in response.get("stream", []):
+                event_queue.put(event)
+            event_queue.put(_SENTINEL)
+
+        loop = asyncio.get_event_loop()
+        loop.run_in_executor(None, _consume_stream)
+
+        while True:
+            event = await loop.run_in_executor(None, event_queue.get)
+            if event is _SENTINEL:
+                break
             if "contentBlockDelta" in event:
                 delta = event["contentBlockDelta"].get("delta", {})
-                text = delta.get("text")
-                if text:
+                if text := delta.get("text"):
                     yield chat.StreamResponsePayload(
                         created=int(time.time()),
                         model=self.config.model.name,
@@ -499,8 +510,7 @@ class AmazonBedrockProvider(BaseProvider):
                     ],
                 )
             elif "metadata" in event:
-                usage = event["metadata"].get("usage", {})
-                if usage:
+                if usage := event["metadata"].get("usage", {}):
                     yield chat.StreamResponsePayload(
                         created=int(time.time()),
                         model=self.config.model.name,
@@ -518,21 +528,14 @@ class AmazonBedrockProvider(BaseProvider):
                         ),
                     )
 
-    async def _embeddings(
-        self, payload: embeddings.RequestPayload
-    ) -> embeddings.ResponsePayload:
-        import asyncio
-
+    async def _embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
         from fastapi.encoders import jsonable_encoder
 
         payload_dict = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload_dict)
 
         input_text = payload_dict.get("input", "")
-        if isinstance(input_text, list):
-            texts = input_text
-        else:
-            texts = [input_text]
+        texts = input_text if isinstance(input_text, list) else [input_text]
 
         embedding_data = []
         total_tokens = 0
@@ -542,7 +545,8 @@ class AmazonBedrockProvider(BaseProvider):
             response = await asyncio.get_event_loop().run_in_executor(
                 None,
                 lambda b=body: json.loads(
-                    self.get_bedrock_client()
+                    self
+                    .get_bedrock_client()
                     .invoke_model(
                         body=json.dumps(b).encode(),
                         modelId=self.config.model.name,

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -6,10 +6,10 @@ from enum import Enum
 from typing import Any, AsyncIterable
 
 from mlflow.gateway.config import (
+    AmazonBedrockConfig,
     AWSBearerToken,
     AWSIdAndKey,
     AWSRole,
-    AmazonBedrockConfig,
     EndpointConfig,
 )
 from mlflow.gateway.constants import (
@@ -19,7 +19,7 @@ from mlflow.gateway.exceptions import AIGatewayConfigException, AIGatewayExcepti
 from mlflow.gateway.providers.anthropic import AnthropicAdapter
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.cohere import CohereAdapter
-from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
+from mlflow.gateway.providers.utils import rename_payload_keys, send_request
 from mlflow.gateway.schemas import chat, completions, embeddings
 
 AWS_BEDROCK_ANTHROPIC_MAXIMUM_MAX_TOKENS = 8191

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -27,11 +27,11 @@ from mlflow.gateway.config import (
     LiteLLMConfig,
     MistralConfig,
     OpenAIAPIType,
-    _OpenAICompatibleConfig,
     OpenAIConfig,
     Provider,
     VertexAIConfig,
     _AuthConfigKey,
+    _OpenAICompatibleConfig,
 )
 from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER, GatewayCaller
 from mlflow.gateway.providers import get_provider
@@ -274,23 +274,27 @@ def _build_endpoint_config(
         auth_mode = auth_config.get(_AuthConfigKey.AUTH_MODE, "api_key")
         if auth_mode == "api_key":
             # Bearer token auth — bypasses boto3 SigV4
-            provider_config = AmazonBedrockConfig(aws_config={
-                "aws_bearer_token": model_config.secret_value.get(_AuthConfigKey.API_KEY, ""),
-                "aws_region": auth_config.get("aws_region_name"),
-            })
+            provider_config = AmazonBedrockConfig(
+                aws_config={
+                    "aws_bearer_token": model_config.secret_value.get(_AuthConfigKey.API_KEY, ""),
+                    "aws_region": auth_config.get("aws_region_name"),
+                }
+            )
         elif auth_mode == "access_keys":
-            provider_config = AmazonBedrockConfig(aws_config={
-                "aws_access_key_id": model_config.secret_value.get("aws_access_key_id"),
-                "aws_secret_access_key": model_config.secret_value.get("aws_secret_access_key"),
-                "aws_region": auth_config.get("aws_region_name"),
-            })
+            provider_config = AmazonBedrockConfig(
+                aws_config={
+                    "aws_access_key_id": model_config.secret_value.get("aws_access_key_id"),
+                    "aws_secret_access_key": model_config.secret_value.get("aws_secret_access_key"),
+                    "aws_region": auth_config.get("aws_region_name"),
+                }
+            )
         elif auth_mode == "iam_role":
-            provider_config = AmazonBedrockConfig(aws_config={
-                "aws_access_key_id": model_config.secret_value.get("aws_access_key_id"),
-                "aws_secret_access_key": model_config.secret_value.get("aws_secret_access_key"),
-                "aws_role_arn": auth_config.get("aws_role_name"),
-                "aws_region": auth_config.get("aws_region_name"),
-            })
+            provider_config = AmazonBedrockConfig(
+                aws_config={
+                    "aws_role_arn": auth_config.get("aws_role_name"),
+                    "aws_region": auth_config.get("aws_region_name"),
+                }
+            )
         else:
             # default_chain — boto3 resolves credentials from the
             # environment (env vars, ~/.aws/credentials, instance profile, etc.)

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -276,7 +276,7 @@ def _build_endpoint_config(
             # Bearer token auth — bypasses boto3 SigV4
             provider_config = AmazonBedrockConfig(
                 aws_config={
-                    "aws_bearer_token": model_config.secret_value.get(_AuthConfigKey.API_KEY, ""),
+                    "aws_bearer_token": model_config.secret_value.get(_AuthConfigKey.API_KEY),
                     "aws_region": auth_config.get("aws_region_name"),
                 }
             )

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -27,11 +27,11 @@ from mlflow.gateway.config import (
     LiteLLMConfig,
     MistralConfig,
     OpenAIAPIType,
+    _OpenAICompatibleConfig,
     OpenAIConfig,
     Provider,
     VertexAIConfig,
     _AuthConfigKey,
-    _OpenAICompatibleConfig,
 )
 from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER, GatewayCaller
 from mlflow.gateway.providers import get_provider
@@ -272,27 +272,32 @@ def _build_endpoint_config(
     elif model_config.provider in (Provider.BEDROCK, Provider.AMAZON_BEDROCK):
         auth_config = model_config.auth_config or {}
         auth_mode = auth_config.get(_AuthConfigKey.AUTH_MODE, "api_key")
-        if auth_mode == "access_keys":
-            aws_config = {
+        if auth_mode == "api_key":
+            # Bearer token auth — bypasses boto3 SigV4
+            provider_config = AmazonBedrockConfig(aws_config={
+                "aws_bearer_token": model_config.secret_value.get(_AuthConfigKey.API_KEY, ""),
+                "aws_region": auth_config.get("aws_region_name"),
+            })
+        elif auth_mode == "access_keys":
+            provider_config = AmazonBedrockConfig(aws_config={
                 "aws_access_key_id": model_config.secret_value.get("aws_access_key_id"),
                 "aws_secret_access_key": model_config.secret_value.get("aws_secret_access_key"),
                 "aws_region": auth_config.get("aws_region_name"),
-            }
+            })
         elif auth_mode == "iam_role":
-            aws_config = {
+            provider_config = AmazonBedrockConfig(aws_config={
                 "aws_access_key_id": model_config.secret_value.get("aws_access_key_id"),
                 "aws_secret_access_key": model_config.secret_value.get("aws_secret_access_key"),
                 "aws_role_arn": auth_config.get("aws_role_name"),
                 "aws_region": auth_config.get("aws_region_name"),
-            }
-        elif auth_mode == "default_chain":
+            })
+        else:
+            # default_chain — boto3 resolves credentials from the
+            # environment (env vars, ~/.aws/credentials, instance profile, etc.)
             aws_config = {"aws_region": auth_config.get("aws_region_name")}
             if role_arn := auth_config.get("aws_role_name"):
                 aws_config["aws_role_arn"] = role_arn
-        else:
-            # api_key mode — use the key as access key for simplicity
-            aws_config = {"aws_region": auth_config.get("aws_region_name")}
-        provider_config = AmazonBedrockConfig(aws_config=aws_config)
+            provider_config = AmazonBedrockConfig(aws_config=aws_config)
         model_config.provider = Provider.BEDROCK
     elif model_config.provider == Provider.VERTEX_AI:
         auth_config = model_config.auth_config or {}

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -18,6 +18,7 @@ from fastapi.responses import StreamingResponse
 from mlflow.entities.gateway_endpoint import GatewayModelLinkageType
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import (
+    AmazonBedrockConfig,
     AnthropicConfig,
     EndpointConfig,
     EndpointType,
@@ -268,6 +269,31 @@ def _build_endpoint_config(
             config_kwargs["token"] = model_config.secret_value.get(_AuthConfigKey.API_KEY)
         provider_config = DatabricksConfig(**config_kwargs)
         model_config.provider = Provider.DATABRICKS
+    elif model_config.provider in (Provider.BEDROCK, Provider.AMAZON_BEDROCK):
+        auth_config = model_config.auth_config or {}
+        auth_mode = auth_config.get(_AuthConfigKey.AUTH_MODE, "api_key")
+        if auth_mode == "access_keys":
+            aws_config = {
+                "aws_access_key_id": model_config.secret_value.get("aws_access_key_id"),
+                "aws_secret_access_key": model_config.secret_value.get("aws_secret_access_key"),
+                "aws_region": auth_config.get("aws_region_name"),
+            }
+        elif auth_mode == "iam_role":
+            aws_config = {
+                "aws_access_key_id": model_config.secret_value.get("aws_access_key_id"),
+                "aws_secret_access_key": model_config.secret_value.get("aws_secret_access_key"),
+                "aws_role_arn": auth_config.get("aws_role_name"),
+                "aws_region": auth_config.get("aws_region_name"),
+            }
+        elif auth_mode == "default_chain":
+            aws_config = {"aws_region": auth_config.get("aws_region_name")}
+            if role_arn := auth_config.get("aws_role_name"):
+                aws_config["aws_role_arn"] = role_arn
+        else:
+            # api_key mode — use the key as access key for simplicity
+            aws_config = {"aws_region": auth_config.get("aws_region_name")}
+        provider_config = AmazonBedrockConfig(aws_config=aws_config)
+        model_config.provider = Provider.BEDROCK
     elif model_config.provider == Provider.VERTEX_AI:
         auth_config = model_config.auth_config or {}
         provider_config = VertexAIConfig(

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -171,6 +171,12 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
                     "secret": True,
                     "required": True,
                 },
+                {
+                    "name": "aws_region_name",
+                    "description": "AWS Region (must match the region the API key was generated in)",
+                    "secret": False,
+                    "required": True,
+                },
             ],
         },
         "access_keys": {
@@ -199,31 +205,14 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
         },
         "iam_role": {
             "display_name": "IAM Role Assumption",
-            "description": "Assume an IAM role using base credentials (for cross-account access)",
+            "description": "Assume an IAM role using the server's ambient credentials "
+            "(instance profile, IRSA, ECS task role, ~/.aws/credentials, etc.)",
             "fields": [
-                {
-                    "name": "aws_access_key_id",
-                    "description": "AWS Access Key ID (for assuming role)",
-                    "secret": True,
-                    "required": True,
-                },
-                {
-                    "name": "aws_secret_access_key",
-                    "description": "AWS Secret Access Key",
-                    "secret": True,
-                    "required": True,
-                },
                 {
                     "name": "aws_role_name",
                     "description": "IAM Role ARN to assume",
                     "secret": False,
                     "required": True,
-                },
-                {
-                    "name": "aws_session_name",
-                    "description": "Session name for assumed role",
-                    "secret": False,
-                    "required": False,
                 },
                 {
                     "name": "aws_region_name",

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -173,7 +173,7 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
                 },
                 {
                     "name": "aws_region_name",
-                    "description": "AWS Region (must match the region the API key was generated in)",
+                    "description": "AWS Region",
                     "secret": False,
                     "required": True,
                 },

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -420,3 +420,156 @@ async def test_bedrock_request_response(
 def test_amazon_bedrock_model_provider(model_name, expected):
     provider = AmazonBedrockModelProvider.of_str(model_name)
     assert provider == expected
+
+
+# ---- Converse API tests ----
+
+
+def _make_converse_provider():
+    """Create a provider with a mock boto3 client for Converse API tests."""
+    from mlflow.gateway.schemas import chat
+
+    config = {
+        "name": "chat",
+        "endpoint_type": "llm/v1/chat",
+        "model": {
+            "provider": "bedrock",
+            "name": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "config": {"aws_config": {"aws_region": "us-east-1"}},
+        },
+    }
+    provider = AmazonBedrockProvider(EndpointConfig(**config))
+    return provider
+
+
+def _converse_response():
+    return {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Hello from Bedrock!"}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {
+            "inputTokens": 10,
+            "outputTokens": 20,
+            "totalTokens": 30,
+        },
+    }
+
+
+def _converse_stream_response():
+    return {
+        "stream": iter([
+            {"contentBlockDelta": {"delta": {"text": "Hello"}}},
+            {"contentBlockDelta": {"delta": {"text": " from Bedrock!"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30}}},
+        ])
+    }
+
+
+def _embeddings_invoke_response():
+    import io
+
+    body = io.BytesIO(
+        b'{"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 5}'
+    )
+    return {"body": body}
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_chat():
+    from mlflow.gateway.schemas import chat
+
+    provider = _make_converse_provider()
+    mock_client = mock.Mock()
+    mock_client.converse.return_value = _converse_response()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["choices"][0]["message"]["content"] == "Hello from Bedrock!"
+    assert result["choices"][0]["message"]["role"] == "assistant"
+    assert result["usage"]["prompt_tokens"] == 10
+    assert result["usage"]["completion_tokens"] == 20
+    mock_client.converse.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_chat_stream():
+    from mlflow.gateway.schemas import chat
+
+    provider = _make_converse_provider()
+    mock_client = mock.Mock()
+    mock_client.converse_stream.return_value = _converse_stream_response()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        chunks = []
+        async for chunk in provider.chat_stream(payload):
+            chunks.append(jsonable_encoder(chunk))
+
+    # Should have: 2 text deltas + 1 stop + 1 usage
+    assert len(chunks) == 4
+    assert chunks[0]["choices"][0]["delta"]["content"] == "Hello"
+    assert chunks[1]["choices"][0]["delta"]["content"] == " from Bedrock!"
+    assert chunks[2]["choices"][0]["finish_reason"] == "stop"
+    assert chunks[3]["usage"]["prompt_tokens"] == 10
+    mock_client.converse_stream.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_embeddings():
+    from mlflow.gateway.schemas import embeddings
+
+    config = {
+        "name": "embeddings",
+        "endpoint_type": "llm/v1/embeddings",
+        "model": {
+            "provider": "bedrock",
+            "name": "amazon.titan-embed-text-v1",
+            "config": {"aws_config": {"aws_region": "us-east-1"}},
+        },
+    }
+    provider = AmazonBedrockProvider(EndpointConfig(**config))
+    mock_client = mock.Mock()
+    mock_client.invoke_model.return_value = _embeddings_invoke_response()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = embeddings.RequestPayload(input="Test text")
+        response = await provider.embeddings(payload)
+
+    result = jsonable_encoder(response)
+    assert result["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+    assert result["usage"]["prompt_tokens"] == 5
+    mock_client.invoke_model.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_with_system_message():
+    from mlflow.gateway.schemas import chat
+
+    provider = _make_converse_provider()
+    mock_client = mock.Mock()
+    mock_client.converse.return_value = _converse_response()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[
+                {"role": "system", "content": "You are helpful"},
+                {"role": "user", "content": "Hello"},
+            ],
+        )
+        await provider.chat(payload)
+
+    call_kwargs = mock_client.converse.call_args.kwargs
+    assert call_kwargs["system"] == [{"text": "You are helpful"}]
+    assert len(call_kwargs["messages"]) == 1  # only user message

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -1,3 +1,4 @@
+import io
 from unittest import mock
 
 import pytest
@@ -470,8 +471,6 @@ def _converse_stream_response():
 
 
 def _embeddings_invoke_response():
-    import io
-
     body = io.BytesIO(b'{"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 5}')
     return {"body": body}
 

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -12,7 +12,7 @@ from mlflow.gateway.config import (
     EndpointConfig,
 )
 from mlflow.gateway.providers.bedrock import AmazonBedrockModelProvider, AmazonBedrockProvider
-from mlflow.gateway.schemas import completions
+from mlflow.gateway.schemas import chat, completions, embeddings
 
 from tests.gateway.providers.test_anthropic import (
     completions_response as anthropic_completions_response,
@@ -438,8 +438,7 @@ def _make_converse_provider():
             "config": {"aws_config": {"aws_region": "us-east-1"}},
         },
     }
-    provider = AmazonBedrockProvider(EndpointConfig(**config))
-    return provider
+    return AmazonBedrockProvider(EndpointConfig(**config))
 
 
 def _converse_response():
@@ -477,7 +476,6 @@ def _embeddings_invoke_response():
 
 @pytest.mark.asyncio
 async def test_bedrock_converse_chat():
-    from mlflow.gateway.schemas import chat
 
     provider = _make_converse_provider()
     mock_client = mock.Mock()
@@ -499,7 +497,6 @@ async def test_bedrock_converse_chat():
 
 @pytest.mark.asyncio
 async def test_bedrock_converse_chat_stream():
-    from mlflow.gateway.schemas import chat
 
     provider = _make_converse_provider()
     mock_client = mock.Mock()
@@ -509,9 +506,7 @@ async def test_bedrock_converse_chat_stream():
         payload = chat.RequestPayload(
             messages=[{"role": "user", "content": "Hello"}],
         )
-        chunks = []
-        async for chunk in provider.chat_stream(payload):
-            chunks.append(jsonable_encoder(chunk))
+        chunks = [jsonable_encoder(chunk) async for chunk in provider.chat_stream(payload)]
 
     # Should have: 2 text deltas + 1 stop + 1 usage
     assert len(chunks) == 4
@@ -524,7 +519,6 @@ async def test_bedrock_converse_chat_stream():
 
 @pytest.mark.asyncio
 async def test_bedrock_embeddings():
-    from mlflow.gateway.schemas import embeddings
 
     config = {
         "name": "embeddings",
@@ -551,7 +545,6 @@ async def test_bedrock_embeddings():
 
 @pytest.mark.asyncio
 async def test_bedrock_converse_with_system_message():
-    from mlflow.gateway.schemas import chat
 
     provider = _make_converse_provider()
     mock_client = mock.Mock()

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -427,7 +427,6 @@ def test_amazon_bedrock_model_provider(model_name, expected):
 
 def _make_converse_provider():
     """Create a provider with a mock boto3 client for Converse API tests."""
-    from mlflow.gateway.schemas import chat
 
     config = {
         "name": "chat",
@@ -473,9 +472,7 @@ def _converse_stream_response():
 def _embeddings_invoke_response():
     import io
 
-    body = io.BytesIO(
-        b'{"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 5}'
-    )
+    body = io.BytesIO(b'{"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 5}')
     return {"body": body}
 
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/21999/files) to review incremental changes.
- [**stack/bedrock-provider-complete**](https://github.com/mlflow/mlflow/pull/21999) [[Files changed](https://github.com/mlflow/mlflow/pull/21999/files)]

---------
### What changes are proposed in this pull request?

Complete the existing Bedrock provider by adding chat, streaming, and embeddings support using AWS Bedrock's Converse API. Previously only synchronous `_completions()` worked.

**New capabilities:**
- `_chat()`: Uses `converse()` for non-streaming chat (model-agnostic)
- `_chat_stream()`: Uses `converse_stream()` for streaming chat, with tool call support
- `_embeddings()`: Uses `invoke_model()` for Titan/Cohere embeddings
- **Bearer token auth**: New `AWSBearerToken` config for API key authentication (bypasses boto3 SigV4)
- All boto3 calls run in an executor for async compatibility
- Streaming consumes the synchronous boto3 EventStream in a separate thread via `queue.Queue`
- Proper stop reason mapping: `end_turn` → `stop`, `max_tokens` → `length`, `tool_use` → `tool_calls`, `content_filtered` → `content_filter`
- Bedrock routing in `gateway_api.py` for all auth modes (`api_key`, `access_keys`, `iam_role`, `default_chain`)

The existing `_completions()` method (using `invoke_model` with per-model adapters) is preserved for backward compatibility.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests 

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Complete Bedrock provider with Converse API support for chat, streaming, embeddings, and bearer token authentication.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
