### PR TITLE
Fix gateway UI not showing custom model name during endpoint edit

### DIFF
--- a/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
@@ -88,7 +88,13 @@ export const ModelSelect = ({
       />
       {error && <FormUI.Message type="error" message={error} />}
       {selectedModel && !hideCapabilities && <ModelCapabilities model={selectedModel} />}
-      <ModelSelectorModal isOpen={isModalOpen} onClose={handleClose} onSelect={handleSelect} provider={provider} initialValue={value} />
+      <ModelSelectorModal
+        isOpen={isModalOpen}
+        onClose={handleClose}
+        onSelect={handleSelect}
+        provider={provider}
+        initialValue={value}
+      />
     </div>
   );
 };

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
@@ -88,7 +88,7 @@ export const ModelSelect = ({
       />
       {error && <FormUI.Message type="error" message={error} />}
       {selectedModel && !hideCapabilities && <ModelCapabilities model={selectedModel} />}
-      <ModelSelectorModal isOpen={isModalOpen} onClose={handleClose} onSelect={handleSelect} provider={provider} />
+      <ModelSelectorModal isOpen={isModalOpen} onClose={handleClose} onSelect={handleSelect} provider={provider} initialValue={value} />
     </div>
   );
 };

--- a/mlflow/server/js/src/gateway/components/model-selector/ModelSelectorModal.tsx
+++ b/mlflow/server/js/src/gateway/components/model-selector/ModelSelectorModal.tsx
@@ -58,21 +58,33 @@ export const ModelSelectorModal = ({ isOpen, onClose, onSelect, provider, initia
   const { data: models, isLoading } = useModelsQuery({ provider: provider || undefined });
   const isCustomMode = customModelName.trim().length > 0;
 
-  // Pre-populate modal state when opening with an existing value
+  // Pre-populate modal state when opening with an existing value.
+  // Initialize from initialValue immediately (as custom) even before models load,
+  // then upgrade to a known-model selection once models arrive.
   useEffect(() => {
-    if (isOpen && initialValue && models && !hasInitialized) {
+    if (!isOpen) {
+      setHasInitialized(false);
+      return;
+    }
+
+    if (!initialValue) {
+      return;
+    }
+
+    // Always initialize from initialValue when opening, even if models are not yet loaded
+    if (!hasInitialized) {
+      setSelectedModelId(null);
+      setCustomModelName(initialValue);
+      setHasInitialized(true);
+    }
+
+    // Once models are available, switch to a known-model selection if a match is found
+    if (models) {
       const knownModel = models.find((m) => m.model === initialValue);
       if (knownModel) {
         setSelectedModelId(knownModel.model);
         setCustomModelName('');
-      } else {
-        setSelectedModelId(null);
-        setCustomModelName(initialValue);
       }
-      setHasInitialized(true);
-    }
-    if (!isOpen) {
-      setHasInitialized(false);
     }
   }, [isOpen, initialValue, models, hasInitialized]);
 

--- a/mlflow/server/js/src/gateway/components/model-selector/ModelSelectorModal.tsx
+++ b/mlflow/server/js/src/gateway/components/model-selector/ModelSelectorModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
 import {
   Button,
@@ -27,6 +27,8 @@ interface ModelSelectorModalProps {
   onClose: () => void;
   onSelect: (model: ProviderModel) => void;
   provider: string;
+  /** Current model name value, used to pre-populate the modal when editing */
+  initialValue?: string;
 }
 
 interface CapabilityFilter {
@@ -41,7 +43,7 @@ interface FilterState {
   capabilities: CapabilityFilter;
 }
 
-export const ModelSelectorModal = ({ isOpen, onClose, onSelect, provider }: ModelSelectorModalProps) => {
+export const ModelSelectorModal = ({ isOpen, onClose, onSelect, provider, initialValue }: ModelSelectorModalProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
@@ -51,9 +53,28 @@ export const ModelSelectorModal = ({ isOpen, onClose, onSelect, provider }: Mode
     capabilities: { tools: false, reasoning: false, promptCaching: false, structuredOutput: false },
   });
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [hasInitialized, setHasInitialized] = useState(false);
 
   const { data: models, isLoading } = useModelsQuery({ provider: provider || undefined });
   const isCustomMode = customModelName.trim().length > 0;
+
+  // Pre-populate modal state when opening with an existing value
+  useEffect(() => {
+    if (isOpen && initialValue && models && !hasInitialized) {
+      const knownModel = models.find((m) => m.model === initialValue);
+      if (knownModel) {
+        setSelectedModelId(knownModel.model);
+        setCustomModelName('');
+      } else {
+        setSelectedModelId(null);
+        setCustomModelName(initialValue);
+      }
+      setHasInitialized(true);
+    }
+    if (!isOpen) {
+      setHasInitialized(false);
+    }
+  }, [isOpen, initialValue, models, hasInitialized]);
 
   const hasActiveFilters = Object.values(filters.capabilities).some(Boolean);
   const filterCount = Object.values(filters.capabilities).filter(Boolean).length;


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The `ModelSelectorModal` always initialized with empty state, so when editing an endpoint that uses a custom model name (not in the provider's known model list), the "Use a custom model name" field appeared blank and the value couldn't be updated.

This PR adds an `initialValue` prop to `ModelSelectorModal` and pre-populates the correct field when the modal opens:
- If the value matches a known model, the radio button is pre-selected
- If it's a custom model name, the custom input field is populated

### How is this PR tested?

- [x] Manual tests

<img width="879" height="823" alt="image" src="https://github.com/user-attachments/assets/5cf85e38-fbca-4bd8-8c65-ebfb304f7315" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix gateway endpoint edit UI not displaying or allowing updates to custom model names.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release