### PR TITLE
docs: Add base_model_path documentation for PEFT models

### DIFF
--- a/docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx
@@ -675,23 +675,90 @@ with mlflow.start_run():
     # Your training code here
     ...
 
-    # Log the PEFT model
-    model_info = mlflow.transformers.log_model(
+    # Option 1: Log with local base model path (recommended for air-gapped environments)
+    model_info_local = mlflow.transformers.log_model(
         transformers_model={
             "model": peft_model,
             "tokenizer": tokenizer,
         },
-        name="peft_model",
+        base_model_path="/path/to/local/base/model",  # NEW: Reference to local base model
+        name="peft_model_local",
+    )
+
+    # Option 2: Log with HuggingFace Hub reference (default)
+    model_info_hub = mlflow.transformers.log_model(
+        transformers_model={
+            "model": peft_model,
+            "tokenizer": tokenizer,
+        },
+        name="peft_model_hub",
     )
 
 # Load the PEFT model
-loaded_model = mlflow.transformers.load_model(model_info.model_uri)
+loaded_model = mlflow.transformers.load_model(model_info_local.model_uri)
 ```
+
+### Local Base Model References with `base_model_path`
+
+For air-gapped environments or when you want to avoid HuggingFace Hub dependencies, use the `base_model_path` parameter to reference a locally stored base model:
+
+```python
+import os
+import mlflow
+from peft import LoraConfig, get_peft_model
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Step 1: Prepare local base model (typically done once in your infrastructure)
+base_model_id = "microsoft/DialoGPT-medium"
+local_base_path = "/shared/models/dialogpt-medium"
+
+# Save base model locally (if not already available)
+base_model = AutoModelForCausalLM.from_pretrained(base_model_id)
+tokenizer = AutoTokenizer.from_pretrained(base_model_id)
+base_model.save_pretrained(local_base_path)
+tokenizer.save_pretrained(local_base_path)
+
+# Step 2: Train PEFT model using local base model
+local_model = AutoModelForCausalLM.from_pretrained(local_base_path)
+local_tokenizer = AutoTokenizer.from_pretrained(local_base_path)
+
+peft_config = LoraConfig(
+    task_type="CAUSAL_LM",
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.1,
+)
+peft_model = get_peft_model(local_model, peft_config)
+
+# Step 3: Log PEFT model with local base model reference
+with mlflow.start_run():
+    model_info = mlflow.transformers.log_model(
+        transformers_model={"model": peft_model, "tokenizer": local_tokenizer},
+        base_model_path=local_base_path,  # Only adapter weights saved, base model referenced
+        name="peft_model_local"
+    )
+
+# Step 4: Load and use the model (base model loaded from local path + adapter applied)
+loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+response = loaded_model.predict("Hello, how are you?")
+```
+
+**Benefits of `base_model_path`:**
+- **Storage Efficiency**: Only PEFT adapter weights (~50-500MB) are saved vs full model (several GB)
+- **Air-Gapped Support**: No internet dependency at inference time
+- **Enterprise Ready**: Compatible with internal model repositories and compliance requirements  
+- **Version Control**: Full control over base model versions and updates
+- **Faster Deployment**: Reduced artifact size leads to faster model loading and deployment
+
+**Important Notes:**
+- The `base_model_path` must exist and contain a valid Transformers model checkpoint at both save and load time
+- This parameter is only supported for PEFT models; regular models will raise an error
+- The path should be accessible from all environments where the model will be loaded
 
 ### PEFT Models in MLflow Tutorial
 
 Check out the tutorial [Fine-Tuning Open-Source LLM using QLoRA with MLflow and PEFT](/ml/deep-learning/transformers/tutorials/fine-tuning/transformers-peft/)
-for a more in-depth guide on how to use PEFT with MLflow,
+for a more in-depth guide on how to use PEFT with MLflow, including examples of both `base_model_path` and traditional approaches.
 
 ### Format of Saved PEFT Model
 

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/fine-tuning/transformers-peft.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/fine-tuning/transformers-peft.ipynb
@@ -1006,10 +1006,94 @@
    "metadata": {},
    "source": [
     "### Save the PEFT Model to MLflow\n",
-    "Finally, we will call [mlflow.transformers.log_model](https://mlflow.org/docs/latest/python_api/mlflow.transformers.html#mlflow.transformers.log_model) API to log the model to MLflow. A few critical points to remember when logging a PEFT model to MLflow are:\n",
+    "\n",
+    "MLflow provides two approaches for saving PEFT models, each optimized for different deployment scenarios:\n",
+    "\n",
+    "1. **HuggingFace Hub Reference (Default)**: Best for environments with internet access\n",
+    "2. **Local Base Model Reference**: Ideal for air-gapped or offline environments\n",
+    "\n",
+    "#### Option 1: Save with Local Base Model Reference (Recommended for Air-Gapped Environments)\n",
+    "\n",
+    "When working in air-gapped environments or wanting to avoid duplicating large base model weights, you can use the `base_model_path` parameter to reference a local base model directory. This approach provides maximum storage efficiency and eliminates dependency on HuggingFace Hub at inference time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, save the base model locally (if not already available)\n",
+    "import os\n",
+    "\n",
+    "# Define local path for base model storage\n",
+    "base_model_local_path = \"./local_models/mistral-7b-v0.1\"\n",
+    "os.makedirs(base_model_local_path, exist_ok=True)\n",
+    "\n",
+    "# Save the base model and tokenizer to local directory\n",
+    "# Note: In production, this would typically be pre-downloaded in your infrastructure\n",
+    "base_model_for_storage = AutoModelForCausalLM.from_pretrained(base_model_id)\n",
+    "tokenizer_for_storage = AutoTokenizer.from_pretrained(base_model_id)\n",
+    "\n",
+    "base_model_for_storage.save_pretrained(base_model_local_path)\n",
+    "tokenizer_for_storage.save_pretrained(base_model_local_path)\n",
+    "\n",
+    "print(f\"Base model saved to: {os.path.abspath(base_model_local_path)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Log PEFT model with local base model reference\n",
+    "with mlflow.start_run(run_id=last_run_id):\n",
+    "    mlflow.log_params(peft_config.to_dict())\n",
+    "    \n",
+    "    # Option 1: Log with base_model_path (adapter-only, local base model reference)\n",
+    "    model_info_local = mlflow.transformers.log_model(\n",
+    "        transformers_model={\"model\": trainer.model, \"tokenizer\": tokenizer_no_pad},\n",
+    "        base_model_path=base_model_local_path,  # NEW: Reference to local base model\n",
+    "        prompt_template=prompt_template,\n",
+    "        signature=signature,\n",
+    "        name=\"model_local_base\",  # Different name to distinguish from traditional approach\n",
+    "    )\n",
+    "    \n",
+    "    print(f\"✅ PEFT model logged with local base model reference\")\n",
+    "    print(f\"📊 Artifact size: Only adapter weights (~100MB vs ~20GB for full model)\")\n",
+    "    print(f\"🔗 Base model reference: {os.path.abspath(base_model_local_path)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Benefits of using `base_model_path`:**\n",
+    "- **🗄️ Storage Efficiency**: Only PEFT adapter weights are saved (~100MB vs ~20GB for full model)\n",
+    "- **🔒 Air-Gapped Support**: No dependency on HuggingFace Hub at load time\n",
+    "- **🏢 Enterprise Ready**: Works with internal model repositories and data residency requirements\n",
+    "- **📌 Version Control**: Full control over base model versions and updates\n",
+    "- **⚡ Faster Logging**: Significantly reduced upload time due to smaller artifact size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Option 2: Save with HuggingFace Hub Reference (Default Behavior)\n",
+    "\n",
+    "This is the traditional approach that works well when you have reliable internet access and want MLflow to automatically handle base model retrieval from HuggingFace Hub."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Key points for both approaches:**\n",
     "\n",
     "1. **MLflow logs the Transformer model as a [Pipeline](https://huggingface.co/docs/transformers/en/main_classes/pipelines).** A pipeline bundles a model with its tokenizer (or other components, depending on the task type) and simplifies the prediction steps into an easy-to-use interface, making it an excellent tool for ensuring reproducibility. In the code below, we pass the model and tokenizer as a dictionary, then MLflow automatically deduces the correct pipeline type and saves it.\n",
-    "2. **MLflow does not save the base model weight for the PEFT model**. When executing `mlflow.transformers.log_model`, MLflow only saves the small number of trained parameters, i.e., the PEFT adapter. For the base model, MLflow instead records a reference to the HuggingFace hub (repository name and commit hash), and downloads the base model weights on the fly when loading the PEFT model. This approach significantly reduces storage usage and logging latency; for instance, the logged artifacts size in this tutorial is less than 1GB, while the full Mistral 7B model is about 20GB.\n",
+    "2. **MLflow does not save the base model weights for PEFT models**. When executing `mlflow.transformers.log_model`, MLflow only saves the small number of trained parameters, i.e., the PEFT adapter. For the base model, MLflow either stores a local path reference (when using `base_model_path`) or records a reference to the HuggingFace hub (repository name and commit hash), and loads the base model weights accordingly when loading the PEFT model.\n",
     "3. **Save a tokenizer without padding**. During fine-tuning, we applied padding to the dataset to standardize the sequence length in a batch. However, padding is no longer necessary at inference, so we save a different tokenizer without padding. This ensures the loaded model can be used for inference immediately.\n",
     "\n",
     "**Note**: Currently, manual logging is required for the PEFT adapter and config, while other information, such as dataset, metrics, Trainer parameters, etc., are automatically logged. However, this process may be automated in future versions of MLflow and Transformers."


### PR DESCRIPTION
Addresses #22020 documentation request. Added comprehensive examples for base_model_path parameter in PEFT tutorial and guide.