### PR TITLE
Add trace_location parameter to create_experiment

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2284,6 +2284,7 @@ def create_experiment(
     name: str,
     artifact_location: str | None = None,
     tags: dict[str, Any] | None = None,
+    trace_location: UnityCatalog | None = None,
 ) -> str:
     """
     Create an experiment.
@@ -2293,6 +2294,10 @@ def create_experiment(
         artifact_location: The location to store run artifacts. If not provided, the server picks
             an appropriate default.
         tags: An optional dictionary of string keys and values to set as tags on the experiment.
+        trace_location: Optional UC trace location to link to the experiment. Must be an instance
+            of ``mlflow.entities.trace_location.UnityCatalog(...)``. If ``table_prefix`` is not
+            set, it defaults to the experiment ID. Note: call ``mlflow.set_experiment`` afterward
+            to activate the experiment and sync the trace provider.
 
     Returns:
         String ID of the created experiment.
@@ -2328,7 +2333,32 @@ def create_experiment(
         Lifecycle_stage: active
         Creation timestamp: 1662004217511
     """
-    return MlflowClient().create_experiment(name, artifact_location, tags)
+    client = MlflowClient()
+    experiment_id = client.create_experiment(name, artifact_location, tags)
+
+    if trace_location is not None:
+        experiment = client.get_experiment(experiment_id)
+
+        if trace_location.table_prefix is None:
+            trace_location = UnityCatalog(
+                catalog_name=trace_location.catalog_name,
+                schema_name=trace_location.schema_name,
+                table_prefix=experiment_id,
+            )
+
+        try:
+            _resolve_experiment_to_trace_location(
+                experiment=experiment,
+                trace_location=trace_location,
+            )
+        except MlflowException as e:
+            raise MlflowException.invalid_parameter_value(
+                f"Experiment '{name}' (ID: {experiment_id}) was created "
+                f"but linking to trace location '{trace_location.full_table_prefix}' failed: "
+                f"{e.message} Please delete the experiment and retry."
+            ) from e
+
+    return experiment_id
 
 
 def delete_experiment(experiment_id: str) -> None:

--- a/tests/tracking/fluent/test_create_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_create_experiment_trace_location.py
@@ -1,0 +1,142 @@
+from unittest import mock
+
+import pytest
+
+import mlflow
+from mlflow.entities import Experiment
+from mlflow.entities.experiment_tag import ExperimentTag
+from mlflow.entities.trace_location import UnityCatalog
+from mlflow.exceptions import MlflowException
+
+
+def _experiment(experiment_id="789"):
+    return Experiment(
+        experiment_id=experiment_id,
+        name="test-experiment",
+        artifact_location="file:/tmp",
+        lifecycle_stage="active",
+        tags=[ExperimentTag("key", "val")],
+    )
+
+
+def test_without_trace_location_unchanged():
+    with mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls:
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "789"
+
+        assert mlflow.create_experiment("my-exp", tags={"k": "v"}) == "789"
+        client.create_experiment.assert_called_once_with("my-exp", None, {"k": "v"})
+        client.get_experiment.assert_not_called()
+
+
+def test_defaults_empty_prefix_to_experiment_id():
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ) as mock_resolve,
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "789"
+        client.get_experiment.return_value = _experiment()
+
+        original = UnityCatalog("catalog", "schema")
+        mlflow.create_experiment("my-exp", trace_location=original)
+
+        passed_location = mock_resolve.call_args.kwargs["trace_location"]
+        assert passed_location.table_prefix == "789"
+        assert original.table_prefix is None
+
+
+def test_explicit_prefix_preserved():
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ) as mock_resolve,
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "789"
+        client.get_experiment.return_value = _experiment()
+
+        mlflow.create_experiment(
+            "my-exp",
+            trace_location=UnityCatalog("catalog", "schema", "custom_prefix"),
+        )
+
+        assert mock_resolve.call_args.kwargs["trace_location"].table_prefix == "custom_prefix"
+
+
+def test_resolve_receives_experiment_object():
+    exp = _experiment()
+
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ) as mock_resolve,
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "789"
+        client.get_experiment.return_value = exp
+
+        result = mlflow.create_experiment(
+            "my-exp",
+            trace_location=UnityCatalog("catalog", "schema", "pfx"),
+        )
+
+        assert result == "789"
+        assert mock_resolve.call_args.kwargs["experiment"] is exp
+
+
+def test_does_not_sync_provider_or_set_active():
+    import mlflow.tracking.fluent as fluent_module
+
+    original_active = fluent_module._active_experiment_id
+
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ),
+        mock.patch(
+            "mlflow.tracking.fluent._sync_trace_destination_and_provider",
+        ) as mock_sync,
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "789"
+        client.get_experiment.return_value = _experiment()
+
+        mlflow.create_experiment(
+            "my-exp",
+            trace_location=UnityCatalog("catalog", "schema", "pfx"),
+        )
+
+        mock_sync.assert_not_called()
+        assert fluent_module._active_experiment_id == original_active
+
+
+def test_link_failure_includes_retry_guidance():
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            side_effect=MlflowException("backend error"),
+        ),
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "456"
+        client.get_experiment.return_value = _experiment(experiment_id="456")
+
+        with pytest.raises(MlflowException, match="delete the experiment and retry") as exc_info:
+            mlflow.create_experiment(
+                "new-exp",
+                trace_location=UnityCatalog("cat", "sch", "pfx"),
+            )
+
+        assert "was created" in exc_info.value.message
+        assert "backend error" in exc_info.value.message

--- a/tests/tracking/fluent/test_create_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_create_experiment_trace_location.py
@@ -3,12 +3,11 @@ from unittest import mock
 import pytest
 
 import mlflow
-
+import mlflow.tracking.fluent as fluent_module
 from mlflow.entities import Experiment
 from mlflow.entities.experiment_tag import ExperimentTag
 from mlflow.entities.trace_location import UnityCatalog
 from mlflow.exceptions import MlflowException
-import mlflow.tracking.fluent as fluent_module
 
 
 def _experiment(experiment_id="789"):

--- a/tests/tracking/fluent/test_create_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_create_experiment_trace_location.py
@@ -3,10 +3,12 @@ from unittest import mock
 import pytest
 
 import mlflow
+
 from mlflow.entities import Experiment
 from mlflow.entities.experiment_tag import ExperimentTag
 from mlflow.entities.trace_location import UnityCatalog
 from mlflow.exceptions import MlflowException
+import mlflow.tracking.fluent as fluent_module
 
 
 def _experiment(experiment_id="789"):
@@ -93,8 +95,6 @@ def test_resolve_receives_experiment_object():
 
 
 def test_does_not_sync_provider_or_set_active():
-    import mlflow.tracking.fluent as fluent_module
-
     original_active = fluent_module._active_experiment_id
 
     with (


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Relates to databricks-eng/universe#1738024

### What changes are proposed in this pull request?

Add `trace_location` parameter to `mlflow.create_experiment()`, allowing users to create an experiment and bind it to a Unity Catalog trace location in a single call. If `table_prefix` is not specified, it defaults to the experiment ID (same behavior as `set_experiment`).

Users still need to call `set_experiment` afterward to activate the experiment.

### How is this PR tested?

- [x] New unit/integration tests

6 new tests in `tests/tracking/fluent/test_create_experiment_trace_location.py` covering prefix defaulting, explicit prefix, resolve delegation, no provider sync, and error handling.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] API references

Docstring updated with the new `trace_location` parameter.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.create_experiment()` now accepts a `trace_location` parameter to bind a Unity Catalog trace location at creation time.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
