### PR TITLE
Fix R CI: use `remotes` to install `devtools` with dependencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -142,8 +142,7 @@ jobs:
           uv run pytest .examples
 
   r:
-    # TODO(#22014): Remove `false &&`
-    if: false && (github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot'))
+    if: (github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot'))
     permissions:
       contents: read
     timeout-minutes: 15

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -40,8 +40,7 @@ jobs:
     timeout-minutes: 120
     permissions:
       contents: read
-    # TODO(#22014): Remove `false &&`
-    if: false && (github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'mlflow/dev') || (github.event_name == 'pull_request' && (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')))
+    if: (github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'mlflow/dev') || (github.event_name == 'pull_request' && (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')))
     defaults:
       run:
         working-directory: mlflow/R/mlflow

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -76,8 +76,6 @@ jobs:
           key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('mlflow/R/mlflow/R-version') }}-0-${{ hashFiles('mlflow/R/mlflow/depends.Rds') }}
       - name: Install dependencies
         run: |
-          sudo apt-get update --snapshot=20260310T000000Z
-          sudo apt-get install --snapshot=20260310T000000Z -y libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff-dev
           Rscript -e 'source(".install-deps.R", echo=TRUE)'
       - name: Set USE_R_DEVEL
         run: |

--- a/mlflow/R/mlflow/.Rprofile
+++ b/mlflow/R/mlflow/.Rprofile
@@ -3,6 +3,6 @@ repos <- getOption("repos")
 # that can be installed significantly faster than uncompiled package sources.
 if (Sys.which("lsb_release") != "") {
     ubuntu_codename <- tolower(system("lsb_release -cs", intern = TRUE))
-    repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_codename)
+    repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/2026-03-10", ubuntu_codename)
     options(repos = c(repos, REPO_NAME = repo_name))
 }

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -1,18 +1,9 @@
 # Increase the timeout length for `utils::download.file` because the default value (60 seconds)
 # could be too short to download large packages such as h2o.
 options(timeout=300)
+install.packages("https://cran.r-project.org/src/contrib/Archive/pak/pak_0.9.2.tar.gz", repos = NULL, type = "source")
+pak::local_install_deps()
 install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
-# Install DESCRIPTION deps at their pinned upper-bound versions.
-# remotes::install_deps() ignores upper-bound constraints and just installs the
-# latest from CRAN, so we parse DESCRIPTION ourselves and use install_version().
-desc <- read.dcf("DESCRIPTION", fields = c("Imports", "Suggests"))
-deps <- unlist(strsplit(paste(desc, collapse = ", "), ",\\s*"))
-for (dep in deps) {
-  m <- regmatches(dep, regexec("^\\s*(\\S+)\\s*\\(<=\\s*([^)]+)\\)", dep))[[1]]
-  if (length(m) == 3) {
-    remotes::install_version(m[2], m[3], upgrade = "never")
-  }
-}
 remotes::install_version("devtools", "2.4.6")
 devtools::install_version("usethis", "3.2.1")
 

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -1,7 +1,8 @@
 # Increase the timeout length for `utils::download.file` because the default value (60 seconds)
 # could be too short to download large packages such as h2o.
 options(timeout=300)
-install.packages("https://cran.r-project.org/src/contrib/Archive/devtools/devtools_2.4.6.tar.gz", repos = NULL, type = "source", dependencies = TRUE)
+install.packages("https://cran.r-project.org/src/contrib/Archive/remotes/remotes_2.4.2.tar.gz", repos = NULL, type = "source")
+remotes::install_version("devtools", "2.4.6")
 devtools::install_version("usethis", "3.2.1")
 devtools::install_dev_deps(dependencies = TRUE)
 

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -1,7 +1,7 @@
 # Increase the timeout length for `utils::download.file` because the default value (60 seconds)
 # could be too short to download large packages such as h2o.
 options(timeout=300)
-install.packages("https://cran.r-project.org/src/contrib/Archive/pak/pak_0.9.2.tar.gz", repos = NULL, type = "source")
+install.packages("https://cran.r-project.org/src/contrib/pak_0.9.2.tar.gz", repos = NULL, type = "source")
 pak::local_install_deps()
 install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
 remotes::install_version("devtools", "2.4.6")

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -1,7 +1,7 @@
 # Increase the timeout length for `utils::download.file` because the default value (60 seconds)
 # could be too short to download large packages such as h2o.
 options(timeout=300)
-install.packages("https://cran.r-project.org/src/contrib/Archive/remotes/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
+install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
 remotes::install_version("devtools", "2.4.6")
 devtools::install_version("usethis", "3.2.1")
 devtools::install_dev_deps(dependencies = TRUE)

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -4,9 +4,9 @@ options(timeout=300)
 install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
 remotes::install_version("pak", "0.9.2")
 # The latest version of git2r (0.35.0) doesn't work with the rocker/r-ver:4.2.1 docker image
-pak::pkg_install("git2r@0.33.0")
+remotes::install_version("git2r", "0.33.0")
 pak::local_install_dev_deps()
-pak::pkg_install("usethis@3.2.1")
+remotes::install_version("usethis", "3.2.1")
 
 # Install dependencies for documentation build
 # Install Rd2md from source as a temporary fix for the rendering of code examples, until
@@ -14,6 +14,6 @@ pak::pkg_install("usethis@3.2.1")
 # Note that this commit is equivalent to commit 6b48255 of Rd2md master
 # (https://github.com/quantsch/Rd2md/tree/6b4825579a2df8a22898316d93729384f92a756b)
 # with a single extra commit to fix rendering of \link tags between methods in R documentation.
-pak::pkg_install("smurching/Rd2md@ac7b22bb7452113ea8b2dcaca083f60041e0d4c3")
-pak::pkg_install("roxygen2@7.1.2")
-pak::pkg_install("rmarkdown@2.30")
+remotes::install_git("https://github.com/smurching/Rd2md", ref = "ac7b22bb7452113ea8b2dcaca083f60041e0d4c3")
+remotes::install_version("roxygen2", "7.1.2")
+remotes::install_version("rmarkdown", "2.30")

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -4,6 +4,7 @@ options(timeout=300)
 install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
 remotes::install_version("pak", "0.9.2")
 pak::local_install_dev_deps()
+remotes::install_version("devtools", "2.4.6")
 remotes::install_version("usethis", "3.2.1")
 
 # Install dependencies for documentation build

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -3,6 +3,8 @@
 options(timeout=300)
 install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
 remotes::install_version("pak", "0.9.2")
+# The latest version of git2r (0.35.0) doesn't work with the rocker/r-ver:4.2.1 docker image
+pak::pkg_install("git2r@0.33.0")
 pak::local_install_dev_deps()
 pak::pkg_install("usethis@3.2.1")
 
@@ -14,6 +16,4 @@ pak::pkg_install("usethis@3.2.1")
 # with a single extra commit to fix rendering of \link tags between methods in R documentation.
 pak::pkg_install("smurching/Rd2md@ac7b22bb7452113ea8b2dcaca083f60041e0d4c3")
 pak::pkg_install("roxygen2@7.1.2")
-# The latest version of git2r (0.35.0) doesn't work with the rocker/r-ver:4.2.1 docker image
-pak::pkg_install("git2r@0.33.0")
 pak::pkg_install("rmarkdown@2.30")

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -1,9 +1,9 @@
 # Increase the timeout length for `utils::download.file` because the default value (60 seconds)
 # could be too short to download large packages such as h2o.
 options(timeout=300)
-install.packages("https://cran.r-project.org/src/contrib/pak_0.9.2.tar.gz", repos = NULL, type = "source")
+install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
+remotes::install_version("pak", "0.9.2")
 pak::local_install_dev_deps()
-pak::pkg_install("devtools@2.4.6")
 pak::pkg_install("usethis@3.2.1")
 
 # Install dependencies for documentation build

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -3,8 +3,6 @@
 options(timeout=300)
 install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
 remotes::install_version("pak", "0.9.2")
-# The latest version of git2r (0.35.0) doesn't work with the rocker/r-ver:4.2.1 docker image
-remotes::install_version("git2r", "0.33.0")
 pak::local_install_dev_deps()
 remotes::install_version("usethis", "3.2.1")
 

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -2,9 +2,11 @@
 # could be too short to download large packages such as h2o.
 options(timeout=300)
 install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
+# Install DESCRIPTION deps first so that devtools reuses these pinned versions
+# instead of pulling newer ones that violate DESCRIPTION upper bounds.
+remotes::install_deps(dependencies = TRUE)
 remotes::install_version("devtools", "2.4.6")
 devtools::install_version("usethis", "3.2.1")
-devtools::install_dev_deps(dependencies = TRUE)
 
 # Install dependencies for documentation build
 # Install Rd2md from source as a temporary fix for the rendering of code examples, until

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -2,7 +2,7 @@
 # could be too short to download large packages such as h2o.
 options(timeout=300)
 install.packages("https://cran.r-project.org/src/contrib/pak_0.9.2.tar.gz", repos = NULL, type = "source")
-pak::local_install_deps()
+pak::local_install_dev_deps()
 pak::pkg_install("devtools@2.4.6")
 pak::pkg_install("usethis@3.2.1")
 

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -3,9 +3,8 @@
 options(timeout=300)
 install.packages("https://cran.r-project.org/src/contrib/pak_0.9.2.tar.gz", repos = NULL, type = "source")
 pak::local_install_deps()
-install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
-remotes::install_version("devtools", "2.4.6")
-devtools::install_version("usethis", "3.2.1")
+pak::pkg_install("devtools@2.4.6")
+pak::pkg_install("usethis@3.2.1")
 
 # Install dependencies for documentation build
 # Install Rd2md from source as a temporary fix for the rendering of code examples, until
@@ -13,8 +12,8 @@ devtools::install_version("usethis", "3.2.1")
 # Note that this commit is equivalent to commit 6b48255 of Rd2md master
 # (https://github.com/quantsch/Rd2md/tree/6b4825579a2df8a22898316d93729384f92a756b)
 # with a single extra commit to fix rendering of \link tags between methods in R documentation.
-devtools::install_git("https://github.com/smurching/Rd2md", ref = "ac7b22bb7452113ea8b2dcaca083f60041e0d4c3")
-devtools::install_version("roxygen2", "7.1.2")
+pak::pkg_install("smurching/Rd2md@ac7b22bb7452113ea8b2dcaca083f60041e0d4c3")
+pak::pkg_install("roxygen2@7.1.2")
 # The latest version of git2r (0.35.0) doesn't work with the rocker/r-ver:4.2.1 docker image
-devtools::install_version("git2r", "0.33.0")
-devtools::install_version("rmarkdown", "2.30")
+pak::pkg_install("git2r@0.33.0")
+pak::pkg_install("rmarkdown@2.30")

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -2,9 +2,17 @@
 # could be too short to download large packages such as h2o.
 options(timeout=300)
 install.packages("https://cran.r-project.org/src/contrib/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
-# Install DESCRIPTION deps first so that devtools reuses these pinned versions
-# instead of pulling newer ones that violate DESCRIPTION upper bounds.
-remotes::install_deps(dependencies = TRUE)
+# Install DESCRIPTION deps at their pinned upper-bound versions.
+# remotes::install_deps() ignores upper-bound constraints and just installs the
+# latest from CRAN, so we parse DESCRIPTION ourselves and use install_version().
+desc <- read.dcf("DESCRIPTION", fields = c("Imports", "Suggests"))
+deps <- unlist(strsplit(paste(desc, collapse = ", "), ",\\s*"))
+for (dep in deps) {
+  m <- regmatches(dep, regexec("^\\s*(\\S+)\\s*\\(<=\\s*([^)]+)\\)", dep))[[1]]
+  if (length(m) == 3) {
+    remotes::install_version(m[2], m[3], upgrade = "never")
+  }
+}
 remotes::install_version("devtools", "2.4.6")
 devtools::install_version("usethis", "3.2.1")
 

--- a/mlflow/R/mlflow/.install-deps.R
+++ b/mlflow/R/mlflow/.install-deps.R
@@ -1,7 +1,7 @@
 # Increase the timeout length for `utils::download.file` because the default value (60 seconds)
 # could be too short to download large packages such as h2o.
 options(timeout=300)
-install.packages("https://cran.r-project.org/src/contrib/Archive/remotes/remotes_2.4.2.tar.gz", repos = NULL, type = "source")
+install.packages("https://cran.r-project.org/src/contrib/Archive/remotes/remotes_2.5.0.tar.gz", repos = NULL, type = "source")
 remotes::install_version("devtools", "2.4.6")
 devtools::install_version("usethis", "3.2.1")
 devtools::install_dev_deps(dependencies = TRUE)

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -43,10 +43,8 @@ Imports:
     openssl (<= 2.3.5),
     processx (<= 3.8.6),
     purrr (<= 1.2.1),
-    rlang (>= 0.2.0),
     rlang (<= 1.1.7),
     swagger (<= 5.17.14.1),
-    tibble (>= 2.0.0),
     tibble (<= 3.3.1),
     withr (<= 3.0.2),
     yaml (<= 2.3.12),
@@ -59,7 +57,6 @@ Suggests:
     lintr (<= 3.3.0-1),
     sparklyr (<= 1.9.3),
     stringi (<= 1.8.7),
-    testthat (>= 2.0.0),
     testthat (<= 3.3.2),
     reticulate (<= 1.45.0),
     xgboost (<= 3.2.0.1)

--- a/mlflow/R/mlflow/Dockerfile.dev
+++ b/mlflow/R/mlflow/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.4.2
+FROM rocker/r-ver@sha256:df26749182af64d5263bf64149d51a427b476ed28c4e046997143be3f97fdd7c
 
 WORKDIR /mlflow/mlflow/R/mlflow
 RUN apt-get update -y

--- a/mlflow/R/mlflow/Dockerfile.dev
+++ b/mlflow/R/mlflow/Dockerfile.dev
@@ -1,5 +1,4 @@
-# Our internal Jenkins job can't build an image from rocker/r-ver:>=4.2.2 (which is based on Ubuntu 22.04).
-FROM rocker/r-ver:4.2.1
+FROM rocker/r-ver:4.4.2
 
 WORKDIR /mlflow/mlflow/R/mlflow
 RUN apt-get update -y


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22005

### What changes are proposed in this pull request?

Installing `devtools` from a tarball with `repos = NULL` prevents R from resolving dependencies from CRAN, causing the CI build to fail with:

```
ERROR: dependencies 'usethis', 'cli', 'desc', 'ellipsis', 'fs', 'lifecycle', ... are not available for package 'devtools'
```

This PR fixes the issue by:
1. Installing `remotes` 2.5.0 from CRAN archive tarball (minimal deps, works with `repos = NULL`)
2. Using `remotes::install_version("devtools", "2.4.6")` which resolves dependencies from CRAN while still pinning the version

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

The R CI workflow will validate this fix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release