### PR TITLE
Pin R dependencies

### DIFF
--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -11,8 +11,8 @@ devtools::install_dev_deps(dependencies = TRUE)
 # Note that this commit is equivalent to commit 6b48255 of Rd2md master
 # (https://github.com/quantsch/Rd2md/tree/6b4825579a2df8a22898316d93729384f92a756b)
 # with a single extra commit to fix rendering of \link tags between methods in R documentation.
-devtools::install_git("https://github.com/smurching/Rd2md", ref = "mlflow-patches")
+devtools::install_git("https://github.com/smurching/Rd2md", ref = "ac7b22bb7452113ea8b2dcaca083f60041e0d4c3")
 devtools::install_version("roxygen2", "7.1.2")
 # The latest version of git2r (0.35.0) doesn't work with the rocker/r-ver:4.2.1 docker image
 devtools::install_version("git2r", "0.33.0")
-install.packages("rmarkdown", repos = "https://cloud.r-project.org")
+devtools::install_version("rmarkdown", "2.30")

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -1,7 +1,7 @@
 # Increase the timeout length for `utils::download.file` because the default value (60 seconds)
 # could be too short to download large packages such as h2o.
 options(timeout=300)
-install.packages("devtools", dependencies = TRUE)
+install.packages("https://cran.r-project.org/src/contrib/Archive/devtools/devtools_2.4.6.tar.gz", repos = NULL, type = "source", dependencies = TRUE)
 devtools::install_version("usethis", "3.2.1")
 devtools::install_dev_deps(dependencies = TRUE)
 

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -43,8 +43,10 @@ Imports:
     openssl (<= 2.3.5),
     processx (<= 3.8.6),
     purrr (<= 1.2.1),
+    rlang (>= 0.2.0),
     rlang (<= 1.1.7),
     swagger (<= 5.17.14.1),
+    tibble (>= 2.0.0),
     tibble (<= 3.3.1),
     withr (<= 3.0.2),
     yaml (<= 2.3.12),
@@ -57,6 +59,7 @@ Suggests:
     lintr (<= 3.3.0-1),
     sparklyr (<= 1.9.3),
     stringi (<= 1.8.7),
+    testthat (>= 2.0.0),
     testthat (<= 3.3.2),
     reticulate (<= 1.45.0),
     xgboost (<= 3.2.1.1)

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -32,34 +32,34 @@ BugReports: https://github.com/mlflow/mlflow/issues
 Depends:
     R (>= 3.3.0)
 Imports:
-    base64enc,
-    fs,
-    git2r,
-    glue,
-    httpuv,
-    httr,
-    ini,
-    jsonlite,
-    openssl,
-    processx,
-    purrr,
-    rlang (>= 0.2.0),
-    swagger,
-    tibble (>= 2.0.0),
-    withr,
-    yaml,
-    zeallot
+    base64enc (<= 0.1-6),
+    fs (<= 2.0.1),
+    git2r (<= 0.36.2),
+    glue (<= 1.8.0),
+    httpuv (<= 1.6.17),
+    httr (<= 1.4.8),
+    ini (<= 0.3.1),
+    jsonlite (<= 2.0.0),
+    openssl (<= 2.3.5),
+    processx (<= 3.8.6),
+    purrr (<= 1.2.1),
+    rlang (<= 1.1.7),
+    swagger (<= 5.17.14.1),
+    tibble (<= 3.3.1),
+    withr (<= 3.0.2),
+    yaml (<= 2.3.12),
+    zeallot (<= 0.2.0)
 Suggests:
-    carrier,
-    covr,
-    h2o,
-    keras,
-    lintr,
-    sparklyr,
-    stringi,
-    testthat (>= 2.0.0),
-    reticulate,
-    xgboost
+    carrier (<= 0.3.0.4),
+    covr (<= 3.6.5),
+    h2o (<= 3.44.0.3),
+    keras (<= 2.16.1),
+    lintr (<= 3.3.0-1),
+    sparklyr (<= 1.9.3),
+    stringi (<= 1.8.7),
+    testthat (<= 3.3.2),
+    reticulate (<= 1.45.0),
+    xgboost (<= 3.2.1.1)
 Encoding: UTF-8
 RoxygenNote: 7.1.2
 Collate:

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     fs (<= 2.0.1),
     git2r (<= 0.36.2),
     glue (<= 1.8.0),
-    httpuv (<= 1.6.17),
+    httpuv (<= 1.6.16),
     httr (<= 1.4.8),
     ini (<= 0.3.1),
     jsonlite (<= 2.0.0),


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21981

### What changes are proposed in this pull request?

Pin R package dependencies to improve supply chain security and build reproducibility:

1. **`Rd2md`**: Pin `install_git` from branch name (`mlflow-patches`) to commit SHA (`ac7b22bb7452113ea8b2dcaca083f60041e0d4c3`) in `.install-deps.R` — prevents arbitrary code execution if the fork account is compromised
2. **`rmarkdown`**: Pin to version `2.30` via `devtools::install_version` instead of unpinned `install.packages`
3. **All DESCRIPTION deps**: Add upper version bounds (`<=`) to all 26 Imports and Suggests packages, preventing unexpected new versions from being installed in CI

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified locally that `devtools::install_dev_deps(dependencies = TRUE)` succeeds with the pinned DESCRIPTION, and that `tools:::.check_package_description()` validates cleanly.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release