### PR TITLE
fix(tracking): warn when MlflowClient.search_runs() silently truncates results

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -3843,6 +3843,7 @@ class MlflowClient:
         max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
         order_by: list[str] | None = None,
         page_token: str | None = None,
+        _suppress_default_limit_warning: bool = False,
     ) -> PagedList[Run]:
         """
         Search for Runs that fit the specified criteria.
@@ -3924,10 +3925,23 @@ class MlflowClient:
             metrics: {'m': 1.55}
             tags: {'s.release': '1.1.0-RC'}
         """
-        return self._tracking_client.search_runs(
+        result= self._tracking_client.search_runs(
             experiment_ids, filter_string, run_view_type, max_results, order_by, page_token
         )
-
+        if (
+        not _suppress_default_limit_warning
+        and max_results == SEARCH_MAX_RESULTS_DEFAULT
+        and result.token is not None
+    ):
+            warnings.warn(
+            f"MlflowClient.search_runs() returned {len(result)} results but more are available. "
+            f"Results are limited to the default max_results={SEARCH_MAX_RESULTS_DEFAULT}. "
+            "To retrieve all results, either increase max_results or use mlflow.search_runs() "
+            "which paginates automatically.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return result
     # Registry API
 
     # Registered Model Methods

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -3316,6 +3316,7 @@ def search_runs(
                 number_to_get,
                 order_by,
                 next_page_token,
+                _suppress_default_limit_warning=True,
             )
 
         runs = get_results_from_paginated_fn(

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1392,7 +1392,33 @@ def test_client_search_runs_page_token(mock_store):
         page_token="blah",
     )
 
+def test_client_search_runs_warns_when_results_truncated(mock_store):
+    from mlflow.store.entities.paged_list import PagedList
+    import warnings
 
+    # Simulate store returning 1000 results with a next-page token
+    mock_runs = [mock.MagicMock()] * SEARCH_MAX_RESULTS_DEFAULT
+    mock_store.search_runs.return_value = PagedList(mock_runs, token="next-page-token")
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        MlflowClient().search_runs(["0"])
+        assert len(w) == 1
+        assert "more are available" in str(w[0].message)
+        assert issubclass(w[0].category, UserWarning)
+
+def test_client_search_runs_no_warn_when_suppressed(mock_store):
+    from mlflow.store.entities.paged_list import PagedList
+    import warnings
+
+    mock_runs = [mock.MagicMock()] * SEARCH_MAX_RESULTS_DEFAULT
+    mock_store.search_runs.return_value = PagedList(mock_runs, token="next-page-token")
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        MlflowClient().search_runs(["0"], _suppress_default_limit_warning=True)
+        assert len(w) == 0  # No warning when suppressed
+        
 def test_update_registered_model(mock_registry_store):
     """
     Update registered model no longer supports name change.


### PR DESCRIPTION
## What does this PR do?
Adds a UserWarning when MlflowClient().search_runs() silently returns
truncated results due to the default max_results=1000 limit, so users
are no longer misled into thinking they received all matching runs.

## Related Issue
Closes #15814

## Changes made
- `mlflow/tracking/client.py`: Added warning logic to `search_runs()`
  and a `_suppress_default_limit_warning` keyword-only parameter
- `mlflow/tracking/fluent.py`: Passed `_suppress_default_limit_warning=True`
  in the internal pagination call inside `mlflow.search_runs()`
- `tests/tracking/test_client.py`: Added tests covering all four cases

## How to test
Run: `python -m pytest tests/tracking/test_client.py -k "search_runs" -v`
<img width="1893" height="826" alt="Screenshot 2026-04-01 051021" src="https://github.com/user-attachments/assets/6b44e89e-76c7-48e9-a7cb-e5692cd4cc96" />
<img width="1880" height="803" alt="Screenshot 2026-04-01 051040" src="https://github.com/user-attachments/assets/a9ce8e15-82d2-49f9-8cfb-6a800ab38919" />
