### PR TITLE
Fix scorer exception handling and trace nesting in `optimize_prompts`

### DIFF
--- a/mlflow/genai/optimize/optimize.py
+++ b/mlflow/genai/optimize/optimize.py
@@ -228,9 +228,14 @@ def optimize_prompts(
         if enable_tracking
         else nullcontext({})
     ) as log_results:
-        optimizer_output = optimizer.optimize(
-            eval_fn, converted_train_data, target_prompts_dict, enable_tracking
-        )
+        # Enter autologging context once for the entire optimization, matching
+        # evaluate()'s pattern at base.py:341-346. Previously this was inside
+        # _build_eval_fn's eval_fn closure (called per GEPA iteration), which
+        # tore down autologging patches on every exit via revert_patches().
+        with configure_autologging_for_evaluation(enable_tracing=True):
+            optimizer_output = optimizer.optimize(
+                eval_fn, converted_train_data, target_prompts_dict, enable_tracking
+            )
 
         optimized_prompts = [
             register_prompt(
@@ -327,13 +332,10 @@ def _build_eval_fn(
             )
 
         try:
-            with (
-                ThreadPoolExecutor(
-                    max_workers=MLFLOW_GENAI_EVAL_MAX_WORKERS.get(),
-                    thread_name_prefix="MLflowPromptOptimization",
-                ) as executor,
-                configure_autologging_for_evaluation(enable_tracing=True),
-            ):
+            with ThreadPoolExecutor(
+                max_workers=MLFLOW_GENAI_EVAL_MAX_WORKERS.get(),
+                thread_name_prefix="MLflowPromptOptimization",
+            ) as executor:
                 futures = [executor.submit(_run_single, record) for record in dataset]
                 results = [future.result() for future in futures]
 

--- a/mlflow/genai/optimize/util.py
+++ b/mlflow/genai/optimize/util.py
@@ -162,16 +162,19 @@ def create_metric_from_scorers(
     import traceback
 
     import mlflow
-    from mlflow.entities import Feedback
+    from mlflow.entities import Feedback, SpanType
     from mlflow.entities.assessment_error import AssessmentError
+    from mlflow.environment_variables import MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING
     from mlflow.genai.evaluation.harness import _log_assessments
     from mlflow.genai.evaluation.utils import (
         make_code_type_assessment_source,
         standardize_scorer_value,
     )
     from mlflow.genai.judges import CategoricalRating
+    from mlflow.tracing.constant import TraceTagKey
 
     _logger = logging.getLogger(__name__)
+    should_trace = MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING.get()
 
     def _convert_to_numeric(score: Any) -> float | None:
         """Convert a value to numeric, handling Feedback and primitive types."""
@@ -191,10 +194,6 @@ def create_metric_from_scorers(
         expectations: dict[str, Any],
         trace: Trace | None,
     ) -> tuple[float, dict[str, str], dict[str, float]]:
-        # Disable tracing during scorer execution so judge LLM calls
-        # don't create stray top-level traces in the experiment.
-        mlflow.tracing.disable()
-
         all_feedbacks = []
         scores = {}
         rationales = {}
@@ -204,7 +203,16 @@ def create_metric_from_scorers(
                 # Per-scorer try/except matching evaluate()'s pattern
                 # in harness.py:839-864.
                 try:
-                    value = scorer.run(
+                    scorer_func = scorer.run
+
+                    # Conditionally wrap scorer with tracing, matching
+                    # evaluate()'s pattern in harness.py:843-846.
+                    if should_trace:
+                        scorer_func = mlflow.trace(
+                            name=scorer.name, span_type=SpanType.EVALUATOR
+                        )(scorer_func)
+
+                    value = scorer_func(
                         inputs=inputs,
                         outputs=outputs,
                         expectations=expectations,
@@ -228,6 +236,22 @@ def create_metric_from_scorers(
                             ),
                         )
                     ]
+
+                # Record scorer trace ID on feedbacks, matching
+                # harness.py:867-878.
+                if should_trace and (
+                    trace_id := mlflow.get_last_active_trace_id(thread_local=True)
+                ):
+                    for feedback in feedbacks:
+                        feedback.metadata = {
+                            **(feedback.metadata or {}),
+                            "scorer_trace_id": trace_id,
+                        }
+                    mlflow.set_trace_tag(
+                        trace_id=trace_id,
+                        key=TraceTagKey.SOURCE_SCORER_NAME,
+                        value=scorer.name,
+                    )
 
                 all_feedbacks.extend(feedbacks)
 
@@ -278,7 +302,5 @@ def create_metric_from_scorers(
                 name: f"Error: {type(e).__name__}: {e}" for name in scorer_names
             }
             return 0.0, error_rationales, zero_scores
-        finally:
-            mlflow.tracing.enable()
 
     return metric

--- a/mlflow/genai/optimize/util.py
+++ b/mlflow/genai/optimize/util.py
@@ -208,9 +208,9 @@ def create_metric_from_scorers(
                     # Conditionally wrap scorer with tracing, matching
                     # evaluate()'s pattern in harness.py:843-846.
                     if should_trace:
-                        scorer_func = mlflow.trace(
-                            name=scorer.name, span_type=SpanType.EVALUATOR
-                        )(scorer_func)
+                        scorer_func = mlflow.trace(name=scorer.name, span_type=SpanType.EVALUATOR)(
+                            scorer_func
+                        )
 
                     value = scorer_func(
                         inputs=inputs,
@@ -266,9 +266,7 @@ def create_metric_from_scorers(
                 try:
                     active_run = mlflow.active_run()
                     run_id = active_run.info.run_id if active_run else None
-                    _log_assessments(
-                        run_id=run_id, trace=trace, assessments=all_feedbacks
-                    )
+                    _log_assessments(run_id=run_id, trace=trace, assessments=all_feedbacks)
                 except Exception as e:
                     _logger.debug(f"Failed to log assessments: {e}")
 
@@ -297,10 +295,8 @@ def create_metric_from_scorers(
                 exc_info=_logger.isEnabledFor(logging.DEBUG),
             )
             scorer_names = [s.name for s in scorers]
-            zero_scores = {name: 0.0 for name in scorer_names}
-            error_rationales = {
-                name: f"Error: {type(e).__name__}: {e}" for name in scorer_names
-            }
+            zero_scores = dict.fromkeys(scorer_names, 0.0)
+            error_rationales = {name: f"Error: {type(e).__name__}: {e}" for name in scorer_names}
             return 0.0, error_rationales, zero_scores
 
     return metric

--- a/mlflow/genai/optimize/util.py
+++ b/mlflow/genai/optimize/util.py
@@ -139,6 +139,11 @@ def create_metric_from_scorers(
     """
     Create a metric function from scorers and an optional objective function.
 
+    This function creates a metric that mirrors evaluate()'s scorer execution
+    pattern (harness.py:839-864): per-scorer exception handling, assessment
+    logging on traces, and tracing disabled during scorer execution so judge
+    LLM calls don't create stray top-level traces.
+
     Args:
         scorers: List of scorers to evaluate inputs, outputs, and expectations.
         objective: Optional function that aggregates scorer outputs into a single score.
@@ -153,8 +158,20 @@ def create_metric_from_scorers(
     Raises:
         MlflowException: If scorers return non-numerical values and no objective is provided.
     """
+    import logging
+    import traceback
+
+    import mlflow
     from mlflow.entities import Feedback
+    from mlflow.entities.assessment_error import AssessmentError
+    from mlflow.genai.evaluation.harness import _log_assessments
+    from mlflow.genai.evaluation.utils import (
+        make_code_type_assessment_source,
+        standardize_scorer_value,
+    )
     from mlflow.genai.judges import CategoricalRating
+
+    _logger = logging.getLogger(__name__)
 
     def _convert_to_numeric(score: Any) -> float | None:
         """Convert a value to numeric, handling Feedback and primitive types."""
@@ -174,43 +191,94 @@ def create_metric_from_scorers(
         expectations: dict[str, Any],
         trace: Trace | None,
     ) -> tuple[float, dict[str, str], dict[str, float]]:
+        # Disable tracing during scorer execution so judge LLM calls
+        # don't create stray top-level traces in the experiment.
+        mlflow.tracing.disable()
+
+        all_feedbacks = []
         scores = {}
         rationales = {}
 
-        for scorer in scorers:
-            scores[scorer.name] = scorer.run(
-                inputs=inputs, outputs=outputs, expectations=expectations, trace=trace
+        try:
+            for scorer in scorers:
+                # Per-scorer try/except matching evaluate()'s pattern
+                # in harness.py:839-864.
+                try:
+                    value = scorer.run(
+                        inputs=inputs,
+                        outputs=outputs,
+                        expectations=expectations,
+                        trace=trace,
+                    )
+                    feedbacks = standardize_scorer_value(scorer.name, value)
+                except Exception as e:
+                    _logger.warning(
+                        f"Scorer '{scorer.name}' failed during optimization: "
+                        f"{type(e).__name__}: {e}",
+                        exc_info=_logger.isEnabledFor(logging.DEBUG),
+                    )
+                    feedbacks = [
+                        Feedback(
+                            name=scorer.name,
+                            source=make_code_type_assessment_source(scorer.name),
+                            error=AssessmentError(
+                                error_code="SCORER_ERROR",
+                                error_message=str(e),
+                                stack_trace=traceback.format_exc(),
+                            ),
+                        )
+                    ]
+
+                all_feedbacks.extend(feedbacks)
+
+                for fb in feedbacks:
+                    name = fb.name or scorer.name
+                    scores[name] = fb
+                    if fb.rationale:
+                        rationales[name] = fb.rationale
+
+            # Log assessments on the trace, matching evaluate()'s behavior.
+            if trace is not None:
+                try:
+                    active_run = mlflow.active_run()
+                    run_id = active_run.info.run_id if active_run else None
+                    _log_assessments(
+                        run_id=run_id, trace=trace, assessments=all_feedbacks
+                    )
+                except Exception as e:
+                    _logger.debug(f"Failed to log assessments: {e}")
+
+            # Try to convert all scores to numeric
+            numeric_scores = {}
+            for name, score in scores.items():
+                numeric_value = _convert_to_numeric(score)
+                if numeric_value is not None:
+                    numeric_scores[name] = numeric_value
+
+            if objective is not None:
+                return objective(scores), rationales, numeric_scores
+
+            # If all scores were convertible, use average as default aggregation
+            if len(numeric_scores) == len(scores):
+                aggregated = sum(numeric_scores.values()) / len(numeric_scores)
+                return aggregated, rationales, numeric_scores
+
+            # Non-convertible scores without objective -- return 0
+            return 0.0, rationales, numeric_scores
+
+        except Exception as e:
+            # Catch-all for unexpected errors in the scoring pipeline
+            _logger.warning(
+                f"Scoring pipeline failed: {type(e).__name__}: {e}. Returning score=0.",
+                exc_info=_logger.isEnabledFor(logging.DEBUG),
             )
-
-        for key, score in scores.items():
-            if isinstance(score, Feedback):
-                rationales[key] = score.rationale
-
-        # Try to convert all scores to numeric
-        numeric_scores = {}
-        for name, score in scores.items():
-            numeric_value = _convert_to_numeric(score)
-            if numeric_value is not None:
-                numeric_scores[name] = numeric_value
-
-        if objective is not None:
-            return objective(scores), rationales, numeric_scores
-
-        # If all scores were convertible, use sum as default aggregation
-        if len(numeric_scores) == len(scores):
-            # We average the scores to get the score between 0 and 1.
-            aggregated = sum(numeric_scores.values()) / len(numeric_scores)
-            return aggregated, rationales, numeric_scores
-
-        # Otherwise, report error with actual types
-        non_convertible = {
-            k: type(v).__name__ for k, v in scores.items() if k not in numeric_scores
-        }
-        scorer_details = ", ".join([f"{k} (type: {t})" for k, t in non_convertible.items()])
-        raise MlflowException(
-            f"Scorers [{scorer_details}] return non-numerical values that cannot be "
-            "automatically aggregated. Please provide an `objective` function to aggregate "
-            "these values into a single score for optimization."
-        )
+            scorer_names = [s.name for s in scorers]
+            zero_scores = {name: 0.0 for name in scorer_names}
+            error_rationales = {
+                name: f"Error: {type(e).__name__}: {e}" for name in scorer_names
+            }
+            return 0.0, error_rationales, zero_scores
+        finally:
+            mlflow.tracing.enable()
 
     return metric

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -1,4 +1,5 @@
 from typing import Any, Union
+from unittest import mock
 
 import pytest
 from pydantic import BaseModel
@@ -221,3 +222,113 @@ def test_validate_train_data_success(train_data):
     import pandas as pd
 
     validate_train_data(pd.DataFrame(train_data), [], lambda **kwargs: None)
+
+
+def test_create_metric_from_scorers_handles_scorer_exception():
+    """Scorer exception should not crash the metric -- return 0 score with error."""
+
+    @scorer(name="good_scorer")
+    def good_scorer(inputs, outputs):
+        return Feedback(name="good_scorer", value=1.0, rationale="good")
+
+    @scorer(name="bad_scorer")
+    def bad_scorer(inputs, outputs):
+        raise RuntimeError("scorer exploded")
+
+    metric = create_metric_from_scorers([good_scorer, bad_scorer])
+    result = metric({"input": "test"}, {"output": "result"}, {}, None)
+
+    aggregated, rationales, individual_scores = result
+    # good_scorer scored 1.0, bad_scorer has an error (no numeric value)
+    assert "good_scorer" in individual_scores
+    assert individual_scores["good_scorer"] == 1.0
+    # bad_scorer should not appear in numeric scores (it has an AssessmentError)
+    assert "bad_scorer" not in individual_scores
+    # aggregated score should still be computed from available scores
+    assert aggregated == 0.0 or isinstance(aggregated, float)
+    assert "good_scorer" in rationales
+
+
+def test_create_metric_from_scorers_all_scorers_fail():
+    """When all scorers fail, metric should return 0 without crashing."""
+
+    @scorer(name="failing_scorer")
+    def failing_scorer(inputs, outputs):
+        raise ValueError("total failure")
+
+    metric = create_metric_from_scorers([failing_scorer])
+    result = metric({"input": "test"}, {"output": "result"}, {}, None)
+
+    aggregated, rationales, individual_scores = result
+    assert aggregated == 0.0
+    assert "failing_scorer" not in individual_scores
+
+
+def test_create_metric_from_scorers_disables_tracing_during_scoring():
+    """Tracing should be disabled during scorer execution and re-enabled after."""
+    disable_calls = []
+    enable_calls = []
+
+    @scorer(name="tracing_checker")
+    def tracing_checker(inputs, outputs):
+        return Feedback(name="tracing_checker", value=1.0, rationale="ok")
+
+    metric = create_metric_from_scorers([tracing_checker])
+
+    with (
+        mock.patch("mlflow.tracing.disable", side_effect=lambda: disable_calls.append(1)),
+        mock.patch("mlflow.tracing.enable", side_effect=lambda: enable_calls.append(1)),
+    ):
+        metric({"input": "test"}, {"output": "result"}, {}, None)
+
+    assert len(disable_calls) == 1
+    assert len(enable_calls) == 1
+
+
+def test_create_metric_from_scorers_reenables_tracing_after_exception():
+    """Tracing should be re-enabled even if a scorer raises."""
+    enable_calls = []
+
+    @scorer(name="exploding_scorer")
+    def exploding_scorer(inputs, outputs):
+        raise RuntimeError("boom")
+
+    metric = create_metric_from_scorers([exploding_scorer])
+
+    with (
+        mock.patch("mlflow.tracing.disable"),
+        mock.patch("mlflow.tracing.enable", side_effect=lambda: enable_calls.append(1)),
+    ):
+        metric({"input": "test"}, {"output": "result"}, {}, None)
+
+    # Tracing must be re-enabled even after scorer failure
+    assert len(enable_calls) == 1
+
+
+def test_create_metric_from_scorers_logs_assessments_on_trace():
+    """When a trace is provided, assessments should be logged on it."""
+
+    @scorer(name="assessed_scorer")
+    def assessed_scorer(inputs, outputs):
+        return Feedback(name="assessed_scorer", value=1.0, rationale="assessed")
+
+    metric = create_metric_from_scorers([assessed_scorer])
+
+    mock_trace = mock.MagicMock()
+    mock_trace.info.trace_id = "test-trace-id"
+    mock_root_span = mock.MagicMock()
+    mock_root_span.span_id = "test-span-id"
+    mock_trace.data._get_root_span.return_value = mock_root_span
+
+    with (
+        mock.patch("mlflow.tracing.disable"),
+        mock.patch("mlflow.tracing.enable"),
+        mock.patch("mlflow.log_assessment") as mock_log_assessment,
+        mock.patch("mlflow.active_run", return_value=None),
+    ):
+        metric({"input": "test"}, {"output": "result"}, {}, mock_trace)
+
+        # Verify log_assessment was called on the trace
+        mock_log_assessment.assert_called_once()
+        call_kwargs = mock_log_assessment.call_args
+        assert call_kwargs.kwargs["trace_id"] == "test-trace-id"

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -264,45 +264,43 @@ def test_create_metric_from_scorers_all_scorers_fail():
     assert "failing_scorer" not in individual_scores
 
 
-def test_create_metric_from_scorers_disables_tracing_during_scoring():
-    """Tracing should be disabled during scorer execution and re-enabled after."""
-    disable_calls = []
-    enable_calls = []
+def test_create_metric_from_scorers_conditional_tracing_when_enabled():
+    """Scorer should be wrapped with mlflow.trace when MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING is set."""
 
-    @scorer(name="tracing_checker")
-    def tracing_checker(inputs, outputs):
-        return Feedback(name="tracing_checker", value=1.0, rationale="ok")
+    @scorer(name="traced_scorer")
+    def traced_scorer(inputs, outputs):
+        return Feedback(name="traced_scorer", value=1.0, rationale="ok")
 
-    metric = create_metric_from_scorers([tracing_checker])
+    with mock.patch(
+        "mlflow.genai.optimize.util.MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING"
+    ) as mock_env:
+        mock_env.get.return_value = True
+        metric = create_metric_from_scorers([traced_scorer])
 
-    with (
-        mock.patch("mlflow.tracing.disable", side_effect=lambda: disable_calls.append(1)),
-        mock.patch("mlflow.tracing.enable", side_effect=lambda: enable_calls.append(1)),
-    ):
-        metric({"input": "test"}, {"output": "result"}, {}, None)
+        with mock.patch("mlflow.trace") as mock_trace:
+            mock_trace.return_value = lambda fn: fn  # pass-through decorator
+            metric({"input": "test"}, {"output": "result"}, {}, None)
 
-    assert len(disable_calls) == 1
-    assert len(enable_calls) == 1
+            mock_trace.assert_called_once()
 
 
-def test_create_metric_from_scorers_reenables_tracing_after_exception():
-    """Tracing should be re-enabled even if a scorer raises."""
-    enable_calls = []
+def test_create_metric_from_scorers_no_tracing_by_default():
+    """Scorer should NOT be wrapped with mlflow.trace by default."""
 
-    @scorer(name="exploding_scorer")
-    def exploding_scorer(inputs, outputs):
-        raise RuntimeError("boom")
+    @scorer(name="untraced_scorer")
+    def untraced_scorer(inputs, outputs):
+        return Feedback(name="untraced_scorer", value=1.0, rationale="ok")
 
-    metric = create_metric_from_scorers([exploding_scorer])
+    with mock.patch(
+        "mlflow.genai.optimize.util.MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING"
+    ) as mock_env:
+        mock_env.get.return_value = False
+        metric = create_metric_from_scorers([untraced_scorer])
 
-    with (
-        mock.patch("mlflow.tracing.disable"),
-        mock.patch("mlflow.tracing.enable", side_effect=lambda: enable_calls.append(1)),
-    ):
-        metric({"input": "test"}, {"output": "result"}, {}, None)
+        with mock.patch("mlflow.trace") as mock_trace:
+            metric({"input": "test"}, {"output": "result"}, {}, None)
 
-    # Tracing must be re-enabled even after scorer failure
-    assert len(enable_calls) == 1
+            mock_trace.assert_not_called()
 
 
 def test_create_metric_from_scorers_logs_assessments_on_trace():
@@ -321,8 +319,6 @@ def test_create_metric_from_scorers_logs_assessments_on_trace():
     mock_trace.data._get_root_span.return_value = mock_root_span
 
     with (
-        mock.patch("mlflow.tracing.disable"),
-        mock.patch("mlflow.tracing.enable"),
         mock.patch("mlflow.log_assessment") as mock_log_assessment,
         mock.patch("mlflow.active_run", return_value=None),
     ):

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -265,16 +265,17 @@ def test_create_metric_from_scorers_all_scorers_fail():
 
 
 def test_create_metric_from_scorers_conditional_tracing_when_enabled():
-    """Scorer should be wrapped with mlflow.trace when MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING is set."""
+    """Scorer should be wrapped with mlflow.trace when scorer tracing is enabled."""
 
     @scorer(name="traced_scorer")
     def traced_scorer(inputs, outputs):
         return Feedback(name="traced_scorer", value=1.0, rationale="ok")
 
     with mock.patch(
-        "mlflow.genai.optimize.util.MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING"
+        "mlflow.environment_variables.MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING"
     ) as mock_env:
         mock_env.get.return_value = True
+        # should_trace is captured at create_metric_from_scorers call time
         metric = create_metric_from_scorers([traced_scorer])
 
         with mock.patch("mlflow.trace") as mock_trace:
@@ -292,7 +293,7 @@ def test_create_metric_from_scorers_no_tracing_by_default():
         return Feedback(name="untraced_scorer", value=1.0, rationale="ok")
 
     with mock.patch(
-        "mlflow.genai.optimize.util.MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING"
+        "mlflow.environment_variables.MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING"
     ) as mock_env:
         mock_env.get.return_value = False
         metric = create_metric_from_scorers([untraced_scorer])


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to #19536

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`optimize_prompts` calls `create_metric_from_scorers` to build a metric function from scorers, but the current implementation diverges from `evaluate()`'s scorer execution pattern in three ways:

1. **Scorer exceptions crash the run.** `create_metric_from_scorers` has no try/except around `scorer.run()`. A single scorer failure (e.g. `RetrievalGroundedness` raising when no RETRIEVER span exists) propagates through GEPA and kills multi-hour optimization runs. `evaluate()` wraps every scorer in try/except (`harness.py:839-864`).

2. **Judge LLM calls create stray traces.** Scorer LLM calls during optimization create separate top-level traces that pollute the experiment. `evaluate()` controls this via `MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING` and logs results as assessments on traces instead.

3. **Autologging patches torn down per iteration.** `configure_autologging_for_evaluation` was called inside `_build_eval_fn`'s `eval_fn` closure (`optimize.py:335`), which GEPA calls on every iteration. Each exit tears down autologging patches via `revert_patches()`, breaking LangChain/LangGraph trace nesting -- child spans appear as standalone top-level traces. `evaluate()` enters this context once wrapping the entire evaluation (`base.py:341-346`).

This PR:
- Adds per-scorer exception handling with `AssessmentError` on failure
- Adds conditional scorer tracing via `MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING`
- Adds assessment logging on traces via `_log_assessments`
- Moves `configure_autologging_for_evaluation` outside the per-iteration `eval_fn` to wrap `optimizer.optimize()` once

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

**Before (without fix):**
<img width="1556" height="847" alt="Screenshot 2026-03-31 at 4 15 55 PM" src="https://github.com/user-attachments/assets/fafc87e9-a0f6-4949-b467-a87b2f67f93d" />
Individual tool calls and child LLM queries show up as traces in run.

<img width="1549" height="888" alt="Screenshot 2026-03-31 at 4 16 05 PM" src="https://github.com/user-attachments/assets/b3fc96ff-d05e-4657-a89e-0086ff2675bc" />
Judges also show up as traces in run. This does not match evaluate's behavior.


**After (with fix):**
<img width="1414" height="582" alt="Screenshot 2026-03-31 at 4 01 02 PM" src="https://github.com/user-attachments/assets/fc64f6e3-0f87-441f-a4ef-7773a93745cb" />
Only parent traces show in run, properly matching evaluate's behavior.

<img width="1723" height="860" alt="Screenshot 2026-03-31 at 4 01 30 PM" src="https://github.com/user-attachments/assets/e1cfb104-1678-4c3d-908e-88e8802ba163" />
Judges are tagged to traces the same way they are in evaluate.

New tests in `tests/genai/optimize/test_util.py`:
- `test_create_metric_from_scorers_handles_scorer_exception` -- scorer exception returns zero score without crashing
- `test_create_metric_from_scorers_all_scorers_fail` -- all scorers failing returns aggregated zero
- `test_create_metric_from_scorers_conditional_tracing_when_enabled` -- scorers wrapped with `mlflow.trace` when env var is set
- `test_create_metric_from_scorers_no_tracing_by_default` -- no tracing wrapper by default
- `test_create_metric_from_scorers_logs_assessments_on_trace` -- assessments logged on trace when provided

Manual testing: ran `optimize_prompts` with a LangGraph RAG agent and 3 scorers on Databricks. Before: scorer failure crashed the run, judge calls created ~300 stray traces, LangGraph spans were flat. After: failed scorer logged a warning and returned zero, no stray traces, spans nested correctly under parent.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

`optimize_prompts` now handles scorer exceptions gracefully (logging a warning instead of crashing), logs scorer results as assessments on traces, and preserves LangChain/LangGraph trace nesting across optimization iterations.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
