### PR TITLE
Fix `evaluate()` hang when mixing built-in and custom scorers

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import queue
 import threading
@@ -874,11 +875,20 @@ def _compute_eval_scores(
     # Use a thread pool to run scorers in parallel
     # Limit concurrent scorers to prevent rate limiting errors with external LLM APIs
     max_scorer_workers = min(len(scorers), MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS.get())
+
+    # Capture the current context so that ContextVar values (e.g. the rate-limit
+    # retry disable flags set by eval_retry_context) propagate into the inner
+    # worker threads.  Without this, Python < 3.12 ThreadPoolExecutor threads
+    # start with an empty context, causing built-in scorers to run with litellm's
+    # own retry logic enabled *in addition to* the harness retry — leading to
+    # extremely long (effectively infinite) hangs on rate-limit errors.
+    ctx = contextvars.copy_context()
+
     with ThreadPoolExecutor(
         max_workers=max_scorer_workers,
         thread_name_prefix="MlflowGenAIEvalScorer",
     ) as executor:
-        futures = [executor.submit(run_scorer, scorer) for scorer in scorers]
+        futures = [executor.submit(ctx.run, run_scorer, scorer) for scorer in scorers]
 
         try:
             results = [future.result() for future in as_completed(futures)]

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -882,13 +882,16 @@ def _compute_eval_scores(
     # start with an empty context, causing built-in scorers to run with litellm's
     # own retry logic enabled *in addition to* the harness retry — leading to
     # extremely long (effectively infinite) hangs on rate-limit errors.
-    ctx = contextvars.copy_context()
-
+    # Each scorer gets its own context copy because Context.run() cannot be
+    # entered concurrently from multiple threads.
     with ThreadPoolExecutor(
         max_workers=max_scorer_workers,
         thread_name_prefix="MlflowGenAIEvalScorer",
     ) as executor:
-        futures = [executor.submit(ctx.run, run_scorer, scorer) for scorer in scorers]
+        futures = [
+            executor.submit(contextvars.copy_context().run, run_scorer, scorer)
+            for scorer in scorers
+        ]
 
         try:
             results = [future.result() for future in as_completed(futures)]

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -1,7 +1,11 @@
+import threading
+import uuid
+
 import pytest
 
 from mlflow.genai.evaluation.harness import (
     AUTO_INITIAL_RPS,
+    _compute_eval_scores,
     _make_rate_limiter,
     _parse_rate_limit,
 )
@@ -406,3 +410,60 @@ def test_litellm_retry_policy_disables_rate_limit_retries_when_flag_set():
         policy = _get_litellm_retry_policy(3)
     assert policy.RateLimitErrorRetries == 0
     assert policy.TimeoutErrorRetries == 3
+
+
+def test_eval_retry_context_propagates_to_scorer_threads():
+    """Regression test: ContextVar flags must be visible inside _compute_eval_scores worker
+    threads. Without propagation (Python < 3.12 default), built-in scorers run with litellm's
+    own retry loop enabled on top of the harness retry, causing an indefinite hang.
+    """
+    from mlflow.genai.evaluation.entities import EvalItem
+    from mlflow.genai.scorers.base import scorer
+
+    # Track which threads saw the retry flags and their values
+    observations = {}
+    lock = threading.Lock()
+
+    @scorer
+    def flag_checker_a(inputs):
+        with lock:
+            observations["a"] = {
+                "thread": threading.current_thread().name,
+                "429_disabled": is_429_retry_disabled(),
+                "litellm_disabled": is_litellm_rate_limit_retries_disabled(),
+            }
+        return True
+
+    @scorer
+    def flag_checker_b(inputs):
+        with lock:
+            observations["b"] = {
+                "thread": threading.current_thread().name,
+                "429_disabled": is_429_retry_disabled(),
+                "litellm_disabled": is_litellm_rate_limit_retries_disabled(),
+            }
+        return True
+
+    eval_item = EvalItem(
+        request_id=uuid.uuid4().hex,
+        inputs={"question": "test"},
+        outputs="test",
+        expectations={},
+    )
+
+    with eval_retry_context():
+        _compute_eval_scores(
+            eval_item=eval_item,
+            scorers=[flag_checker_a, flag_checker_b],
+        )
+
+    # Both scorers must see the retry-disable flags even though they run in
+    # inner ThreadPoolExecutor threads that would otherwise get an empty context.
+    for name in ("a", "b"):
+        assert observations[name]["429_disabled"], (
+            f"Scorer {name} did not see _DISABLE_429_RETRY in thread {observations[name]['thread']}"
+        )
+        assert observations[name]["litellm_disabled"], (
+            f"Scorer {name} did not see _DISABLE_RATE_LIMIT_RETRIES in thread "
+            f"{observations[name]['thread']}"
+        )


### PR DESCRIPTION
### Related Issues/PRs

Closes #21805

### What changes are proposed in this pull request?

- Propagate `ContextVar` values into the inner scorer `ThreadPoolExecutor` in `_compute_eval_scores()` using `contextvars.copy_context()`
- In Python < 3.12, `ThreadPoolExecutor` worker threads start with an empty context, so the rate-limit retry disable flags set by `eval_retry_context()` were invisible to built-in scorers running in the nested pool
- This caused litellm's own retry loop (`num_retries=10` with exponential backoff) to run **on top of** the harness's `call_with_retry`, leading to extremely long (effectively indefinite) hangs when rate-limit errors occurred

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `mlflow.genai.evaluate()` hanging indefinitely when using a mix of built-in scorers and custom scorers due to `ContextVar` values not propagating to inner `ThreadPoolExecutor` threads in Python < 3.12.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.