### PR TITLE
Pin pyenv to v2.6.25 for reproducible CI builds

### DIFF
--- a/.github/actions/setup-pyenv/action.yml
+++ b/.github/actions/setup-pyenv/action.yml
@@ -19,7 +19,7 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        git clone https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
+        git clone --branch v2.6.25 --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
     - name: Setup environment variables
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/actions/setup-pyenv/action.yml
+++ b/.github/actions/setup-pyenv/action.yml
@@ -19,7 +19,14 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
+        # Pin to pyenv v2.6.25 by tag + SHA verification for reproducible builds
         git clone --branch v2.6.25 --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
+        actual_sha=$(git -C "$HOME/.pyenv" rev-parse HEAD)
+        expected_sha="aa2e8b82605b8ba085dd15f7a31fe1990fabdcfa"
+        if [ "$actual_sha" != "$expected_sha" ]; then
+          echo "::error::pyenv SHA mismatch: expected $expected_sha, got $actual_sha"
+          exit 1
+        fi
     - name: Setup environment variables
       if: runner.os == 'Linux'
       shell: bash


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22015

### What changes are proposed in this pull request?

Pin the pyenv clone in the `setup-pyenv` action to tag `v2.6.25` (released 2026-03-03) with `--depth 1` for a shallow clone. This ensures reproducible CI builds by preventing unexpected changes from newer pyenv versions, consistent with the snapshot pinning already done for `apt-get` in #22015.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release