### PR TITLE
Fix dataset details drawer: local source display, profile parsing, broken link

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetDrawer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetDrawer.tsx
@@ -244,27 +244,60 @@ const ExperimentViewDatasetDrawerImpl = ({
                     </div>
                   }
                 />
-                <Typography.Title
-                  level={4}
-                  color="secondary"
-                  css={{ marginBottom: theme.spacing.xs, marginTop: theme.spacing.xs }}
-                  title={fullProfile}
-                >
-                  {datasetWithTags.dataset.profile && datasetWithTags.dataset.profile !== 'null' ? (
-                    datasetWithTags.dataset.profile.length > MAX_PROFILE_LENGTH ? (
-                      `${datasetWithTags.dataset.profile.substring(0, MAX_PROFILE_LENGTH)} ...`
-                    ) : (
-                      datasetWithTags.dataset.profile
-                    )
-                  ) : (
+                {datasetWithTags.dataset.profile && datasetWithTags.dataset.profile !== 'null' ? (
+                  (() => {
+                    try {
+                      const parsed = JSON.parse(datasetWithTags.dataset.profile);
+                      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+                        return (
+                          <div css={{ marginBottom: theme.spacing.xs, marginTop: theme.spacing.xs }}>
+                            {Object.entries(parsed).map(([key, value]) => {
+                              const isObject = value !== null && typeof value === 'object';
+                              const displayValue = isObject ? JSON.stringify(value) : String(value);
+                              const truncatedValue =
+                                displayValue.length > MAX_PROFILE_LENGTH
+                                  ? `${displayValue.substring(0, MAX_PROFILE_LENGTH)} ...`
+                                  : displayValue;
+
+                              return (
+                                <Typography.Hint key={key} css={{ display: 'block', marginBottom: 2 }}>
+                                  {key.replace(/_/g, ' ')}: <strong>{truncatedValue}</strong>
+                                </Typography.Hint>
+                              );
+                            })}
+                          </div>
+                        );
+                      }
+                    } catch {
+                      // Fall through to raw display
+                    }
+                    return (
+                      <Typography.Title
+                        level={4}
+                        color="secondary"
+                        css={{ marginBottom: theme.spacing.xs, marginTop: theme.spacing.xs }}
+                        title={fullProfile}
+                      >
+                        {datasetWithTags.dataset.profile.length > MAX_PROFILE_LENGTH
+                          ? `${datasetWithTags.dataset.profile.substring(0, MAX_PROFILE_LENGTH)} ...`
+                          : datasetWithTags.dataset.profile}
+                      </Typography.Title>
+                    );
+                  })()
+                ) : (
+                  <Typography.Title
+                    level={4}
+                    color="secondary"
+                    css={{ marginBottom: theme.spacing.xs, marginTop: theme.spacing.xs }}
+                  >
                     <FormattedMessage
                       defaultMessage="No profile available"
                       description="Text for no profile available in the experiment run dataset drawer"
                     />
-                  )}
-                </Typography.Title>
+                  </Typography.Title>
+                )}
               </div>
-              <ExperimentViewDatasetLink datasetWithTags={datasetWithTags} runTags={tags} experimentId={experimentId} />
+              <ExperimentViewDatasetLink datasetWithTags={datasetWithTags} />
             </div>
             <div css={{ flexShrink: 0, display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
               <ExperimentViewDatasetDigest datasetWithTags={datasetWithTags} />

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetLink.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetLink.test.tsx
@@ -1,4 +1,4 @@
-import { describe, test, expect } from '@jest/globals';
+import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import { renderWithIntl, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { ExperimentViewDatasetLink } from './ExperimentViewDatasetLink';
 import { DatasetSourceTypes } from '../../../../types';
@@ -17,52 +17,72 @@ const createDatasetWithTags = (sourceType: string, source: string): RunDatasetWi
     tags: [],
   }) as any;
 
-const testRunTags = {} as Record<string, { key: string; value: string }>;
-
-const renderComponent = (datasetWithTags: RunDatasetWithTags, experimentId?: string) => {
+const renderComponent = (datasetWithTags: RunDatasetWithTags) => {
   return renderWithIntl(
     <MemoryRouter>
       <DesignSystemProvider>
-        <ExperimentViewDatasetLink
-          datasetWithTags={datasetWithTags}
-          runTags={testRunTags}
-          experimentId={experimentId}
-        />
+        <ExperimentViewDatasetLink datasetWithTags={datasetWithTags} />
       </DesignSystemProvider>
     </MemoryRouter>,
   );
 };
 
 describe('ExperimentViewDatasetLink', () => {
-  test('renders link to datasets tab when experimentId is provided', () => {
-    const dataset = createDatasetWithTags(DatasetSourceTypes.HTTP, JSON.stringify({ url: 'https://example.com/data' }));
-    renderComponent(dataset, '123');
+  let windowOpenSpy: jest.SpiedFunction<typeof window.open>;
 
-    const link = screen.getByRole('link', { name: /Open dataset/i });
-    expect(link).toHaveAttribute('href', expect.stringContaining('/experiments/123/datasets'));
+  beforeEach(() => {
+    windowOpenSpy = jest.spyOn(window, 'open').mockReturnValue(null);
   });
 
-  test('renders link for any source type when experimentId is provided', () => {
-    const dataset = createDatasetWithTags(
-      DatasetSourceTypes.HUGGING_FACE,
-      JSON.stringify({ path: 'org/dataset-name' }),
-    );
-    renderComponent(dataset, '456');
-
-    const link = screen.getByRole('link', { name: /Open dataset/i });
-    expect(link).toHaveAttribute('href', expect.stringContaining('/experiments/456/datasets'));
+  afterEach(() => {
+    windowOpenSpy.mockRestore();
   });
 
-  test('renders copy button for S3 source type without experimentId', () => {
+  test('renders copy button for S3 source type', () => {
     const dataset = createDatasetWithTags(DatasetSourceTypes.S3, JSON.stringify({ uri: 's3://bucket/path' }));
     renderComponent(dataset);
 
     expect(screen.getByText(/Copy S3 URI to clipboard/i)).toBeInTheDocument();
   });
 
-  test('renders nothing for unknown source type without experimentId', () => {
+  test('renders open dataset button for HTTP source type and opens URL on click', () => {
+    const dataset = createDatasetWithTags(DatasetSourceTypes.HTTP, JSON.stringify({ url: 'https://example.com/data' }));
+    renderComponent(dataset);
+
+    const button = screen.getByText(/Open dataset/i);
+    expect(button).toBeInTheDocument();
+    button.click();
+    expect(windowOpenSpy).toHaveBeenCalledWith('https://example.com/data', '_blank', 'noopener,noreferrer');
+  });
+
+  test('renders open dataset button for Hugging Face source type and opens URL on click', () => {
+    const dataset = createDatasetWithTags(
+      DatasetSourceTypes.HUGGING_FACE,
+      JSON.stringify({ path: 'org/dataset-name' }),
+    );
+    renderComponent(dataset);
+
+    const button = screen.getByText(/Open dataset/i);
+    expect(button).toBeInTheDocument();
+    button.click();
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      'https://huggingface.co/datasets/org/dataset-name',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  test('renders nothing for local source type', () => {
+    const dataset = createDatasetWithTags(DatasetSourceTypes.LOCAL, JSON.stringify({ uri: '/data/photos/my-concept' }));
+    const { container } = renderComponent(dataset);
+    expect(container.innerHTML).toBe('');
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+  });
+
+  test('renders nothing for unknown source type', () => {
     const dataset = createDatasetWithTags('unknown', JSON.stringify({ url: 'https://example.com' }));
     const { container } = renderComponent(dataset);
     expect(container.innerHTML).toBe('');
+    expect(windowOpenSpy).not.toHaveBeenCalled();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetLink.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetLink.tsx
@@ -4,40 +4,13 @@ import { DatasetSourceTypes } from '../../../../types';
 import { FormattedMessage } from 'react-intl';
 import { getDatasetSourceUrl } from '../../../../utils/DatasetUtils';
 import { CopyButton } from '../../../../../shared/building_blocks/CopyButton';
-import { Link } from '../../../../../common/utils/RoutingUtils';
-import Routes from '../../../../routes';
-import { ExperimentPageTabName } from '../../../../constants';
 
 export interface DatasetLinkProps {
   datasetWithTags: RunDatasetWithTags;
-  runTags: Record<string, { key: string; value: string }>;
-  experimentId?: string;
 }
 
-export function ExperimentViewDatasetLink({ datasetWithTags, experimentId }: DatasetLinkProps): JSX.Element | null {
+export function ExperimentViewDatasetLink({ datasetWithTags }: DatasetLinkProps): JSX.Element | null {
   const { dataset } = datasetWithTags;
-
-  if (experimentId) {
-    const datasetsRoute = Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Datasets);
-    return (
-      <Button
-        componentId="codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_1"
-        icon={<TableIcon />}
-        type="primary"
-      >
-        <Link
-          componentId="mlflow.experiment_tracking.dataset_link.open_dataset_link"
-          to={datasetsRoute}
-          css={{ color: 'inherit', '&:hover': { color: 'inherit', textDecoration: 'none' } }}
-        >
-          <FormattedMessage
-            defaultMessage="Open dataset"
-            description="Text for the button that navigates to the datasets tab in the experiment run dataset drawer"
-          />
-        </Link>
-      </Button>
-    );
-  }
 
   if (dataset.sourceType === DatasetSourceTypes.S3) {
     const url = getDatasetSourceUrl(datasetWithTags);
@@ -53,6 +26,34 @@ export function ExperimentViewDatasetLink({ datasetWithTags, experimentId }: Dat
             description="Text for the S3 URI copy button in the experiment run dataset drawer"
           />
         </CopyButton>
+      );
+    }
+  }
+
+  if (
+    dataset.sourceType === DatasetSourceTypes.HTTP ||
+    dataset.sourceType === DatasetSourceTypes.EXTERNAL ||
+    dataset.sourceType === DatasetSourceTypes.HUGGING_FACE
+  ) {
+    const url = getDatasetSourceUrl(datasetWithTags);
+    if (url) {
+      return (
+        <Button
+          componentId="codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_1"
+          icon={<TableIcon />}
+          type="primary"
+          onClick={() => {
+            const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
+            if (newWindow) {
+              newWindow.opener = null;
+            }
+          }}
+        >
+          <FormattedMessage
+            defaultMessage="Open dataset"
+            description="Text for the button that opens the dataset source URL in a new tab"
+          />
+        </Button>
       );
     }
   }

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetSourceType.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetSourceType.tsx
@@ -38,6 +38,14 @@ export const ExperimentViewDatasetSourceType = ({ datasetWithTags }: ExperimentV
         />
       );
     }
+    if (sourceType === DatasetSourceTypes.LOCAL) {
+      return (
+        <FormattedMessage
+          defaultMessage="Local"
+          description="Experiment dataset drawer > source type > Local source type label"
+        />
+      );
+    }
     return null;
   };
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetSourceURL.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewDatasetSourceURL.tsx
@@ -65,5 +65,26 @@ export const ExperimentViewDatasetSourceURL = ({ datasetWithTags }: ExperimentVi
       return null;
     }
   }
+  if (sourceType === DatasetSourceTypes.LOCAL) {
+    try {
+      const { uri } = JSON.parse(dataset.source);
+      if (uri) {
+        return (
+          <Typography.Hint
+            title={uri}
+            css={{
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            Path: {uri}
+          </Typography.Hint>
+        );
+      }
+    } catch {
+      return null;
+    }
+  }
   return null;
 };

--- a/mlflow/server/js/src/experiment-tracking/utils/DatasetUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/DatasetUtils.ts
@@ -20,6 +20,8 @@ export function getDatasetSourceUrl(datasetWithTags: RunDatasetWithTags): string
         return parsed.uri ?? null;
       case DatasetSourceTypes.HUGGING_FACE:
         return parsed.path ? `https://huggingface.co/datasets/${parsed.path}` : null;
+      case DatasetSourceTypes.LOCAL:
+        return parsed.uri ?? null;
       default:
         return null;
     }

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3454,6 +3454,10 @@
     "defaultMessage": "Latency Comparison",
     "description": "Title for the tool latency comparison chart"
   },
+  "LBaK9z": {
+    "defaultMessage": "Open dataset",
+    "description": "Text for the button that opens the dataset source URL in a new tab"
+  },
   "LED2z5": {
     "defaultMessage": "To disable or enable this display, call {disableFunction} or {enableFunction} and re-run the cell",
     "description": "Content in an info popover that instructs the user on how to disable the display. The disable and enable functions are code snippets with the real function names"
@@ -4708,10 +4712,6 @@
   "TSXmaB": {
     "defaultMessage": "Create",
     "description": "A label for the confirm button in the create prompt modal in the prompt management UI"
-  },
-  "TTsPbw": {
-    "defaultMessage": "Open dataset",
-    "description": "Text for the button that navigates to the datasets tab in the experiment run dataset drawer"
   },
   "TWnsnV": {
     "defaultMessage": "Run Name",
@@ -9758,6 +9758,10 @@
   "zC/uKl": {
     "defaultMessage": "Auto-refresh",
     "description": "Run page > Charts tab > Auto-refresh toggle button"
+  },
+  "zCtyPo": {
+    "defaultMessage": "Local",
+    "description": "Experiment dataset drawer > source type > Local source type label"
   },
   "zDRvO3": {
     "defaultMessage": "Detect Issues",


### PR DESCRIPTION
### Related Issues/PRs

Closes #22124

### What changes are proposed in this pull request?

The dataset details drawer has a few issues when displaying datasets logged via `mlflow.log_input()`:

1. The "Open dataset" button links to the evaluation datasets tab (`/experiments/{id}/datasets`) which is a completely separate system from run-logged datasets. It always shows "No evaluation datasets found" which is confusing. Removed that link and instead open the actual source URL for HTTP/HuggingFace datasets, show a copy button for S3, and show nothing for local (no external page to open).

2. Datasets with `source_type: "local"` don't show any source information. The source type label and path are missing because `ExperimentViewDatasetSourceType` and `ExperimentViewDatasetSourceURL` only handle HTTP, S3 and Hugging Face. Added support for local so the path (stored in `dataset.source`) is actually displayed.

3. The profile field is rendered as a raw truncated JSON string. Parsed it as key-value pairs when it's a valid JSON object, which makes it readable for integrations that send rich metadata (like image count, resolution, format, etc). Falls back to the raw string if parsing fails.

Also cleaned up unused `experimentId` and `runTags` props from `ExperimentViewDatasetLink` since they were dead code after the fix.

#### Before

<img width="1112" height="862" alt="image" src="https://github.com/user-attachments/assets/24fb6e1f-66fd-42b8-8bc0-133c6a619828" />
#### After

**Local dataset:**

<img width="1112" height="862" alt="image" src="https://github.com/user-attachments/assets/fd526ca5-1a23-4ee4-baf8-429ee3f8ab6c" />
**HTTP dataset:**

<img width="1112" height="862" alt="image" src="https://github.com/user-attachments/assets/38185aef-c7c4-4e35-83a6-8459022dd849" />
**S3 dataset:**

<img width="1112" height="862" alt="image" src="https://github.com/user-attachments/assets/61dcd928-1c82-490a-9721-ab33212a9fa0" />
**HuggingFace dataset:**

<img width="1112" height="862" alt="image" src="https://github.com/user-attachments/assets/ae5fa7d1-4ca6-4b0a-86e8-bc8a849dd828" />
### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Updated `ExperimentViewDatasetLink.test.tsx` to match the new behavior. Tested manually with HTTP, S3, HuggingFace and local datasets in the same run to verify each source type renders correctly and no regressions.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Dataset details drawer now shows source type and path for local datasets, renders profile metadata as readable key-value pairs, and no longer links to the unrelated evaluation datasets page.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release