### PR TITLE
Skip `test_set_matrix.py` tests disabled by #21985

### DIFF
--- a/dev/tests/test_set_matrix.py
+++ b/dev/tests/test_set_matrix.py
@@ -7,6 +7,10 @@ from unittest import mock
 
 import pytest
 
+pytestmark = pytest.mark.skip(
+    reason="Disabled by #21985: dev installs use git+ which doesn't respect UV_EXCLUDE_NEWER"
+)
+
 from dev.set_matrix import generate_matrix
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21985

### What changes are proposed in this pull request?

Skip the entire `dev/tests/test_set_matrix.py` test module. These tests were broken by #21985 which intentionally disabled dev version testing because `git+` installs don't respect `UV_EXCLUDE_NEWER`.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release