### PR TITLE
fix(types): guard numpy-dependent imports in mlflow/types/__init__.py…

### DIFF
--- a/mlflow/types/__init__.py
+++ b/mlflow/types/__init__.py
@@ -6,16 +6,20 @@ components to describe interface independent of other frameworks or languages.
 from mlflow.version import IS_TRACING_SDK_ONLY
 
 if not IS_TRACING_SDK_ONLY:
-    import mlflow.types.llm  # noqa: F401
+    try:
+        import mlflow.types.llm  # noqa: F401
 
-    # Our typing system depends on numpy, which is not included in mlflow-tracing package
-    from mlflow.types.schema import ColSpec, DataType, ParamSchema, ParamSpec, Schema, TensorSpec
+        # Our typing system depends on numpy, which is not included in mlflow-tracing package
+        # or environments where numpy is not installed (e.g. mlflow-skinny without numpy).
+        from mlflow.types.schema import ColSpec, DataType, ParamSchema, ParamSpec, Schema, TensorSpec
 
-    __all__ = [
-        "Schema",
-        "ColSpec",
-        "DataType",
-        "TensorSpec",
-        "ParamSchema",
-        "ParamSpec",
-    ]
+        __all__ = [
+            "Schema",
+            "ColSpec",
+            "DataType",
+            "TensorSpec",
+            "ParamSchema",
+            "ParamSpec",
+        ]
+    except ImportError:
+        pass


### PR DESCRIPTION
### Related Issues/PRs
Closes #21779

### What changes are proposed in this pull request?
`mlflow-skinny` does not declare `numpy` as a dependency, but `mlflow.anthropic.autolog()` was failing with `ModuleNotFoundError: No module named 'numpy'` when numpy is not installed.

The import chain was:
`mlflow.anthropic` → `mlflow.anthropic.autolog` → `mlflow.anthropic.chat` → `mlflow.types.chat` → `mlflow.types` → `mlflow.types.__init__.py` → `mlflow.types.llm` → `mlflow.types.schema` → `numpy`

This PR wraps the numpy-dependent imports in `mlflow/types/__init__.py` with a `try/except ImportError` block, so packages like `mlflow.anthropic.autolog` that do not actually use numpy can still be imported when numpy is not installed.

### How is this PR tested?
- [x] Manual tests

Verified manually.

### Does this PR change the release notes?
No