### PR TITLE
Exclude package versions released after cutoff date in `set_matrix.py`

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -192,7 +192,7 @@ def read_yaml(location, if_error=None):
         raise
 
 
-RELEASED_BEFORE = datetime(2026, 3, 10, tzinfo=timezone.utc)
+RELEASE_CUTOFF = datetime(2026, 3, 10, tzinfo=timezone.utc)
 
 
 def get_released_versions(package_name: str) -> list[Version]:
@@ -211,8 +211,8 @@ def get_released_versions(package_name: str) -> list[Version]:
 
         release_date = min(upload_times) if upload_times else None
 
-        # Exclude versions released after the cutoff date
-        if not release_date or release_date >= RELEASED_BEFORE:
+        # Exclude versions with unknown release dates or released on/after the cutoff date
+        if not release_date or release_date >= RELEASE_CUTOFF:
             continue
 
         try:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -192,6 +192,9 @@ def read_yaml(location, if_error=None):
         raise
 
 
+RELEASED_BEFORE = datetime(2026, 3, 10, tzinfo=timezone.utc)
+
+
 def get_released_versions(package_name: str) -> list[Version]:
     data = pypi_json(package_name)
     versions: list[Version] = []
@@ -207,6 +210,11 @@ def get_released_versions(package_name: str) -> list[Version]:
         ]
 
         release_date = min(upload_times) if upload_times else None
+
+        # Exclude versions released after the cutoff date
+        if not release_date or release_date >= RELEASED_BEFORE:
+            continue
+
         try:
             version = Version(version_str, release_date)
         except InvalidVersion:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21985

### What changes are proposed in this pull request?

Exclude package versions released on or after March 10, 2026 from the cross-version test matrix in `dev/set_matrix.py`. Versions with unknown upload times are also excluded.

### How is this PR tested?

- [x] Manual tests

Ran `python dev/set_matrix.py --flavors sklearn --only-latest` and verified the output only includes versions released before the cutoff date.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release