### PR TITLE
Fix sidebar navigation and workflow type not updating on URL navigation or browser Back/Forward

### DIFF
--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
@@ -16,7 +16,7 @@ import { ExperimentPageTabName } from '../../experiment-tracking/constants';
 import { FormattedMessage } from 'react-intl';
 import {
   isTracesRelatedTab,
-  getTimeRangeQueryString,
+  getPreservedQueryString,
 } from '../../experiment-tracking/pages/experiment-page-tabs/side-nav/utils';
 import { useExperimentHasV4Location } from '../../experiment-tracking/hooks/useExperimentHasV4Location';
 import { Fragment } from 'react';
@@ -117,7 +117,7 @@ export const MlflowSidebarExperimentItems = ({
                 key={item.componentId}
                 to={{
                   pathname: ExperimentTrackingRoutes.getExperimentPageTabRoute(experimentId ?? '', item.tabName),
-                  search: preserveQueryParams ? search : getTimeRangeQueryString(search),
+                  search: preserveQueryParams ? search : getPreservedQueryString(search),
                 }}
                 componentId={item.componentId}
                 isActive={isActive}

--- a/mlflow/server/js/src/common/contexts/WorkflowTypeContext.test.tsx
+++ b/mlflow/server/js/src/common/contexts/WorkflowTypeContext.test.tsx
@@ -1,0 +1,53 @@
+import { describe, test, expect } from '@jest/globals';
+import { getWorkflowTypeFromUrl, buildWorkflowTypeQueryString, WorkflowType } from './WorkflowTypeContext';
+
+describe('getWorkflowTypeFromUrl', () => {
+  test('returns genai when URL has workflowType=genai', () => {
+    const params = new URLSearchParams('workflowType=genai');
+    expect(getWorkflowTypeFromUrl(params, WorkflowType.MACHINE_LEARNING)).toBe(WorkflowType.GENAI);
+  });
+
+  test('returns machine_learning when URL has workflowType=machine_learning', () => {
+    const params = new URLSearchParams('workflowType=machine_learning');
+    expect(getWorkflowTypeFromUrl(params, WorkflowType.GENAI)).toBe(WorkflowType.MACHINE_LEARNING);
+  });
+
+  test('returns fallback when URL has no workflowType param', () => {
+    const params = new URLSearchParams('');
+    expect(getWorkflowTypeFromUrl(params, WorkflowType.GENAI)).toBe(WorkflowType.GENAI);
+    expect(getWorkflowTypeFromUrl(params, WorkflowType.MACHINE_LEARNING)).toBe(WorkflowType.MACHINE_LEARNING);
+  });
+
+  test('returns fallback when URL has invalid workflowType value', () => {
+    const params = new URLSearchParams('workflowType=invalid');
+    expect(getWorkflowTypeFromUrl(params, WorkflowType.GENAI)).toBe(WorkflowType.GENAI);
+  });
+
+  test('ignores unrelated params', () => {
+    const params = new URLSearchParams('workspace=default&startTimeLabel=LAST_24_HOURS');
+    expect(getWorkflowTypeFromUrl(params, WorkflowType.MACHINE_LEARNING)).toBe(WorkflowType.MACHINE_LEARNING);
+  });
+});
+
+describe('buildWorkflowTypeQueryString', () => {
+  test('builds query with workflowType only', () => {
+    const params = new URLSearchParams('');
+    expect(buildWorkflowTypeQueryString(WorkflowType.GENAI, params)).toBe('workflowType=genai');
+  });
+
+  test('preserves workspace param', () => {
+    const params = new URLSearchParams('workspace=default');
+    const result = buildWorkflowTypeQueryString(WorkflowType.MACHINE_LEARNING, params);
+    expect(result).toContain('workflowType=machine_learning');
+    expect(result).toContain('workspace=default');
+  });
+
+  test('does not carry over unrelated params', () => {
+    const params = new URLSearchParams('selectedTraceId=trace-123&startTimeLabel=LAST_24_HOURS&workspace=default');
+    const result = buildWorkflowTypeQueryString(WorkflowType.GENAI, params);
+    expect(result).toContain('workflowType=genai');
+    expect(result).toContain('workspace=default');
+    expect(result).not.toContain('selectedTraceId');
+    expect(result).not.toContain('startTimeLabel');
+  });
+});

--- a/mlflow/server/js/src/common/contexts/WorkflowTypeContext.tsx
+++ b/mlflow/server/js/src/common/contexts/WorkflowTypeContext.tsx
@@ -1,12 +1,41 @@
 import React, { createContext, useCallback, useContext, useMemo } from 'react';
 import { useLocalStorage } from '@databricks/web-shared/hooks';
-import { useNavigate, useParams } from '../utils/RoutingUtils';
+import { useNavigate, useParams, useSearchParams } from '../utils/RoutingUtils';
 import Routes from '../../experiment-tracking/routes';
 
 export enum WorkflowType {
   GENAI = 'genai',
   MACHINE_LEARNING = 'machine_learning',
 }
+
+/**
+ * Reads the workflowType search param from the URL. Returns the param value
+ * if it is a valid WorkflowType, otherwise returns the provided fallback.
+ */
+export const getWorkflowTypeFromUrl = (searchParams: URLSearchParams, fallback: WorkflowType): WorkflowType => {
+  const value = searchParams.get('workflowType');
+  if (value === WorkflowType.GENAI || value === WorkflowType.MACHINE_LEARNING) {
+    return value;
+  }
+  return fallback;
+};
+
+/**
+ * Builds a query string containing the workflowType and any existing workspace
+ * param. Used when navigating between experiment pages to preserve sidebar state.
+ */
+export const buildWorkflowTypeQueryString = (
+  workflowType: WorkflowType,
+  currentSearchParams: URLSearchParams,
+): string => {
+  const params = new URLSearchParams();
+  params.set('workflowType', workflowType);
+  const workspace = currentSearchParams.get('workspace');
+  if (workspace) {
+    params.set('workspace', workspace);
+  }
+  return params.toString();
+};
 
 const WORKFLOW_TYPE_STORAGE_KEY = 'mlflow.workflowType';
 const WORKFLOW_TYPE_STORAGE_VERSION = 1;
@@ -31,27 +60,30 @@ export const WorkflowTypeProvider = ({ children }: { children: React.ReactNode }
   });
 
   const { experimentId } = useParams();
+  const [searchParams] = useSearchParams();
+  const effectiveWorkflowType = getWorkflowTypeFromUrl(searchParams, workflowType);
+
   const handleWorkflowTypeChange = useCallback(
     (newWorkflowType: WorkflowType) => {
-      if (newWorkflowType === workflowType) {
+      if (newWorkflowType === effectiveWorkflowType) {
         return;
       }
 
       setWorkflowType(newWorkflowType);
       if (experimentId) {
-        // if an experiment is active, redirect to experiment default tab on change
-        navigate(Routes.getExperimentPageRoute(experimentId));
+        const query = buildWorkflowTypeQueryString(newWorkflowType, searchParams);
+        navigate(`${Routes.getExperimentPageRoute(experimentId)}?${query}`);
       }
     },
-    [experimentId, navigate, setWorkflowType, workflowType],
+    [effectiveWorkflowType, experimentId, navigate, searchParams, setWorkflowType],
   );
 
   const contextValue = useMemo(
     () => ({
-      workflowType,
+      workflowType: effectiveWorkflowType,
       setWorkflowType: handleWorkflowTypeChange,
     }),
-    [workflowType, handleWorkflowTypeChange],
+    [effectiveWorkflowType, handleWorkflowTypeChange],
   );
 
   return <WorkflowTypeContext.Provider value={contextValue}>{children}</WorkflowTypeContext.Provider>;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModal.tsx
@@ -12,7 +12,7 @@ import {
 import { FormattedMessage } from '@databricks/i18n';
 import { useLocation, useNavigate } from '../../../../../common/utils/RoutingUtils';
 import Routes from '../../../../routes';
-import { getTimeRangeQueryString } from '../../../../pages/experiment-page-tabs/side-nav/utils';
+import { getPreservedQueryString } from '../../../../pages/experiment-page-tabs/side-nav/utils';
 import { SelectTracesModal } from '../../../SelectTracesModal';
 import { useCreateSecret } from '../../../../../gateway/hooks/useCreateSecret';
 import { ALL_ISSUE_CATEGORIES, type IssueCategory } from './IssueDetectionCategories';
@@ -113,7 +113,7 @@ export const IssueDetectionModal: React.FC<IssueDetectionModalProps> = ({
             onClose();
             navigate({
               pathname: Routes.getIssueDetectionRunDetailsRoute(experimentId, response.run_id),
-              search: getTimeRangeQueryString(location.search),
+              search: getPreservedQueryString(location.search),
             });
           },
         },

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useNavigateToExperimentPageTab.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useNavigateToExperimentPageTab.test.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable jest/no-standalone-expect */
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
+import { useEffect } from 'react';
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import { useNavigateToExperimentPageTab } from './useNavigateToExperimentPageTab';
 import { setupTestRouter, testRoute, TestRouter } from '../../../../common/utils/RoutingTestUtils';
-import { createMLflowRoutePath, useParams } from '../../../../common/utils/RoutingUtils';
+import { createMLflowRoutePath, useLocation, useParams } from '../../../../common/utils/RoutingUtils';
 import { TestApolloProvider } from '../../../../common/utils/TestApolloProvider';
 import { setupServer } from '../../../../common/utils/setup-msw';
 import { graphql, rest } from 'msw';
@@ -44,8 +45,18 @@ describe('useNavigateToExperimentPageTab', () => {
     }),
   );
 
+  const locationSpyFn = jest.fn<(url: string) => void>();
+  const LocationSpy = () => {
+    const location = useLocation();
+    useEffect(() => {
+      locationSpyFn([location.pathname, location.search].join(''));
+    }, [location]);
+    return null;
+  };
+
   beforeEach(() => {
     server.resetHandlers();
+    locationSpyFn.mockClear();
   });
 
   const { history } = setupTestRouter();
@@ -89,10 +100,20 @@ describe('useNavigateToExperimentPageTab', () => {
     const TestExperimentTabsPage = () => {
       // /experiments/:experimentId/:tabName
       const { tabName } = useParams();
-      return <span>experiment page displaying {tabName} tab</span>;
+      return (
+        <>
+          <LocationSpy />
+          <span>experiment page displaying {tabName} tab</span>
+        </>
+      );
     };
     const TestExperimentOverviewPage = () => {
-      return <span>experiment page displaying overview tab</span>;
+      return (
+        <>
+          <LocationSpy />
+          <span>experiment page displaying overview tab</span>
+        </>
+      );
     };
     const queryClient = new QueryClient();
     return render(
@@ -133,6 +154,7 @@ describe('useNavigateToExperimentPageTab', () => {
     renderTestHook(createMLflowRoutePath('/experiments/123'));
 
     expect(await screen.findByText('experiment page displaying overview tab')).toBeInTheDocument();
+    expect(locationSpyFn).toHaveBeenCalledWith(expect.stringContaining('workflowType=genai'));
   });
 
   test('should redirect to the traces tab on custom development experiment kind', async () => {
@@ -144,6 +166,7 @@ describe('useNavigateToExperimentPageTab', () => {
     renderTestHook(createMLflowRoutePath('/experiments/123'));
 
     expect(await screen.findByText('experiment page displaying runs tab')).toBeInTheDocument();
+    expect(locationSpyFn).toHaveBeenCalledWith(expect.stringContaining('workflowType=machine_learning'));
   });
 
   test('should redirect to the traces tab on GenAI experiment kind when using FileStore', async () => {
@@ -159,5 +182,6 @@ describe('useNavigateToExperimentPageTab', () => {
     renderTestHook(createMLflowRoutePath('/experiments/123'));
 
     expect(await screen.findByText('experiment page displaying traces tab')).toBeInTheDocument();
+    expect(locationSpyFn).toHaveBeenCalledWith(expect.stringContaining('workflowType=genai'));
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useNavigateToExperimentPageTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useNavigateToExperimentPageTab.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useMemo } from 'react';
-import { useNavigate } from '../../../../common/utils/RoutingUtils';
+import { useNavigate, useSearchParams } from '../../../../common/utils/RoutingUtils';
 import Routes from '../../../routes';
 import { ExperimentKind, ExperimentPageTabName } from '../../../constants';
 import { useGetExperimentQuery } from '../../../hooks/useExperimentQuery';
-import { useExperimentKind } from '../../../utils/ExperimentKindUtils';
+import { useExperimentKind, getWorkflowTypeForExperimentKind } from '../../../utils/ExperimentKindUtils';
 import { coerceToEnum } from '@databricks/web-shared/utils';
 import { shouldEnableExperimentOverviewTab } from '../../../../common/utils/FeatureUtils';
+import { WorkflowType } from '../../../../common/contexts/WorkflowTypeContext';
 import { useIsFileStore } from '../../../hooks/useServerInfo';
 import { useExperimentHasV4Location } from '../../../hooks/useExperimentHasV4Location';
+import { getPreservedQueryString } from '../../../pages/experiment-page-tabs/side-nav/utils';
 
 /**
  * This hook navigates user to the appropriate tab in the experiment page based on the experiment kind.
@@ -20,6 +22,7 @@ export const useNavigateToExperimentPageTab = ({
   experimentId: string;
 }) => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const isFileStore = useIsFileStore();
 
   const { data: experiment, loading: loadingExperiment } = useGetExperimentQuery({
@@ -66,8 +69,17 @@ export const useNavigateToExperimentPageTab = ({
           : ExperimentPageTabName.Traces;
     }
 
-    navigate(Routes.getExperimentPageTabRoute(experimentId, targetTab), { replace: true });
-  }, [navigate, experimentId, enabled, experimentKind, isFileStore, hasV4Location]);
+    const workflowType =
+      searchParams.get('workflowType') ??
+      getWorkflowTypeForExperimentKind(experimentKind) ??
+      WorkflowType.MACHINE_LEARNING;
+    const params = new URLSearchParams(searchParams);
+    params.set('workflowType', workflowType);
+    const search = getPreservedQueryString(params.toString()) ?? '';
+    navigate(`${Routes.getExperimentPageTabRoute(experimentId, targetTab)}${search}`, {
+      replace: true,
+    });
+  }, [navigate, experimentId, enabled, experimentKind, isFileStore, hasV4Location, searchParams]);
 
   return {
     isEnabled: enabled,

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewModeSwitch.tsx
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import { useNavigate, useParams, useSearchParams } from '../../../common/utils/RoutingUtils';
 import Routes from '../../routes';
 import { RunPageTabName } from '../../constants';
-import { getTimeRangeQueryString } from '../../pages/experiment-page-tabs/side-nav/utils';
+import { getPreservedQueryString } from '../../pages/experiment-page-tabs/side-nav/utils';
 import { useRunViewActiveTab } from './useRunViewActiveTab';
 import { useState, type ReactNode } from 'react';
 import type { KeyValueEntity } from '../../../common/types';
@@ -83,7 +83,7 @@ export const RunViewModeSwitch = ({
 
     setRemoveTabMargin(TABS_WITHOUT_MARGIN.includes(newTabKey as RunPageTabName));
 
-    const timeRangeSearch = getTimeRangeQueryString(searchParams.toString());
+    const timeRangeSearch = getPreservedQueryString(searchParams.toString());
     const withSearchParams = (route: string) => (timeRangeSearch ? `${route}${timeRangeSearch}` : route);
 
     if (newTabKey === RunPageTabName.OVERVIEW) {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -21,7 +21,7 @@ import { DatasetSourceTypes, RunEntity } from '../../types';
 import { Link, useNavigate, useSearchParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import { useGetLoggedModelQuery } from '../../hooks/logged-models/useGetLoggedModelQuery';
 import Routes from '../../routes';
-import { getTimeRangeQueryString } from '../experiment-page-tabs/side-nav/utils';
+import { getPreservedQueryString } from '../experiment-page-tabs/side-nav/utils';
 import { useSaveExperimentRunColor } from '../../components/experiment-page/hooks/useExperimentRunColor';
 import { useGetExperimentRunColor } from '../../components/experiment-page/hooks/useExperimentRunColor';
 import { RunColorPill } from '../../components/experiment-page/components/RunColorPill';
@@ -96,7 +96,7 @@ export const RunNameCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({
     // When flag is ON and clicking on an issue detection run, navigate to the issue detection run details page
     if (isIssueDetectionRun && showIssuesPanelFlag) {
       const route = Routes.getIssueDetectionRunDetailsRoute(experimentId, runUuid);
-      const timeRangeSearch = getTimeRangeQueryString(searchParams.toString());
+      const timeRangeSearch = getPreservedQueryString(searchParams.toString());
       navigate(timeRangeSearch ? `${route}${timeRangeSearch}` : route);
       return;
     }

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate, useParams, useSearchParams } from '../../../common/u
 import { RunPage } from '../../components/run-page/RunPage';
 import { ExperimentPageTabName, RunPageTabName, MLFLOW_ISSUE_DETECTION_JOB_ID_TAG } from '../../constants';
 import Routes from '../../routes';
-import { getTimeRangeQueryString } from '../experiment-page-tabs/side-nav/utils';
+import { getPreservedQueryString } from '../experiment-page-tabs/side-nav/utils';
 import { useGetExperimentQuery } from '../../hooks/useExperimentQuery';
 import { IssueDetectionRunOverview } from '../../components/run-page/overview/IssueDetectionRunOverview';
 
@@ -18,7 +18,7 @@ export const IssueDetectionRunDetailsPage = () => {
   const [searchParams] = useSearchParams();
 
   const safeExperimentId = experimentId as string;
-  const timeRangeSearch = useMemo(() => getTimeRangeQueryString(searchParams.toString()), [searchParams]);
+  const timeRangeSearch = useMemo(() => getPreservedQueryString(searchParams.toString()), [searchParams]);
 
   // Fetch experiment data for breadcrumb
   const { data: experiment } = useGetExperimentQuery({ experimentId: safeExperimentId });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavSection.tsx
@@ -17,7 +17,7 @@ import { ExperimentPageTabName } from '../../../constants';
 import { Link, useLocation, useParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
 import invariant from 'invariant';
-import { isTracesRelatedTab, getTimeRangeQueryString } from './utils';
+import { isTracesRelatedTab, getPreservedQueryString } from './utils';
 import { useLogTelemetryEvent } from '@mlflow/mlflow/src/telemetry/hooks/useLogTelemetryEvent';
 import { useMemo } from 'react';
 
@@ -83,7 +83,7 @@ export const ExperimentPageSideNavSection = ({
             key={`${sectionKey}-${item.tabName}`}
             to={{
               pathname: Routes.getExperimentPageTabRoute(experimentId, item.tabName),
-              search: preserveQueryParams ? search : getTimeRangeQueryString(search),
+              search: preserveQueryParams ? search : getPreservedQueryString(search),
             }}
             onClick={() =>
               logTelemetryEvent({

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/utils.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/utils.test.tsx
@@ -1,0 +1,56 @@
+import { describe, test, expect } from '@jest/globals';
+import { getPreservedQueryString, isTracesRelatedTab } from './utils';
+import { ExperimentPageTabName } from '../../../constants';
+
+describe('getPreservedQueryString', () => {
+  test('preserves time range params', () => {
+    const result = getPreservedQueryString('?startTimeLabel=LAST_24_HOURS&startTime=2024-01-01&endTime=2024-01-02');
+    expect(result).toContain('startTimeLabel=LAST_24_HOURS');
+    expect(result).toContain('startTime=2024-01-01');
+    expect(result).toContain('endTime=2024-01-02');
+  });
+
+  test('preserves workflowType param', () => {
+    const result = getPreservedQueryString('?workflowType=genai&startTimeLabel=LAST_24_HOURS');
+    expect(result).toContain('workflowType=genai');
+    expect(result).toContain('startTimeLabel=LAST_24_HOURS');
+  });
+
+  test('preserves workspace param', () => {
+    const result = getPreservedQueryString('?workspace=default&startTimeLabel=LAST_24_HOURS&workflowType=genai');
+    expect(result).toContain('workspace=default');
+    expect(result).toContain('startTimeLabel=LAST_24_HOURS');
+    expect(result).toContain('workflowType=genai');
+  });
+
+  test('strips non-preserved params', () => {
+    const result = getPreservedQueryString(
+      '?startTimeLabel=LAST_24_HOURS&selectedTraceId=trace-123&viewMode=list&workflowType=machine_learning&workspace=default',
+    );
+    expect(result).toContain('startTimeLabel=LAST_24_HOURS');
+    expect(result).toContain('workflowType=machine_learning');
+    expect(result).toContain('workspace=default');
+    expect(result).not.toContain('selectedTraceId');
+    expect(result).not.toContain('viewMode');
+  });
+
+  test('returns undefined when no preserved params exist', () => {
+    expect(getPreservedQueryString('?selectedTraceId=trace-123')).toBeUndefined();
+    expect(getPreservedQueryString('')).toBeUndefined();
+  });
+});
+
+describe('isTracesRelatedTab', () => {
+  test('returns true for traces-related tabs', () => {
+    expect(isTracesRelatedTab(ExperimentPageTabName.Overview)).toBe(true);
+    expect(isTracesRelatedTab(ExperimentPageTabName.Traces)).toBe(true);
+    expect(isTracesRelatedTab(ExperimentPageTabName.ChatSessions)).toBe(true);
+    expect(isTracesRelatedTab(ExperimentPageTabName.SingleChatSession)).toBe(true);
+  });
+
+  test('returns false for non-traces-related tabs', () => {
+    expect(isTracesRelatedTab(ExperimentPageTabName.Runs)).toBe(false);
+    expect(isTracesRelatedTab(ExperimentPageTabName.Models)).toBe(false);
+    expect(isTracesRelatedTab(ExperimentPageTabName.Datasets)).toBe(false);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/utils.tsx
@@ -1,6 +1,6 @@
 import { ExperimentPageTabName } from '../../../constants';
 
-const TIME_RANGE_PARAMS = ['startTimeLabel', 'startTime', 'endTime'];
+const PRESERVED_QUERY_PARAMS = ['startTimeLabel', 'startTime', 'endTime', 'workflowType', 'workspace'];
 
 export const isTracesRelatedTab = (tabName: ExperimentPageTabName) => {
   return (
@@ -11,17 +11,21 @@ export const isTracesRelatedTab = (tabName: ExperimentPageTabName) => {
   );
 };
 
-export const getTimeRangeQueryString = (search: string): string | undefined => {
+/**
+ * Builds a query string preserving only the params that should carry across
+ * experiment tab navigations (time range filters, workflow type, and workspace).
+ */
+export const getPreservedQueryString = (search: string): string | undefined => {
   const searchParams = new URLSearchParams(search);
-  const timeRangeParams = new URLSearchParams();
+  const preservedParams = new URLSearchParams();
 
-  for (const param of TIME_RANGE_PARAMS) {
+  for (const param of PRESERVED_QUERY_PARAMS) {
     const value = searchParams.get(param);
     if (value) {
-      timeRangeParams.set(param, value);
+      preservedParams.set(param, value);
     }
   }
 
-  const result = timeRangeParams.toString();
+  const result = preservedParams.toString();
   return result ? `?${result}` : undefined;
 };

--- a/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from '@jest/globals';
+import { ExperimentKind } from '../constants';
+import { WorkflowType } from '../../common/contexts/WorkflowTypeContext';
+import { getWorkflowTypeForExperimentKind } from './ExperimentKindUtils';
+
+describe('getWorkflowTypeForExperimentKind', () => {
+  test('maps GenAI kinds to GENAI', () => {
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.GENAI_DEVELOPMENT)).toBe(WorkflowType.GENAI);
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.GENAI_DEVELOPMENT_INFERRED)).toBe(WorkflowType.GENAI);
+  });
+
+  test('maps ML kinds to MACHINE_LEARNING', () => {
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.CUSTOM_MODEL_DEVELOPMENT)).toBe(
+      WorkflowType.MACHINE_LEARNING,
+    );
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.CUSTOM_MODEL_DEVELOPMENT_INFERRED)).toBe(
+      WorkflowType.MACHINE_LEARNING,
+    );
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.FINETUNING)).toBe(WorkflowType.MACHINE_LEARNING);
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.REGRESSION)).toBe(WorkflowType.MACHINE_LEARNING);
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.CLASSIFICATION)).toBe(WorkflowType.MACHINE_LEARNING);
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.FORECASTING)).toBe(WorkflowType.MACHINE_LEARNING);
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.AUTOML)).toBe(WorkflowType.MACHINE_LEARNING);
+  });
+
+  test('returns undefined for ambiguous or absent kinds', () => {
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.NO_INFERRED_TYPE)).toBeUndefined();
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.EMPTY)).toBeUndefined();
+    expect(getWorkflowTypeForExperimentKind(undefined)).toBeUndefined();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.ts
@@ -167,3 +167,23 @@ export const getExperimentKindForWorkflowType = (workflowType: WorkflowType): Ex
   }
   return ExperimentKind.CUSTOM_MODEL_DEVELOPMENT;
 };
+
+export const getWorkflowTypeForExperimentKind = (
+  experimentKind: ExperimentKind | undefined,
+): WorkflowType | undefined => {
+  switch (experimentKind) {
+    case ExperimentKind.GENAI_DEVELOPMENT:
+    case ExperimentKind.GENAI_DEVELOPMENT_INFERRED:
+      return WorkflowType.GENAI;
+    case ExperimentKind.CUSTOM_MODEL_DEVELOPMENT:
+    case ExperimentKind.CUSTOM_MODEL_DEVELOPMENT_INFERRED:
+    case ExperimentKind.FINETUNING:
+    case ExperimentKind.REGRESSION:
+    case ExperimentKind.CLASSIFICATION:
+    case ExperimentKind.FORECASTING:
+    case ExperimentKind.AUTOML:
+      return WorkflowType.MACHINE_LEARNING;
+    default:
+      return undefined;
+  }
+};


### PR DESCRIPTION
### Related Issues/PRs

Closes #21516

### What changes are proposed in this pull request?

When navigating to an experiment page via URL (e.g., `/experiments/xx/overview?workspace=default`) or using browser Back/Forward buttons, the sidebar navigation did not update to reflect the correct workflow type (GenAI vs Model Training) or highlight the active tab. This PR fixes the issue by encoding the `workflowType` in URL search params so browser navigation correctly restores the sidebar state.

Key changes:
- **`WorkflowTypeContext.tsx`**: Added `getWorkflowTypeFromUrl` and `buildWorkflowTypeQueryString` utilities. The context now derives `effectiveWorkflowType` from the URL (with localStorage as fallback) and exposes it to all consumers, ensuring consistent behavior across the sidebar, header, background gradient, and experiment kind classification.
- **`MlflowSidebar.tsx`**: Simplified to consume the URL-aware workflow type directly from context. Also clears `lastSelectedExperimentIdRef` when navigating away from experiment pages so the sidebar resets properly.
- **`useNavigateToExperimentPageTab.tsx`**: Includes `workflowType` (and `workspace`) in the URL when auto-navigating to a tab. Uses extracted primitive values in `useEffect` deps to prevent unnecessary re-fires when the URL changes.
- **`utils.tsx`**: Renamed `getTimeRangeQueryString` to `getPreservedQueryString`, added `workflowType` and `workspace` to the preserved params list so they carry across tab navigations.
- **`MlflowSidebarExperimentItems.tsx` / `ExperimentPageSideNavSection.tsx`**: Updated to use the renamed `getPreservedQueryString`.

https://github.com/user-attachments/assets/91dbefdd-3194-4561-b800-31e832614f6d

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests added:
- `WorkflowTypeContext.test.tsx`: Tests for `getWorkflowTypeFromUrl` (valid/invalid/missing params) and `buildWorkflowTypeQueryString` (workspace preservation, param filtering).
- `utils.test.tsx`: Tests for `getPreservedQueryString` (time range, workflowType, workspace preservation) and `isTracesRelatedTab`.
- `useNavigateToExperimentPageTab.test.tsx`: Added `LocationSpy` assertions to verify the navigated URL contains the correct `workflowType` search param.

Manual testing: Verified sidebar correctly updates workflow type and active tab when navigating via URL, toggling the workflow switch, and using browser Back/Forward.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix sidebar navigation selection and workflow type (GenAI/Model Training) not updating when navigating via URL or using browser Back/Forward buttons.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Made with [Cursor](https://cursor.com)