### PR TITLE
Add Gateway-first model adapter for DeepEval scorer

### DIFF
--- a/mlflow/genai/scorers/deepeval/models.py
+++ b/mlflow/genai/scorers/deepeval/models.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import json
 
-from deepeval.models import LiteLLMModel
 from deepeval.models.base_model import DeepEvalBaseLLM
 from pydantic import ValidationError
 
+from mlflow.gateway.provider_registry import is_supported_provider
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
-from mlflow.metrics.genai.model_utils import _parse_model_uri
+from mlflow.metrics.genai.model_utils import _call_llm_provider_api, _parse_model_uri
 
 
 def _build_json_prompt_with_schema(prompt: str, schema) -> str:
@@ -67,14 +67,56 @@ class DatabricksDeepEvalLLM(DeepEvalBaseLLM):
         return _DATABRICKS_DEFAULT_JUDGE_MODEL
 
 
+class GatewayDeepEvalLLM(DeepEvalBaseLLM):
+    """DeepEval model adapter using MLflow Gateway providers.
+
+    Uses the native provider infrastructure (_call_llm_provider_api) instead
+    of litellm. Handles structured output via JSON prompt injection and
+    response parsing (same approach as DatabricksDeepEvalLLM).
+    """
+
+    def __init__(self, provider: str, model_name: str):
+        super().__init__(model_name=f"{provider}/{model_name}")
+        self._provider = provider
+        self._model_name = model_name
+
+    def load_model(self, **kwargs):
+        return self
+
+    def generate(self, prompt: str, schema=None) -> str:
+        # Return type is str when schema is None, or a validated schema instance when
+        # schema is provided. The -> str annotation matches DeepEvalBaseLLM's abstract
+        # method signature; DeepEval's own LiteLLMModel follows the same convention.
+        if schema is not None:
+            prompt = _build_json_prompt_with_schema(prompt, schema)
+
+        response = _call_llm_provider_api(
+            self._provider,
+            self._model_name,
+            input_data=prompt,
+        )
+
+        if schema is not None:
+            return _parse_json_output_with_schema(response.strip(), schema)
+        return response
+
+    async def a_generate(self, prompt: str, schema=None) -> str:
+        return self.generate(prompt, schema=schema)
+
+    def get_model_name(self) -> str:
+        return f"{self._provider}/{self._model_name}"
+
+
 def create_deepeval_model(model_uri: str):
     if model_uri == "databricks":
         return DatabricksDeepEvalLLM()
 
-    # Parse provider:/model format using shared helper
     provider, model_name = _parse_model_uri(model_uri)
 
+    # Gateway endpoints require litellm-based routing
     if provider == "gateway":
+        from deepeval.models import LiteLLMModel
+
         config = get_gateway_litellm_config(model_name)
         return LiteLLMModel(
             model=config.model,
@@ -85,6 +127,12 @@ def create_deepeval_model(model_uri: str):
                 **({"extra_headers": config.extra_headers} if config.extra_headers else {}),
             },
         )
+
+    # Use native gateway provider for supported providers, litellm for others
+    if is_supported_provider(provider):
+        return GatewayDeepEvalLLM(provider, model_name)
+
+    from deepeval.models import LiteLLMModel
 
     return LiteLLMModel(
         model=f"{provider}/{model_name}",

--- a/mlflow/genai/scorers/deepeval/models.py
+++ b/mlflow/genai/scorers/deepeval/models.py
@@ -9,7 +9,6 @@ from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
-from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
 from mlflow.metrics.genai.model_utils import (
     _call_llm_provider_api,
     _get_provider_instance,
@@ -115,21 +114,6 @@ def create_deepeval_model(model_uri: str):
         return DatabricksDeepEvalLLM()
 
     provider, model_name = _parse_model_uri(model_uri)
-
-    # Gateway endpoints require litellm-based routing
-    if provider == "gateway":
-        from deepeval.models import LiteLLMModel
-
-        config = get_gateway_litellm_config(model_name)
-        return LiteLLMModel(
-            model=config.model,
-            base_url=config.api_base,
-            api_key=config.api_key,
-            generation_kwargs={
-                "drop_params": True,
-                **({"extra_headers": config.extra_headers} if config.extra_headers else {}),
-            },
-        )
 
     # Use native gateway provider if _get_provider_instance can construct it,
     # otherwise fall back to litellm

--- a/mlflow/genai/scorers/deepeval/models.py
+++ b/mlflow/genai/scorers/deepeval/models.py
@@ -5,6 +5,7 @@ import json
 from deepeval.models.base_model import DeepEvalBaseLLM
 from pydantic import ValidationError
 
+from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
@@ -119,9 +120,10 @@ def create_deepeval_model(model_uri: str):
     # otherwise fall back to litellm
     try:
         _get_provider_instance(provider, model_name)
-        return GatewayDeepEvalLLM(provider, model_name)
-    except Exception:
+    except MlflowException:
         pass
+    else:
+        return GatewayDeepEvalLLM(provider, model_name)
 
     from deepeval.models import LiteLLMModel
 

--- a/mlflow/genai/scorers/deepeval/models.py
+++ b/mlflow/genai/scorers/deepeval/models.py
@@ -5,13 +5,16 @@ import json
 from deepeval.models.base_model import DeepEvalBaseLLM
 from pydantic import ValidationError
 
-from mlflow.gateway.provider_registry import is_supported_provider
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
-from mlflow.metrics.genai.model_utils import _call_llm_provider_api, _parse_model_uri
+from mlflow.metrics.genai.model_utils import (
+    _call_llm_provider_api,
+    _get_provider_instance,
+    _parse_model_uri,
+)
 
 
 def _build_json_prompt_with_schema(prompt: str, schema) -> str:
@@ -128,9 +131,13 @@ def create_deepeval_model(model_uri: str):
             },
         )
 
-    # Use native gateway provider for supported providers, litellm for others
-    if is_supported_provider(provider):
+    # Use native gateway provider if _get_provider_instance can construct it,
+    # otherwise fall back to litellm
+    try:
+        _get_provider_instance(provider, model_name)
         return GatewayDeepEvalLLM(provider, model_name)
+    except Exception:
+        pass
 
     from deepeval.models import LiteLLMModel
 

--- a/tests/genai/scorers/deepeval/test_deepeval_scorer.py
+++ b/tests/genai/scorers/deepeval/test_deepeval_scorer.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import pydantic
 import pytest
 
 import mlflow
@@ -349,3 +350,105 @@ def test_deepeval_scorer_telemetry_in_genai_evaluate(
             "eval_data_provided_fields": ["expectations", "inputs", "outputs"],
         },
     )
+
+
+# --- Model adapter tests ---
+
+
+def test_gateway_deepeval_llm_generate():
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM
+
+    adapter = GatewayDeepEvalLLM("openai", "gpt-4")
+
+    with patch(
+        "mlflow.genai.scorers.deepeval.models._call_llm_provider_api",
+        return_value="The answer is 42.",
+    ) as mock_call:
+        result = adapter.generate("What is the answer?")
+
+    assert result == "The answer is 42."
+    mock_call.assert_called_once_with("openai", "gpt-4", input_data="What is the answer?")
+
+
+def test_gateway_deepeval_llm_generate_with_schema():
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM
+
+    class TestSchema(pydantic.BaseModel):
+        result: str
+        score: int
+
+    adapter = GatewayDeepEvalLLM("openai", "gpt-4")
+
+    with patch(
+        "mlflow.genai.scorers.deepeval.models._call_llm_provider_api",
+        return_value='{"result": "good", "score": 5}',
+    ) as mock_call:
+        result = adapter.generate("Rate this", schema=TestSchema)
+
+    assert isinstance(result, TestSchema)
+    assert result.result == "good"
+    assert result.score == 5
+    mock_call.assert_called_once()
+    prompt = mock_call.call_args.kwargs["input_data"]
+    assert "Rate this" in prompt
+    assert "Return your response as valid JSON" in prompt
+
+
+def test_gateway_deepeval_llm_get_model_name():
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM
+
+    adapter = GatewayDeepEvalLLM("anthropic", "claude-3")
+    assert adapter.get_model_name() == "anthropic/claude-3"
+
+
+@pytest.mark.parametrize(
+    ("model_uri", "env_var"),
+    [
+        ("openai:/gpt-4", "OPENAI_API_KEY"),
+        ("anthropic:/claude-3", "ANTHROPIC_API_KEY"),
+    ],
+)
+def test_create_deepeval_model_uses_gateway_for_supported_providers(
+    model_uri, env_var, monkeypatch
+):
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM, create_deepeval_model
+
+    monkeypatch.setenv(env_var, "test-key")
+    model = create_deepeval_model(model_uri)
+    assert isinstance(model, GatewayDeepEvalLLM)
+
+
+def test_create_deepeval_model_falls_back_to_litellm_for_unsupported_provider():
+    from deepeval.models import LiteLLMModel
+
+    from mlflow.genai.scorers.deepeval.models import create_deepeval_model
+
+    model = create_deepeval_model("some_unknown:/model")
+    assert isinstance(model, LiteLLMModel)
+
+
+def test_create_deepeval_model_uses_litellm_for_gateway_uri():
+    from deepeval.models import LiteLLMModel
+
+    from mlflow.genai.scorers.deepeval.models import create_deepeval_model
+
+    with patch("mlflow.genai.scorers.deepeval.models.get_gateway_litellm_config") as mock_config:
+        mock_config.return_value = Mock(
+            model="my-endpoint",
+            api_base="http://localhost:5000",
+            api_key="test-key",
+            extra_headers=None,
+        )
+        model = create_deepeval_model("gateway:/my-endpoint")
+
+    assert isinstance(model, LiteLLMModel)
+
+
+def test_create_deepeval_model_uses_databricks_for_bare_uri():
+    from mlflow.genai.scorers.deepeval.models import (
+        DatabricksDeepEvalLLM,
+        create_deepeval_model,
+    )
+
+    model = create_deepeval_model("databricks")
+    assert isinstance(model, DatabricksDeepEvalLLM)

--- a/tests/genai/scorers/deepeval/test_deepeval_scorer.py
+++ b/tests/genai/scorers/deepeval/test_deepeval_scorer.py
@@ -452,3 +452,43 @@ def test_create_deepeval_model_uses_databricks_for_bare_uri():
 
     model = create_deepeval_model("databricks")
     assert isinstance(model, DatabricksDeepEvalLLM)
+
+
+@pytest.mark.parametrize("provider", ["cohere", "mosaicml", "palm"])
+def test_create_deepeval_model_registered_but_unsupported_falls_back_to_litellm(provider):
+    from deepeval.models import LiteLLMModel
+
+    from mlflow.genai.scorers.deepeval.models import create_deepeval_model
+
+    model = create_deepeval_model(f"{provider}:/my-model")
+    assert isinstance(model, LiteLLMModel)
+
+
+def test_high_level_scorer_call_chain():
+    """Exercises the full call chain: AnswerRelevancy(model=...) → scorer(inputs=..., outputs=...)
+    as recommended in docs/blogs.
+    """
+
+    with patch(
+        "mlflow.genai.scorers.deepeval.models._call_llm_provider_api",
+        return_value='{"score": 0.9, "reason": "Highly relevant"}',
+    ):
+        scorer = AnswerRelevancy(threshold=0.7, model="openai:/gpt-4")
+
+        # Mock the metric's measure to avoid DeepEval's internal LLM calls
+        scorer._metric.score = 0.9
+        scorer._metric.reason = "Highly relevant"
+        scorer._metric.threshold = 0.7
+        scorer._metric.is_successful = Mock(return_value=True)
+        scorer._metric.measure = Mock()
+
+        feedback = scorer(
+            inputs="What is MLflow?",
+            outputs="MLflow is an open-source platform for managing ML workflows.",
+        )
+
+    assert isinstance(feedback, Feedback)
+    assert feedback.name == "AnswerRelevancy"
+    assert feedback.value is not None
+    assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
+    assert feedback.source.source_id == "openai:/gpt-4"

--- a/tests/genai/scorers/deepeval/test_deepeval_scorer.py
+++ b/tests/genai/scorers/deepeval/test_deepeval_scorer.py
@@ -427,21 +427,15 @@ def test_create_deepeval_model_falls_back_to_litellm_for_unsupported_provider():
     assert isinstance(model, LiteLLMModel)
 
 
-def test_create_deepeval_model_uses_litellm_for_gateway_uri():
-    from deepeval.models import LiteLLMModel
+def test_create_deepeval_model_uses_gateway_for_gateway_uri():
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM, create_deepeval_model
 
-    from mlflow.genai.scorers.deepeval.models import create_deepeval_model
-
-    with patch("mlflow.genai.scorers.deepeval.models.get_gateway_litellm_config") as mock_config:
-        mock_config.return_value = Mock(
-            model="my-endpoint",
-            api_base="http://localhost:5000",
-            api_key="test-key",
-            extra_headers=None,
-        )
+    with patch(
+        "mlflow.genai.scorers.deepeval.models._get_provider_instance",
+    ):
         model = create_deepeval_model("gateway:/my-endpoint")
 
-    assert isinstance(model, LiteLLMModel)
+    assert isinstance(model, GatewayDeepEvalLLM)
 
 
 def test_create_deepeval_model_uses_databricks_for_bare_uri():

--- a/tests/genai/scorers/deepeval/test_models.py
+++ b/tests/genai/scorers/deepeval/test_models.py
@@ -55,7 +55,7 @@ def test_create_deepeval_model_gateway_sets_api_base_and_key():
             "mlflow.genai.scorers.deepeval.models.get_gateway_litellm_config",
             return_value=mock_config,
         ),
-        patch("mlflow.genai.scorers.deepeval.models.LiteLLMModel") as mock_litellm_model,
+        patch("deepeval.models.LiteLLMModel") as mock_litellm_model,
     ):
         create_deepeval_model("gateway:/my-endpoint")
 
@@ -67,18 +67,10 @@ def test_create_deepeval_model_gateway_sets_api_base_and_key():
     )
 
 
-@pytest.mark.parametrize(
-    ("model_uri", "expected_model_arg"),
-    [
-        ("openai:/gpt-4", "openai/gpt-4"),
-        ("databricks:/my-endpoint", "databricks/my-endpoint"),
-    ],
-)
-def test_create_deepeval_model_non_gateway(model_uri, expected_model_arg):
-    with patch("mlflow.genai.scorers.deepeval.models.LiteLLMModel") as mock_litellm_model:
-        create_deepeval_model(model_uri)
+def test_create_deepeval_model_supported_provider_uses_gateway(monkeypatch):
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM
 
-    mock_litellm_model.assert_called_once_with(
-        model=expected_model_arg,
-        generation_kwargs={"drop_params": True},
-    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    model = create_deepeval_model("openai:/gpt-4")
+    assert isinstance(model, GatewayDeepEvalLLM)
+    assert model.get_model_name() == "openai/gpt-4"

--- a/tests/genai/scorers/deepeval/test_models.py
+++ b/tests/genai/scorers/deepeval/test_models.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 from mlflow.genai.scorers.deepeval.models import DatabricksDeepEvalLLM, create_deepeval_model
-from mlflow.genai.utils.gateway_utils import GatewayLiteLLMConfig
 
 
 @pytest.fixture
@@ -26,45 +25,14 @@ def test_databricks_deepeval_llm_generate(mock_call_chat_completions):
     )
 
 
-def test_create_deepeval_model_gateway():
-    mock_config = GatewayLiteLLMConfig(
-        api_base="http://localhost:5000/gateway/mlflow/v1/",
-        api_key="mlflow-gateway-auth",
-        model="openai/my-endpoint",
-        extra_headers=None,
-    )
-    with patch(
-        "mlflow.genai.scorers.deepeval.models.get_gateway_litellm_config",
-        return_value=mock_config,
-    ) as mock_get_config:
+def test_create_deepeval_model_gateway_uses_native_provider():
+    from mlflow.genai.scorers.deepeval.models import GatewayDeepEvalLLM
+
+    with patch("mlflow.genai.scorers.deepeval.models._get_provider_instance"):
         model = create_deepeval_model("gateway:/my-endpoint")
 
-    mock_get_config.assert_called_once_with("my-endpoint")
-    assert model.__class__.__name__ == "LiteLLMModel"
-
-
-def test_create_deepeval_model_gateway_sets_api_base_and_key():
-    mock_config = GatewayLiteLLMConfig(
-        api_base="http://localhost:5000/gateway/mlflow/v1/",
-        api_key="mlflow-gateway-auth",
-        model="openai/my-endpoint",
-        extra_headers=None,
-    )
-    with (
-        patch(
-            "mlflow.genai.scorers.deepeval.models.get_gateway_litellm_config",
-            return_value=mock_config,
-        ),
-        patch("deepeval.models.LiteLLMModel") as mock_litellm_model,
-    ):
-        create_deepeval_model("gateway:/my-endpoint")
-
-    mock_litellm_model.assert_called_once_with(
-        model="openai/my-endpoint",
-        base_url="http://localhost:5000/gateway/mlflow/v1/",
-        api_key="mlflow-gateway-auth",
-        generation_kwargs={"drop_params": True},
-    )
+    assert isinstance(model, GatewayDeepEvalLLM)
+    assert model.get_model_name() == "gateway/my-endpoint"
 
 
 def test_create_deepeval_model_supported_provider_uses_gateway(monkeypatch):

--- a/tests/genai/scorers/deepeval/test_utils.py
+++ b/tests/genai/scorers/deepeval/test_utils.py
@@ -20,14 +20,15 @@ def test_create_deepeval_model_databricks():
 
 def test_create_deepeval_model_databricks_serving_endpoint():
     model = create_deepeval_model("databricks:/my-endpoint")
-    assert model.__class__.__name__ == "LiteLLMModel"
-    assert model.name == "databricks/my-endpoint"
+    assert model.__class__.__name__ == "GatewayDeepEvalLLM"
+    assert model.get_model_name() == "databricks/my-endpoint"
 
 
-def test_create_deepeval_model_openai():
+def test_create_deepeval_model_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     model = create_deepeval_model("openai:/gpt-4")
-    assert model.__class__.__name__ == "LiteLLMModel"
-    assert model.name == "openai/gpt-4"
+    assert model.__class__.__name__ == "GatewayDeepEvalLLM"
+    assert model.get_model_name() == "openai/gpt-4"
 
 
 def test_create_deepeval_model_rejects_provider_no_slash():


### PR DESCRIPTION
### Related Issues/PRs

Part of the litellm removal effort. Independent of the judge adapter stack (#22148, #22155, #22157).

### What changes are proposed in this pull request?

Adds `GatewayDeepEvalLLM`, a `DeepEvalBaseLLM` implementation that uses MLflow's native Gateway provider infrastructure (`_call_llm_provider_api`) instead of litellm.

**`create_deepeval_model` factory routing:**
1. `"databricks"` → `DatabricksDeepEvalLLM` (unchanged)
2. Any provider constructable by `_get_provider_instance` (openai, anthropic, gemini, gateway, databricks, etc.) → `GatewayDeepEvalLLM`
3. Unsupported providers (cohere, palm, etc.) → `LiteLLMModel` fallback

The `_get_provider_instance` probe catches only `MlflowException` so that legitimate configuration errors (missing keys, import failures) propagate instead of silently falling back to litellm.

This means for common providers like `openai:/gpt-4`, `gateway:/endpoint`, and `anthropic:/claude-3`, DeepEval scorers no longer invoke litellm at the MLflow layer. Users who have litellm installed (via deepeval's own dependency) still get it as a fallback for providers MLflow's Gateway doesn't handle natively.

Structured output is handled via JSON prompt injection + response parsing, matching the existing `DatabricksDeepEvalLLM` pattern.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests include:
- `GatewayDeepEvalLLM.generate()` with and without schema
- Factory routing: gateway adapter for supported providers, litellm fallback for unsupported
- Registered-but-unsupported providers (cohere, mosaicml, palm) fall back to litellm
- `gateway:/` URIs route through native provider (not litellm)
- High-level scorer integration test: `AnswerRelevancy(model="openai:/gpt-4")` → `scorer(inputs=..., outputs=...)`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release