### PR TITLE
Fix gateway:/ judges to work without litellm

### DIFF
--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -25,7 +25,8 @@ from mlflow.genai.judges.utils.parsing_utils import (
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, INVALID_PARAMETER_VALUE
 
 # "endpoints" is a special case for MLflow deployment endpoints (e.g. Databricks model serving).
-_NATIVE_PROVIDERS = ["openai", "anthropic", "gemini", "mistral", "endpoints"]
+# "gateway" is for MLflow AI Gateway endpoints.
+_NATIVE_PROVIDERS = ["openai", "anthropic", "gemini", "mistral", "endpoints", "gateway"]
 
 
 def _invoke_via_gateway(
@@ -82,6 +83,14 @@ def _invoke_via_gateway(
             endpoint_type=get_endpoint_type(model_uri) or EndpointType.LLM_V1_CHAT,
         )
 
+    # "endpoints" and "gateway" providers only support string prompts
+    if provider in ("endpoints", "gateway"):
+        raise MlflowException(
+            f"LiteLLM is required for using '{provider}' LLM with ChatMessage-style prompts. "
+            "Please install it with `pip install litellm`.",
+            error_code=BAD_REQUEST,
+        )
+
     _, model_name = _parse_model_uri(model_uri)
     rf_dict = _pydantic_to_response_format(response_format) if response_format else None
     return _call_llm_provider_api(
@@ -107,9 +116,9 @@ class GatewayAdapter(BaseJudgeAdapter):
         model_provider, _ = _parse_model_uri(model_uri)
         if model_provider not in _NATIVE_PROVIDERS:
             return False
-        # "endpoints" (Databricks model serving) only supports string prompts
-        # via score_model_on_payload; _get_provider_instance doesn't handle it.
-        if isinstance(prompt, list) and model_provider == "endpoints":
+        # "endpoints" and "gateway" (Databricks model serving / AI Gateway) only support
+        # string prompts via score_model_on_payload; _get_provider_instance doesn't handle them.
+        if isinstance(prompt, list) and model_provider in ("endpoints", "gateway"):
             return False
         return True
 
@@ -120,14 +129,14 @@ class GatewayAdapter(BaseJudgeAdapter):
                 "Please install it with `pip install litellm`.",
             )
 
-        # base_url and extra_headers are not supported for deployment endpoints
-        if input_params.model_provider == "endpoints" and (
+        # base_url and extra_headers are not supported for deployment endpoints or gateway
+        if input_params.model_provider in ("endpoints", "gateway") and (
             input_params.base_url is not None or input_params.extra_headers is not None
         ):
             raise MlflowException(
                 "base_url and extra_headers are not supported for deployment "
-                "endpoints (endpoints:/...). The endpoint URL is determined by the "
-                "deployment target configuration.",
+                "endpoints (endpoints:/...) or gateway (gateway:/...). The endpoint URL "
+                "is determined by the deployment target configuration.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 

--- a/tests/genai/judges/adapters/test_utils.py
+++ b/tests/genai/judges/adapters/test_utils.py
@@ -36,6 +36,8 @@ def list_prompt():
         ("openai:/gpt-4", "string", GatewayAdapter),
         ("anthropic:/claude-3-5-sonnet-20241022", "string", GatewayAdapter),
         ("gemini:/gemini-2.5-flash", "string", GatewayAdapter),
+        # Gateway AI Gateway endpoints (without litellm)
+        ("gateway:/my-endpoint", "string", GatewayAdapter),
     ],
 )
 def test_get_adapter_without_litellm(
@@ -65,6 +67,9 @@ def test_get_adapter_without_litellm(
         ("openai:/gpt-4", "list", LiteLLMAdapter),
         ("anthropic:/claude-3-5-sonnet-20241022", "string", LiteLLMAdapter),
         ("anthropic:/claude-3-5-sonnet-20241022", "list", LiteLLMAdapter),
+        # Gateway AI Gateway endpoints (with litellm - uses LiteLLM adapter)
+        ("gateway:/my-endpoint", "string", LiteLLMAdapter),
+        ("gateway:/my-endpoint", "list", LiteLLMAdapter),
     ],
 )
 def test_get_adapter_with_litellm(
@@ -92,6 +97,7 @@ def test_get_adapter_gateway_with_list(list_prompt):
     ("model_uri", "prompt_type"),
     [
         ("endpoints:/my-endpoint", "list"),
+        ("gateway:/my-endpoint", "list"),
         ("vertex_ai:/gemini-pro", "list"),
         ("bedrock:/anthropic.claude-3-5-sonnet-20241022-v2:0", "list"),
         ("bedrock:/anthropic.claude-3-5-sonnet-20241022-v2:0", "string"),


### PR DESCRIPTION
This PR fixes issue #22112 where `gateway:/...` judges fail in the default GenAI setup unless `litellm` is installed.

## Problem
In the current repo setup, `gateway:/<endpoint>` judge models do not work cleanly in the default GenAI environment. With a natural setup such as `uv sync --extra genai`, users can create and successfully invoke an AI Gateway endpoint, but built-in and custom judges such as `Correctness(model="gateway:/my-endpoint")` or `make_judge(..., model="gateway:/my-endpoint")` fail unless litellm is installed.

## Changes
- Added `gateway` to `_NATIVE_PROVIDERS` list in `gateway_adapter.py`
- Updated `GatewayAdapter.is_applicable()` to handle `gateway:/...` URIs
- Added validation for list prompts with gateway provider (not supported without litellm)
- Updated error messages to include gateway provider
- Added test cases for `gateway:/...` URIs in `test_utils.py`

## Testing
- `gateway:/my-endpoint` with string prompt now works without litellm (uses GatewayAdapter)
- `gateway:/my-endpoint` with list prompt raises appropriate error without litellm
- `gateway:/my-endpoint` with litellm installed uses LiteLLMAdapter

Fixes #22112