### PR TITLE
Fix evaluate() hang from stale cached connections under sustained load

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -936,6 +936,16 @@ MLFLOW_HTTP_TCP_KEEPALIVE_INTERVAL = _EnvironmentVariable(
 #: (default: ``3``)
 MLFLOW_HTTP_TCP_KEEPALIVE_COUNT = _EnvironmentVariable("MLFLOW_HTTP_TCP_KEEPALIVE_COUNT", int, 3)
 
+#: Specifies the time-to-live (TTL) in seconds for the cached Databricks ``WorkspaceClient``.
+#: Under sustained load (e.g., streaming jobs), HTTP connections in the cached client's pool can
+#: go stale when the cloud load balancer drops idle connection state. Stale connections cause
+#: ``recv()`` to block indefinitely on half-open TCP connections. This TTL ensures the client and
+#: its connection pool are periodically recreated with fresh connections.
+#: Set to ``0`` to disable caching (create a new client for every request).
+#: (default: ``120``)
+MLFLOW_WORKSPACE_CLIENT_CACHE_TTL = _EnvironmentVariable(
+    "MLFLOW_WORKSPACE_CLIENT_CACHE_TTL", int, 120
+)
 #: (Deprecated) Enable Unity Catalog integration for MLflow AI Gateway.
 #: This feature is deprecated and will be removed in a future release.
 #: (default: ``False``)

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -83,6 +83,7 @@ from mlflow.genai.utils.trace_utils import (
 )
 from mlflow.pyfunc.context import Context, set_prediction_context
 from mlflow.tracing.constant import AssessmentMetadataKey, TraceTagKey
+from mlflow.tracing.provider import is_tracing_enabled
 from mlflow.tracing.utils.copy import copy_trace_to_experiment
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils.mlflow_tags import IMMUTABLE_TAGS
@@ -680,14 +681,23 @@ def run(
         if trace_id in multi_turn_assessments:
             result.assessments.extend(multi_turn_assessments[trace_id])
 
-    # Link traces to the run if the backend support it
-    batch_link_traces_to_run(run_id=run_id, eval_results=eval_results)
+    # Skip trace-related operations when tracing is disabled. The operations below
+    # make HTTP calls to the tracking server (search_traces, get_trace, log_assessment,
+    # etc.) that are unconditional and can hang on stale connections under sustained load.
+    # When tracing is disabled, these calls fail with NO_OP trace IDs — skipping them
+    # avoids both the crash and the potential hang.
+    _tracing_enabled = is_tracing_enabled()
 
-    # Refresh traces on eval_results to include all logged assessments.
-    # This is done once after all assessments (single-turn and multi-turn) are logged to the traces.
-    _refresh_eval_result_traces(eval_results)
+    if _tracing_enabled:
+        # Link traces to the run if the backend support it
+        batch_link_traces_to_run(run_id=run_id, eval_results=eval_results)
 
-    # Aggregate metrics and log to MLflow run
+        # Refresh traces on eval_results to include all logged assessments.
+        # This is done once after all assessments (single-turn and multi-turn)
+        # are logged to the traces.
+        _refresh_eval_result_traces(eval_results)
+
+    # Aggregate metrics and log to MLflow run (always, regardless of tracing state)
     aggregated_metrics = compute_aggregated_metrics(eval_results, scorers=scorers)
     mlflow.log_metrics(aggregated_metrics)
 
@@ -696,22 +706,25 @@ def run(
     except Exception as e:
         _logger.debug(f"Failed to emit metric usage event: {e}", exc_info=True)
 
-    # Search for all traces in the run. We need to fetch the traces from backend here to include
-    # all traces in the result.
-    # Fetch the experiment ID from the run to ensure we search in the correct experiment.
-    traces = mlflow.search_traces(
-        locations=[experiment_id], run_id=run_id, include_spans=False, return_type="list"
-    )
+    if _tracing_enabled:
+        # Search for all traces in the run. We need to fetch the traces from backend
+        # here to include all traces in the result.
+        # Fetch the experiment ID from the run to ensure we search in the correct experiment.
+        traces = mlflow.search_traces(
+            locations=[experiment_id], run_id=run_id, include_spans=False, return_type="list"
+        )
 
-    # Collect trace IDs from eval results to preserve them during cleanup.
-    input_trace_ids = {
-        result.eval_item.trace.info.trace_id
-        for result in eval_results
-        if result.eval_item.trace is not None
-    }
+        # Collect trace IDs from eval results to preserve them during cleanup.
+        input_trace_ids = {
+            result.eval_item.trace.info.trace_id
+            for result in eval_results
+            if result.eval_item.trace is not None
+        }
 
-    # Clean up noisy traces generated during evaluation
-    clean_up_extra_traces(traces, eval_start_time, experiment_id, input_trace_ids)
+        # Clean up noisy traces generated during evaluation
+        clean_up_extra_traces(traces, eval_start_time, experiment_id, input_trace_ids)
+    else:
+        traces = []
 
     return EvaluationResult(
         run_id=run_id,
@@ -790,20 +803,26 @@ def _run_score(
     tags = eval_item.tags if not is_none_or_nan(eval_item.tags) else {}
     validate_tags(tags)
 
-    for key in tags.keys() - IMMUTABLE_TAGS:
-        try:
-            mlflow.set_trace_tag(trace_id=eval_item.trace.info.trace_id, key=key, value=tags[key])
-        except Exception as e:
-            _logger.warning(f"Failed to log tag {key} to MLflow: {e}")
+    # Skip trace tag and assessment logging when tracing is disabled.
+    # With tracing disabled, traces have NO_OP span IDs that the tracking
+    # server rejects, causing crashes instead of graceful no-ops.
+    if is_tracing_enabled():
+        for key in tags.keys() - IMMUTABLE_TAGS:
+            try:
+                mlflow.set_trace_tag(
+                    trace_id=eval_item.trace.info.trace_id, key=key, value=tags[key]
+                )
+            except Exception as e:
+                _logger.warning(f"Failed to log tag {key} to MLflow: {e}")
 
-    try:
-        _log_assessments(
-            run_id=run_id,
-            trace=eval_item.trace,
-            assessments=eval_result.assessments,
-        )
-    except Exception as e:
-        _logger.warning(f"Failed to log trace and assessments to MLflow: {e}")
+        try:
+            _log_assessments(
+                run_id=run_id,
+                trace=eval_item.trace,
+                assessments=eval_result.assessments,
+            )
+        except Exception as e:
+            _logger.warning(f"Failed to log trace and assessments to MLflow: {e}")
 
     return eval_result
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -3,10 +3,10 @@ import contextlib
 import json
 import logging
 import random
+import threading
 import time
 import warnings
 from contextvars import ContextVar
-from functools import lru_cache
 from typing import Any, Callable
 
 import requests
@@ -22,6 +22,7 @@ from mlflow.environment_variables import (
     MLFLOW_HTTP_REQUEST_MAX_RETRIES,
     MLFLOW_HTTP_REQUEST_TIMEOUT,
     MLFLOW_HTTP_RESPECT_RETRY_AFTER_HEADER,
+    MLFLOW_WORKSPACE_CLIENT_CACHE_TTL,
 )
 from mlflow.exceptions import (
     CUSTOMER_UNAUTHORIZED,
@@ -301,8 +302,12 @@ def http_request(
         raise MlflowException(f"API request to {url} failed with exception {e}")
 
 
-@lru_cache(maxsize=5)
-def get_workspace_client(
+_workspace_client_cache: dict = {}
+_workspace_client_cache_lock = threading.Lock()
+_workspace_client_cache_timestamps: dict = {}
+
+
+def _create_workspace_client(
     use_secret_scope_token,
     host,
     token,
@@ -326,6 +331,80 @@ def get_workspace_client(
     )
     # Note: If we use `config` param, all SDK configurations must be set in `config` object.
     return WorkspaceClient(config=config)
+
+
+def get_workspace_client(
+    use_secret_scope_token,
+    host,
+    token,
+    databricks_auth_profile,
+    retry_timeout_seconds=None,
+    timeout=None,
+):
+    """Get or create a cached WorkspaceClient with TTL-based expiration.
+
+    The client is cached to avoid creating a new SDK client for every HTTP call.
+    However, under sustained load (e.g., streaming jobs), the client's connection
+    pool can accumulate stale TCP connections when the cloud load balancer drops
+    idle connection state (~30s timeout). A stale connection causes ``recv()`` to
+    block indefinitely on a half-open TCP connection.
+
+    The TTL (controlled by ``MLFLOW_WORKSPACE_CLIENT_CACHE_TTL``, default 120s)
+    ensures the client and its connection pool are periodically recreated with
+    fresh connections, preventing stale connection hangs.
+    """
+    ttl = MLFLOW_WORKSPACE_CLIENT_CACHE_TTL.get()
+    cache_key = (
+        use_secret_scope_token,
+        host,
+        token,
+        databricks_auth_profile,
+        retry_timeout_seconds,
+        timeout,
+    )
+
+    with _workspace_client_cache_lock:
+        if cache_key in _workspace_client_cache:
+            created_at = _workspace_client_cache_timestamps[cache_key]
+            if ttl > 0 and (time.time() - created_at) < ttl:
+                return _workspace_client_cache[cache_key]
+            # TTL expired — remove stale entry
+            del _workspace_client_cache[cache_key]
+            del _workspace_client_cache_timestamps[cache_key]
+
+    client = _create_workspace_client(
+        use_secret_scope_token,
+        host,
+        token,
+        databricks_auth_profile,
+        retry_timeout_seconds,
+        timeout,
+    )
+
+    if ttl > 0:
+        with _workspace_client_cache_lock:
+            # Evict oldest entries if cache exceeds max size (5)
+            while len(_workspace_client_cache) >= 5:
+                oldest_key = min(
+                    _workspace_client_cache_timestamps,
+                    key=_workspace_client_cache_timestamps.get,
+                )
+                del _workspace_client_cache[oldest_key]
+                del _workspace_client_cache_timestamps[oldest_key]
+            _workspace_client_cache[cache_key] = client
+            _workspace_client_cache_timestamps[cache_key] = time.time()
+
+    return client
+
+
+# Backward compatibility: allow callers to clear the cache (e.g., tests, workarounds)
+def _clear_workspace_client_cache():
+    with _workspace_client_cache_lock:
+        _workspace_client_cache.clear()
+        _workspace_client_cache_timestamps.clear()
+
+
+get_workspace_client.cache_clear = _clear_workspace_client_cache
 
 
 def _can_parse_as_json_object(string):

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1722,3 +1722,62 @@ def test_adaptive_rate_reduces_on_429(monkeypatch):
     # At least one throttle event observed, and the rate was reduced
     assert len(rate_after_throttle) >= 1
     assert rate_after_throttle[0] < AUTO_INITIAL_RPS
+
+
+# ── Tracing-Disabled Tests ───────────────────────────────────────────────
+
+
+class TestEvaluateWithTracingDisabled:
+    """Tests for mlflow.genai.evaluate() when tracing is disabled.
+
+    Previously, calling mlflow.tracing.disable() before evaluate() caused crashes:
+    the harness unconditionally created NO_OP traces and then tried to call
+    get_trace(NO_OP_ID), which returned None, crashing on .info access.
+    After the fix, the harness skips trace operations when tracing is disabled.
+    """
+
+    @mock.patch("mlflow.genai.evaluation.harness.is_tracing_enabled", return_value=False)
+    @mock.patch("mlflow.genai.evaluation.harness.batch_link_traces_to_run")
+    @mock.patch("mlflow.genai.evaluation.harness._refresh_eval_result_traces")
+    @mock.patch("mlflow.genai.evaluation.harness.clean_up_extra_traces")
+    def test_skips_trace_operations_when_disabled(
+        self,
+        mock_cleanup,
+        mock_refresh,
+        mock_batch_link,
+        mock_tracing_enabled,
+    ):
+        @scorer
+        def always_pass(*, outputs) -> Feedback:
+            return Feedback(value="yes", rationale="pass")
+
+        with mock.patch("mlflow.search_traces") as mock_search:
+            result = mlflow.genai.evaluate(
+                data=[{"inputs": {"q": "test"}, "outputs": {"a": "answer"}}],
+                scorers=[always_pass],
+            )
+
+        # Trace operations should NOT have been called
+        mock_batch_link.assert_not_called()
+        mock_refresh.assert_not_called()
+        mock_search.assert_not_called()
+        mock_cleanup.assert_not_called()
+
+        # Metrics should still be logged and result returned
+        assert result.metrics is not None
+
+    @mock.patch("mlflow.genai.evaluation.harness.is_tracing_enabled", return_value=True)
+    def test_trace_operations_run_when_enabled(self, mock_tracing_enabled):
+        @scorer
+        def always_pass(*, outputs) -> Feedback:
+            return Feedback(value="yes", rationale="pass")
+
+        with mock.patch("mlflow.genai.evaluation.harness.batch_link_traces_to_run") as mock_link:
+            result = mlflow.genai.evaluate(
+                data=[{"inputs": {"q": "test"}, "outputs": {"a": "answer"}}],
+                scorers=[always_pass],
+            )
+            # When tracing is enabled, batch_link should be called
+            mock_link.assert_called_once()
+
+        assert result.metrics is not None

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -978,3 +978,98 @@ def test_validate_deployment_timeout_config(timeout, retry_timeout_seconds, shou
                 timeout=timeout, retry_timeout_seconds=retry_timeout_seconds
             )
             assert len(w) == 0
+
+
+# ── WorkspaceClient TTL Cache Tests ──────────────────────────────────────
+
+
+class TestWorkspaceClientTTLCache:
+    """Tests for TTL-based caching of WorkspaceClient.
+
+    The WorkspaceClient was previously @lru_cache'd with no TTL, causing stale
+    TCP connections to accumulate under sustained load (e.g., streaming jobs).
+    The TTL cache ensures periodic recreation of the client and its connection pool.
+    """
+
+    def setup_method(self):
+        """Clear the cache before each test."""
+        get_workspace_client.cache_clear()
+
+    def teardown_method(self):
+        get_workspace_client.cache_clear()
+
+    @mock.patch(
+        "mlflow.utils.rest_utils._create_workspace_client",
+        return_value=mock.MagicMock(),
+    )
+    def test_cache_reuse_within_ttl(self, mock_create):
+        client1 = get_workspace_client(True, "host", "token", None)
+        client2 = get_workspace_client(True, "host", "token", None)
+        assert client1 is client2
+        mock_create.assert_called_once()
+
+    @mock.patch(
+        "mlflow.utils.rest_utils._create_workspace_client",
+        side_effect=[mock.MagicMock(), mock.MagicMock()],
+    )
+    @mock.patch("mlflow.utils.rest_utils.MLFLOW_WORKSPACE_CLIENT_CACHE_TTL")
+    def test_cache_expires_after_ttl(self, mock_ttl_var, mock_create):
+        mock_ttl_var.get.return_value = 1  # 1 second TTL
+        client1 = get_workspace_client(True, "host", "token", None)
+        time.sleep(1.1)
+        client2 = get_workspace_client(True, "host", "token", None)
+        assert client1 is not client2
+        assert mock_create.call_count == 2
+
+    @mock.patch(
+        "mlflow.utils.rest_utils._create_workspace_client",
+        side_effect=[mock.MagicMock(), mock.MagicMock()],
+    )
+    def test_cache_clear_forces_new_client(self, mock_create):
+        client1 = get_workspace_client(True, "host", "token", None)
+        get_workspace_client.cache_clear()
+        client2 = get_workspace_client(True, "host", "token", None)
+        assert client1 is not client2
+        assert mock_create.call_count == 2
+
+    @mock.patch(
+        "mlflow.utils.rest_utils._create_workspace_client",
+        return_value=mock.MagicMock(),
+    )
+    def test_different_params_get_different_clients(self, mock_create):
+        mock_create.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        client1 = get_workspace_client(True, "host1", "token1", None)
+        client2 = get_workspace_client(True, "host2", "token2", None)
+        assert client1 is not client2
+        assert mock_create.call_count == 2
+
+    @mock.patch(
+        "mlflow.utils.rest_utils._create_workspace_client",
+        side_effect=[mock.MagicMock() for _ in range(6)],
+    )
+    def test_cache_evicts_oldest_when_full(self, mock_create):
+        # Fill cache with 5 entries (max size)
+        for i in range(5):
+            get_workspace_client(True, f"host{i}", "token", None)
+        assert mock_create.call_count == 5
+
+        # 6th entry should evict the oldest
+        get_workspace_client(True, "host5", "token", None)
+        assert mock_create.call_count == 6
+
+        # host0 was evicted, should create a new client
+        get_workspace_client(True, "host0", "token", None)
+        assert mock_create.call_count == 7
+
+    @mock.patch(
+        "mlflow.utils.rest_utils._create_workspace_client",
+        return_value=mock.MagicMock(),
+    )
+    @mock.patch("mlflow.utils.rest_utils.MLFLOW_WORKSPACE_CLIENT_CACHE_TTL")
+    def test_ttl_zero_disables_caching(self, mock_ttl_var, mock_create):
+        mock_ttl_var.get.return_value = 0
+        mock_create.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        client1 = get_workspace_client(True, "host", "token", None)
+        client2 = get_workspace_client(True, "host", "token", None)
+        assert client1 is not client2
+        assert mock_create.call_count == 2


### PR DESCRIPTION
### Related Issues/PRs

Relates to #15124 (Close connection when exporting traces — same class of issue)
Relates to #12669 (Traces stuck in progress — thread-safety bug in tracer)

### What changes are proposed in this pull request?

**Problem:** `mlflow.genai.evaluate()` hangs indefinitely after ~30 seconds of sustained use on Databricks (e.g., streaming jobs, batch evaluation loops). The hang occurs in post-scorer HTTP calls (`search_traces` at `harness.py:221`) and never recovers.

**Root cause:** `get_workspace_client()` in `rest_utils.py:284` uses `@lru_cache(maxsize=5)` with no TTL. The cached `WorkspaceClient` and its TCP connection pool persist for the entire process lifetime. Under sustained load, connections go stale when the cloud load balancer drops idle connection state (~30s timeout). When a thread picks up a half-open connection:

1. `send()` succeeds (TCP send buffer accepts the bytes)
2. The LB silently drops the packet (no connection tracking state)
3. `recv()` blocks indefinitely (TCP kernel retransmits at the OS level for 15-30 minutes)
4. No application-level timeout fires — the Databricks SDK path bypasses `MLFLOW_HTTP_REQUEST_TIMEOUT`

**Additionally:** `mlflow.tracing.disable()` does not prevent the hang because the evaluation harness makes all 8 post-scorer trace operations unconditionally (no `if tracing_enabled` checks). With tracing disabled, the harness creates NO_OP traces that crash on `get_trace()` → `AttributeError: 'NoneType' object has no attribute 'info'`.

**Changes:**

1. **Replace `@lru_cache` with TTL-based cache on `get_workspace_client()`** — Adds a thread-safe TTL cache (default 120s, controlled by `MLFLOW_WORKSPACE_CLIENT_CACHE_TTL`). The client and its connection pool are periodically recreated with fresh TCP connections, preventing stale connection hangs. Maintains backward compatibility with `cache_clear()`.

2. **Add `is_tracing_enabled()` checks in the evaluation harness** — When tracing is disabled, the harness now skips `batch_link_traces_to_run()`, `_refresh_eval_result_traces()`, `search_traces()`, `clean_up_extra_traces()`, `set_trace_tag()`, and `_log_assessments()`. Metrics logging (`log_metrics`) is always performed. `construct_eval_result_df()` already handles empty traces by returning `None`.

3. **Add `MLFLOW_WORKSPACE_CLIENT_CACHE_TTL` environment variable** — Allows users to control the TTL (default 120s). Set to 0 to disable caching entirely (useful for debugging).

**Reproduction:**

On Databricks (DBR 14.3, MLflow 3.10.1), run `mlflow.genai.evaluate()` in a loop:

```python
# Without fix: hangs at iteration ~14 (~31s elapsed)
for i in range(20):
    mlflow.genai.evaluate(data=EVAL_DATA, scorers=SCORERS)  # hangs at search_traces()

# With cache_clear() workaround: passes 30+ iterations
from mlflow.utils.rest_utils import get_workspace_client
for i in range(30):
    get_workspace_client.cache_clear()
    mlflow.genai.evaluate(data=EVAL_DATA, scorers=SCORERS)  # all pass
```

The ~31-second hang threshold matches the cloud LB idle connection timeout (~30s). Same Databricks workspace, same tracking server, same network — only difference is fresh vs stale connections.

**Why existing timeouts don't help:**

| Timeout | Why it fails |
|---------|-------------|
| `MLFLOW_HTTP_REQUEST_TIMEOUT` | Ignored on Databricks SDK path (`ws_client.api_client.do()` bypasses it) |
| `MLFLOW_TRACE_TIMEOUT_SECONDS` | Only affects trace collection, not post-scorer HTTP calls |
| `MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT` | Only checks between retries, not during a blocked `recv()` |
| `socket.setdefaulttimeout()` | SDK creates connections before the call; existing pooled connections unaffected |

**Why different environments behave differently:**

| Environment | Hang frequency | Why |
|-------------|---------------|-----|
| Notebook (sequential) | Never | Connections don't survive long enough to go stale |
| `applyInPandas` (separate processes) | Rarely | Each executor has its own pool |
| `ThreadPoolExecutor` (shared process) | Frequently | Shared pool under constant pressure |
| Streaming (sustained load) | After ~20 batches | `@lru_cache` persists forever, connections go stale after ~30s |

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**New tests:**
- `TestWorkspaceClientTTLCache` in `tests/utils/test_rest_utils.py` — Tests TTL expiry, cache reuse within TTL, cache clearing, different params, eviction, and TTL=0 (caching disabled)
- `TestEvaluateWithTracingDisabled` in `tests/genai/evaluate/test_evaluation.py` — Tests that trace operations are skipped when tracing is disabled, and still run when enabled

**Manual testing:**
Reproduction notebook on Databricks Runtime 14.3 validated:
- Hang reproduces at iteration ~14 without fix
- 30+ iterations pass with TTL cache / `cache_clear()`
- `mlflow.tracing.disable()` no longer crashes evaluate()

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `mlflow.genai.evaluate()` hanging indefinitely under sustained load (streaming jobs, batch loops) due to stale TCP connections in the cached `WorkspaceClient`. The client cache now uses TTL-based expiration (configurable via `MLFLOW_WORKSPACE_CLIENT_CACHE_TTL`, default 120s) to periodically recreate connections. Also fix `mlflow.tracing.disable()` to correctly skip post-scorer trace operations in the evaluation harness instead of crashing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)