### PR TITLE
Fix bool coercion for LLM judge feedback_value_type

### DIFF
--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -8,7 +8,7 @@ import threading
 from contextlib import ContextDecorator
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator, Literal, get_args, get_origin
 
 import pydantic
 
@@ -453,6 +453,56 @@ def _remove_oldest_tool_call_pair(
     ]
 
 
+def _coerce_result_value(value: Any, response_format: type[pydantic.BaseModel] | None) -> Any:
+    """Coerce the raw result value from the LLM response to the expected type.
+
+    When a model doesn't support structured outputs (or returns non-conforming JSON),
+    boolean values may come back as strings like "True" or "False". This function
+    casts the value to the type declared in the response_format model's "result" field,
+    preventing spurious extra categories in judge evaluations.
+    """
+    if response_format is None:
+        return value
+
+    result_field = response_format.model_fields.get("result")
+    if result_field is None:
+        return value
+
+    expected_type = result_field.annotation
+    if expected_type is None:
+        return value
+
+    # Handle Literal types — check membership, with case-insensitive string fallback.
+    if get_origin(expected_type) is Literal:
+        allowed = get_args(expected_type)
+        if value in allowed:
+            return value
+        if isinstance(value, str):
+            for allowed_val in allowed:
+                if str(allowed_val).lower() == value.lower():
+                    return allowed_val
+        return value
+
+    # For plain types, skip coercion if already correct.
+    try:
+        if isinstance(value, expected_type):
+            return value
+    except TypeError:
+        return value
+
+    try:
+        if expected_type is bool:
+            if isinstance(value, str):
+                return value.strip().lower() in ("true", "1", "yes")
+            return bool(value)
+        return expected_type(value)
+    except (TypeError, ValueError):
+        _logger.debug(
+            f"Could not coerce judge result {value!r} to {expected_type}; using raw value."
+        )
+        return value
+
+
 def _get_default_judge_response_schema() -> type[pydantic.BaseModel]:
     """
     Get the default Pydantic schema for judge evaluations.
@@ -625,7 +675,7 @@ class LiteLLMAdapter(BaseJudgeAdapter):
 
             feedback = Feedback(
                 name=input_params.assessment_name,
-                value=response_dict["result"],
+                value=_coerce_result_value(response_dict["result"], input_params.response_format),
                 rationale=_sanitize_justification(response_dict.get("rationale", "")),
                 source=AssessmentSource(
                     source_type=AssessmentSourceType.LLM_JUDGE, source_id=input_params.model_uri

--- a/tests/genai/judges/adapters/test_litellm_adapter.py
+++ b/tests/genai/judges/adapters/test_litellm_adapter.py
@@ -15,6 +15,7 @@ from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER
 from mlflow.genai.judges.adapters.base_adapter import AdapterInvocationInput
 from mlflow.genai.judges.adapters.litellm_adapter import (
     _MODEL_RESPONSE_FORMAT_CAPABILITIES,
+    _coerce_result_value,
     _invoke_litellm,
     _remove_oldest_tool_call_pair,
 )
@@ -785,3 +786,200 @@ def test_record_failure_telemetry_without_databricks_agents():
 
         mock_logger.debug.assert_called_once()
         assert "databricks-agents needs to be installed" in str(mock_logger.debug.call_args)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _coerce_result_value
+# ---------------------------------------------------------------------------
+
+
+class BoolResponseFormat(BaseModel):
+    result: bool = Field(description="Boolean result")
+    rationale: str = Field(description="Rationale")
+
+
+class StrResponseFormat(BaseModel):
+    result: str = Field(description="String result")
+    rationale: str = Field(description="Rationale")
+
+
+def test_coerce_result_value_no_response_format():
+    """Raw value is returned unchanged when no response_format is provided."""
+    assert _coerce_result_value("True", None) == "True"
+    assert _coerce_result_value(42, None) == 42
+
+
+def test_coerce_result_value_bool_already_correct():
+    """Python booleans pass through unchanged."""
+    assert _coerce_result_value(True, BoolResponseFormat) is True
+    assert _coerce_result_value(False, BoolResponseFormat) is False
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("True", True),
+    ("False", False),
+    ("true", True),
+    ("false", False),
+    ("TRUE", True),
+    ("FALSE", False),
+    ("  true  ", True),
+    ("yes", True),
+    ("1", True),
+    ("no", False),
+    ("0", False),
+    ("random", False),
+])
+def test_coerce_result_value_bool_from_string(raw, expected):
+    """String boolean representations are coerced to actual booleans."""
+    assert _coerce_result_value(raw, BoolResponseFormat) is expected
+
+
+def test_coerce_result_value_str_type_already_string():
+    """String values pass through for str-typed result fields."""
+    assert _coerce_result_value("yes", StrResponseFormat) == "yes"
+
+
+def test_coerce_result_value_str_type_coerces_int():
+    """Non-string values are cast when the expected type is str."""
+    assert _coerce_result_value(42, StrResponseFormat) == "42"
+
+
+def test_coerce_result_value_no_result_field():
+    """Returns raw value when the response_format has no 'result' field."""
+    class NoResultModel(BaseModel):
+        score: int = Field(description="Score")
+
+    assert _coerce_result_value("True", NoResultModel) == "True"
+
+
+def test_coerce_result_value_literal_type_exact_match():
+    """Literal values that already match are returned as-is."""
+    from typing import Literal
+
+    class LiteralModel(BaseModel):
+        result: Literal["yes", "no"] = Field(description="yes or no")
+
+    assert _coerce_result_value("yes", LiteralModel) == "yes"
+    assert _coerce_result_value("no", LiteralModel) == "no"
+
+
+def test_coerce_result_value_literal_type_case_insensitive():
+    """Literal values are matched case-insensitively."""
+    from typing import Literal
+
+    class LiteralModel(BaseModel):
+        result: Literal["yes", "no"] = Field(description="yes or no")
+
+    assert _coerce_result_value("YES", LiteralModel) == "yes"
+    assert _coerce_result_value("No", LiteralModel) == "no"
+
+
+def test_coerce_result_value_literal_type_no_match_returns_raw():
+    """Raw value is returned when it doesn't match any Literal option."""
+    from typing import Literal
+
+    class LiteralModel(BaseModel):
+        result: Literal["yes", "no"] = Field(description="yes or no")
+
+    assert _coerce_result_value("maybe", LiteralModel) == "maybe"
+
+
+# ---------------------------------------------------------------------------
+# Tests for LiteLLMAdapter.invoke bool coercion (integration)
+# ---------------------------------------------------------------------------
+
+
+def _make_invoke_input(response_format=None):
+    return AdapterInvocationInput(
+        prompt="Evaluate this.",
+        assessment_name="named_diagnosis",
+        model_uri="databricks:/databricks-gpt-5",
+        trace=None,
+        num_retries=3,
+        response_format=response_format,
+    )
+
+
+def test_invoke_coerces_string_true_to_bool():
+    """String 'True' from the model is coerced to Python True when feedback_value_type=bool."""
+    from mlflow.genai.judges.adapters.litellm_adapter import LiteLLMAdapter
+
+    adapter = LiteLLMAdapter()
+
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm_and_handle_tools",
+        return_value=mock.Mock(
+            response='{"result": "True", "rationale": "It qualifies."}',
+            cost=None,
+            num_prompt_tokens=None,
+            num_completion_tokens=None,
+            request_id=None,
+        ),
+    ):
+        result = adapter.invoke(_make_invoke_input(response_format=BoolResponseFormat))
+
+    assert result.feedback.value is True
+
+
+def test_invoke_coerces_string_false_to_bool():
+    """String 'False' from the model is coerced to Python False when feedback_value_type=bool."""
+    from mlflow.genai.judges.adapters.litellm_adapter import LiteLLMAdapter
+
+    adapter = LiteLLMAdapter()
+
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm_and_handle_tools",
+        return_value=mock.Mock(
+            response='{"result": "False", "rationale": "Does not qualify."}',
+            cost=None,
+            num_prompt_tokens=None,
+            num_completion_tokens=None,
+            request_id=None,
+        ),
+    ):
+        result = adapter.invoke(_make_invoke_input(response_format=BoolResponseFormat))
+
+    assert result.feedback.value is False
+
+
+def test_invoke_passes_through_native_bool():
+    """JSON boolean true/false (Python True/False after json.loads) is preserved as-is."""
+    from mlflow.genai.judges.adapters.litellm_adapter import LiteLLMAdapter
+
+    adapter = LiteLLMAdapter()
+
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm_and_handle_tools",
+        return_value=mock.Mock(
+            response='{"result": true, "rationale": "It qualifies."}',
+            cost=None,
+            num_prompt_tokens=None,
+            num_completion_tokens=None,
+            request_id=None,
+        ),
+    ):
+        result = adapter.invoke(_make_invoke_input(response_format=BoolResponseFormat))
+
+    assert result.feedback.value is True
+
+
+def test_invoke_no_coercion_without_response_format():
+    """Without response_format, string values are left unchanged (existing behaviour)."""
+    from mlflow.genai.judges.adapters.litellm_adapter import LiteLLMAdapter
+
+    adapter = LiteLLMAdapter()
+
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm_and_handle_tools",
+        return_value=mock.Mock(
+            response='{"result": "True", "rationale": "It qualifies."}',
+            cost=None,
+            num_prompt_tokens=None,
+            num_completion_tokens=None,
+            request_id=None,
+        ),
+    ):
+        result = adapter.invoke(_make_invoke_input(response_format=None))
+
+    # No coercion — stays as the raw string
+    assert result.feedback.value == "True"


### PR DESCRIPTION
### Related Issues/PRs

  Relates to PR #18897                                                                                                                                                                                                                     
   
  ### What changes are proposed in this pull request?                                                                                                                                                                                            
                  
  When calling `make_judge(feedback_value_type=bool, ...)`, the LLM can return                                                                                                                                                                   
  the string `"True"` or `"False"` instead of a Python `bool` when the model does
  not fully honour structured outputs (`response_format`). This causes                                                                                                                                                                           
  `Feedback.value` to be a string, producing spurious extra categories when                                                                                                                                                                      
  aggregating judge evaluation results.                                                                                                                                                                                                          
                                                                                                                                                                                                                                                 
  Fix adds a `_coerce_result_value()` helper in
  `mlflow/genai/judges/adapters/litellm_adapter.py` that inspects the `result`                                                                                                                                                                   
  field annotation on the `response_format` Pydantic model and coerces the raw                                                                                                                                                                   
  JSON value before building the `Feedback` object:
  - `bool`: maps `"true"` / `"1"` / `"yes"` → `True`, anything else → `False`                                                                                                                                                                    
  - `Literal[...]`: case-insensitive string fallback to allowed values                                                                                                                                                                           
  - Other types: best-effort cast, returns original value on failure                                                                                                                                                                             
                                                                                                                                                                                                                                                 
  The helper is wired into `LiteLLMAdapter.invoke()` at the `Feedback`                                                                                                                                                                           
  construction site.                                                                                                                                                                                                                             
                  
  ### How is this PR tested?

  - [x] New unit/integration tests                                                                                                                                                                                                               
   
  15 new tests in `tests/genai/judges/adapters/test_litellm_adapter.py`:                                                                                                                                                                         
  - Unit tests for `_coerce_result_value` covering `bool`, `Literal`, generic
    types, `None` response_format, missing `result` field, and already-correct                                                                                                                                                                   
    value pass-through.                                                                                                                                                                                                                          
  - Integration tests for `LiteLLMAdapter.invoke()` verifying end-to-end                                                                                                                                                                         
    coercion for `bool` and `Literal` feedback types.                                                                                                                                                                                            
                                                                                                                                                                                                                                                 
  ### Does this PR require documentation update?
                                                                                                                                                                                                                                                 
  - [x] No.       

  ### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

  - [x] No.                                                                                                                                                                                                                                      
   
  ### Release Notes                                                                                                                                                                                                                              
                  
  #### Is this a user-facing change?

  - [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

  `make_judge(feedback_value_type=bool, ...)` now correctly returns Python                                                                                                                                                                       
  `bool` values instead of the strings `"True"`/`"False"` when the underlying
  model does not fully honour structured outputs, preventing spurious extra                                                                                                                                                                      
  categories in LLM judge evaluation results.
                                                                                                                                                                                                                                                 
  #### What component(s), interfaces, languages, and integrations does this PR affect?

  - [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows                                                                                                                                        
   
  #### How should the PR be classified in the release notes? Choose one:                                                                                                                                                                         
                  
  - [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes                                                                                                                                                               
   
  #### Is this PR a critical bugfix or security fix that should go into the next patch release?                                                                                                                                                  
                  
  - [ ] This PR is critical and needs to be in the next patch release
  - [x] This PR can wait for the next minor release
