### PR TITLE
Decouple telemetry from judge adapters via dependency injection

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -751,6 +751,7 @@ mlflow.gateway.base_models.ConfigModel
 mlflow.gateway.config.AI21LabsConfig
 mlflow.gateway.config.AI21LabsConfig.validate_ai21labs_api_key
 mlflow.gateway.config.AWSBaseConfig
+mlflow.gateway.config.AWSBearerToken
 mlflow.gateway.config.AWSIdAndKey
 mlflow.gateway.config.AWSRole
 mlflow.gateway.config.AliasedConfigModel

--- a/docs/api_reference/build-tsdoc.sh
+++ b/docs/api_reference/build-tsdoc.sh
@@ -15,11 +15,8 @@ build_tsdoc() {
 
     pushd "$package_path"
 
-    # Skip npm install since we're using yarn workspaces
-    # Dependencies should be installed at the workspace root
-
     # Generate TypeDoc documentation
-    npx typedoc \
+    npm exec -- typedoc \
         --out "$output_path" \
         --name "$package_name" \
         --readme README.md \
@@ -44,7 +41,7 @@ DOCS_OUTPUT_BASE="build/html/typescript_api"
 # First ensure dependencies are installed at workspace root
 echo "Ensuring TypeScript workspace dependencies are installed..."
 pushd "$TYPESCRIPT_BASE"
-npm install
+npm ci
 popd
 
 # Remove existing docs if they exist

--- a/docs/docs/self-hosting/workspaces/configuration.mdx
+++ b/docs/docs/self-hosting/workspaces/configuration.mdx
@@ -43,6 +43,46 @@ mlflow db migrate-to-default-workspace <database_uri> --dry-run
 
 Use `--verbose` to list all conflicts instead of a truncated sample.
 
+### Admin Utility: move resources between workspaces
+
+To selectively move resources from one workspace to another, use:
+
+```bash
+mlflow db move-resources <database_uri> \
+  --from <source_workspace> --to <target_workspace> \
+  --resource-type <table_name>
+```
+
+The `--resource-type` value is the database table name (`experiments`, `registered_models`,
+`evaluation_datasets`, `webhooks`, `jobs`).
+
+:::note Gateway resources not supported
+Gateway resources (`secrets`, `endpoints`, `model_definitions`, `budget_policies`) are not
+supported by this command because they have inter-table foreign-key dependencies that make moving
+them independently unsafe.
+:::
+
+Filter which resources to move by name or tag:
+
+```bash
+# Move specific experiments by name
+mlflow db move-resources <database_uri> \
+  --from default --to team-a --resource-type experiments \
+  --name training-v1 --name training-v2
+
+# Move experiments matching tags (AND logic when multiple tags are given)
+mlflow db move-resources <database_uri> \
+  --from default --to team-a --resource-type experiments \
+  --tag team=team-a --tag env=prod
+```
+
+When neither `--name` nor `--tag` is specified, all resources of the given type in the source
+workspace are moved. Tag filtering is supported for `experiments` and `registered_models` only.
+
+Use `--dry-run` to preview what would be moved without making changes, and `-y` to skip the
+confirmation prompt. The command aborts if any resource name would conflict with an existing
+resource in the target workspace.
+
 ## Client Workspace Selection (summary)
 
 - Explicit: `mlflow.set_workspace("team-a")`

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -22,6 +22,8 @@ from mlflow.environment_variables import (
     MLFLOW_EXPERIMENT_NAME,
     MLFLOW_TRACKING_URI,
 )
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey, TraceMetadataKey
 from mlflow.tracing.provider import _get_trace_exporter
 from mlflow.tracing.trace_manager import InMemoryTraceManager
@@ -117,6 +119,8 @@ def setup_mlflow() -> None:
             mlflow.set_experiment(experiment_name)
     except Exception as e:
         get_logger().warning("Failed to set experiment: %s", e)
+
+    _record_event(AutologgingEvent, {"flavor": "claude_code"})
 
 
 def is_tracing_enabled() -> bool:

--- a/mlflow/db.py
+++ b/mlflow/db.py
@@ -56,6 +56,8 @@ def migrate_to_default_workspace(url, dry_run, verbose, yes):
     **IMPORTANT**: This operation runs in a single transaction, but can still be long-running.
     Always take a backup of your database before running this command.
     """
+    import sqlalchemy.exc
+
     import mlflow.store.db.utils
     from mlflow.store.db.workspace_migration import migrate_to_default_workspace as migrate
 
@@ -88,6 +90,195 @@ def migrate_to_default_workspace(url, dry_run, verbose, yes):
         click.echo(f"Moved {total} rows to the default workspace.")
     except RuntimeError as e:
         raise click.ClickException(str(e)) from e
+    except sqlalchemy.exc.SQLAlchemyError as e:
+        raise click.ClickException(f"Database error: {e}") from e
+    finally:
+        if engine is not None:
+            engine.dispose()
+
+
+def _parse_tag(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise click.BadParameter(
+            f"Tag {value!r} must be in key=value format (e.g. --tag team=team-a)."
+        )
+    key, _, val = value.partition("=")
+    if not key:
+        raise click.BadParameter(f"Tag {value!r} has an empty key. Use key=value format.")
+    return key, val
+
+
+@commands.command("move-resources")
+@click.argument("url")
+@click.option(
+    "--from",
+    "source_workspace",
+    required=True,
+    help="Source workspace name.",
+)
+@click.option(
+    "--to",
+    "target_workspace",
+    required=True,
+    help="Target workspace name.",
+)
+@click.option(
+    "--resource-type",
+    required=True,
+    help="Table name of the resource type to move (e.g. experiments, registered_models).",
+)
+@click.option(
+    "--name",
+    multiple=True,
+    help="Resource name(s) to move. Repeatable.",
+)
+@click.option(
+    "--tag",
+    multiple=True,
+    help=(
+        "Tag filter as key=value. Repeatable. "
+        "When multiple tags are given, only resources matching ALL tags are included."
+    ),
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    show_default=True,
+    help="Show what would be moved without making changes.",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="List all conflicts instead of truncating the output.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+def move_resources(
+    url, source_workspace, target_workspace, resource_type, name, tag, dry_run, verbose, yes
+):
+    """
+    Move resources from one workspace to another.
+
+    Selectively move workspace-scoped resources between workspaces by name
+    or tag filter (mutually exclusive). When neither --name nor --tag is
+    specified, all resources of the given type in the source workspace are moved.
+
+    The --resource-type value is the database table name (e.g. experiments,
+    registered_models, evaluation_datasets, webhooks, jobs).
+
+    Tag filtering (--tag) is supported for experiments and registered_models
+    only. When multiple --tag flags are given, only resources matching ALL tags
+    are included (AND logic).
+
+    \b
+    Examples:
+      # Move specific experiments by name
+      mlflow db move-resources sqlite:///mlflow.db \\
+        --from default --to team-a --resource-type experiments \\
+        --name training-v1 --name training-v2
+      # Move experiments matching ALL specified tags
+      mlflow db move-resources sqlite:///mlflow.db \\
+        --from default --to team-a --resource-type experiments \\
+        --tag team=team-a --tag env=prod
+      # Move all registered models from one workspace to another
+      mlflow db move-resources sqlite:///mlflow.db \\
+        --from default --to team-a --resource-type registered_models
+
+    **IMPORTANT**: Always take a backup of your database before running this command.
+    """
+    import sqlalchemy.exc
+
+    import mlflow.store.db.utils
+    from mlflow.store.db.workspace_move import RESOURCE_TYPE_CHOICES
+    from mlflow.store.db.workspace_move import move_resources as move
+    from mlflow.store.db.workspace_utils import format_truncated_list
+
+    if resource_type not in RESOURCE_TYPE_CHOICES:
+        raise click.ClickException(
+            f"Unknown resource type {resource_type!r}. "
+            f"Valid types: {', '.join(RESOURCE_TYPE_CHOICES)}"
+        )
+
+    parsed_tags = [_parse_tag(t) for t in tag] if tag else None
+    parsed_names = list(name) if name else None
+
+    engine = None
+    try:
+        engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(url)
+        needs_confirmation = not dry_run and not yes
+
+        result = move(
+            engine,
+            source_workspace=source_workspace,
+            target_workspace=target_workspace,
+            resource_type=resource_type,
+            names=parsed_names,
+            tags=parsed_tags,
+            dry_run=dry_run or needs_confirmation,
+            verbose=verbose,
+        )
+
+        if not result.names:
+            click.echo(f"No {resource_type} to move.")
+            return
+
+        max_display = None if verbose else 20
+        name_list = format_truncated_list(result.names, max_rows=max_display)
+
+        extra_notes: list[str] = []
+        if result.row_count > len(result.names):
+            extra_notes.append(
+                f"Note: {result.row_count} rows match {len(result.names)} distinct "
+                f"name(s). All rows with a matching name will be moved."
+            )
+
+        if dry_run:
+            click.echo(
+                f"Dry run completed. {result.row_count} {resource_type} row(s) would be moved "
+                f"from {source_workspace!r} to {target_workspace!r}:{name_list}"
+            )
+            for note in extra_notes:
+                click.echo(note)
+            return
+
+        if needs_confirmation:
+            click.echo(
+                f"{result.row_count} {resource_type} row(s) to move from "
+                f"{source_workspace!r} to {target_workspace!r}:{name_list}"
+            )
+            for note in extra_notes:
+                click.echo(note)
+            click.confirm("Proceed with move?", default=False, abort=True)
+            # Re-run the full move (including conflict detection) in a new
+            # transaction. The preview counts above may differ from the
+            # actual move if another admin modified the data in between,
+            # but the second call is self-consistent and safe.
+            result = move(
+                engine,
+                source_workspace=source_workspace,
+                target_workspace=target_workspace,
+                resource_type=resource_type,
+                names=parsed_names,
+                tags=parsed_tags,
+                dry_run=False,
+                verbose=verbose,
+            )
+
+        click.echo(
+            f"Moved {result.row_count} {resource_type} row(s) "
+            f"from {source_workspace!r} to {target_workspace!r}."
+        )
+    except RuntimeError as e:
+        raise click.ClickException(str(e)) from e
+    except sqlalchemy.exc.SQLAlchemyError as e:
+        raise click.ClickException(f"Database error: {e}") from e
     finally:
         if engine is not None:
             engine.dispose()

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -243,9 +243,13 @@ class AWSIdAndKey(AWSBaseConfig):
     aws_session_token: str | None = None
 
 
+class AWSBearerToken(AWSBaseConfig):
+    aws_bearer_token: str
+
+
 class AmazonBedrockConfig(ConfigModel):
     # order here is important, at least for pydantic<2
-    aws_config: AWSRole | AWSIdAndKey | AWSBaseConfig
+    aws_config: AWSBearerToken | AWSRole | AWSIdAndKey | AWSBaseConfig
 
 
 class MistralConfig(ConfigModel):

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -85,6 +85,14 @@ class BaseProvider(ABC):
         self.config = config
         self._enable_tracing = enable_tracing
 
+    def get_endpoint_url(self, route_type: str) -> str:
+        """Return the full endpoint URL for the given route type.
+
+        Subclasses that support direct HTTP invocation (e.g. for judge
+        evaluation) should override this method.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not implement get_endpoint_url")
+
     # -------------------------------------------------------------------------
     # Internal implementation methods (override these in subclasses)
     # -------------------------------------------------------------------------

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -1,8 +1,17 @@
+import asyncio
 import json
+import queue
 import time
 from enum import Enum
+from typing import Any, AsyncIterable
 
-from mlflow.gateway.config import AmazonBedrockConfig, AWSIdAndKey, AWSRole, EndpointConfig
+from mlflow.gateway.config import (
+    AmazonBedrockConfig,
+    AWSBearerToken,
+    AWSIdAndKey,
+    AWSRole,
+    EndpointConfig,
+)
 from mlflow.gateway.constants import (
     MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
 )
@@ -10,8 +19,8 @@ from mlflow.gateway.exceptions import AIGatewayConfigException, AIGatewayExcepti
 from mlflow.gateway.providers.anthropic import AnthropicAdapter
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.cohere import CohereAdapter
-from mlflow.gateway.providers.utils import rename_payload_keys
-from mlflow.gateway.schemas import completions
+from mlflow.gateway.providers.utils import rename_payload_keys, send_request
+from mlflow.gateway.schemas import chat, completions, embeddings
 
 AWS_BEDROCK_ANTHROPIC_MAXIMUM_MAX_TOKENS = 8191
 
@@ -182,6 +191,10 @@ class AmazonBedrockProvider(BaseProvider):
         self._client = None
         self._client_created = 0
 
+    @property
+    def _is_token_auth(self) -> bool:
+        return isinstance(self.bedrock_config.aws_config, AWSBearerToken)
+
     def _client_expired(self):
         if not isinstance(self.bedrock_config.aws_config, AWSRole):
             return False
@@ -192,8 +205,11 @@ class AmazonBedrockProvider(BaseProvider):
         )
 
     def get_bedrock_client(self):
-        import boto3
-        import botocore.exceptions
+        try:
+            import boto3
+            import botocore.exceptions
+        except ImportError:
+            raise ImportError("Bedrock provider requires boto3. Install it with: pip install boto3")
 
         if self._client is not None and not self._client_expired():
             return self._client
@@ -287,6 +303,386 @@ class AmazonBedrockProvider(BaseProvider):
 
         except botocore.exceptions.ReadTimeoutError as e:
             raise AIGatewayException(status_code=408) from e
+
+    # ---- Converse API helpers ----
+
+    def _build_converse_kwargs(
+        self, messages: list[dict[str, Any]], payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build kwargs for the Converse API call."""
+        system_prompts = []
+        converse_messages = []
+
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+
+            # Normalize content: extract text from list of content parts
+            if isinstance(content, list):
+                content = "\n".join(
+                    p.get("text", "")
+                    for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                )
+
+            if role == "system":
+                system_prompts.append({"text": content})
+            elif role == "assistant":
+                converse_messages.append({
+                    "role": "assistant",
+                    "content": [{"text": content}],
+                })
+            elif role == "tool":
+                converse_messages.append({
+                    "role": "user",
+                    "content": [
+                        {
+                            "toolResult": {
+                                "toolUseId": msg.get("tool_call_id", ""),
+                                "content": [{"text": content}],
+                            }
+                        }
+                    ],
+                })
+            else:
+                converse_messages.append({
+                    "role": "user",
+                    "content": [{"text": content}],
+                })
+
+        kwargs = {
+            "modelId": self.config.model.name,
+            "messages": converse_messages,
+        }
+
+        if system_prompts:
+            kwargs["system"] = system_prompts
+
+        # Build inferenceConfig from OpenAI params
+        inference_config = {}
+        if "temperature" in payload:
+            inference_config["temperature"] = payload["temperature"]
+        if "top_p" in payload:
+            inference_config["topP"] = payload["top_p"]
+        if max_tokens := payload.get("max_tokens") or payload.get("max_completion_tokens"):
+            inference_config["maxTokens"] = max_tokens
+        if "stop" in payload:
+            stop = payload["stop"]
+            inference_config["stopSequences"] = stop if isinstance(stop, list) else [stop]
+
+        if inference_config:
+            kwargs["inferenceConfig"] = inference_config
+
+        # Convert tools to Bedrock format
+        if tools := payload.get("tools"):
+            bedrock_tools = []
+            for tool in tools:
+                if tool.get("type") == "function":
+                    func = tool["function"]
+                    bedrock_tools.append({
+                        "toolSpec": {
+                            "name": func["name"],
+                            "description": func.get("description", ""),
+                            "inputSchema": {"json": func.get("parameters", {})},
+                        }
+                    })
+            if bedrock_tools:
+                kwargs["toolConfig"] = {"tools": bedrock_tools}
+
+        return kwargs
+
+    def _converse_to_chat_response(self, response: dict[str, Any]) -> chat.ResponsePayload:
+        """Convert Bedrock Converse response to OpenAI chat format."""
+        output = response.get("output", {})
+        message = output.get("message", {})
+        content_blocks = message.get("content", [])
+
+        text_parts = []
+        tool_calls = []
+
+        for block in content_blocks:
+            if "text" in block:
+                text_parts.append(block["text"])
+            elif "toolUse" in block:
+                tool_use = block["toolUse"]
+                tool_calls.append(
+                    chat.ToolCall(
+                        id=tool_use.get("toolUseId", ""),
+                        type="function",
+                        function=chat.ToolCallFunction(
+                            name=tool_use.get("name", ""),
+                            arguments=json.dumps(tool_use.get("input", {})),
+                        ),
+                    )
+                )
+
+        usage = response.get("usage", {})
+        finish_reason = self._map_stop_reason(response.get("stopReason", "end_turn"))
+
+        return chat.ResponsePayload(
+            created=int(time.time()),
+            object="chat.completion",
+            model=self.config.model.name,
+            choices=[
+                chat.Choice(
+                    index=0,
+                    message=chat.ResponseMessage(
+                        role="assistant",
+                        content="\n".join(text_parts) if text_parts else None,
+                        tool_calls=tool_calls or None,
+                    ),
+                    finish_reason=finish_reason,
+                )
+            ],
+            usage=chat.ChatUsage(
+                prompt_tokens=usage.get("inputTokens"),
+                completion_tokens=usage.get("outputTokens"),
+                total_tokens=usage.get("totalTokens"),
+            ),
+        )
+
+    # ---- API methods ----
+
+    def _get_token_auth_base_url(self) -> str:
+        region = self.bedrock_config.aws_config.aws_region
+        if not region:
+            raise AIGatewayException(
+                status_code=400,
+                detail="aws_region_name is required for Bedrock API key authentication. "
+                "The API key can only be used in the AWS Region it was generated in.",
+            )
+        return f"https://bedrock-runtime.{region}.amazonaws.com"
+
+    def _get_token_auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.bedrock_config.aws_config.aws_bearer_token}"}
+
+    def _make_stream_chunk(
+        self,
+        delta: chat.StreamDelta,
+        finish_reason: str | None = None,
+        usage: chat.ChatUsage | None = None,
+    ) -> chat.StreamResponsePayload:
+        return chat.StreamResponsePayload(
+            created=int(time.time()),
+            model=self.config.model.name,
+            choices=[chat.StreamChoice(index=0, finish_reason=finish_reason, delta=delta)],
+            usage=usage,
+        )
+
+    @staticmethod
+    def _map_stop_reason(stop_reason: str) -> str:
+        match stop_reason:
+            case "tool_use":
+                return "tool_calls"
+            case "max_tokens":
+                return "length"
+            case "content_filtered":
+                return "content_filter"
+            case _:
+                return "stop"
+
+    def _parse_stream_event(self, event: dict[str, Any]) -> chat.StreamResponsePayload | None:
+        if "contentBlockStart" in event:
+            start = event["contentBlockStart"].get("start", {})
+            if "toolUse" in start:
+                tool_use = start["toolUse"]
+                return self._make_stream_chunk(
+                    delta=chat.StreamDelta(
+                        role=None,
+                        content=None,
+                        tool_calls=[
+                            chat.ToolCallDelta(
+                                index=event["contentBlockStart"].get("contentBlockIndex", 0),
+                                id=tool_use.get("toolUseId"),
+                                type="function",
+                                function=chat.Function(
+                                    name=tool_use.get("name"),
+                                    arguments="",
+                                ),
+                            )
+                        ],
+                    ),
+                )
+        elif "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            if text := delta.get("text"):
+                return self._make_stream_chunk(
+                    delta=chat.StreamDelta(role=None, content=text),
+                )
+            elif "toolUse" in delta:
+                tool_input = delta["toolUse"].get("input", "")
+                if isinstance(tool_input, dict):
+                    arguments = json.dumps(tool_input)
+                else:
+                    arguments = str(tool_input)
+                return self._make_stream_chunk(
+                    delta=chat.StreamDelta(
+                        role=None,
+                        content=None,
+                        tool_calls=[
+                            chat.ToolCallDelta(
+                                index=event["contentBlockDelta"].get("contentBlockIndex", 0),
+                                function=chat.Function(arguments=arguments),
+                            )
+                        ],
+                    ),
+                )
+        elif "messageStop" in event:
+            stop_reason = event["messageStop"].get("stopReason", "end_turn")
+            return self._make_stream_chunk(
+                delta=chat.StreamDelta(role=None, content=None),
+                finish_reason=self._map_stop_reason(stop_reason),
+            )
+        elif "metadata" in event:
+            if usage := event["metadata"].get("usage", {}):
+                return self._make_stream_chunk(
+                    delta=chat.StreamDelta(role=None, content=None),
+                    usage=chat.ChatUsage(
+                        prompt_tokens=usage.get("inputTokens"),
+                        completion_tokens=usage.get("outputTokens"),
+                        total_tokens=usage.get("totalTokens"),
+                    ),
+                )
+        return None
+
+    async def _chat_with_token(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        """Chat using bearer token auth via direct HTTP to Bedrock Converse API."""
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+
+        messages = payload_dict.pop("messages", [])
+        kwargs = self._build_converse_kwargs(messages, payload_dict)
+        model_id = kwargs.pop("modelId")
+
+        resp = await send_request(
+            headers=self._get_token_auth_headers(),
+            base_url=self._get_token_auth_base_url(),
+            path=f"model/{model_id}/converse",
+            payload=kwargs,
+        )
+        return self._converse_to_chat_response(resp)
+
+    async def _chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        if self._is_token_auth:
+            return await self._chat_with_token(payload)
+
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+
+        messages = payload_dict.pop("messages", [])
+        kwargs = self._build_converse_kwargs(messages, payload_dict)
+
+        response = await asyncio.get_running_loop().run_in_executor(
+            None, lambda: self.get_bedrock_client().converse(**kwargs)
+        )
+
+        return self._converse_to_chat_response(response)
+
+    async def _chat_stream(
+        self, payload: chat.RequestPayload
+    ) -> AsyncIterable[chat.StreamResponsePayload]:
+        if self._is_token_auth:
+            raise AIGatewayException(
+                status_code=501,
+                detail="Streaming is not yet supported for Bedrock API key (bearer token) auth. "
+                "Use a non-streaming chat request instead.",
+            )
+
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+
+        messages = payload_dict.pop("messages", [])
+        kwargs = self._build_converse_kwargs(messages, payload_dict)
+
+        # Consume the synchronous boto3 EventStream in a thread to avoid
+        # blocking the async event loop.
+        event_queue: queue.Queue = queue.Queue()
+        _SENTINEL = object()
+        _stream_error: list[BaseException] = []
+
+        def _consume_stream():
+            try:
+                response = self.get_bedrock_client().converse_stream(**kwargs)
+                for event in response.get("stream", []):
+                    event_queue.put(event)
+            except BaseException as e:
+                _stream_error.append(e)
+            finally:
+                event_queue.put(_SENTINEL)
+
+        loop = asyncio.get_running_loop()
+        # Fire-and-forget: stream is consumed in background thread,
+        # events are read from the queue below. Not awaited intentionally.
+        loop.run_in_executor(None, _consume_stream)
+
+        while True:
+            event = await loop.run_in_executor(None, event_queue.get)
+            if event is _SENTINEL:
+                if _stream_error:
+                    raise _stream_error[0]
+                break
+            if chunk := self._parse_stream_event(event):
+                yield chunk
+
+    async def _embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        if self._is_token_auth:
+            raise AIGatewayException(
+                status_code=501,
+                detail="Embeddings are not supported for Bedrock API key (bearer token) auth. "
+                "Use access_keys or default_chain auth mode for embeddings.",
+            )
+
+        from fastapi.encoders import jsonable_encoder
+
+        payload_dict = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload_dict)
+
+        input_text = payload_dict.get("input", "")
+        texts = input_text if isinstance(input_text, list) else [input_text]
+
+        embedding_data = []
+        total_tokens = 0
+
+        for idx, text in enumerate(texts):
+            body = {"inputText": text}
+            response = await asyncio.get_running_loop().run_in_executor(
+                None,
+                lambda b=body: json.loads(
+                    self
+                    .get_bedrock_client()
+                    .invoke_model(
+                        body=json.dumps(b).encode(),
+                        modelId=self.config.model.name,
+                        accept="application/json",
+                        contentType="application/json",
+                    )
+                    .get("body")
+                    .read()
+                ),
+            )
+
+            embedding_data.append(
+                embeddings.EmbeddingObject(
+                    embedding=response.get("embedding", []),
+                    index=idx,
+                )
+            )
+            total_tokens += response.get("inputTextTokenCount", 0)
+
+        return embeddings.ResponsePayload(
+            data=embedding_data,
+            model=self.config.model.name,
+            usage=embeddings.EmbeddingsUsage(
+                prompt_tokens=total_tokens,
+                total_tokens=total_tokens,
+            ),
+        )
 
     async def _completions(
         self, payload: completions.RequestPayload

--- a/mlflow/gateway/providers/databricks.py
+++ b/mlflow/gateway/providers/databricks.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from mlflow.gateway.base_models import ConfigModel
-from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.config import EndpointConfig, EndpointType
 from mlflow.gateway.providers.base import PassthroughAction
 from mlflow.gateway.providers.openai_compatible import (
     OpenAICompatibleAdapter,
@@ -107,6 +107,20 @@ class DatabricksProvider(OpenAICompatibleProvider):
         client = self._get_workspace_client()
         host = client.config.host.rstrip("/")
         return normalize_databricks_base_url(host)
+
+    def get_endpoint_url(self, route_type: str) -> str:
+        _SUPPORTED = {
+            EndpointType.LLM_V1_CHAT,
+            EndpointType.LLM_V1_COMPLETIONS,
+            EndpointType.LLM_V1_EMBEDDINGS,
+        }
+        if route_type not in _SUPPORTED:
+            raise ValueError(
+                f"Unsupported route_type '{route_type}' for Databricks provider. "
+                f"Supported: {sorted(_SUPPORTED)}"
+            )
+        model_name = self.config.model.name
+        return f"{self._api_base}/{model_name}/invocations"
 
     @property
     def headers(self) -> dict[str, str]:

--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -9,7 +9,7 @@ a NAME, and a default base URL.
 
 from typing import Any, AsyncIterable
 
-from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.config import EndpointConfig, EndpointType
 from mlflow.gateway.providers.base import BaseProvider, PassthroughAction, ProviderAdapter
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat, embeddings
@@ -210,6 +210,16 @@ class OpenAICompatibleProvider(BaseProvider):
     @property
     def adapter_class(self) -> type[ProviderAdapter]:
         return OpenAICompatibleAdapter
+
+    def get_endpoint_url(self, route_type: str) -> str:
+        path_map = {
+            EndpointType.LLM_V1_CHAT: "chat/completions",
+            EndpointType.LLM_V1_COMPLETIONS: "completions",
+            EndpointType.LLM_V1_EMBEDDINGS: "embeddings",
+        }
+        if (path := path_map.get(route_type)) is None:
+            raise ValueError(f"Invalid route type {route_type}")
+        return f"{self._api_base}/{path}"
 
     def _get_headers(
         self,

--- a/mlflow/genai/discovery/utils.py
+++ b/mlflow/genai/discovery/utils.py
@@ -276,8 +276,9 @@ def _call_llm_via_gateway(
     response_format: type[pydantic.BaseModel] | None = None,
     token_counter: _TokenCounter | None = None,
 ) -> Any:
-    # Lightweight fallback for when LiteLLM is not installed. Only supports
-    # providers with MLflow gateway adapters (OpenAI, Anthropic, Gemini, Mistral).
+    # Lightweight fallback for when LiteLLM is not installed. Supports
+    # providers with MLflow gateway adapters (OpenAI, Anthropic, Gemini, Mistral)
+    # and the MLflow AI Gateway (gateway:/ URIs).
     # Known gaps vs the LiteLLM path: no drop_params
     # (https://docs.litellm.ai/docs/completion/drop_params) - LiteLLM silently
     # strips unsupported params (e.g. response_format) per model before sending

--- a/mlflow/genai/judges/adapters/base_adapter.py
+++ b/mlflow/genai/judges/adapters/base_adapter.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import pydantic
 
@@ -11,6 +12,9 @@ if TYPE_CHECKING:
     from mlflow.types.llm import ChatMessage
 
 from mlflow.entities.assessment import Feedback
+from mlflow.exceptions import MlflowException
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -86,10 +90,69 @@ class AdapterInvocationOutput:
     cost: float | None = None
 
 
+# ---------------------------------------------------------------------------
+# Telemetry
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class JudgeTelemetryRecorder(Protocol):
+    def record_success(
+        self,
+        input_params: AdapterInvocationInput,
+        output: AdapterInvocationOutput,
+    ) -> None: ...
+
+    def record_failure(
+        self,
+        input_params: AdapterInvocationInput,
+        error: MlflowException,
+    ) -> None: ...
+
+
+class DatabricksTelemetryRecorder:
+    def record_success(
+        self,
+        input_params: AdapterInvocationInput,
+        output: AdapterInvocationOutput,
+    ) -> None:
+        from mlflow.genai.judges.utils.telemetry_utils import (
+            _record_judge_model_usage_success_databricks_telemetry,
+        )
+
+        _record_judge_model_usage_success_databricks_telemetry(
+            request_id=output.request_id,
+            model_provider=input_params.model_provider,
+            endpoint_name=input_params.model_name,
+            num_prompt_tokens=output.num_prompt_tokens,
+            num_completion_tokens=output.num_completion_tokens,
+        )
+
+    def record_failure(
+        self,
+        input_params: AdapterInvocationInput,
+        error: MlflowException,
+    ) -> None:
+        from mlflow.genai.judges.utils.telemetry_utils import (
+            _record_judge_model_usage_failure_databricks_telemetry,
+        )
+
+        _record_judge_model_usage_failure_databricks_telemetry(
+            model_provider=input_params.model_provider,
+            endpoint_name=input_params.model_name,
+            error_code=error.error_code or "UNKNOWN",
+            error_message=str(error),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Base adapter
+# ---------------------------------------------------------------------------
+
+
 class BaseJudgeAdapter(ABC):
-    """
-    Abstract base class for judge model adapters.
-    """
+    def __init__(self, telemetry: JudgeTelemetryRecorder | None = None):
+        self._telemetry = telemetry
 
     @classmethod
     @abstractmethod
@@ -109,20 +172,41 @@ class BaseJudgeAdapter(ABC):
             True if this adapter can handle the model and prompt type, False otherwise.
         """
 
-    @abstractmethod
     def invoke(self, input_params: AdapterInvocationInput) -> AdapterInvocationOutput:
+        """Invoke the adapter with telemetry recording.
+
+        Subclasses implement ``_invoke`` with the actual invocation logic.
+        This method wraps it with success/failure telemetry when a recorder
+        is injected.
         """
-        Invoke the judge model using this adapter.
+        try:
+            output = self._invoke(input_params)
 
-        Args:
-            input_params: The input parameters for the invocation.
+            if self._telemetry:
+                try:
+                    self._telemetry.record_success(input_params, output)
+                except Exception:
+                    _logger.debug("Failed to record judge model usage success telemetry")
 
-        Returns:
-            The output from the invocation including feedback and metadata.
+            return output
 
-        Raises:
-            MlflowException: If the invocation fails.
-        """
+        except MlflowException as e:
+            if self._telemetry:
+                try:
+                    self._telemetry.record_failure(input_params, e)
+                except Exception:
+                    _logger.debug("Failed to record judge model usage failure telemetry")
+            raise
+
+    @abstractmethod
+    def _invoke(self, input_params: AdapterInvocationInput) -> AdapterInvocationOutput:
+        """Subclass extension point — implement the actual invocation logic."""
 
 
-__all__ = ["BaseJudgeAdapter", "AdapterInvocationInput", "AdapterInvocationOutput"]
+__all__ = [
+    "BaseJudgeAdapter",
+    "AdapterInvocationInput",
+    "AdapterInvocationOutput",
+    "JudgeTelemetryRecorder",
+    "DatabricksTelemetryRecorder",
+]

--- a/mlflow/genai/judges/adapters/databricks_managed_judge_adapter.py
+++ b/mlflow/genai/judges/adapters/databricks_managed_judge_adapter.py
@@ -375,7 +375,7 @@ class DatabricksManagedJudgeAdapter(BaseJudgeAdapter):
     ) -> bool:
         return model_uri == _DATABRICKS_DEFAULT_JUDGE_MODEL
 
-    def invoke(self, input_params: AdapterInvocationInput) -> AdapterInvocationOutput:
+    def _invoke(self, input_params: AdapterInvocationInput) -> AdapterInvocationOutput:
         if input_params.base_url is not None or input_params.extra_headers is not None:
             raise MlflowException(
                 "base_url and extra_headers are not supported for Databricks Managed Judge. "

--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -26,7 +26,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import EndpointType
 from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER, GatewayCaller
 from mlflow.gateway.provider_registry import is_supported_provider
-from mlflow.gateway.providers.openai_compatible import OpenAICompatibleAdapter
 from mlflow.genai.discovery.utils import _pydantic_to_response_format
 from mlflow.genai.judges.adapters.base_adapter import (
     AdapterInvocationInput,
@@ -48,7 +47,6 @@ from mlflow.genai.judges.utils.tool_calling_utils import (
     _raise_iteration_limit_exceeded,
     _remove_oldest_tool_call_pair,
 )
-from mlflow.genai.utils.gateway_utils import get_gateway_config
 from mlflow.metrics.genai.model_utils import (
     _call_llm_provider_api,
     _get_provider_instance,
@@ -83,64 +81,6 @@ class InvokeOutput:
 # ---------------------------------------------------------------------------
 # MLflow Gateway provider (lightweight provider-like object)
 # ---------------------------------------------------------------------------
-
-
-class _ModelRef:
-    def __init__(self, name):
-        self.name = name
-
-
-class _ProviderConfig:
-    def __init__(self, model_name):
-        self.model = _ModelRef(model_name)
-
-
-class _MlflowGatewayProvider:
-    """Lightweight provider-like object for MLflow AI Gateway endpoints.
-
-    Matches the provider interface used by the tool-calling loop:
-    ``.get_endpoint_url()``, ``.headers``, ``.adapter_class``, ``.config``.
-    """
-
-    adapter_class = OpenAICompatibleAdapter
-
-    def __init__(self, api_base, headers, config):
-        self._api_base = api_base
-        self.headers = headers
-        self.config = config
-
-    def get_endpoint_url(self, _endpoint_type):
-        return f"{self._api_base.rstrip('/')}/chat/completions"
-
-
-# ---------------------------------------------------------------------------
-# Provider resolution
-# ---------------------------------------------------------------------------
-
-
-def _get_provider(
-    provider_name: str,
-    model_name: str,
-) -> "BaseProvider":
-    """Get a configured provider instance for the given provider and model.
-
-    For the "gateway" provider (MLflow AI Gateway endpoints), returns a
-    provider-like object with the gateway's URL and headers.
-    For all other providers, delegates to ``_get_provider_instance``.
-    """
-    if provider_name == "gateway":
-        return _get_mlflow_gateway_provider(model_name)
-
-    return _get_provider_instance(provider_name, model_name)
-
-
-def _get_mlflow_gateway_provider(model_name: str) -> _MlflowGatewayProvider:
-    """Create a minimal provider-like object for MLflow AI Gateway endpoints."""
-    gw_config = get_gateway_config(model_name)
-    headers = {**(gw_config.extra_headers or {})}
-    headers[MLFLOW_GATEWAY_CALLER_HEADER] = GatewayCaller.JUDGE.value
-
-    return _MlflowGatewayProvider(gw_config.api_base, headers, _ProviderConfig(model_name))
 
 
 # ---------------------------------------------------------------------------
@@ -359,27 +299,6 @@ def _invoke_via_gateway(
     Raises:
         MlflowException: If the provider is not supported or invocation fails.
     """
-    # "gateway" uses the gateway config to call the endpoint directly,
-    # matching how LiteLLMAdapter handles gateway:/ URIs.
-    if provider == "gateway":
-        _, endpoint_name = _parse_model_uri(model_uri)
-        config = get_gateway_config(endpoint_name)
-        headers = {
-            **(config.extra_headers or {}),
-            MLFLOW_GATEWAY_CALLER_HEADER: GatewayCaller.JUDGE.value,
-        }
-        messages = [{"role": "user", "content": prompt}] if isinstance(prompt, str) else prompt
-        payload = {"model": config.endpoint_name, "messages": messages}
-        if inference_params:
-            payload.update(inference_params)
-
-        endpoint = f"{config.api_base.rstrip('/')}/chat/completions"
-        response = send_chat_request(
-            endpoint=endpoint, headers=headers, payload=payload, num_retries=3
-        )
-        content = response["choices"][0]["message"]["content"]
-        return content[0]["text"] if isinstance(content, list) else content
-
     if isinstance(prompt, str):
         return score_model_on_payload(
             model_uri=model_uri,
@@ -595,9 +514,12 @@ class GatewayAdapter(BaseJudgeAdapter):
         # Resolve provider for config, URL, headers, and request/response transformation.
         # Each provider's get_endpoint_url() returns the full endpoint path
         # (e.g. OpenAI: .../chat/completions, Anthropic: .../messages).
-        provider_instance = _get_provider(provider, model_name)
+        provider_instance = _get_provider_instance(provider, model_name)
         endpoint = base_url or provider_instance.get_endpoint_url("llm/v1/chat")
         headers = dict(provider_instance.headers or {})
+        # Tag gateway requests so the server can attribute traffic to the judge
+        if provider == "gateway":
+            headers[MLFLOW_GATEWAY_CALLER_HEADER] = GatewayCaller.JUDGE.value
         if extra_headers:
             headers.update(extra_headers)
 

--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -348,7 +348,7 @@ class GatewayAdapter(BaseJudgeAdapter):
             return False
         return True
 
-    def invoke(self, input_params: AdapterInvocationInput) -> AdapterInvocationOutput:
+    def _invoke(self, input_params: AdapterInvocationInput) -> AdapterInvocationOutput:
         # base_url and extra_headers are not supported for deployment endpoints
         if input_params.model_provider == "endpoints" and (
             input_params.base_url is not None or input_params.extra_headers is not None
@@ -490,7 +490,12 @@ class GatewayAdapter(BaseJudgeAdapter):
             metadata=metadata,
         )
 
-        return AdapterInvocationOutput(feedback=feedback)
+        return AdapterInvocationOutput(
+            feedback=feedback,
+            request_id=output.request_id,
+            num_prompt_tokens=output.num_prompt_tokens,
+            num_completion_tokens=output.num_completion_tokens,
+        )
 
     # TODO: Consider extending _call_llm_provider_api to accept `tools` and return
     # the full ChatResponse (not just text). This would allow replacing the custom

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -32,10 +32,6 @@ from mlflow.genai.judges.utils.parsing_utils import (
     _sanitize_justification,
     _strip_markdown_code_blocks,
 )
-from mlflow.genai.judges.utils.telemetry_utils import (
-    _record_judge_model_usage_failure_databricks_telemetry,
-    _record_judge_model_usage_success_databricks_telemetry,
-)
 from mlflow.genai.judges.utils.tool_calling_utils import (
     _process_tool_calls,
     _raise_iteration_limit_exceeded,
@@ -559,7 +555,7 @@ class LiteLLMAdapter(BaseJudgeAdapter):
     ) -> bool:
         return _is_litellm_available()
 
-    def invoke(self, input_params: AdapterInvocationInput) -> AdapterInvocationOutput:
+    def _invoke(self, input_params: AdapterInvocationInput) -> AdapterInvocationOutput:
         from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
         from mlflow.types.llm import ChatMessage
 
@@ -569,10 +565,8 @@ class LiteLLMAdapter(BaseJudgeAdapter):
             else input_params.prompt
         )
 
-        is_model_provider_databricks = input_params.model_provider in ("databricks", "endpoints")
-
         # Reject base_url / extra_headers for Databricks providers
-        if is_model_provider_databricks and (
+        if input_params.model_provider in ("databricks", "endpoints") and (
             input_params.base_url is not None or input_params.extra_headers is not None
         ):
             raise MlflowException(
@@ -581,78 +575,54 @@ class LiteLLMAdapter(BaseJudgeAdapter):
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
+        output = _invoke_litellm_and_handle_tools(
+            provider=input_params.model_provider,
+            model_name=input_params.model_name,
+            messages=messages,
+            trace=input_params.trace,
+            num_retries=input_params.num_retries,
+            response_format=input_params.response_format,
+            inference_params=input_params.inference_params,
+            base_url=input_params.base_url,
+            extra_headers=input_params.extra_headers,
+        )
+
+        cleaned_response = _strip_markdown_code_blocks(output.response)
+
         try:
-            output = _invoke_litellm_and_handle_tools(
-                provider=input_params.model_provider,
-                model_name=input_params.model_name,
-                messages=messages,
-                trace=input_params.trace,
-                num_retries=input_params.num_retries,
-                response_format=input_params.response_format,
-                inference_params=input_params.inference_params,
-                base_url=input_params.base_url,
-                extra_headers=input_params.extra_headers,
-            )
+            response_dict = json.loads(cleaned_response)
+        except json.JSONDecodeError as e:
+            raise MlflowException(
+                f"Failed to parse response from judge model. Response: {output.response}"
+            ) from e
 
-            cleaned_response = _strip_markdown_code_blocks(output.response)
+        metadata = {}
+        if output.cost:
+            metadata[AssessmentMetadataKey.JUDGE_COST] = output.cost
+        if output.num_prompt_tokens:
+            metadata[AssessmentMetadataKey.JUDGE_INPUT_TOKENS] = output.num_prompt_tokens
+        if output.num_completion_tokens:
+            metadata[AssessmentMetadataKey.JUDGE_OUTPUT_TOKENS] = output.num_completion_tokens
+        metadata = metadata or None
 
-            try:
-                response_dict = json.loads(cleaned_response)
-            except json.JSONDecodeError as e:
-                raise MlflowException(
-                    f"Failed to parse response from judge model. Response: {output.response}"
-                ) from e
+        if "error" in response_dict:
+            raise MlflowException(f"Judge evaluation failed with error: {response_dict['error']}")
 
-            metadata = {}
-            if output.cost:
-                metadata[AssessmentMetadataKey.JUDGE_COST] = output.cost
-            if output.num_prompt_tokens:
-                metadata[AssessmentMetadataKey.JUDGE_INPUT_TOKENS] = output.num_prompt_tokens
-            if output.num_completion_tokens:
-                metadata[AssessmentMetadataKey.JUDGE_OUTPUT_TOKENS] = output.num_completion_tokens
-            metadata = metadata or None
+        feedback = Feedback(
+            name=input_params.assessment_name,
+            value=response_dict["result"],
+            rationale=_sanitize_justification(response_dict.get("rationale", "")),
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id=input_params.model_uri
+            ),
+            trace_id=input_params.trace.info.trace_id if input_params.trace is not None else None,
+            metadata=metadata,
+        )
 
-            if "error" in response_dict:
-                raise MlflowException(
-                    f"Judge evaluation failed with error: {response_dict['error']}"
-                )
-
-            feedback = Feedback(
-                name=input_params.assessment_name,
-                value=response_dict["result"],
-                rationale=_sanitize_justification(response_dict.get("rationale", "")),
-                source=AssessmentSource(
-                    source_type=AssessmentSourceType.LLM_JUDGE, source_id=input_params.model_uri
-                ),
-                trace_id=input_params.trace.info.trace_id
-                if input_params.trace is not None
-                else None,
-                metadata=metadata,
-            )
-
-            if is_model_provider_databricks:
-                try:
-                    _record_judge_model_usage_success_databricks_telemetry(
-                        request_id=output.request_id,
-                        model_provider=input_params.model_provider,
-                        endpoint_name=input_params.model_name,
-                        num_prompt_tokens=output.num_prompt_tokens,
-                        num_completion_tokens=output.num_completion_tokens,
-                    )
-                except Exception:
-                    _logger.debug("Failed to record judge model usage success telemetry")
-
-            return AdapterInvocationOutput(feedback=feedback, cost=output.cost)
-
-        except MlflowException as e:
-            if is_model_provider_databricks:
-                try:
-                    _record_judge_model_usage_failure_databricks_telemetry(
-                        model_provider=input_params.model_provider,
-                        endpoint_name=input_params.model_name,
-                        error_code=e.error_code or "UNKNOWN",
-                        error_message=str(e),
-                    )
-                except Exception:
-                    _logger.debug("Failed to record judge model usage failure telemetry")
-            raise
+        return AdapterInvocationOutput(
+            feedback=feedback,
+            request_id=output.request_id,
+            num_prompt_tokens=output.num_prompt_tokens,
+            num_completion_tokens=output.num_completion_tokens,
+            cost=output.cost,
+        )

--- a/mlflow/genai/judges/adapters/utils.py
+++ b/mlflow/genai/judges/adapters/utils.py
@@ -18,6 +18,8 @@ from mlflow.gateway.constants import (
 )
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, INTERNAL_ERROR
 
+_DATABRICKS_PROVIDERS = {"databricks", "endpoints"}
+
 # ---------------------------------------------------------------------------
 # Adapter selection
 # ---------------------------------------------------------------------------
@@ -41,13 +43,22 @@ def get_adapter(
     Raises:
         MlflowException: If no suitable adapter is found.
     """
-    # Lazy imports to avoid circular imports: utils.py is imported by both
-    # gateway_adapter.py and litellm_adapter.py, so we can't import them at module level.
+    # Lazy imports to avoid circular imports and heavyweight dependency chains.
+    # _parse_model_uri is in mlflow.metrics.genai.model_utils which transitively
+    # imports pandas via mlflow.metrics.genai.genai_metric, breaking the skinny client.
+    from mlflow.genai.judges.adapters.base_adapter import DatabricksTelemetryRecorder
     from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
         DatabricksManagedJudgeAdapter,
     )
     from mlflow.genai.judges.adapters.gateway_adapter import GatewayAdapter
     from mlflow.genai.judges.adapters.litellm_adapter import LiteLLMAdapter
+    from mlflow.metrics.genai.model_utils import _parse_model_uri
+
+    telemetry = None
+    if ":" in model_uri:
+        provider, _ = _parse_model_uri(model_uri)
+        if provider in _DATABRICKS_PROVIDERS:
+            telemetry = DatabricksTelemetryRecorder()
 
     # TODO: Reorder to [Databricks, Gateway, LiteLLM] to prioritize native
     # providers over litellm. Requires migrating ~50 tests that mock
@@ -60,7 +71,7 @@ def get_adapter(
 
     for adapter_class in adapters:
         if adapter_class.is_applicable(model_uri=model_uri, prompt=prompt):
-            return adapter_class()
+            return adapter_class(telemetry=telemetry)
 
     raise MlflowException(
         f"No suitable adapter found for model_uri='{model_uri}'.",

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -6,6 +6,9 @@ import requests
 from pydantic import BaseModel
 
 from mlflow.exceptions import MlflowException
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.openai import OpenAIConfig, OpenAIProvider
+from mlflow.genai.utils.gateway_utils import get_gateway_config
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
 if TYPE_CHECKING:
@@ -280,9 +283,25 @@ def _call_llm_provider_api(
     return content[0].text if isinstance(content, list) else content
 
 
+class _MlflowGatewayProvider(OpenAIProvider):
+    """OpenAI-compatible provider for MLflow AI Gateway endpoints.
+
+    Overrides ``headers`` to use gateway auth headers instead of
+    the standard ``Bearer {api_key}`` used by OpenAIProvider.
+    """
+
+    def __init__(self, config: EndpointConfig, extra_headers: dict[str, str] | None = None):
+        super().__init__(config)
+        self._extra_headers = extra_headers
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return {**(self._extra_headers or {})}
+
+
 def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
     """Get the provider instance for the given provider name and the model name."""
-    from mlflow.gateway.config import EndpointConfig, Provider
+    from mlflow.gateway.config import Provider
 
     def _get_route_config(config):
         return EndpointConfig(
@@ -298,7 +317,6 @@ def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
     # NB: Not all LLM providers in MLflow Gateway are supported here. We can add
     # new ones as requested, as long as the provider support chat endpoints.
     if provider == Provider.OPENAI:
-        from mlflow.gateway.providers.openai import OpenAIConfig, OpenAIProvider
         from mlflow.openai.model import _get_api_config, _OAITokenHolder
 
         api_config = _get_api_config()
@@ -366,6 +384,23 @@ def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
 
         config = TogetherAIConfig(togetherai_api_key=os.environ.get("TOGETHERAI_API_KEY"))
         return TogetherAIProvider(_get_route_config(config))
+
+    elif provider == "gateway":
+        gw_config = get_gateway_config(model)
+        openai_config = OpenAIConfig(
+            openai_api_key="mlflow-gateway-auth",
+            openai_api_base=gw_config.api_base.rstrip("/"),
+        )
+        route_config = EndpointConfig(
+            name="gateway",
+            endpoint_type="llm/v1/chat",
+            model={
+                "provider": "openai",
+                "name": model,
+                "config": openai_config.model_dump(),
+            },
+        )
+        return _MlflowGatewayProvider(route_config, extra_headers=gw_config.extra_headers)
 
     raise MlflowException(f"Provider '{provider}' is not supported for evaluation.")
 

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -402,6 +402,62 @@ def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
         )
         return _MlflowGatewayProvider(route_config, extra_headers=gw_config.extra_headers)
 
+    elif provider == Provider.GROQ:
+        from mlflow.gateway.config import _OpenAICompatibleConfig
+        from mlflow.gateway.providers.groq import GroqProvider
+
+        config = _OpenAICompatibleConfig(api_key=os.environ.get("GROQ_API_KEY"))
+        return GroqProvider(_get_route_config(config))
+
+    elif provider == Provider.DEEPSEEK:
+        from mlflow.gateway.config import _OpenAICompatibleConfig
+        from mlflow.gateway.providers.deepseek import DeepSeekProvider
+
+        config = _OpenAICompatibleConfig(api_key=os.environ.get("DEEPSEEK_API_KEY"))
+        return DeepSeekProvider(_get_route_config(config))
+
+    elif provider == Provider.XAI:
+        from mlflow.gateway.config import _OpenAICompatibleConfig
+        from mlflow.gateway.providers.xai import XAIProvider
+
+        config = _OpenAICompatibleConfig(api_key=os.environ.get("XAI_API_KEY"))
+        return XAIProvider(_get_route_config(config))
+
+    elif provider == Provider.OPENROUTER:
+        from mlflow.gateway.config import _OpenAICompatibleConfig
+        from mlflow.gateway.providers.openrouter import OpenRouterProvider
+
+        config = _OpenAICompatibleConfig(api_key=os.environ.get("OPENROUTER_API_KEY"))
+        return OpenRouterProvider(_get_route_config(config))
+
+    elif provider == Provider.OLLAMA:
+        from mlflow.gateway.providers.ollama import OllamaConfig, OllamaProvider
+
+        config = OllamaConfig(api_key=os.environ.get("OLLAMA_API_KEY", "ollama"))
+        return OllamaProvider(_get_route_config(config))
+
+    elif provider == Provider.DATABRICKS:
+        from mlflow.gateway.providers.databricks import DatabricksConfig, DatabricksProvider
+
+        config = DatabricksConfig(
+            host=os.environ.get("DATABRICKS_HOST"),
+            token=os.environ.get("DATABRICKS_TOKEN"),
+            client_id=os.environ.get("DATABRICKS_CLIENT_ID"),
+            client_secret=os.environ.get("DATABRICKS_CLIENT_SECRET"),
+        )
+        return DatabricksProvider(_get_route_config(config))
+
+    elif provider == Provider.VERTEX_AI:
+        from mlflow.gateway.config import VertexAIConfig
+        from mlflow.gateway.providers.vertex_ai import VertexAIProvider
+
+        config = VertexAIConfig(
+            vertex_project=os.environ.get("VERTEX_PROJECT", ""),
+            vertex_location=os.environ.get("VERTEX_LOCATION"),
+            vertex_credentials=os.environ.get("VERTEX_CREDENTIALS"),
+        )
+        return VertexAIProvider(_get_route_config(config))
+
     raise MlflowException(f"Provider '{provider}' is not supported for evaluation.")
 
 

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -18,6 +18,7 @@ from fastapi.responses import StreamingResponse
 from mlflow.entities.gateway_endpoint import GatewayModelLinkageType
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import (
+    AmazonBedrockConfig,
     AnthropicConfig,
     EndpointConfig,
     EndpointType,
@@ -268,6 +269,40 @@ def _build_endpoint_config(
             config_kwargs["token"] = model_config.secret_value.get(_AuthConfigKey.API_KEY)
         provider_config = DatabricksConfig(**config_kwargs)
         model_config.provider = Provider.DATABRICKS
+    elif model_config.provider in (Provider.BEDROCK, Provider.AMAZON_BEDROCK):
+        auth_config = model_config.auth_config or {}
+        auth_mode = auth_config.get(_AuthConfigKey.AUTH_MODE, "api_key")
+        if auth_mode == "api_key":
+            # Bearer token auth — bypasses boto3 SigV4
+            provider_config = AmazonBedrockConfig(
+                aws_config={
+                    "aws_bearer_token": model_config.secret_value.get(_AuthConfigKey.API_KEY),
+                    "aws_region": auth_config.get("aws_region_name"),
+                }
+            )
+        elif auth_mode == "access_keys":
+            provider_config = AmazonBedrockConfig(
+                aws_config={
+                    "aws_access_key_id": model_config.secret_value.get("aws_access_key_id"),
+                    "aws_secret_access_key": model_config.secret_value.get("aws_secret_access_key"),
+                    "aws_region": auth_config.get("aws_region_name"),
+                }
+            )
+        elif auth_mode == "iam_role":
+            provider_config = AmazonBedrockConfig(
+                aws_config={
+                    "aws_role_arn": auth_config.get("aws_role_name"),
+                    "aws_region": auth_config.get("aws_region_name"),
+                }
+            )
+        else:
+            # default_chain — boto3 resolves credentials from the
+            # environment (env vars, ~/.aws/credentials, instance profile, etc.)
+            aws_config = {"aws_region": auth_config.get("aws_region_name")}
+            if role_arn := auth_config.get("aws_role_name"):
+                aws_config["aws_role_arn"] = role_arn
+            provider_config = AmazonBedrockConfig(aws_config=aws_config)
+        model_config.provider = Provider.BEDROCK
     elif model_config.provider == Provider.VERTEX_AI:
         auth_config = model_config.auth_config or {}
         provider_config = VertexAIConfig(

--- a/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebarExperimentItems.tsx
@@ -94,7 +94,8 @@ export const MlflowSidebarExperimentItems = ({
               if (item.tabName === ExperimentPageTabName.EvaluationRuns) {
                 return (
                   activeTabByRoute === ExperimentPageTabName.EvaluationRuns ||
-                  Boolean(matchPath(RoutePaths.runPageWithTab, pathname))
+                  Boolean(matchPath(RoutePaths.runPageWithTab, pathname)) ||
+                  Boolean(matchPath(RoutePaths.experimentPageTabIssueDetectionRunDetailsWithTab, pathname))
                 );
               }
               if (item.tabName === ExperimentPageTabName.Runs && workflowType === WorkflowType.MACHINE_LEARNING) {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/IssueDetectionRunDetailsPage.tsx
@@ -63,7 +63,7 @@ export const IssueDetectionRunDetailsPage = () => {
       tabSwitchProps={{
         getBaseRoute: Routes.getIssueDetectionRunDetailsRoute,
         getTabRoute: Routes.getIssueDetectionRunDetailsTabRoute,
-        visibleTabs: [RunPageTabName.OVERVIEW, RunPageTabName.TRACES, RunPageTabName.ISSUES],
+        visibleTabs: [RunPageTabName.OVERVIEW, RunPageTabName.ISSUES, RunPageTabName.TRACES],
       }}
       onDeleteSuccess={handleDeleteSuccess}
       hideTracesCompareSelector

--- a/mlflow/store/db/workspace_migration.py
+++ b/mlflow/store/db/workspace_migration.py
@@ -1,21 +1,14 @@
 import sqlalchemy as sa
 
+from mlflow.store.db.workspace_utils import (
+    MODEL_CHILD_TABLES,
+    format_truncated_list,
+    get_workspace_table,
+)
 from mlflow.store.workspace.sqlalchemy_store import _WORKSPACE_ROOT_MODELS
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
-# Derive table names from the shared ORM model list and add child/tags tables that also carry
-# a workspace column but are not "root" tables (they are updated via FK cascades during
-# delete_workspace, but the migration script must handle them explicitly).
-_WORKSPACE_CHILD_TABLES = [
-    "model_versions",
-    "registered_model_tags",
-    "model_version_tags",
-    "registered_model_aliases",
-]
-
-_WORKSPACE_TABLES = [
-    model.__tablename__ for model in _WORKSPACE_ROOT_MODELS
-] + _WORKSPACE_CHILD_TABLES
+_WORKSPACE_TABLES = [model.__tablename__ for model in _WORKSPACE_ROOT_MODELS] + MODEL_CHILD_TABLES
 
 _CONFLICT_SPECS = [
     ("experiments", ("name",), "experiments with the same name"),
@@ -49,26 +42,13 @@ def _format_conflicts(
     *,
     max_rows: int | None,
 ) -> str:
-    rows = conflicts if max_rows is None else conflicts[:max_rows]
-    formatted_conflicts = "\n  ".join(
-        ", ".join(f"{column}={value!r}" for column, value in zip(columns, row)) for row in rows
-    )
-    if formatted_conflicts:
-        formatted_conflicts = f"\n  {formatted_conflicts}"
+    display = conflicts if max_rows is None else conflicts[:max_rows]
+    items = [
+        ", ".join(f"{column}={value!r}" for column, value in zip(columns, row)) for row in display
+    ]
     if max_rows is not None and len(conflicts) > max_rows:
-        formatted_conflicts += f"\n  ... ({len(conflicts) - max_rows} more)"
-    return formatted_conflicts
-
-
-def _get_table(conn, table_name: str) -> sa.Table:
-    table = sa.Table(table_name, sa.MetaData(), autoload_with=conn)
-    if "workspace" not in table.c:
-        raise RuntimeError(
-            "Move aborted: the specified tracking server does not have workspaces enabled. "
-            "This command is intended for a workspace-enabled tracking server. Please make sure "
-            "the specified tracking URI is correct."
-        )
-    return table
+        items.append(f"... ({len(conflicts) - max_rows} more)")
+    return format_truncated_list(items, max_rows=None)
 
 
 def _assert_no_workspace_conflicts(
@@ -79,7 +59,7 @@ def _assert_no_workspace_conflicts(
     *,
     verbose: bool,
 ) -> None:
-    table = _get_table(conn, table_name)
+    table = get_workspace_table(conn, table_name)
     group_columns = [table.c[column] for column in columns]
     conflict_keys = (
         sa.select(*group_columns).group_by(*group_columns).having(sa.func.count() > 1).subquery()
@@ -131,7 +111,7 @@ def migrate_to_default_workspace(
 
         counts = {}
         for table_name in _WORKSPACE_TABLES:
-            table = _get_table(conn, table_name)
+            table = get_workspace_table(conn, table_name)
             stmt = (
                 sa
                 .select(sa.func.count())

--- a/mlflow/store/db/workspace_move.py
+++ b/mlflow/store/db/workspace_move.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import sqlalchemy as sa
+
+from mlflow.store.db.workspace_utils import (
+    MODEL_CHILD_TABLES,
+    format_truncated_list,
+    get_workspace_table,
+    validate_workspace_exists,
+)
+from mlflow.store.model_registry.dbmodels.models import (
+    SqlRegisteredModel,
+    SqlRegisteredModelTag,
+    SqlWebhook,
+)
+from mlflow.store.tracking.dbmodels.models import (
+    SqlEvaluationDataset,
+    SqlExperiment,
+    SqlExperimentTag,
+    SqlJob,
+)
+from mlflow.store.workspace.sqlalchemy_store import _WORKSPACE_ROOT_MODELS
+
+
+@dataclass(frozen=True)
+class MoveResult:
+    """Result of a move-resources operation."""
+
+    names: list[str]
+    row_count: int
+
+
+@dataclass(frozen=True)
+class _ResourceSpec:
+    """Metadata for a movable resource type."""
+
+    model: type
+    name_column: str = "name"
+    tag_model: type | None = None
+    # Column used to join the tag table back to the resource table.
+    # For experiments the tag table joins via experiment_id, not workspace+name.
+    tag_join_column: str | None = None
+    child_tables: tuple[str, ...] = ()
+    child_name_column: str = "name"
+    has_unique_name: bool = True
+
+    @property
+    def table(self) -> sa.Table:
+        return self.model.__table__
+
+    @property
+    def tag_table(self) -> sa.Table | None:
+        return self.tag_model.__table__ if self.tag_model else None
+
+
+# Per-model spec.  Keyed by ORM model class; the CLI resource type is derived
+# from model.__tablename__ (e.g. "experiments", "registered_models").
+# Models in _WORKSPACE_ROOT_MODELS without an entry here are silently skipped;
+# a unit test verifies the omissions are intentional.
+#
+# Gateway resources (secrets, endpoints, model_definitions, budget_policies)
+# are intentionally excluded because they have inter-table FK dependencies
+# that make moving them independently unsafe.  They can be added later with
+# proper dependency-aware handling.
+_SPEC_BY_MODEL: dict[type, _ResourceSpec] = {
+    SqlExperiment: _ResourceSpec(
+        model=SqlExperiment,
+        name_column=SqlExperiment.name.key,
+        tag_model=SqlExperimentTag,
+        tag_join_column=SqlExperimentTag.experiment_id.key,
+    ),
+    SqlRegisteredModel: _ResourceSpec(
+        model=SqlRegisteredModel,
+        name_column=SqlRegisteredModel.name.key,
+        tag_model=SqlRegisteredModelTag,
+        child_tables=tuple(MODEL_CHILD_TABLES),
+    ),
+    SqlEvaluationDataset: _ResourceSpec(
+        model=SqlEvaluationDataset,
+        name_column=SqlEvaluationDataset.name.key,
+        has_unique_name=False,
+    ),
+    SqlWebhook: _ResourceSpec(
+        model=SqlWebhook,
+        name_column=SqlWebhook.name.key,
+        has_unique_name=False,
+    ),
+    SqlJob: _ResourceSpec(
+        model=SqlJob,
+        name_column=SqlJob.job_name.key,
+        has_unique_name=False,
+    ),
+}
+
+_RESOURCE_SPECS: dict[str, _ResourceSpec] = {
+    model.__tablename__: _SPEC_BY_MODEL[model]
+    for model in _WORKSPACE_ROOT_MODELS
+    if model in _SPEC_BY_MODEL
+}
+RESOURCE_TYPE_CHOICES = sorted(_RESOURCE_SPECS)
+
+
+def _tag_names_subquery(
+    spec: _ResourceSpec,
+    source_workspace: str,
+    tags: list[tuple[str, str]],
+) -> sa.Select:
+    """Build a SELECT subquery of resource names matching ALL given tags.
+
+    The intersection logic uses ``GROUP BY … HAVING COUNT`` so the entire
+    resolution stays in SQL and avoids materializing a large parameter list.
+    """
+    table = spec.table
+    tag_table = spec.tag_table
+    unique_tags = list(dict.fromkeys(tags))
+
+    tag_conditions = sa.or_(*[
+        sa.and_(tag_table.c.key == k, tag_table.c.value == v) for k, v in unique_tags
+    ])
+
+    if spec.tag_join_column:
+        # Experiments: tags reference the resource via a surrogate key
+        # (experiment_id), so we JOIN back to the resource table to get
+        # the name and scope by the resource table's workspace column.
+        id_col = spec.tag_join_column
+        name_col = table.c[spec.name_column]
+        subq = (
+            sa
+            .select(name_col)
+            .select_from(table.join(tag_table, table.c[id_col] == tag_table.c[id_col]))
+            .where(table.c.workspace == source_workspace)
+            .where(tag_conditions)
+            .group_by(name_col)
+        )
+    else:
+        # Registered models: the tag table carries workspace + name
+        # directly, so we can query it without joining the parent table.
+        name_col = tag_table.c[spec.name_column]
+        subq = (
+            sa
+            .select(name_col)
+            .where(tag_table.c.workspace == source_workspace)
+            .where(tag_conditions)
+            .group_by(name_col)
+        )
+
+    if len(unique_tags) > 1:
+        subq = subq.having(sa.func.count() == len(unique_tags))
+
+    return subq
+
+
+def _resolve_names(
+    conn,
+    spec: _ResourceSpec,
+    workspace: str,
+    names: list[str] | None = None,
+) -> set[str]:
+    """Return resource names in *workspace*, optionally filtered to *names*."""
+    table = spec.table
+    name_col = table.c[spec.name_column]
+    stmt = sa.select(name_col).where(table.c.workspace == workspace)
+    if names is not None:
+        stmt = stmt.where(name_col.in_(names))
+    return {row[0] for row in conn.execute(stmt).fetchall()}
+
+
+def _find_conflicts(
+    conn,
+    spec: _ResourceSpec,
+    source_workspace: str,
+    target_workspace: str,
+    name_filter: list[str] | sa.Select | None = None,
+) -> list[str]:
+    """Return source resource names that already exist in *target_workspace*.
+
+    *name_filter* can be a ``list`` (literal names), a ``Select`` subquery,
+    or ``None`` (move-all, falls back to a source-workspace subquery).
+    SQLAlchemy's ``in_()`` handles both lists and subqueries transparently.
+    """
+    if not spec.has_unique_name:
+        return []
+    table = spec.table
+    name_col = table.c[spec.name_column]
+    stmt = sa.select(name_col).where(table.c.workspace == target_workspace)
+
+    if name_filter is not None:
+        stmt = stmt.where(name_col.in_(name_filter))
+    else:
+        source_subq = sa.select(name_col).where(table.c.workspace == source_workspace)
+        stmt = stmt.where(name_col.in_(source_subq))
+
+    return [row[0] for row in conn.execute(stmt.order_by(name_col)).fetchall()]
+
+
+def move_resources(
+    engine: sa.Engine,
+    source_workspace: str,
+    target_workspace: str,
+    resource_type: str,
+    names: list[str] | None = None,
+    tags: list[tuple[str, str]] | None = None,
+    dry_run: bool = False,
+    *,
+    verbose: bool = False,
+) -> MoveResult:
+    """
+    Move resources of *resource_type* from *source_workspace* to *target_workspace*.
+
+    Filter by *names* or *tags* (mutually exclusive).  When neither is provided
+    all resources of the type in the source workspace are moved.
+
+    Returns a :class:`MoveResult` with ``names`` (sorted list of distinct
+    resource names that were moved or would be moved) and ``row_count`` (the
+    number of rows in the root resource table that were moved; child-table
+    rows such as model versions or tags are not included in this count).
+    For resource types whose names are not unique, ``row_count`` may exceed
+    ``len(names)`` when multiple rows share the same name.
+    """
+    if source_workspace == target_workspace:
+        raise RuntimeError("Source and target workspaces must be different.")
+
+    spec = _RESOURCE_SPECS.get(resource_type)
+    if spec is None:
+        raise RuntimeError(
+            f"Unknown resource type {resource_type!r}. "
+            f"Valid types: {', '.join(RESOURCE_TYPE_CHOICES)}"
+        )
+
+    if names and tags:
+        raise RuntimeError("--name and --tag are mutually exclusive.")
+
+    if tags and spec.tag_table is None:
+        raise RuntimeError(f"Resource type {resource_type!r} does not support tag filtering.")
+
+    with engine.begin() as conn:
+        validate_workspace_exists(conn, source_workspace)
+        validate_workspace_exists(conn, target_workspace)
+
+        # Fail fast with a clear message if the resource table lacks a
+        # workspace column (DB not migrated to workspace-enabled schema).
+        get_workspace_table(conn, spec.table.name)
+
+        # Build a unified name filter: a SQL subquery (--tag), a small
+        # literal list (--name), or None (move-all).  SQLAlchemy's in_()
+        # handles lists and Select objects identically, so every subsequent
+        # query uses the same one-branch pattern.
+        if tags:
+            name_filter = _tag_names_subquery(spec, source_workspace, tags)
+            matched = {row[0] for row in conn.execute(name_filter).fetchall()}
+        elif names:
+            matched = _resolve_names(conn, spec, source_workspace, names)
+            name_filter = list(matched)
+        else:
+            matched = _resolve_names(conn, spec, source_workspace)
+            name_filter = None
+
+        if not matched:
+            return MoveResult(names=[], row_count=0)
+
+        if conflicts := _find_conflicts(
+            conn, spec, source_workspace, target_workspace, name_filter
+        ):
+            formatted = format_truncated_list(
+                [repr(name) for name in conflicts],
+                max_rows=None if verbose else 10,
+            )
+            raise RuntimeError(
+                f"Move aborted: the following {resource_type} already exist "
+                f"in workspace {target_workspace!r} and would conflict: "
+                f"{formatted}\n"
+                "Rename or remove the conflicting resources in the target "
+                "workspace, then retry."
+            )
+
+        table = spec.table
+        name_col = table.c[spec.name_column]
+
+        def _filtered(stmt, col, _nf=name_filter):
+            return stmt.where(col.in_(_nf)) if _nf is not None else stmt
+
+        row_count = conn.execute(
+            _filtered(
+                sa
+                .select(sa.func.count())
+                .select_from(table)
+                .where(table.c.workspace == source_workspace),
+                name_col,
+            )
+        ).scalar()
+
+        if not dry_run:
+            conn.execute(
+                _filtered(
+                    table
+                    .update()
+                    .where(table.c.workspace == source_workspace)
+                    .values(workspace=target_workspace),
+                    name_col,
+                )
+            )
+
+            # Explicitly update child tables because not all backends honour
+            # ON UPDATE CASCADE (e.g. SQLite without the foreign_keys pragma).
+            for child_table_name in spec.child_tables:
+                child = get_workspace_table(conn, child_table_name)
+                conn.execute(
+                    _filtered(
+                        child
+                        .update()
+                        .where(child.c.workspace == source_workspace)
+                        .values(workspace=target_workspace),
+                        child.c[spec.child_name_column],
+                    )
+                )
+
+    return MoveResult(names=sorted(matched), row_count=row_count)

--- a/mlflow/store/db/workspace_utils.py
+++ b/mlflow/store/db/workspace_utils.py
@@ -1,0 +1,66 @@
+"""Shared helpers for workspace-related database operations.
+
+Used by both ``workspace_migration`` (migrate-to-default-workspace) and
+``workspace_move`` (move-resources).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+# Child tables of registered_models that carry their own workspace column.
+# These must be updated explicitly because not all backends honour
+# ON UPDATE CASCADE at the SQL level (e.g. SQLite without foreign_keys pragma).
+MODEL_CHILD_TABLES = [
+    "model_versions",
+    "registered_model_tags",
+    "model_version_tags",
+    "registered_model_aliases",
+]
+
+
+_NOT_ENABLED_MSG = (
+    "Aborted: the database does not have workspaces enabled. This command "
+    "operates directly on the SQL database used by the default workspace "
+    "provider. Please make sure the specified database URI is correct and "
+    "that workspaces have been enabled via `mlflow db upgrade`."
+)
+
+
+def get_workspace_table(conn, table_name: str) -> sa.Table:
+    """Reflect *table_name* and verify it contains a ``workspace`` column."""
+    try:
+        table = sa.Table(table_name, sa.MetaData(), autoload_with=conn)
+    except sa.exc.NoSuchTableError:
+        raise RuntimeError(f"{_NOT_ENABLED_MSG} (missing table {table_name!r}).")
+    if "workspace" not in table.c:
+        raise RuntimeError(_NOT_ENABLED_MSG)
+    return table
+
+
+def validate_workspace_exists(conn, workspace_name: str) -> None:
+    """Raise ``RuntimeError`` if *workspace_name* is not in the workspaces table."""
+    try:
+        workspaces = sa.Table("workspaces", sa.MetaData(), autoload_with=conn)
+    except sa.exc.NoSuchTableError:
+        raise RuntimeError(_NOT_ENABLED_MSG)
+    exists = conn.execute(
+        sa.select(sa.literal(1)).select_from(workspaces).where(workspaces.c.name == workspace_name)
+    ).first()
+    if not exists:
+        raise RuntimeError(f"Workspace {workspace_name!r} does not exist.")
+
+
+def format_truncated_list(
+    items: list[str],
+    *,
+    max_rows: int | None,
+) -> str:
+    """Format a list of display strings with optional truncation."""
+    rows = items if max_rows is None else items[:max_rows]
+    formatted = "\n  ".join(rows)
+    if formatted:
+        formatted = f"\n  {formatted}"
+    if max_rows is not None and len(items) > max_rows:
+        formatted += f"\n  ... ({len(items) - max_rows} more)"
+    return formatted

--- a/mlflow/store/db_migrations/versions/a5b4c3d2e1f0_add_metrics_run_key_step_index.py
+++ b/mlflow/store/db_migrations/versions/a5b4c3d2e1f0_add_metrics_run_key_step_index.py
@@ -1,0 +1,23 @@
+"""add composite index on metrics (run_uuid, key, step)
+
+Create Date: 2026-03-10 20:46:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a5b4c3d2e1f0"
+down_revision = "c3d6457b6d8a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add composite index to speed up metric history queries that filter by
+    # run_uuid and key, and order by step. See https://github.com/mlflow/mlflow/issues/12813
+    op.create_index("index_metrics_run_uuid_key_step", "metrics", ["run_uuid", "key", "step"])
+
+
+def downgrade():
+    op.drop_index("index_metrics_run_uuid_key_step", table_name="metrics")

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -398,6 +398,7 @@ class SqlMetric(Base):
             "key", "timestamp", "step", "run_uuid", "value", "is_nan", name="metric_pk"
         ),
         Index(f"index_{__tablename__}_run_uuid", "run_uuid"),
+        Index(f"index_{__tablename__}_run_uuid_key_step", "run_uuid", "key", "step"),
     )
 
     key = Column(String(250))

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2284,6 +2284,7 @@ def create_experiment(
     name: str,
     artifact_location: str | None = None,
     tags: dict[str, Any] | None = None,
+    trace_location: UnityCatalog | None = None,
 ) -> str:
     """
     Create an experiment.
@@ -2293,6 +2294,10 @@ def create_experiment(
         artifact_location: The location to store run artifacts. If not provided, the server picks
             an appropriate default.
         tags: An optional dictionary of string keys and values to set as tags on the experiment.
+        trace_location: Optional UC trace location to link to the experiment. Must be an instance
+            of ``mlflow.entities.trace_location.UnityCatalog(...)``. If ``table_prefix`` is not
+            set, it defaults to the experiment ID. Note: call ``mlflow.set_experiment`` afterward
+            to activate the experiment and sync the trace provider.
 
     Returns:
         String ID of the created experiment.
@@ -2328,7 +2333,32 @@ def create_experiment(
         Lifecycle_stage: active
         Creation timestamp: 1662004217511
     """
-    return MlflowClient().create_experiment(name, artifact_location, tags)
+    client = MlflowClient()
+    experiment_id = client.create_experiment(name, artifact_location, tags)
+
+    if trace_location is not None:
+        experiment = client.get_experiment(experiment_id)
+
+        if trace_location.table_prefix is None:
+            trace_location = UnityCatalog(
+                catalog_name=trace_location.catalog_name,
+                schema_name=trace_location.schema_name,
+                table_prefix=experiment_id,
+            )
+
+        try:
+            _resolve_experiment_to_trace_location(
+                experiment=experiment,
+                trace_location=trace_location,
+            )
+        except MlflowException as e:
+            raise MlflowException.invalid_parameter_value(
+                f"Experiment '{name}' (ID: {experiment_id}) was created "
+                f"but linking to trace location '{trace_location.full_table_prefix}' failed: "
+                f"{e.message} Please delete the experiment and retry."
+            ) from e
+
+    return experiment_id
 
 
 def delete_experiment(experiment_id: str) -> None:

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -171,6 +171,12 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
                     "secret": True,
                     "required": True,
                 },
+                {
+                    "name": "aws_region_name",
+                    "description": "AWS Region",
+                    "secret": False,
+                    "required": True,
+                },
             ],
         },
         "access_keys": {
@@ -199,31 +205,14 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
         },
         "iam_role": {
             "display_name": "IAM Role Assumption",
-            "description": "Assume an IAM role using base credentials (for cross-account access)",
+            "description": "Assume an IAM role using the server's ambient credentials "
+            "(instance profile, IRSA, ECS task role, ~/.aws/credentials, etc.)",
             "fields": [
-                {
-                    "name": "aws_access_key_id",
-                    "description": "AWS Access Key ID (for assuming role)",
-                    "secret": True,
-                    "required": True,
-                },
-                {
-                    "name": "aws_secret_access_key",
-                    "description": "AWS Secret Access Key",
-                    "secret": True,
-                    "required": True,
-                },
                 {
                     "name": "aws_role_name",
                     "description": "IAM Role ARN to assume",
                     "secret": False,
                     "required": True,
-                },
-                {
-                    "name": "aws_session_name",
-                    "description": "Session name for assumed role",
-                    "secret": False,
-                    "required": False,
                 },
                 {
                     "name": "aws_region_name",

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -720,6 +720,11 @@ _CORE_PROVIDER_ENV_VARS = {
     "anthropic": "ANTHROPIC_API_KEY",
     "gemini": "GEMINI_API_KEY",
     "mistral": "MISTRAL_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "xai": "XAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "togetherai": "TOGETHERAI_API_KEY",
     "bedrock": {
         "aws_access_key_id": "AWS_ACCESS_KEY_ID",
         "aws_secret_access_key": "AWS_SECRET_ACCESS_KEY",

--- a/tests/db/test_workspace_move.py
+++ b/tests/db/test_workspace_move.py
@@ -1,0 +1,424 @@
+import uuid
+
+import pytest
+
+from mlflow.entities import ExperimentTag
+from mlflow.entities.model_registry import ModelVersionTag, RegisteredModelTag
+from mlflow.entities.workspace import Workspace
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+from mlflow.store.db.workspace_move import _SPEC_BY_MODEL, MoveResult, move_resources
+from mlflow.store.model_registry.sqlalchemy_workspace_store import (
+    WorkspaceAwareSqlAlchemyStore as WorkspaceAwareRegistryStore,
+)
+from mlflow.store.workspace.sqlalchemy_store import (
+    SqlAlchemyStore as WorkspaceStore,
+)
+from mlflow.tracking._tracking_service import utils as tracking_utils
+from mlflow.utils.workspace_context import WorkspaceContext
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+
+@pytest.fixture(autouse=True)
+def _enable_workspaces(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+
+
+@pytest.fixture
+def tracking_store(tmp_path, db_uri, _enable_workspaces):
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    store = tracking_utils._get_sqlalchemy_store(db_uri, artifact_dir.as_uri())
+    try:
+        yield store
+    finally:
+        store._dispose_engine()
+
+
+@pytest.fixture
+def registry_store(db_uri, _enable_workspaces):
+    store = WorkspaceAwareRegistryStore(db_uri)
+    try:
+        yield store
+    finally:
+        store.engine.dispose()
+
+
+@pytest.fixture
+def workspace_store(db_uri, _enable_workspaces):
+    store = WorkspaceStore(db_uri)
+    try:
+        yield store
+    finally:
+        store._engine.dispose()
+
+
+@pytest.fixture
+def engine(tracking_store):
+    return tracking_store.engine
+
+
+def _create_workspace(ws_store, name):
+    ws_store.create_workspace(Workspace(name=name))
+
+
+# ---------------------------------------------------------------------------
+# Experiments
+# ---------------------------------------------------------------------------
+
+
+def test_move_experiments_by_name(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("exp-1")
+        tracking_store.create_experiment("exp-2")
+        tracking_store.create_experiment("exp-3")
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        names=["exp-1", "exp-3"],
+    )
+
+    assert result.names == ["exp-1", "exp-3"]
+    assert result.row_count == 2
+
+    with WorkspaceContext("team-a"):
+        assert tracking_store.get_experiment_by_name("exp-1") is not None
+        assert tracking_store.get_experiment_by_name("exp-3") is not None
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        assert tracking_store.get_experiment_by_name("exp-2") is not None
+        assert tracking_store.get_experiment_by_name("exp-1") is None
+
+
+def test_move_experiment_by_tag(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        exp_id_1 = tracking_store.create_experiment("exp-1")
+        tracking_store.create_experiment("exp-2")
+        tracking_store.set_experiment_tag(exp_id_1, ExperimentTag("team", "team-a"))
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        tags=[("team", "team-a")],
+    )
+
+    assert result.names == ["exp-1"]
+    assert result.row_count == 1
+
+
+def test_error_name_and_tag_mutually_exclusive(workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with pytest.raises(RuntimeError, match="mutually exclusive"):
+        move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace="team-a",
+            resource_type="experiments",
+            names=["exp-1"],
+            tags=[("team", "team-a")],
+        )
+
+
+def test_move_experiment_by_multiple_tags_and(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        exp_id_1 = tracking_store.create_experiment("exp-1")
+        exp_id_2 = tracking_store.create_experiment("exp-2")
+        tracking_store.set_experiment_tag(exp_id_1, ExperimentTag("team", "team-a"))
+        tracking_store.set_experiment_tag(exp_id_1, ExperimentTag("env", "prod"))
+        tracking_store.set_experiment_tag(exp_id_2, ExperimentTag("team", "team-a"))
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        tags=[("team", "team-a"), ("env", "prod")],
+    )
+
+    assert result.names == ["exp-1"]
+    assert result.row_count == 1
+
+
+def test_move_all_experiments_no_filter(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("exp-1")
+        tracking_store.create_experiment("exp-2")
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+    )
+
+    assert len(result.names) >= 2
+    assert "exp-1" in result.names
+    assert "exp-2" in result.names
+    assert result.row_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# Registered models
+# ---------------------------------------------------------------------------
+
+
+def test_move_model_by_tag(registry_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        registry_store.create_registered_model("model-1")
+        registry_store.create_registered_model("model-2")
+        registry_store.set_registered_model_tag("model-1", RegisteredModelTag("team", "team-a"))
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="registered_models",
+        tags=[("team", "team-a")],
+    )
+
+    assert result.names == ["model-1"]
+    assert result.row_count == 1
+
+    with WorkspaceContext("team-a"):
+        assert registry_store.get_registered_model("model-1") is not None
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        assert registry_store.get_registered_model("model-2") is not None
+
+
+def test_move_model_cascades_to_child_tables(registry_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        registry_store.create_registered_model("model-1")
+        mv1 = registry_store.create_model_version(
+            "model-1", "s3://bucket/v1", run_id=uuid.uuid4().hex
+        )
+        registry_store.create_model_version("model-1", "s3://bucket/v2", run_id=uuid.uuid4().hex)
+        registry_store.set_registered_model_tag("model-1", RegisteredModelTag("stage", "prod"))
+        registry_store.set_registered_model_alias("model-1", "champion", str(mv1.version))
+        registry_store.set_model_version_tag(
+            "model-1", str(mv1.version), ModelVersionTag("metric", "0.95")
+        )
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="registered_models",
+        names=["model-1"],
+    )
+
+    assert result.names == ["model-1"]
+    assert result.row_count == 1
+
+    with WorkspaceContext("team-a"):
+        rm = registry_store.get_registered_model("model-1")
+        assert rm.tags == {"stage": "prod"}
+        assert rm.aliases == {"champion": mv1.version}
+
+        versions = registry_store.search_model_versions(filter_string="name='model-1'")
+        assert len(versions) == 2
+
+        mv = registry_store.get_model_version("model-1", str(mv1.version))
+        assert mv.tags == {"metric": "0.95"}
+
+
+# ---------------------------------------------------------------------------
+# Conflict detection, dry run, and error handling
+# ---------------------------------------------------------------------------
+
+
+def test_conflict_detection(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("dup-exp")
+    with WorkspaceContext("team-a"):
+        tracking_store.create_experiment("dup-exp")
+
+    with pytest.raises(RuntimeError, match="already exist in workspace"):
+        move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace="team-a",
+            resource_type="experiments",
+            names=["dup-exp"],
+        )
+
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        assert tracking_store.get_experiment_by_name("dup-exp") is not None
+
+
+def test_dry_run_does_not_modify(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("exp-1")
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        names=["exp-1"],
+        dry_run=True,
+    )
+
+    assert result.names == ["exp-1"]
+    assert result.row_count == 1
+
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        assert tracking_store.get_experiment_by_name("exp-1") is not None
+
+
+def test_validation_errors(engine):
+    with pytest.raises(RuntimeError, match="does not exist"):
+        move_resources(
+            engine,
+            source_workspace="nonexistent",
+            target_workspace=DEFAULT_WORKSPACE_NAME,
+            resource_type="experiments",
+        )
+
+    with pytest.raises(RuntimeError, match="does not exist"):
+        move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace="nonexistent",
+            resource_type="experiments",
+        )
+
+    with pytest.raises(RuntimeError, match="must be different"):
+        move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace=DEFAULT_WORKSPACE_NAME,
+            resource_type="experiments",
+        )
+
+
+def test_error_tag_on_unsupported_resource_type(workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with pytest.raises(RuntimeError, match="does not support tag filtering"):
+        move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace="team-a",
+            resource_type="webhooks",
+            tags=[("team", "team-a")],
+        )
+
+
+def test_noop_when_nothing_matches(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("exp-1")
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        names=["nonexistent"],
+    )
+    assert result == MoveResult(names=[], row_count=0)
+
+    result = move_resources(
+        engine,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        tags=[("team", "nonexistent")],
+    )
+    assert result == MoveResult(names=[], row_count=0)
+
+
+# ---------------------------------------------------------------------------
+# All resource types
+# ---------------------------------------------------------------------------
+
+
+def test_move_all_resource_types(
+    tracking_store, registry_store, workspace_store, engine, monkeypatch
+):
+    from mlflow.entities.webhook import WebhookAction, WebhookEntity, WebhookEvent
+    from mlflow.store.jobs.sqlalchemy_workspace_store import (
+        WorkspaceAwareSqlAlchemyJobStore,
+    )
+
+    monkeypatch.setattr(
+        "mlflow.store.model_registry.sqlalchemy_store._validate_webhook_url", lambda url: None
+    )
+    _create_workspace(workspace_store, "target")
+    job_store = WorkspaceAwareSqlAlchemyJobStore(str(engine.url))
+
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        tracking_store.create_experiment("move-exp")
+        tracking_store.create_dataset("move-ds")
+        registry_store.create_registered_model("move-model")
+        registry_store.create_webhook(
+            name="move-webhook",
+            url="https://example.com/hook",
+            events=[WebhookEvent(WebhookEntity.MODEL_VERSION, WebhookAction.CREATED)],
+        )
+        job_store.create_job(job_name="move-job", params="{}")
+
+    resource_names = {
+        "experiments": "move-exp",
+        "evaluation_datasets": "move-ds",
+        "registered_models": "move-model",
+        "webhooks": "move-webhook",
+        "jobs": "move-job",
+    }
+
+    for resource_type, name in resource_names.items():
+        result = move_resources(
+            engine,
+            source_workspace=DEFAULT_WORKSPACE_NAME,
+            target_workspace="target",
+            resource_type=resource_type,
+            names=[name],
+        )
+        assert name in result.names, f"Expected {name!r} in moved list for {resource_type}"
+        assert result.row_count >= 1, f"Expected row_count >= 1 for {resource_type}"
+
+
+# ---------------------------------------------------------------------------
+# Spec coverage
+# ---------------------------------------------------------------------------
+
+
+def test_all_workspace_root_models_have_spec():
+    from mlflow.store.tracking.dbmodels.models import (
+        SqlGatewayBudgetPolicy,
+        SqlGatewayEndpoint,
+        SqlGatewayModelDefinition,
+        SqlGatewaySecret,
+    )
+    from mlflow.store.workspace.sqlalchemy_store import _WORKSPACE_ROOT_MODELS
+
+    # Gateway resources are intentionally excluded due to inter-table FK
+    # dependencies that make moving them independently unsafe.
+    _INTENTIONALLY_OMITTED = {
+        SqlGatewaySecret,
+        SqlGatewayEndpoint,
+        SqlGatewayModelDefinition,
+        SqlGatewayBudgetPolicy,
+    }
+
+    missing = {
+        model.__name__
+        for model in _WORKSPACE_ROOT_MODELS
+        if model not in _SPEC_BY_MODEL and model not in _INTENTIONALLY_OMITTED
+    }
+    assert not missing, (
+        f"These models are in _WORKSPACE_ROOT_MODELS but have no entry in "
+        f"_SPEC_BY_MODEL (mlflow/store/db/workspace_move.py): {sorted(missing)}. "
+        f"Add a _ResourceSpec so move-resources can handle them, or add "
+        f"to _INTENTIONALLY_OMITTED if they cannot be moved independently."
+    )

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -1,3 +1,4 @@
+import io
 from unittest import mock
 
 import pytest
@@ -11,7 +12,7 @@ from mlflow.gateway.config import (
     EndpointConfig,
 )
 from mlflow.gateway.providers.bedrock import AmazonBedrockModelProvider, AmazonBedrockProvider
-from mlflow.gateway.schemas import completions
+from mlflow.gateway.schemas import chat, completions, embeddings
 
 from tests.gateway.providers.test_anthropic import (
     completions_response as anthropic_completions_response,
@@ -420,3 +421,144 @@ async def test_bedrock_request_response(
 def test_amazon_bedrock_model_provider(model_name, expected):
     provider = AmazonBedrockModelProvider.of_str(model_name)
     assert provider == expected
+
+
+# ---- Converse API tests ----
+
+
+def _make_converse_provider():
+    """Create a provider with a mock boto3 client for Converse API tests."""
+
+    config = {
+        "name": "chat",
+        "endpoint_type": "llm/v1/chat",
+        "model": {
+            "provider": "bedrock",
+            "name": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "config": {"aws_config": {"aws_region": "us-east-1"}},
+        },
+    }
+    return AmazonBedrockProvider(EndpointConfig(**config))
+
+
+def _converse_response():
+    return {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Hello from Bedrock!"}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {
+            "inputTokens": 10,
+            "outputTokens": 20,
+            "totalTokens": 30,
+        },
+    }
+
+
+def _converse_stream_response():
+    return {
+        "stream": iter([
+            {"contentBlockDelta": {"delta": {"text": "Hello"}}},
+            {"contentBlockDelta": {"delta": {"text": " from Bedrock!"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30}}},
+        ])
+    }
+
+
+def _embeddings_invoke_response():
+    body = io.BytesIO(b'{"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 5}')
+    return {"body": body}
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_chat():
+
+    provider = _make_converse_provider()
+    mock_client = mock.Mock()
+    mock_client.converse.return_value = _converse_response()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["choices"][0]["message"]["content"] == "Hello from Bedrock!"
+    assert result["choices"][0]["message"]["role"] == "assistant"
+    assert result["usage"]["prompt_tokens"] == 10
+    assert result["usage"]["completion_tokens"] == 20
+    mock_client.converse.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_chat_stream():
+
+    provider = _make_converse_provider()
+    mock_client = mock.Mock()
+    mock_client.converse_stream.return_value = _converse_stream_response()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        chunks = [jsonable_encoder(chunk) async for chunk in provider.chat_stream(payload)]
+
+    # Should have: 2 text deltas + 1 stop + 1 usage
+    assert len(chunks) == 4
+    assert chunks[0]["choices"][0]["delta"]["content"] == "Hello"
+    assert chunks[1]["choices"][0]["delta"]["content"] == " from Bedrock!"
+    assert chunks[2]["choices"][0]["finish_reason"] == "stop"
+    assert chunks[3]["usage"]["prompt_tokens"] == 10
+    mock_client.converse_stream.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_embeddings():
+
+    config = {
+        "name": "embeddings",
+        "endpoint_type": "llm/v1/embeddings",
+        "model": {
+            "provider": "bedrock",
+            "name": "amazon.titan-embed-text-v1",
+            "config": {"aws_config": {"aws_region": "us-east-1"}},
+        },
+    }
+    provider = AmazonBedrockProvider(EndpointConfig(**config))
+    mock_client = mock.Mock()
+    mock_client.invoke_model.return_value = _embeddings_invoke_response()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = embeddings.RequestPayload(input="Test text")
+        response = await provider.embeddings(payload)
+
+    result = jsonable_encoder(response)
+    assert result["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+    assert result["usage"]["prompt_tokens"] == 5
+    mock_client.invoke_model.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_with_system_message():
+
+    provider = _make_converse_provider()
+    mock_client = mock.Mock()
+    mock_client.converse.return_value = _converse_response()
+
+    with mock.patch.object(provider, "get_bedrock_client", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[
+                {"role": "system", "content": "You are helpful"},
+                {"role": "user", "content": "Hello"},
+            ],
+        )
+        await provider.chat(payload)
+
+    call_kwargs = mock_client.converse.call_args.kwargs
+    assert call_kwargs["system"] == [{"text": "You are helpful"}]
+    assert len(call_kwargs["messages"]) == 1  # only user message

--- a/tests/genai/discovery/test_utils.py
+++ b/tests/genai/discovery/test_utils.py
@@ -27,8 +27,9 @@ from mlflow.genai.discovery.utils import (
     group_traces_by_session,
     log_discovery_artifacts,
 )
-from mlflow.genai.utils.gateway_utils import GatewayLiteLLMConfig
+from mlflow.genai.utils.gateway_utils import GatewayConfig, GatewayLiteLLMConfig
 from mlflow.genai.utils.trace_utils import _extract_trace_timing_info
+from mlflow.metrics.genai.model_utils import _get_provider_instance
 from mlflow.types.chat import ChatChoice, ChatCompletionResponse, ChatMessage, ChatUsage
 
 
@@ -602,3 +603,74 @@ def test_call_llm_tracks_tokens():
         assert counter.input_tokens == 100
         assert counter.output_tokens == 50
         assert counter.cost_usd == 0.01
+
+
+# ---- gateway:/ URI via _get_provider_instance ----
+
+
+def test_call_llm_via_gateway_dispatches_gateway_uri_without_litellm():
+    mock_provider = mock.MagicMock()
+    mock_provider.adapter_class.chat_to_model.side_effect = lambda payload, config: payload
+    mock_provider.get_endpoint_url.return_value = (
+        "http://localhost:5000/gateway/mlflow/v1/chat/completions"
+    )
+    mock_provider.headers = {"Authorization": "Bearer token"}
+
+    raw_response = {
+        "id": "chatcmpl-gw",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": "my-endpoint",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "gateway response"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    mock_chat_response = mock.MagicMock()
+    mock_chat_response.choices = [
+        mock.MagicMock(message=mock.MagicMock(content="gateway response"))
+    ]
+    mock_chat_response.usage = mock.MagicMock(prompt_tokens=10, completion_tokens=5)
+    mock_provider.adapter_class.model_to_chat.return_value = mock_chat_response
+
+    with (
+        mock.patch("mlflow.genai.discovery.utils._is_litellm_available", return_value=False),
+        mock.patch(
+            "mlflow.metrics.genai.model_utils._get_provider_instance",
+            return_value=mock_provider,
+        ) as mock_get_provider,
+        mock.patch(
+            "mlflow.metrics.genai.model_utils._send_request",
+            return_value=raw_response,
+        ) as mock_send,
+    ):
+        messages = [{"role": "user", "content": "test"}]
+        result = _call_llm("gateway:/my-endpoint", messages)
+
+    mock_get_provider.assert_called_once_with("gateway", "my-endpoint")
+    mock_send.assert_called_once()
+    assert result.choices[0].message.content == "gateway response"
+
+
+def test_get_mlflow_gateway_provider():
+    gateway_config = GatewayConfig(
+        api_base="http://localhost:5000/gateway/mlflow/v1/",
+        endpoint_name="chat",
+        extra_headers={"X-Custom": "header"},
+    )
+
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils.get_gateway_config",
+        return_value=gateway_config,
+    ) as mock_get_config:
+        provider = _get_provider_instance("gateway", "chat")
+
+    mock_get_config.assert_called_once_with("chat")
+    assert provider.get_endpoint_url("llm/v1/chat").endswith("/chat/completions")
+    assert provider.headers == {"X-Custom": "header"}
+    assert provider.config.model.name == "chat"

--- a/tests/genai/judges/adapters/test_base_adapter.py
+++ b/tests/genai/judges/adapters/test_base_adapter.py
@@ -1,0 +1,204 @@
+"""Tests for BaseJudgeAdapter template method and telemetry injection.
+
+Uses a minimal FakeAdapter stub so these tests are adapter-agnostic —
+they verify the base class behavior without coupling to any specific
+adapter implementation.
+"""
+
+from unittest import mock
+
+import pytest
+
+from mlflow.entities.assessment import Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.adapters.base_adapter import (
+    AdapterInvocationInput,
+    AdapterInvocationOutput,
+    BaseJudgeAdapter,
+    DatabricksTelemetryRecorder,
+    JudgeTelemetryRecorder,
+)
+
+
+class FakeAdapter(BaseJudgeAdapter):
+    """Minimal adapter stub for testing the base class template method."""
+
+    def __init__(self, result=None, error=None, **kwargs):
+        super().__init__(**kwargs)
+        self._result = result
+        self._error = error
+
+    @classmethod
+    def is_applicable(cls, model_uri, prompt):
+        return True
+
+    def _invoke(self, input_params):
+        if self._error:
+            raise self._error
+        return self._result
+
+
+def _make_input(model_uri="openai:/gpt-4"):
+    return AdapterInvocationInput(
+        model_uri=model_uri,
+        prompt="test prompt",
+        assessment_name="test_metric",
+    )
+
+
+def _make_output(value="yes", request_id=None, prompt_tokens=None, completion_tokens=None):
+    return AdapterInvocationOutput(
+        feedback=Feedback(
+            name="test_metric",
+            value=value,
+            rationale="Good",
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE,
+                source_id="openai:/gpt-4",
+            ),
+        ),
+        request_id=request_id,
+        num_prompt_tokens=prompt_tokens,
+        num_completion_tokens=completion_tokens,
+    )
+
+
+# --- Protocol conformance ---
+
+
+def test_databricks_telemetry_recorder_satisfies_protocol():
+    assert isinstance(DatabricksTelemetryRecorder(), JudgeTelemetryRecorder)
+
+
+# --- Template method: success path ---
+
+
+def test_invoke_calls_invoke_and_returns_output():
+    output = _make_output()
+    adapter = FakeAdapter(result=output)
+    result = adapter.invoke(_make_input())
+    assert result is output
+    assert result.feedback.value == "yes"
+
+
+def test_telemetry_recorder_called_on_success():
+    recorder = mock.Mock()
+    output = _make_output(request_id="req-1", prompt_tokens=10, completion_tokens=5)
+    adapter = FakeAdapter(result=output, telemetry=recorder)
+    input_params = _make_input()
+
+    result = adapter.invoke(input_params)
+
+    recorder.record_success.assert_called_once_with(input_params, result)
+    recorder.record_failure.assert_not_called()
+
+
+def test_no_telemetry_when_recorder_is_none():
+    output = _make_output()
+    adapter = FakeAdapter(result=output)  # no telemetry
+    result = adapter.invoke(_make_input())
+    assert result.feedback.value == "yes"
+
+
+def test_telemetry_success_error_does_not_break_invoke():
+    recorder = mock.Mock()
+    recorder.record_success.side_effect = Exception("Telemetry failed")
+    output = _make_output()
+    adapter = FakeAdapter(result=output, telemetry=recorder)
+
+    result = adapter.invoke(_make_input())
+
+    assert result.feedback.value == "yes"
+    recorder.record_success.assert_called_once()
+
+
+# --- Template method: failure path ---
+
+
+def test_telemetry_recorder_called_on_failure():
+    recorder = mock.Mock()
+    error = MlflowException("Model error", error_code="INTERNAL_ERROR")
+    adapter = FakeAdapter(error=error, telemetry=recorder)
+    input_params = _make_input()
+
+    with pytest.raises(MlflowException, match="Model error"):
+        adapter.invoke(input_params)
+
+    recorder.record_failure.assert_called_once_with(input_params, error)
+    recorder.record_success.assert_not_called()
+
+
+def test_no_failure_telemetry_when_recorder_is_none():
+    error = MlflowException("Model error")
+    adapter = FakeAdapter(error=error)  # no telemetry
+
+    with pytest.raises(MlflowException, match="Model error"):
+        adapter.invoke(_make_input())
+
+
+def test_telemetry_failure_error_does_not_suppress_exception():
+    recorder = mock.Mock()
+    recorder.record_failure.side_effect = Exception("Telemetry failed")
+    adapter = FakeAdapter(
+        error=MlflowException("Model error"),
+        telemetry=recorder,
+    )
+
+    with pytest.raises(MlflowException, match="Model error"):
+        adapter.invoke(_make_input())
+
+    recorder.record_failure.assert_called_once()
+
+
+def test_non_mlflow_exception_skips_failure_telemetry():
+    recorder = mock.Mock()
+    adapter = FakeAdapter(error=KeyError("result"), telemetry=recorder)
+
+    with pytest.raises(KeyError, match="result"):
+        adapter.invoke(_make_input())
+
+    recorder.record_failure.assert_not_called()
+    recorder.record_success.assert_not_called()
+
+
+# --- DatabricksTelemetryRecorder ---
+
+
+def test_databricks_recorder_success_calls_telemetry_util():
+    recorder = DatabricksTelemetryRecorder()
+    input_params = _make_input("databricks:/test-model")
+    output = _make_output(request_id="req-1", prompt_tokens=10, completion_tokens=5)
+
+    with mock.patch(
+        "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_success_databricks_telemetry"
+    ) as mock_telemetry:
+        recorder.record_success(input_params, output)
+
+    mock_telemetry.assert_called_once_with(
+        request_id="req-1",
+        model_provider="databricks",
+        endpoint_name="test-model",
+        num_prompt_tokens=10,
+        num_completion_tokens=5,
+    )
+
+
+def test_databricks_recorder_failure_calls_telemetry_util():
+    recorder = DatabricksTelemetryRecorder()
+    from mlflow.protos.databricks_pb2 import BAD_REQUEST
+
+    input_params = _make_input("endpoints:/my-endpoint")
+    error = MlflowException("Bad request", error_code=BAD_REQUEST)
+
+    with mock.patch(
+        "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_failure_databricks_telemetry"
+    ) as mock_telemetry:
+        recorder.record_failure(input_params, error)
+
+    mock_telemetry.assert_called_once_with(
+        model_provider="endpoints",
+        endpoint_name="my-endpoint",
+        error_code="BAD_REQUEST",
+        error_message=str(error),
+    )

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -937,3 +937,33 @@ def test_proactive_pruning_triggers_during_tool_loop(mock_trace):
 
     mock_prune.assert_called_once()
     assert json.loads(output.response) == {"result": "yes"}
+
+
+# --- Output field population tests ---
+
+
+def test_invoke_with_tools_populates_output_fields(mock_trace):
+    adapter = GatewayAdapter()
+    mock_output = InvokeOutput(
+        response=json.dumps({"result": "yes", "rationale": "Looks good"}),
+        request_id="req-123",
+        num_prompt_tokens=10,
+        num_completion_tokens=5,
+    )
+
+    input_params = AdapterInvocationInput(
+        model_uri="openai:/gpt-4",
+        prompt=[ChatMessage(role="user", content="evaluate this")],
+        assessment_name="test_metric",
+        trace=mock_trace,
+    )
+
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.GatewayAdapter._invoke_and_handle_tools",
+        return_value=mock_output,
+    ):
+        result = adapter.invoke(input_params)
+
+    assert result.request_id == "req-123"
+    assert result.num_prompt_tokens == 10
+    assert result.num_completion_tokens == 5

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -9,19 +9,23 @@ from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_location import TraceLocation
 from mlflow.entities.trace_state import TraceState
 from mlflow.exceptions import MlflowException
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.openai import OpenAIConfig
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleAdapter
 from mlflow.genai.judges.adapters.base_adapter import AdapterInvocationInput
 from mlflow.genai.judges.adapters.gateway_adapter import (
     GatewayAdapter,
     InvokeOutput,
     _build_request,
     _get_max_context_tokens,
-    _get_mlflow_gateway_provider,
-    _get_provider,
+    _invoke_via_gateway,
     _parse_response_message,
     _should_proactively_prune,
 )
 from mlflow.genai.judges.adapters.utils import ChatCompletionError, is_context_window_error
 from mlflow.genai.judges.utils.tool_calling_utils import _remove_oldest_tool_call_pair
+from mlflow.genai.utils.gateway_utils import GatewayConfig
+from mlflow.metrics.genai.model_utils import _get_provider_instance, _MlflowGatewayProvider
 from mlflow.types.llm import ChatMessage
 
 
@@ -52,8 +56,6 @@ def _chat_response(content, tool_calls=None, usage=None):
 
 
 def _mock_provider(endpoint_url="https://api.openai.com/v1/chat/completions", headers=None):
-    from mlflow.gateway.providers.openai_compatible import OpenAICompatibleAdapter
-
     provider = mock.MagicMock()
     provider.get_endpoint_url.return_value = endpoint_url
     provider.headers = headers or {}
@@ -251,31 +253,22 @@ def test_endpoints_rejects_trace(mock_trace):
 # --- _invoke_via_gateway with gateway:/ URI tests ---
 
 
-def _mock_gateway_config(api_base="http://localhost:5000/gateway/mlflow/v1/", extra_headers=None):
-    from mlflow.genai.utils.gateway_utils import GatewayConfig
-
-    return GatewayConfig(
-        api_base=api_base,
-        endpoint_name="my-endpoint",
-        extra_headers=extra_headers,
-    )
+def _gateway_chat_response(content):
+    return {
+        "id": "chatcmpl-gw",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "my-endpoint",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": content}}],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
 
 
 def test_invoke_via_gateway_string_prompt():
-    from mlflow.genai.judges.adapters.gateway_adapter import _invoke_via_gateway
-
-    response_json = {"choices": [{"message": {"content": '{"result": "yes", "rationale": "ok"}'}}]}
-
-    with (
-        mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.get_gateway_config",
-            return_value=_mock_gateway_config(),
-        ),
-        mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.send_chat_request",
-            return_value=response_json,
-        ) as mock_send,
-    ):
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+        return_value='{"result": "yes", "rationale": "ok"}',
+    ) as mock_score:
         result = _invoke_via_gateway(
             model_uri="gateway:/my-endpoint",
             provider="gateway",
@@ -283,17 +276,11 @@ def test_invoke_via_gateway_string_prompt():
         )
 
     assert '{"result": "yes"' in result
-    call_kwargs = mock_send.call_args[1]
-    # String prompt should be wrapped in a message
-    assert call_kwargs["payload"]["messages"] == [{"role": "user", "content": "Is this helpful?"}]
-    # Model should be endpoint name, not litellm format
-    assert call_kwargs["payload"]["model"] == "my-endpoint"
+    mock_score.assert_called_once()
+    assert mock_score.call_args[1]["payload"] == "Is this helpful?"
 
 
 def test_invoke_via_gateway_list_prompt():
-    from mlflow.genai.judges.adapters.gateway_adapter import _invoke_via_gateway
-
-    response_json = {"choices": [{"message": {"content": '{"result": "no", "rationale": "bad"}'}}]}
     messages = [
         {"role": "system", "content": "You are a judge"},
         {"role": "user", "content": "test"},
@@ -301,12 +288,12 @@ def test_invoke_via_gateway_list_prompt():
 
     with (
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.get_gateway_config",
-            return_value=_mock_gateway_config(),
+            "mlflow.metrics.genai.model_utils._get_provider_instance",
+            return_value=_mock_provider(),
         ),
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.send_chat_request",
-            return_value=response_json,
+            "mlflow.metrics.genai.model_utils._send_request",
+            return_value=_gateway_chat_response('{"result": "no", "rationale": "bad"}'),
         ) as mock_send,
     ):
         _invoke_via_gateway(
@@ -316,52 +303,25 @@ def test_invoke_via_gateway_list_prompt():
         )
 
     call_kwargs = mock_send.call_args[1]
-    assert call_kwargs["payload"]["messages"] == messages
-    assert call_kwargs["payload"]["model"] == "my-endpoint"
-
-
-def test_invoke_via_gateway_sets_caller_header():
-    from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER, GatewayCaller
-    from mlflow.genai.judges.adapters.gateway_adapter import _invoke_via_gateway
-
-    response_json = {"choices": [{"message": {"content": "ok"}}]}
-
-    with (
-        mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.get_gateway_config",
-            return_value=_mock_gateway_config(),
-        ),
-        mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.send_chat_request",
-            return_value=response_json,
-        ) as mock_send,
-    ):
-        _invoke_via_gateway(model_uri="gateway:/my-endpoint", provider="gateway", prompt="test")
-
-    call_kwargs = mock_send.call_args[1]
-    assert MLFLOW_GATEWAY_CALLER_HEADER in call_kwargs["headers"]
-    assert call_kwargs["headers"][MLFLOW_GATEWAY_CALLER_HEADER] == GatewayCaller.JUDGE.value
+    assert call_kwargs["payload"]["model"] == "gpt-4"
+    assert any(m["content"] == "test" for m in call_kwargs["payload"]["messages"])
 
 
 def test_invoke_via_gateway_with_inference_params():
-    from mlflow.genai.judges.adapters.gateway_adapter import _invoke_via_gateway
-
-    response_json = {"choices": [{"message": {"content": "ok"}}]}
-
     with (
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.get_gateway_config",
-            return_value=_mock_gateway_config(),
+            "mlflow.metrics.genai.model_utils._get_provider_instance",
+            return_value=_mock_provider(),
         ),
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.send_chat_request",
-            return_value=response_json,
+            "mlflow.metrics.genai.model_utils._send_request",
+            return_value=_gateway_chat_response("ok"),
         ) as mock_send,
     ):
         _invoke_via_gateway(
             model_uri="gateway:/my-endpoint",
             provider="gateway",
-            prompt="test",
+            prompt=[{"role": "user", "content": "test"}],
             inference_params={"temperature": 0.5},
         )
 
@@ -370,24 +330,24 @@ def test_invoke_via_gateway_with_inference_params():
 
 
 def test_invoke_via_gateway_endpoint_url():
-    from mlflow.genai.judges.adapters.gateway_adapter import _invoke_via_gateway
-
-    response_json = {"choices": [{"message": {"content": "ok"}}]}
-
-    with (
-        mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.get_gateway_config",
-            return_value=_mock_gateway_config(api_base="http://myserver:8080/gateway/v1/"),
-        ),
-        mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.send_chat_request",
-            return_value=response_json,
-        ) as mock_send,
-    ):
-        _invoke_via_gateway(model_uri="gateway:/my-endpoint", provider="gateway", prompt="test")
-
-    call_kwargs = mock_send.call_args[1]
-    assert call_kwargs["endpoint"] == "http://myserver:8080/gateway/v1/chat/completions"
+    gw_config = GatewayConfig(
+        api_base="http://myserver:8080/gateway/v1/",
+        endpoint_name="my-endpoint",
+        extra_headers=None,
+    )
+    openai_config = OpenAIConfig(
+        openai_api_key="mlflow-gateway-auth",
+        openai_api_base=gw_config.api_base.rstrip("/"),
+    )
+    route_config = EndpointConfig(
+        name="gateway",
+        endpoint_type="llm/v1/chat",
+        model={"provider": "openai", "name": "my-endpoint", "config": openai_config.model_dump()},
+    )
+    provider = _MlflowGatewayProvider(route_config)
+    assert provider.get_endpoint_url("llm/v1/chat") == (
+        "http://myserver:8080/gateway/v1/chat/completions"
+    )
 
 
 # --- _build_request tests ---
@@ -472,7 +432,7 @@ def test_parse_response_empty_choices_raises():
 
 def test_parse_anthropic_response_with_tool_calls(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-    provider = _get_provider("anthropic", "claude-3-5-sonnet")
+    provider = _get_provider_instance("anthropic", "claude-3-5-sonnet")
 
     anthropic_response = {
         "id": "msg_123",
@@ -502,7 +462,7 @@ def test_parse_anthropic_response_with_tool_calls(monkeypatch):
 
 def test_parse_anthropic_response_text_only(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-    provider = _get_provider("anthropic", "claude-3-5-sonnet")
+    provider = _get_provider_instance("anthropic", "claude-3-5-sonnet")
 
     anthropic_response = {
         "id": "msg_456",
@@ -589,7 +549,7 @@ def test_non_context_error():
 
 def test_get_provider_delegates_to_get_provider_instance(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    provider = _get_provider("openai", "gpt-4")
+    provider = _get_provider_instance("openai", "gpt-4")
     assert provider.adapter_class is not None
     assert provider.config is not None
     assert provider.config.model.name == "gpt-4"
@@ -600,28 +560,26 @@ def test_get_provider_delegates_to_get_provider_instance(monkeypatch):
 
 def test_get_provider_anthropic(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-    provider = _get_provider("anthropic", "claude-3-5-sonnet")
+    provider = _get_provider_instance("anthropic", "claude-3-5-sonnet")
     assert provider.config.model.name == "claude-3-5-sonnet"
     assert "anthropic.com" in provider.get_endpoint_url("llm/v1/chat")
 
 
-def test_get_mlflow_gateway_provider():
+def test_get_provider_instance_gateway():
     mock_config = mock.MagicMock()
     mock_config.api_base = "http://localhost:5000/gateway/mlflow/v1/"
-    mock_config.extra_headers = None
+    mock_config.extra_headers = {"X-Auth": "token"}
 
     with mock.patch(
-        "mlflow.genai.judges.adapters.gateway_adapter.get_gateway_config",
+        "mlflow.metrics.genai.model_utils.get_gateway_config",
         return_value=mock_config,
     ):
-        provider = _get_mlflow_gateway_provider("my-endpoint")
+        provider = _get_provider_instance("gateway", "my-endpoint")
 
-    assert (
-        provider.get_endpoint_url("llm/v1/chat")
-        == "http://localhost:5000/gateway/mlflow/v1/chat/completions"
-    )
+    assert "chat/completions" in provider.get_endpoint_url("llm/v1/chat")
     assert provider.config is not None
     assert provider.config.model.name == "my-endpoint"
+    assert provider.headers == {"X-Auth": "token"}
     payload = provider.adapter_class.chat_to_model(
         {"messages": [{"role": "user", "content": "hi"}]}, provider.config
     )
@@ -630,7 +588,7 @@ def test_get_mlflow_gateway_provider():
 
 def test_get_provider_unsupported_raises():
     with pytest.raises(MlflowException, match="not supported"):
-        _get_provider("cohere", "command-r")
+        _get_provider_instance("nonexistent-provider", "some-model")
 
 
 # --- _invoke_and_handle_tools tests ---
@@ -641,7 +599,7 @@ def test_single_shot_no_tools():
 
     with (
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter._get_provider",
+            "mlflow.genai.judges.adapters.gateway_adapter._get_provider_instance",
             return_value=_mock_provider(),
         ),
         mock.patch(
@@ -679,7 +637,7 @@ def test_tool_calling_loop(mock_trace):
 
     with (
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter._get_provider",
+            "mlflow.genai.judges.adapters.gateway_adapter._get_provider_instance",
             return_value=_mock_provider(),
         ),
         mock.patch(
@@ -740,7 +698,7 @@ def test_context_window_error_triggers_pruning(mock_trace):
 
     with (
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter._get_provider",
+            "mlflow.genai.judges.adapters.gateway_adapter._get_provider_instance",
             return_value=_mock_provider(),
         ),
         mock.patch(
@@ -776,7 +734,7 @@ def test_max_iterations_exceeded(mock_trace, monkeypatch):
 
     with (
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter._get_provider",
+            "mlflow.genai.judges.adapters.gateway_adapter._get_provider_instance",
             return_value=_mock_provider(),
         ),
         mock.patch(
@@ -818,7 +776,7 @@ def test_response_format_fallback():
 
     with (
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter._get_provider",
+            "mlflow.genai.judges.adapters.gateway_adapter._get_provider_instance",
             return_value=_mock_provider(),
         ),
         mock.patch(
@@ -844,7 +802,7 @@ def test_custom_base_url_overrides_provider():
 
     with (
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter._get_provider",
+            "mlflow.genai.judges.adapters.gateway_adapter._get_provider_instance",
             return_value=_mock_provider(),
         ),
         mock.patch(
@@ -949,7 +907,7 @@ def test_proactive_pruning_triggers_during_tool_loop(mock_trace):
 
     with (
         mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter._get_provider",
+            "mlflow.genai.judges.adapters.gateway_adapter._get_provider_instance",
             return_value=_mock_provider(),
         ),
         mock.patch(

--- a/tests/genai/judges/adapters/test_utils.py
+++ b/tests/genai/judges/adapters/test_utils.py
@@ -113,3 +113,26 @@ def test_get_adapter_unsupported_without_litellm(
             MlflowException, match=f"No suitable adapter found for model_uri='{model_uri}'"
         ):
             get_adapter(model_uri, prompt)
+
+
+# --- Telemetry injection ---
+
+
+@pytest.mark.parametrize("model_uri", ["databricks:/test-model", "endpoints:/my-endpoint"])
+def test_get_adapter_injects_telemetry_for_databricks(model_uri):
+    from mlflow.genai.judges.adapters.base_adapter import DatabricksTelemetryRecorder
+
+    adapter = get_adapter(model_uri=model_uri, prompt="test")
+    assert isinstance(adapter._telemetry, DatabricksTelemetryRecorder)
+
+
+@pytest.mark.parametrize("model_uri", ["openai:/gpt-4", "anthropic:/claude-3"])
+def test_get_adapter_no_telemetry_for_non_databricks(model_uri):
+    adapter = get_adapter(model_uri=model_uri, prompt="test")
+    assert adapter._telemetry is None
+
+
+def test_get_adapter_no_telemetry_for_bare_databricks():
+    adapter = get_adapter(model_uri="databricks", prompt="test")
+    assert isinstance(adapter, DatabricksManagedJudgeAdapter)
+    assert adapter._telemetry is None

--- a/tests/genai/judges/utils/test_invocation_utils.py
+++ b/tests/genai/judges/utils/test_invocation_utils.py
@@ -992,7 +992,7 @@ def test_invoke_judge_model_databricks_failure_telemetry(model_uri: str, expecte
             ),
         ),
         mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._record_judge_model_usage_failure_databricks_telemetry"
+            "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_failure_databricks_telemetry"
         ) as mock_failure_telemetry,
     ):
         with pytest.raises(MlflowException, match="Rate limit exceeded"):
@@ -1048,7 +1048,7 @@ def test_invoke_judge_model_databricks_success_telemetry(
     with (
         mock.patch("litellm.completion", return_value=mock_response),
         mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._record_judge_model_usage_success_databricks_telemetry"
+            "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_success_databricks_telemetry"
         ) as mock_success_telemetry,
     ):
         feedback = invoke_judge_model(
@@ -1085,7 +1085,7 @@ def test_invoke_judge_model_databricks_telemetry_error_handling(
     with (
         mock.patch("litellm.completion", return_value=mock_response),
         mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._record_judge_model_usage_success_databricks_telemetry",
+            "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_success_databricks_telemetry",
             side_effect=Exception("Telemetry failed"),
         ) as mock_success_telemetry,
     ):
@@ -1121,10 +1121,10 @@ def test_invoke_judge_model_non_databricks_no_telemetry(model_uri: str, mock_res
     with (
         mock.patch("litellm.completion", return_value=mock_response),
         mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._record_judge_model_usage_success_databricks_telemetry"
+            "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_success_databricks_telemetry"
         ) as mock_success_telemetry,
         mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._record_judge_model_usage_failure_databricks_telemetry"
+            "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_failure_databricks_telemetry"
         ) as mock_failure_telemetry,
     ):
         feedback = invoke_judge_model(

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -700,6 +700,129 @@ def test_score_model_caches_unsupported_output_config(monkeypatch):
     _MODELS_WITHOUT_OUTPUT_CONFIG.discard(("anthropic", model_name))
 
 
+@pytest.mark.parametrize(
+    ("provider", "env_var", "api_key", "expected_endpoint"),
+    [
+        ("groq", "GROQ_API_KEY", "groq-key", "https://api.groq.com/openai/v1/chat/completions"),
+        (
+            "deepseek",
+            "DEEPSEEK_API_KEY",
+            "ds-key",
+            "https://api.deepseek.com/v1/chat/completions",
+        ),
+        ("xai", "XAI_API_KEY", "xai-key", "https://api.x.ai/v1/chat/completions"),
+        (
+            "openrouter",
+            "OPENROUTER_API_KEY",
+            "or-key",
+            "https://openrouter.ai/api/v1/chat/completions",
+        ),
+    ],
+)
+def test_score_model_openai_compatible_providers(
+    monkeypatch, provider, env_var, api_key, expected_endpoint
+):
+    monkeypatch.setenv(env_var, api_key)
+
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_request:
+        response = score_model_on_payload(
+            model_uri=f"{provider}:/some-model",
+            payload="input prompt",
+        )
+
+    assert response == "\n\nThis is a test!"
+    mock_request.assert_called_once_with(
+        endpoint=expected_endpoint,
+        headers={"Authorization": f"Bearer {api_key}"},
+        payload={
+            "model": "some-model",
+            "messages": [{"role": "user", "content": "input prompt"}],
+        },
+    )
+
+
+def test_score_model_ollama(monkeypatch):
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_request:
+        response = score_model_on_payload(
+            model_uri="ollama:/llama3",
+            payload="input prompt",
+        )
+
+    assert response == "\n\nThis is a test!"
+    # Ollama runs locally; no auth header is sent when using the default "ollama" key
+    mock_request.assert_called_once_with(
+        endpoint="http://localhost:11434/v1/chat/completions",
+        headers={},
+        payload={
+            "model": "llama3",
+            "messages": [{"role": "user", "content": "input prompt"}],
+        },
+    )
+
+
+def test_score_model_databricks(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://my-workspace.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-test-token")
+
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+    ) as mock_request:
+        response = score_model_on_payload(
+            model_uri="databricks:/databricks-meta-llama-3-3-70b-instruct",
+            payload="input prompt",
+        )
+
+    assert response == "\n\nThis is a test!"
+    call_kwargs = mock_request.call_args[1]
+    assert (
+        "serving-endpoints/databricks-meta-llama-3-3-70b-instruct/invocations"
+        in call_kwargs["endpoint"]
+    )
+
+
+def test_score_model_vertex_ai(monkeypatch):
+    monkeypatch.setenv("VERTEX_PROJECT", "my-gcp-project")
+    monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+
+    # VertexAI response uses Gemini format (content list), not OpenAI format
+    vertex_resp = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "\n\nThis is a test!"}], "role": "model"},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {"promptTokenCount": 5, "candidatesTokenCount": 7},
+    }
+
+    mock_token = mock.MagicMock()
+    mock_token.token = "fake-gcp-token"
+    mock_token.valid = True
+
+    with (
+        mock.patch(
+            "mlflow.gateway.providers.vertex_ai.VertexAIProvider._get_credentials",
+            return_value=mock_token,
+        ),
+        mock.patch(
+            "mlflow.metrics.genai.model_utils._send_request", return_value=vertex_resp
+        ) as mock_request,
+    ):
+        response = score_model_on_payload(
+            model_uri="vertex_ai:/gemini-2.0-flash",
+            payload="input prompt",
+        )
+
+    assert response == "\n\nThis is a test!"
+    call_kwargs = mock_request.call_args[1]
+    assert "my-gcp-project" in call_kwargs["endpoint"]
+    assert "gemini-2.0-flash" in call_kwargs["endpoint"]
+
+
 def test_score_model_does_not_retry_on_other_400_errors(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
 

--- a/tests/store/tracking/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/test_sqlalchemy_store_schema.py
@@ -147,6 +147,38 @@ def test_create_index_on_run_uuid(tmp_path, db_url):
         assert run_uuid_index_names.issubset(all_index_names)
 
 
+def test_create_index_on_metrics_run_uuid_key_step_via_migration(tmp_path, db_url):
+    # Test that the index is created when upgrading from initial schema via migrations
+    engine = sqlalchemy.create_engine(db_url)
+    InitialBase.metadata.create_all(engine)
+    invoke_cli_runner(mlflow.db.commands, ["upgrade", db_url])
+    with sqlite3.connect(db_url[len("sqlite:///") :]) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type = 'index'")
+        all_index_names = [r[0] for r in cursor.fetchall()]
+        assert "index_metrics_run_uuid_key_step" in all_index_names
+
+        cursor.execute("PRAGMA index_info('index_metrics_run_uuid_key_step')")
+        columns = [row[2] for row in cursor.fetchall()]
+        assert columns == ["run_uuid", "key", "step"]
+
+
+def test_create_index_on_metrics_run_uuid_key_step(tmp_path, db_url):
+    # Test for
+    # mlflow/store/db_migrations/versions/a5b4c3d2e1f0_add_metrics_run_key_step_index.py
+    SqlAlchemyStore(db_url, tmp_path.joinpath("ARTIFACTS").as_uri())
+    with sqlite3.connect(db_url[len("sqlite:///") :]) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type = 'index'")
+        all_index_names = [r[0] for r in cursor.fetchall()]
+        assert "index_metrics_run_uuid_key_step" in all_index_names
+
+        # Verify the index columns and order
+        cursor.execute("PRAGMA index_info('index_metrics_run_uuid_key_step')")
+        columns = [row[2] for row in cursor.fetchall()]
+        assert columns == ["run_uuid", "key", "step"]
+
+
 def test_index_for_dataset_tables(tmp_path, db_url):
     # Test for
     # mlflow/store/db_migrations/versions/7f2a7d5fae7d_add_datasets_inputs_input_tags_tables.py

--- a/tests/tracking/fluent/test_create_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_create_experiment_trace_location.py
@@ -1,0 +1,141 @@
+from unittest import mock
+
+import pytest
+
+import mlflow
+import mlflow.tracking.fluent as fluent_module
+from mlflow.entities import Experiment
+from mlflow.entities.experiment_tag import ExperimentTag
+from mlflow.entities.trace_location import UnityCatalog
+from mlflow.exceptions import MlflowException
+
+
+def _experiment(experiment_id="789"):
+    return Experiment(
+        experiment_id=experiment_id,
+        name="test-experiment",
+        artifact_location="file:/tmp",
+        lifecycle_stage="active",
+        tags=[ExperimentTag("key", "val")],
+    )
+
+
+def test_without_trace_location_unchanged():
+    with mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls:
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "789"
+
+        assert mlflow.create_experiment("my-exp", tags={"k": "v"}) == "789"
+        client.create_experiment.assert_called_once_with("my-exp", None, {"k": "v"})
+        client.get_experiment.assert_not_called()
+
+
+def test_defaults_empty_prefix_to_experiment_id():
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ) as mock_resolve,
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "789"
+        client.get_experiment.return_value = _experiment()
+
+        original = UnityCatalog("catalog", "schema")
+        mlflow.create_experiment("my-exp", trace_location=original)
+
+        passed_location = mock_resolve.call_args.kwargs["trace_location"]
+        assert passed_location.table_prefix == "789"
+        assert original.table_prefix is None
+
+
+def test_explicit_prefix_preserved():
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ) as mock_resolve,
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "789"
+        client.get_experiment.return_value = _experiment()
+
+        mlflow.create_experiment(
+            "my-exp",
+            trace_location=UnityCatalog("catalog", "schema", "custom_prefix"),
+        )
+
+        assert mock_resolve.call_args.kwargs["trace_location"].table_prefix == "custom_prefix"
+
+
+def test_resolve_receives_experiment_object():
+    exp = _experiment()
+
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ) as mock_resolve,
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "789"
+        client.get_experiment.return_value = exp
+
+        result = mlflow.create_experiment(
+            "my-exp",
+            trace_location=UnityCatalog("catalog", "schema", "pfx"),
+        )
+
+        assert result == "789"
+        assert mock_resolve.call_args.kwargs["experiment"] is exp
+
+
+def test_does_not_sync_provider_or_set_active():
+    original_active = fluent_module._active_experiment_id
+
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            return_value=None,
+        ),
+        mock.patch(
+            "mlflow.tracking.fluent._sync_trace_destination_and_provider",
+        ) as mock_sync,
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "789"
+        client.get_experiment.return_value = _experiment()
+
+        mlflow.create_experiment(
+            "my-exp",
+            trace_location=UnityCatalog("catalog", "schema", "pfx"),
+        )
+
+        mock_sync.assert_not_called()
+        assert fluent_module._active_experiment_id == original_active
+
+
+def test_link_failure_includes_retry_guidance():
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            side_effect=MlflowException("backend error"),
+        ),
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "456"
+        client.get_experiment.return_value = _experiment(experiment_id="456")
+
+        with pytest.raises(MlflowException, match="delete the experiment and retry") as exc_info:
+            mlflow.create_experiment(
+                "new-exp",
+                trace_location=UnityCatalog("cat", "sch", "pfx"),
+            )
+
+        assert "was created" in exc_info.value.message
+        assert "backend error" in exc_info.value.message


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22148

### What changes are proposed in this pull request?

Refactors judge adapter telemetry using the template method + dependency injection pattern (matching `BaseProvider` in `mlflow/gateway`).

- `BaseJudgeAdapter` now owns the `invoke()` skeleton: calls `_invoke()` (subclass extension point), then records success/failure telemetry via an optional `JudgeTelemetryRecorder` injected at construction.
- Adapters implement `_invoke()` with pure business logic — no telemetry code.
- `DatabricksTelemetryRecorder` implements the recorder protocol for `databricks`/`endpoints` providers.
- `get_adapter()` factory injects the recorder based on `model_uri`.
- Adapters now populate `AdapterInvocationOutput.request_id` and token count fields so the recorder has data to work with.

This is a prerequisite for the adapter reorder PR (Gateway-first over LiteLLM) — ensures telemetry is handled at the base class level so changing adapter priority doesn't silently lose telemetry.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New `test_base_adapter.py` (11 tests) covers:
- Template method success/failure paths with mock recorder
- `DatabricksTelemetryRecorder` correctness
- Telemetry errors don't break invocation
- Non-`MlflowException` errors skip failure telemetry
- Protocol conformance

Factory injection tests added to `test_utils.py`:
- `databricks:/` and `endpoints:/` URIs get telemetry injected
- Other providers get `None`
- Bare `"databricks"` URI (DatabricksManagedJudgeAdapter) gets `None`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.