### PR TITLE
fix(langchain): elevate secondary autolog exception handlers to logger.warning

### DIFF
--- a/mlflow/langchain/autolog.py
+++ b/mlflow/langchain/autolog.py
@@ -74,8 +74,8 @@ def autolog(
             "merge",
             _patched_callback_manager_merge,
         )
-    except Exception:
-        logger.debug("Failed to patch RunnableSequence or BaseCallbackManager.", exc_info=True)
+    except Exception as e:
+        logger.warning(f"Failed to apply RunnableSequence.batch or BaseCallbackManager.merge patch: {e}")
 
     _record_event(
         AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -1349,3 +1349,40 @@ async def test_autolog_run_tracer_inline_with_manual_traces_async():
     # Find and verify ChatOpenAI span has model name
     chat_model_span = next(s for s in spans if s.name == "ChatOpenAI")
     assert chat_model_span.model_name == "gpt-3.5-turbo"
+
+
+def test_autolog_secondary_patch_failure_emits_warning(caplog):
+    """
+    Verify that when the secondary patches for RunnableSequence.batch or
+    BaseCallbackManager.merge fail, a logger.warning is emitted (not logger.debug),
+    so users are informed at default log levels.
+
+    Regression test for https://github.com/mlflow/mlflow/issues/22032.
+    """
+    import logging
+
+    from mlflow.langchain import autolog as autolog_module
+
+    # Patch safe_patch so that the first call (BaseCallbackManager.__init__) succeeds
+    # but the second block (RunnableSequence.batch / BaseCallbackManager.merge) raises.
+    call_count = 0
+
+    def _safe_patch_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        # First call is the primary __init__ patch — let it succeed silently.
+        # Second call (inside the secondary try block) raises to trigger the warning.
+        if call_count >= 2:
+            raise RuntimeError("simulated patch failure")
+
+    with mock.patch(
+        "mlflow.langchain.autolog.safe_patch", side_effect=_safe_patch_side_effect
+    ):
+        with caplog.at_level(logging.WARNING, logger="mlflow.langchain.autolog"):
+            mlflow.langchain.autolog()
+
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "Failed to apply RunnableSequence.batch or BaseCallbackManager.merge patch" in m
+        for m in warning_messages
+    ), f"Expected warning not found. Captured warnings: {warning_messages}"


### PR DESCRIPTION
### Related Issues/PRs

Closes #22032

### What changes are proposed in this pull request?

Elevates secondary `mlflow.langchain.autolog()` exception handlers from `logger.debug()` to `logger.warning()` so users are informed when partial tracing instrumentation fails.

The secondary patches for `RunnableSequence.batch` and `BaseCallbackManager.merge` catch exceptions silently at `debug` level. Users running at the default log level have no way to know that partial tracing instrumentation failed — they only see incomplete traces with no error message.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_autolog_secondary_patch_failure_emits_warning` to `tests/langchain/test_langchain_autolog.py`. The test mocks `safe_patch` to raise on the secondary patching block and asserts `logger.warning` is emitted with the expected message via `caplog`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Elevates secondary autolog exception handlers from `logger.debug()` to `logger.warning()` so users are informed when `RunnableSequence.batch` or `BaseCallbackManager.merge` patches fail silently.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release