### PR TITLE
Update databricks API calls to use new GRPC APIs instead of py4j APIs

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -135,10 +135,13 @@ def _get_dbutils():
 
 
 def _get_runtime_integration_client():
-    from dbruntime import UserNamespaceInitializer
+    try:
+        from dbruntime import UserNamespaceInitializer
 
-    driver_connection = UserNamespaceInitializer.getOrCreate().get_driver_connection()
-    return driver_connection.runtime_integration_client
+        driver_connection = UserNamespaceInitializer.getOrCreate().get_driver_connection()
+        return driver_connection.runtime_integration_client
+    except Exception:
+        return None
 
 
 class _NoDbutilsError(Exception):
@@ -508,10 +511,8 @@ def get_repl_id():
     Returns:
         The ID of the current Databricks Python REPL.
     """
-    try:
-        return _get_runtime_integration_client().getReplId()
-    except Exception:
-        pass
+    if client := _get_runtime_integration_client():
+        return client.getReplId()
 
     # Fallback for runtimes without runtime_integration_client: use entry_point directly.
     try:
@@ -1484,10 +1485,8 @@ def get_databricks_nfs_temp_dir():
     entry_point = _get_dbutils().entry_point
     if getpass.getuser().lower() == "root":
         return entry_point.getReplNFSTempDir()
-    try:
-        return _get_runtime_integration_client().getUserNFSTempDir()
-    except Exception:
-        pass
+    if client := _get_runtime_integration_client():
+        return client.getUserNFSTempDir()
     try:
         return entry_point.getUserNFSTempDir()
     except Exception:
@@ -1498,10 +1497,8 @@ def get_databricks_local_temp_dir():
     entry_point = _get_dbutils().entry_point
     if getpass.getuser().lower() == "root":
         return entry_point.getReplLocalTempDir()
-    try:
-        return _get_runtime_integration_client().getUserLocalTempDir()
-    except Exception:
-        pass
+    if client := _get_runtime_integration_client():
+        return client.getUserLocalTempDir()
     try:
         return entry_point.getUserLocalTempDir()
     except Exception:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -135,18 +135,12 @@ def _get_dbutils():
 
 
 def _get_runtime_integration_client():
-    try:
-        import IPython
+    from dbruntime import UserNamespaceInitializer
 
-        ip_shell = IPython.get_ipython()
-        if ip_shell is None:
-            raise _NoDbutilsError
-        kernel = ip_shell.kernel
-        if kernel is None or kernel._driver_connection is None:
-            raise _NoDbutilsError
-        return kernel._driver_connection.runtime_integration_client
-    except (ImportError, AttributeError):
+    driver_connection = UserNamespaceInitializer.getOrCreate().get_driver_connection()
+    if driver_connection is None:
         raise _NoDbutilsError
+    return driver_connection.runtime_integration_client
 
 
 class _NoDbutilsError(Exception):
@@ -523,7 +517,16 @@ def get_repl_id():
     except Exception:
         pass
 
-    # If the runtime integration client is unavailable due to an older runtime version (< 9.0),
+    # Fallback for runtimes without runtime_integration_client: use entry_point directly.
+    try:
+        dbutils = _get_dbutils()
+        repl_id = dbutils.entry_point.getReplId()
+        if repl_id is not None:
+            return repl_id
+    except Exception:
+        pass
+
+    # If the REPL ID entrypoint property is unavailable due to an older runtime version (< 9.0),
     # attempt to fetch the REPL ID from the Spark Context. This property may not be available
     # until several seconds after REPL startup
     try:
@@ -1482,19 +1485,31 @@ if is_in_databricks_runtime():
 
 
 def get_databricks_nfs_temp_dir():
+    entry_point = _get_dbutils().entry_point
     if getpass.getuser().lower() == "root":
-        return _get_dbutils().entry_point.getReplNFSTempDir()
-    # Safe-spark: get the user-scoped NFS temp directory via runtime_integration_client,
-    # which routes to gRPC or Py4J depending on cluster configuration.
-    return _get_runtime_integration_client().getUserNFSTempDir()
+        return entry_point.getReplNFSTempDir()
+    try:
+        return _get_runtime_integration_client().getUserNFSTempDir()
+    except Exception:
+        pass
+    try:
+        return entry_point.getUserNFSTempDir()
+    except Exception:
+        return entry_point.getReplNFSTempDir()
 
 
 def get_databricks_local_temp_dir():
+    entry_point = _get_dbutils().entry_point
     if getpass.getuser().lower() == "root":
-        return _get_dbutils().entry_point.getReplLocalTempDir()
-    # Safe-spark: get the user-scoped local temp directory via runtime_integration_client,
-    # which routes to gRPC or Py4J depending on cluster configuration.
-    return _get_runtime_integration_client().getUserLocalTempDir()
+        return entry_point.getReplLocalTempDir()
+    try:
+        return _get_runtime_integration_client().getUserLocalTempDir()
+    except Exception:
+        pass
+    try:
+        return entry_point.getUserLocalTempDir()
+    except Exception:
+        return entry_point.getReplLocalTempDir()
 
 
 def stage_model_for_databricks_model_serving(model_name: str, model_version: str):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -138,8 +138,6 @@ def _get_runtime_integration_client():
     from dbruntime import UserNamespaceInitializer
 
     driver_connection = UserNamespaceInitializer.getOrCreate().get_driver_connection()
-    if driver_connection is None:
-        raise _NoDbutilsError
     return driver_connection.runtime_integration_client
 
 
@@ -511,9 +509,7 @@ def get_repl_id():
         The ID of the current Databricks Python REPL.
     """
     try:
-        repl_id = _get_runtime_integration_client().getReplId()
-        if repl_id is not None:
-            return repl_id
+        return _get_runtime_integration_client().getReplId()
     except Exception:
         pass
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -135,13 +135,10 @@ def _get_dbutils():
 
 
 def _get_runtime_integration_client():
-    try:
-        from dbruntime import UserNamespaceInitializer
+    from dbruntime import UserNamespaceInitializer
 
-        driver_connection = UserNamespaceInitializer.getOrCreate().get_driver_connection()
-        return driver_connection.runtime_integration_client
-    except Exception:
-        return None
+    driver_connection = UserNamespaceInitializer.getOrCreate().get_driver_connection()
+    return driver_connection.runtime_integration_client
 
 
 class _NoDbutilsError(Exception):
@@ -511,8 +508,10 @@ def get_repl_id():
     Returns:
         The ID of the current Databricks Python REPL.
     """
-    if client := _get_runtime_integration_client():
-        return client.getReplId()
+    try:
+        return _get_runtime_integration_client().getReplId()
+    except Exception:
+        pass
 
     # Fallback for runtimes without runtime_integration_client: use entry_point directly.
     try:
@@ -1485,8 +1484,10 @@ def get_databricks_nfs_temp_dir():
     entry_point = _get_dbutils().entry_point
     if getpass.getuser().lower() == "root":
         return entry_point.getReplNFSTempDir()
-    if client := _get_runtime_integration_client():
-        return client.getUserNFSTempDir()
+    try:
+        return _get_runtime_integration_client().getUserNFSTempDir()
+    except Exception:
+        pass
     try:
         return entry_point.getUserNFSTempDir()
     except Exception:
@@ -1497,8 +1498,10 @@ def get_databricks_local_temp_dir():
     entry_point = _get_dbutils().entry_point
     if getpass.getuser().lower() == "root":
         return entry_point.getReplLocalTempDir()
-    if client := _get_runtime_integration_client():
-        return client.getUserLocalTempDir()
+    try:
+        return _get_runtime_integration_client().getUserLocalTempDir()
+    except Exception:
+        pass
     try:
         return entry_point.getUserLocalTempDir()
     except Exception:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -134,6 +134,21 @@ def _get_dbutils():
         raise _NoDbutilsError
 
 
+def _get_runtime_integration_client():
+    try:
+        import IPython
+
+        ip_shell = IPython.get_ipython()
+        if ip_shell is None:
+            raise _NoDbutilsError
+        kernel = ip_shell.kernel
+        if kernel is None or kernel._driver_connection is None:
+            raise _NoDbutilsError
+        return kernel._driver_connection.runtime_integration_client
+    except (ImportError, AttributeError):
+        raise _NoDbutilsError
+
+
 class _NoDbutilsError(Exception):
     pass
 
@@ -501,17 +516,14 @@ def get_repl_id():
     Returns:
         The ID of the current Databricks Python REPL.
     """
-    # Attempt to fetch the REPL ID from the Python REPL's entrypoint object. This REPL ID
-    # is guaranteed to be set upon REPL startup in DBR / MLR 9.0
     try:
-        dbutils = _get_dbutils()
-        repl_id = dbutils.entry_point.getReplId()
+        repl_id = _get_runtime_integration_client().getReplId()
         if repl_id is not None:
             return repl_id
     except Exception:
         pass
 
-    # If the REPL ID entrypoint property is unavailable due to an older runtime version (< 9.0),
+    # If the runtime integration client is unavailable due to an older runtime version (< 9.0),
     # attempt to fetch the REPL ID from the Spark Context. This property may not be available
     # until several seconds after REPL startup
     try:
@@ -1470,33 +1482,19 @@ if is_in_databricks_runtime():
 
 
 def get_databricks_nfs_temp_dir():
-    entry_point = _get_dbutils().entry_point
     if getpass.getuser().lower() == "root":
-        return entry_point.getReplNFSTempDir()
-    else:
-        try:
-            # If it is not ROOT user, it means the code is running in Safe-spark.
-            # In this case, we should get temporary directory of current user.
-            # and `getReplNFSTempDir` will be deprecated for this case.
-            return entry_point.getUserNFSTempDir()
-        except Exception:
-            # fallback
-            return entry_point.getReplNFSTempDir()
+        return _get_dbutils().entry_point.getReplNFSTempDir()
+    # Safe-spark: get the user-scoped NFS temp directory via runtime_integration_client,
+    # which routes to gRPC or Py4J depending on cluster configuration.
+    return _get_runtime_integration_client().getUserNFSTempDir()
 
 
 def get_databricks_local_temp_dir():
-    entry_point = _get_dbutils().entry_point
     if getpass.getuser().lower() == "root":
-        return entry_point.getReplLocalTempDir()
-    else:
-        try:
-            # If it is not ROOT user, it means the code is running in Safe-spark.
-            # In this case, we should get temporary directory of current user.
-            # and `getReplLocalTempDir` will be deprecated for this case.
-            return entry_point.getUserLocalTempDir()
-        except Exception:
-            # fallback
-            return entry_point.getReplLocalTempDir()
+        return _get_dbutils().entry_point.getReplLocalTempDir()
+    # Safe-spark: get the user-scoped local temp directory via runtime_integration_client,
+    # which routes to gRPC or Py4J depending on cluster configuration.
+    return _get_runtime_integration_client().getUserLocalTempDir()
 
 
 def stage_model_for_databricks_model_serving(model_name: str, model_version: str):

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -365,10 +365,13 @@ def test_get_repl_id():
     # When runtime_integration_client is unavailable, fall back to entry_point.
     mock_dbutils = mock.MagicMock()
     mock_dbutils.entry_point.getReplId.return_value = "testReplId1"
-    with mock.patch(
-        "mlflow.utils.databricks_utils._get_runtime_integration_client",
-        side_effect=Exception("unavailable"),
-    ), mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+    with (
+        mock.patch(
+            "mlflow.utils.databricks_utils._get_runtime_integration_client",
+            side_effect=Exception("unavailable"),
+        ),
+        mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils),
+    ):
         assert databricks_utils.get_repl_id() == "testReplId1"
         mock_dbutils.entry_point.getReplId.assert_called_once()
 
@@ -1054,3 +1057,63 @@ token = test-token
     result = get_databricks_host_creds("databricks")
     assert result.host == "https://test-workspace.databricks.com"
     assert result.token == "test-token"
+
+
+def test_get_databricks_nfs_temp_dir():
+    mock_dbutils = mock.MagicMock()
+    mock_client = mock.MagicMock()
+    mock_client.getUserNFSTempDir.return_value = "/nfs/user/grpc"
+
+    # When runtime_integration_client is available, use getUserNFSTempDir from client
+    with (
+        mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils),
+        mock.patch(
+            "mlflow.utils.databricks_utils._get_runtime_integration_client",
+            return_value=mock_client,
+        ),
+    ):
+        assert databricks_utils.get_databricks_nfs_temp_dir() == "/nfs/user/grpc"
+        mock_client.getUserNFSTempDir.assert_called_once()
+
+    # When runtime_integration_client raises, fall back to entry_point.getUserNFSTempDir
+    mock_dbutils2 = mock.MagicMock()
+    mock_dbutils2.entry_point.getUserNFSTempDir.return_value = "/nfs/user"
+    with (
+        mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils2),
+        mock.patch(
+            "mlflow.utils.databricks_utils._get_runtime_integration_client",
+            side_effect=Exception("unavailable"),
+        ),
+    ):
+        assert databricks_utils.get_databricks_nfs_temp_dir() == "/nfs/user"
+        mock_dbutils2.entry_point.getUserNFSTempDir.assert_called_once()
+
+
+def test_get_databricks_local_temp_dir():
+    mock_dbutils = mock.MagicMock()
+    mock_client = mock.MagicMock()
+    mock_client.getUserLocalTempDir.return_value = "/local/user/grpc"
+
+    # When runtime_integration_client is available, use getUserLocalTempDir from client
+    with (
+        mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils),
+        mock.patch(
+            "mlflow.utils.databricks_utils._get_runtime_integration_client",
+            return_value=mock_client,
+        ),
+    ):
+        assert databricks_utils.get_databricks_local_temp_dir() == "/local/user/grpc"
+        mock_client.getUserLocalTempDir.assert_called_once()
+
+    # When runtime_integration_client raises, fall back to entry_point.getUserLocalTempDir
+    mock_dbutils2 = mock.MagicMock()
+    mock_dbutils2.entry_point.getUserLocalTempDir.return_value = "/local/user"
+    with (
+        mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils2),
+        mock.patch(
+            "mlflow.utils.databricks_utils._get_runtime_integration_client",
+            side_effect=Exception("unavailable"),
+        ),
+    ):
+        assert databricks_utils.get_databricks_local_temp_dir() == "/local/user"
+        mock_dbutils2.entry_point.getUserLocalTempDir.assert_called_once()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -362,6 +362,16 @@ def test_get_repl_id():
         assert databricks_utils.get_repl_id() == "testReplId1"
         mock_client.getReplId.assert_called_once()
 
+    # When runtime_integration_client is unavailable, fall back to entry_point.
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.entry_point.getReplId.return_value = "testReplId1"
+    with mock.patch(
+        "mlflow.utils.databricks_utils._get_runtime_integration_client",
+        side_effect=Exception("unavailable"),
+    ), mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        assert databricks_utils.get_repl_id() == "testReplId1"
+        mock_dbutils.entry_point.getReplId.assert_called_once()
+
     mock_sparkcontext_inst = mock.MagicMock()
     mock_sparkcontext_inst.getLocalProperty.return_value = "testReplId2"
     mock_sparkcontext_class = mock.MagicMock()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -368,7 +368,7 @@ def test_get_repl_id():
     with (
         mock.patch(
             "mlflow.utils.databricks_utils._get_runtime_integration_client",
-            side_effect=Exception("unavailable"),
+            return_value=None,
         ),
         mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils),
     ):
@@ -1075,14 +1075,14 @@ def test_get_databricks_nfs_temp_dir():
         assert databricks_utils.get_databricks_nfs_temp_dir() == "/nfs/user/grpc"
         mock_client.getUserNFSTempDir.assert_called_once()
 
-    # When runtime_integration_client raises, fall back to entry_point.getUserNFSTempDir
+    # When runtime_integration_client is unavailable, fall back to entry_point.getUserNFSTempDir
     mock_dbutils2 = mock.MagicMock()
     mock_dbutils2.entry_point.getUserNFSTempDir.return_value = "/nfs/user"
     with (
         mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils2),
         mock.patch(
             "mlflow.utils.databricks_utils._get_runtime_integration_client",
-            side_effect=Exception("unavailable"),
+            return_value=None,
         ),
     ):
         assert databricks_utils.get_databricks_nfs_temp_dir() == "/nfs/user"
@@ -1105,14 +1105,14 @@ def test_get_databricks_local_temp_dir():
         assert databricks_utils.get_databricks_local_temp_dir() == "/local/user/grpc"
         mock_client.getUserLocalTempDir.assert_called_once()
 
-    # When runtime_integration_client raises, fall back to entry_point.getUserLocalTempDir
+    # When runtime_integration_client is unavailable, fall back to entry_point.getUserLocalTempDir
     mock_dbutils2 = mock.MagicMock()
     mock_dbutils2.entry_point.getUserLocalTempDir.return_value = "/local/user"
     with (
         mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils2),
         mock.patch(
             "mlflow.utils.databricks_utils._get_runtime_integration_client",
-            side_effect=Exception("unavailable"),
+            return_value=None,
         ),
     ):
         assert databricks_utils.get_databricks_local_temp_dir() == "/local/user"

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -353,10 +353,14 @@ def test_get_repl_id():
     # Outside of Databricks environments, the Databricks REPL ID should be absent
     assert databricks_utils.get_repl_id() is None
 
-    mock_dbutils = mock.MagicMock()
-    mock_dbutils.entry_point.getReplId.return_value = "testReplId1"
-    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+    mock_client = mock.MagicMock()
+    mock_client.getReplId.return_value = "testReplId1"
+    with mock.patch(
+        "mlflow.utils.databricks_utils._get_runtime_integration_client",
+        return_value=mock_client,
+    ):
         assert databricks_utils.get_repl_id() == "testReplId1"
+        mock_client.getReplId.assert_called_once()
 
     mock_sparkcontext_inst = mock.MagicMock()
     mock_sparkcontext_inst.getLocalProperty.return_value = "testReplId2"

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -368,7 +368,7 @@ def test_get_repl_id():
     with (
         mock.patch(
             "mlflow.utils.databricks_utils._get_runtime_integration_client",
-            return_value=None,
+            side_effect=Exception("unavailable"),
         ),
         mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils),
     ):
@@ -1075,14 +1075,14 @@ def test_get_databricks_nfs_temp_dir():
         assert databricks_utils.get_databricks_nfs_temp_dir() == "/nfs/user/grpc"
         mock_client.getUserNFSTempDir.assert_called_once()
 
-    # When runtime_integration_client is unavailable, fall back to entry_point.getUserNFSTempDir
+    # When runtime_integration_client raises, fall back to entry_point.getUserNFSTempDir
     mock_dbutils2 = mock.MagicMock()
     mock_dbutils2.entry_point.getUserNFSTempDir.return_value = "/nfs/user"
     with (
         mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils2),
         mock.patch(
             "mlflow.utils.databricks_utils._get_runtime_integration_client",
-            return_value=None,
+            side_effect=Exception("unavailable"),
         ),
     ):
         assert databricks_utils.get_databricks_nfs_temp_dir() == "/nfs/user"
@@ -1105,14 +1105,14 @@ def test_get_databricks_local_temp_dir():
         assert databricks_utils.get_databricks_local_temp_dir() == "/local/user/grpc"
         mock_client.getUserLocalTempDir.assert_called_once()
 
-    # When runtime_integration_client is unavailable, fall back to entry_point.getUserLocalTempDir
+    # When runtime_integration_client raises, fall back to entry_point.getUserLocalTempDir
     mock_dbutils2 = mock.MagicMock()
     mock_dbutils2.entry_point.getUserLocalTempDir.return_value = "/local/user"
     with (
         mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils2),
         mock.patch(
             "mlflow.utils.databricks_utils._get_runtime_integration_client",
-            return_value=None,
+            side_effect=Exception("unavailable"),
         ),
     ):
         assert databricks_utils.get_databricks_local_temp_dir() == "/local/user"


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Update databricks API calls to use new GRPC APIs instead of py4j APIs

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
