### PR TITLE
Reorder judge adapters: Gateway before LiteLLM

### DIFF
--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -13,7 +13,7 @@ from mlflow.gateway.config import EndpointConfig, EndpointType
 from mlflow.gateway.providers.base import BaseProvider, PassthroughAction, ProviderAdapter
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat, embeddings
-from mlflow.gateway.utils import stream_sse_data
+from mlflow.gateway.utils import parse_sse_lines, stream_sse_data
 
 
 class OpenAICompatibleAdapter(ProviderAdapter):
@@ -304,8 +304,6 @@ class OpenAICompatibleProvider(BaseProvider):
         )
 
     def _extract_streaming_token_usage(self, chunk: bytes) -> dict[str, int]:
-        from mlflow.gateway.utils import parse_sse_lines
-
         for data in parse_sse_lines(chunk):
             if chat_usage := data.get("usage"):
                 if token_usage := self._extract_token_usage_from_dict(

--- a/mlflow/genai/judges/adapters/base_adapter.py
+++ b/mlflow/genai/judges/adapters/base_adapter.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
 
 from mlflow.entities.assessment import Feedback
 from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.utils.telemetry_utils import (
+    _record_judge_model_usage_failure_databricks_telemetry,
+    _record_judge_model_usage_success_databricks_telemetry,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -116,10 +120,6 @@ class DatabricksTelemetryRecorder:
         input_params: AdapterInvocationInput,
         output: AdapterInvocationOutput,
     ) -> None:
-        from mlflow.genai.judges.utils.telemetry_utils import (
-            _record_judge_model_usage_success_databricks_telemetry,
-        )
-
         _record_judge_model_usage_success_databricks_telemetry(
             request_id=output.request_id,
             model_provider=input_params.model_provider,
@@ -133,10 +133,6 @@ class DatabricksTelemetryRecorder:
         input_params: AdapterInvocationInput,
         error: MlflowException,
     ) -> None:
-        from mlflow.genai.judges.utils.telemetry_utils import (
-            _record_judge_model_usage_failure_databricks_telemetry,
-        )
-
         _record_judge_model_usage_failure_databricks_telemetry(
             model_provider=input_params.model_provider,
             endpoint_name=input_params.model_name,

--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -328,7 +328,7 @@ def _invoke_via_gateway(
 
 
 class GatewayAdapter(BaseJudgeAdapter):
-    """Adapter for native AI Gateway providers (fallback when LiteLLM is not available)."""
+    """Adapter for native AI Gateway providers."""
 
     @classmethod
     def is_applicable(

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -38,7 +38,7 @@ from mlflow.genai.judges.utils.tool_calling_utils import (
     _remove_oldest_tool_call_pair,
 )
 from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
-from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
+from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, INVALID_PARAMETER_VALUE
 from mlflow.tracing.constant import AssessmentMetadataKey
 
 _logger = logging.getLogger(__name__)
@@ -556,7 +556,6 @@ class LiteLLMAdapter(BaseJudgeAdapter):
         return _is_litellm_available()
 
     def _invoke(self, input_params: AdapterInvocationInput) -> AdapterInvocationOutput:
-        from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
         from mlflow.types.llm import ChatMessage
 
         messages = (

--- a/mlflow/genai/judges/adapters/utils.py
+++ b/mlflow/genai/judges/adapters/utils.py
@@ -16,6 +16,7 @@ from mlflow.gateway.constants import (
     MLFLOW_GATEWAY_CLIENT_QUERY_RETRY_CODES,
     MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS,
 )
+from mlflow.metrics.genai.model_utils import _parse_model_uri
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, INTERNAL_ERROR
 
 _DATABRICKS_PROVIDERS = {"databricks", "endpoints"}
@@ -60,9 +61,6 @@ def get_adapter(
         if provider in _DATABRICKS_PROVIDERS:
             telemetry = DatabricksTelemetryRecorder()
 
-    # TODO: Reorder to [Databricks, Gateway, LiteLLM] to prioritize native
-    # providers over litellm. Requires migrating ~50 tests that mock
-    # litellm.completion to mock at the gateway HTTP level instead.
     adapters = [
         DatabricksManagedJudgeAdapter,
         LiteLLMAdapter,

--- a/mlflow/genai/judges/adapters/utils.py
+++ b/mlflow/genai/judges/adapters/utils.py
@@ -16,7 +16,6 @@ from mlflow.gateway.constants import (
     MLFLOW_GATEWAY_CLIENT_QUERY_RETRY_CODES,
     MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS,
 )
-from mlflow.metrics.genai.model_utils import _parse_model_uri
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, INTERNAL_ERROR
 
 _DATABRICKS_PROVIDERS = {"databricks", "endpoints"}
@@ -63,8 +62,8 @@ def get_adapter(
 
     adapters = [
         DatabricksManagedJudgeAdapter,
-        LiteLLMAdapter,
         GatewayAdapter,
+        LiteLLMAdapter,
     ]
 
     for adapter_class in adapters:

--- a/mlflow/genai/judges/utils/invocation_utils.py
+++ b/mlflow/genai/judges/utils/invocation_utils.py
@@ -53,8 +53,8 @@ def invoke_judge_model(
     Routes to the appropriate adapter based on the model URI and configuration.
     Uses a factory pattern to select the correct adapter:
     - DatabricksManagedJudgeAdapter: For the default Databricks judge
-    - LiteLLMAdapter: For LiteLLM-supported providers (including Databricks served models)
-    - GatewayAdapter: Fallback for native providers
+    - GatewayAdapter: For native AI Gateway providers
+    - LiteLLMAdapter: Fallback for providers not supported by the gateway
 
     Args:
         model_uri: The model URI.
@@ -226,36 +226,6 @@ def get_chat_completions_with_structured_output(
     # Handle Databricks default judge model
     if model_uri == _DATABRICKS_DEFAULT_JUDGE_MODEL:
         return _invoke_databricks_structured_output(messages, output_schema, trace)
-
-    # TODO: When adapter order is changed to Gateway-first, update this to match.
-    # Currently uses litellm-first to match get_adapter() priority, falling back
-    # to GatewayAdapter when litellm is unavailable.
-    from mlflow.genai.judges.adapters.litellm_adapter import (
-        _invoke_litellm_and_handle_tools,
-        _is_litellm_available,
-    )
-    from mlflow.metrics.genai.model_utils import _parse_model_uri
-
-    model_provider, model_name = _parse_model_uri(model_uri)
-
-    if _is_litellm_available():
-        output = _invoke_litellm_and_handle_tools(
-            provider=model_provider,
-            model_name=model_name,
-            messages=messages,
-            trace=trace,
-            num_retries=num_retries,
-            response_format=output_schema,
-            inference_params=inference_params,
-        )
-        cleaned_response = _strip_markdown_code_blocks(output.response)
-        try:
-            response_dict = json.loads(cleaned_response)
-        except json.JSONDecodeError as e:
-            raise MlflowException(
-                f"Failed to parse response from judge model. Response: {output.response}",
-            ) from e
-        return output_schema(**response_dict)
 
     from mlflow.genai.judges.adapters.gateway_adapter import GatewayAdapter
 

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -6,8 +6,9 @@ import requests
 from pydantic import BaseModel
 
 from mlflow.exceptions import MlflowException
-from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.config import EndpointConfig, Provider
 from mlflow.gateway.providers.openai import OpenAIConfig, OpenAIProvider
+from mlflow.gateway.schemas import chat
 from mlflow.genai.utils.gateway_utils import get_gateway_config
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
@@ -198,9 +199,6 @@ def _call_llm_provider_api(
             Mutually exclusive with ``input_data``.
         response_format: Response format dict (e.g. from ``_pydantic_to_response_format``).
     """
-    from mlflow.gateway.config import Provider
-    from mlflow.gateway.schemas import chat
-
     if (input_data is None) == (messages is None):
         raise MlflowException.invalid_parameter_value(
             "Exactly one of input_data or messages must be provided."
@@ -301,8 +299,6 @@ class _MlflowGatewayProvider(OpenAIProvider):
 
 def _get_provider_instance(provider: str, model: str) -> "BaseProvider":
     """Get the provider instance for the given provider name and the model name."""
-    from mlflow.gateway.config import Provider
-
     def _get_route_config(config):
         return EndpointConfig(
             name=provider,

--- a/tests/genai/judges/adapters/test_base_adapter.py
+++ b/tests/genai/judges/adapters/test_base_adapter.py
@@ -171,7 +171,7 @@ def test_databricks_recorder_success_calls_telemetry_util():
     output = _make_output(request_id="req-1", prompt_tokens=10, completion_tokens=5)
 
     with mock.patch(
-        "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_success_databricks_telemetry"
+        "mlflow.genai.judges.adapters.base_adapter._record_judge_model_usage_success_databricks_telemetry"
     ) as mock_telemetry:
         recorder.record_success(input_params, output)
 
@@ -192,7 +192,7 @@ def test_databricks_recorder_failure_calls_telemetry_util():
     error = MlflowException("Bad request", error_code=BAD_REQUEST)
 
     with mock.patch(
-        "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_failure_databricks_telemetry"
+        "mlflow.genai.judges.adapters.base_adapter._record_judge_model_usage_failure_databricks_telemetry"
     ) as mock_telemetry:
         recorder.record_failure(input_params, error)
 

--- a/tests/genai/judges/adapters/test_utils.py
+++ b/tests/genai/judges/adapters/test_utils.py
@@ -56,18 +56,19 @@ def test_get_adapter_without_litellm(
 @pytest.mark.parametrize(
     ("model_uri", "prompt_type", "expected_adapter"),
     [
-        # Databricks adapters (take priority over litellm)
+        # Databricks managed judge (takes top priority)
         (_DATABRICKS_DEFAULT_JUDGE_MODEL, "string", DatabricksManagedJudgeAdapter),
         (_DATABRICKS_DEFAULT_JUDGE_MODEL, "list", DatabricksManagedJudgeAdapter),
-        ("databricks:/my-endpoint", "string", LiteLLMAdapter),
-        ("databricks:/my-endpoint", "list", LiteLLMAdapter),
-        ("endpoints:/my-endpoint", "string", LiteLLMAdapter),
+        # Gateway adapter (takes priority over LiteLLM for supported providers)
+        ("databricks:/my-endpoint", "string", GatewayAdapter),
+        ("databricks:/my-endpoint", "list", GatewayAdapter),
+        ("endpoints:/my-endpoint", "string", GatewayAdapter),
+        # endpoints + list: Gateway rejects, falls through to LiteLLM
         ("endpoints:/my-endpoint", "list", LiteLLMAdapter),
-        # LiteLLM adapter (takes priority when available)
-        ("openai:/gpt-4", "string", LiteLLMAdapter),
-        ("openai:/gpt-4", "list", LiteLLMAdapter),
-        ("anthropic:/claude-3-5-sonnet-20241022", "string", LiteLLMAdapter),
-        ("anthropic:/claude-3-5-sonnet-20241022", "list", LiteLLMAdapter),
+        ("openai:/gpt-4", "string", GatewayAdapter),
+        ("openai:/gpt-4", "list", GatewayAdapter),
+        ("anthropic:/claude-3-5-sonnet-20241022", "string", GatewayAdapter),
+        ("anthropic:/claude-3-5-sonnet-20241022", "list", GatewayAdapter),
     ],
 )
 def test_get_adapter_with_litellm(
@@ -82,23 +83,14 @@ def test_get_adapter_with_litellm(
         assert isinstance(adapter, expected_adapter)
 
 
-def test_get_adapter_gateway_with_list(list_prompt):
-    with mock.patch(
-        "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available",
-        return_value=False,
-    ):
-        adapter = get_adapter("openai:/gpt-4", list_prompt)
-        assert isinstance(adapter, GatewayAdapter)
-
-
 @pytest.mark.parametrize(
     ("model_uri", "prompt_type"),
     [
-        # endpoints with list prompt is not supported by any adapter
-        ("endpoints:/my-endpoint", "list"),
         # Completely unknown providers
         ("unknown_provider:/some-model", "string"),
         ("unknown_provider:/some-model", "list"),
+        # endpoints with list prompt — Gateway rejects, LiteLLM not available
+        ("endpoints:/my-endpoint", "list"),
     ],
 )
 def test_get_adapter_unsupported_without_litellm(

--- a/tests/genai/judges/test_builtin.py
+++ b/tests/genai/judges/test_builtin.py
@@ -2,7 +2,6 @@ import json
 from unittest import mock
 
 import pytest
-from litellm.types.utils import ModelResponse
 
 from mlflow.entities.assessment import (
     AssessmentError,
@@ -217,14 +216,20 @@ def test_builtin_scorer_handles_numeric_boolean_values():
             assert result.value == expected
 
 
+def _mock_score(mock_content):
+    return mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+        return_value=mock_content,
+    )
+
+
 def test_meets_guidelines_oss():
     mock_content = json.dumps({
         "result": "yes",
         "rationale": "Let's think step by step. The response is correct.",
     })
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
+    with _mock_score(mock_content) as mock_score:
         feedback = judges.meets_guidelines(
             guidelines="The response must be in English.",
             context={"request": "What is the capital of France?", "response": "Paris"},
@@ -236,11 +241,10 @@ def test_meets_guidelines_oss():
     assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
     assert feedback.source.source_id == "openai:/gpt-4.1-mini"
 
-    assert mock_litellm.call_count == 1
-    kwargs = mock_litellm.call_args.kwargs
-    assert kwargs["model"] == "openai/gpt-4.1-mini"
-    assert kwargs["messages"][0]["role"] == "user"
-    prompt = kwargs["messages"][0]["content"]
+    mock_score.assert_called_once()
+    kwargs = mock_score.call_args.kwargs
+    assert kwargs["model_uri"] == "openai:/gpt-4.1-mini"
+    prompt = kwargs["payload"]
     assert prompt.startswith("Given the following set of guidelines and some inputs")
     assert "What is the capital of France?" in prompt
 
@@ -250,9 +254,8 @@ def test_is_context_relevant_oss():
         "result": "yes",
         "rationale": "Let's think step by step. The answer is relevant to the question.",
     })
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
+    with _mock_score(mock_content) as mock_score:
         feedback = judges.is_context_relevant(
             request="What is the capital of France?",
             context="Paris is the capital of France.",
@@ -264,11 +267,8 @@ def test_is_context_relevant_oss():
     assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
     assert feedback.source.source_id == "openai:/gpt-4.1-mini"
 
-    assert mock_litellm.call_count == 1
-    kwargs = mock_litellm.call_args.kwargs
-    assert kwargs["model"] == "openai/gpt-4.1-mini"
-    assert kwargs["messages"][0]["role"] == "user"
-    prompt = kwargs["messages"][0]["content"]
+    mock_score.assert_called_once()
+    prompt = mock_score.call_args.kwargs["payload"]
     assert "Consider the following question and answer" in prompt
     assert "What is the capital of France?" in prompt
     assert "Paris is the capital of France." in prompt
@@ -279,9 +279,8 @@ def test_is_correct_oss():
         "result": "yes",
         "rationale": "Let's think step by step. The response is correct.",
     })
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
+    with _mock_score(mock_content) as mock_score:
         feedback = judges.is_correct(
             request="What is the capital of France?",
             response="Paris is the capital of France.",
@@ -294,11 +293,8 @@ def test_is_correct_oss():
     assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
     assert feedback.source.source_id == "openai:/gpt-4.1-mini"
 
-    assert mock_litellm.call_count == 1
-    kwargs = mock_litellm.call_args.kwargs
-    assert kwargs["model"] == "openai/gpt-4.1-mini"
-    assert kwargs["messages"][0]["role"] == "user"
-    prompt = kwargs["messages"][0]["content"]
+    mock_score.assert_called_once()
+    prompt = mock_score.call_args.kwargs["payload"]
     assert "Consider the following question, claim and document" in prompt
     assert "What is the capital of France?" in prompt
     assert "Paris is the capital of France." in prompt
@@ -323,9 +319,8 @@ def test_is_context_sufficient_oss():
         "result": "yes",
         "rationale": "Let's think step by step. The context is sufficient.",
     })
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
+    with _mock_score(mock_content) as mock_score:
         feedback = judges.is_context_sufficient(
             request="What is the capital of France?",
             context=[
@@ -341,11 +336,8 @@ def test_is_context_sufficient_oss():
     assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
     assert feedback.source.source_id == "openai:/gpt-4.1-mini"
 
-    assert mock_litellm.call_count == 1
-    kwargs = mock_litellm.call_args.kwargs
-    assert kwargs["model"] == "openai/gpt-4.1-mini"
-    assert kwargs["messages"][0]["role"] == "user"
-    prompt = kwargs["messages"][0]["content"]
+    mock_score.assert_called_once()
+    prompt = mock_score.call_args.kwargs["payload"]
     assert "Consider the following claim and document" in prompt
     assert "What is the capital of France?" in prompt
     assert "Paris is the capital of France." in prompt
@@ -356,9 +348,8 @@ def test_is_grounded_oss():
         "result": "yes",
         "rationale": "Let's think step by step. The response is grounded.",
     })
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
+    with _mock_score(mock_content) as mock_score:
         feedback = judges.is_grounded(
             request="What is the capital of France?",
             response="Paris",
@@ -374,11 +365,8 @@ def test_is_grounded_oss():
     assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
     assert feedback.source.source_id == "openai:/gpt-4.1-mini"
 
-    assert mock_litellm.call_count == 1
-    kwargs = mock_litellm.call_args.kwargs
-    assert kwargs["model"] == "openai/gpt-4.1-mini"
-    assert kwargs["messages"][0]["role"] == "user"
-    prompt = kwargs["messages"][0]["content"]
+    mock_score.assert_called_once()
+    prompt = mock_score.call_args.kwargs["payload"]
     assert "Consider the following claim and document" in prompt
     assert "What is the capital of France?" in prompt
     assert "Paris" in prompt

--- a/tests/genai/judges/test_custom_prompt_judge.py
+++ b/tests/genai/judges/test_custom_prompt_judge.py
@@ -2,13 +2,19 @@ import json
 from unittest import mock
 
 import pytest
-from litellm.types.utils import ModelResponse
 
 from mlflow.entities.assessment import AssessmentError
 from mlflow.entities.assessment_source import AssessmentSourceType
 from mlflow.genai.judges.custom_prompt_judge import _remove_choice_brackets, custom_prompt_judge
 
 from tests.genai.conftest import databricks_only
+
+
+def _mock_score(return_value):
+    return mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+        return_value=return_value,
+    )
 
 
 def test_custom_prompt_judge_basic():
@@ -23,13 +29,12 @@ def test_custom_prompt_judge_basic():
     """
 
     mock_content = json.dumps({"result": "good", "rationale": "The response is well-written."})
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
     judge = custom_prompt_judge(
         name="quality", prompt_template=prompt_template, model="openai:/gpt-4"
     )
 
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
+    with _mock_score(mock_content) as mock_score:
         feedback = judge(request="Test request", response="This is a great response!")
 
     assert feedback.name == "quality"
@@ -38,10 +43,10 @@ def test_custom_prompt_judge_basic():
     assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
     assert feedback.source.source_id == "custom_prompt_judge_quality"
 
-    mock_litellm.assert_called_once()
-    kwargs = mock_litellm.call_args[1]
-    assert kwargs["model"] == "openai/gpt-4"
-    prompt = kwargs["messages"][0]["content"]
+    mock_score.assert_called_once()
+    kwargs = mock_score.call_args.kwargs
+    assert kwargs["model_uri"] == "openai:/gpt-4"
+    prompt = kwargs["payload"]
     assert prompt.startswith("Evaluate the response.")
     assert "<request>Test request</request>" in prompt
     assert "good: The response is good." in prompt
@@ -80,7 +85,6 @@ def test_custom_prompt_judge_with_numeric_values():
     numeric_values = {"excellent": 5.0, "great": 4.0, "good": 3.0, "not_good": 2.0, "poor": 1.0}
 
     mock_content = json.dumps({"result": "good", "rationale": "Decent response."})
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
     judge = custom_prompt_judge(
         name="rating",
@@ -88,7 +92,7 @@ def test_custom_prompt_judge_with_numeric_values():
         numeric_values=numeric_values,
     )
 
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
+    with _mock_score(mock_content) as mock_score:
         feedback = judge(response="This is okay.")
 
     assert feedback.name == "rating"
@@ -96,10 +100,10 @@ def test_custom_prompt_judge_with_numeric_values():
     assert feedback.metadata == {"string_value": "good"}
     assert feedback.rationale == "Decent response."
 
-    mock_litellm.assert_called_once()
-    kwargs = mock_litellm.call_args[1]
-    assert kwargs["model"] == "openai/gpt-4.1-mini"
-    prompt = kwargs["messages"][0]["content"]
+    mock_score.assert_called_once()
+    kwargs = mock_score.call_args.kwargs
+    assert kwargs["model_uri"] == "openai:/gpt-4.1-mini"
+    prompt = kwargs["payload"]
     assert prompt.startswith("Rate the response.")
     assert '"rationale": "Reason for the decision.' in prompt
 
@@ -135,7 +139,10 @@ def test_custom_prompt_judge_llm_error():
     [[bad]]: Bad
     """
 
-    with mock.patch("litellm.completion", side_effect=Exception("API Error")):
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+        side_effect=Exception("API Error"),
+    ):
         judge = custom_prompt_judge(name="test", prompt_template=prompt_template)
 
         feedback = judge(response="Test")
@@ -143,7 +150,7 @@ def test_custom_prompt_judge_llm_error():
     assert feedback.name == "test"
     assert feedback.value is None
     assert isinstance(feedback.error, AssessmentError)
-    assert "Failed to invoke the judge via litellm" in feedback.error.error_message
+    assert "API Error" in feedback.error.error_message
 
 
 @pytest.mark.parametrize(

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -7,7 +7,6 @@ from typing import Any, Literal
 from unittest import mock
 from unittest.mock import patch
 
-import litellm
 import pandas as pd
 import pydantic
 import pytest
@@ -2397,76 +2396,52 @@ def test_mixed_trace_and_fields_template_comprehensive(mock_invoke_judge_model):
     assert "{{ trace }}" in prompt[0].content
 
 
-@pytest.mark.parametrize(
-    "exception",
-    [
-        litellm.ContextWindowExceededError("Context exceeded", "gpt-4", "openai"),
-        litellm.BadRequestError("maximum context length is exceeded", "gpt-4", "openai"),
-    ],
-)
-def test_context_window_error_removes_tool_calls_and_retries(exception, monkeypatch, mock_trace):
-    exception_raised = False
-    captured_error_messages = None
-    captured_retry_messages = None
+def test_context_window_error_removes_tool_calls_and_retries(mock_trace):
+    from mlflow.entities.assessment import Feedback
+    from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+    from mlflow.genai.judges.adapters.base_adapter import AdapterInvocationOutput
 
-    def mock_completion(**kwargs):
-        nonlocal exception_raised
-        nonlocal captured_error_messages
-        nonlocal captured_retry_messages
-
-        if len(kwargs["messages"]) >= 8 and not exception_raised:
-            captured_error_messages = kwargs["messages"]
-            exception_raised = True
-            raise exception
-
-        mock_response = mock.Mock()
-        mock_response.choices = [mock.Mock()]
-        if exception_raised:
-            captured_retry_messages = kwargs["messages"]
-            mock_response.choices[0].message = litellm.Message(
-                role="assistant",
-                content='{"result": "pass", "rationale": "Test passed"}',
-                tool_calls=None,
-            )
-            mock_response._hidden_params = {"response_cost": 0.05}
-        else:
-            call_id = f"call_{len(kwargs['messages'])}"
-            mock_response.choices[0].message = litellm.Message(
-                role="assistant",
-                content=None,
-                tool_calls=[{"id": call_id, "function": {"name": "get_span", "arguments": "{}"}}],
-            )
-            mock_response._hidden_params = {"response_cost": 0.05}
-        return mock_response
-
-    monkeypatch.setattr("litellm.completion", mock_completion)
-    monkeypatch.setattr("litellm.token_counter", lambda model, messages: len(messages) * 20)
-    monkeypatch.setattr("litellm.get_model_info", lambda model: {"max_input_tokens": 120})
-
-    judge = make_judge(
-        name="test", instructions="test {{inputs}}", feedback_value_type=str, model="openai:/gpt-4"
+    mock_output = AdapterInvocationOutput(
+        feedback=Feedback(
+            name="test",
+            value="pass",
+            rationale="Test passed after pruning",
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id="openai:/gpt-4"
+            ),
+            trace_id="test-trace-123",
+        ),
     )
-    judge(inputs={"input": "test"}, outputs={"output": "test"}, trace=mock_trace)
 
-    # Verify pruning happened; we expect that 2 messages were removed (one tool call pair consisting
-    # of 1. assistant message and 2. tool call result message)
-    assert captured_retry_messages == captured_error_messages[:2] + captured_error_messages[4:8]
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.GatewayAdapter._invoke",
+        return_value=mock_output,
+    ) as mock_invoke:
+        judge = make_judge(
+            name="test",
+            instructions="test {{inputs}}",
+            feedback_value_type=str,
+            model="openai:/gpt-4",
+        )
+        result = judge(inputs={"input": "test"}, outputs={"output": "test"}, trace=mock_trace)
+
+    mock_invoke.assert_called_once()
+    assert result.value == "pass"
 
 
-def test_non_context_error_does_not_trigger_pruning(monkeypatch):
-    def mock_completion(**kwargs):
-        raise Exception("some other error")
-
-    monkeypatch.setattr("litellm.completion", mock_completion)
-
-    judge = make_judge(
-        name="test_judge",
-        instructions="Check if {{inputs}} is correct",
-        feedback_value_type=str,
-        model="openai:/gpt-4",
-    )
-    with pytest.raises(MlflowException, match="some other error"):
-        judge(inputs={"input": "test"}, outputs={"output": "test"})
+def test_non_context_error_does_not_trigger_pruning():
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter._invoke_via_gateway",
+        side_effect=MlflowException("some other error"),
+    ):
+        judge = make_judge(
+            name="test_judge",
+            instructions="Check if {{inputs}} is correct",
+            feedback_value_type=str,
+            model="openai:/gpt-4",
+        )
+        with pytest.raises(MlflowException, match="some other error"):
+            judge(inputs={"input": "test"}, outputs={"output": "test"})
 
 
 def test_trace_template_with_expectations_extracts_correctly(mock_invoke_judge_model):
@@ -2847,44 +2822,21 @@ def test_instructions_judge_repr():
     assert "template_variables=['inputs', 'outputs']" in repr_long
 
 
-def test_make_judge_with_feedback_value_type(monkeypatch):
-    captured_response_format = None
+def test_make_judge_with_feedback_value_type():
+    mock_content = '{"result": 5, "rationale": "Excellent quality work"}'
 
-    def mock_litellm_completion(**kwargs):
-        nonlocal captured_response_format
-        captured_response_format = kwargs.get("response_format")
-
-        mock_response = mock.Mock()
-        mock_response.choices = [mock.Mock()]
-        mock_response.choices[0].message = litellm.Message(
-            role="assistant",
-            content='{"result": 5, "rationale": "Excellent quality work"}',
-            tool_calls=None,
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter._invoke_via_gateway",
+        return_value=mock_content,
+    ):
+        judge = make_judge(
+            name="test_judge",
+            instructions="Rate the quality of {{ outputs }} on a scale of 1-5",
+            model="openai:/gpt-4",
+            feedback_value_type=int,
         )
-        mock_response._hidden_params = None
-        return mock_response
 
-    monkeypatch.setattr("litellm.completion", mock_litellm_completion)
-
-    judge = make_judge(
-        name="test_judge",
-        instructions="Rate the quality of {{ outputs }} on a scale of 1-5",
-        model="openai:/gpt-4",
-        feedback_value_type=int,
-    )
-
-    result = judge(outputs={"text": "Great work!"})
-
-    # Verify response_format was correctly captured by litellm.completion
-    assert captured_response_format is not None
-    assert issubclass(captured_response_format, pydantic.BaseModel)
-
-    model_fields = captured_response_format.model_fields
-    assert "result" in model_fields
-    assert "rationale" in model_fields
-
-    assert model_fields["result"].annotation == int
-    assert model_fields["rationale"].annotation == str
+        result = judge(outputs={"text": "Great work!"})
 
     assert result.value == 5
     assert result.rationale == "Excellent quality work"
@@ -3078,26 +3030,7 @@ def test_make_judge_validates_feedback_value_type():
         )
 
 
-def test_make_judge_with_default_feedback_value_type(monkeypatch):
-    # Test that feedback_value_type defaults to str when omitted
-    captured_response_format = None
-
-    def mock_litellm_completion(**kwargs):
-        nonlocal captured_response_format
-        captured_response_format = kwargs.get("response_format")
-
-        mock_response = mock.Mock()
-        mock_response.choices = [mock.Mock()]
-        mock_response.choices[0].message = litellm.Message(
-            role="assistant",
-            content='{"result": "Good quality", "rationale": "The response is clear and accurate"}',
-            tool_calls=None,
-        )
-        mock_response._hidden_params = None
-        return mock_response
-
-    monkeypatch.setattr("litellm.completion", mock_litellm_completion)
-
+def test_make_judge_with_default_feedback_value_type():
     judge = make_judge(
         name="default_judge",
         instructions="Evaluate {{ outputs }}",
@@ -3114,17 +3047,13 @@ def test_make_judge_with_default_feedback_value_type(monkeypatch):
     }
 
     # Verify execution with default str type
-    result = judge(outputs={"text": "Great work!"})
+    mock_content = '{"result": "Good quality", "rationale": "The response is clear and accurate"}'
 
-    assert captured_response_format is not None
-    assert issubclass(captured_response_format, pydantic.BaseModel)
-
-    model_fields = captured_response_format.model_fields
-    assert "result" in model_fields
-    assert "rationale" in model_fields
-
-    assert model_fields["result"].annotation == str
-    assert model_fields["rationale"].annotation == str
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter._invoke_via_gateway",
+        return_value=mock_content,
+    ):
+        result = judge(outputs={"text": "Great work!"})
 
     assert result.value == "Good quality"
     assert result.rationale == "The response is clear and accurate"

--- a/tests/genai/judges/utils/test_invocation_utils.py
+++ b/tests/genai/judges/utils/test_invocation_utils.py
@@ -1,10 +1,15 @@
+"""Tests for invoke_judge_model and get_chat_completions_with_structured_output.
+
+These tests verify routing (which adapter is selected), payload passthrough,
+and output parsing. Adapter internals (RetryPolicy, litellm.Message types,
+cost tracking, response_format caching) are tested in the adapter-specific
+test files (test_litellm_adapter.py, test_gateway_adapter.py).
+"""
+
 import json
 from unittest import mock
 
-import litellm
 import pytest
-from litellm import RetryPolicy
-from litellm.types.utils import ModelResponse, Usage
 from pydantic import BaseModel, Field
 
 from mlflow.entities.assessment import AssessmentSourceType
@@ -13,36 +18,19 @@ from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_location import TraceLocation
 from mlflow.entities.trace_state import TraceState
 from mlflow.exceptions import MlflowException
-from mlflow.genai.judges.adapters.litellm_adapter import _MODEL_RESPONSE_FORMAT_CAPABILITIES
-from mlflow.genai.judges.utils import CategoricalRating
+from mlflow.genai.judges.adapters.gateway_adapter import InvokeOutput
 from mlflow.genai.judges.utils.invocation_utils import (
     _invoke_databricks_structured_output,
     get_chat_completions_with_structured_output,
     invoke_judge_model,
 )
-from mlflow.tracing.constant import AssessmentMetadataKey
 from mlflow.types.llm import ChatMessage
 
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
 
-@pytest.fixture(autouse=True)
-def clear_model_capabilities_cache():
-    _MODEL_RESPONSE_FORMAT_CAPABILITIES.clear()
-
-
-@pytest.fixture
-def mock_response():
-    content = json.dumps({"result": "yes", "rationale": "The response meets all criteria."})
-    response = ModelResponse(choices=[{"message": {"content": content}}])
-    response._hidden_params = {"response_cost": 0.123}
-    return response
-
-
-@pytest.fixture
-def mock_tool_response():
-    tool_calls = [{"id": "call_123", "function": {"name": "get_trace_info", "arguments": "{}"}}]
-    response = ModelResponse(choices=[{"message": {"tool_calls": tool_calls, "content": None}}])
-    response._hidden_params = {"response_cost": 0.05}
-    return response
+_MOCK_JSON = json.dumps({"result": "yes", "rationale": "The response meets all criteria."})
 
 
 @pytest.fixture
@@ -56,110 +44,96 @@ def mock_trace():
     return Trace(info=trace_info, data=None)
 
 
-@pytest.mark.parametrize("num_retries", [None, 3])
-def test_invoke_judge_model_successful_with_litellm(num_retries, mock_response):
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
-        kwargs = {
-            "model_uri": "openai:/gpt-4",
-            "prompt": "Evaluate this response",
-            "assessment_name": "quality_check",
-        }
-        if num_retries is not None:
-            kwargs["num_retries"] = num_retries
-
-        feedback = invoke_judge_model(**kwargs)
-
-    expected_retries = 10 if num_retries is None else num_retries
-    expected_retry_policy = RetryPolicy(
-        TimeoutErrorRetries=expected_retries,
-        RateLimitErrorRetries=expected_retries,
-        InternalServerErrorRetries=expected_retries,
-        ContentPolicyViolationErrorRetries=expected_retries,
-        BadRequestErrorRetries=0,
-        AuthenticationErrorRetries=0,
-    )
-
-    # Check that the messages were converted to litellm.Message objects
-    call_args = mock_litellm.call_args
-    assert len(call_args.kwargs["messages"]) == 1
-    msg = call_args.kwargs["messages"][0]
-    assert isinstance(msg, litellm.Message)
-    assert msg.role == "user"
-    assert msg.content == "Evaluate this response"
-
-    call_kwargs = mock_litellm.call_args.kwargs
-    assert call_kwargs["model"] == "openai/gpt-4"
-    assert call_kwargs["tools"] is None
-    assert call_kwargs["tool_choice"] is None
-    assert call_kwargs["retry_policy"] == expected_retry_policy
-    assert call_kwargs["retry_strategy"] == "exponential_backoff_retry"
-    assert call_kwargs["max_retries"] == 0
-    assert call_kwargs["drop_params"] is True
-
-    response_format = call_kwargs["response_format"]
-    assert issubclass(response_format, BaseModel)
-    assert "result" in response_format.model_fields
-    assert "rationale" in response_format.model_fields
-
-    assert feedback.name == "quality_check"
-    assert feedback.value == CategoricalRating.YES
-    assert feedback.rationale == "The response meets all criteria."
-    assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
-    assert feedback.source.source_id == "openai:/gpt-4"
-    assert feedback.trace_id is None
-    assert feedback.metadata is not None
-    assert feedback.metadata[AssessmentMetadataKey.JUDGE_COST] == pytest.approx(0.123)
+# ---------------------------------------------------------------------------
+# Routing tests
+# ---------------------------------------------------------------------------
 
 
-def test_invoke_judge_model_with_chat_messages(mock_response):
-    messages = [
-        ChatMessage(role="system", content="You are a helpful assistant"),
-        ChatMessage(role="user", content="Evaluate this response"),
-    ]
-
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
-        feedback = invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt=messages,
-            assessment_name="quality_check",
-        )
-
-    mock_litellm.assert_called_once()
-    call_args = mock_litellm.call_args
-    messages_arg = call_args.kwargs["messages"]
-
-    assert len(messages_arg) == 2
-    assert isinstance(messages_arg[0], litellm.Message)
-    assert messages_arg[0].role == "system"
-    assert messages_arg[0].content == "You are a helpful assistant"
-    assert isinstance(messages_arg[1], litellm.Message)
-    assert messages_arg[1].role == "user"
-    assert messages_arg[1].content == "Evaluate this response"
-
-    assert feedback.name == "quality_check"
-    assert feedback.value == CategoricalRating.YES
-    assert feedback.trace_id is None
-
-
-def test_invoke_judge_model_successful_with_native_provider():
-    mock_response = json.dumps({"result": "yes", "rationale": "The response meets all criteria."})
-
-    with (
-        mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available", return_value=False
-        ),
-        mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
-            return_value=mock_response,
-        ) as mock_score_model_on_payload,
-    ):
+def test_invoke_judge_model_routes_to_gateway_for_openai():
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+        return_value=_MOCK_JSON,
+    ) as mock_score:
         feedback = invoke_judge_model(
             model_uri="openai:/gpt-4",
             prompt="Evaluate this response",
             assessment_name="quality_check",
         )
 
-    mock_score_model_on_payload.assert_called_once_with(
+    mock_score.assert_called_once()
+    assert mock_score.call_args.kwargs["model_uri"] == "openai:/gpt-4"
+    assert feedback.name == "quality_check"
+    assert feedback.value == "yes"
+    assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
+    assert feedback.source.source_id == "openai:/gpt-4"
+
+
+def test_invoke_judge_model_routes_databricks_uri_to_gateway():
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+        return_value=_MOCK_JSON,
+    ) as mock_score:
+        feedback = invoke_judge_model(
+            model_uri="databricks:/test-model",
+            prompt="Test prompt",
+            assessment_name="test_assessment",
+        )
+
+    mock_score.assert_called_once()
+    assert mock_score.call_args.kwargs["model_uri"] == "databricks:/test-model"
+    assert feedback.name == "test_assessment"
+    assert feedback.value == "yes"
+    assert feedback.source.source_id == "databricks:/test-model"
+
+
+def test_invoke_judge_model_routes_endpoints_uri_to_gateway():
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter._invoke_via_gateway",
+        return_value=_MOCK_JSON,
+    ) as mock_invoke:
+        feedback = invoke_judge_model(
+            model_uri="endpoints:/my-endpoint",
+            prompt="Test prompt",
+            assessment_name="test_assessment",
+        )
+
+    mock_invoke.assert_called_once()
+    assert mock_invoke.call_args[0][0] == "endpoints:/my-endpoint"
+    assert feedback.name == "test_assessment"
+    assert feedback.value == "yes"
+    assert feedback.source.source_id == "endpoints:/my-endpoint"
+
+
+def test_invoke_judge_model_with_unsupported_provider():
+    with (
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available",
+            return_value=False,
+        ),
+        pytest.raises(MlflowException, match=r"No suitable adapter found"),
+    ):
+        invoke_judge_model(
+            model_uri="unsupported:/model", prompt="Test prompt", assessment_name="test"
+        )
+
+
+# ---------------------------------------------------------------------------
+# String prompt path (score_model_on_payload)
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_judge_model_string_prompt():
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+        return_value=_MOCK_JSON,
+    ) as mock_score:
+        feedback = invoke_judge_model(
+            model_uri="openai:/gpt-4",
+            prompt="Evaluate this response",
+            assessment_name="quality_check",
+        )
+
+    mock_score.assert_called_once_with(
         model_uri="openai:/gpt-4",
         payload="Evaluate this response",
         eval_parameters=None,
@@ -167,490 +141,161 @@ def test_invoke_judge_model_successful_with_native_provider():
         proxy_url=None,
         endpoint_type="llm/v1/chat",
     )
-
     assert feedback.name == "quality_check"
-    assert feedback.value == CategoricalRating.YES
-    assert feedback.rationale == "The response meets all criteria."
-    assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
-    assert feedback.source.source_id == "openai:/gpt-4"
-    assert feedback.trace_id is None
-    assert feedback.metadata is None
-
-
-def test_invoke_judge_model_with_unsupported_provider():
-    with pytest.raises(MlflowException, match=r"No suitable adapter found"):
-        with mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available", return_value=False
-        ):
-            invoke_judge_model(
-                model_uri="unsupported:/model", prompt="Test prompt", assessment_name="test"
-            )
-
-
-def test_invoke_judge_model_with_trace_works_without_litellm(mock_trace):
-    mock_output = mock.MagicMock()
-    mock_output.response = json.dumps({"result": "yes", "rationale": "ok"})
-    mock_output.num_prompt_tokens = 10
-    mock_output.num_completion_tokens = 5
-
-    with (
-        mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available",
-            return_value=False,
-        ),
-        mock.patch(
-            "mlflow.genai.judges.adapters.gateway_adapter.GatewayAdapter._invoke_and_handle_tools",
-            return_value=mock_output,
-        ),
-    ):
-        feedback = invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt="Test prompt",
-            assessment_name="test",
-            trace=mock_trace,
-        )
     assert feedback.value == "yes"
-
-
-def test_invoke_judge_model_invalid_json_response():
-    mock_content = "This is not valid JSON"
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
-
-    with mock.patch("litellm.completion", return_value=mock_response):
-        with pytest.raises(MlflowException, match=r"Failed to parse"):
-            invoke_judge_model(
-                model_uri="openai:/gpt-4", prompt="Test prompt", assessment_name="test"
-            )
-
-
-def test_invoke_judge_model_with_trace_passes_tools(mock_trace, mock_response):
-    with (
-        mock.patch("litellm.completion", return_value=mock_response) as mock_litellm,
-        mock.patch("mlflow.genai.judges.tools.list_judge_tools") as mock_list_tools,
-    ):
-        # Mock some tools being available
-        mock_tool1 = mock.Mock()
-        mock_tool1.name = "get_trace_info"
-        mock_tool1.get_definition.return_value.to_dict.return_value = {
-            "name": "get_trace_info",
-            "description": "Get trace info",
-        }
-
-        mock_tool2 = mock.Mock()
-        mock_tool2.name = "list_spans"
-        mock_tool2.get_definition.return_value.to_dict.return_value = {
-            "name": "list_spans",
-            "description": "List spans",
-        }
-
-        mock_list_tools.return_value = [mock_tool1, mock_tool2]
-
-        feedback = invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt="Evaluate this response",
-            assessment_name="quality_check",
-            trace=mock_trace,
-        )
-
-    # Verify tools were passed to litellm completion
-    mock_litellm.assert_called_once()
-    call_kwargs = mock_litellm.call_args.kwargs
-    assert call_kwargs["tools"] == [
-        {"name": "get_trace_info", "description": "Get trace info"},
-        {"name": "list_spans", "description": "List spans"},
-    ]
-    assert call_kwargs["tool_choice"] == "auto"
-    assert feedback.trace_id == "test-trace"
-
-
-def test_invoke_judge_model_tool_calling_loop(mock_trace):
-    # First call: model requests tool call
-    mock_tool_call_response = ModelResponse(
-        choices=[
-            {
-                "message": {
-                    "tool_calls": [
-                        {
-                            "id": "call_123",
-                            "function": {"name": "get_trace_info", "arguments": "{}"},
-                        }
-                    ],
-                    "content": None,
-                }
-            }
-        ],
-    )
-    mock_tool_call_response._hidden_params = {"response_cost": 0.05}
-
-    # Second call: model provides final answer
-    mock_final_response = ModelResponse(
-        choices=[
-            {
-                "message": {
-                    "content": json.dumps({"result": "yes", "rationale": "The trace looks good."})
-                }
-            }
-        ],
-    )
-    mock_final_response._hidden_params = {"response_cost": 0.15}
-
-    with (
-        mock.patch(
-            "litellm.completion", side_effect=[mock_tool_call_response, mock_final_response]
-        ) as mock_litellm,
-        mock.patch("mlflow.genai.judges.tools.list_judge_tools") as mock_list_tools,
-        mock.patch(
-            "mlflow.genai.judges.tools.registry._judge_tool_registry.invoke"
-        ) as mock_invoke_tool,
-    ):
-        mock_tool = mock.Mock()
-        mock_tool.name = "get_trace_info"
-        mock_tool.get_definition.return_value.to_dict.return_value = {"name": "get_trace_info"}
-        mock_list_tools.return_value = [mock_tool]
-
-        mock_invoke_tool.return_value = {"trace_id": "test-trace", "state": "OK"}
-
-        feedback = invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt="Evaluate this response",
-            assessment_name="quality_check",
-            trace=mock_trace,
-        )
-
-    # Verify litellm.completion was called twice (tool call + final response)
-    assert mock_litellm.call_count == 2
-
-    # Verify tool was invoked
-    mock_invoke_tool.assert_called_once()
-    tool_call_arg = mock_invoke_tool.call_args.kwargs["tool_call"]
-    from mlflow.types.llm import ToolCall
-
-    assert isinstance(tool_call_arg, ToolCall)
-    assert tool_call_arg.function.name == "get_trace_info"
-
-    assert feedback.value == CategoricalRating.YES
-    assert feedback.rationale == "The trace looks good."
-    assert feedback.trace_id == "test-trace"
-    assert feedback.metadata is not None
-    assert feedback.metadata[AssessmentMetadataKey.JUDGE_COST] == pytest.approx(0.20)
-
-
-@pytest.mark.parametrize("env_var_value", ["3", None])
-def test_invoke_judge_model_completion_iteration_limit(mock_trace, monkeypatch, env_var_value):
-    if env_var_value is not None:
-        monkeypatch.setenv("MLFLOW_JUDGE_MAX_ITERATIONS", env_var_value)
-        expected_limit = int(env_var_value)
-    else:
-        monkeypatch.delenv("MLFLOW_JUDGE_MAX_ITERATIONS", raising=False)
-        expected_limit = 30
-    mock_tool_call_response = ModelResponse(
-        choices=[
-            {
-                "message": {
-                    "tool_calls": [
-                        {
-                            "id": "call_123",
-                            "function": {"name": "get_trace_info", "arguments": "{}"},
-                        }
-                    ],
-                    "content": None,
-                }
-            }
-        ]
-    )
-
-    with (
-        mock.patch("litellm.completion", return_value=mock_tool_call_response) as mock_litellm,
-        mock.patch("mlflow.genai.judges.tools.list_judge_tools") as mock_list_tools,
-        mock.patch(
-            "mlflow.genai.judges.tools.registry._judge_tool_registry.invoke"
-        ) as mock_invoke_tool,
-    ):
-        mock_tool = mock.Mock()
-        mock_tool.name = "get_trace_info"
-        mock_tool.get_definition.return_value.to_dict.return_value = {"name": "get_trace_info"}
-        mock_list_tools.return_value = [mock_tool]
-        mock_invoke_tool.return_value = {"trace_id": "test-trace", "state": "OK"}
-
-        with pytest.raises(
-            MlflowException, match="Completion iteration limit.*exceeded"
-        ) as exc_info:
-            invoke_judge_model(
-                model_uri="openai:/gpt-4",
-                prompt="Evaluate this response",
-                assessment_name="quality_check",
-                trace=mock_trace,
-            )
-
-        error_msg = str(exc_info.value)
-        assert f"Completion iteration limit of {expected_limit} exceeded" in error_msg
-        assert "model is not powerful enough" in error_msg
-        assert mock_litellm.call_count == expected_limit
-
-
-def test_invoke_judge_model_with_custom_response_format():
-    class ResponseFormat(BaseModel):
-        result: int
-        rationale: str
-
-    # Mock litellm to return structured JSON
-    mock_response = ModelResponse(
-        choices=[
-            {
-                "message": {
-                    "content": '{"result": 8, "rationale": "High quality"}',
-                    "tool_calls": None,
-                }
-            }
-        ]
-    )
-
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_completion:
-        feedback = invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt=[ChatMessage(role="user", content="Evaluate this")],
-            assessment_name="test_judge",
-            response_format=ResponseFormat,
-        )
-
-    # Verify the result was correctly parsed and converted to dict
-    assert feedback.name == "test_judge"
-    assert feedback.value == 8
-    assert feedback.rationale == "High quality"
-
-    # Verify response_format was passed to litellm.completion
-    call_kwargs = mock_completion.call_args.kwargs
-    assert "response_format" in call_kwargs
-    assert call_kwargs["response_format"] == ResponseFormat
-
-
-# Tests for LiteLLM adapter integration with invoke_judge_model
-def test_litellm_nonfatal_error_messages_suppressed():
-    suppression_state_during_call = {}
-
-    def mock_completion(**kwargs):
-        # Capture the state of litellm flags during the call
-        suppression_state_during_call["set_verbose"] = litellm.set_verbose
-        suppression_state_during_call["suppress_debug_info"] = litellm.suppress_debug_info
-
-        return ModelResponse(
-            choices=[{"message": {"content": '{"result": "pass", "rationale": "Test completed"}'}}]
-        )
-
-    with mock.patch("litellm.completion", side_effect=mock_completion):
-        result = invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt="Test prompt for suppression",
-            assessment_name="suppression_test",
-        )
-
-        # Verify suppression was active during the litellm.completion call
-        assert suppression_state_during_call["set_verbose"] is False
-        assert suppression_state_during_call["suppress_debug_info"] is True
-
-        # Verify the call succeeded
-        assert result.value == "pass"
-
-
-def test_unsupported_response_format_handling_supports_multiple_threads():
-    model_key = "openai/gpt-4-race-bug"
-    _MODEL_RESPONSE_FORMAT_CAPABILITIES.clear()
-
-    bad_request_error = litellm.BadRequestError(
-        message="response_format not supported", model=model_key, llm_provider="openai"
-    )
-
-    call_count = 0
-    capabilities_cache_call_count = 0
-
-    def mock_completion(**kwargs):
-        nonlocal call_count
-        call_count += 1
-        if "response_format" in kwargs:
-            raise bad_request_error
-        else:
-            return ModelResponse(
-                choices=[{"message": {"content": '{"result": "yes", "rationale": "Success"}'}}]
-            )
-
-    class MockCapabilitiesCache(dict):
-        def get(self, key, default=None):
-            nonlocal capabilities_cache_call_count
-            capabilities_cache_call_count += 1
-
-            if capabilities_cache_call_count == 1:
-                return True
-            elif capabilities_cache_call_count == 2:
-                return False
-            else:
-                return False
-
-    with (
-        mock.patch("litellm.completion", side_effect=mock_completion),
-        mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._MODEL_RESPONSE_FORMAT_CAPABILITIES",
-            MockCapabilitiesCache(),
-        ),
-    ):
-        result = invoke_judge_model(
-            model_uri=f"openai:/{model_key}",
-            prompt="Test prompt",
-            assessment_name="race_bug_test",
-        )
-
-        assert call_count == 2, "Should make 2 calls: initial (fails) + retry (succeeds)"
-        assert capabilities_cache_call_count == 1
-        assert result.value == "yes"
+    assert feedback.rationale == "The response meets all criteria."
+    assert feedback.trace_id is None
 
 
 @pytest.mark.parametrize(
-    ("error_type", "error_class"),
+    "inference_params",
     [
-        ("BadRequestError", litellm.BadRequestError),
-        ("UnsupportedParamsError", litellm.UnsupportedParamsError),
+        None,
+        {"temperature": 0},
+        {"temperature": 0.5, "max_tokens": 100},
     ],
 )
-def test_invoke_judge_model_retries_without_response_format_on_bad_request(error_type, error_class):
-    mock_response = ModelResponse(
-        choices=[{"message": {"content": '{"result": "yes", "rationale": "Test rationale"}'}}]
-    )
-    error = error_class(
-        message="response_format not supported", model="openai/gpt-4", llm_provider="openai"
+def test_invoke_judge_model_inference_params_passed_through(inference_params):
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+        return_value=_MOCK_JSON,
+    ) as mock_score:
+        invoke_judge_model(
+            model_uri="openai:/gpt-4",
+            prompt="Evaluate this",
+            assessment_name="test",
+            inference_params=inference_params,
+        )
+
+    assert mock_score.call_args.kwargs["eval_parameters"] == inference_params
+
+
+# ---------------------------------------------------------------------------
+# Chat message prompt path (_call_llm_provider_api)
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_judge_model_with_chat_messages():
+    messages = [
+        ChatMessage(role="system", content="You are a helpful assistant"),
+        ChatMessage(role="user", content="Evaluate this response"),
+    ]
+
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter._call_llm_provider_api",
+        return_value=_MOCK_JSON,
+    ) as mock_call:
+        feedback = invoke_judge_model(
+            model_uri="openai:/gpt-4",
+            prompt=messages,
+            assessment_name="quality_check",
+        )
+
+    mock_call.assert_called_once()
+    call_kwargs = mock_call.call_args
+    assert call_kwargs[0][0] == "openai"  # provider
+    assert call_kwargs[0][1] == "gpt-4"  # model_name
+    assert feedback.name == "quality_check"
+    assert feedback.value == "yes"
+
+
+# ---------------------------------------------------------------------------
+# Trace / tool-calling path (send_chat_request)
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_judge_model_with_trace(mock_trace):
+    mock_output = InvokeOutput(
+        response=_MOCK_JSON,
+        request_id="req-123",
+        num_prompt_tokens=10,
+        num_completion_tokens=5,
     )
 
-    with mock.patch("litellm.completion", side_effect=[error, mock_response]) as mock_litellm:
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.GatewayAdapter._invoke_and_handle_tools",
+        return_value=mock_output,
+    ):
         feedback = invoke_judge_model(
             model_uri="openai:/gpt-4",
             prompt="Test prompt",
             assessment_name="test",
+            trace=mock_trace,
         )
 
-        # Should have been called twice - once with response_format, once without
-        assert mock_litellm.call_count == 2
-
-        # First call should include response_format
-        first_call_kwargs = mock_litellm.call_args_list[0].kwargs
-        assert "response_format" in first_call_kwargs
-
-        # Second call should not include response_format
-        second_call_kwargs = mock_litellm.call_args_list[1].kwargs
-        assert "response_format" not in second_call_kwargs
-
-        # Should still return valid feedback
-        assert feedback.name == "test"
-        assert feedback.value == "yes"
-        assert feedback.trace_id is None
+    assert feedback.value == "yes"
+    assert feedback.trace_id == "test-trace"
 
 
-def test_invoke_judge_model_stops_trying_response_format_after_failure():
-    bad_request_error = litellm.BadRequestError(
-        message="response_format not supported", model="openai/gpt-4", llm_provider="openai"
+def test_invoke_judge_model_with_trace_uses_tool_calling(mock_trace):
+    mock_output = InvokeOutput(
+        response=_MOCK_JSON,
+        request_id="req-456",
+        num_prompt_tokens=15,
+        num_completion_tokens=8,
     )
 
-    # Mock responses for: initial fail, retry success, tool call 1, tool call 2
-    tool_call_response = ModelResponse(
-        choices=[
-            {
-                "message": {
-                    "tool_calls": [
-                        {"id": "call_123", "function": {"name": "test_tool", "arguments": "{}"}}
-                    ],
-                    "content": None,
-                }
-            }
-        ]
-    )
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.GatewayAdapter._invoke_and_handle_tools",
+        return_value=mock_output,
+    ) as mock_invoke:
+        feedback = invoke_judge_model(
+            model_uri="openai:/gpt-4",
+            prompt="Evaluate this response",
+            assessment_name="quality_check",
+            trace=mock_trace,
+        )
 
-    success_response = ModelResponse(
-        choices=[{"message": {"content": '{"result": "yes", "rationale": "Test rationale"}'}}]
-    )
+    mock_invoke.assert_called_once()
+    call_kwargs = mock_invoke.call_args.kwargs
+    assert call_kwargs["provider"] == "openai"
+    assert call_kwargs["model_name"] == "gpt-4"
+    assert call_kwargs["trace"] is mock_trace
+    assert feedback.trace_id == "test-trace"
 
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_judge_model_invalid_json_response():
     with (
         mock.patch(
-            "litellm.completion",
-            side_effect=[
-                bad_request_error,
-                tool_call_response,
-                success_response,
-            ],
-        ) as mock_litellm,
-        mock.patch("mlflow.genai.judges.tools.list_judge_tools") as mock_list_tools,
-        mock.patch("mlflow.genai.judges.tools.registry._judge_tool_registry.invoke") as mock_invoke,
+            "mlflow.genai.judges.adapters.gateway_adapter.score_model_on_payload",
+            return_value="This is not valid JSON",
+        ),
+        pytest.raises(MlflowException, match=r"Failed to parse"),
     ):
-        mock_tool = mock.Mock()
-        mock_tool.get_definition.return_value.to_dict.return_value = {"name": "test_tool"}
-        mock_list_tools.return_value = [mock_tool]
-        mock_invoke.return_value = {"result": "tool executed"}
+        invoke_judge_model(model_uri="openai:/gpt-4", prompt="Test prompt", assessment_name="test")
 
-        feedback = invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt="Test prompt",
+
+# ---------------------------------------------------------------------------
+# Endpoint restrictions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "extra_kwargs",
+    [
+        {"base_url": "http://proxy:8080"},
+        {"extra_headers": {"Authorization": "Bearer token"}},
+        {"base_url": "http://proxy:8080", "extra_headers": {"Authorization": "Bearer token"}},
+    ],
+)
+def test_invoke_judge_model_base_url_and_extra_headers_not_supported_for_endpoints(extra_kwargs):
+    with pytest.raises(MlflowException, match="not supported for deployment endpoints"):
+        invoke_judge_model(
+            model_uri="endpoints:/my-endpoint",
+            prompt="Evaluate this",
             assessment_name="test",
-            trace=mock.Mock(),
+            **extra_kwargs,
         )
 
-        # Should have been called 3 times total
-        assert mock_litellm.call_count == 3
 
-        # First call should include response_format and fail
-        first_call_kwargs = mock_litellm.call_args_list[0].kwargs
-        assert "response_format" in first_call_kwargs
-
-        # Second call should not include response_format and succeed with tool call
-        second_call_kwargs = mock_litellm.call_args_list[1].kwargs
-        assert "response_format" not in second_call_kwargs
-
-        # Third call (after tool execution) should also not include response_format
-        third_call_kwargs = mock_litellm.call_args_list[2].kwargs
-        assert "response_format" not in third_call_kwargs
-
-        assert feedback.name == "test"
-
-
-def test_invoke_judge_model_caches_capabilities_globally():
-    bad_request_error = litellm.BadRequestError(
-        message="response_format not supported", model="openai/gpt-4", llm_provider="openai"
-    )
-
-    success_response = ModelResponse(
-        choices=[{"message": {"content": '{"result": "yes", "rationale": "Test rationale"}'}}]
-    )
-
-    # First call - should try response_format and cache the failure
-    with mock.patch(
-        "litellm.completion", side_effect=[bad_request_error, success_response]
-    ) as mock_litellm:
-        feedback1 = invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt="Test prompt 1",
-            assessment_name="test1",
-        )
-
-        # Should have been called twice (initial fail + retry)
-        assert mock_litellm.call_count == 2
-        assert feedback1.name == "test1"
-        assert feedback1.trace_id is None
-
-        # Verify capability was cached
-        assert _MODEL_RESPONSE_FORMAT_CAPABILITIES.get("openai/gpt-4") is False
-
-    # Second call - should directly use cached capability (no response_format)
-    with mock.patch("litellm.completion", return_value=success_response) as mock_litellm_2:
-        feedback2 = invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt="Test prompt 2",
-            assessment_name="test2",
-        )
-
-        # Should only be called once (no retry needed)
-        assert mock_litellm_2.call_count == 1
-
-        # Should not include response_format
-        call_kwargs = mock_litellm_2.call_args.kwargs
-        assert "response_format" not in call_kwargs
-
-        assert feedback2.name == "test2"
-        assert feedback2.trace_id is None
+# ---------------------------------------------------------------------------
+# get_chat_completions_with_structured_output
+# ---------------------------------------------------------------------------
 
 
 def test_get_chat_completions_with_structured_output():
@@ -658,19 +303,17 @@ def test_get_chat_completions_with_structured_output():
         inputs: str = Field(description="The user's original request")
         outputs: str = Field(description="The system's final response")
 
-    mock_response = ModelResponse(
-        choices=[
-            {
-                "message": {
-                    "content": '{"inputs": "What is MLflow?", "outputs": "MLflow is a platform"}',
-                    "tool_calls": None,
-                }
-            }
-        ]
+    mock_output = InvokeOutput(
+        response='{"inputs": "What is MLflow?", "outputs": "MLflow is a platform"}',
+        request_id="req-1",
+        num_prompt_tokens=10,
+        num_completion_tokens=5,
     )
-    mock_response._hidden_params = {"response_cost": 0.05}
 
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_completion:
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.GatewayAdapter._invoke_and_handle_tools",
+        return_value=mock_output,
+    ):
         result = get_chat_completions_with_structured_output(
             model_uri="openai:/gpt-4",
             messages=[
@@ -684,60 +327,23 @@ def test_get_chat_completions_with_structured_output():
     assert result.inputs == "What is MLflow?"
     assert result.outputs == "MLflow is a platform"
 
-    call_kwargs = mock_completion.call_args.kwargs
-    assert "response_format" in call_kwargs
-    assert call_kwargs["response_format"] == FieldExtraction
-
 
 def test_get_chat_completions_with_structured_output_with_trace(mock_trace):
     class FieldExtraction(BaseModel):
         inputs: str = Field(description="The user's original request")
         outputs: str = Field(description="The system's final response")
 
-    tool_call_response = ModelResponse(
-        choices=[
-            {
-                "message": {
-                    "tool_calls": [
-                        {
-                            "id": "call_123",
-                            "function": {
-                                "name": "get_trace_info",
-                                "arguments": "{}",
-                            },
-                        }
-                    ],
-                    "content": None,
-                }
-            }
-        ]
+    mock_output = InvokeOutput(
+        response='{"inputs": "question from trace", "outputs": "answer from trace"}',
+        request_id="req-2",
+        num_prompt_tokens=15,
+        num_completion_tokens=8,
     )
-    tool_call_response._hidden_params = {"response_cost": 0.05}
 
-    final_response = ModelResponse(
-        choices=[
-            {
-                "message": {
-                    "content": '{"inputs": "question from trace", "outputs": "answer from trace"}',
-                    "tool_calls": None,
-                }
-            }
-        ]
-    )
-    final_response._hidden_params = {"response_cost": 0.10}
-
-    with (
-        mock.patch(
-            "litellm.completion", side_effect=[tool_call_response, final_response]
-        ) as mock_completion,
-        mock.patch("mlflow.genai.judges.tools.list_judge_tools") as mock_list_tools,
-        mock.patch("mlflow.genai.judges.tools.registry._judge_tool_registry.invoke") as mock_invoke,
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter.GatewayAdapter._invoke_and_handle_tools",
+        return_value=mock_output,
     ):
-        mock_tool = mock.Mock()
-        mock_tool.get_definition.return_value.to_dict.return_value = {"name": "get_trace_info"}
-        mock_list_tools.return_value = [mock_tool]
-        mock_invoke.return_value = {"trace_id": "test-trace", "state": "OK"}
-
         result = get_chat_completions_with_structured_output(
             model_uri="openai:/gpt-4",
             messages=[
@@ -752,109 +358,10 @@ def test_get_chat_completions_with_structured_output_with_trace(mock_trace):
     assert result.inputs == "question from trace"
     assert result.outputs == "answer from trace"
 
-    assert mock_completion.call_count == 2
-    mock_invoke.assert_called_once()
 
-
-@pytest.mark.parametrize(
-    "inference_params",
-    [
-        None,
-        {"temperature": 0},
-        {"temperature": 0.5, "max_tokens": 100},
-        {"temperature": 0.5, "top_p": 0.9, "max_tokens": 500, "presence_penalty": 0.1},
-    ],
-)
-def test_invoke_judge_model_with_inference_params(mock_response, inference_params):
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
-        feedback = invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt="Evaluate this",
-            assessment_name="test",
-            inference_params=inference_params,
-        )
-
-    assert feedback.name == "test"
-    call_kwargs = mock_litellm.call_args.kwargs
-
-    if inference_params:
-        for key, value in inference_params.items():
-            assert call_kwargs[key] == value
-    else:
-        assert "temperature" not in call_kwargs
-
-
-def test_get_chat_completions_with_inference_params():
-    class OutputSchema(BaseModel):
-        result: str
-
-    mock_response_obj = ModelResponse(choices=[{"message": {"content": '{"result": "pass"}'}}])
-
-    inference_params = {"temperature": 0.1}
-
-    with mock.patch("litellm.completion", return_value=mock_response_obj) as mock_litellm:
-        result = get_chat_completions_with_structured_output(
-            model_uri="openai:/gpt-4",
-            messages=[ChatMessage(role="user", content="Test")],
-            output_schema=OutputSchema,
-            inference_params=inference_params,
-        )
-
-    assert result.result == "pass"
-    call_kwargs = mock_litellm.call_args.kwargs
-    assert call_kwargs["temperature"] == 0.1
-
-
-def test_inference_params_in_tool_calling_loop(mock_trace):
-    inference_params = {"temperature": 0.2}
-
-    tool_call_response = ModelResponse(
-        choices=[
-            {
-                "message": {
-                    "tool_calls": [
-                        {
-                            "id": "call_1",
-                            "function": {"name": "get_trace_info", "arguments": "{}"},
-                        }
-                    ],
-                    "content": None,
-                }
-            }
-        ]
-    )
-
-    final_response = ModelResponse(
-        choices=[{"message": {"content": '{"result": "yes", "rationale": "OK"}'}}]
-    )
-
-    with (
-        mock.patch(
-            "litellm.completion", side_effect=[tool_call_response, final_response]
-        ) as mock_litellm,
-        mock.patch("mlflow.genai.judges.tools.list_judge_tools") as mock_list_tools,
-        mock.patch("mlflow.genai.judges.tools.registry._judge_tool_registry.invoke") as mock_invoke,
-    ):
-        mock_tool = mock.Mock()
-        mock_tool.get_definition.return_value.to_dict.return_value = {"name": "get_trace_info"}
-        mock_list_tools.return_value = [mock_tool]
-        mock_invoke.return_value = {"result": "info"}
-
-        invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt="Evaluate",
-            assessment_name="test",
-            trace=mock_trace,
-            inference_params=inference_params,
-        )
-
-    # Both calls should have temperature set
-    assert mock_litellm.call_count == 2
-    for call in mock_litellm.call_args_list:
-        assert call.kwargs["temperature"] == 0.2
-
-
-# Tests for _invoke_databricks_structured_output
+# ---------------------------------------------------------------------------
+# _invoke_databricks_structured_output
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -901,8 +408,6 @@ def test_structured_output_schema_injection(
             trace=None,
         )
 
-    # Verify schema injection result
-    # With existing system message, schema is appended; without, a new system message is added
     expected_message_count = len(input_messages) + (0 if has_existing_system_message else 1)
     assert len(captured_messages) == expected_message_count
     assert captured_messages[0].role == "system"
@@ -912,253 +417,10 @@ def test_structured_output_schema_injection(
     assert '"outputs"' in captured_messages[0].content
 
     if has_existing_system_message:
-        # Verify schema was appended to existing system message
         assert "You are a helpful assistant." in captured_messages[0].content
     else:
-        # Verify user message remains unchanged
         assert captured_messages[1].role == "user"
         assert captured_messages[1].content == "Extract the outputs"
 
     assert isinstance(result, TestSchema)
     assert result.outputs == "test result"
-
-
-@pytest.mark.parametrize(
-    ("model_uri", "expected_model_name"),
-    [
-        ("databricks:/test-model", "test-model"),
-        ("endpoints:/databricks-gpt-oss-120b", "databricks-gpt-oss-120b"),
-    ],
-)
-@pytest.mark.parametrize("with_trace", [False, True])
-def test_invoke_judge_model_databricks_via_litellm(
-    model_uri: str, expected_model_name: str, with_trace: bool, mock_response, mock_trace
-):
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
-        kwargs = {
-            "model_uri": model_uri,
-            "prompt": "Test prompt",
-            "assessment_name": "test_assessment",
-        }
-        if with_trace:
-            kwargs["trace"] = mock_trace
-
-        feedback = invoke_judge_model(**kwargs)
-
-    provider = model_uri.split(":/", 1)[0]
-    call_kwargs = mock_litellm.call_args.kwargs
-    assert call_kwargs["model"] == f"{provider}/{expected_model_name}"
-
-    assert feedback.name == "test_assessment"
-    assert feedback.value == "yes"
-    assert feedback.rationale == "The response meets all criteria."
-    assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
-    assert feedback.trace_id == ("test-trace" if with_trace else None)
-
-
-@pytest.mark.parametrize(
-    "model_uri",
-    [
-        "databricks:/test-model",
-        "endpoints:/databricks-gpt-oss-120b",
-    ],
-)
-def test_invoke_judge_model_databricks_source_id(model_uri: str, mock_response):
-    with mock.patch("litellm.completion", return_value=mock_response):
-        feedback = invoke_judge_model(
-            model_uri=model_uri,
-            prompt="Test prompt",
-            assessment_name="test_assessment",
-        )
-
-    assert feedback.source.source_id == model_uri
-
-
-@pytest.mark.parametrize(
-    ("model_uri", "expected_model_name"),
-    [
-        ("databricks:/test-model", "test-model"),
-        ("endpoints:/databricks-gpt-oss-120b", "databricks-gpt-oss-120b"),
-    ],
-)
-def test_invoke_judge_model_databricks_failure_telemetry(model_uri: str, expected_model_name: str):
-    with (
-        mock.patch(
-            "litellm.completion",
-            side_effect=litellm.RateLimitError(
-                message="Rate limit exceeded",
-                model=f"databricks/{expected_model_name}",
-                llm_provider="databricks",
-            ),
-        ),
-        mock.patch(
-            "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_failure_databricks_telemetry"
-        ) as mock_failure_telemetry,
-    ):
-        with pytest.raises(MlflowException, match="Rate limit exceeded"):
-            invoke_judge_model(
-                model_uri=model_uri,
-                prompt="Test prompt",
-                assessment_name="test_assessment",
-            )
-
-        provider = model_uri.split(":/", 1)[0]
-        mock_failure_telemetry.assert_called_once()
-        call_kwargs = mock_failure_telemetry.call_args.kwargs
-        assert call_kwargs["model_provider"] == provider
-        assert call_kwargs["endpoint_name"] == expected_model_name
-        assert call_kwargs["error_code"] == "INTERNAL_ERROR"
-        assert "Rate limit exceeded" in call_kwargs["error_message"]
-
-
-def test_invoke_judge_model_databricks_with_response_format(mock_response):
-    class ResponseFormat(BaseModel):
-        result: str = Field(description="The result")
-        rationale: str = Field(description="The rationale")
-
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
-        feedback = invoke_judge_model(
-            model_uri="databricks:/my-endpoint",
-            prompt="Test prompt",
-            assessment_name="test_assessment",
-            response_format=ResponseFormat,
-        )
-
-    call_kwargs = mock_litellm.call_args.kwargs
-    assert call_kwargs["model"] == "databricks/my-endpoint"
-    assert "response_format" in call_kwargs
-    assert call_kwargs["response_format"] == ResponseFormat
-
-    assert feedback.name == "test_assessment"
-
-
-@pytest.mark.parametrize(
-    ("model_uri", "expected_model_name"),
-    [
-        ("databricks:/test-model", "test-model"),
-        ("endpoints:/databricks-gpt-oss-120b", "databricks-gpt-oss-120b"),
-    ],
-)
-def test_invoke_judge_model_databricks_success_telemetry(
-    model_uri: str, expected_model_name: str, mock_response
-):
-    mock_response.usage = Usage(prompt_tokens=15, completion_tokens=8, total_tokens=23)
-    mock_response.id = "req-456"
-
-    with (
-        mock.patch("litellm.completion", return_value=mock_response),
-        mock.patch(
-            "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_success_databricks_telemetry"
-        ) as mock_success_telemetry,
-    ):
-        feedback = invoke_judge_model(
-            model_uri=model_uri,
-            prompt="Test prompt",
-            assessment_name="test_assessment",
-        )
-
-    mock_success_telemetry.assert_called_once_with(
-        request_id="req-456",
-        model_provider=model_uri.split(":/", 1)[0],
-        endpoint_name=expected_model_name,
-        num_prompt_tokens=15,
-        num_completion_tokens=8,
-    )
-
-    assert feedback.name == "test_assessment"
-    assert feedback.value == "yes"
-
-
-@pytest.mark.parametrize(
-    ("model_uri", "expected_model_name"),
-    [
-        ("databricks:/test-model", "test-model"),
-        ("endpoints:/databricks-gpt-oss-120b", "databricks-gpt-oss-120b"),
-    ],
-)
-def test_invoke_judge_model_databricks_telemetry_error_handling(
-    model_uri: str, expected_model_name: str, mock_response
-):
-    mock_response.usage = Usage(prompt_tokens=5, completion_tokens=3, total_tokens=8)
-    mock_response.id = "req-789"
-
-    with (
-        mock.patch("litellm.completion", return_value=mock_response),
-        mock.patch(
-            "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_success_databricks_telemetry",
-            side_effect=Exception("Telemetry failed"),
-        ) as mock_success_telemetry,
-    ):
-        feedback = invoke_judge_model(
-            model_uri=model_uri,
-            prompt="Test prompt",
-            assessment_name="test_assessment",
-        )
-
-    mock_success_telemetry.assert_called_once_with(
-        request_id="req-789",
-        model_provider=model_uri.split(":/", 1)[0],
-        endpoint_name=expected_model_name,
-        num_prompt_tokens=5,
-        num_completion_tokens=3,
-    )
-
-    assert feedback.name == "test_assessment"
-    assert feedback.value == "yes"
-
-
-@pytest.mark.parametrize(
-    "model_uri",
-    [
-        "openai:/gpt-4",
-        "anthropic:/claude-3-sonnet",
-    ],
-)
-def test_invoke_judge_model_non_databricks_no_telemetry(model_uri: str, mock_response):
-    mock_response.usage = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
-    mock_response.id = "req-123"
-
-    with (
-        mock.patch("litellm.completion", return_value=mock_response),
-        mock.patch(
-            "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_success_databricks_telemetry"
-        ) as mock_success_telemetry,
-        mock.patch(
-            "mlflow.genai.judges.utils.telemetry_utils._record_judge_model_usage_failure_databricks_telemetry"
-        ) as mock_failure_telemetry,
-    ):
-        feedback = invoke_judge_model(
-            model_uri=model_uri,
-            prompt="Test prompt",
-            assessment_name="test_assessment",
-        )
-
-    mock_success_telemetry.assert_not_called()
-    mock_failure_telemetry.assert_not_called()
-
-    assert feedback.name == "test_assessment"
-    assert feedback.value == "yes"
-
-
-@pytest.mark.parametrize(
-    ("extra_kwargs"),
-    [
-        {"base_url": "http://proxy:8080"},
-        {"extra_headers": {"Authorization": "Bearer token"}},
-        {"base_url": "http://proxy:8080", "extra_headers": {"Authorization": "Bearer token"}},
-    ],
-)
-def test_invoke_judge_model_base_url_and_extra_headers_not_supported_for_endpoints(extra_kwargs):
-    with (
-        pytest.raises(MlflowException, match="not supported for deployment endpoints"),
-        mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available",
-            return_value=False,
-        ),
-    ):
-        invoke_judge_model(
-            model_uri="endpoints:/my-endpoint",
-            prompt="Evaluate this",
-            assessment_name="test",
-            **extra_kwargs,
-        )

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -3,7 +3,6 @@ from unittest import mock
 from unittest.mock import Mock, call, patch
 
 import pytest
-from litellm.types.utils import ModelResponse
 
 import mlflow
 from mlflow.entities.assessment import Feedback
@@ -699,9 +698,11 @@ def test_fluency_default_name():
         "result": "yes",
         "rationale": "The text is fluent.",
     })
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
-    with patch("litellm.completion", return_value=mock_response):
+    with patch(
+        "mlflow.genai.judges.adapters.gateway_adapter._invoke_via_gateway",
+        return_value=mock_content,
+    ):
         scorer = Fluency()
         result = scorer(outputs="The cat sat on the mat.")
 
@@ -715,9 +716,11 @@ def test_fluency_with_custom_model():
         "result": "yes",
         "rationale": "The text is fluent.",
     })
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
-    with patch("litellm.completion", return_value=mock_response):
+    with patch(
+        "mlflow.genai.judges.adapters.gateway_adapter._invoke_via_gateway",
+        return_value=mock_content,
+    ):
         custom_model = "anthropic:/claude-3-opus"
         scorer = Fluency(model=custom_model)
         result = scorer(outputs="This is a fluent response")
@@ -732,9 +735,11 @@ def test_fluency_with_custom_name():
         "result": "no",
         "rationale": "The text has issues.",
     })
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
-    with patch("litellm.completion", return_value=mock_response):
+    with patch(
+        "mlflow.genai.judges.adapters.gateway_adapter._invoke_via_gateway",
+        return_value=mock_content,
+    ):
         scorer = Fluency(name="my_fluency_check")
         result = scorer(outputs="Bad text")
 

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -1206,12 +1206,12 @@ def test_git_model_versioning(mock_requests, mock_telemetry_client):
 
 
 @pytest.mark.parametrize(
-    ("model_uri", "expected_provider", "litellm_available", "use_native_provider"),
+    ("model_uri", "expected_provider"),
     [
-        ("databricks:/llama-3.1-70b", "databricks", True, False),
-        ("openai:/gpt-4o-mini", "openai", True, False),
-        ("endpoints:/my-endpoint", "endpoints", True, False),
-        ("anthropic:/claude-3-opus", "anthropic", True, False),
+        ("databricks:/llama-3.1-70b", "databricks"),
+        ("openai:/gpt-4o-mini", "openai"),
+        ("endpoints:/my-endpoint", "endpoints"),
+        ("anthropic:/claude-3-opus", "anthropic"),
     ],
 )
 def test_invoke_custom_judge_model(
@@ -1219,69 +1219,20 @@ def test_invoke_custom_judge_model(
     mock_telemetry_client: TelemetryClient,
     model_uri,
     expected_provider,
-    litellm_available,
-    use_native_provider,
 ):
     from mlflow.genai.judges.utils import invoke_judge_model
-    from mlflow.utils.rest_utils import MlflowHostCreds
 
     mock_response = json.dumps({"result": 0.8, "rationale": "Test rationale"})
 
-    # Mock Databricks credentials for databricks:// URIs
-    mock_creds = MlflowHostCreds(host="https://test.databricks.com", token="test-token")
-
-    with (
-        mock.patch(
-            "mlflow.genai.judges.utils._is_litellm_available",
-            return_value=litellm_available,
-        ),
-        mock.patch(
-            "mlflow.utils.databricks_utils.get_databricks_host_creds",
-            return_value=mock_creds,
-        ),
+    with mock.patch(
+        "mlflow.genai.judges.adapters.gateway_adapter._invoke_via_gateway",
+        return_value=mock_response,
     ):
-        if use_native_provider:
-            with (
-                mock.patch.object(
-                    __import__(
-                        "mlflow.metrics.genai.model_utils",
-                        fromlist=["score_model_on_payload"],
-                    ),
-                    "score_model_on_payload",
-                    return_value=mock_response,
-                ),
-                mock.patch.object(
-                    __import__(
-                        "mlflow.metrics.genai.model_utils",
-                        fromlist=["get_endpoint_type"],
-                    ),
-                    "get_endpoint_type",
-                    return_value="llm/v1/chat",
-                ),
-            ):
-                invoke_judge_model(
-                    model_uri=model_uri,
-                    prompt="Test prompt",
-                    assessment_name="test_assessment",
-                )
-        else:
-            from mlflow.genai.judges.adapters.litellm_adapter import InvokeLiteLLMOutput
-
-            with mock.patch(
-                "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm_and_handle_tools",
-                return_value=InvokeLiteLLMOutput(
-                    response=mock_response,
-                    request_id="req-123",
-                    num_prompt_tokens=5,
-                    num_completion_tokens=3,
-                    cost=10,
-                ),
-            ):
-                invoke_judge_model(
-                    model_uri=model_uri,
-                    prompt="Test prompt",
-                    assessment_name="test_assessment",
-                )
+        invoke_judge_model(
+            model_uri=model_uri,
+            prompt="Test prompt",
+            assessment_name="test_assessment",
+        )
 
         expected_params = {"model_provider": expected_provider}
         validate_telemetry_record(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22155

### What changes are proposed in this pull request?

Reorders the adapter priority in `get_adapter()` from `[Databricks, LiteLLM, Gateway]` to `[Databricks, Gateway, LiteLLM]`.

This makes the native AI Gateway provider infrastructure the primary path for all supported providers (`openai`, `anthropic`, `databricks`, `endpoints`, `groq`, etc.), with LiteLLM as a fallback for unsupported providers or cases Gateway can't handle (`endpoints:/` + list prompts).

**Test migration:**
- `test_invocation_utils.py`: Rewritten to test routing, payload passthrough, and output parsing — no litellm-specific assertions. Reduced from 29 to 19 tests.
- `test_builtin.py`: 5 OSS tests now mock `score_model_on_payload` instead of `litellm.completion`.
- `test_custom_prompt_judge.py`: 3 tests similarly migrated.
- `test_utils.py`: Updated adapter routing expectations to reflect new priority order.
- Removed top-level litellm imports from all three test files.

**Import cleanup** across all 3 stacks: moved `INVALID_PARAMETER_VALUE`, telemetry utils, `parse_sse_lines`, `Provider`/`EndpointConfig`/`chat` to top level where possible.

**Note on test count reduction (29 → 19):** The removed tests covered litellm-specific internals (RetryPolicy configuration, `litellm.Message` type conversion, response_format fallback/caching, cost tracking via `_hidden_params["response_cost"]`, debug suppression, databricks telemetry success/failure). These behaviors are already tested in `test_litellm_adapter.py` at the adapter level. Cost tracking (`JUDGE_COST` metadata) is a litellm-specific feature — the Gateway adapter doesn't have it because `score_model_on_payload` and `_invoke_via_gateway` don't return cost data. If cost tracking is needed on the Gateway path in the future, it should be added to the Gateway adapter with its own tests.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

199 tests pass (10 skipped databricks-only). The test migration follows the design principle: adapter-level tests (`test_litellm_adapter.py`, `test_gateway_adapter.py`) test internals in detail; `test_invocation_utils.py` only tests `invoke_judge_model` routing, payload passthrough, and output parsing.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.