### PR TITLE
Fix _all_tables_exist to include SqlLoggedModel* tables

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -57,6 +57,10 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlInputTag,
     SqlJob,
     SqlLatestMetric,
+    SqlLoggedModel,
+    SqlLoggedModelMetric,
+    SqlLoggedModelParam,
+    SqlLoggedModelTag,
     SqlMetric,
     SqlParam,
     SqlRun,
@@ -108,6 +112,10 @@ def _all_tables_exist(engine):
         SqlScorerVersion.__tablename__,
         SqlJob.__tablename__,
         SqlWorkspace.__tablename__,
+        SqlLoggedModel.__tablename__,
+        SqlLoggedModelMetric.__tablename__,
+        SqlLoggedModelParam.__tablename__,
+        SqlLoggedModelTag.__tablename__,
     }
     actual_tables = {
         t for t in sqlalchemy.inspect(engine).get_table_names() if not t.startswith("alembic_")


### PR DESCRIPTION
This PR fixes #22096 by adding the missing SqlLoggedModel* table names to the _all_tables_exist function in mlflow/store/db/utils.py.

## Changes
- Added imports for SqlLoggedModel, SqlLoggedModelMetric, SqlLoggedModelParam, and SqlLoggedModelTag
- Added these table names to the expected_tables set in _all_tables_exist

This ensures that the database initialization check correctly identifies when the logged model tables are missing, preventing unnecessary calls to _initialize_tables which can cause migration errors.