### PR TITLE
Document supported provider environment variables for judge models

### DIFF
--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/custom-judges/supported-models.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/custom-judges/supported-models.mdx
@@ -21,22 +21,22 @@ To use AI Gateway endpoints, select the endpoint from the UI dropdown or specify
 
 MLflow supports calling model providers directly using the format `provider:/model-name`. Each provider may require specific credentials set as environment variables:
 
-| Provider | URI Format | Environment Variables |
-|---|---|---|
-| OpenAI | `openai:/gpt-5.4-mini` | `OPENAI_API_KEY` |
-| Azure OpenAI | `azure:/my-deployment` | `AZURE_API_KEY`, `AZURE_API_BASE`, `AZURE_API_VERSION` |
-| Anthropic | `anthropic:/claude-sonnet-4-5` | `ANTHROPIC_API_KEY` |
-| Amazon Bedrock | `bedrock:/google.gemma-3-4b-it` | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` (optional). Alternatively: `AWS_BEARER_TOKEN_BEDROCK` for API key auth, or `AWS_ROLE_ARN` for IAM role. |
-| Google Gemini | `gemini:/gemini-3.1-pro-preview` | `GEMINI_API_KEY` |
-| Mistral | `mistral:/mistral-small-2603` | `MISTRAL_API_KEY` |
-| xAI | `xai:/grok-4.20-0309-reasoning` | `XAI_API_KEY` |
-| Vertex AI | `vertex_ai:/gemini-3-flash-preview` | `VERTEX_PROJECT`, `VERTEX_LOCATION` (optional), `VERTEX_CREDENTIALS` (optional) |
-| Groq | `groq:/llama-3.3-70b-versatile` | `GROQ_API_KEY` |
-| DeepSeek | `deepseek:/deepseek-chat` | `DEEPSEEK_API_KEY` |
-| OpenRouter | `openrouter:/openai/gpt-5.4-nano` | `OPENROUTER_API_KEY`. See [OpenRouter model list](https://openrouter.ai/models) for model names. |
-| Together AI | `togetherai:/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` | `TOGETHERAI_API_KEY` |
-| Ollama | `ollama:/llama3.2` | None (local) |
-| Databricks | `databricks:/databricks-claude-sonnet-4-5` | [Databricks SDK authentication](https://docs.databricks.com/aws/en/dev-tools/auth/index.html) (e.g. `DATABRICKS_HOST` + `DATABRICKS_TOKEN`, or other supported methods) |
+| Provider       | URI Format                                                      | Environment Variables                                                                                                                                                                   |
+| -------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenAI         | `openai:/gpt-5.4-mini`                                          | `OPENAI_API_KEY`                                                                                                                                                                        |
+| Azure OpenAI   | `azure:/my-deployment`                                          | `AZURE_API_KEY`, `AZURE_API_BASE`, `AZURE_API_VERSION`                                                                                                                                  |
+| Anthropic      | `anthropic:/claude-sonnet-4-5`                                  | `ANTHROPIC_API_KEY`                                                                                                                                                                     |
+| Amazon Bedrock | `bedrock:/google.gemma-3-4b-it`                                 | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` (optional). Alternatively: `AWS_BEARER_TOKEN_BEDROCK` for API key auth, or `AWS_ROLE_ARN` for IAM role. |
+| Google Gemini  | `gemini:/gemini-3.1-pro-preview`                                | `GEMINI_API_KEY`                                                                                                                                                                        |
+| Mistral        | `mistral:/mistral-small-2603`                                   | `MISTRAL_API_KEY`                                                                                                                                                                       |
+| xAI            | `xai:/grok-4.20-0309-reasoning`                                 | `XAI_API_KEY`                                                                                                                                                                           |
+| Vertex AI      | `vertex_ai:/gemini-3-flash-preview`                             | `VERTEX_PROJECT`, `VERTEX_LOCATION` (optional), `VERTEX_CREDENTIALS` (optional)                                                                                                         |
+| Groq           | `groq:/llama-3.3-70b-versatile`                                 | `GROQ_API_KEY`                                                                                                                                                                          |
+| DeepSeek       | `deepseek:/deepseek-chat`                                       | `DEEPSEEK_API_KEY`                                                                                                                                                                      |
+| OpenRouter     | `openrouter:/openai/gpt-5.4-nano`                               | `OPENROUTER_API_KEY`. See [OpenRouter model list](https://openrouter.ai/models) for model names.                                                                                        |
+| Together AI    | `togetherai:/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` | `TOGETHERAI_API_KEY`                                                                                                                                                                    |
+| Ollama         | `ollama:/llama3.2`                                              | None (local)                                                                                                                                                                            |
+| Databricks     | `databricks:/databricks-claude-sonnet-4-5`                      | [Databricks SDK authentication](https://docs.databricks.com/aws/en/dev-tools/auth/index.html) (e.g. `DATABRICKS_HOST` + `DATABRICKS_TOKEN`, or other supported methods)                 |
 
 :::warning
 Judges configured with direct model providers require credentials to be available locally (typically via environment variables) and **cannot be run from the UI**. Use AI Gateway endpoints if you want to run the judges from the UI.

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/custom-judges/supported-models.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/custom-judges/supported-models.mdx
@@ -19,22 +19,30 @@ To use AI Gateway endpoints, select the endpoint from the UI dropdown or specify
 
 ## Direct Model Providers
 
-MLflow also supports calling model providers directly:
+MLflow supports calling model providers directly using the format `provider:/model-name`. Each provider may require specific credentials set as environment variables:
 
-- OpenAI / Azure OpenAI
-- Anthropic
-- Amazon Bedrock
-- Gemini
-- xAI
-- Vertex AI
-- Mistral
-- [Many others](https://mlflow.org/docs/latest/api_reference/python_api/mlflow.gateway.html#mlflow.gateway.config.Provider)
+| Provider | URI Format | Environment Variables |
+|---|---|---|
+| OpenAI | `openai:/gpt-5.4-mini` | `OPENAI_API_KEY` |
+| Azure OpenAI | `azure:/my-deployment` | `AZURE_API_KEY`, `AZURE_API_BASE`, `AZURE_API_VERSION` |
+| Anthropic | `anthropic:/claude-sonnet-4-5` | `ANTHROPIC_API_KEY` |
+| Amazon Bedrock | `bedrock:/google.gemma-3-4b-it` | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` (optional). Alternatively: `AWS_BEARER_TOKEN_BEDROCK` for API key auth, or `AWS_ROLE_ARN` for IAM role. |
+| Google Gemini | `gemini:/gemini-3.1-pro-preview` | `GEMINI_API_KEY` |
+| Mistral | `mistral:/mistral-small-2603` | `MISTRAL_API_KEY` |
+| xAI | `xai:/grok-4.20-0309-reasoning` | `XAI_API_KEY` |
+| Vertex AI | `vertex_ai:/gemini-3-flash-preview` | `VERTEX_PROJECT`, `VERTEX_LOCATION` (optional), `VERTEX_CREDENTIALS` (optional) |
+| Groq | `groq:/llama-3.3-70b-versatile` | `GROQ_API_KEY` |
+| DeepSeek | `deepseek:/deepseek-chat` | `DEEPSEEK_API_KEY` |
+| OpenRouter | `openrouter:/openai/gpt-5.4-nano` | `OPENROUTER_API_KEY`. See [OpenRouter model list](https://openrouter.ai/models) for model names. |
+| Together AI | `togetherai:/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` | `TOGETHERAI_API_KEY` |
+| Ollama | `ollama:/llama3.2` | None (local) |
+| Databricks | `databricks:/databricks-claude-sonnet-4-5` | [Databricks SDK authentication](https://docs.databricks.com/aws/en/dev-tools/auth/index.html) (e.g. `DATABRICKS_HOST` + `DATABRICKS_TOKEN`, or other supported methods) |
 
 :::warning
-Judges configured with direct model providers require API keys to be set locally (e.g., `OPENAI_API_KEY`) and **cannot be run from the UI**. Use AI Gateway endpoints if you want to run the judges from the UI.
+Judges configured with direct model providers require credentials to be available locally (typically via environment variables) and **cannot be run from the UI**. Use AI Gateway endpoints if you want to run the judges from the UI.
 :::
 
-For any models that are not supported natively, it is also possible to use LiteLLM. Since LiteLLM is not a dependency of MLflow, you'll need to install it separately by running `pip install litellm`. After this, simply specify the provider and model name in the same format as natively supported providers, e.g., `gemini:/gemini-2.0-flash`.
+For any models that are not supported natively, it is also possible to use LiteLLM. Since LiteLLM is not a dependency of MLflow, you'll need to install it separately by running `pip install litellm`. After this, simply specify the provider and model name in the same format as natively supported providers.
 
 ## Databricks-Hosted Models
 


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #22148

### What changes are proposed in this pull request?

Updates the supported models documentation with a table listing all natively supported providers, their URI format, and required environment variables. This documents the providers added in #22148 (Groq, DeepSeek, xAI, OpenRouter, Ollama, Databricks, Vertex AI, Azure) and Bedrock bearer token auth.

The environment variable names come from the provider blocks in mlflow/metrics/genai/model_utils.py

  - OpenAI (line 325): OPENAI_API_KEY                                                                                                                                                                                                               
  - Azure (lines 331-336): AZURE_API_KEY, AZURE_API_BASE, AZURE_API_VERSION (from mlflow/utils/providers.py:717-719)                                                                                                                                
  - Anthropic (line 341): ANTHROPIC_API_KEY                                                                                                                                                                                                         
  - Bedrock (lines 347-360): AWS_BEARER_TOKEN_BEDROCK, AWS_ROLE_ARN, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_REGION                                                                                                        
  - Gemini (line 375): GEMINI_API_KEY (via _CORE_PROVIDER_ENV_VARS)                                                                                                                                                                                 
  - Mistral (line 381): MISTRAL_API_KEY                                                                                                                                                                                                             
  - TogetherAI (line 387): TOGETHERAI_API_KEY                                                                                                                                                                                                       
  - Groq (line 394): GROQ_API_KEY                                                                                                                                                                                                                   
  - DeepSeek (line 400): DEEPSEEK_API_KEY                                                                                                                                                                                                           
  - xAI (line 406): XAI_API_KEY                                                                                                                                                                                                                     
  - OpenRouter (line 412): OPENROUTER_API_KEY                                                                                                                                                                                                       
  - Ollama (line 418): OLLAMA_API_KEY (defaults to "ollama")                                                                                                                                                                                        
  - Databricks (lines 423-428): DATABRICKS_HOST, DATABRICKS_TOKEN, DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET                                                                                                                                   
  - Vertex AI (lines 433-439): VERTEX_PROJECT, VERTEX_LOCATION, VERTEX_CREDENTIALS    

### How is this PR tested?

- [x] Manual tests

Documentation-only change.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Documents the environment variables needed for each supported LLM provider when using direct model URIs for judge evaluation.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.