### PR TITLE
feat(cli): add `mlflow claude-setup` command for Claude Code skill installation

### DIFF
--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -1297,6 +1297,11 @@ from mlflow.cli.demo import demo
 
 cli.add_command(demo)
 
+# Add Claude Code skill-installation command
+from mlflow.cli.claude_setup import claude_setup
+
+cli.add_command(claude_setup)
+
 # Add AI commands CLI
 cli.add_command(ai_commands.commands)
 

--- a/mlflow/cli/claude_setup.py
+++ b/mlflow/cli/claude_setup.py
@@ -1,0 +1,91 @@
+"""CLI command for installing MLflow Claude Code skills."""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import click
+
+
+@click.command("claude-setup")
+@click.option(
+    "--skills-repo",
+    default="https://github.com/mlflow/skills",
+    show_default=True,
+    help="URL of the skills repository to clone.",
+)
+@click.option(
+    "--target-dir",
+    default=str(Path.home() / ".claude" / "skills"),
+    show_default=True,
+    help="Target directory where skills will be installed.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing skills.",
+)
+def claude_setup(skills_repo: str, target_dir: str, force: bool) -> None:
+    """Install MLflow skills for Claude Code.
+
+    Clones the mlflow/skills repository and installs each top-level skill
+    directory into the target directory (default: ~/.claude/skills/).
+
+    After installation, restart Claude Code to activate the new skills.
+
+    \b
+    Examples:
+        mlflow claude-setup
+        mlflow claude-setup --force
+        mlflow claude-setup --target-dir /path/to/skills
+        mlflow claude-setup --skills-repo https://github.com/my-org/my-skills
+    """
+    target = Path(target_dir).expanduser()
+    target.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        click.echo(f"Cloning {skills_repo}...")
+        try:
+            subprocess.run(
+                ["git", "clone", "--depth", "1", skills_repo, tmpdir],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.decode(errors="replace").strip()
+            raise click.ClickException(
+                f"Failed to clone {skills_repo}.\n{stderr}"
+            ) from None
+
+        installed = []
+        skipped = []
+
+        for skill_dir in sorted(Path(tmpdir).iterdir()):
+            if not skill_dir.is_dir() or skill_dir.name.startswith("."):
+                continue
+
+            dest = target / skill_dir.name
+            if dest.exists() and not force:
+                skipped.append(skill_dir.name)
+                continue
+
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(str(skill_dir), str(dest))
+            installed.append(skill_dir.name)
+            click.echo(f"  \u2713 {skill_dir.name}")
+
+        if skipped:
+            click.echo(f"\nSkipped (already installed): {', '.join(skipped)}")
+            click.echo("Use --force to overwrite.")
+
+        if installed:
+            click.echo(
+                f"\nInstalled {len(installed)} MLflow skill(s) to {target}"
+            )
+        else:
+            click.echo(f"\nNo new skills installed to {target}")
+
+        click.echo("Restart Claude Code to activate.")

--- a/tests/cli/test_claude_setup.py
+++ b/tests/cli/test_claude_setup.py
@@ -1,0 +1,232 @@
+"""Tests for the `mlflow claude-setup` CLI command."""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from mlflow.cli import cli
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_clone(skill_names):
+    """Return a side_effect for subprocess.run that populates tmpdir with dirs."""
+
+    def _side_effect(cmd, check, capture_output):
+        # cmd is: ["git", "clone", "--depth", "1", repo_url, tmpdir]
+        tmpdir = cmd[-1]
+        for name in skill_names:
+            Path(tmpdir, name).mkdir(parents=True)
+            # put a marker file so copytree has something to copy
+            (Path(tmpdir, name) / "SKILL.md").write_text(f"# {name}")
+        # also plant a dot-directory that should be skipped
+        Path(tmpdir, ".git").mkdir()
+
+    return _side_effect
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_claude_setup_happy_path(tmp_path):
+    """Skills are cloned and copied to the target directory."""
+    runner = CliRunner()
+    skill_names = ["mlflow-tracking", "mlflow-evaluation"]
+
+    with (
+        mock.patch("subprocess.run", side_effect=_make_fake_clone(skill_names)) as mock_run,
+        mock.patch("shutil.copytree") as mock_copytree,
+    ):
+        result = runner.invoke(
+            cli,
+            ["claude-setup", "--target-dir", str(tmp_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_run.assert_called_once()
+    assert mock_copytree.call_count == len(skill_names)
+    for name in skill_names:
+        assert f"\u2713 {name}" in result.output
+    assert "Restart Claude Code" in result.output
+
+
+def test_claude_setup_creates_target_dir(tmp_path):
+    """Target directory is created if it does not exist."""
+    runner = CliRunner()
+    nested = tmp_path / "deep" / "nested" / "skills"
+
+    with (
+        mock.patch("subprocess.run", side_effect=_make_fake_clone(["skill-a"])),
+        mock.patch("shutil.copytree"),
+    ):
+        result = runner.invoke(
+            cli,
+            ["claude-setup", "--target-dir", str(nested)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert nested.exists()
+
+
+# ---------------------------------------------------------------------------
+# --force flag
+# ---------------------------------------------------------------------------
+
+
+def test_claude_setup_skips_existing_without_force(tmp_path):
+    """Existing skills are skipped when --force is not used."""
+    runner = CliRunner()
+    skill_names = ["skill-a", "skill-b"]
+
+    # Pre-create one of the skill directories to simulate it already existing
+    (tmp_path / "skill-a").mkdir()
+
+    with (
+        mock.patch("subprocess.run", side_effect=_make_fake_clone(skill_names)),
+        mock.patch("shutil.copytree") as mock_copytree,
+    ):
+        result = runner.invoke(
+            cli,
+            ["claude-setup", "--target-dir", str(tmp_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+    # skill-a already existed → should be skipped, not overwritten
+    assert mock_copytree.call_count == 1  # only skill-b copied
+    assert "Skipped (already installed): skill-a" in result.output
+    assert "Use --force to overwrite." in result.output
+    assert "\u2713 skill-b" in result.output
+
+
+def test_claude_setup_force_overwrites_existing(tmp_path):
+    """Existing skills are removed and reinstalled when --force is used."""
+    import importlib
+
+    _module = importlib.import_module("mlflow.cli.claude_setup")
+
+    runner = CliRunner()
+    skill_names = ["skill-a", "skill-b"]
+
+    # Pre-create both skill directories in the target
+    for name in skill_names:
+        (tmp_path / name).mkdir()
+
+    with (
+        mock.patch("subprocess.run", side_effect=_make_fake_clone(skill_names)),
+        mock.patch.object(_module.shutil, "copytree") as mock_copytree,
+        mock.patch.object(_module.shutil, "rmtree") as mock_rmtree,
+    ):
+        result = runner.invoke(
+            cli,
+            ["claude-setup", "--target-dir", str(tmp_path), "--force"],
+        )
+
+    assert result.exit_code == 0, result.output
+    # Both skills should be copied
+    assert mock_copytree.call_count == len(skill_names)
+    # Each pre-existing skill dir should have been removed before re-copy.
+    # rmtree may also be called by TemporaryDirectory cleanup, so we check
+    # that each target skill path appears in the rmtree call args.
+    rmtree_paths = {str(c.args[0]) for c in mock_rmtree.call_args_list}
+    for name in skill_names:
+        assert str(tmp_path / name) in rmtree_paths
+    assert "Skipped" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# --skills-repo option
+# ---------------------------------------------------------------------------
+
+
+def test_claude_setup_custom_repo(tmp_path):
+    """--skills-repo is forwarded to git clone."""
+    runner = CliRunner()
+    custom_repo = "https://github.com/my-org/my-skills"
+
+    with (
+        mock.patch("subprocess.run", side_effect=_make_fake_clone(["skill-x"])) as mock_run,
+        mock.patch("shutil.copytree"),
+    ):
+        result = runner.invoke(
+            cli,
+            ["claude-setup", "--target-dir", str(tmp_path), "--skills-repo", custom_repo],
+        )
+
+    assert result.exit_code == 0, result.output
+    cmd_used = mock_run.call_args[0][0]
+    assert custom_repo in cmd_used
+
+
+# ---------------------------------------------------------------------------
+# --target-dir option
+# ---------------------------------------------------------------------------
+
+
+def test_claude_setup_custom_target_dir(tmp_path):
+    """--target-dir controls where skills are installed."""
+    runner = CliRunner()
+    custom_target = tmp_path / "custom-skills"
+
+    with (
+        mock.patch("subprocess.run", side_effect=_make_fake_clone(["skill-y"])),
+        mock.patch("shutil.copytree") as mock_copytree,
+    ):
+        result = runner.invoke(
+            cli,
+            ["claude-setup", "--target-dir", str(custom_target)],
+        )
+
+    assert result.exit_code == 0, result.output
+    # The destination passed to copytree should be inside custom_target
+    dest_arg = mock_copytree.call_args[0][1]
+    assert str(custom_target) in dest_arg
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_claude_setup_git_failure(tmp_path):
+    """A failing git clone exits with a non-zero code and shows an error."""
+    runner = CliRunner()
+
+    with mock.patch(
+        "subprocess.run",
+        side_effect=__import__("subprocess").CalledProcessError(
+            128, ["git"], stderr=b"repository not found"
+        ),
+    ):
+        result = runner.invoke(
+            cli,
+            ["claude-setup", "--target-dir", str(tmp_path)],
+        )
+
+    assert result.exit_code != 0
+    assert "Failed to clone" in result.output
+
+
+def test_claude_setup_no_skills_in_repo(tmp_path):
+    """An empty repo (no skill dirs) reports zero installed skills."""
+    runner = CliRunner()
+
+    # Clone side-effect creates no skill directories
+    with (
+        mock.patch("subprocess.run", side_effect=_make_fake_clone([])),
+        mock.patch("shutil.copytree") as mock_copytree,
+    ):
+        result = runner.invoke(
+            cli,
+            ["claude-setup", "--target-dir", str(tmp_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_copytree.assert_not_called()
+    assert "No new skills installed" in result.output


### PR DESCRIPTION
### Related Issues/PRs

Closes #22031

### What changes are proposed in this pull request?

Adds `mlflow claude-setup` CLI command that installs MLflow's Claude Code skills from `github.com/mlflow/skills` into `~/.claude/skills/`.

`pip install mlflow` cannot auto-install `.claude/` skill files due to Python packaging constraints. This command provides a single, discoverable entry point: after installing mlflow, run `mlflow claude-setup` and restart Claude Code.

The command follows the same pattern as `mlflow/cli/demo.py` — implemented in its own file (`mlflow/cli/claude_setup.py`) and registered in `__init__.py`.

**Usage:**
```bash
mlflow claude-setup                          # Install to ~/.claude/skills/
mlflow claude-setup --force                  # Overwrite existing skills
mlflow claude-setup --target-dir /path/      # Install to custom location
mlflow claude-setup --skills-repo <url>      # Use a different skills source
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests

Added `tests/cli/test_claude_setup.py` with 8 unit tests covering: happy path, `--force` flag, `--target-dir` option, skipping dot-directories, skipping existing skills without `--force`. All tests pass. `git clone` is mocked — no network access required.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds `mlflow claude-setup` CLI command that installs MLflow skills for Claude Code in one step, removing the need to manually discover and clone `github.com/mlflow/skills`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release