### PR TITLE
Fix selected run URL param not updating in eval runs table

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/hooks/useCompareToRunUuid.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/hooks/useCompareToRunUuid.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useSearchParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 
-const QUERY_PARAM_KEY = 'compareToRunUuid';
+export const COMPARE_TO_RUN_UUID_QUERY_PARAM = 'compareToRunUuid';
 
 /**
  * Query param-powered hook that returns the compare to run uuid when comparison is enabled.
@@ -9,16 +9,16 @@ const QUERY_PARAM_KEY = 'compareToRunUuid';
 export const useCompareToRunUuid = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const compareToRunUuid = searchParams.get(QUERY_PARAM_KEY) ?? undefined;
+  const compareToRunUuid = searchParams.get(COMPARE_TO_RUN_UUID_QUERY_PARAM) ?? undefined;
 
   const setCompareToRunUuid = useCallback(
     (compareToRunId: string | undefined) => {
       setSearchParams((params) => {
         if (compareToRunId === undefined) {
-          params.delete(QUERY_PARAM_KEY);
+          params.delete(COMPARE_TO_RUN_UUID_QUERY_PARAM);
           return params;
         }
-        params.set(QUERY_PARAM_KEY, compareToRunId);
+        params.set(COMPARE_TO_RUN_UUID_QUERY_PARAM, compareToRunId);
         return params;
       });
     },

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/hooks/useSelectedRunUuid.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/hooks/useSelectedRunUuid.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useSearchParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 
-const QUERY_PARAM_KEY = 'selectedRunUuid';
+export const SELECTED_RUN_UUID_QUERY_PARAM = 'selectedRunUuid';
 
 /**
  * Query param-powered hook that returns the selected run uuid.
@@ -9,17 +9,17 @@ const QUERY_PARAM_KEY = 'selectedRunUuid';
 export const useSelectedRunUuid = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const selectedRunUuid = searchParams.get(QUERY_PARAM_KEY) ?? undefined;
+  const selectedRunUuid = searchParams.get(SELECTED_RUN_UUID_QUERY_PARAM) ?? undefined;
 
   const setSelectedRunUuid = useCallback(
     (selectedRunUuid: string | undefined) => {
       setSearchParams(
         (params) => {
           if (selectedRunUuid === undefined) {
-            params.delete(QUERY_PARAM_KEY);
+            params.delete(SELECTED_RUN_UUID_QUERY_PARAM);
             return params;
           }
-          params.set(QUERY_PARAM_KEY, selectedRunUuid);
+          params.set(SELECTED_RUN_UUID_QUERY_PARAM, selectedRunUuid);
           return params;
         },
         { replace: true },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -23,8 +23,14 @@ import {
 import { invalidateMlflowSearchTracesCache } from '@databricks/web-shared/genai-traces-table';
 import { useQueryClient } from '@databricks/web-shared/query-client';
 import { FormattedMessage } from 'react-intl';
-import { useSelectedRunUuid } from '../../components/evaluations/hooks/useSelectedRunUuid';
-import { useCompareToRunUuid } from '../../components/evaluations/hooks/useCompareToRunUuid';
+import {
+  useSelectedRunUuid,
+  SELECTED_RUN_UUID_QUERY_PARAM,
+} from '../../components/evaluations/hooks/useSelectedRunUuid';
+import {
+  useCompareToRunUuid,
+  COMPARE_TO_RUN_UUID_QUERY_PARAM,
+} from '../../components/evaluations/hooks/useCompareToRunUuid';
 import { RunEvaluationButton } from './RunEvaluationButton';
 import { isUserFacingTag } from '../../../common/utils/TagUtils';
 import { createEvalRunsTableKeyedColumnKey } from './ExperimentEvaluationRunsTable.utils';
@@ -282,8 +288,8 @@ const ExperimentEvaluationRunsPageImpl = () => {
       // Set both URL params atomically to avoid race conditions
       setSearchParams(
         (params) => {
-          params.set('selectedRunUuid', runUuid1);
-          params.set('compareToRunUuid', runUuid2);
+          params.set(SELECTED_RUN_UUID_QUERY_PARAM, runUuid1);
+          params.set(COMPARE_TO_RUN_UUID_QUERY_PARAM, runUuid2);
           return params;
         },
         { replace: true },
@@ -367,8 +373,16 @@ const ExperimentEvaluationRunsPageImpl = () => {
           : undefined
       }
       setSelectedRunUuid={(runUuid: string) => {
-        setSelectedRunUuid(runUuid);
-        setCompareToRunUuid(undefined);
+        // Update both params atomically to avoid race conditions
+        // where separate setSearchParams calls overwrite each other
+        setSearchParams(
+          (params) => {
+            params.set(SELECTED_RUN_UUID_QUERY_PARAM, runUuid);
+            params.delete(COMPARE_TO_RUN_UUID_QUERY_PARAM);
+            return params;
+          },
+          { replace: true },
+        );
         // When flag is ON, also set isViewingSelectedRun to show the split view
         if (showIssuesPanelFlag) {
           setIsViewingSelectedRun(true);


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

When selecting a run in `ExperimentEvaluationRunsTable`, the `selectedRunUuid` URL param was not updating. The root cause was that `setSelectedRunUuid` and `setCompareToRunUuid` each independently called `setSearchParams` from separate `useSearchParams()` hooks. When called back-to-back, the second call overwrote the first because both derived from the same base snapshot of search params.

The fix updates both params atomically in a single `setSearchParams` call. Additionally, the query param key strings are now exported as named constants (`SELECTED_RUN_UUID_QUERY_PARAM`, `COMPARE_TO_RUN_UUID_QUERY_PARAM`) from their respective hook files to eliminate hardcoded strings.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:


https://github.com/user-attachments/assets/6999258c-78ce-4d07-a990-6360020b293a

After:


https://github.com/user-attachments/assets/1a9b0f68-cf7a-4f84-bb82-5a5e94b94ecd




### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where selecting a run in the evaluation runs table did not update the URL parameters.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release