### PR TITLE
Add `gateway:/` URI support to `GatewayAdapter`

### DIFF
--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -93,10 +93,13 @@ def _invoke_via_gateway(
             rf_dict = _pydantic_to_response_format(response_format)
             if rf_dict is not None:
                 payload["response_format"] = rf_dict
-        response = call_deployments_api(model_name, payload, inference_params, "llm/v1/chat")
+        response = call_deployments_api(
+            model_name, payload, inference_params, EndpointType.LLM_V1_CHAT
+        )
         if not isinstance(response, str):
             raise MlflowException(
-                "Expected a string response from the gateway deployment for 'llm/v1/chat', "
+                f"Expected a string response from gateway deployment '{model_name}' "
+                f"for endpoint type '{EndpointType.LLM_V1_CHAT}', "
                 f"but got {type(response).__name__}.",
                 error_code=BAD_REQUEST,
             )

--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -88,9 +88,19 @@ def _invoke_via_gateway(
 
     # gateway:/ routes through the MLflow tracking server's deployments client
     if provider == "gateway":
-        return call_deployments_api(
-            model_name, {"messages": prompt}, inference_params, "llm/v1/chat"
-        )
+        payload = {"messages": prompt}
+        if response_format is not None:
+            rf_dict = _pydantic_to_response_format(response_format)
+            if rf_dict is not None:
+                payload["response_format"] = rf_dict
+        response = call_deployments_api(model_name, payload, inference_params, "llm/v1/chat")
+        if not isinstance(response, str):
+            raise MlflowException(
+                "Expected a string response from the gateway deployment for 'llm/v1/chat', "
+                f"but got {type(response).__name__}.",
+                error_code=BAD_REQUEST,
+            )
+        return response
 
     rf_dict = _pydantic_to_response_format(response_format) if response_format else None
     return _call_llm_provider_api(
@@ -137,6 +147,17 @@ class GatewayAdapter(BaseJudgeAdapter):
                 "base_url and extra_headers are not supported for deployment "
                 "endpoints (endpoints:/...). The endpoint URL is determined by the "
                 "deployment target configuration.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
+        # gateway:/ routes through the MLflow tracking server; base_url and extra_headers
+        # should be configured on the server, not per-request.
+        if input_params.model_provider == "gateway" and (
+            input_params.base_url is not None or input_params.extra_headers is not None
+        ):
+            raise MlflowException(
+                "base_url and extra_headers are not supported for the gateway provider "
+                "(gateway:/...). Configure the MLflow AI Gateway on the tracking server instead.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 

--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -25,7 +25,8 @@ from mlflow.genai.judges.utils.parsing_utils import (
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, INVALID_PARAMETER_VALUE
 
 # "endpoints" is a special case for MLflow deployment endpoints (e.g. Databricks model serving).
-_NATIVE_PROVIDERS = ["openai", "anthropic", "gemini", "mistral", "endpoints"]
+# "gateway" routes requests through the MLflow tracking server's gateway proxy.
+_NATIVE_PROVIDERS = ["openai", "anthropic", "gemini", "mistral", "endpoints", "gateway"]
 
 
 def _invoke_via_gateway(
@@ -61,6 +62,7 @@ def _invoke_via_gateway(
     from mlflow.metrics.genai.model_utils import (
         _call_llm_provider_api,
         _parse_model_uri,
+        call_deployments_api,
         get_endpoint_type,
         score_model_on_payload,
     )
@@ -83,6 +85,13 @@ def _invoke_via_gateway(
         )
 
     _, model_name = _parse_model_uri(model_uri)
+
+    # gateway:/ routes through the MLflow tracking server's deployments client
+    if provider == "gateway":
+        return call_deployments_api(
+            model_name, {"messages": prompt}, inference_params, "llm/v1/chat"
+        )
+
     rf_dict = _pydantic_to_response_format(response_format) if response_format else None
     return _call_llm_provider_api(
         provider,

--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -62,7 +62,6 @@ def _invoke_via_gateway(
     from mlflow.metrics.genai.model_utils import (
         _call_llm_provider_api,
         _parse_model_uri,
-        call_deployments_api,
         get_endpoint_type,
         score_model_on_payload,
     )
@@ -86,24 +85,9 @@ def _invoke_via_gateway(
 
     _, model_name = _parse_model_uri(model_uri)
 
-    # gateway:/ routes through the MLflow tracking server's deployments client
+    # gateway:/ routes through the MLflow tracking server's gateway HTTP API
     if provider == "gateway":
-        payload = {"messages": prompt}
-        if response_format is not None:
-            rf_dict = _pydantic_to_response_format(response_format)
-            if rf_dict is not None:
-                payload["response_format"] = rf_dict
-        response = call_deployments_api(
-            model_name, payload, inference_params, EndpointType.LLM_V1_CHAT
-        )
-        if not isinstance(response, str):
-            raise MlflowException(
-                f"Expected a string response from gateway deployment '{model_name}' "
-                f"for endpoint type '{EndpointType.LLM_V1_CHAT}', "
-                f"but got {type(response).__name__}.",
-                error_code=BAD_REQUEST,
-            )
-        return response
+        return _invoke_gateway_chat(model_name, prompt, inference_params, response_format)
 
     rf_dict = _pydantic_to_response_format(response_format) if response_format else None
     return _call_llm_provider_api(
@@ -113,6 +97,73 @@ def _invoke_via_gateway(
         eval_parameters=inference_params,
         response_format=rf_dict,
     )
+
+
+def _invoke_gateway_chat(
+    endpoint_name: str,
+    messages: list[dict[str, str]],
+    inference_params: dict[str, Any] | None = None,
+    response_format: type[pydantic.BaseModel] | None = None,
+) -> str:
+    """
+    Invoke a gateway endpoint via the MLflow tracking server's chat completions API.
+
+    Sends a POST request to ``/gateway/mlflow/v1/chat/completions`` on the tracking
+    server, using the OpenAI-compatible format where the endpoint name is passed as
+    the ``model`` field in the request body.
+
+    Args:
+        endpoint_name: The gateway endpoint name (e.g., "my-chat" from "gateway:/my-chat").
+        messages: List of message dicts with "role" and "content" keys.
+        inference_params: Optional inference parameters (temperature, etc.).
+        response_format: Optional Pydantic model for structured output.
+
+    Returns:
+        The model's response content as a string.
+    """
+    import requests
+
+    from mlflow.environment_variables import MLFLOW_GATEWAY_URI
+    from mlflow.tracking import get_tracking_uri
+    from mlflow.utils.uri import is_http_uri
+
+    gateway_uri = MLFLOW_GATEWAY_URI.get() or get_tracking_uri()
+    if not is_http_uri(gateway_uri):
+        raise MlflowException(
+            f"Gateway provider requires an HTTP(S) tracking URI, but got: '{gateway_uri}'. "
+            "Please set MLFLOW_TRACKING_URI to a valid HTTP(S) URL "
+            "(e.g., 'http://localhost:5000').",
+            error_code=BAD_REQUEST,
+        )
+    url = f"{gateway_uri.rstrip('/')}/gateway/mlflow/v1/chat/completions"
+
+    payload: dict[str, Any] = {"model": endpoint_name, "messages": messages}
+    if inference_params:
+        payload.update(inference_params)
+    if response_format is not None:
+        rf_dict = _pydantic_to_response_format(response_format)
+        if rf_dict is not None:
+            payload["response_format"] = rf_dict
+
+    try:
+        resp = requests.post(url=url, json=payload, timeout=60)
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        body = getattr(e.response, "text", "")
+        raise MlflowException(
+            f"Failed to call gateway endpoint '{endpoint_name}' at {url}.\n"
+            f"- Error: {e}\n- Response body: {body}",
+            error_code=BAD_REQUEST,
+        ) from e
+
+    data = resp.json()
+    try:
+        return data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as e:
+        raise MlflowException(
+            f"Unexpected response format from gateway endpoint '{endpoint_name}': {data}",
+            error_code=BAD_REQUEST,
+        ) from e
 
 
 class GatewayAdapter(BaseJudgeAdapter):

--- a/tests/genai/judges/adapters/test_utils.py
+++ b/tests/genai/judges/adapters/test_utils.py
@@ -92,32 +92,31 @@ def test_get_adapter_gateway_with_list(list_prompt):
 
 
 def test_gateway_adapter_invoke_with_list_prompt(list_prompt):
-    """Test that GatewayAdapter routes gateway:/ list prompts through call_deployments_api."""
+    """Test that GatewayAdapter routes gateway:/ list prompts via gateway HTTP API."""
     adapter = GatewayAdapter()
     input_params = AdapterInvocationInput(
         model_uri="gateway:/my-endpoint",
         prompt=list_prompt,
         assessment_name="test",
     )
-    mock_response = '{"result": "yes", "rationale": "looks good"}'
-    with mock.patch(
-        "mlflow.metrics.genai.model_utils.call_deployments_api",
-        return_value=mock_response,
-    ) as mock_api:
+    mock_json = {
+        "choices": [{"message": {"content": '{"result": "yes", "rationale": "looks good"}'}}]
+    }
+    mock_resp = mock.MagicMock()
+    mock_resp.json.return_value = mock_json
+    with (
+        mock.patch("mlflow.tracking.get_tracking_uri", return_value="http://localhost:5000"),
+        mock.patch("requests.post", return_value=mock_resp) as mock_post,
+    ):
         output = adapter.invoke(input_params)
-        from mlflow.gateway.config import EndpointType
-
-        mock_api.assert_called_once_with(
-            "my-endpoint",
-            {
-                "messages": [
-                    {"role": "system", "content": "You are a helpful assistant"},
-                    {"role": "user", "content": "Please evaluate this"},
-                ],
-            },
-            None,
-            EndpointType.LLM_V1_CHAT,
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs.kwargs["url"] == (
+            "http://localhost:5000/gateway/mlflow/v1/chat/completions"
         )
+        payload = call_kwargs.kwargs["json"]
+        assert payload["model"] == "my-endpoint"
+        assert len(payload["messages"]) == 2
         assert output.feedback.value == "yes"
         assert output.feedback.rationale == "looks good"
 

--- a/tests/genai/judges/adapters/test_utils.py
+++ b/tests/genai/judges/adapters/test_utils.py
@@ -36,6 +36,8 @@ def list_prompt():
         ("openai:/gpt-4", "string", GatewayAdapter),
         ("anthropic:/claude-3-5-sonnet-20241022", "string", GatewayAdapter),
         ("gemini:/gemini-2.5-flash", "string", GatewayAdapter),
+        ("gateway:/my-endpoint", "string", GatewayAdapter),
+        ("gateway:/my-endpoint", "list", GatewayAdapter),
     ],
 )
 def test_get_adapter_without_litellm(

--- a/tests/genai/judges/adapters/test_utils.py
+++ b/tests/genai/judges/adapters/test_utils.py
@@ -105,6 +105,8 @@ def test_gateway_adapter_invoke_with_list_prompt(list_prompt):
         return_value=mock_response,
     ) as mock_api:
         output = adapter.invoke(input_params)
+        from mlflow.gateway.config import EndpointType
+
         mock_api.assert_called_once_with(
             "my-endpoint",
             {
@@ -114,7 +116,7 @@ def test_gateway_adapter_invoke_with_list_prompt(list_prompt):
                 ],
             },
             None,
-            "llm/v1/chat",
+            EndpointType.LLM_V1_CHAT,
         )
         assert output.feedback.value == "yes"
         assert output.feedback.rationale == "looks good"

--- a/tests/genai/judges/adapters/test_utils.py
+++ b/tests/genai/judges/adapters/test_utils.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.adapters.base_adapter import AdapterInvocationInput
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     DatabricksManagedJudgeAdapter,
 )
@@ -88,6 +89,47 @@ def test_get_adapter_gateway_with_list(list_prompt):
     ):
         adapter = get_adapter("openai:/gpt-4", list_prompt)
         assert isinstance(adapter, GatewayAdapter)
+
+
+def test_gateway_adapter_invoke_with_list_prompt(list_prompt):
+    """Test that GatewayAdapter routes gateway:/ list prompts through call_deployments_api."""
+    adapter = GatewayAdapter()
+    input_params = AdapterInvocationInput(
+        model_uri="gateway:/my-endpoint",
+        prompt=list_prompt,
+        assessment_name="test",
+    )
+    mock_response = '{"result": "yes", "rationale": "looks good"}'
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils.call_deployments_api",
+        return_value=mock_response,
+    ) as mock_api:
+        output = adapter.invoke(input_params)
+        mock_api.assert_called_once_with(
+            "my-endpoint",
+            {
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant"},
+                    {"role": "user", "content": "Please evaluate this"},
+                ],
+            },
+            None,
+            "llm/v1/chat",
+        )
+        assert output.feedback.value == "yes"
+        assert output.feedback.rationale == "looks good"
+
+
+def test_gateway_adapter_rejects_base_url_for_gateway():
+    adapter = GatewayAdapter()
+    input_params = AdapterInvocationInput(
+        model_uri="gateway:/my-endpoint",
+        prompt="test",
+        assessment_name="test",
+        base_url="http://custom-url",
+    )
+    with pytest.raises(MlflowException, match="base_url and extra_headers are not supported"):
+        adapter.invoke(input_params)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

Relates to litellm removal effort from judge adapter chain.

### What changes are proposed in this pull request?

Adds `gateway:/` URI support to `GatewayAdapter` so that `gateway:/` model URIs no longer require `LiteLLMAdapter` (and thus the `litellm` dependency) to function.

- Adds `"gateway"` to the `_NATIVE_PROVIDERS` list in `GatewayAdapter`
- Routes `gateway:/` ChatMessage list prompts through `call_deployments_api()`, which proxies through the MLflow tracking server's deployments client
- String prompts for `gateway:/` already worked via `score_model_on_payload()` — no change needed there
- Adds test cases for `gateway:/` with both string and list prompts

This is the first step toward fully removing `LiteLLMAdapter` from the judge adapter chain.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release