### PR TITLE
Remove `--snapshot` pinning from `apt-get` commands in CI

### DIFF
--- a/.github/actions/setup-pyenv/action.yml
+++ b/.github/actions/setup-pyenv/action.yml
@@ -10,9 +10,9 @@ runs:
       # Ref: https://github.com/pyenv/pyenv/wiki#suggested-build-environment
       # Note: llvm is optional (required only for building PyPy/clang)
       run: |
-        sudo apt-get update --snapshot=20260310T000000Z
+        sudo apt-get update
         sudo apt-get purge -y man-db || true
-        sudo apt-get install --snapshot=20260310T000000Z -y --no-install-recommends make build-essential libssl-dev zlib1g-dev \
+        sudo apt-get install -y --no-install-recommends make build-essential libssl-dev zlib1g-dev \
         libbz2-dev libreadline-dev libsqlite3-dev wget curl \
         libncursesw5-dev xz-utils libffi-dev liblzma-dev
     - name: Install pyenv

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -95,8 +95,8 @@ jobs:
           source ./dev/install-common-deps.sh --ml
           uv pip install --system fastapi uvicorn
           # Required for the transformers example that uses the Whisper model
-          sudo apt-get update --snapshot=20260310T000000Z
-          sudo apt-get install --snapshot=20260310T000000Z -y ffmpeg
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
 
       - name: Run example tests
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || steps.check-diff.outputs.examples_changed == 'true'

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -76,8 +76,6 @@ jobs:
           key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('mlflow/R/mlflow/R-version') }}-0-${{ hashFiles('mlflow/R/mlflow/depends.Rds') }}
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff-dev
           Rscript -e 'source(".install-deps.R", echo=TRUE)'
       - name: Set USE_R_DEVEL
         run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -76,6 +76,8 @@ jobs:
           key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('mlflow/R/mlflow/R-version') }}-0-${{ hashFiles('mlflow/R/mlflow/depends.Rds') }}
       - name: Install dependencies
         run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff-dev
           Rscript -e 'source(".install-deps.R", echo=TRUE)'
       - name: Set USE_R_DEVEL
         run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -480,8 +480,8 @@ transformers:
       ">= 4.38.2": ["tf-keras"] # Transformers doesn't support Keras 3.0. tf-keras needs to be installed.
       "< 4.52.0.dev0": ["accelerate<1"]
     pre_test: |
-      sudo apt-get update --snapshot=20260310T000000Z
-      sudo apt-get install --snapshot=20260310T000000Z -y ffmpeg
+      sudo apt-get update
+      sudo apt-get install -y ffmpeg
       export PYTHONPATH=./
       python tests/transformers/helper.py
     run: |


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22051

### What changes are proposed in this pull request?

Remove `--snapshot=20260310T000000Z` from all `apt-get` commands in CI workflows. The APT snapshot mirror can be unstable and slow, causing CI flakiness.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)