### PR TITLE
Map user.id span attribute to mlflow.trace.user during OTel ingestion

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4579,6 +4579,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             aggregated_token_usage = {}
             aggregated_cost = {}
             session_id = None
+            user_id = None
             span_rows = []
             metric_rows = []
             for span in spans:
@@ -4596,6 +4597,11 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         span_session_id := span_attributes.get("session.id")
                     ):
                         session_id = span_session_id
+                    # user id used by OTel semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/user/#user-id
+                    if user_id is None and (
+                        span_user_id := span_attributes.get("user.id")
+                    ):
+                        user_id = span_user_id
                     # Get cost for span metrics
                     span_cost = span_attributes.get(SpanAttributeKey.LLM_COST)
 
@@ -4710,6 +4716,25 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                             request_id=trace_id,
                             key=TraceMetadataKey.TRACE_SESSION,
                             value=session_id,
+                        )
+                    )
+
+            if user_id:
+                existing_user_id = (
+                    session
+                    .query(SqlTraceMetadata)
+                    .filter(
+                        SqlTraceMetadata.request_id == trace_id,
+                        SqlTraceMetadata.key == TraceMetadataKey.TRACE_USER,
+                    )
+                    .one_or_none()
+                )
+                if not existing_user_id:
+                    session.merge(
+                        SqlTraceMetadata(
+                            request_id=trace_id,
+                            key=TraceMetadataKey.TRACE_USER,
+                            value=user_id,
                         )
                     )
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4598,9 +4598,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     ):
                         session_id = span_session_id
                     # user id used by OTel semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/user/#user-id
-                    if user_id is None and (
-                        span_user_id := span_attributes.get("user.id")
-                    ):
+                    if user_id is None and (span_user_id := span_attributes.get("user.id")):
                         user_id = span_user_id
                     # Get cost for span metrics
                     span_cost = span_attributes.get(SpanAttributeKey.LLM_COST)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -13805,6 +13805,70 @@ def test_log_spans_session_id_handling(store: SqlAlchemyStore) -> None:
     assert TraceMetadataKey.TRACE_SESSION not in trace_info3.trace_metadata
 
 
+def test_log_spans_user_id_handling(store: SqlAlchemyStore) -> None:
+    experiment_id = store.create_experiment("test_user_id")
+
+    # User ID gets stored from span attributes
+    trace_id1 = f"tr-{uuid.uuid4().hex}"
+    otel_span1 = create_test_otel_span(trace_id=trace_id1)
+    otel_span1._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id1, cls=TraceJSONEncoder),
+        "user.id": "alice",
+    }
+    span1 = create_mlflow_span(otel_span1, trace_id1, "LLM")
+    store.log_spans(experiment_id, [span1])
+
+    trace_info1 = store.get_trace_info(trace_id1)
+    assert trace_info1.trace_metadata.get(TraceMetadataKey.TRACE_USER) == "alice"
+
+    # Existing user ID is preserved
+    trace_id2 = f"tr-{uuid.uuid4().hex}"
+    trace_with_user = TraceInfo(
+        trace_id=trace_id2,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=1234,
+        execution_duration=100,
+        state=TraceState.IN_PROGRESS,
+        trace_metadata={TraceMetadataKey.TRACE_USER: "existing-user"},
+    )
+    store.start_trace(trace_with_user)
+
+    otel_span2 = create_test_otel_span(trace_id=trace_id2)
+    otel_span2._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id2, cls=TraceJSONEncoder),
+        "user.id": "different-user",
+    }
+    span2 = create_mlflow_span(otel_span2, trace_id2, "LLM")
+    store.log_spans(experiment_id, [span2])
+
+    trace_info2 = store.get_trace_info(trace_id2)
+    assert trace_info2.trace_metadata.get(TraceMetadataKey.TRACE_USER) == "existing-user"
+
+    # No user ID means no metadata
+    trace_id3 = f"tr-{uuid.uuid4().hex}"
+    otel_span3 = create_test_otel_span(trace_id=trace_id3)
+    span3 = create_mlflow_span(otel_span3, trace_id3, "LLM")
+    store.log_spans(experiment_id, [span3])
+
+    trace_info3 = store.get_trace_info(trace_id3)
+    assert TraceMetadataKey.TRACE_USER not in trace_info3.trace_metadata
+
+    # Both session and user ID work together
+    trace_id4 = f"tr-{uuid.uuid4().hex}"
+    otel_span4 = create_test_otel_span(trace_id=trace_id4)
+    otel_span4._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id4, cls=TraceJSONEncoder),
+        "session.id": "session-456",
+        "user.id": "bob",
+    }
+    span4 = create_mlflow_span(otel_span4, trace_id4, "LLM")
+    store.log_spans(experiment_id, [span4])
+
+    trace_info4 = store.get_trace_info(trace_id4)
+    assert trace_info4.trace_metadata.get(TraceMetadataKey.TRACE_SESSION) == "session-456"
+    assert trace_info4.trace_metadata.get(TraceMetadataKey.TRACE_USER) == "bob"
+
+
 def test_find_completed_sessions(store: SqlAlchemyStore):
     """
     Test finding completed sessions based on their last trace timestamp.


### PR DESCRIPTION
### Related Issues/PRs

Closes #22119

### What changes are proposed in this pull request?

 Maps the `user.id` OTel span attribute to `mlflow.trace.user` trace metadata during OTLP ingestion in `log_spans()`, following the same pattern as the existing `session.id` → `mlflow.trace.session` mapping.

Without this fix, the User column in the MLflow Traces UI remains empty for OTel-ingested traces, even though `user.id` is correctly set as a span attribute.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The `user.id` OTel span attribute is now mapped to `mlflow.trace.user` during OTLP trace ingestion, populating the User column in the Traces UI for externally ingested traces.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
