### PR TITLE
Remove `huey_store_path=HUEY_STORAGE_PATH_ENV_VAR` assignment in launcher program

### DIFF
--- a/mlflow/server/jobs/_job_runner.py
+++ b/mlflow/server/jobs/_job_runner.py
@@ -15,7 +15,6 @@ import logging
 import os
 import time
 
-from mlflow.server import HUEY_STORAGE_PATH_ENV_VAR
 from mlflow.server.constants import MLFLOW_SERVER_UP_TIME
 from mlflow.server.jobs.utils import (
     _enqueue_unfinished_jobs,
@@ -29,8 +28,6 @@ if __name__ == "__main__":
     logger = logging.getLogger("mlflow.server.jobs._job_runner")
     server_up_time = int(os.environ[MLFLOW_SERVER_UP_TIME])
     _start_watcher_to_kill_job_runner_if_mlflow_server_dies()
-
-    huey_store_path = os.environ[HUEY_STORAGE_PATH_ENV_VAR]
 
     for job_name in _job_name_to_fn_fullname_map:
         try:


### PR DESCRIPTION
Hi again. This is just another very nit in code cosmetics within an area we have been exploring lately.

The symbol `huey_store_path`, assigned from reading the `HUEY_STORAGE_PATH_ENV_VAR` environment variable, is apparently not used within the code fragment at hand. Unless the removal has any other non-obvious detrimental side effects, it might be safe.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
