### PR TITLE
Move native providers to non-LiteLLM in gateway UI

### DIFF
--- a/mlflow/server/js/src/gateway/utils/providerUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.ts
@@ -1,4 +1,18 @@
-export const COMMON_PROVIDERS = ['openai', 'anthropic', 'databricks', 'bedrock', 'gemini', 'vertex_ai', 'xai'] as const;
+export const COMMON_PROVIDERS = [
+  'openai',
+  'anthropic',
+  'databricks',
+  'bedrock',
+  'gemini',
+  'vertex_ai',
+  'xai',
+  'mistral',
+  'groq',
+  'deepseek',
+  'openrouter',
+  'ollama',
+  'together_ai',
+] as const;
 
 export interface ProviderGroup {
   groupId: string;
@@ -83,6 +97,9 @@ const PROVIDER_DISPLAY_NAMES = {
   deepinfra: 'DeepInfra',
   nvidia_nim: 'NVIDIA NIM',
   cerebras: 'Cerebras',
+  deepseek: 'DeepSeek',
+  openrouter: 'OpenRouter',
+  ollama: 'Ollama',
 } satisfies Record<string, string>;
 
 export function formatProviderName(provider: string): string {


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Adds mistral, groq, deepseek, openrouter, ollama, and together_ai to `COMMON_PROVIDERS` so they appear directly in the gateway provider dropdown instead of being hidden behind the "LiteLLM" modal. Also adds missing display names for deepseek, openrouter, and ollama.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

<img width="929" height="548" alt="image" src="https://github.com/user-attachments/assets/94546e7c-caf6-490f-a9ca-1c806e54ed79" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Mistral, Groq, DeepSeek, OpenRouter, Ollama, and Together AI now appear as first-class providers in the gateway UI dropdown instead of being hidden under the LiteLLM modal.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.