### PR TITLE
Harmonize Huey subprocess invocations with other process launchers

### DIFF
--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -127,31 +127,6 @@ def is_process_alive(pid: int) -> bool:
         return True
 
 
-def _find_huey_consumer_script() -> str:
-    """
-    Find the huey_consumer.py script path.
-
-    The script is typically installed in the same bin directory as sys.executable
-    (e.g., in the virtual environment's bin/). We check there first before
-    falling back to PATH lookup via shutil.which(), since the venv bin dir may
-    not be on PATH when the server is launched via tools like 'uv tool install'.
-    """
-    python_bin_dir = os.path.dirname(sys.executable)
-    candidate = os.path.join(python_bin_dir, "huey_consumer.py")
-    if os.path.isfile(candidate):
-        return candidate
-    found = shutil.which("huey_consumer.py")
-    if found is None:
-        raise MlflowException(
-            f"Could not find huey_consumer.py. Looked for '{candidate}' next to the current "
-            f"Python executable ('{sys.executable}') and via PATH lookup (shutil.which). "
-            "Ensure the 'huey' package is installed in the same Python environment as MLflow, "
-            "and that its huey_consumer.py script is either colocated with the Python "
-            "executable or discoverable on your PATH."
-        )
-    return found
-
-
 def _start_huey_consumer_proc(
     huey_instance_key: str,
     max_job_parallelism: int,
@@ -161,7 +136,8 @@ def _start_huey_consumer_proc(
 
     cmd = [
         sys.executable,
-        _find_huey_consumer_script(),
+        "-m",
+        "huey.bin.huey_consumer",
         "mlflow.server.jobs._huey_consumer.huey_instance",
         "-w",
         str(max_job_parallelism),
@@ -548,7 +524,8 @@ def _launch_periodic_tasks_consumer() -> None:
 def _start_periodic_tasks_consumer_proc():
     cmd = [
         sys.executable,
-        _find_huey_consumer_script(),
+        "-m",
+        "huey.bin.huey_consumer",
         "mlflow.server.jobs._periodic_tasks_consumer.huey_instance",
         "-w",
         str(PERIODIC_TASKS_WORKER_COUNT),

--- a/tests/server/jobs/test_utils.py
+++ b/tests/server/jobs/test_utils.py
@@ -1,15 +1,9 @@
 import os
-import sys
-from unittest import mock
 
 import pytest
 
 from mlflow.exceptions import MlflowException
-from mlflow.server.jobs.utils import (
-    _find_huey_consumer_script,
-    _load_function,
-    _validate_function_parameters,
-)
+from mlflow.server.jobs.utils import _load_function, _validate_function_parameters
 
 pytestmark = pytest.mark.skipif(
     os.name == "nt", reason="MLflow job execution is not supported on Windows"
@@ -140,54 +134,3 @@ def test_compute_exclusive_lock_key():
     # Key format is job_name:hash
     assert key1.startswith("job_name:")
     assert key5.startswith("other_job:")
-
-
-def test_find_huey_consumer_script_found_next_to_executable(tmp_path):
-    # Create a fake huey_consumer.py next to a fake python executable
-    fake_python_bin_dir = tmp_path / "bin"
-    fake_python_bin_dir.mkdir()
-    fake_python = fake_python_bin_dir / "python"
-    fake_python.touch()
-    fake_huey = fake_python_bin_dir / "huey_consumer.py"
-    fake_huey.touch()
-
-    with mock.patch.object(sys, "executable", str(fake_python)):
-        result = _find_huey_consumer_script()
-
-    assert result == str(fake_huey)
-
-
-def test_find_huey_consumer_script_found_via_path(tmp_path):
-    # huey_consumer.py is NOT next to the python executable, but on PATH
-    fake_python_bin_dir = tmp_path / "bin"
-    fake_python_bin_dir.mkdir()
-    fake_python = fake_python_bin_dir / "python"
-    fake_python.touch()
-
-    path_bin_dir = tmp_path / "path_bin"
-    path_bin_dir.mkdir()
-    fake_huey_on_path = path_bin_dir / "huey_consumer.py"
-    fake_huey_on_path.touch()
-
-    with (
-        mock.patch.object(sys, "executable", str(fake_python)),
-        mock.patch("shutil.which", return_value=str(fake_huey_on_path)),
-    ):
-        result = _find_huey_consumer_script()
-
-    assert result == str(fake_huey_on_path)
-
-
-def test_find_huey_consumer_script_not_found(tmp_path):
-    # huey_consumer.py is neither next to the executable nor on PATH
-    fake_python_bin_dir = tmp_path / "bin"
-    fake_python_bin_dir.mkdir()
-    fake_python = fake_python_bin_dir / "python"
-    fake_python.touch()
-
-    with (
-        mock.patch.object(sys, "executable", str(fake_python)),
-        mock.patch("shutil.which", return_value=None),
-    ):
-        with pytest.raises(MlflowException, match="Could not find huey_consumer.py"):
-            _find_huey_consumer_script()


### PR DESCRIPTION
First things first: Thank you very much for conceiving and maintaining MLflow. This patch includes a very little improvement in the area of code cosmetics, nothing wild.

Functions `_exec_job_in_subproc` and `_launch_job_runner` use `{sys.executable} -m` to invoke Python modules, while `_start_huey_consumer_proc` and `_start_periodic_tasks_consumer_proc` used `shutil.which` to find a program on the system/environment path.

Because the Huey consumer can also be invoked by using the `huey.bin.huey_consumer` module, invocations of external programs are standardized / more symmetric / more Pythonic than before.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to #22089

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

No. It's just code cosmetics.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
