### PR TITLE
Add useCountInfo hook for accurate trace count in paginated mode

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -360,6 +360,7 @@ const TracesV3LogsImpl = React.memo(
 
     const countInfo = useCountInfo({
       experimentIds,
+      timeRange,
       traceInfosCount: traceInfos?.length,
       traceInfosLoading,
       metadataTotalCount: totalCount,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -30,7 +30,6 @@ import {
   TracesTableColumnType,
   useSearchMlflowTraces,
   useSelectedColumns,
-  getEvalTabTotalTracesLimit,
   GenAITracesTableProvider,
   useFilters,
   getTracesTagKeys,
@@ -69,6 +68,7 @@ import {
   useRunJudgesOnTracesConfiguration,
 } from '../../../../pages/experiment-scorers/hooks/useRunScorerInTracesViewConfiguration';
 import { IssueDetectionModal } from './IssueDetectionModal';
+import { useCountInfo } from './hooks/useCountInfo';
 
 const JudgeContextProvider = ({
   children,
@@ -358,14 +358,13 @@ const TracesV3LogsImpl = React.memo(
       RunJudgesModal,
     ]);
 
-    const countInfo = useMemo(() => {
-      return {
-        currentCount: traceInfos?.length,
-        logCountLoading: traceInfosLoading,
-        totalCount: totalCount,
-        maxAllowedCount: getEvalTabTotalTracesLimit(),
-      };
-    }, [traceInfos, totalCount, traceInfosLoading]);
+    const countInfo = useCountInfo({
+      experimentIds,
+      traceInfosCount: traceInfos?.length,
+      traceInfosLoading,
+      metadataTotalCount: totalCount,
+      disabled: isQueryDisabled,
+    });
 
     // Loading state:
     // - Show skeleton only during initial metadata loading (or initial time filter loading for empty check)

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useCountInfo.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useCountInfo.ts
@@ -10,11 +10,6 @@ import {
   TraceMetricKey,
   createTraceMetadataFilter,
 } from '@databricks/web-shared/model-trace-explorer';
-import {
-  getAbsoluteStartEndTime,
-  useMonitoringFilters,
-} from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringFilters';
-import { useMonitoringConfig } from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringConfig';
 
 /**
  * Returns the countInfo object for the traces table toolbar badge.
@@ -29,6 +24,7 @@ import { useMonitoringConfig } from '@mlflow/mlflow/src/experiment-tracking/hook
 export function useCountInfo({
   experimentIds,
   runUuid,
+  timeRange,
   traceInfosCount,
   traceInfosLoading,
   metadataTotalCount,
@@ -36,6 +32,7 @@ export function useCountInfo({
 }: {
   experimentIds: string[];
   runUuid?: string;
+  timeRange?: { startTime?: string; endTime?: string };
   traceInfosCount: number | undefined;
   traceInfosLoading: boolean;
   metadataTotalCount: number;
@@ -47,17 +44,8 @@ export function useCountInfo({
     [runUuid],
   );
 
-  // Use getAbsoluteStartEndTime to properly compute time range from labels
-  const [monitoringFilters] = useMonitoringFilters();
-  const monitoringConfig = useMonitoringConfig();
-  const { startTime, endTime } = useMemo(
-    () => getAbsoluteStartEndTime(monitoringConfig.dateNow, monitoringFilters),
-    [monitoringConfig.dateNow, monitoringFilters],
-  );
-
-  // Convert ISO strings to milliseconds for the API
-  const startTimeMs = startTime ? new Date(startTime).getTime() : undefined;
-  const endTimeMs = endTime ? new Date(endTime).getTime() : undefined;
+  const startTimeMs = timeRange?.startTime ? Number(timeRange.startTime) : undefined;
+  const endTimeMs = timeRange?.endTime ? Number(timeRange.endTime) : undefined;
 
   const { data: traceCountMetrics, isLoading: traceCountLoading } = useTraceMetricsQuery({
     experimentIds,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useCountInfo.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useCountInfo.ts
@@ -1,0 +1,85 @@
+import { useMemo } from 'react';
+import {
+  shouldUseInfinitePaginatedTraces,
+  getEvalTabTotalTracesLimit,
+} from '@databricks/web-shared/genai-traces-table';
+import { useTraceMetricsQuery } from '../../../../../pages/experiment-overview/hooks/useTraceMetricsQuery';
+import { MetricViewType, AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
+import {
+  getAbsoluteStartEndTime,
+  useMonitoringFilters,
+} from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringFilters';
+import { useMonitoringConfig } from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringConfig';
+
+/**
+ * Returns the countInfo object for the traces table toolbar badge.
+ *
+ * When infinite pagination is enabled, queries the trace metrics endpoint
+ * to get the true total count of traces so the badge shows "X of Y" where
+ * X = loaded traces and Y = total traces in the time period.
+ *
+ * When infinite pagination is disabled, falls back to the existing behavior
+ * where totalCount comes from the metadata hook.
+ */
+export function useCountInfo({
+  experimentIds,
+  traceInfosCount,
+  traceInfosLoading,
+  metadataTotalCount,
+  disabled,
+}: {
+  experimentIds: string[];
+  traceInfosCount: number | undefined;
+  traceInfosLoading: boolean;
+  metadataTotalCount: number;
+  disabled: boolean;
+}) {
+  const usingInfinitePagination = shouldUseInfinitePaginatedTraces();
+
+  // Use getAbsoluteStartEndTime to properly compute time range from labels
+  const [monitoringFilters] = useMonitoringFilters();
+  const monitoringConfig = useMonitoringConfig();
+  const { startTime, endTime } = useMemo(
+    () => getAbsoluteStartEndTime(monitoringConfig.dateNow, monitoringFilters),
+    [monitoringConfig.dateNow, monitoringFilters],
+  );
+
+  // Convert ISO strings to milliseconds for the API
+  const startTimeMs = startTime ? new Date(startTime).getTime() : undefined;
+  const endTimeMs = endTime ? new Date(endTime).getTime() : 0;
+
+  const { data: traceCountMetrics, isLoading: traceCountLoading } = useTraceMetricsQuery({
+    experimentIds,
+    viewType: MetricViewType.TRACES,
+    metricName: TraceMetricKey.TRACE_COUNT,
+    aggregations: [{ aggregation_type: AggregationType.COUNT }],
+    startTimeMs,
+    endTimeMs,
+    enabled: usingInfinitePagination && !disabled,
+  });
+  const metricsTotal = traceCountMetrics?.data_points?.[0]?.values?.[AggregationType.COUNT];
+
+  return useMemo(() => {
+    if (usingInfinitePagination) {
+      return {
+        currentCount: traceInfosCount,
+        logCountLoading: traceInfosLoading || traceCountLoading,
+        totalCount: metricsTotal ?? traceInfosCount ?? 0,
+        maxAllowedCount: Infinity,
+      };
+    }
+    return {
+      currentCount: traceInfosCount,
+      logCountLoading: traceInfosLoading,
+      totalCount: metadataTotalCount,
+      maxAllowedCount: getEvalTabTotalTracesLimit(),
+    };
+  }, [
+    usingInfinitePagination,
+    traceInfosCount,
+    metadataTotalCount,
+    traceInfosLoading,
+    traceCountLoading,
+    metricsTotal,
+  ]);
+}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useCountInfo.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useCountInfo.ts
@@ -57,7 +57,7 @@ export function useCountInfo({
 
   // Convert ISO strings to milliseconds for the API
   const startTimeMs = startTime ? new Date(startTime).getTime() : undefined;
-  const endTimeMs = endTime ? new Date(endTime).getTime() : 0;
+  const endTimeMs = endTime ? new Date(endTime).getTime() : undefined;
 
   const { data: traceCountMetrics, isLoading: traceCountLoading } = useTraceMetricsQuery({
     experimentIds,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useCountInfo.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/useCountInfo.ts
@@ -4,7 +4,12 @@ import {
   getEvalTabTotalTracesLimit,
 } from '@databricks/web-shared/genai-traces-table';
 import { useTraceMetricsQuery } from '../../../../../pages/experiment-overview/hooks/useTraceMetricsQuery';
-import { MetricViewType, AggregationType, TraceMetricKey } from '@databricks/web-shared/model-trace-explorer';
+import {
+  MetricViewType,
+  AggregationType,
+  TraceMetricKey,
+  createTraceMetadataFilter,
+} from '@databricks/web-shared/model-trace-explorer';
 import {
   getAbsoluteStartEndTime,
   useMonitoringFilters,
@@ -23,18 +28,24 @@ import { useMonitoringConfig } from '@mlflow/mlflow/src/experiment-tracking/hook
  */
 export function useCountInfo({
   experimentIds,
+  runUuid,
   traceInfosCount,
   traceInfosLoading,
   metadataTotalCount,
   disabled,
 }: {
   experimentIds: string[];
+  runUuid?: string;
   traceInfosCount: number | undefined;
   traceInfosLoading: boolean;
   metadataTotalCount: number;
   disabled: boolean;
 }) {
   const usingInfinitePagination = shouldUseInfinitePaginatedTraces();
+  const filters = useMemo(
+    () => (runUuid ? [createTraceMetadataFilter('mlflow.sourceRun', runUuid)] : undefined),
+    [runUuid],
+  );
 
   // Use getAbsoluteStartEndTime to properly compute time range from labels
   const [monitoringFilters] = useMonitoringFilters();
@@ -56,6 +67,7 @@ export function useCountInfo({
     startTimeMs,
     endTimeMs,
     enabled: usingInfinitePagination && !disabled,
+    filters,
   });
   const metricsTotal = traceCountMetrics?.data_points?.[0]?.values?.[AggregationType.COUNT];
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
@@ -109,7 +109,11 @@ export {
   createTestColumns,
 } from './test-fixtures/EvaluatedTraceTestUtils';
 
-export { shouldUseTracesV4API, shouldUseLongRunningTracesAPI } from './utils/FeatureUtils';
+export {
+  shouldUseTracesV4API,
+  shouldUseLongRunningTracesAPI,
+  shouldUseInfinitePaginatedTraces,
+} from './utils/FeatureUtils';
 export { createTraceLocationForExperiment, createTraceLocationForUCSchema } from './utils/TraceLocationUtils';
 export type { GetTraceFunction } from './hooks/useGetTrace';
 export { useFetchTraceV4LazyQuery, useFetchTraceV4Query, getTraceV4QueryKey } from './hooks/useFetchTraceV4';


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22154/files) to review incremental changes.
- [**stack/pagination-part-3**](https://github.com/mlflow/mlflow/pull/22154) [[Files changed](https://github.com/mlflow/mlflow/pull/22154/files)]
  - [stack/pagination-part-4](https://github.com/mlflow/mlflow/pull/22190) [[Files changed](https://github.com/mlflow/mlflow/pull/22190/files/6f2b5cc7948699f1fcce3c064d8010c356ac010b..83bb4c2c5dfe46e912507f2bc3f723cf2cd77d25)]
    - [stack/pagination-part-5](https://github.com/mlflow/mlflow/pull/22272) [[Files changed](https://github.com/mlflow/mlflow/pull/22272/files/83bb4c2c5dfe46e912507f2bc3f723cf2cd77d25..2fd5aabc71f35be9fd152df13d759aadaed079d9)]
      - [stack/pagination-part-6](https://github.com/mlflow/mlflow/pull/22273) [[Files changed](https://github.com/mlflow/mlflow/pull/22273/files/2fd5aabc71f35be9fd152df13d759aadaed079d9..d4c4c30c58005f609698c298768b0b4570feda78)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

In the top-right of the trace table, we have a small text that shows how many traces you have loaded vs. available in the backend. Currently it only goes up to 1k, since that is the limit we set on the UI.

With the new pagination, we can simply query the trace metrics backend to have an accurate count. This PR adds a new hook to manage displaying old / new values based on the flag. It also respects time filters.

**Note:** The assessment aggregation headers are still client side, they will be updated in next PR.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

https://github.com/user-attachments/assets/4623f451-af1d-4f57-accc-20fc7b5cd186


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
