### PR TITLE
Add claude code tracing telemetry

### DIFF
--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -120,7 +120,14 @@ def setup_mlflow() -> None:
     except Exception as e:
         get_logger().warning("Failed to set experiment: %s", e)
 
-    _record_event(AutologgingEvent, {"flavor": "claude_code"})
+    _record_event(
+        AutologgingEvent,
+        {
+            "flavor": "claude_code",
+            "log_traces": is_tracing_enabled(),
+            "disable": not is_tracing_enabled(),
+        },
+    )
 
 
 def is_tracing_enabled() -> bool:

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -22,6 +22,8 @@ from mlflow.environment_variables import (
     MLFLOW_EXPERIMENT_NAME,
     MLFLOW_TRACKING_URI,
 )
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey, TraceMetadataKey
 from mlflow.tracing.provider import _get_trace_exporter
 from mlflow.tracing.trace_manager import InMemoryTraceManager
@@ -118,13 +120,7 @@ def setup_mlflow() -> None:
     except Exception as e:
         get_logger().warning("Failed to set experiment: %s", e)
 
-    try:
-        from mlflow.telemetry.events import AutologgingEvent
-        from mlflow.telemetry.track import _record_event
-
-        _record_event(AutologgingEvent, {"flavor": "claude_code"})
-    except Exception:
-        pass
+    _record_event(AutologgingEvent, {"flavor": "claude_code"})
 
 
 def is_tracing_enabled() -> bool:

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -118,6 +118,14 @@ def setup_mlflow() -> None:
     except Exception as e:
         get_logger().warning("Failed to set experiment: %s", e)
 
+    try:
+        from mlflow.telemetry.events import AutologgingEvent
+        from mlflow.telemetry.track import _record_event
+
+        _record_event(AutologgingEvent, {"flavor": "claude_code"})
+    except Exception:
+        pass
+
 
 def is_tracing_enabled() -> bool:
     """Check if MLflow Claude tracing is enabled via environment variable."""

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -120,14 +120,7 @@ def setup_mlflow() -> None:
     except Exception as e:
         get_logger().warning("Failed to set experiment: %s", e)
 
-    _record_event(
-        AutologgingEvent,
-        {
-            "flavor": "claude_code",
-            "log_traces": is_tracing_enabled(),
-            "disable": not is_tracing_enabled(),
-        },
-    )
+    _record_event(AutologgingEvent, {"flavor": "claude_code"})
 
 
 def is_tracing_enabled() -> bool:


### PR DESCRIPTION
### What changes are proposed in this pull request?

ttle

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
