### PR TITLE
Fix `gateway:/ provider` routing to use direct HTTP calls instead of deployments client

### DIFF
--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -37,22 +37,32 @@ def get_endpoint_type(endpoint_uri: str) -> str | None:
 
 # TODO: improve this name
 def score_model_on_payload(
-    model_uri,
-    payload,
-    eval_parameters=None,
-    extra_headers=None,
-    proxy_url=None,
-    endpoint_type=None,
+    model_uri: str,
+    payload: str,
+    eval_parameters: dict[str, Any] | None = None,
+    extra_headers: dict[str, str] | None = None,
+    proxy_url: str | None = None,
+    endpoint_type: str | None = None,
 ):
     """Call the model identified by the given uri with the given string prompt."""
-    from mlflow.deployments import get_deploy_client
-
     eval_parameters = eval_parameters or {}
     extra_headers = extra_headers or {}
 
     prefix, suffix = _parse_model_uri(model_uri)
 
-    if prefix in ["gateway", "endpoints"]:
+    if prefix == "gateway":
+        return _call_llm_provider_api(
+            "gateway",
+            suffix,
+            input_data=payload,
+            eval_parameters=eval_parameters,
+            extra_headers=extra_headers,
+            proxy_url=proxy_url,
+        )
+
+    elif prefix == "endpoints":
+        from mlflow.deployments import get_deploy_client
+
         if isinstance(payload, str) and endpoint_type is None:
             client = get_deploy_client()
             endpoint_type = client.get_endpoint(suffix).endpoint_type

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 
 from mlflow.exceptions import MlflowException
+from mlflow.genai.utils.gateway_utils import GatewayConfig
 from mlflow.metrics.genai import model_utils
 from mlflow.metrics.genai.model_utils import (
     _MODELS_WITHOUT_OUTPUT_CONFIG,
@@ -338,43 +339,27 @@ def test_score_model_togetherai(monkeypatch):
 
 
 def test_score_model_gateway_completions():
-    expected_text = "man, one giant leap for mankind."
-
-    with mock.patch(
-        "mlflow.metrics.genai.model_utils._call_llm_provider_api",
-        return_value=expected_text,
-    ) as mock_call:
-        response = score_model_on_payload("gateway:/my-route", "my prompt")
-        assert response == expected_text
-        mock_call.assert_called_once_with(
-            "gateway",
-            "my-route",
-            input_data="my prompt",
-            eval_parameters={},
-            extra_headers={},
-            proxy_url=None,
-        )
-
-
-def test_score_model_gateway_chat():
-    expected_text = (
-        "The core of the sun is estimated to have a temperature of about "
-        "15 million degrees Celsius (27 million degrees Fahrenheit)."
+    gw_config = GatewayConfig(
+        api_base="http://localhost:5000/gateway/mlflow/v1/",
+        endpoint_name="my-route",
+        extra_headers=None,
     )
 
-    with mock.patch(
-        "mlflow.metrics.genai.model_utils._call_llm_provider_api",
-        return_value=expected_text,
-    ) as mock_call:
+    with (
+        mock.patch(
+            "mlflow.metrics.genai.model_utils.get_gateway_config", return_value=gw_config
+        ) as mock_get_config,
+        mock.patch(
+            "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+        ) as mock_send,
+    ):
         response = score_model_on_payload("gateway:/my-route", "my prompt")
-        assert response == expected_text
-        mock_call.assert_called_once_with(
-            "gateway",
-            "my-route",
-            input_data="my prompt",
-            eval_parameters={},
-            extra_headers={},
-            proxy_url=None,
+        assert response == "\n\nThis is a test!"
+        mock_get_config.assert_called_once_with("my-route")
+        mock_send.assert_called_once_with(
+            endpoint="http://localhost:5000/gateway/mlflow/v1/chat/completions",
+            headers={},
+            payload={"model": "my-route", "messages": [{"role": "user", "content": "my prompt"}]},
         )
 
 

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -6,9 +6,7 @@ from unittest import mock
 import pytest
 import requests
 
-from mlflow.deployments.server.config import Endpoint
 from mlflow.exceptions import MlflowException
-from mlflow.gateway.config import EndpointModelInfo
 from mlflow.metrics.genai import model_utils
 from mlflow.metrics.genai.model_utils import (
     _MODELS_WITHOUT_OUTPUT_CONFIG,
@@ -340,86 +338,44 @@ def test_score_model_togetherai(monkeypatch):
 
 
 def test_score_model_gateway_completions():
-    from mlflow.deployments.mlflow import MlflowDeploymentClient
+    expected_text = "man, one giant leap for mankind."
 
-    expected_output = {
-        "choices": [
-            {"text": "man, one giant leap for mankind.", "metadata": {"finish_reason": "stop"}}
-        ],
-        "metadata": {
-            "model": "gpt-4-0613",
-            "input_tokens": 13,
-            "total_tokens": 21,
-            "output_tokens": 8,
-            "endpoint_type": "llm/v1/completions",
-        },
-    }
-
-    with (
-        mock.patch(
-            "mlflow.deployments.MlflowDeploymentClient.get_endpoint",
-            return_value=Endpoint(
-                name="my-route",
-                endpoint_type="llm/v1/completions",
-                model=EndpointModelInfo(provider="openai"),
-                endpoint_url="my-route",
-                limit=None,
-            ),
-        ),
-        mock.patch(
-            "mlflow.deployments.MlflowDeploymentClient.predict", return_value=expected_output
-        ),
-        mock.patch(
-            "mlflow.deployments.get_deploy_client", return_value=MlflowDeploymentClient("url")
-        ),
-    ):
-        response = score_model_on_payload("gateway:/my-route", "")
-        assert response == expected_output["choices"][0]["text"]
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._call_llm_provider_api",
+        return_value=expected_text,
+    ) as mock_call:
+        response = score_model_on_payload("gateway:/my-route", "my prompt")
+        assert response == expected_text
+        mock_call.assert_called_once_with(
+            "gateway",
+            "my-route",
+            input_data="my prompt",
+            eval_parameters={},
+            extra_headers={},
+            proxy_url=None,
+        )
 
 
 def test_score_model_gateway_chat():
-    from mlflow.deployments.mlflow import MlflowDeploymentClient
+    expected_text = (
+        "The core of the sun is estimated to have a temperature of about "
+        "15 million degrees Celsius (27 million degrees Fahrenheit)."
+    )
 
-    expected_output = {
-        "choices": [
-            {
-                "message": {
-                    "role": "assistant",
-                    "content": "The core of the sun is estimated to have a temperature of about "
-                    "15 million degrees Celsius (27 million degrees Fahrenheit).",
-                },
-                "metadata": {"finish_reason": "stop"},
-            }
-        ],
-        "metadata": {
-            "input_tokens": 17,
-            "output_tokens": 24,
-            "total_tokens": 41,
-            "model": "gpt-4o-mini",
-            "endpoint_type": "llm/v1/chat",
-        },
-    }
-
-    with (
-        mock.patch(
-            "mlflow.deployments.MlflowDeploymentClient.get_endpoint",
-            return_value=Endpoint(
-                name="my-route",
-                endpoint_type="llm/v1/chat",
-                model=EndpointModelInfo(provider="openai"),
-                endpoint_url="my-route",
-                limit=None,
-            ),
-        ),
-        mock.patch(
-            "mlflow.deployments.MlflowDeploymentClient.predict", return_value=expected_output
-        ),
-        mock.patch(
-            "mlflow.deployments.get_deploy_client", return_value=MlflowDeploymentClient("url")
-        ),
-    ):
-        response = score_model_on_payload("gateway:/my-route", "")
-        assert response == expected_output["choices"][0]["message"]["content"]
+    with mock.patch(
+        "mlflow.metrics.genai.model_utils._call_llm_provider_api",
+        return_value=expected_text,
+    ) as mock_call:
+        response = score_model_on_payload("gateway:/my-route", "my prompt")
+        assert response == expected_text
+        mock_call.assert_called_once_with(
+            "gateway",
+            "my-route",
+            input_data="my prompt",
+            eval_parameters={},
+            extra_headers={},
+            proxy_url=None,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Route gateway:/ model URIs through direct HTTP calls to the MLflow tracking server instead of the deployments client, fixing a NoneType error when no deployments target is  configured.
```
score_model_on_payload
    return call_deployments_api(suffix, payload, eval_parameters, endpoint_type)
  File "/Users/daniel.lok/mlflow/mlflow/metrics/genai/model_utils.py", line 469, in call_deployments_api
    raise MlflowException(
mlflow.exceptions.MlflowException: Failed to call the deployment endpoint. Please check the deployment URL is set correctly and the input payload is valid.

- Error: 'NoneType' object has no attribute 'predict'
```

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
