### PR TITLE
Fix assistant stream killed by unhandled `rate_limit_event` from Claude Code CLI

### DIFF
--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -577,6 +577,9 @@ class ClaudeCodeProvider(AssistantProvider):
                 except KeyError as e:
                     return Event.from_error(f"Failed to parse stream_event message: {e}")
 
+            case "rate_limit_event":
+                return None
+
             case _:
                 return Event.from_error(f"Unknown message type: {message_type}")
 

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -265,3 +265,37 @@ async def test_astream_handles_error_message_type():
 
     assert events[0].type == EventType.ERROR
     assert "rate limit" in events[0].data["error"]
+
+
+@pytest.mark.asyncio
+async def test_astream_skips_rate_limit_event():
+    mock_stdout = AsyncIterator([
+        b'{"type": "rate_limit_event", "data": {"retry_after": 1.0}}\n',
+        b'{"type": "assistant", "message": {"content": [{"type": "text", "text": "hello"}]}}\n',
+        b'{"type": "result", "result": null, "session_id": "sess-123"}\n',
+    ])
+
+    mock_process = MagicMock()
+    mock_process.stdout = mock_stdout
+    mock_process.stderr = MagicMock()
+    mock_process.stderr.read = AsyncMock(return_value=b"")
+    mock_process.wait = AsyncMock()
+    mock_process.returncode = 0
+    mock_process.pid = 12345
+
+    with (
+        patch(
+            "mlflow.assistant.providers.claude_code.shutil.which",
+            return_value="/usr/bin/claude",
+        ),
+        patch(
+            "mlflow.assistant.providers.claude_code.asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        ),
+    ):
+        provider = ClaudeCodeProvider()
+        events = [e async for e in provider.astream("test prompt", "http://localhost:5000")]
+
+    assert len(events) == 2
+    assert events[0].type == EventType.MESSAGE
+    assert events[1].type == EventType.DONE


### PR DESCRIPTION
### Related Issues/PRs

Closes #22066

### What changes are proposed in this pull request?

The Claude Code CLI emits `rate_limit_event` messages in its `stream-json` output. The message parser in `ClaudeCodeProvider._parse_message_to_event()` did not handle this type, causing it to fall through to the catch-all case which converted it into an error event. The frontend SSE error handler then closed the `EventSource`, terminating the entire stream before the actual assistant response could arrive.

This PR adds a case to skip `rate_limit_event` messages (return `None`), consistent with how other informational message types like `system` are handled.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New test `test_astream_skips_rate_limit_event` verifies that `rate_limit_event` messages are silently skipped and subsequent assistant messages are delivered correctly.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix MLflow Assistant failing with "Unknown message type: rate_limit_event" when the Claude Code CLI emits rate limit events during streaming. The error previously killed the entire response stream.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release