### PR TITLE
feat(ui): display scorer description in tooltip for custom judges

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTable.tsx
@@ -81,6 +81,7 @@ function GenAiTracesTableImpl({
   onTraceTagsEdit,
   traceActions,
   initialSelectedColumns,
+  scorerDescriptionsByName,
 }: {
   experimentId: string;
   currentEvaluationResults: RunEvaluationTracesDataEntry[];
@@ -103,6 +104,13 @@ function GenAiTracesTableImpl({
   onTraceTagsEdit?: (trace: ModelTraceInfoV3) => void;
   traceActions?: TraceActions;
   initialSelectedColumns?: (allColumns: TracesTableColumn[]) => TracesTableColumn[];
+  /**
+   * Optional map from scorer name to description string. When provided, custom scorers
+   * (source_type === 'CODE') will display their description in the column tooltip instead
+   * of the generic "This assessment is produced by a custom metric." message.
+   * Keys are scorer names (matching assessment source.sourceId).
+   */
+  scorerDescriptionsByName?: Record<string, string>;
 }) {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -126,8 +134,8 @@ function GenAiTracesTableImpl({
   const [searchQuery, setSearchQuery] = useEvaluationsSearchQuery();
 
   const assessmentInfos = useMemo(() => {
-    return getAssessmentInfos(intl, currentEvaluationResults, compareToEvaluationResults);
-  }, [intl, currentEvaluationResults, compareToEvaluationResults]);
+    return getAssessmentInfos(intl, currentEvaluationResults, compareToEvaluationResults, scorerDescriptionsByName);
+  }, [intl, currentEvaluationResults, compareToEvaluationResults, scorerDescriptionsByName]);
 
   const allColumns: TracesTableColumn[] = useTableColumns(intl, currentEvaluationResults, assessmentInfos, runUuid);
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.test.ts
@@ -442,6 +442,81 @@ describe('getAssessmentInfos', () => {
 
     expect(mixedAssessmentInfo?.isSessionLevelAssessment).toBe(true);
   });
+
+  describe('scorer description in tooltip', () => {
+    const codeSource: RunEvaluationResultAssessmentSource = {
+      sourceType: 'CODE',
+      sourceId: 'my_custom_scorer',
+      metadata: {},
+    };
+
+    it('falls back to generic message when no scorerDescriptionsByName is provided', () => {
+      const currentEvaluationResults = makeTracesFromAssessments([
+        {
+          responseAssessmentsByName: {
+            my_custom_scorer: [{ name: 'my_custom_scorer', booleanValue: true, source: codeSource }],
+          },
+        },
+      ]);
+
+      const result = getAssessmentInfos(intl, currentEvaluationResults, undefined);
+      const info = result.find((r) => r.name === 'my_custom_scorer');
+
+      expect(info?.description).toBe('This assessment is produced by a custom metric.');
+    });
+
+    it('falls back to generic message when scorer is not in scorerDescriptionsByName', () => {
+      const currentEvaluationResults = makeTracesFromAssessments([
+        {
+          responseAssessmentsByName: {
+            my_custom_scorer: [{ name: 'my_custom_scorer', booleanValue: true, source: codeSource }],
+          },
+        },
+      ]);
+
+      const result = getAssessmentInfos(intl, currentEvaluationResults, undefined, { other_scorer: 'Other desc' });
+      const info = result.find((r) => r.name === 'my_custom_scorer');
+
+      expect(info?.description).toBe('This assessment is produced by a custom metric.');
+    });
+
+    it('shows scorer name and description when scorerDescriptionsByName has an entry for the scorer', () => {
+      const currentEvaluationResults = makeTracesFromAssessments([
+        {
+          responseAssessmentsByName: {
+            my_custom_scorer: [{ name: 'my_custom_scorer', booleanValue: true, source: codeSource }],
+          },
+        },
+      ]);
+
+      const scorerDescriptionsByName = { my_custom_scorer: 'Checks whether the response is accurate.' };
+      const result = getAssessmentInfos(intl, currentEvaluationResults, undefined, scorerDescriptionsByName);
+      const info = result.find((r) => r.name === 'my_custom_scorer');
+
+      expect(info?.description).toBe('my_custom_scorer \u2014 Checks whether the response is accurate.');
+    });
+
+    it('does not use scorerDescriptionsByName for HUMAN-sourced assessments', () => {
+      const humanSource: RunEvaluationResultAssessmentSource = {
+        sourceType: 'HUMAN',
+        sourceId: 'human_annotator',
+        metadata: {},
+      };
+      const currentEvaluationResults = makeTracesFromAssessments([
+        {
+          responseAssessmentsByName: {
+            human_annotator: [{ name: 'human_annotator', booleanValue: true, source: humanSource }],
+          },
+        },
+      ]);
+
+      const scorerDescriptionsByName = { human_annotator: 'Should not appear' };
+      const result = getAssessmentInfos(intl, currentEvaluationResults, undefined, scorerDescriptionsByName);
+      const info = result.find((r) => r.name === 'human_annotator');
+
+      expect(info?.description).toBe('This assessment is produced by a human judge.');
+    });
+  });
 });
 
 describe('getAssessmentAggregateOverallFraction', () => {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/AggregationUtils.ts
@@ -75,11 +75,17 @@ const PASS_FAIL_VALUES: string[] = [
 ];
 /**
  * Computes global metadata for each of the assessments.
+ *
+ * @param scorerDescriptionsByName Optional map from scorer name to description string.
+ *   When provided, custom scorers (source_type === 'CODE') that have an entry in this
+ *   map will show "{scorer_name} — {description}" in their tooltip instead of the
+ *   generic "This assessment is produced by a custom metric." fallback.
  */
 export function getAssessmentInfos(
   intl: IntlShape,
   currentEvaluationResults: RunEvaluationTracesDataEntry[],
   otherEvaluationResults: RunEvaluationTracesDataEntry[] | undefined,
+  scorerDescriptionsByName?: Record<string, string>,
 ): AssessmentInfo[] {
   const assessmentInfos: Record<string, AssessmentInfo> = {};
   // Compute dtypes in the first pass.
@@ -223,6 +229,9 @@ export function getAssessmentInfos(
           assessmentName in KnownEvaluationResultAssessmentValueMissingTooltip
             ? intl.formatMessage(KnownEvaluationResultAssessmentValueMissingTooltip[assessmentName])
             : '';
+        const customScorerName = assessment?.source?.sourceId;
+        const customScorerDescription =
+          customScorerName && scorerDescriptionsByName ? scorerDescriptionsByName[customScorerName] : undefined;
         const description =
           assessmentName in KnownEvaluationResultAssessmentValueDescription
             ? intl.formatMessage(KnownEvaluationResultAssessmentValueDescription[assessmentName])
@@ -231,10 +240,12 @@ export function getAssessmentInfos(
                   defaultMessage: 'This assessment is produced by a human judge.',
                   description: 'Human judge assessment description',
                 })
-              : intl.formatMessage({
-                  defaultMessage: 'This assessment is produced by a custom metric.',
-                  description: 'Custom judge assessment description',
-                });
+              : customScorerDescription
+                ? `${customScorerName} \u2014 ${customScorerDescription}`
+                : intl.formatMessage({
+                    defaultMessage: 'This assessment is produced by a custom metric.',
+                    description: 'Custom judge assessment description',
+                  });
 
         const uniqueValues = new Set<AssessmentValueType>();
         // If no assessments exist for this name, add undefined to track missing assessments


### PR DESCRIPTION
## Changes

Custom scorers registered with a description via `mlflow.register_scorer(description=...)` now display that description in the Traces UI tooltip.

**Before:** All custom scorers show: `This assessment is produced by a custom metric.`

**After:** Custom scorers with a description show: `{scorer_name} — {description}`

Built-in LLM judges already display their full description — this change brings custom code scorers to parity.

## Implementation

The fix is entirely in the frontend display layer — no API contract changes.

- `getAssessmentInfos()` in `AggregationUtils.ts` gains an optional `scorerDescriptionsByName?: Record<string, string>` parameter. When a CODE-sourced assessment's `source.sourceId` (the scorer name) has an entry in this map, the tooltip shows `{scorer_name} — {description}` instead of the generic fallback.

- `GenAiTracesTable` gains a matching optional `scorerDescriptionsByName` prop so callers with access to the scorer registry can pass descriptions through. Callers that don't pass it get the existing behavior unchanged.

**Key finding:** The scorer `description` is NOT in the assessment data itself — it lives in `serialized_scorer` in the scorer registry API. The assessment's `source.sourceId` = scorer name (the lookup key). Callers with `experimentId` can fetch scorer descriptions via `listScorers` and pass them via the new prop.

## Why it's backward-compatible

All four existing callers (`getAssessmentInfos`, both in `GenAITracesTable.tsx` and `useMlflowTraces.tsx`) work without modification. The `scorerDescriptionsByName` parameter is optional with `undefined` as the default, which produces the same output as before.

## Tests

Four new unit tests in `AggregationUtils.test.ts` cover:
- No descriptions map provided → generic fallback
- Scorer not in the map → generic fallback  
- Scorer found in the map → shows `{name} — {description}`
- HUMAN-sourced assessment → human message (not affected by scorer map)

## Release Notes

- [x] Feature

Fixes #22034