### PR TITLE
fix: handle proto-JSON response format in  trace detail view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/utils/TraceUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/TraceUtils.ts
@@ -33,11 +33,16 @@ export async function getTrace(
   // only set when the backend is OSS SQLAlchemyStore.
   if (getSpansLocation(traceInfo as ModelTraceInfoV3) === TRACKING_STORE_SPANS_LOCATION) {
     const traceResp = await getExperimentTraceV3({ traceId });
-    if (traceResp?.trace && traceResp.trace.data) {
-      return {
-        info: traceResp.trace.trace_info || {},
-        data: traceResp.trace.data,
-      };
+    if (traceResp?.trace) {
+      // The proto-JSON response returns spans at `trace.spans` (not `trace.data.spans`),
+      // because the protobuf Trace message has `trace_info` and `spans` as top-level fields.
+      const spans = traceResp.trace.data?.spans || traceResp.trace.spans;
+      if (spans) {
+        return {
+          info: traceResp.trace.trace_info || {},
+          data: { spans },
+        };
+      }
     }
   }
 


### PR DESCRIPTION
### Related Issues/PRs

Fixes #22022

### What changes are proposed in this pull request?

The `GET /traces/get` endpoint serializes the protobuf `Trace` message via `message_to_json()`, which returns spans at `trace.spans`. But `TraceUtils.ts` only checks `trace.data`, which doesn't exist in the proto response. This causes trace spans to never render when using OSS SQLAlchemyStore with `spansLocation=TRACKING_STORE`.

The fix handles both response formats: `trace.data.spans` (if it ever exists) and `trace.spans` (the actual proto-JSON format).

### How is this PR tested?

- [x] Manual tests

Verified with `curl` against a live MLflow 3.10.0 server:

```bash
curl -s ".../ajax-api/3.0/mlflow/traces/get?trace_id=tr-xxx&allow_partial=true" \
  | python3 -c "
import sys, json
trace = json.load(sys.stdin)['trace']
print('Keys:', list(trace.keys()))       # ['trace_info', 'spans']
print('trace.data:', trace.get('data'))  # None
print('trace.spans:', len(trace.get('spans', [])))  # 49
"
```

Also confirmed with a unit test simulating proto serialization:

```python
response_message = GetTrace.Response(trace=trace.to_proto())
json_str = message_to_json(response_message)
response_json = json.loads(json_str)
assert "data" not in response_json["trace"]  # passes
assert "spans" in response_json["trace"] or not trace.data.spans  # passes
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Trace detail view now correctly renders spans when using OSS SQLAlchemyStore backend.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release