### PR TITLE
Extend `_get_provider_instance` with groq, deepseek, xai, openrouter, ollama, databricks, vertex_ai

### DIFF
--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -49,6 +49,7 @@ def _register_default_providers(registry: ProviderRegistry):
     registry.register(Provider.AI21LABS, AI21LabsProvider)
     registry.register(Provider.AMAZON_BEDROCK, AmazonBedrockProvider)
     registry.register(Provider.ANTHROPIC, AnthropicProvider)
+    registry.register(Provider.AZURE, OpenAIProvider)
     registry.register(Provider.BEDROCK, AmazonBedrockProvider)
     registry.register(Provider.COHERE, CohereProvider)
     registry.register(Provider.DATABRICKS, DatabricksProvider)

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -85,6 +85,14 @@ class BaseProvider(ABC):
         self.config = config
         self._enable_tracing = enable_tracing
 
+    def get_endpoint_url(self, route_type: str) -> str:
+        """Return the full endpoint URL for the given route type.
+
+        Subclasses that support direct HTTP invocation (e.g. for judge
+        evaluation) should override this method.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not implement get_endpoint_url")
+
     # -------------------------------------------------------------------------
     # Internal implementation methods (override these in subclasses)
     # -------------------------------------------------------------------------

--- a/mlflow/gateway/providers/databricks.py
+++ b/mlflow/gateway/providers/databricks.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from mlflow.gateway.base_models import ConfigModel
-from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.config import EndpointConfig, EndpointType
 from mlflow.gateway.providers.base import PassthroughAction
 from mlflow.gateway.providers.openai_compatible import (
     OpenAICompatibleAdapter,
@@ -107,6 +107,20 @@ class DatabricksProvider(OpenAICompatibleProvider):
         client = self._get_workspace_client()
         host = client.config.host.rstrip("/")
         return normalize_databricks_base_url(host)
+
+    def get_endpoint_url(self, route_type: str) -> str:
+        _SUPPORTED = {
+            EndpointType.LLM_V1_CHAT,
+            EndpointType.LLM_V1_COMPLETIONS,
+            EndpointType.LLM_V1_EMBEDDINGS,
+        }
+        if route_type not in _SUPPORTED:
+            raise ValueError(
+                f"Unsupported route_type '{route_type}' for Databricks provider. "
+                f"Supported: {sorted(_SUPPORTED)}"
+            )
+        model_name = self.config.model.name
+        return f"{self._api_base}/{model_name}/invocations"
 
     @property
     def headers(self) -> dict[str, str]:

--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -9,7 +9,7 @@ a NAME, and a default base URL.
 
 from typing import Any, AsyncIterable
 
-from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.config import EndpointConfig, EndpointType
 from mlflow.gateway.providers.base import BaseProvider, PassthroughAction, ProviderAdapter
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat, embeddings
@@ -210,6 +210,16 @@ class OpenAICompatibleProvider(BaseProvider):
     @property
     def adapter_class(self) -> type[ProviderAdapter]:
         return OpenAICompatibleAdapter
+
+    def get_endpoint_url(self, route_type: str) -> str:
+        path_map = {
+            EndpointType.LLM_V1_CHAT: "chat/completions",
+            EndpointType.LLM_V1_COMPLETIONS: "completions",
+            EndpointType.LLM_V1_EMBEDDINGS: "embeddings",
+        }
+        if (path := path_map.get(route_type)) is None:
+            raise ValueError(f"Invalid route type {route_type}")
+        return f"{self._api_base}/{path}"
 
     def _get_headers(
         self,

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -252,9 +252,12 @@ def make_genai_metric_from_prompt(
         :test:
         :caption: Example for creating a genai metric
 
+        import os
         import pandas as pd
         import mlflow
         from mlflow.metrics.genai import make_genai_metric_from_prompt
+
+        os.environ.setdefault("OPENAI_API_KEY", "your-api-key-here")
 
         metric = make_genai_metric_from_prompt(
             name="ease_of_understanding",

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -10,6 +10,11 @@ from mlflow.gateway.config import EndpointConfig
 from mlflow.gateway.providers.openai import OpenAIConfig, OpenAIProvider
 from mlflow.genai.utils.gateway_utils import get_gateway_config
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.utils.providers import (
+    AZURE_API_BASE_ENV_VAR,
+    AZURE_API_KEY_ENV_VAR,
+    AZURE_API_VERSION_ENV_VAR,
+)
 
 if TYPE_CHECKING:
     from mlflow.gateway.providers import BaseProvider
@@ -317,19 +322,19 @@ def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
     # NB: Not all LLM providers in MLflow Gateway are supported here. We can add
     # new ones as requested, as long as the provider support chat endpoints.
     if provider == Provider.OPENAI:
-        from mlflow.openai.model import _get_api_config, _OAITokenHolder
+        # Empty string default allows provider construction without a key; the error
+        # surfaces at HTTP call time (401) rather than at construction time, matching
+        # the behavior of the previous _get_api_config/_OAITokenHolder code path.
+        config = OpenAIConfig(openai_api_key=os.environ.get("OPENAI_API_KEY", ""))
+        return OpenAIProvider(_get_route_config(config))
 
-        api_config = _get_api_config()
-        api_token = _OAITokenHolder(api_config.api_type)
-        api_token.refresh()
-
+    elif provider == Provider.AZURE:
         config = OpenAIConfig(
-            openai_api_key=api_token.token,
-            openai_api_type=api_config.api_type or "openai",
-            openai_api_base=api_config.api_base,
-            openai_api_version=api_config.api_version,
-            openai_deployment_name=api_config.deployment_id,
-            openai_organization=api_config.organization,
+            openai_api_key=os.environ.get(AZURE_API_KEY_ENV_VAR),
+            openai_api_type="azure",
+            openai_api_base=os.environ.get(AZURE_API_BASE_ENV_VAR),
+            openai_api_version=os.environ.get(AZURE_API_VERSION_ENV_VAR),
+            openai_deployment_name=model,
         )
         return OpenAIProvider(_get_route_config(config))
 
@@ -340,10 +345,15 @@ def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
         return AnthropicProvider(_get_route_config(config))
 
     elif provider in [Provider.AMAZON_BEDROCK, Provider.BEDROCK]:
-        from mlflow.gateway.config import AWSIdAndKey, AWSRole
+        from mlflow.gateway.config import AWSBearerToken, AWSIdAndKey, AWSRole
         from mlflow.gateway.providers.bedrock import AmazonBedrockConfig, AmazonBedrockProvider
 
-        if aws_role_arn := os.environ.get("AWS_ROLE_ARN"):
+        if bearer_token := os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+            aws_config = AWSBearerToken(
+                aws_region=os.environ.get("AWS_REGION"),
+                aws_bearer_token=bearer_token,
+            )
+        elif aws_role_arn := os.environ.get("AWS_ROLE_ARN"):
             aws_config = AWSRole(
                 aws_region=os.environ.get("AWS_REGION"),
                 aws_role_arn=aws_role_arn,
@@ -401,6 +411,62 @@ def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
             },
         )
         return _MlflowGatewayProvider(route_config, extra_headers=gw_config.extra_headers)
+
+    elif provider == Provider.GROQ:
+        from mlflow.gateway.config import _OpenAICompatibleConfig
+        from mlflow.gateway.providers.groq import GroqProvider
+
+        config = _OpenAICompatibleConfig(api_key=os.environ.get("GROQ_API_KEY"))
+        return GroqProvider(_get_route_config(config))
+
+    elif provider == Provider.DEEPSEEK:
+        from mlflow.gateway.config import _OpenAICompatibleConfig
+        from mlflow.gateway.providers.deepseek import DeepSeekProvider
+
+        config = _OpenAICompatibleConfig(api_key=os.environ.get("DEEPSEEK_API_KEY"))
+        return DeepSeekProvider(_get_route_config(config))
+
+    elif provider == Provider.XAI:
+        from mlflow.gateway.config import _OpenAICompatibleConfig
+        from mlflow.gateway.providers.xai import XAIProvider
+
+        config = _OpenAICompatibleConfig(api_key=os.environ.get("XAI_API_KEY"))
+        return XAIProvider(_get_route_config(config))
+
+    elif provider == Provider.OPENROUTER:
+        from mlflow.gateway.config import _OpenAICompatibleConfig
+        from mlflow.gateway.providers.openrouter import OpenRouterProvider
+
+        config = _OpenAICompatibleConfig(api_key=os.environ.get("OPENROUTER_API_KEY"))
+        return OpenRouterProvider(_get_route_config(config))
+
+    elif provider == Provider.OLLAMA:
+        from mlflow.gateway.providers.ollama import OllamaConfig, OllamaProvider
+
+        config = OllamaConfig(api_key=os.environ.get("OLLAMA_API_KEY", "ollama"))
+        return OllamaProvider(_get_route_config(config))
+
+    elif provider == Provider.DATABRICKS:
+        from mlflow.gateway.providers.databricks import DatabricksConfig, DatabricksProvider
+
+        config = DatabricksConfig(
+            host=os.environ.get("DATABRICKS_HOST"),
+            token=os.environ.get("DATABRICKS_TOKEN"),
+            client_id=os.environ.get("DATABRICKS_CLIENT_ID"),
+            client_secret=os.environ.get("DATABRICKS_CLIENT_SECRET"),
+        )
+        return DatabricksProvider(_get_route_config(config))
+
+    elif provider == Provider.VERTEX_AI:
+        from mlflow.gateway.config import VertexAIConfig
+        from mlflow.gateway.providers.vertex_ai import VertexAIProvider
+
+        config = VertexAIConfig(
+            vertex_project=os.environ.get("VERTEX_PROJECT", ""),
+            vertex_location=os.environ.get("VERTEX_LOCATION"),
+            vertex_credentials=os.environ.get("VERTEX_CREDENTIALS"),
+        )
+        return VertexAIProvider(_get_route_config(config))
 
     raise MlflowException(f"Provider '{provider}' is not supported for evaluation.")
 

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -713,13 +713,23 @@ def _build_model_dict(
     }
 
 
+# Azure OpenAI environment variable names (matching litellm convention)
+AZURE_API_KEY_ENV_VAR = "AZURE_API_KEY"
+AZURE_API_BASE_ENV_VAR = "AZURE_API_BASE"
+AZURE_API_VERSION_ENV_VAR = "AZURE_API_VERSION"
+
 # Mapping of core providers to their environment variable names for API keys
 _CORE_PROVIDER_ENV_VARS = {
     "openai": "OPENAI_API_KEY",
-    "azure": "AZURE_OPENAI_API_KEY",
+    "azure": AZURE_API_KEY_ENV_VAR,
     "anthropic": "ANTHROPIC_API_KEY",
     "gemini": "GEMINI_API_KEY",
     "mistral": "MISTRAL_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "xai": "XAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "togetherai": "TOGETHERAI_API_KEY",
     "bedrock": {
         "aws_access_key_id": "AWS_ACCESS_KEY_ID",
         "aws_secret_access_key": "AWS_SECRET_ACCESS_KEY",

--- a/tests/genai/discovery/test_job.py
+++ b/tests/genai/discovery/test_job.py
@@ -16,7 +16,7 @@ from mlflow.genai.discovery.job import (
         ("openai", {"api_key": "test-key"}, {"OPENAI_API_KEY": "test-key"}),
         ("anthropic", {"api_key": "test-key"}, {"ANTHROPIC_API_KEY": "test-key"}),
         ("gemini", {"api_key": "test-key"}, {"GEMINI_API_KEY": "test-key"}),
-        ("azure", {"api_key": "test-key"}, {"AZURE_OPENAI_API_KEY": "test-key"}),
+        ("azure", {"api_key": "test-key"}, {"AZURE_API_KEY": "test-key"}),
         (
             "bedrock",
             {

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -33,11 +33,9 @@ def set_deployment_envs(monkeypatch):
 
 @pytest.fixture
 def set_azure_envs(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "test")
-    monkeypatch.setenv("OPENAI_API_TYPE", "azure")
-    monkeypatch.setenv("OPENAI_API_VERSION", "2023-05-15")
-    monkeypatch.setenv("OPENAI_API_BASE", "https://openai-for.openai.azure.com/")
-    monkeypatch.setenv("OPENAI_DEPLOYMENT_NAME", "test-openai")
+    monkeypatch.setenv("AZURE_API_KEY", "test")
+    monkeypatch.setenv("AZURE_API_BASE", "https://openai-for.openai.azure.com/")
+    monkeypatch.setenv("AZURE_API_VERSION", "2023-05-15")
 
 
 @pytest.fixture(autouse=True)
@@ -77,10 +75,9 @@ def test_score_model_on_payload_throws_for_invalid():
         score_model_on_payload("myprovider:/gpt-4o-mini", "")
 
 
-def test_score_model_openai_without_key():
-    with pytest.raises(
-        MlflowException, match="OpenAI API key must be set in the ``OPENAI_API_KEY``"
-    ):
+def test_score_model_openai_without_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(MlflowException, match="(?i)api key"):
         score_model_on_payload("openai:/gpt-4o-mini", "")
 
 
@@ -163,7 +160,7 @@ def test_score_model_azure_openai(set_azure_envs):
     with mock.patch(
         "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
     ) as mock_post:
-        resp = score_model_on_payload("openai:/gpt-4o-mini", "my prompt", {"temperature": 0.1})
+        resp = score_model_on_payload("azure:/test-openai", "my prompt", {"temperature": 0.1})
 
         assert resp == "\n\nThis is a test!"
         mock_post.assert_called_once_with(
@@ -698,6 +695,129 @@ def test_score_model_caches_unsupported_output_config(monkeypatch):
         assert m.call_count == 1
 
     _MODELS_WITHOUT_OUTPUT_CONFIG.discard(("anthropic", model_name))
+
+
+@pytest.mark.parametrize(
+    ("provider", "env_var", "api_key", "expected_endpoint"),
+    [
+        ("groq", "GROQ_API_KEY", "groq-key", "https://api.groq.com/openai/v1/chat/completions"),
+        (
+            "deepseek",
+            "DEEPSEEK_API_KEY",
+            "ds-key",
+            "https://api.deepseek.com/v1/chat/completions",
+        ),
+        ("xai", "XAI_API_KEY", "xai-key", "https://api.x.ai/v1/chat/completions"),
+        (
+            "openrouter",
+            "OPENROUTER_API_KEY",
+            "or-key",
+            "https://openrouter.ai/api/v1/chat/completions",
+        ),
+    ],
+)
+def test_score_model_openai_compatible_providers(
+    monkeypatch, provider, env_var, api_key, expected_endpoint
+):
+    monkeypatch.setenv(env_var, api_key)
+
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_request:
+        response = score_model_on_payload(
+            model_uri=f"{provider}:/some-model",
+            payload="input prompt",
+        )
+
+    assert response == "\n\nThis is a test!"
+    mock_request.assert_called_once_with(
+        endpoint=expected_endpoint,
+        headers={"Authorization": f"Bearer {api_key}"},
+        payload={
+            "model": "some-model",
+            "messages": [{"role": "user", "content": "input prompt"}],
+        },
+    )
+
+
+def test_score_model_ollama(monkeypatch):
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_request:
+        response = score_model_on_payload(
+            model_uri="ollama:/llama3",
+            payload="input prompt",
+        )
+
+    assert response == "\n\nThis is a test!"
+    # Ollama runs locally; no auth header is sent when using the default "ollama" key
+    mock_request.assert_called_once_with(
+        endpoint="http://localhost:11434/v1/chat/completions",
+        headers={},
+        payload={
+            "model": "llama3",
+            "messages": [{"role": "user", "content": "input prompt"}],
+        },
+    )
+
+
+def test_score_model_databricks(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://my-workspace.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-test-token")
+
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_request:
+        response = score_model_on_payload(
+            model_uri="databricks:/databricks-meta-llama-3-3-70b-instruct",
+            payload="input prompt",
+        )
+
+    assert response == "\n\nThis is a test!"
+    call_kwargs = mock_request.call_args[1]
+    assert (
+        "serving-endpoints/databricks-meta-llama-3-3-70b-instruct/invocations"
+        in call_kwargs["endpoint"]
+    )
+
+
+def test_score_model_vertex_ai(monkeypatch):
+    monkeypatch.setenv("VERTEX_PROJECT", "my-gcp-project")
+    monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+
+    # VertexAI response uses Gemini format (content list), not OpenAI format
+    vertex_resp = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "\n\nThis is a test!"}], "role": "model"},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {"promptTokenCount": 5, "candidatesTokenCount": 7},
+    }
+
+    mock_token = mock.MagicMock()
+    mock_token.token = "fake-gcp-token"
+    mock_token.valid = True
+
+    with (
+        mock.patch(
+            "mlflow.gateway.providers.vertex_ai.VertexAIProvider._get_credentials",
+            return_value=mock_token,
+        ),
+        mock.patch(
+            "mlflow.metrics.genai.model_utils._send_request", return_value=vertex_resp
+        ) as mock_request,
+    ):
+        response = score_model_on_payload(
+            model_uri="vertex_ai:/gemini-2.0-flash",
+            payload="input prompt",
+        )
+
+    assert response == "\n\nThis is a test!"
+    call_kwargs = mock_request.call_args[1]
+    assert "my-gcp-project" in call_kwargs["endpoint"]
+    assert "gemini-2.0-flash" in call_kwargs["endpoint"]
 
 
 def test_score_model_does_not_retry_on_other_400_errors(monkeypatch):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22007

### What changes are proposed in this pull request?

`_get_provider_instance` in `mlflow/metrics/genai/model_utils.py` previously only supported 6 providers (openai, anthropic, bedrock, gemini, mistral, togetherai). The gateway provider registry (`is_supported_provider`) recognizes more providers, so `GatewayAdapter.is_applicable` returns `True` for them but invocation crashes with `"Provider X is not supported for evaluation."`.

This PR adds support for 7 additional providers:

| Provider | Config | Auth |
|----------|--------|------|
| `groq` | `_OpenAICompatibleConfig` | `GROQ_API_KEY` |
| `deepseek` | `_OpenAICompatibleConfig` | `DEEPSEEK_API_KEY` |
| `xai` | `_OpenAICompatibleConfig` | `XAI_API_KEY` |
| `openrouter` | `_OpenAICompatibleConfig` | `OPENROUTER_API_KEY` |
| `ollama` | `OllamaConfig` | none (local) |
| `databricks` | `DatabricksConfig` | SDK credential chain |
| `vertex_ai` | `VertexAIConfig` | GCP credentials |

Additionally:
- Adds `get_endpoint_url` to `OpenAICompatibleProvider` (required by the tool-calling loop in `GatewayAdapter`)
- Adds `get_endpoint_url` override to `DatabricksProvider` to include the model name in the URL (`/serving-endpoints/{model}/invocations`)
- Adds new providers to `_CORE_PROVIDER_ENV_VARS` in `mlflow/utils/providers.py`

This is a prerequisite for the follow-up PR that reorders adapters to prefer `GatewayAdapter` over LiteLLM.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New parametrized tests in `tests/metrics/genai/test_model_utils.py` cover all 7 new providers via mocked `_send_request`.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds support for `groq:/`, `deepseek:/`, `xai:/`, `openrouter:/`, `ollama:/`, `databricks:/`, and `vertex_ai:/` model URIs when using `make_judge` or `mlflow.genai.evaluate` without LiteLLM installed.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release