### PR TITLE
fix(types): guard numpy-dependent imports in mlflow/types/__init__.py for mlflow-skinny without numpy

### DIFF
--- a/mlflow/types/__init__.py
+++ b/mlflow/types/__init__.py
@@ -6,16 +6,20 @@ components to describe interface independent of other frameworks or languages.
 from mlflow.version import IS_TRACING_SDK_ONLY
 
 if not IS_TRACING_SDK_ONLY:
-    import mlflow.types.llm  # noqa: F401
+    try:
+        import mlflow.types.llm  # noqa: F401
 
-    # Our typing system depends on numpy, which is not included in mlflow-tracing package
-    from mlflow.types.schema import ColSpec, DataType, ParamSchema, ParamSpec, Schema, TensorSpec
+        # Our typing system depends on numpy, which is not included in mlflow-tracing package
+        # or environments where numpy is not installed (e.g. mlflow-skinny without numpy).
+        from mlflow.types.schema import ColSpec, DataType, ParamSchema, ParamSpec, Schema, TensorSpec
 
-    __all__ = [
-        "Schema",
-        "ColSpec",
-        "DataType",
-        "TensorSpec",
-        "ParamSchema",
-        "ParamSpec",
-    ]
+        __all__ = [
+            "Schema",
+            "ColSpec",
+            "DataType",
+            "TensorSpec",
+            "ParamSchema",
+            "ParamSpec",
+        ]
+    except ImportError:
+        pass

--- a/mlflow/types/__init__.py
+++ b/mlflow/types/__init__.py
@@ -21,5 +21,6 @@ if not IS_TRACING_SDK_ONLY:
             "ParamSchema",
             "ParamSpec",
         ]
-    except ImportError:
-        pass
+    except ModuleNotFoundError as e:
+        if "numpy" not in e.name:
+            raise


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Closes #21779

### What changes are proposed in this pull request?

Guard numpy-dependent imports in `mlflow/types/__init__.py` behind a try/except block so that `mlflow-skinny` does not crash on import when numpy is not installed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Guard numpy imports in `mlflow/types/__init__.py` to fix `mlflow-skinny` crash when numpy is not installed.

#### What component(s) does this PR affect?

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release