### PR TITLE
Pin apt packages to versions released before March 10, 2026

### DIFF
--- a/.github/actions/setup-pyenv/action.yml
+++ b/.github/actions/setup-pyenv/action.yml
@@ -10,9 +10,10 @@ runs:
       # Ref: https://github.com/pyenv/pyenv/wiki#suggested-build-environment
       # Note: llvm is optional (required only for building PyPy/clang)
       run: |
-        sudo apt-get update -y
+        SNAPSHOT_FLAG="${APT_SNAPSHOT:+--snapshot $APT_SNAPSHOT}"
+        sudo apt-get update $SNAPSHOT_FLAG -y
         sudo apt-get purge -y man-db || true
-        sudo apt-get install -y --no-install-recommends make build-essential libssl-dev zlib1g-dev \
+        sudo apt-get install $SNAPSHOT_FLAG -y --no-install-recommends make build-essential libssl-dev zlib1g-dev \
         libbz2-dev libreadline-dev libsqlite3-dev wget curl \
         libncursesw5-dev xz-utils libffi-dev liblzma-dev
     - name: Install pyenv

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -47,6 +47,7 @@ env:
   PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
   PYTHONFAULTHANDLER: "1"
+  APT_SNAPSHOT: "20260310T000000Z"
 
 jobs:
   examples:
@@ -94,9 +95,9 @@ jobs:
         run: |
           source ./dev/install-common-deps.sh --ml
           uv pip install --system fastapi uvicorn
-          sudo apt-get update -y
+          sudo apt-get update --snapshot $APT_SNAPSHOT -y
           # Required for the transformers example that uses the Whisper model
-          sudo apt-get install -y ffmpeg
+          sudo apt-get install --snapshot $APT_SNAPSHOT -y ffmpeg
 
       - name: Run example tests
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || steps.check-diff.outputs.examples_changed == 'true' }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -33,6 +33,7 @@ defaults:
 env:
   MLFLOW_HOME: ${{ github.workspace }}
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
+  APT_SNAPSHOT: "20260310T000000Z"
 
 jobs:
   r:
@@ -76,7 +77,8 @@ jobs:
           key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('mlflow/R/mlflow/R-version') }}-0-${{ hashFiles('mlflow/R/mlflow/depends.Rds') }}
       - name: Install dependencies
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff-dev
+          sudo apt-get update --snapshot $APT_SNAPSHOT -y
+          sudo apt-get install --snapshot $APT_SNAPSHOT -y libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff-dev
           Rscript -e 'source(".install-deps.R", echo=TRUE)'
       - name: Set USE_R_DEVEL
         run: |


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21985

### What changes are proposed in this pull request?

Pin apt packages to a specific snapshot date using `apt-get --snapshot` to guard against supply chain attacks, similar to how `UV_EXCLUDE_NEWER` pins Python packages.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)