### PR TITLE
Add Gateway-first model adapter for RAGAS scorer

### DIFF
--- a/mlflow/genai/scorers/ragas/models.py
+++ b/mlflow/genai/scorers/ragas/models.py
@@ -9,15 +9,17 @@ from openai import AsyncOpenAI
 from pydantic import BaseModel
 from ragas.embeddings import OpenAIEmbeddings
 from ragas.llms import InstructorBaseRagasLLM
-from ragas.llms.litellm_llm import LiteLLMStructuredLLM
 
+from mlflow.gateway.provider_registry import is_supported_provider
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.judges.utils.parsing_utils import _strip_markdown_code_blocks
 from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
-from mlflow.metrics.genai.model_utils import _parse_model_uri
+from mlflow.metrics.genai.model_utils import _call_llm_provider_api, _parse_model_uri
+
+T = t.TypeVar("T", bound=BaseModel)
 
 
 class DatabricksRagasLLM(InstructorBaseRagasLLM):
@@ -43,6 +45,36 @@ class DatabricksRagasLLM(InstructorBaseRagasLLM):
         return _DATABRICKS_DEFAULT_JUDGE_MODEL
 
 
+class GatewayRagasLLM(InstructorBaseRagasLLM):
+    """RAGAS LLM adapter using MLflow Gateway providers.
+
+    Uses the native provider infrastructure (_call_llm_provider_api) instead
+    of litellm. Handles structured output via JSON prompt injection and
+    response parsing (same approach as DatabricksRagasLLM).
+    """
+
+    def __init__(self, provider: str, model_name: str):
+        super().__init__()
+        self.is_async = False
+        self._provider = provider
+        self._model_name = model_name
+
+    def generate(self, prompt: str, response_model: type[T]) -> T:
+        full_prompt = _build_json_prompt(prompt, response_model)
+        response = _call_llm_provider_api(
+            self._provider,
+            self._model_name,
+            input_data=full_prompt,
+        )
+        return _parse_json_response(response, response_model)
+
+    async def agenerate(self, prompt: str, response_model: type[T]) -> T:
+        return self.generate(prompt, response_model)
+
+    def get_model_name(self) -> str:
+        return f"{self._provider}/{self._model_name}"
+
+
 def create_ragas_model(model_uri: str):
     """
     Create a RAGAS LLM adapter from a model URI.
@@ -52,7 +84,7 @@ def create_ragas_model(model_uri: str):
             - "databricks" - Use default Databricks managed judge
             - "databricks:/endpoint" - Use Databricks serving endpoint
             - "gateway:/endpoint" - Use MLflow AI Gateway endpoint
-            - "provider:/model" - Use LiteLLM (e.g., "openai:/gpt-4")
+            - "provider:/model" - Use native gateway provider or LiteLLM fallback
 
     Returns:
         A RAGAS-compatible LLM adapter
@@ -63,12 +95,13 @@ def create_ragas_model(model_uri: str):
     if model_uri == "databricks":
         return DatabricksRagasLLM()
 
-    import litellm
-
-    # Parse provider:/model format using shared helper
     provider, model_name = _parse_model_uri(model_uri)
 
+    # Gateway endpoints require litellm-based routing
     if provider == "gateway":
+        import litellm
+        from ragas.llms.litellm_llm import LiteLLMStructuredLLM
+
         config = get_gateway_litellm_config(model_name)
         bound_completion = functools.partial(
             litellm.acompletion,
@@ -83,6 +116,13 @@ def create_ragas_model(model_uri: str):
             provider="openai",
             drop_params=True,
         )
+
+    # Use native gateway provider for supported providers, litellm for others
+    if is_supported_provider(provider):
+        return GatewayRagasLLM(provider, model_name)
+
+    import litellm
+    from ragas.llms.litellm_llm import LiteLLMStructuredLLM
 
     client = instructor.from_litellm(litellm.acompletion)
     return LiteLLMStructuredLLM(
@@ -101,9 +141,6 @@ def create_default_embeddings():
         An OpenAIEmbeddings instance configured with a sync client.
     """
     return OpenAIEmbeddings(client=AsyncOpenAI())
-
-
-T = t.TypeVar("T", bound=BaseModel)
 
 
 def _build_json_prompt(prompt: str, response_model: type[T]) -> str:

--- a/mlflow/genai/scorers/ragas/models.py
+++ b/mlflow/genai/scorers/ragas/models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import json
 import typing as t
 
@@ -10,14 +9,16 @@ from pydantic import BaseModel
 from ragas.embeddings import OpenAIEmbeddings
 from ragas.llms import InstructorBaseRagasLLM
 
-from mlflow.gateway.provider_registry import is_supported_provider
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.judges.utils.parsing_utils import _strip_markdown_code_blocks
-from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
-from mlflow.metrics.genai.model_utils import _call_llm_provider_api, _parse_model_uri
+from mlflow.metrics.genai.model_utils import (
+    _call_llm_provider_api,
+    _get_provider_instance,
+    _parse_model_uri,
+)
 
 T = t.TypeVar("T", bound=BaseModel)
 
@@ -97,29 +98,13 @@ def create_ragas_model(model_uri: str):
 
     provider, model_name = _parse_model_uri(model_uri)
 
-    # Gateway endpoints require litellm-based routing
-    if provider == "gateway":
-        import litellm
-        from ragas.llms.litellm_llm import LiteLLMStructuredLLM
-
-        config = get_gateway_litellm_config(model_name)
-        bound_completion = functools.partial(
-            litellm.acompletion,
-            api_base=config.api_base,
-            api_key=config.api_key,
-            **({"extra_headers": config.extra_headers} if config.extra_headers else {}),
-        )
-        client = instructor.from_litellm(bound_completion)
-        return LiteLLMStructuredLLM(
-            client=client,
-            model=config.model,
-            provider="openai",
-            drop_params=True,
-        )
-
-    # Use native gateway provider for supported providers, litellm for others
-    if is_supported_provider(provider):
+    # Use native gateway provider if _get_provider_instance can construct it,
+    # otherwise fall back to litellm
+    try:
+        _get_provider_instance(provider, model_name)
         return GatewayRagasLLM(provider, model_name)
+    except Exception:
+        pass
 
     import litellm
     from ragas.llms.litellm_llm import LiteLLMStructuredLLM

--- a/mlflow/genai/scorers/ragas/models.py
+++ b/mlflow/genai/scorers/ragas/models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from ragas.embeddings import OpenAIEmbeddings
 from ragas.llms import InstructorBaseRagasLLM
 
+from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
@@ -102,9 +103,10 @@ def create_ragas_model(model_uri: str):
     # otherwise fall back to litellm
     try:
         _get_provider_instance(provider, model_name)
-        return GatewayRagasLLM(provider, model_name)
-    except Exception:
+    except MlflowException:
         pass
+    else:
+        return GatewayRagasLLM(provider, model_name)
 
     import litellm
     from ragas.llms.litellm_llm import LiteLLMStructuredLLM

--- a/tests/genai/scorers/ragas/test_models.py
+++ b/tests/genai/scorers/ragas/test_models.py
@@ -59,12 +59,15 @@ def test_create_ragas_model_databricks():
 
 def test_create_ragas_model_databricks_serving_endpoint():
     model = create_ragas_model("databricks:/my-endpoint")
-    assert model.__class__.__name__ == "LiteLLMStructuredLLM"
+    assert model.__class__.__name__ == "GatewayRagasLLM"
+    assert model.get_model_name() == "databricks/my-endpoint"
 
 
-def test_create_ragas_model_openai():
+def test_create_ragas_model_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     model = create_ragas_model("openai:/gpt-4")
-    assert model.__class__.__name__ == "LiteLLMStructuredLLM"
+    assert model.__class__.__name__ == "GatewayRagasLLM"
+    assert model.get_model_name() == "openai/gpt-4"
 
 
 def test_create_ragas_model_rejects_provider_no_slash():

--- a/tests/genai/scorers/ragas/test_models.py
+++ b/tests/genai/scorers/ragas/test_models.py
@@ -1,4 +1,3 @@
-import functools
 import sys
 from unittest.mock import Mock, patch
 
@@ -7,7 +6,6 @@ from pydantic import BaseModel
 
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers.ragas.models import DatabricksRagasLLM, create_ragas_model
-from mlflow.genai.utils.gateway_utils import GatewayLiteLLMConfig
 
 
 class DummyResponseModel(BaseModel):
@@ -80,46 +78,17 @@ def test_create_ragas_model_rejects_model_name_only():
         create_ragas_model("gpt-4")
 
 
-def test_create_ragas_model_gateway():
-    mock_config = GatewayLiteLLMConfig(
-        api_base="http://localhost:5000/gateway/mlflow/v1/",
-        api_key="mlflow-gateway-auth",
-        model="openai/my-endpoint",
-        extra_headers=None,
-    )
-    with patch(
-        "mlflow.genai.scorers.ragas.models.get_gateway_litellm_config",
-        return_value=mock_config,
-    ) as mock_get_config:
+def test_create_ragas_model_gateway_uses_native_provider():
+    from mlflow.genai.scorers.ragas.models import GatewayRagasLLM
+
+    with patch("mlflow.genai.scorers.ragas.models._get_provider_instance"):
         model = create_ragas_model("gateway:/my-endpoint")
 
-    mock_get_config.assert_called_once_with("my-endpoint")
+    assert isinstance(model, GatewayRagasLLM)
+    assert model.get_model_name() == "gateway/my-endpoint"
+
+
+@pytest.mark.parametrize("provider", ["cohere", "mosaicml", "palm"])
+def test_create_ragas_model_registered_but_unsupported_falls_back_to_litellm(provider):
+    model = create_ragas_model(f"{provider}:/my-model")
     assert model.__class__.__name__ == "LiteLLMStructuredLLM"
-    assert model.model == "openai/my-endpoint"
-
-
-def test_create_ragas_model_gateway_uses_partial_with_api_base_and_key():
-    mock_config = GatewayLiteLLMConfig(
-        api_base="http://localhost:5000/gateway/mlflow/v1/",
-        api_key="mlflow-gateway-auth",
-        model="openai/my-endpoint",
-        extra_headers=None,
-    )
-    mock_litellm = Mock()
-    with (
-        patch.dict(sys.modules, {"litellm": mock_litellm}),
-        patch(
-            "mlflow.genai.scorers.ragas.models.get_gateway_litellm_config",
-            return_value=mock_config,
-        ),
-        patch("mlflow.genai.scorers.ragas.models.instructor") as mock_instructor,
-    ):
-        mock_instructor.from_litellm.return_value = Mock()
-        create_ragas_model("gateway:/my-endpoint")
-
-    mock_instructor.from_litellm.assert_called_once()
-    partial_arg = mock_instructor.from_litellm.call_args[0][0]
-    assert isinstance(partial_arg, functools.partial)
-    assert partial_arg.keywords["api_base"] == "http://localhost:5000/gateway/mlflow/v1/"
-    assert partial_arg.keywords["api_key"] == "mlflow-gateway-auth"
-    assert partial_arg.func is mock_litellm.acompletion

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -428,22 +428,13 @@ def test_create_ragas_model_falls_back_to_litellm_for_unsupported_provider():
     assert isinstance(model, LiteLLMStructuredLLM)
 
 
-def test_create_ragas_model_uses_litellm_for_gateway_uri():
-    pytest.importorskip("litellm")
-    from ragas.llms.litellm_llm import LiteLLMStructuredLLM
+def test_create_ragas_model_uses_gateway_for_gateway_uri():
+    from mlflow.genai.scorers.ragas.models import GatewayRagasLLM, create_ragas_model
 
-    from mlflow.genai.scorers.ragas.models import create_ragas_model
-
-    with patch("mlflow.genai.scorers.ragas.models.get_gateway_litellm_config") as mock_config:
-        mock_config.return_value = MagicMock(
-            model="my-endpoint",
-            api_base="http://localhost:5000",
-            api_key="test",
-            extra_headers=None,
-        )
+    with patch("mlflow.genai.scorers.ragas.models._get_provider_instance"):
         model = create_ragas_model("gateway:/my-endpoint")
 
-    assert isinstance(model, LiteLLMStructuredLLM)
+    assert isinstance(model, GatewayRagasLLM)
 
 
 def test_create_ragas_model_uses_databricks_for_bare_uri():
@@ -451,3 +442,35 @@ def test_create_ragas_model_uses_databricks_for_bare_uri():
 
     model = create_ragas_model("databricks")
     assert isinstance(model, DatabricksRagasLLM)
+
+
+@pytest.mark.parametrize("provider", ["cohere", "mosaicml", "palm"])
+def test_create_ragas_model_registered_but_unsupported_falls_back_to_litellm(provider):
+    pytest.importorskip("litellm")
+    from ragas.llms.litellm_llm import LiteLLMStructuredLLM
+
+    from mlflow.genai.scorers.ragas.models import create_ragas_model
+
+    model = create_ragas_model(f"{provider}:/my-model")
+    assert isinstance(model, LiteLLMStructuredLLM)
+
+
+def test_high_level_scorer_call_chain():
+    """Exercises the full call chain as recommended in docs/blogs:
+    Faithfulness(model=...) → scorer(inputs=..., outputs=..., expectations=...)
+    """
+    scorer = Faithfulness(model="openai:/gpt-4", threshold=0.7)
+    scorer._metric.threshold = 0.7
+
+    with patch.object(scorer._metric, "ascore", make_mock_ascore(0.9)):
+        feedback = scorer(
+            inputs="What is MLflow?",
+            outputs="MLflow is an open-source platform.",
+            expectations={"context": "MLflow is an open-source platform for ML."},
+        )
+
+    assert isinstance(feedback, Feedback)
+    assert feedback.name == "Faithfulness"
+    assert feedback.value == CategoricalRating.YES
+    assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
+    assert feedback.source.source_id == "openai:/gpt-4"

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import BaseModel
 from ragas.embeddings.base import BaseRagasEmbedding
 
 import mlflow
@@ -366,3 +367,87 @@ def test_agentic_scorer_with_expectations(scorer_class, expectations, sample_ass
 
     assert isinstance(result, Feedback)
     assert result.name == scorer_class.metric_name
+
+
+# --- Model adapter tests ---
+
+
+def test_gateway_ragas_llm_generate():
+    from mlflow.genai.scorers.ragas.models import GatewayRagasLLM
+
+    class TestOutput(BaseModel):
+        score: int
+        reason: str
+
+    adapter = GatewayRagasLLM("openai", "gpt-4")
+
+    with patch(
+        "mlflow.genai.scorers.ragas.models._call_llm_provider_api",
+        return_value='{"score": 5, "reason": "Excellent"}',
+    ) as mock_call:
+        result = adapter.generate("Rate this", response_model=TestOutput)
+
+    assert isinstance(result, TestOutput)
+    assert result.score == 5
+    assert result.reason == "Excellent"
+    mock_call.assert_called_once()
+    prompt = mock_call.call_args.kwargs["input_data"]
+    assert "Rate this" in prompt
+    assert "score" in prompt
+
+
+def test_gateway_ragas_llm_get_model_name():
+    from mlflow.genai.scorers.ragas.models import GatewayRagasLLM
+
+    adapter = GatewayRagasLLM("anthropic", "claude-3")
+    assert adapter.get_model_name() == "anthropic/claude-3"
+
+
+@pytest.mark.parametrize(
+    ("model_uri", "env_var"),
+    [
+        ("openai:/gpt-4", "OPENAI_API_KEY"),
+        ("anthropic:/claude-3", "ANTHROPIC_API_KEY"),
+    ],
+)
+def test_create_ragas_model_uses_gateway_for_supported_providers(model_uri, env_var, monkeypatch):
+    from mlflow.genai.scorers.ragas.models import GatewayRagasLLM, create_ragas_model
+
+    monkeypatch.setenv(env_var, "test-key")
+    model = create_ragas_model(model_uri)
+    assert isinstance(model, GatewayRagasLLM)
+
+
+def test_create_ragas_model_falls_back_to_litellm_for_unsupported_provider():
+    pytest.importorskip("litellm")
+    from ragas.llms.litellm_llm import LiteLLMStructuredLLM
+
+    from mlflow.genai.scorers.ragas.models import create_ragas_model
+
+    model = create_ragas_model("some_unknown:/model")
+    assert isinstance(model, LiteLLMStructuredLLM)
+
+
+def test_create_ragas_model_uses_litellm_for_gateway_uri():
+    pytest.importorskip("litellm")
+    from ragas.llms.litellm_llm import LiteLLMStructuredLLM
+
+    from mlflow.genai.scorers.ragas.models import create_ragas_model
+
+    with patch("mlflow.genai.scorers.ragas.models.get_gateway_litellm_config") as mock_config:
+        mock_config.return_value = MagicMock(
+            model="my-endpoint",
+            api_base="http://localhost:5000",
+            api_key="test",
+            extra_headers=None,
+        )
+        model = create_ragas_model("gateway:/my-endpoint")
+
+    assert isinstance(model, LiteLLMStructuredLLM)
+
+
+def test_create_ragas_model_uses_databricks_for_bare_uri():
+    from mlflow.genai.scorers.ragas.models import DatabricksRagasLLM, create_ragas_model
+
+    model = create_ragas_model("databricks")
+    assert isinstance(model, DatabricksRagasLLM)


### PR DESCRIPTION
### Related Issues/PRs

Part of the litellm removal effort. Independent of the judge adapter stack (#22148, #22155, #22157) and the DeepEval PR (#22183).

### What changes are proposed in this pull request?

Adds `GatewayRagasLLM`, an `InstructorBaseRagasLLM` implementation that uses MLflow's native Gateway provider infrastructure (`_call_llm_provider_api`) instead of litellm.

**`create_ragas_model` factory routing:**
1. `"databricks"` → `DatabricksRagasLLM` (unchanged)
2. Any provider constructable by `_get_provider_instance` (openai, anthropic, gemini, gateway, databricks, etc.) → `GatewayRagasLLM`
3. Unsupported providers (cohere, palm, etc.) → `LiteLLMStructuredLLM` fallback

The `_get_provider_instance` probe catches only `MlflowException` so that legitimate configuration errors propagate instead of silently falling back to litellm.

Structured output is handled via JSON prompt injection + response parsing, matching the existing `DatabricksRagasLLM` pattern.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests include:
- `GatewayRagasLLM.generate()` with response model parsing
- Factory routing: gateway adapter for supported providers, litellm fallback for unsupported
- Registered-but-unsupported providers (cohere, mosaicml, palm) fall back to litellm
- `gateway:/` URIs route through native provider
- High-level scorer integration test: `Faithfulness(model="openai:/gpt-4")` → `scorer(inputs=..., outputs=..., expectations=...)`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release