### PR TITLE
Run prettier in model prices update workflow

### DIFF
--- a/.github/workflows/update-model-prices.yml
+++ b/.github/workflows/update-model-prices.yml
@@ -13,7 +13,7 @@ defaults:
 jobs:
   update-model-prices:
     if: github.repository == 'mlflow/mlflow'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write
@@ -29,14 +29,23 @@ jobs:
         with:
           persist-credentials: true
 
+      - uses: ./.github/actions/setup-python
+        with:
+          pin-micro-version: false
+      - uses: ./.github/actions/setup-node
+
       - name: Download latest model prices
         run: |
           curl -fsSL \
             https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json \
             -o mlflow/utils/model_prices_and_context_window.json
 
-      - name: Format JSON with prettier
-        run: npx prettier --write mlflow/utils/model_prices_and_context_window.json
+      - name: Run pre-commit
+        run: |
+          uv sync --locked --only-group lint
+          uv run --no-sync pre-commit install --install-hooks
+          uv run --no-sync pre-commit run install-bin -a -v
+          uv run --no-sync pre-commit run --files mlflow/utils/model_prices_and_context_window.json || true
 
       - name: Check for changes
         id: diff

--- a/.github/workflows/update-model-prices.yml
+++ b/.github/workflows/update-model-prices.yml
@@ -35,6 +35,9 @@ jobs:
             https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json \
             -o mlflow/utils/model_prices_and_context_window.json
 
+      - name: Format JSON with prettier
+        run: npx prettier --write mlflow/utils/model_prices_and_context_window.json
+
       - name: Check for changes
         id: diff
         run: |

--- a/.github/workflows/update-model-prices.yml
+++ b/.github/workflows/update-model-prices.yml
@@ -45,6 +45,8 @@ jobs:
           uv sync --locked --only-group lint
           uv run --no-sync pre-commit install --install-hooks
           uv run --no-sync pre-commit run install-bin -a -v
+          # pre-commit exits 1 when it auto-fixes files (e.g. prettier reformats JSON).
+          # That's expected here — the fixes are picked up by the subsequent git diff.
           uv run --no-sync pre-commit run --files mlflow/utils/model_prices_and_context_window.json || true
 
       - name: Check for changes


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21986

### What changes are proposed in this pull request?

Adds a `npx prettier --write` step to the `update-model-prices` workflow so the downloaded JSON is formatted before committing. This prevents pre-commit/CI formatting failures on the automated PR.

### How is this PR tested?

- [x] Manual tests

The workflow was triggered manually and the formatting step was verified to work.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release