### PR TITLE
Pin uv version in `setup-uv` to reduce GitHub API rate limit consumption

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -51,7 +51,7 @@ runs:
         python-version: ${{ steps.get-python-version.outputs.version }}
     - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
       with:
-        resolution-strategy: "lowest"
+        version: "0.10.12"
     - run: |
         # The default `first-index` strategy is too strict. Use `unsafe-first-match` instead.
         # https://docs.astral.sh/uv/configuration/environment/#uv_index_strategy

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -75,9 +75,7 @@ jobs:
               throw new Error(`User not allowed to trigger workflow: ${comment.user.login} (association: ${authorAssociation})`);
             }
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
-        with:
-          resolution-strategy: "lowest"
+      - uses: ./.github/actions/setup-python
       - name: Install Claude CLI
         run: |
           curl -fsSL https://claude.ai/install.sh | bash -s 2.1.71


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/mlflow/actions/workflows/protect.yml?page=3

### What changes are proposed in this pull request?

With `resolution-strategy: "lowest"`, `setup-uv` paginates all 265 uv releases (~10 API calls per job) to resolve the version. Pinning `version: "0.10.12"` skips this entirely (0 API calls).

Verified on https://github.com/harupy/mlflow/pull/112 — with the pinned version, rate limit before and after `setup-uv` differed by 0 (only the `gh api rate_limit` measurement calls themselves).

### How is this PR tested?

- [x] Manual tests

Rate limit consumption verified via `gh api rate_limit` before/after `setup-uv` on a fork.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)