### PR TITLE
Add Gateway-first model adapter for DeepEval scorer

### DIFF
--- a/mlflow/genai/scorers/deepeval/models.py
+++ b/mlflow/genai/scorers/deepeval/models.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import json
 
-from deepeval.models import LiteLLMModel
 from deepeval.models.base_model import DeepEvalBaseLLM
 from pydantic import ValidationError
 
+from mlflow.gateway.provider_registry import is_supported_provider
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
-from mlflow.metrics.genai.model_utils import _parse_model_uri
+from mlflow.metrics.genai.model_utils import _call_llm_provider_api, _parse_model_uri
 
 
 def _build_json_prompt_with_schema(prompt: str, schema) -> str:
@@ -67,14 +67,56 @@ class DatabricksDeepEvalLLM(DeepEvalBaseLLM):
         return _DATABRICKS_DEFAULT_JUDGE_MODEL
 
 
+class GatewayDeepEvalLLM(DeepEvalBaseLLM):
+    """DeepEval model adapter using MLflow Gateway providers.
+
+    Uses the native provider infrastructure (_call_llm_provider_api) instead
+    of litellm. Handles structured output via JSON prompt injection and
+    response parsing (same approach as DatabricksDeepEvalLLM).
+    """
+
+    def __init__(self, provider: str, model_name: str):
+        super().__init__(model_name=f"{provider}/{model_name}")
+        self._provider = provider
+        self._model_name = model_name
+
+    def load_model(self, **kwargs):
+        return self
+
+    def generate(self, prompt: str, schema=None) -> str:
+        # Return type is str when schema is None, or a validated schema instance when
+        # schema is provided. The -> str annotation matches DeepEvalBaseLLM's abstract
+        # method signature; DeepEval's own LiteLLMModel follows the same convention.
+        if schema is not None:
+            prompt = _build_json_prompt_with_schema(prompt, schema)
+
+        response = _call_llm_provider_api(
+            self._provider,
+            self._model_name,
+            input_data=prompt,
+        )
+
+        if schema is not None:
+            return _parse_json_output_with_schema(response.strip(), schema)
+        return response
+
+    async def a_generate(self, prompt: str, schema=None) -> str:
+        return self.generate(prompt, schema=schema)
+
+    def get_model_name(self) -> str:
+        return f"{self._provider}/{self._model_name}"
+
+
 def create_deepeval_model(model_uri: str):
     if model_uri == "databricks":
         return DatabricksDeepEvalLLM()
 
-    # Parse provider:/model format using shared helper
     provider, model_name = _parse_model_uri(model_uri)
 
+    # Gateway endpoints require litellm-based routing
     if provider == "gateway":
+        from deepeval.models import LiteLLMModel
+
         config = get_gateway_litellm_config(model_name)
         return LiteLLMModel(
             model=config.model,
@@ -85,6 +127,12 @@ def create_deepeval_model(model_uri: str):
                 **({"extra_headers": config.extra_headers} if config.extra_headers else {}),
             },
         )
+
+    # Use native gateway provider for supported providers, litellm for others
+    if is_supported_provider(provider):
+        return GatewayDeepEvalLLM(provider, model_name)
+
+    from deepeval.models import LiteLLMModel
 
     return LiteLLMModel(
         model=f"{provider}/{model_name}",

--- a/tests/genai/scorers/deepeval/test_deepeval_scorer.py
+++ b/tests/genai/scorers/deepeval/test_deepeval_scorer.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import pydantic
 import pytest
 
 import mlflow
@@ -349,3 +350,105 @@ def test_deepeval_scorer_telemetry_in_genai_evaluate(
             "eval_data_provided_fields": ["expectations", "inputs", "outputs"],
         },
     )
+
+
+# --- Model adapter tests ---
+
+
+def test_gateway_deepeval_llm_generate():
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM
+
+    adapter = GatewayDeepEvalLLM("openai", "gpt-4")
+
+    with patch(
+        "mlflow.genai.scorers.deepeval.models._call_llm_provider_api",
+        return_value="The answer is 42.",
+    ) as mock_call:
+        result = adapter.generate("What is the answer?")
+
+    assert result == "The answer is 42."
+    mock_call.assert_called_once_with("openai", "gpt-4", input_data="What is the answer?")
+
+
+def test_gateway_deepeval_llm_generate_with_schema():
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM
+
+    class TestSchema(pydantic.BaseModel):
+        result: str
+        score: int
+
+    adapter = GatewayDeepEvalLLM("openai", "gpt-4")
+
+    with patch(
+        "mlflow.genai.scorers.deepeval.models._call_llm_provider_api",
+        return_value='{"result": "good", "score": 5}',
+    ) as mock_call:
+        result = adapter.generate("Rate this", schema=TestSchema)
+
+    assert isinstance(result, TestSchema)
+    assert result.result == "good"
+    assert result.score == 5
+    mock_call.assert_called_once()
+    prompt = mock_call.call_args.kwargs["input_data"]
+    assert "Rate this" in prompt
+    assert "Return your response as valid JSON" in prompt
+
+
+def test_gateway_deepeval_llm_get_model_name():
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM
+
+    adapter = GatewayDeepEvalLLM("anthropic", "claude-3")
+    assert adapter.get_model_name() == "anthropic/claude-3"
+
+
+@pytest.mark.parametrize(
+    ("model_uri", "env_var"),
+    [
+        ("openai:/gpt-4", "OPENAI_API_KEY"),
+        ("anthropic:/claude-3", "ANTHROPIC_API_KEY"),
+    ],
+)
+def test_create_deepeval_model_uses_gateway_for_supported_providers(
+    model_uri, env_var, monkeypatch
+):
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM, create_deepeval_model
+
+    monkeypatch.setenv(env_var, "test-key")
+    model = create_deepeval_model(model_uri)
+    assert isinstance(model, GatewayDeepEvalLLM)
+
+
+def test_create_deepeval_model_falls_back_to_litellm_for_unsupported_provider():
+    from deepeval.models import LiteLLMModel
+
+    from mlflow.genai.scorers.deepeval.models import create_deepeval_model
+
+    model = create_deepeval_model("some_unknown:/model")
+    assert isinstance(model, LiteLLMModel)
+
+
+def test_create_deepeval_model_uses_litellm_for_gateway_uri():
+    from deepeval.models import LiteLLMModel
+
+    from mlflow.genai.scorers.deepeval.models import create_deepeval_model
+
+    with patch("mlflow.genai.scorers.deepeval.models.get_gateway_litellm_config") as mock_config:
+        mock_config.return_value = Mock(
+            model="my-endpoint",
+            api_base="http://localhost:5000",
+            api_key="test-key",
+            extra_headers=None,
+        )
+        model = create_deepeval_model("gateway:/my-endpoint")
+
+    assert isinstance(model, LiteLLMModel)
+
+
+def test_create_deepeval_model_uses_databricks_for_bare_uri():
+    from mlflow.genai.scorers.deepeval.models import (
+        DatabricksDeepEvalLLM,
+        create_deepeval_model,
+    )
+
+    model = create_deepeval_model("databricks")
+    assert isinstance(model, DatabricksDeepEvalLLM)

--- a/tests/genai/scorers/deepeval/test_models.py
+++ b/tests/genai/scorers/deepeval/test_models.py
@@ -55,7 +55,7 @@ def test_create_deepeval_model_gateway_sets_api_base_and_key():
             "mlflow.genai.scorers.deepeval.models.get_gateway_litellm_config",
             return_value=mock_config,
         ),
-        patch("mlflow.genai.scorers.deepeval.models.LiteLLMModel") as mock_litellm_model,
+        patch("deepeval.models.LiteLLMModel") as mock_litellm_model,
     ):
         create_deepeval_model("gateway:/my-endpoint")
 
@@ -67,18 +67,10 @@ def test_create_deepeval_model_gateway_sets_api_base_and_key():
     )
 
 
-@pytest.mark.parametrize(
-    ("model_uri", "expected_model_arg"),
-    [
-        ("openai:/gpt-4", "openai/gpt-4"),
-        ("databricks:/my-endpoint", "databricks/my-endpoint"),
-    ],
-)
-def test_create_deepeval_model_non_gateway(model_uri, expected_model_arg):
-    with patch("mlflow.genai.scorers.deepeval.models.LiteLLMModel") as mock_litellm_model:
-        create_deepeval_model(model_uri)
+def test_create_deepeval_model_supported_provider_uses_gateway(monkeypatch):
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM
 
-    mock_litellm_model.assert_called_once_with(
-        model=expected_model_arg,
-        generation_kwargs={"drop_params": True},
-    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    model = create_deepeval_model("openai:/gpt-4")
+    assert isinstance(model, GatewayDeepEvalLLM)
+    assert model.get_model_name() == "openai/gpt-4"

--- a/tests/genai/scorers/deepeval/test_utils.py
+++ b/tests/genai/scorers/deepeval/test_utils.py
@@ -20,14 +20,15 @@ def test_create_deepeval_model_databricks():
 
 def test_create_deepeval_model_databricks_serving_endpoint():
     model = create_deepeval_model("databricks:/my-endpoint")
-    assert model.__class__.__name__ == "LiteLLMModel"
-    assert model.name == "databricks/my-endpoint"
+    assert model.__class__.__name__ == "GatewayDeepEvalLLM"
+    assert model.get_model_name() == "databricks/my-endpoint"
 
 
-def test_create_deepeval_model_openai():
+def test_create_deepeval_model_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     model = create_deepeval_model("openai:/gpt-4")
-    assert model.__class__.__name__ == "LiteLLMModel"
-    assert model.name == "openai/gpt-4"
+    assert model.__class__.__name__ == "GatewayDeepEvalLLM"
+    assert model.get_model_name() == "openai/gpt-4"
 
 
 def test_create_deepeval_model_rejects_provider_no_slash():


### PR DESCRIPTION
### Related Issues/PRs

Part of the litellm removal effort. Independent of the judge adapter stack (#22148, #22155, #22157).

### What changes are proposed in this pull request?

Adds `GatewayDeepEvalLLM`, a `DeepEvalBaseLLM` implementation that uses MLflow's native Gateway provider infrastructure (`_call_llm_provider_api`) instead of litellm.

**`create_deepeval_model` factory now uses Gateway-first routing:**
1. `"databricks"` → `DatabricksDeepEvalLLM` (unchanged)
2. `"gateway:/..."` → `LiteLLMModel` (unchanged — gateway endpoints need litellm routing)
3. Supported providers (openai, anthropic, etc.) → tries `GatewayDeepEvalLLM` first, falls back to `LiteLLMModel` if the provider isn't supported by `_get_provider_instance`
4. Unsupported providers → `LiteLLMModel` (unchanged)

This means for common providers like `openai:/gpt-4` and `anthropic:/claude-3`, DeepEval scorers no longer invoke litellm at the MLflow layer. Users who have litellm installed (via deepeval's own dependency) still get it as a fallback for providers MLflow's Gateway doesn't handle natively.

Structured output is handled via JSON prompt injection + response parsing, matching the existing `DatabricksDeepEvalLLM` pattern.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

8 new tests:
- `GatewayDeepEvalLLM.generate()` with and without schema
- `get_model_name()` returns correct format
- Factory routing: gateway for supported providers, litellm fallback for unsupported, litellm for gateway:/ URIs, Databricks for bare URI

27 total tests pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.