### PR TITLE
Add builtin `cost_per_token` to remove litellm dependency for cost tracking

### DIFF
--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -23,6 +23,23 @@ from mlflow.types.chat import Function, ToolCallDelta
 _logger = logging.getLogger(__name__)
 
 
+def _normalize_anthropic_input_tokens(
+    token_usage: dict[str, int] | None,
+) -> dict[str, int] | None:
+    """Anthropic's input_tokens excludes cache tokens. Add them so input_tokens
+    represents the total input (consistent with OpenAI/Gemini).
+    """
+    if not token_usage or TokenUsageKey.INPUT_TOKENS not in token_usage:
+        return token_usage
+    cache_read = token_usage.get(TokenUsageKey.CACHE_READ_INPUT_TOKENS, 0)
+    cache_creation = token_usage.get(TokenUsageKey.CACHE_CREATION_INPUT_TOKENS, 0)
+    if cache_read or cache_creation:
+        token_usage[TokenUsageKey.INPUT_TOKENS] += cache_read + cache_creation
+        if TokenUsageKey.TOTAL_TOKENS in token_usage:
+            token_usage[TokenUsageKey.TOTAL_TOKENS] += cache_read + cache_creation
+    return token_usage
+
+
 class _UnsupportedSchemaError(Exception):
     """Schema contains constructs that Anthropic structured outputs cannot represent."""
 
@@ -277,21 +294,30 @@ class AnthropicAdapter(ProviderAdapter):
 
     @classmethod
     def _build_chat_usage(cls, usage_data: dict[str, Any]) -> chat.ChatUsage:
+        # Anthropic's input_tokens excludes cache tokens, but we normalize prompt_tokens
+        # to include them (consistent with OpenAI/Gemini) so cost calculation works uniformly.
+        # Ref: https://platform.claude.com/docs/en/build-with-claude/prompt-caching
         input_tokens = usage_data.get("input_tokens")
         output_tokens = usage_data.get("output_tokens")
+        cache_read = usage_data.get("cache_read_input_tokens")
+        cache_creation = usage_data.get("cache_creation_input_tokens")
+
+        prompt_tokens = input_tokens
+        if prompt_tokens is not None:
+            prompt_tokens += (cache_read or 0) + (cache_creation or 0)
+
         total_tokens = None
-        if input_tokens is not None and output_tokens is not None:
-            total_tokens = input_tokens + output_tokens
+        if prompt_tokens is not None and output_tokens is not None:
+            total_tokens = prompt_tokens + output_tokens
+
         prompt_tokens_details = None
-        if "cache_read_input_tokens" in usage_data:
-            prompt_tokens_details = chat.PromptTokensDetails(
-                cached_tokens=usage_data["cache_read_input_tokens"]
-            )
+        if cache_read is not None:
+            prompt_tokens_details = chat.PromptTokensDetails(cached_tokens=cache_read)
         extra = {}
-        if "cache_creation_input_tokens" in usage_data:
-            extra["cache_creation_input_tokens"] = usage_data["cache_creation_input_tokens"]
+        if cache_creation is not None:
+            extra["cache_creation_input_tokens"] = cache_creation
         return chat.ChatUsage(
-            prompt_tokens=input_tokens,
+            prompt_tokens=prompt_tokens,
             completion_tokens=output_tokens,
             total_tokens=total_tokens,
             prompt_tokens_details=prompt_tokens_details,
@@ -637,13 +663,14 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
             }
         }
         """
-        return self._extract_token_usage_from_dict(
+        token_usage = self._extract_token_usage_from_dict(
             result.get("usage"),
             "input_tokens",
             "output_tokens",
             cache_read_key="cache_read_input_tokens",
             cache_creation_key="cache_creation_input_tokens",
         )
+        return _normalize_anthropic_input_tokens(token_usage)
 
     def _extract_streaming_token_usage(self, chunk: bytes) -> dict[str, int]:
         """
@@ -672,7 +699,8 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
                         usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = created
                 case {"type": "message_delta", "usage": {"output_tokens": int(output_tokens)}}:
                     usage[TokenUsageKey.OUTPUT_TOKENS] = output_tokens
-        return usage
+        # Anthropic's input_tokens excludes cache tokens; normalize to include them.
+        return _normalize_anthropic_input_tokens(usage) or usage
 
     async def _passthrough(
         self,

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -296,13 +296,6 @@ def calculate_cost_by_model_and_token_usage(
     if not model_name or not usage:
         return None
 
-    try:
-        import litellm
-        from litellm import cost_per_token
-    except ImportError:
-        _logger.debug("LiteLLM not available for cost calculation")
-        return None
-
     prompt_tokens = usage.get(TokenUsageKey.INPUT_TOKENS, 0)
     completion_tokens = usage.get(TokenUsageKey.OUTPUT_TOKENS, 0)
 
@@ -315,19 +308,30 @@ def calculate_cost_by_model_and_token_usage(
     if (created := usage.get(TokenUsageKey.CACHE_CREATION_INPUT_TOKENS)) is not None:
         cache_kwargs["cache_creation_input_tokens"] = created
 
-    original_suppress = None
     try:
-        # Suppress litellm debug messages (e.g. "Provider List: ...") unless
-        # MLflow's logger is set to DEBUG level.
+        import litellm
+        from litellm import cost_per_token
+    except ImportError:
+        from mlflow.utils.providers import cost_per_token
+
+        litellm = None
+
+    if litellm is not None:
         original_suppress = getattr(litellm, "suppress_debug_info")
-        litellm.suppress_debug_info = not _logger.isEnabledFor(logging.DEBUG)
+
+    try:
+        if litellm is not None:
+            # Suppress litellm debug messages (e.g. "Provider List: ...") unless
+            # MLflow's logger is set to DEBUG level.
+            litellm.suppress_debug_info = not _logger.isEnabledFor(logging.DEBUG)
+
         input_cost_usd, output_cost_usd = cost_per_token(
             model=model_name,
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             **cache_kwargs,
         )
-    except Exception as e:
+    except Exception:
         if model_provider:
             # pass model_provider only in exception case to avoid invalid model_provider
             # being used when model_name itself is enough to calculate cost, since model_provider
@@ -347,12 +351,12 @@ def calculate_cost_by_model_and_token_usage(
                 return None
         else:
             _logger.debug(
-                f"Failed to calculate cost for model {model_name} without provider: {e}",
+                f"Failed to calculate cost for model {model_name} without provider",
                 exc_info=True,
             )
             return None
     finally:
-        if original_suppress is not None:
+        if litellm is not None:
             litellm.suppress_debug_info = original_suppress
 
     return {

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -325,40 +325,48 @@ def calculate_cost_by_model_and_token_usage(
             # MLflow's logger is set to DEBUG level.
             litellm.suppress_debug_info = not _logger.isEnabledFor(logging.DEBUG)
 
-        input_cost_usd, output_cost_usd = cost_per_token(
+        result = cost_per_token(
             model=model_name,
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             **cache_kwargs,
         )
     except Exception:
+        result = None
         if model_provider:
             # pass model_provider only in exception case to avoid invalid model_provider
             # being used when model_name itself is enough to calculate cost, since model_provider
             # field can be with any value and litellm may not support it.
             try:
-                input_cost_usd, output_cost_usd = cost_per_token(
+                result = cost_per_token(
                     model=model_name,
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     custom_llm_provider=model_provider,
                     **cache_kwargs,
                 )
-            except Exception as e:
-                _logger.debug(
-                    f"Failed to calculate cost for model {model_name}: {e}", exc_info=True
-                )
-                return None
-        else:
-            _logger.debug(
-                f"Failed to calculate cost for model {model_name} without provider",
-                exc_info=True,
-            )
-            return None
+            except Exception:
+                pass
     finally:
         if litellm is not None:
             litellm.suppress_debug_info = original_suppress
 
+    if result is None:
+        # Try with provider as a last resort (builtin path only, litellm already tried above)
+        if litellm is None and model_provider:
+            result = cost_per_token(
+                model=model_name,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                custom_llm_provider=model_provider,
+                **cache_kwargs,
+            )
+
+    if result is None:
+        _logger.debug(f"Failed to calculate cost for model {model_name}")
+        return None
+
+    input_cost_usd, output_cost_usd = result
     return {
         CostKey.INPUT_COST: input_cost_usd,
         CostKey.OUTPUT_COST: output_cost_usd,

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -80,13 +80,15 @@ def _get_model_cost() -> dict[tuple[str | None, str], ModelInfo]:
             raw = json.load(f)
     except FileNotFoundError:
         return {}
+    model_info_keys = ModelInfo.__annotations__
     result: dict[tuple[str | None, str], ModelInfo] = {}
     for key, info in raw.items():
         provider = info.get("litellm_provider")
         model_name = key.split("/", 1)[-1]
+        filtered = {k: v for k, v in info.items() if k in model_info_keys}
         if provider:
-            result.setdefault((provider, model_name), info)
-        result.setdefault((None, model_name), info)
+            result.setdefault((provider, model_name), filtered)
+        result.setdefault((None, model_name), filtered)
     return result
 
 

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -59,6 +59,70 @@ def _get_model_cost() -> dict[str, Any]:
         return {}
 
 
+def _lookup_model_info(model: str, custom_llm_provider: str | None = None) -> dict[str, Any] | None:
+    """Look up model cost info from the bundled JSON, trying multiple key formats."""
+    model_cost = _get_model_cost()
+
+    # Exact match (handles most models like "gpt-4o", "claude-sonnet-4-20250514")
+    if model in model_cost:
+        return model_cost[model]
+
+    # Try with provider prefix (e.g. "azure/gpt-4o", "vertex_ai/gemini-2.5-flash")
+    if custom_llm_provider:
+        prefixed = f"{custom_llm_provider}/{model}"
+        if prefixed in model_cost:
+            return model_cost[prefixed]
+
+    return None
+
+
+def cost_per_token(
+    model: str,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+    custom_llm_provider: str | None = None,
+    cache_read_input_tokens: int | None = None,
+    cache_creation_input_tokens: int | None = None,
+) -> tuple[float, float]:
+    """Calculate cost per token using the bundled model price data.
+
+    Returns:
+        A tuple of (input_cost, output_cost) in USD.
+
+    Raises:
+        ValueError: If the model is not found in the cost data or has no pricing info.
+    """
+    info = _lookup_model_info(model, custom_llm_provider)
+    if info is None:
+        raise ValueError(f"Model {model!r} not found in model cost data")
+
+    input_cost_per_token = info.get("input_cost_per_token")
+    output_cost_per_token = info.get("output_cost_per_token")
+    if input_cost_per_token is None and output_cost_per_token is None:
+        raise ValueError(f"No token pricing info for model {model!r}")
+
+    input_cost_per_token = input_cost_per_token or 0.0
+    output_cost_per_token = output_cost_per_token or 0.0
+
+    # prompt_tokens includes cache tokens (both Anthropic and OpenAI report it this way),
+    # so we subtract them to get the regular (non-cached) portion, then price each
+    # category at its own rate.
+    cache_read = cache_read_input_tokens or 0
+    cache_creation = cache_creation_input_tokens or 0
+    regular_input_tokens = max(prompt_tokens - cache_read - cache_creation, 0)
+
+    input_cost = regular_input_tokens * input_cost_per_token
+    if cache_read > 0:
+        input_cost += cache_read * info.get("cache_read_input_token_cost", input_cost_per_token)
+    if cache_creation > 0:
+        input_cost += cache_creation * info.get(
+            "cache_creation_input_token_cost", input_cost_per_token
+        )
+    output_cost = completion_tokens * output_cost_per_token
+
+    return input_cost, output_cost
+
+
 # Auth modes for providers with multiple authentication options.
 # Each mode defines:
 #   - display_name: Human-readable name for UI

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -49,32 +49,30 @@ class ProviderConfigResponse(TypedDict):
     default_mode: str
 
 
-_MODEL_INFO_FIELDS = frozenset({
+class ModelInfo(TypedDict, total=False):
     # Used by _build_model_dict
-    "supports_function_calling",
-    "supports_vision",
-    "supports_reasoning",
-    "supports_prompt_caching",
-    "supports_response_schema",
-    "max_input_tokens",
-    "max_output_tokens",
-    "input_cost_per_token",
-    "output_cost_per_token",
-    "deprecation_date",
+    supports_function_calling: bool
+    supports_vision: bool
+    supports_reasoning: bool
+    supports_prompt_caching: bool
+    supports_response_schema: bool
+    max_input_tokens: int
+    max_output_tokens: int
+    input_cost_per_token: float
+    output_cost_per_token: float
+    deprecation_date: str
     # Used by cost_per_token
-    "cache_read_input_token_cost",
-    "cache_creation_input_token_cost",
+    cache_read_input_token_cost: float
+    cache_creation_input_token_cost: float
     # Used by get_all_providers / get_models / _extract_models
-    "mode",
-})
+    mode: str
 
 
 @functools.lru_cache(maxsize=1)
-def _get_model_cost() -> dict[tuple[str | None, str], dict[str, Any]]:
+def _get_model_cost() -> dict[tuple[str | None, str], ModelInfo]:
     """Load model cost data keyed by ``(provider, model_name)``.
 
     Each JSON key is split on the first ``/`` to derive provider and model name.
-    Only fields used by ``_build_model_dict`` and ``cost_per_token`` are retained.
     """
     ref = importlib.resources.files(__package__).joinpath("model_prices_and_context_window.json")
     try:
@@ -82,33 +80,24 @@ def _get_model_cost() -> dict[tuple[str | None, str], dict[str, Any]]:
             raw = json.load(f)
     except FileNotFoundError:
         return {}
-    result: dict[tuple[str | None, str], dict[str, Any]] = {}
+    result: dict[tuple[str | None, str], ModelInfo] = {}
     for key, info in raw.items():
-        filtered = {k: v for k, v in info.items() if k in _MODEL_INFO_FIELDS}
         provider = info.get("litellm_provider")
-        model_name = key.split("/", 1)[1] if "/" in key else key
-        # (provider, model) for provider-specific lookup
+        model_name = key.split("/", 1)[-1]
         if provider:
-            result.setdefault((provider, model_name), filtered)
-        # (None, model) for provider-agnostic lookup
-        result.setdefault((None, model_name), filtered)
+            result.setdefault((provider, model_name), info)
+        result.setdefault((None, model_name), info)
     return result
 
 
-def _lookup_model_info(model: str, custom_llm_provider: str | None = None) -> dict[str, Any] | None:
+def _lookup_model_info(model: str, custom_llm_provider: str | None = None) -> ModelInfo | None:
     """Look up model cost info by ``(provider, model)``."""
     index = _get_model_cost()
-    bare_model = model.split("/", 1)[-1] if "/" in model else model
-
-    # 1. Provider-specific lookup
-    if custom_llm_provider:
-        if info := index.get((custom_llm_provider, bare_model)):
-            return info
-
-    # 2. Provider-agnostic lookup
-    if info := index.get((None, bare_model)):
+    bare_model = model.split("/", 1)[-1]
+    if info := index.get((custom_llm_provider, bare_model)):
         return info
-
+    if custom_llm_provider:
+        return index.get((None, bare_model))
     return None
 
 

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -60,18 +60,34 @@ def _get_model_cost() -> dict[str, Any]:
 
 
 def _lookup_model_info(model: str, custom_llm_provider: str | None = None) -> dict[str, Any] | None:
-    """Look up model cost info from the bundled JSON, trying multiple key formats."""
+    """Look up model cost info from the bundled JSON, trying multiple key formats.
+
+    This resolves:
+    - Unprefixed model names (e.g. "gpt-4o-mini").
+    - Provider-prefixed names passed either via:
+      * ``model="gpt-4o-mini", custom_llm_provider="openai"`` -> "openai/gpt-4o-mini".
+      * ``model="openai/gpt-4o-mini"`` (as some libraries like DSPy record spans).
+    When only the bare model name exists in the JSON, provider prefixes are stripped.
+    """
     model_cost = _get_model_cost()
 
-    # Exact match (handles most models like "gpt-4o", "claude-sonnet-4-20250514")
+    # 1. Exact match (handles most models like "gpt-4o", "claude-sonnet-4-20250514")
     if model in model_cost:
         return model_cost[model]
 
-    # Try with provider prefix (e.g. "azure/gpt-4o", "vertex_ai/gemini-2.5-flash")
+    # 2. Try with provider prefix (e.g. "azure/gpt-4o", "vertex_ai/gemini-2.5-flash")
     if custom_llm_provider:
-        prefixed = f"{custom_llm_provider}/{model}"
-        if prefixed in model_cost:
-            return model_cost[prefixed]
+        provider_prefix = f"{custom_llm_provider}/"
+        if not model.startswith(provider_prefix):
+            prefixed = f"{provider_prefix}{model}"
+            if prefixed in model_cost:
+                return model_cost[prefixed]
+
+    # 3. Strip provider prefix from "provider/model" style inputs (e.g. "openai/gpt-4o-mini")
+    if "/" in model:
+        _, bare_model = model.split("/", 1)
+        if bare_model in model_cost:
+            return model_cost[bare_model]
 
     return None
 
@@ -104,8 +120,8 @@ def cost_per_token(
     input_cost_per_token = input_cost_per_token or 0.0
     output_cost_per_token = output_cost_per_token or 0.0
 
-    # prompt_tokens includes cache tokens (both Anthropic and OpenAI report it this way),
-    # so we subtract them to get the regular (non-cached) portion, then price each
+    # In this function, prompt_tokens is expected to include cache tokens, so we subtract
+    # cache_read and cache_creation to get the regular (non-cached) portion, then price each
     # category at its own rate.
     cache_read = cache_read_input_tokens or 0
     cache_creation = cache_creation_input_tokens or 0

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -71,17 +71,18 @@ def _lookup_model_info(model: str, custom_llm_provider: str | None = None) -> di
     """
     model_cost = _get_model_cost()
 
-    # 1. Exact match (handles most models like "gpt-4o", "claude-sonnet-4-20250514")
-    if model in model_cost:
-        return model_cost[model]
-
-    # 2. Try with provider prefix (e.g. "azure/gpt-4o", "vertex_ai/gemini-2.5-flash")
+    # 1. If provider is given, prefer provider-specific pricing (e.g. "azure/gpt-4o")
     if custom_llm_provider:
         provider_prefix = f"{custom_llm_provider}/"
         if not model.startswith(provider_prefix):
             prefixed = f"{provider_prefix}{model}"
             if prefixed in model_cost:
                 return model_cost[prefixed]
+
+    # 2. Exact match (handles most models like "gpt-4o", "claude-sonnet-4-20250514",
+    #    and also "provider/model" keys that exist directly in the JSON)
+    if model in model_cost:
+        return model_cost[model]
 
     # 3. Strip provider prefix from "provider/model" style inputs (e.g. "openai/gpt-4o-mini")
     if "/" in model:

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -49,42 +49,65 @@ class ProviderConfigResponse(TypedDict):
     default_mode: str
 
 
+_MODEL_INFO_FIELDS = frozenset({
+    # Used by _build_model_dict
+    "supports_function_calling",
+    "supports_vision",
+    "supports_reasoning",
+    "supports_prompt_caching",
+    "supports_response_schema",
+    "max_input_tokens",
+    "max_output_tokens",
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "deprecation_date",
+    # Used by cost_per_token
+    "cache_read_input_token_cost",
+    "cache_creation_input_token_cost",
+    # Used by get_all_providers / get_models / _extract_models
+    "mode",
+})
+
+
 @functools.lru_cache(maxsize=1)
-def _get_model_cost() -> dict[str, Any]:
+def _get_model_cost() -> dict[tuple[str | None, str], dict[str, Any]]:
+    """Load model cost data keyed by ``(provider, model_name)``.
+
+    Each JSON key is split on the first ``/`` to derive provider and model name.
+    Only fields used by ``_build_model_dict`` and ``cost_per_token`` are retained.
+    """
     ref = importlib.resources.files(__package__).joinpath("model_prices_and_context_window.json")
     try:
         with importlib.resources.as_file(ref) as path, path.open(encoding="utf-8") as f:
-            return json.load(f)
+            raw = json.load(f)
     except FileNotFoundError:
         return {}
+    result: dict[tuple[str | None, str], dict[str, Any]] = {}
+    for key, info in raw.items():
+        filtered = {k: v for k, v in info.items() if k in _MODEL_INFO_FIELDS}
+        provider = info.get("litellm_provider")
+        model_name = key.split("/", 1)[1] if "/" in key else key
+        # (provider, model) for provider-specific lookup
+        if provider:
+            result.setdefault((provider, model_name), filtered)
+        # (None, model) for provider-agnostic lookup
+        result.setdefault((None, model_name), filtered)
+    return result
 
 
 def _lookup_model_info(model: str, custom_llm_provider: str | None = None) -> dict[str, Any] | None:
-    """Look up model cost info from the bundled JSON.
-
-    Tries, in order:
-    1. ``provider/model`` key if a provider is given.
-    2. Exact ``model`` key.
-    3. Bare model name after stripping a ``provider/`` prefix.
-    """
-    model_cost = _get_model_cost()
-
-    # Strip provider prefix from "provider/model" inputs (e.g. "openai/gpt-4o-mini")
+    """Look up model cost info by ``(provider, model)``."""
+    index = _get_model_cost()
     bare_model = model.split("/", 1)[-1] if "/" in model else model
 
-    # 1. Provider-specific lookup (e.g. "azure/gpt-4o")
-    if custom_llm_provider and not model.startswith(f"{custom_llm_provider}/"):
-        prefixed = f"{custom_llm_provider}/{bare_model}"
-        if prefixed in model_cost:
-            return model_cost[prefixed]
+    # 1. Provider-specific lookup
+    if custom_llm_provider:
+        if info := index.get((custom_llm_provider, bare_model)):
+            return info
 
-    # 2. Exact match (handles "gpt-4o", "claude-sonnet-4-20250514", "azure/gpt-4o")
-    if model in model_cost:
-        return model_cost[model]
-
-    # 3. Bare model name after stripping prefix (e.g. "openai/gpt-4o-mini" -> "gpt-4o-mini")
-    if bare_model != model and bare_model in model_cost:
-        return model_cost[bare_model]
+    # 2. Provider-agnostic lookup
+    if info := index.get((None, bare_model)):
+        return info
 
     return None
 
@@ -608,14 +631,13 @@ def get_all_providers() -> list[str]:
     Provider variants are consolidated into a single provider (e.g., all vertex_ai-*
     variants are returned as just vertex_ai).
     """
-    model_cost = _get_model_cost()
     providers = set()
-    for _, info in model_cost.items():
+    for (provider, _), info in _get_model_cost().items():
+        if provider is None:
+            continue
         mode = info.get("mode")
-        if mode in _SUPPORTED_MODEL_MODES:
-            if provider := info.get("litellm_provider"):
-                if provider not in _EXCLUDED_PROVIDERS:
-                    providers.add(_normalize_provider(provider))
+        if mode in _SUPPORTED_MODEL_MODES and provider not in _EXCLUDED_PROVIDERS:
+            providers.add(_normalize_provider(provider))
     return list(providers)
 
 
@@ -648,12 +670,9 @@ def get_models(provider: str | None = None) -> list[dict[str, Any]]:
             - deprecation_date: Date when model will be deprecated (if known)
     """
     entries = (
-        (
-            name,
-            info.get("litellm_provider"),
-            info,
-        )
-        for name, info in _get_model_cost().items()
+        (model_name, provider, info)
+        for (provider, model_name), info in _get_model_cost().items()
+        if provider is not None
     )
     return _extract_models(entries, provider_filter=provider)
 

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -60,35 +60,31 @@ def _get_model_cost() -> dict[str, Any]:
 
 
 def _lookup_model_info(model: str, custom_llm_provider: str | None = None) -> dict[str, Any] | None:
-    """Look up model cost info from the bundled JSON, trying multiple key formats.
+    """Look up model cost info from the bundled JSON.
 
-    This resolves:
-    - Unprefixed model names (e.g. "gpt-4o-mini").
-    - Provider-prefixed names passed either via:
-      * ``model="gpt-4o-mini", custom_llm_provider="openai"`` -> "openai/gpt-4o-mini".
-      * ``model="openai/gpt-4o-mini"`` (as some libraries like DSPy record spans).
-    When only the bare model name exists in the JSON, provider prefixes are stripped.
+    Tries, in order:
+    1. ``provider/model`` key if a provider is given.
+    2. Exact ``model`` key.
+    3. Bare model name after stripping a ``provider/`` prefix.
     """
     model_cost = _get_model_cost()
 
-    # 1. If provider is given, prefer provider-specific pricing (e.g. "azure/gpt-4o")
-    if custom_llm_provider:
-        provider_prefix = f"{custom_llm_provider}/"
-        if not model.startswith(provider_prefix):
-            prefixed = f"{provider_prefix}{model}"
-            if prefixed in model_cost:
-                return model_cost[prefixed]
+    # Strip provider prefix from "provider/model" inputs (e.g. "openai/gpt-4o-mini")
+    bare_model = model.split("/", 1)[-1] if "/" in model else model
 
-    # 2. Exact match (handles most models like "gpt-4o", "claude-sonnet-4-20250514",
-    #    and also "provider/model" keys that exist directly in the JSON)
+    # 1. Provider-specific lookup (e.g. "azure/gpt-4o")
+    if custom_llm_provider and not model.startswith(f"{custom_llm_provider}/"):
+        prefixed = f"{custom_llm_provider}/{bare_model}"
+        if prefixed in model_cost:
+            return model_cost[prefixed]
+
+    # 2. Exact match (handles "gpt-4o", "claude-sonnet-4-20250514", "azure/gpt-4o")
     if model in model_cost:
         return model_cost[model]
 
-    # 3. Strip provider prefix from "provider/model" style inputs (e.g. "openai/gpt-4o-mini")
-    if "/" in model:
-        _, bare_model = model.split("/", 1)
-        if bare_model in model_cost:
-            return model_cost[bare_model]
+    # 3. Bare model name after stripping prefix (e.g. "openai/gpt-4o-mini" -> "gpt-4o-mini")
+    if bare_model != model and bare_model in model_cost:
+        return model_cost[bare_model]
 
     return None
 
@@ -100,26 +96,18 @@ def cost_per_token(
     custom_llm_provider: str | None = None,
     cache_read_input_tokens: int | None = None,
     cache_creation_input_tokens: int | None = None,
-) -> tuple[float, float]:
+) -> tuple[float, float] | None:
     """Calculate cost per token using the bundled model price data.
 
     Returns:
-        A tuple of (input_cost, output_cost) in USD.
-
-    Raises:
-        ValueError: If the model is not found in the cost data or has no pricing info.
+        A tuple of (input_cost, output_cost) in USD, or None if the model is not found.
     """
     info = _lookup_model_info(model, custom_llm_provider)
     if info is None:
-        raise ValueError(f"Model {model!r} not found in model cost data")
+        return None
 
-    input_cost_per_token = info.get("input_cost_per_token")
-    output_cost_per_token = info.get("output_cost_per_token")
-    if input_cost_per_token is None and output_cost_per_token is None:
-        raise ValueError(f"No token pricing info for model {model!r}")
-
-    input_cost_per_token = input_cost_per_token or 0.0
-    output_cost_per_token = output_cost_per_token or 0.0
+    input_cost_per_token = info.get("input_cost_per_token", 0.0)
+    output_cost_per_token = info.get("output_cost_per_token", 0.0)
 
     # In this function, prompt_tokens is expected to include cache tokens, so we subtract
     # cache_read and cache_creation to get the regular (non-cached) portion, then price each

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -1343,10 +1343,12 @@ def test_anthropic_extract_passthrough_token_usage_with_cached_tokens():
     token_usage = provider._extract_passthrough_token_usage(
         PassthroughAction.ANTHROPIC_MESSAGES, result
     )
+    # Anthropic's input_tokens (100) excludes cache tokens, so after normalization
+    # input_tokens = 100 + 25 + 15 = 140
     assert token_usage == {
-        "input_tokens": 100,
+        "input_tokens": 140,
         "output_tokens": 50,
-        "total_tokens": 150,
+        "total_tokens": 190,
         "cache_read_input_tokens": 25,
         "cache_creation_input_tokens": 15,
     }
@@ -1361,8 +1363,10 @@ def test_anthropic_extract_streaming_token_usage_message_start_with_cached_token
         b'"cache_creation_input_tokens":15}}}\n'
     )
     result = provider._extract_streaming_token_usage(chunk)
+    # Anthropic's input_tokens (100) excludes cache tokens, so after normalization
+    # input_tokens = 100 + 25 + 15 = 140
     assert result == {
-        "input_tokens": 100,
+        "input_tokens": 140,
         "cache_read_input_tokens": 25,
         "cache_creation_input_tokens": 15,
     }
@@ -1373,13 +1377,14 @@ def test_anthropic_extract_streaming_full_stream_with_cached_tokens():
     accumulated_usage = {}
 
     # message_start with input_tokens and cached tokens
+    # Anthropic's input_tokens (100) excludes cache, normalized to 100 + 25 = 125
     chunk1 = (
         b"event: message_start\n"
         b'data: {"type":"message_start","message":{"id":"msg_123",'
         b'"usage":{"input_tokens":100,"cache_read_input_tokens":25}}}\n'
     )
     accumulated_usage.update(provider._extract_streaming_token_usage(chunk1))
-    assert accumulated_usage == {"input_tokens": 100, "cache_read_input_tokens": 25}
+    assert accumulated_usage == {"input_tokens": 125, "cache_read_input_tokens": 25}
 
     # message_delta with output_tokens
     chunk2 = (
@@ -1389,7 +1394,7 @@ def test_anthropic_extract_streaming_full_stream_with_cached_tokens():
     )
     accumulated_usage.update(provider._extract_streaming_token_usage(chunk2))
     assert accumulated_usage == {
-        "input_tokens": 100,
+        "input_tokens": 125,
         "output_tokens": 50,
         "cache_read_input_tokens": 25,
     }
@@ -1403,9 +1408,10 @@ def test_anthropic_adapter_build_chat_usage_with_cached_tokens():
         "cache_creation_input_tokens": 10,
     }
     usage = AnthropicAdapter._build_chat_usage(usage_data)
-    assert usage.prompt_tokens == 50
+    # Anthropic's input_tokens (50) excludes cache tokens, so prompt_tokens = 50 + 30 + 10 = 90
+    assert usage.prompt_tokens == 90
     assert usage.completion_tokens == 20
-    assert usage.total_tokens == 70
+    assert usage.total_tokens == 110
     assert usage.prompt_tokens_details is not None
     assert usage.prompt_tokens_details.cached_tokens == 30
     assert getattr(usage, "cache_creation_input_tokens") == 10

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -635,6 +635,50 @@ def test_generate_trace_id_v4_from_otel_trace_id():
     assert parsed_id == expected_hex_id
 
 
+def test_builtin_cost_fallback_when_litellm_unavailable():
+    with mock.patch.dict("sys.modules", {"litellm": None}):
+        result = calculate_cost_by_model_and_token_usage(
+            "gpt-4o", {"input_tokens": 1000, "output_tokens": 500}
+        )
+    assert result is not None
+    assert result["input_cost"] == pytest.approx(0.0025)
+    assert result["output_cost"] == pytest.approx(0.005)
+    assert result["total_cost"] == pytest.approx(0.0075)
+
+
+def test_builtin_cost_fallback_returns_none_for_unknown_model():
+    with mock.patch.dict("sys.modules", {"litellm": None}):
+        result = calculate_cost_by_model_and_token_usage(
+            "unknown-model", {"input_tokens": 100, "output_tokens": 50}
+        )
+    assert result is None
+
+
+def test_builtin_cost_fallback_with_cache_tokens():
+    with mock.patch.dict("sys.modules", {"litellm": None}):
+        result = calculate_cost_by_model_and_token_usage(
+            "gpt-4o",
+            {
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_read_input_tokens": 200,
+            },
+        )
+    assert result is not None
+    assert result["input_cost"] == pytest.approx(0.00225)
+
+
+def test_builtin_cost_fallback_with_provider():
+    with mock.patch.dict("sys.modules", {"litellm": None}):
+        result = calculate_cost_by_model_and_token_usage(
+            "gpt-4o",
+            {"input_tokens": 1000, "output_tokens": 500},
+            model_provider="openai",
+        )
+    assert result is not None
+    assert result["total_cost"] == pytest.approx(0.0075)
+
+
 def test_litellm_provider_list_not_printed_during_cost_calculation(capsys):
     litellm.suppress_debug_info = False
 

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -1,7 +1,10 @@
 from unittest import mock
 
+import pytest
+
 from mlflow.utils.providers import (
     _normalize_provider,
+    cost_per_token,
     get_all_providers,
     get_models,
     get_provider_config_response,
@@ -171,3 +174,86 @@ def test_get_provider_config_sagemaker_has_default_chain():
     config = get_provider_config_response("sagemaker")
     modes = {m["mode"] for m in config["auth_modes"]}
     assert "default_chain" in modes
+
+
+def test_cost_per_token_basic():
+    input_cost, output_cost = cost_per_token(
+        model="gpt-4o", prompt_tokens=1000, completion_tokens=500
+    )
+    # gpt-4o: input_cost_per_token=2.5e-6, output_cost_per_token=1e-5
+    assert input_cost == pytest.approx(0.0025)
+    assert output_cost == pytest.approx(0.005)
+
+
+def test_cost_per_token_with_provider_prefix():
+    input_cost, output_cost = cost_per_token(
+        model="gpt-4o", prompt_tokens=1000, completion_tokens=500, custom_llm_provider="openai"
+    )
+    assert input_cost == pytest.approx(0.0025)
+    assert output_cost == pytest.approx(0.005)
+
+
+def test_cost_per_token_cache_read_tokens():
+    input_cost, output_cost = cost_per_token(
+        model="gpt-4o",
+        prompt_tokens=1000,
+        completion_tokens=500,
+        cache_read_input_tokens=200,
+    )
+    # gpt-4o: cache_read_input_token_cost=1.25e-6
+    # regular: (1000-200) * 2.5e-6 = 0.002
+    # cache_read: 200 * 1.25e-6 = 0.00025
+    assert input_cost == pytest.approx(0.00225)
+    assert output_cost == pytest.approx(0.005)
+
+
+def test_cost_per_token_cache_creation_tokens():
+    input_cost, output_cost = cost_per_token(
+        model="claude-sonnet-4-20250514",
+        prompt_tokens=1000,
+        completion_tokens=500,
+        cache_creation_input_tokens=300,
+    )
+    assert input_cost > 0
+    assert output_cost > 0
+
+
+def test_cost_per_token_zero_tokens():
+    input_cost, output_cost = cost_per_token(model="gpt-4o", prompt_tokens=0, completion_tokens=0)
+    assert input_cost == 0.0
+    assert output_cost == 0.0
+
+
+def test_cost_per_token_unknown_model_raises():
+    with pytest.raises(ValueError, match="not found"):
+        cost_per_token(model="totally-unknown-model", prompt_tokens=100)
+
+
+def test_cost_per_token_unknown_model_with_provider_raises():
+    with pytest.raises(ValueError, match="not found"):
+        cost_per_token(
+            model="totally-unknown-model",
+            prompt_tokens=100,
+            custom_llm_provider="unknown-provider",
+        )
+
+
+def test_cost_per_token_no_cache_cost_falls_back_to_input_rate():
+    with mock.patch("mlflow.utils.providers._get_model_cost") as mock_cost:
+        mock_cost.return_value = {
+            "test-model": {
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 2e-6,
+            }
+        }
+        input_cost, output_cost = cost_per_token(
+            model="test-model",
+            prompt_tokens=1000,
+            completion_tokens=500,
+            cache_read_input_tokens=200,
+        )
+        # No cache_read_input_token_cost, falls back to input_cost_per_token
+        # regular: 800 * 1e-6 = 0.0008
+        # cache_read: 200 * 1e-6 = 0.0002 (same rate as regular)
+        assert input_cost == pytest.approx(0.001)
+        assert output_cost == pytest.approx(0.001)

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -184,6 +184,7 @@ _MOCK_MODEL_COST = {
         "cache_creation_input_token_cost": 3e-6,
     },
     "openai/test-provider-model": {
+        "litellm_provider": "openai",
         "input_cost_per_token": 1e-6,
         "output_cost_per_token": 2e-6,
     },
@@ -260,18 +261,19 @@ def test_cost_per_token_zero_tokens(mock_model_cost):
     assert output_cost == 0.0
 
 
-def test_cost_per_token_unknown_model_raises(mock_model_cost):
-    with pytest.raises(ValueError, match="not found"):
-        cost_per_token(model="totally-unknown-model", prompt_tokens=100)
+def test_cost_per_token_unknown_model_returns_none(mock_model_cost):
+    assert cost_per_token(model="totally-unknown-model", prompt_tokens=100) is None
 
 
-def test_cost_per_token_unknown_model_with_provider_raises(mock_model_cost):
-    with pytest.raises(ValueError, match="not found"):
+def test_cost_per_token_unknown_model_with_provider_returns_none(mock_model_cost):
+    assert (
         cost_per_token(
             model="totally-unknown-model",
             prompt_tokens=100,
             custom_llm_provider="unknown-provider",
         )
+        is None
+    )
 
 
 def test_cost_per_token_no_cache_cost_falls_back_to_input_rate():

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -28,17 +28,11 @@ def test_normalize_provider_does_not_normalize_other_providers():
 def test_get_all_providers_consolidates_vertex_ai_variants():
     with mock.patch("mlflow.utils.providers._get_model_cost") as mock_model_cost:
         mock_model_cost.return_value = {
-            "gpt-4o": {"litellm_provider": "openai", "mode": "chat"},
-            "claude-3-5-sonnet": {"litellm_provider": "anthropic", "mode": "chat"},
-            "gemini-1.5-pro": {"litellm_provider": "vertex_ai", "mode": "chat"},
-            "vertex_ai/meta/llama-4-scout": {
-                "litellm_provider": "vertex_ai-llama_models",
-                "mode": "chat",
-            },
-            "vertex_ai/claude-3-5-sonnet": {
-                "litellm_provider": "vertex_ai-anthropic",
-                "mode": "chat",
-            },
+            ("openai", "gpt-4o"): {"mode": "chat"},
+            ("anthropic", "claude-3-5-sonnet"): {"mode": "chat"},
+            ("vertex_ai", "gemini-1.5-pro"): {"mode": "chat"},
+            ("vertex_ai-llama_models", "meta/llama-4-scout"): {"mode": "chat"},
+            ("vertex_ai-anthropic", "claude-3-5-sonnet"): {"mode": "chat"},
         }
 
         providers = get_all_providers()
@@ -54,18 +48,15 @@ def test_get_all_providers_consolidates_vertex_ai_variants():
 def test_get_models_normalizes_vertex_ai_provider_and_strips_prefix():
     with mock.patch("mlflow.utils.providers._get_model_cost") as mock_model_cost:
         mock_model_cost.return_value = {
-            "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas": {
-                "litellm_provider": "vertex_ai-llama_models",
+            ("vertex_ai-llama_models", "meta/llama-4-scout-17b-16e-instruct-maas"): {
                 "mode": "chat",
                 "supports_function_calling": True,
             },
-            "vertex_ai/claude-3-5-sonnet": {
-                "litellm_provider": "vertex_ai-anthropic",
+            ("vertex_ai-anthropic", "claude-3-5-sonnet"): {
                 "mode": "chat",
                 "supports_function_calling": True,
             },
-            "gemini-1.5-pro": {
-                "litellm_provider": "vertex_ai",
+            ("vertex_ai", "gemini-1.5-pro"): {
                 "mode": "chat",
                 "supports_function_calling": True,
             },
@@ -79,25 +70,17 @@ def test_get_models_normalizes_vertex_ai_provider_and_strips_prefix():
         for model in models:
             assert model["provider"] == "vertex_ai"
 
-        # Check that vertex_ai/ prefix is stripped from model names
         model_names = [m["model"] for m in models]
         assert "meta/llama-4-scout-17b-16e-instruct-maas" in model_names
         assert "claude-3-5-sonnet" in model_names
         assert "gemini-1.5-pro" in model_names
 
-        # Ensure the original prefixed names are not present
-        assert "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas" not in model_names
-        assert "vertex_ai/claude-3-5-sonnet" not in model_names
-
 
 def test_get_models_filters_by_consolidated_provider():
     with mock.patch("mlflow.utils.providers._get_model_cost") as mock_model_cost:
         mock_model_cost.return_value = {
-            "gpt-4o": {"litellm_provider": "openai", "mode": "chat"},
-            "vertex_ai/meta/llama-4-scout": {
-                "litellm_provider": "vertex_ai-llama_models",
-                "mode": "chat",
-            },
+            ("openai", "gpt-4o"): {"mode": "chat"},
+            ("vertex_ai-llama_models", "meta/llama-4-scout"): {"mode": "chat"},
         }
 
         # Filtering by vertex_ai should include vertex_ai-* variants
@@ -114,13 +97,11 @@ def test_get_models_filters_by_consolidated_provider():
 def test_get_models_does_not_modify_other_providers():
     with mock.patch("mlflow.utils.providers._get_model_cost") as mock_model_cost:
         mock_model_cost.return_value = {
-            "gpt-4o": {
-                "litellm_provider": "openai",
+            ("openai", "gpt-4o"): {
                 "mode": "chat",
                 "supports_function_calling": True,
             },
-            "claude-3-5-sonnet": {
-                "litellm_provider": "anthropic",
+            ("anthropic", "claude-3-5-sonnet"): {
                 "mode": "chat",
                 "supports_function_calling": True,
             },
@@ -139,13 +120,11 @@ def test_get_models_dedupes_models_after_normalization():
     with mock.patch("mlflow.utils.providers._get_model_cost") as mock_model_cost:
         # Same model appearing under different vertex_ai variants should be deduped
         mock_model_cost.return_value = {
-            "gemini-3-flash-preview": {
-                "litellm_provider": "vertex_ai",
+            ("vertex_ai", "gemini-3-flash-preview"): {
                 "mode": "chat",
                 "supports_function_calling": True,
             },
-            "vertex_ai/gemini-3-flash-preview": {
-                "litellm_provider": "vertex_ai-chat-models",
+            ("vertex_ai-chat-models", "gemini-3-flash-preview"): {
                 "mode": "chat",
                 "supports_function_calling": True,
             },
@@ -177,14 +156,13 @@ def test_get_provider_config_sagemaker_has_default_chain():
 
 
 _MOCK_MODEL_COST = {
-    "test-model": {
+    (None, "test-model"): {
         "input_cost_per_token": 1e-6,
         "output_cost_per_token": 2e-6,
         "cache_read_input_token_cost": 5e-7,
         "cache_creation_input_token_cost": 3e-6,
     },
-    "openai/test-provider-model": {
-        "litellm_provider": "openai",
+    ("openai", "test-provider-model"): {
         "input_cost_per_token": 1e-6,
         "output_cost_per_token": 2e-6,
     },
@@ -279,7 +257,7 @@ def test_cost_per_token_unknown_model_with_provider_returns_none(mock_model_cost
 def test_cost_per_token_no_cache_cost_falls_back_to_input_rate():
     with mock.patch("mlflow.utils.providers._get_model_cost") as mock_cost:
         mock_cost.return_value = {
-            "test-model": {
+            (None, "test-model"): {
                 "input_cost_per_token": 1e-6,
                 "output_cost_per_token": 2e-6,
             }

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -176,60 +176,96 @@ def test_get_provider_config_sagemaker_has_default_chain():
     assert "default_chain" in modes
 
 
-def test_cost_per_token_basic():
+_MOCK_MODEL_COST = {
+    "test-model": {
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 2e-6,
+        "cache_read_input_token_cost": 5e-7,
+        "cache_creation_input_token_cost": 3e-6,
+    },
+    "openai/test-provider-model": {
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 2e-6,
+    },
+}
+
+
+@pytest.fixture
+def mock_model_cost():
+    with mock.patch("mlflow.utils.providers._get_model_cost", return_value=_MOCK_MODEL_COST) as m:
+        yield m
+
+
+def test_cost_per_token_basic(mock_model_cost):
     input_cost, output_cost = cost_per_token(
-        model="gpt-4o", prompt_tokens=1000, completion_tokens=500
+        model="test-model", prompt_tokens=1000, completion_tokens=500
     )
-    # gpt-4o: input_cost_per_token=2.5e-6, output_cost_per_token=1e-5
-    assert input_cost == pytest.approx(0.0025)
-    assert output_cost == pytest.approx(0.005)
+    # input: 1000 * 1e-6 = 0.001, output: 500 * 2e-6 = 0.001
+    assert input_cost == pytest.approx(0.001)
+    assert output_cost == pytest.approx(0.001)
 
 
-def test_cost_per_token_with_provider_prefix():
+def test_cost_per_token_with_provider_prefix(mock_model_cost):
+    # "test-provider-model" only exists under "openai/" prefix, so provider lookup is exercised
     input_cost, output_cost = cost_per_token(
-        model="gpt-4o", prompt_tokens=1000, completion_tokens=500, custom_llm_provider="openai"
+        model="test-provider-model",
+        prompt_tokens=1000,
+        completion_tokens=500,
+        custom_llm_provider="openai",
     )
-    assert input_cost == pytest.approx(0.0025)
-    assert output_cost == pytest.approx(0.005)
+    assert input_cost == pytest.approx(0.001)
+    assert output_cost == pytest.approx(0.001)
 
 
-def test_cost_per_token_cache_read_tokens():
+def test_cost_per_token_strips_provider_prefix(mock_model_cost):
+    # "openai/test-model" should resolve to "test-model" by stripping the prefix
     input_cost, output_cost = cost_per_token(
-        model="gpt-4o",
+        model="openai/test-model", prompt_tokens=1000, completion_tokens=500
+    )
+    assert input_cost == pytest.approx(0.001)
+    assert output_cost == pytest.approx(0.001)
+
+
+def test_cost_per_token_cache_read_tokens(mock_model_cost):
+    input_cost, output_cost = cost_per_token(
+        model="test-model",
         prompt_tokens=1000,
         completion_tokens=500,
         cache_read_input_tokens=200,
     )
-    # gpt-4o: cache_read_input_token_cost=1.25e-6
-    # regular: (1000-200) * 2.5e-6 = 0.002
-    # cache_read: 200 * 1.25e-6 = 0.00025
-    assert input_cost == pytest.approx(0.00225)
-    assert output_cost == pytest.approx(0.005)
+    # regular: (1000-200) * 1e-6 = 0.0008
+    # cache_read: 200 * 5e-7 = 0.0001
+    assert input_cost == pytest.approx(0.0009)
+    assert output_cost == pytest.approx(0.001)
 
 
-def test_cost_per_token_cache_creation_tokens():
+def test_cost_per_token_cache_creation_tokens(mock_model_cost):
     input_cost, output_cost = cost_per_token(
-        model="claude-sonnet-4-20250514",
+        model="test-model",
         prompt_tokens=1000,
         completion_tokens=500,
         cache_creation_input_tokens=300,
     )
-    assert input_cost > 0
-    assert output_cost > 0
+    # regular: (1000-300) * 1e-6 = 0.0007
+    # cache_creation: 300 * 3e-6 = 0.0009
+    assert input_cost == pytest.approx(0.0016)
+    assert output_cost == pytest.approx(0.001)
 
 
-def test_cost_per_token_zero_tokens():
-    input_cost, output_cost = cost_per_token(model="gpt-4o", prompt_tokens=0, completion_tokens=0)
+def test_cost_per_token_zero_tokens(mock_model_cost):
+    input_cost, output_cost = cost_per_token(
+        model="test-model", prompt_tokens=0, completion_tokens=0
+    )
     assert input_cost == 0.0
     assert output_cost == 0.0
 
 
-def test_cost_per_token_unknown_model_raises():
+def test_cost_per_token_unknown_model_raises(mock_model_cost):
     with pytest.raises(ValueError, match="not found"):
         cost_per_token(model="totally-unknown-model", prompt_tokens=100)
 
 
-def test_cost_per_token_unknown_model_with_provider_raises():
+def test_cost_per_token_unknown_model_with_provider_raises(mock_model_cost):
     with pytest.raises(ValueError, match="not found"):
         cost_per_token(
             model="totally-unknown-model",


### PR DESCRIPTION
### Related Issues/PRs
n/a

### What changes are proposed in this pull request?

- Add a builtin `cost_per_token()` function in `mlflow/utils/providers.py` that calculates token costs using the bundled `model_prices_and_context_window.json` data
- When litellm is not installed, `calculate_cost_by_model_and_token_usage` now falls back to the builtin implementation instead of returning `None`
- Supports cache read/creation token pricing with per-model rates from the JSON data
- Fix Anthropic provider to normalize `input_tokens` to include cache tokens (consistent with OpenAI/Gemini), so cost calculation works uniformly across providers

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests added:
- `TestCostPerToken` — tests for the builtin `cost_per_token` function (basic, cache tokens, provider lookup, error cases)
- `TestBuiltinCostFallback` — integration tests verifying fallback works when litellm is unavailable
- Updated Anthropic provider tests to verify cache token normalization

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Cost tracking for LLM traces now works without litellm installed, using bundled model pricing data.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release