### PR TITLE
add missing `SqlLoggedModel` tables to `_all_tables_exist`

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -57,6 +57,10 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlInputTag,
     SqlJob,
     SqlLatestMetric,
+    SqlLoggedModel,
+    SqlLoggedModelMetric,
+    SqlLoggedModelParam,
+    SqlLoggedModelTag,
     SqlMetric,
     SqlParam,
     SqlRun,
@@ -107,6 +111,10 @@ def _all_tables_exist(engine):
         SqlScorer.__tablename__,
         SqlScorerVersion.__tablename__,
         SqlJob.__tablename__,
+        SqlLoggedModel.__tablename__,
+        SqlLoggedModelMetric.__tablename__,
+        SqlLoggedModelParam.__tablename__,
+        SqlLoggedModelTag.__tablename__,
         SqlWorkspace.__tablename__,
     }
     actual_tables = {


### PR DESCRIPTION
### Related Issues/PRs

Closes #22096

### What changes are proposed in this pull request?

adds the newer `SqlLoggedModel`, `SqlLoggedModelMetric`, `SqlLoggedModelParam`, and `SqlLoggedModelTag` table classes to `_all_tables_exist` in `mlflow/store/db/utils.py` - these were missing from the check

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
