### PR TITLE
Fix copy_model_version error when model_id is empty string

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -896,7 +896,7 @@ class UcModelRegistryStore(BaseRestStore):
                     shutil.rmtree(local_model_dir)
 
     def _get_logged_model_from_model_id(self, model_id) -> LoggedModel | None:
-        if model_id is None:
+        if not model_id:
             return None
         try:
             return mlflow.get_logged_model(model_id)

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -979,6 +979,11 @@ def test_get_logged_model_from_model_id_returns_none_for_none_input(store):
     assert result is None
 
 
+def test_get_logged_model_from_model_id_returns_none_for_empty_string(store):
+    result = store._get_logged_model_from_model_id("")
+    assert result is None
+
+
 def test_get_logged_model_from_model_id_reraises_other_exceptions(store):
     with mock.patch(
         "mlflow.get_logged_model",


### PR DESCRIPTION
## What changes are proposed in this pull request?

`copy_model_version` fails with `model_id must be a non-empty string, but got ''` when copying model versions between Unity Catalog locations. This happens because some UC model versions have an empty string `model_id` instead of `None`.

The guard in `_get_logged_model_from_model_id` only checked for `None`, so the empty string slipped through to `get_logged_model` which rejects it via `_validate_model_id_specified`. Changed the check from `if model_id is None` to `if not model_id` so both `None` and `""` are treated as absent.

Added a unit test for the empty string case.

## How is this PR tested?

- Added `test_get_logged_model_from_model_id_returns_none_for_empty_string` alongside the existing `None` input test.
- Existing tests continue to pass.

## Does this PR require documentation update?

No.

## What is the risk level of this change?

Low. The change narrows the set of values that reach `get_logged_model` — empty strings were never valid model IDs, so treating them as absent is strictly correct.

Fixes #22012