### PR TITLE
Fix response parsing for older models

### DIFF
--- a/mlflow/genai/judges/utils/parsing_utils.py
+++ b/mlflow/genai/judges/utils/parsing_utils.py
@@ -1,5 +1,7 @@
 """Response parsing utilities for judge models."""
 
+import re
+
 
 def _strip_markdown_code_blocks(response: str) -> str:
     """
@@ -7,6 +9,8 @@ def _strip_markdown_code_blocks(response: str) -> str:
 
     Some legacy models wrap JSON responses in markdown code blocks (```json...```).
     This function removes those wrappers to extract the raw JSON content.
+    It also handles cases where the JSON block is embedded within a larger response
+    that contains preamble text before the code block.
 
     Args:
         response: The raw response from the LLM
@@ -15,21 +19,26 @@ def _strip_markdown_code_blocks(response: str) -> str:
         The response with markdown code blocks removed
     """
     cleaned = response.strip()
-    if not cleaned.startswith("```"):
-        return cleaned
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        start_idx = 1
+        end_idx = len(lines)
 
-    lines = cleaned.split("\n")
-    start_idx = 0
-    end_idx = len(lines)
+        for i, line in enumerate(lines):
+            if i == 0 and line.startswith("```"):
+                start_idx = 1
+            elif line.strip() == "```" and i > 0:
+                end_idx = i
+                break
 
-    for i, line in enumerate(lines):
-        if i == 0 and line.startswith("```"):
-            start_idx = 1
-        elif line.strip() == "```" and i > 0:
-            end_idx = i
-            break
+        return "\n".join(lines[start_idx:end_idx])
 
-    return "\n".join(lines[start_idx:end_idx])
+    # Handle embedded code blocks (preamble text followed by a JSON code block)
+    match = re.search(r"```(?:json)?\s*\n(.*?)\n```", cleaned, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+
+    return cleaned
 
 
 def _sanitize_justification(justification: str) -> str:

--- a/mlflow/genai/judges/utils/parsing_utils.py
+++ b/mlflow/genai/judges/utils/parsing_utils.py
@@ -7,9 +7,9 @@ def _strip_markdown_code_blocks(response: str) -> str:
     """
     Strip markdown code blocks from LLM responses.
 
-    Some legacy models wrap JSON responses in markdown code blocks (```json...```).
-    This function removes those wrappers to extract the raw JSON content.
-    It also handles cases where the JSON block is embedded within a larger response
+    Some legacy models wrap responses in markdown code blocks (```json...``` or
+    unlabeled fences). This function removes those wrappers to extract the raw content.
+    It also handles cases where a ```json block is embedded within a larger response
     that contains preamble text before the code block.
 
     Args:
@@ -33,10 +33,9 @@ def _strip_markdown_code_blocks(response: str) -> str:
 
         return "\n".join(lines[start_idx:end_idx])
 
-    # Handle embedded code blocks (preamble text followed by a JSON code block)
-    match = re.search(r"```(?:json)?\s*\n(.*?)\n```", cleaned, re.DOTALL)
-    if match:
-        return match.group(1).strip()
+    # Handle embedded code blocks (preamble text followed by a ```json code block)
+    if json_block_match := re.search(r"```json\s*\n(.*?)\n```", cleaned, re.DOTALL | re.IGNORECASE):
+        return json_block_match.group(1).strip()
 
     return cleaned
 

--- a/tests/genai/judges/utils/test_parsing_utils.py
+++ b/tests/genai/judges/utils/test_parsing_utils.py
@@ -109,10 +109,6 @@ This text should not be included"""
             '{"result": "yes"}',
         ),
         (
-            'Here is the result:\n```\n{"result": "yes"}\n```',
-            '{"result": "yes"}',
-        ),
-        (
             'Some preamble text.\n```json\n{\n  "result": "yes",\n  "rationale": "good"\n}\n```',
             '{\n  "result": "yes",\n  "rationale": "good"\n}',
         ),

--- a/tests/genai/judges/utils/test_parsing_utils.py
+++ b/tests/genai/judges/utils/test_parsing_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mlflow.genai.judges.utils.parsing_utils import (
     _sanitize_justification,
     _strip_markdown_code_blocks,
@@ -96,6 +98,31 @@ def test_strip_markdown_closing_with_trailing_content():
 ```
 This text should not be included"""
     expected = '{"result": "yes"}'
+    assert _strip_markdown_code_blocks(response) == expected
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (
+            'Here is the result:\n```json\n{"result": "yes"}\n```',
+            '{"result": "yes"}',
+        ),
+        (
+            'Here is the result:\n```\n{"result": "yes"}\n```',
+            '{"result": "yes"}',
+        ),
+        (
+            'Some preamble text.\n```json\n{\n  "result": "yes",\n  "rationale": "good"\n}\n```',
+            '{\n  "result": "yes",\n  "rationale": "good"\n}',
+        ),
+        (
+            'Preamble\n```json\n{"first": true}\n```\nMiddle\n```json\n{"second": true}\n```',
+            '{"first": true}',
+        ),
+    ],
+)
+def test_strip_markdown_embedded_code_block(response: str, expected: str):
     assert _strip_markdown_code_blocks(response) == expected
 
 


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Some old models (e.g. claude-sonnet-4-6) wraps JSON responses within markdown code blocks, but there could be reasoning text before the block. This PR fixes it by regex match the code blocks wrapped by ```json```. Example:
```
....
The conversation flowed naturally and efficiently, with the assistant proactively offering follow-up options that the user took advantage of.

```json
....
```


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
