### PR TITLE
Fix: Apply --static-prefix to /api/2.0/mlflow/ routes

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5643,7 +5643,7 @@ def _invoke_scorer_handler():
 
 
 def _get_rest_path(base_path, version=2):
-    return f"/api/{version}.0{base_path}"
+    return _add_static_prefix(f"/api/{version}.0{base_path}")
 
 
 def _get_ajax_path(base_path, version=2):


### PR DESCRIPTION
Fixes #22142

## Problem
When using mlflow server with --static-prefix=/<prefix>, the /api/2.0/mlflow/ REST API routes were not prefixed, while the /ajax-api/2.0/mlflow/ routes were correctly prefixed.

## Root Cause
In mlflow/server/handlers.py, _get_rest_path() did NOT call _add_static_prefix(), while _get_ajax_path() did.

## Fix
Added _add_static_prefix() call to _get_rest_path() to ensure consistency between REST and AJAX API routes.

## Changes
- Modified _get_rest_path() in mlflow/server/handlers.py to call _add_static_prefix()

## Testing
- Verified that both /api/ and /ajax-api/ routes now correctly respect the --static-prefix setting
- Verified backward compatibility (no prefix set still works correctly)