### PR TITLE
Lowercase `model_provider` in `calculate_cost_by_model_and_token_usage`

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -342,7 +342,7 @@ def calculate_cost_by_model_and_token_usage(
                     model=model_name,
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
-                    custom_llm_provider=model_provider,
+                    custom_llm_provider=model_provider.lower(),
                     **cache_kwargs,
                 )
             except Exception:
@@ -350,17 +350,6 @@ def calculate_cost_by_model_and_token_usage(
     finally:
         if litellm is not None:
             litellm.suppress_debug_info = original_suppress
-
-    if result is None:
-        # Try with provider as a last resort (builtin path only, litellm already tried above)
-        if litellm is None and model_provider:
-            result = cost_per_token(
-                model=model_name,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                custom_llm_provider=model_provider,
-                **cache_kwargs,
-            )
 
     if result is None:
         _logger.debug(f"Failed to calculate cost for model {model_name}")

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -352,6 +352,17 @@ def calculate_cost_by_model_and_token_usage(
             litellm.suppress_debug_info = original_suppress
 
     if result is None:
+        # Try with provider as a last resort (builtin path only, litellm already tried above)
+        if litellm is None and model_provider:
+            result = cost_per_token(
+                model=model_name,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                custom_llm_provider=model_provider,
+                **cache_kwargs,
+            )
+
+    if result is None:
         _logger.debug(f"Failed to calculate cost for model {model_name}")
         return None
 

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -358,7 +358,7 @@ def calculate_cost_by_model_and_token_usage(
                 model=model_name,
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
-                custom_llm_provider=model_provider,
+                custom_llm_provider=model_provider.lower(),
                 **cache_kwargs,
             )
 

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -679,6 +679,18 @@ def test_builtin_cost_fallback_with_provider():
     assert result["total_cost"] == pytest.approx(0.0075)
 
 
+@pytest.mark.parametrize("model_provider", ["OpenAI", "OPENAI", "openai"])
+def test_builtin_cost_fallback_with_provider_case_insensitive(model_provider):
+    with mock.patch.dict("sys.modules", {"litellm": None}):
+        result = calculate_cost_by_model_and_token_usage(
+            "gpt-4o",
+            {"input_tokens": 1000, "output_tokens": 500},
+            model_provider=model_provider,
+        )
+    assert result is not None
+    assert result["total_cost"] == pytest.approx(0.0075)
+
+
 def test_litellm_provider_list_not_printed_during_cost_calculation(capsys):
     litellm.suppress_debug_info = False
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #22120

### What changes are proposed in this pull request?

- Lowercase `model_provider` before passing it as `custom_llm_provider` to LiteLLM's `cost_per_token()`, which is case-sensitive. This fixes providers like Mistral whose `NAME = "Mistral"` (capitalized) causes silent cost calculation failures.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New parametrized test `test_builtin_cost_fallback_with_provider_case_insensitive` verifies that `"OpenAI"`, `"OPENAI"`, and `"openai"` all produce the same cost result.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix AI Gateway cost calculation for providers with capitalized names (e.g., Mistral) by lowercasing provider names before passing to LiteLLM.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release