### PR TITLE
Fix `--static-prefix` not applied to `/api/` REST routes

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5749,9 +5749,9 @@ def get_endpoints(get_handler=get_handler):
         + get_service_endpoints(MlflowArtifactsService, get_handler)
         + get_service_endpoints(WebhookService, get_handler)
         + [(_add_static_prefix("/graphql"), _graphql, ["GET", "POST"])]
-        # NB: Use _get_paths() (not _add_static_prefix()) so that the endpoint is reachable
-        # both at /api/3.0/mlflow/server-info (for the Python client, unaffected by static prefix)
-        # and at <static-prefix>/ajax-api/3.0/mlflow/server-info (for the frontend).
+        # NB: Use _get_paths() so that the endpoint is reachable at both
+        # <static-prefix>/api/3.0/mlflow/server-info (for the Python client)
+        # and <static-prefix>/ajax-api/3.0/mlflow/server-info (for the frontend).
         + [
             (_path, _get_server_info, ["GET"])
             for _path in _get_paths("/mlflow/server-info", version=3)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5677,7 +5677,7 @@ def _invoke_scorer_handler():
 
 
 def _get_rest_path(base_path, version=2):
-    return f"/api/{version}.0{base_path}"
+    return _add_static_prefix(f"/api/{version}.0{base_path}")
 
 
 def _get_ajax_path(base_path, version=2):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -124,6 +124,7 @@ from mlflow.server import (
 )
 from mlflow.server.handlers import (
     ARTIFACT_STREAM_CHUNK_SIZE,
+    STATIC_PREFIX_ENV_VAR,
     ModelRegistryStoreRegistryWrapper,
     TrackingStoreRegistryWrapper,
     _batch_get_trace_infos,
@@ -150,6 +151,7 @@ from mlflow.server.handlers import (
     _delete_trace_tag_v3,
     _deprecated_search_traces_v2,
     _download_artifact,
+    _get_ajax_path,
     _get_dataset_experiment_ids_handler,
     _get_dataset_handler,
     _get_dataset_records_handler,
@@ -161,6 +163,7 @@ from mlflow.server.handlers import (
     _get_presigned_download_url,
     _get_registered_model,
     _get_request_message,
+    _get_rest_path,
     _get_scorer,
     _get_trace,
     _get_trace_artifact_repo,
@@ -5012,8 +5015,6 @@ def test_cancel_job_success(mock_job_store):
 
 
 def test_get_rest_path_respects_static_prefix(monkeypatch):
-    from mlflow.server.handlers import STATIC_PREFIX_ENV_VAR, _get_ajax_path, _get_rest_path
-
     # Without prefix, both return bare paths
     assert _get_rest_path("/mlflow/experiments/search") == "/api/2.0/mlflow/experiments/search"
     assert _get_ajax_path("/mlflow/experiments/search") == "/ajax-api/2.0/mlflow/experiments/search"

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -5009,3 +5009,21 @@ def test_cancel_job_success(mock_job_store):
 
         assert json_response["status"] == "CANCELED"
         mock_cancel.assert_called_once_with("job-123")
+
+
+def test_get_rest_path_respects_static_prefix(monkeypatch):
+    from mlflow.server.handlers import STATIC_PREFIX_ENV_VAR, _get_ajax_path, _get_rest_path
+
+    # Without prefix, both return bare paths
+    assert _get_rest_path("/mlflow/experiments/search") == "/api/2.0/mlflow/experiments/search"
+    assert _get_ajax_path("/mlflow/experiments/search") == "/ajax-api/2.0/mlflow/experiments/search"
+
+    # With prefix, both should include the prefix
+    monkeypatch.setenv(STATIC_PREFIX_ENV_VAR, "/myapp")
+    assert (
+        _get_rest_path("/mlflow/experiments/search") == "/myapp/api/2.0/mlflow/experiments/search"
+    )
+    assert (
+        _get_ajax_path("/mlflow/experiments/search")
+        == "/myapp/ajax-api/2.0/mlflow/experiments/search"
+    )


### PR DESCRIPTION
### Related Issues/PRs

Closes #22142

### What changes are proposed in this pull request?

Apply `_add_static_prefix()` in `_get_rest_path()` to match the existing behavior of `_get_ajax_path()`, so that `--static-prefix` is honored for both `/api/` and `/ajax-api/` routes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

```bash
mlflow server --host 0.0.0.0 --port 5000 --static-prefix=/myapp
curl http://localhost:5000/myapp/api/2.0/mlflow/experiments/search?max_results=1  # 200 OK
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `--static-prefix` is now correctly applied to `/api/` REST routes, fixing 404 errors when deploying MLflow behind a reverse proxy with path-based routing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release