### PR TITLE
Fix `GatewayStartEvent` to fire at startup instead of shutdown

### DIFF
--- a/mlflow/gateway/cli.py
+++ b/mlflow/gateway/cli.py
@@ -4,7 +4,7 @@ from mlflow.environment_variables import MLFLOW_GATEWAY_CONFIG
 from mlflow.gateway.config import _validate_config
 from mlflow.gateway.runner import run_app
 from mlflow.telemetry.events import GatewayStartEvent
-from mlflow.telemetry.track import record_usage_event
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.os import is_windows
 
 
@@ -44,8 +44,8 @@ def commands():
     default=2,
     help="The number of workers.",
 )
-@record_usage_event(GatewayStartEvent)
 def start(config_path: str, host: str, port: str, workers: int):
     if is_windows():
         raise click.ClickException("MLflow AI Gateway does not support Windows.")
+    _record_event(GatewayStartEvent, {})
     run_app(config_path=config_path, host=host, port=port, workers=workers)

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -1165,12 +1165,13 @@ endpoints:
 """
     )
 
-    runner = CliRunner(catch_exceptions=False)
-    with mock.patch("mlflow.gateway.cli.run_app"):
-        runner.invoke(start, ["--config-path", str(config)])
+    def assert_event_recorded_before_run_app(**kwargs):
+        mock_telemetry_client.flush()
+        validate_telemetry_record(mock_telemetry_client, mock_requests, GatewayStartEvent.name)
 
-    mock_telemetry_client.flush()
-    validate_telemetry_record(mock_telemetry_client, mock_requests, GatewayStartEvent.name)
+    runner = CliRunner(catch_exceptions=False)
+    with mock.patch("mlflow.gateway.cli.run_app", side_effect=assert_event_recorded_before_run_app):
+        runner.invoke(start, ["--config-path", str(config)])
 
 
 def test_ai_command_run(mock_requests, mock_telemetry_client: TelemetryClient):


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The `@record_usage_event(GatewayStartEvent)` decorator on the `gateway start` CLI command only records the telemetry event in its `finally` block — after the wrapped function returns. Since `run_app()` is a blocking call that runs indefinitely (watching for config changes), the event was only recorded when the gateway **shut down**, not when it started. The `duration_ms` also incorrectly captured the entire gateway uptime.

This PR replaces the decorator with a direct `_record_event()` call before `run_app()` so the event fires immediately at startup. The test is updated to verify the event is recorded before `run_app` is called.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release