### PR TITLE
Add Gateway-first model adapter for Phoenix scorer

### DIFF
--- a/mlflow/genai/scorers/phoenix/models.py
+++ b/mlflow/genai/scorers/phoenix/models.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from mlflow.gateway.provider_registry import is_supported_provider
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.scorers.phoenix.utils import _NoOpRateLimiter, check_phoenix_installed
-from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
-from mlflow.metrics.genai.model_utils import _call_llm_provider_api, _parse_model_uri
+from mlflow.metrics.genai.model_utils import (
+    _call_llm_provider_api,
+    _get_provider_instance,
+    _parse_model_uri,
+)
 
 
 # Phoenix has BaseModel in phoenix.evals.models.base, but it requires implementing
@@ -65,9 +67,8 @@ def create_phoenix_model(model_uri: str):
 
     Routing:
         - ``"databricks"`` → DatabricksPhoenixModel (managed judge)
-        - ``"gateway:/endpoint"`` → LiteLLMModel (gateway routing)
-        - Supported providers (e.g. ``"openai:/gpt-4"``) → GatewayPhoenixModel
-        - Unsupported providers → LiteLLMModel (litellm fallback)
+        - Providers constructable by ``_get_provider_instance`` → GatewayPhoenixModel
+        - All other providers → LiteLLMModel (litellm fallback)
     """
     check_phoenix_installed()
 
@@ -76,24 +77,13 @@ def create_phoenix_model(model_uri: str):
 
     provider, model_name = _parse_model_uri(model_uri)
 
-    # Gateway endpoints require litellm-based routing
-    if provider == "gateway":
-        from phoenix.evals import LiteLLMModel
-
-        config = get_gateway_litellm_config(model_name)
-        return LiteLLMModel(
-            model=config.model,
-            model_kwargs={
-                "api_base": config.api_base,
-                "api_key": config.api_key,
-                "drop_params": True,
-                **({"extra_headers": config.extra_headers} if config.extra_headers else {}),
-            },
-        )
-
-    # Use native gateway provider for supported providers, litellm for others
-    if is_supported_provider(provider):
+    # Use native gateway provider if _get_provider_instance can construct it,
+    # otherwise fall back to litellm
+    try:
+        _get_provider_instance(provider, model_name)
         return GatewayPhoenixModel(provider, model_name)
+    except Exception:
+        pass
 
     from phoenix.evals import LiteLLMModel
 

--- a/mlflow/genai/scorers/phoenix/models.py
+++ b/mlflow/genai/scorers/phoenix/models.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from mlflow.gateway.provider_registry import is_supported_provider
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.scorers.phoenix.utils import _NoOpRateLimiter, check_phoenix_installed
 from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
-from mlflow.metrics.genai.model_utils import _parse_model_uri
+from mlflow.metrics.genai.model_utils import _call_llm_provider_api, _parse_model_uri
 
 
 # Phoenix has BaseModel in phoenix.evals.models.base, but it requires implementing
@@ -34,34 +35,51 @@ class DatabricksPhoenixModel:
         return self._model_name
 
 
-def create_phoenix_model(model_uri: str):
+class GatewayPhoenixModel:
+    """Phoenix model adapter using MLflow Gateway providers.
+
+    Uses the native provider infrastructure (_call_llm_provider_api) instead
+    of litellm. Implements the duck-typed callable interface Phoenix expects.
     """
-    Create a Phoenix model adapter from a model URI.
 
-    Args:
-        model_uri: Model URI in one of these formats:
-            - "databricks" - Use default Databricks managed judge
-            - "databricks:/endpoint" - Use Databricks serving endpoint
-            - "gateway:/endpoint" - Use MLflow AI Gateway endpoint
-            - "provider:/model" - Use LiteLLM model (e.g., "openai:/gpt-4")
+    def __init__(self, provider: str, model_name: str):
+        self._provider = provider
+        self._model_name = model_name
+        self._verbose = False
+        self._rate_limiter = _NoOpRateLimiter()
 
-    Returns:
-        A Phoenix-compatible model adapter
+    def __call__(self, prompt, **kwargs) -> str:
+        prompt_str = str(prompt) if not isinstance(prompt, str) else prompt
+        return _call_llm_provider_api(
+            self._provider,
+            self._model_name,
+            input_data=prompt_str,
+        )
 
-    Raises:
-        MlflowException: If the model URI format is invalid
+    def get_model_name(self) -> str:
+        return f"{self._provider}/{self._model_name}"
+
+
+def create_phoenix_model(model_uri: str):
+    """Create a Phoenix model adapter from a model URI.
+
+    Routing:
+        - ``"databricks"`` → DatabricksPhoenixModel (managed judge)
+        - ``"gateway:/endpoint"`` → LiteLLMModel (gateway routing)
+        - Supported providers (e.g. ``"openai:/gpt-4"``) → GatewayPhoenixModel
+        - Unsupported providers → LiteLLMModel (litellm fallback)
     """
     check_phoenix_installed()
 
     if model_uri == "databricks":
         return DatabricksPhoenixModel()
 
-    # Parse provider:/model format using shared helper
-    from phoenix.evals import LiteLLMModel
-
     provider, model_name = _parse_model_uri(model_uri)
 
+    # Gateway endpoints require litellm-based routing
     if provider == "gateway":
+        from phoenix.evals import LiteLLMModel
+
         config = get_gateway_litellm_config(model_name)
         return LiteLLMModel(
             model=config.model,
@@ -72,6 +90,12 @@ def create_phoenix_model(model_uri: str):
                 **({"extra_headers": config.extra_headers} if config.extra_headers else {}),
             },
         )
+
+    # Use native gateway provider for supported providers, litellm for others
+    if is_supported_provider(provider):
+        return GatewayPhoenixModel(provider, model_name)
+
+    from phoenix.evals import LiteLLMModel
 
     return LiteLLMModel(
         model=f"{provider}/{model_name}",

--- a/mlflow/genai/scorers/phoenix/models.py
+++ b/mlflow/genai/scorers/phoenix/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
@@ -81,9 +82,10 @@ def create_phoenix_model(model_uri: str):
     # otherwise fall back to litellm
     try:
         _get_provider_instance(provider, model_name)
-        return GatewayPhoenixModel(provider, model_name)
-    except Exception:
+    except MlflowException:
         pass
+    else:
+        return GatewayPhoenixModel(provider, model_name)
 
     from phoenix.evals import LiteLLMModel
 

--- a/tests/genai/scorers/phoenix/test_models.py
+++ b/tests/genai/scorers/phoenix/test_models.py
@@ -1,6 +1,5 @@
 from unittest.mock import Mock, patch
 
-import phoenix.evals as phoenix_evals
 import pytest
 
 from mlflow.exceptions import MlflowException
@@ -9,7 +8,6 @@ from mlflow.genai.scorers.phoenix.models import (
     GatewayPhoenixModel,
     create_phoenix_model,
 )
-from mlflow.genai.utils.gateway_utils import GatewayLiteLLMConfig
 
 
 @pytest.fixture
@@ -60,52 +58,14 @@ def test_create_phoenix_model_invalid_format():
         create_phoenix_model("gpt-4")
 
 
-def test_create_phoenix_model_gateway(monkeypatch):
-    mock_config = GatewayLiteLLMConfig(
-        api_base="http://localhost:5000/gateway/mlflow/v1/",
-        api_key="mlflow-gateway-auth",
-        model="openai/my-endpoint",
-        extra_headers=None,
-    )
-    monkeypatch.setenv("OPENAI_API_KEY", "mlflow-gateway-auth")
+def test_create_phoenix_model_gateway_uses_native_provider():
     with patch(
-        "mlflow.genai.scorers.phoenix.models.get_gateway_litellm_config",
-        return_value=mock_config,
-    ) as mock_get_config:
+        "mlflow.genai.scorers.phoenix.models._get_provider_instance",
+    ):
         model = create_phoenix_model("gateway:/my-endpoint")
 
-    mock_get_config.assert_called_once_with("my-endpoint")
-    assert isinstance(model, phoenix_evals.LiteLLMModel)
-    assert model.model == "openai/my-endpoint"
-    assert model.model_kwargs["api_base"] == "http://localhost:5000/gateway/mlflow/v1/"
-    assert model.model_kwargs["api_key"] == "mlflow-gateway-auth"
-
-
-def test_create_phoenix_model_gateway_sets_api_base_and_key():
-    mock_config = GatewayLiteLLMConfig(
-        api_base="http://localhost:5000/gateway/mlflow/v1/",
-        api_key="mlflow-gateway-auth",
-        model="openai/my-endpoint",
-        extra_headers=None,
-    )
-    mock_litellm_model = Mock()
-    with (
-        patch(
-            "mlflow.genai.scorers.phoenix.models.get_gateway_litellm_config",
-            return_value=mock_config,
-        ),
-        patch("phoenix.evals.LiteLLMModel", mock_litellm_model),
-    ):
-        create_phoenix_model("gateway:/my-endpoint")
-
-    mock_litellm_model.assert_called_once_with(
-        model="openai/my-endpoint",
-        model_kwargs={
-            "api_base": "http://localhost:5000/gateway/mlflow/v1/",
-            "api_key": "mlflow-gateway-auth",
-            "drop_params": True,
-        },
-    )
+    assert isinstance(model, GatewayPhoenixModel)
+    assert model.get_model_name() == "gateway/my-endpoint"
 
 
 def test_gateway_phoenix_model_call():
@@ -149,3 +109,28 @@ def test_create_phoenix_model_uses_gateway_for_supported_providers(model_uri, en
     monkeypatch.setenv(env_var, "test-key")
     model = create_phoenix_model(model_uri)
     assert isinstance(model, GatewayPhoenixModel)
+
+
+def test_create_phoenix_model_falls_back_to_litellm_for_unsupported_provider():
+    mock_litellm_cls = Mock()
+    with patch("phoenix.evals.LiteLLMModel", mock_litellm_cls):
+        model = create_phoenix_model("some_unknown:/model")
+
+    assert model is mock_litellm_cls.return_value
+    mock_litellm_cls.assert_called_once_with(
+        model="some_unknown/model",
+        model_kwargs={"drop_params": True},
+    )
+
+
+@pytest.mark.parametrize("provider", ["cohere", "mosaicml", "palm"])
+def test_create_phoenix_model_registered_but_unsupported_falls_back_to_litellm(provider):
+    mock_litellm_cls = Mock()
+    with patch("phoenix.evals.LiteLLMModel", mock_litellm_cls):
+        model = create_phoenix_model(f"{provider}:/my-model")
+
+    assert model is mock_litellm_cls.return_value
+    mock_litellm_cls.assert_called_once_with(
+        model=f"{provider}/my-model",
+        model_kwargs={"drop_params": True},
+    )

--- a/tests/genai/scorers/phoenix/test_models.py
+++ b/tests/genai/scorers/phoenix/test_models.py
@@ -6,6 +6,7 @@ import pytest
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers.phoenix.models import (
     DatabricksPhoenixModel,
+    GatewayPhoenixModel,
     create_phoenix_model,
 )
 from mlflow.genai.utils.gateway_utils import GatewayLiteLLMConfig
@@ -44,14 +45,14 @@ def test_create_phoenix_model_databricks():
 
 def test_create_phoenix_model_databricks_endpoint():
     model = create_phoenix_model("databricks:/my-endpoint")
-    assert isinstance(model, phoenix_evals.LiteLLMModel)
-    assert model.model == "databricks/my-endpoint"
+    assert isinstance(model, GatewayPhoenixModel)
+    assert model.get_model_name() == "databricks/my-endpoint"
 
 
 def test_create_phoenix_model_openai(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     model = create_phoenix_model("openai:/gpt-4")
-    assert isinstance(model, phoenix_evals.LiteLLMModel)
+    assert isinstance(model, GatewayPhoenixModel)
 
 
 def test_create_phoenix_model_invalid_format():
@@ -105,3 +106,46 @@ def test_create_phoenix_model_gateway_sets_api_base_and_key():
             "drop_params": True,
         },
     )
+
+
+def test_gateway_phoenix_model_call():
+    model = GatewayPhoenixModel("openai", "gpt-4")
+
+    with patch(
+        "mlflow.genai.scorers.phoenix.models._call_llm_provider_api",
+        return_value="The answer is 42.",
+    ) as mock_call:
+        result = model("What is the answer?")
+
+    assert result == "The answer is 42."
+    mock_call.assert_called_once_with("openai", "gpt-4", input_data="What is the answer?")
+
+
+def test_gateway_phoenix_model_converts_non_string_prompt():
+    model = GatewayPhoenixModel("openai", "gpt-4")
+
+    with patch(
+        "mlflow.genai.scorers.phoenix.models._call_llm_provider_api",
+        return_value="response",
+    ) as mock_call:
+        model(12345)
+
+    mock_call.assert_called_once_with("openai", "gpt-4", input_data="12345")
+
+
+def test_gateway_phoenix_model_get_model_name():
+    model = GatewayPhoenixModel("anthropic", "claude-3")
+    assert model.get_model_name() == "anthropic/claude-3"
+
+
+@pytest.mark.parametrize(
+    ("model_uri", "env_var"),
+    [
+        ("openai:/gpt-4", "OPENAI_API_KEY"),
+        ("anthropic:/claude-3", "ANTHROPIC_API_KEY"),
+    ],
+)
+def test_create_phoenix_model_uses_gateway_for_supported_providers(model_uri, env_var, monkeypatch):
+    monkeypatch.setenv(env_var, "test-key")
+    model = create_phoenix_model(model_uri)
+    assert isinstance(model, GatewayPhoenixModel)

--- a/tests/genai/scorers/phoenix/test_phoenix.py
+++ b/tests/genai/scorers/phoenix/test_phoenix.py
@@ -4,6 +4,7 @@ import phoenix.evals as phoenix_evals
 import pytest
 
 from mlflow.entities.assessment import Feedback
+from mlflow.entities.assessment_source import AssessmentSourceType
 
 
 @pytest.fixture
@@ -124,3 +125,32 @@ def test_phoenix_scorer_error_handling(mock_model):
     assert isinstance(result, Feedback)
     assert result.error is not None
     assert "Evaluation failed" in str(result.error)
+
+
+def test_high_level_scorer_call_chain(monkeypatch):
+    """Exercises the full call chain: Hallucination(model=...) -> scorer(inputs=..., outputs=...)
+    as recommended in docs.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    from mlflow.genai.scorers.phoenix import Hallucination
+
+    scorer = Hallucination(model="openai:/gpt-4")
+
+    with patch.object(
+        scorer._evaluator, "evaluate", return_value=("factual", 0.95, "Grounded.")
+    ) as mock_evaluate:
+        feedback = scorer(
+            inputs="What is MLflow?",
+            outputs="MLflow is an open-source platform for managing ML workflows.",
+            expectations={"context": "MLflow is an open-source ML platform."},
+        )
+
+    mock_evaluate.assert_called_once()
+    assert isinstance(feedback, Feedback)
+    assert feedback.name == "Hallucination"
+    assert feedback.value == "factual"
+    assert feedback.metadata["score"] == 0.95
+    assert feedback.rationale == "Grounded."
+    assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
+    assert feedback.source.source_id == "openai:/gpt-4"


### PR DESCRIPTION
### Related Issues/PRs

Part of the litellm removal effort. Independent of DeepEval (#22183) and RAGAS (#22184).

### What changes are proposed in this pull request?

Adds `GatewayPhoenixModel`, a duck-typed callable that uses MLflow's native Gateway provider infrastructure (`_call_llm_provider_api`) instead of litellm. Phoenix only requires `__call__(prompt) -> str` — no structured output, no async.

**`create_phoenix_model` factory routing:**
1. `"databricks"` → `DatabricksPhoenixModel` (unchanged)
2. Any provider constructable by `_get_provider_instance` (openai, anthropic, gemini, gateway, databricks, etc.) → `GatewayPhoenixModel`
3. Unsupported providers (cohere, palm, etc.) → `LiteLLMModel` fallback

The `_get_provider_instance` probe catches only `MlflowException` so that legitimate configuration errors propagate instead of silently falling back to litellm.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests include:
- `GatewayPhoenixModel.__call__()` invocation
- Factory routing: gateway adapter for supported providers, litellm fallback for unsupported
- Registered-but-unsupported providers (cohere, mosaicml, palm) fall back to litellm
- `gateway:/` URIs route through native provider
- High-level scorer integration test: `Hallucination(model="openai:/gpt-4")` → `scorer(inputs=..., outputs=..., expectations=...)`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release