### PR TITLE
Fix: Treat empty string model_id as None in copy_model_version to prevent validation error

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -896,7 +896,7 @@ class UcModelRegistryStore(BaseRestStore):
                     shutil.rmtree(local_model_dir)
 
     def _get_logged_model_from_model_id(self, model_id) -> LoggedModel | None:
-        if model_id is None:
+        if not model_id:
             return None
         try:
             return mlflow.get_logged_model(model_id)

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -464,7 +464,7 @@ class AbstractStore:
                 tags=[ModelVersionTag(k, v) for k, v in src_mv.tags.items()],
                 run_link=src_mv.run_link,
                 description=src_mv.description,
-                model_id=src_mv.model_id,
+                model_id=src_mv.model_id or None,
             )
             eprint(
                 f"Copied version '{src_mv.version}' of model '{src_mv.name}'"

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -979,6 +979,11 @@ def test_get_logged_model_from_model_id_returns_none_for_none_input(store):
     assert result is None
 
 
+def test_get_logged_model_from_model_id_returns_none_for_empty_string(store):
+    result = store._get_logged_model_from_model_id("")
+    assert result is None
+
+
 def test_get_logged_model_from_model_id_reraises_other_exceptions(store):
     with mock.patch(
         "mlflow.get_logged_model",

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1809,6 +1809,29 @@ def test_copy_model_version(store, copy_to_same_model):
     assert store.get_model_version_download_uri(dst_mv.name, dst_mv.version) == src_mv.source
 
 
+def test_copy_model_version_with_empty_model_id(store):
+    """Test that copy_model_version normalizes empty string model_id to None.
+
+    Regression test for https://github.com/mlflow/mlflow/issues/22012.
+    When copying model versions between UC locations, ModelVersion.model_id
+    can be an empty string '' instead of None, which causes
+    _validate_model_id_specified to reject it.
+    """
+    name = "test_copy_empty_model_id"
+    store.create_registered_model(name)
+    src_mv = _mv_maker(store, name)
+
+    # Simulate a source model version with empty string model_id
+    # (as can happen with UC model versions)
+    from unittest import mock
+
+    original_model_id = src_mv.model_id
+    with mock.patch.object(type(src_mv), "model_id", new_callable=lambda: property(lambda self: "")):
+        dst_mv = store.copy_model_version(src_mv, "test_copy_empty_model_id_dst")
+        assert dst_mv.name == "test_copy_empty_model_id_dst"
+        assert dst_mv.source == f"models:/{src_mv.name}/{src_mv.version}"
+
+
 def test_search_prompts(store):
     store.create_registered_model("model", tags=[RegisteredModelTag(key="fruit", value="apple")])
 


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #22012

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`copy_model_version` throws `MlflowException: 'model_id' must be a non-empty string, but got ''` when copying model versions between Unity Catalog locations. This happens because `ModelVersion.model_id` returns an empty string `''` instead of `None` for UC models that don't have a logged model association.

**Root Cause:**

Two places failed to handle empty string `model_id`:

1. `AbstractStore.copy_model_version()` passes `model_id=src_mv.model_id` directly to `create_model_version()`. When `model_id` is `''`, it eventually reaches `_validate_model_id_specified()` which rejects empty strings.

2. `UcModelRegistryStore._get_logged_model_from_model_id()` only checks `if model_id is None`, so empty string `''` passes through and triggers `mlflow.get_logged_model('')` which fails validation.

**Fix:**

- In `copy_model_version()`: normalize `model_id` using `src_mv.model_id or None` to convert empty string to `None`
- In `_get_logged_model_from_model_id()`: use `if not model_id` instead of `if model_id is None` to handle both `None` and `''`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

New tests added:
- `test_get_logged_model_from_model_id_returns_none_for_empty_string` — verifies the UC rest store guard clause handles empty string
- `test_copy_model_version_with_empty_model_id` — regression test verifying end-to-end copy with empty `model_id`

All existing `copy_model_version` and `_get_logged_model_from_model_id` tests continue to pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `copy_model_version` no longer throws an error when the source model version has an empty string `model_id`, which commonly occurs when copying between Unity Catalog locations.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
