### PR TITLE
Add `mlflow.diffusers` flavor for diffusion model adapters (LoRA)

### DIFF
--- a/examples/diffusers/demo_diffusers_adapter.py
+++ b/examples/diffusers/demo_diffusers_adapter.py
@@ -1,0 +1,115 @@
+"""
+Demo: MLflow Diffusers Adapter Flavor (LoRA)
+
+This script demonstrates the full workflow of logging, registering, and loading
+a diffusion model LoRA adapter using the native mlflow.diffusers flavor.
+
+No GPU or real model weights required — uses a fake adapter for validation.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import yaml
+from safetensors.numpy import save_file
+
+import mlflow
+import mlflow.diffusers
+
+
+def create_fake_lora_adapter(output_dir: Path) -> Path:
+    """Create a minimal fake LoRA adapter in safetensors format."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Simulate LoRA weight matrices (small random tensors)
+    tensors = {
+        "unet.down_blocks.0.attentions.0.transformer_blocks.0.attn1.to_q.lora_down.weight": (
+            np.random.randn(4, 320).astype(np.float32)
+        ),
+        "unet.down_blocks.0.attentions.0.transformer_blocks.0.attn1.to_q.lora_up.weight": (
+            np.random.randn(320, 4).astype(np.float32)
+        ),
+    }
+    adapter_file = output_dir / "adapter_model.safetensors"
+    save_file(tensors, str(adapter_file))
+
+    print(f"Created fake LoRA adapter at: {adapter_file}")
+    print(f"  Adapter size: {adapter_file.stat().st_size} bytes")
+    return output_dir
+
+
+def demo_log_and_load():
+    """Demonstrate the full log -> load -> inspect cycle."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # 1. Create fake adapter
+        adapter_dir = create_fake_lora_adapter(Path(tmpdir) / "my_lora")
+
+        # 2. Log the adapter with MLflow
+        print("\n--- Logging adapter with mlflow.diffusers.log_model() ---")
+        mlflow.set_experiment("diffusers-adapter-poc")
+
+        with mlflow.start_run(run_name="lora-adapter-demo") as run:
+            model_info = mlflow.diffusers.log_model(
+                adapter_path=str(adapter_dir),
+                base_model_id="black-forest-labs/FLUX.1-dev",
+                adapter_type="lora",
+                name="lora_model",
+                metadata={
+                    "lora_rank": 4,
+                    "training_steps": 1000,
+                    "trigger_word": "sks style",
+                },
+            )
+
+            print(f"  Run ID: {run.info.run_id}")
+            print(f"  Model URI: {model_info.model_uri}")
+
+        # 3. Inspect the MLmodel file
+        print("\n--- MLmodel file contents ---")
+        model_uri = f"runs:/{run.info.run_id}/lora_model"
+        local_path = mlflow.artifacts.download_artifacts(model_uri)
+        mlmodel_path = Path(local_path) / "MLmodel"
+
+        with open(mlmodel_path) as f:
+            mlmodel = yaml.safe_load(f)
+
+        print(yaml.dump(mlmodel, default_flow_style=False, indent=2))
+
+        # 4. Load the model back
+        print("--- Loading model back with mlflow.diffusers.load_model() ---")
+        loaded = mlflow.diffusers.load_model(model_uri)
+
+        print(f"  Type: {type(loaded).__name__}")
+        print(f"  Base model: {loaded.base_model_id}")
+        print(f"  Adapter type: {loaded.adapter_type}")
+        print(f"  Adapter path: {loaded.adapter_path}")
+        print(f"  Adapter files: {list(Path(loaded.adapter_path).iterdir())}")
+
+        # 5. Verify adapter config
+        print("\n--- Adapter config ---")
+        config_path = Path(local_path) / "adapter_config.json"
+        with open(config_path) as f:
+            config = json.load(f)
+        print(json.dumps(config, indent=2))
+
+        # 6. Show that pyfunc interface is available
+        print("\n--- Pyfunc model interface ---")
+        print("  mlflow.pyfunc.load_model() would return a wrapper with predict()")
+        print("  predict() accepts: DataFrame/dict with 'prompt' column")
+        print("  predict() returns: list of PNG-encoded image bytes")
+        print("  (Skipping actual pyfunc load — requires base model download)")
+
+        print("\n--- Demo complete! ---")
+        print(
+            "The adapter is logged as a first-class MLflow model with full model registry support."
+        )
+        print(
+            "To generate images, call loaded.load_pipeline() on a machine "
+            "with the base model available."
+        )
+
+
+if __name__ == "__main__":
+    demo_log_and_load()

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -67,6 +67,7 @@ autogen = LazyLoader("mlflow.autogen", globals(), "mlflow.autogen")
 bedrock = LazyLoader("mlflow.bedrock", globals(), "mlflow.bedrock")
 catboost = LazyLoader("mlflow.catboost", globals(), "mlflow.catboost")
 crewai = LazyLoader("mlflow.crewai", globals(), "mlflow.crewai")
+diffusers = LazyLoader("mlflow.diffusers", globals(), "mlflow.diffusers")
 dspy = LazyLoader("mlflow.dspy", globals(), "mlflow.dspy")
 gemini = LazyLoader("mlflow.gemini", globals(), "mlflow.gemini")
 groq = LazyLoader("mlflow.groq", globals(), "mlflow.groq")
@@ -122,6 +123,7 @@ if TYPE_CHECKING:
         bedrock,
         catboost,
         crewai,
+        diffusers,
         dspy,
         gemini,
         groq,

--- a/mlflow/diffusers/__init__.py
+++ b/mlflow/diffusers/__init__.py
@@ -1,0 +1,402 @@
+"""
+The ``mlflow.diffusers`` module provides an API for logging and loading diffusion model
+adapters (LoRA, LoKr, LoHa) as MLflow Models. This module exports adapter models with
+the following flavors:
+
+:py:mod:`mlflow.diffusers`
+    Adapter weights in safetensors format, with a reference to the base model.
+
+:py:mod:`mlflow.pyfunc`
+    Produced for use by generic pyfunc-based deployment tools and batch inference.
+    The pyfunc wrapper loads the base diffusion pipeline and applies the adapter
+    at inference time.
+"""
+
+import json
+import logging
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+import mlflow
+from mlflow import pyfunc
+from mlflow.exceptions import MlflowException
+from mlflow.models import Model, ModelInputExample, ModelSignature
+from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.models.signature import _infer_signature_from_input_example
+from mlflow.models.utils import _save_example
+from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.types import DataType, ParamSchema, ParamSpec, Schema
+from mlflow.types.schema import ColSpec
+from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
+from mlflow.utils.environment import (
+    _CONDA_ENV_FILE_NAME,
+    _CONSTRAINTS_FILE_NAME,
+    _PYTHON_ENV_FILE_NAME,
+    _REQUIREMENTS_FILE_NAME,
+    _mlflow_conda_env,
+    _process_conda_env,
+    _process_pip_requirements,
+    _PythonEnv,
+    _validate_env_arguments,
+)
+from mlflow.utils.file_utils import get_total_file_size, write_to
+from mlflow.utils.model_utils import (
+    _add_code_from_conf_to_system_path,
+    _get_flavor_configuration,
+    _validate_and_copy_code_paths,
+    _validate_and_prepare_target_save_path,
+)
+from mlflow.utils.requirements_utils import _get_pinned_requirement
+
+_logger = logging.getLogger(__name__)
+
+FLAVOR_NAME = "diffusers"
+
+_ADAPTER_WEIGHTS_DIR = "adapter_weights"
+_ADAPTER_CONFIG_FILE = "adapter_config.json"
+
+SUPPORTED_ADAPTER_TYPES = ("lora", "lokr", "loha")
+
+
+def _detect_device(device=None):
+    import torch
+
+    if device is not None:
+        return device
+    if torch.cuda.is_available():
+        return "cuda"
+    try:
+        if torch.backends.mps.is_available():
+            return "mps"
+    except AttributeError:
+        pass
+    return "cpu"
+
+
+def _get_default_signature():
+    return ModelSignature(
+        inputs=Schema([ColSpec(type=DataType.string, name="prompt")]),
+        outputs=Schema([ColSpec(type=DataType.binary, name="image")]),
+        params=ParamSchema([
+            ParamSpec(name="num_inference_steps", dtype=DataType.integer, default=30),
+            ParamSpec(name="guidance_scale", dtype=DataType.double, default=7.5),
+            ParamSpec(name="height", dtype=DataType.integer, default=512),
+            ParamSpec(name="width", dtype=DataType.integer, default=512),
+        ]),
+    )
+
+
+def get_default_pip_requirements():
+    import importlib.util
+
+    # Core requirements — always needed
+    packages = ["diffusers", "transformers", "torch"]
+
+    # Optional but recommended packages — only pin if installed
+    for optional in ["accelerate", "safetensors", "peft"]:
+        if importlib.util.find_spec(optional):
+            packages.append(optional)
+
+    return [_get_pinned_requirement(pkg) for pkg in packages]
+
+
+def get_default_conda_env():
+    return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
+
+
+@dataclass
+class DiffusersAdapterModel:
+    adapter_path: str
+    base_model_id: str
+    adapter_type: Literal["lora", "lokr", "loha"]
+
+    def load_pipeline(self, **kwargs):
+        from diffusers import DiffusionPipeline
+
+        device = _detect_device(kwargs.pop("device", None))
+        kwargs.setdefault("torch_dtype", "auto")
+
+        pipe = DiffusionPipeline.from_pretrained(self.base_model_id, **kwargs)
+
+        if self.adapter_type == "lora":
+            pipe.load_lora_weights(self.adapter_path)
+        else:
+            raise MlflowException(
+                f"Loading adapter type '{self.adapter_type}' is not yet supported. "
+                f"Currently only 'lora' adapters can be loaded at inference time."
+            )
+
+        return pipe.to(device)
+
+
+@format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="diffusers"))
+def save_model(
+    adapter_path,
+    path,
+    base_model_id,
+    adapter_type: Literal["lora", "lokr", "loha"] = "lora",
+    conda_env=None,
+    code_paths=None,
+    mlflow_model=None,
+    signature: ModelSignature = None,
+    input_example: ModelInputExample = None,
+    pip_requirements=None,
+    extra_pip_requirements=None,
+    metadata=None,
+):
+    """Save a diffusers adapter model to a path on the local file system.
+
+    Args:
+        adapter_path: Path to the adapter weights. Can be a single .safetensors file
+            or a directory containing adapter files.
+        path: Local path where the model is to be saved.
+        base_model_id: HuggingFace model ID or local path of the base diffusion model
+            that this adapter was trained on (e.g., "black-forest-labs/FLUX.1-dev").
+        adapter_type: Type of adapter. One of "lora", "lokr", "loha".
+        conda_env: {{ conda_env }}
+        code_paths: {{ code_paths }}
+        mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
+        signature: {{ signature }}
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        metadata: {{ metadata }}
+    """
+    try:
+        import diffusers
+
+        diffusers_version = diffusers.__version__
+    except ImportError:
+        _logger.warning(
+            "diffusers package is not installed. The saved model will not record a "
+            "diffusers version, which may affect reproducibility at load time."
+        )
+        diffusers_version = "unknown"
+
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+
+    adapter_type = adapter_type.lower()
+    if adapter_type not in SUPPORTED_ADAPTER_TYPES:
+        raise MlflowException.invalid_parameter_value(
+            f"Unsupported adapter type: {adapter_type}. "
+            f"Supported types: {SUPPORTED_ADAPTER_TYPES}"
+        )
+
+    adapter_path = Path(adapter_path)
+    if not adapter_path.exists():
+        raise MlflowException.invalid_parameter_value(
+            f"Adapter path does not exist: {adapter_path}"
+        )
+
+    path = Path(path)
+
+    _validate_and_prepare_target_save_path(path)
+    code_path_subdir = _validate_and_copy_code_paths(code_paths, path)
+
+    if mlflow_model is None:
+        mlflow_model = Model()
+
+    saved_example = _save_example(mlflow_model, input_example, path)
+
+    if signature is None and saved_example is not None:
+        signature = _infer_signature_from_input_example(saved_example, None)
+    elif signature is None:
+        signature = _get_default_signature()
+    elif signature is False:
+        signature = None
+
+    if signature is not None:
+        mlflow_model.signature = signature
+    if metadata is not None:
+        mlflow_model.metadata = metadata
+
+    # Copy adapter weights
+    weights_dst = path / _ADAPTER_WEIGHTS_DIR
+    if adapter_path.is_file():
+        weights_dst.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(adapter_path, weights_dst / adapter_path.name)
+    elif adapter_path.is_dir():
+        shutil.copytree(adapter_path, weights_dst)
+    else:
+        raise MlflowException.invalid_parameter_value(
+            f"Adapter path is neither a file nor a directory: {adapter_path}"
+        )
+
+    # Write adapter config
+    adapter_config = {
+        "base_model_id": base_model_id,
+        "adapter_type": adapter_type,
+    }
+    with open(path / _ADAPTER_CONFIG_FILE, "w") as f:
+        json.dump(adapter_config, f, indent=2)
+
+    mlflow_model.add_flavor(
+        FLAVOR_NAME,
+        base_model_id=base_model_id,
+        adapter_type=adapter_type,
+        adapter_weights=_ADAPTER_WEIGHTS_DIR,
+        diffusers_version=diffusers_version,
+        code=code_path_subdir,
+    )
+    pyfunc.add_to_model(
+        mlflow_model,
+        loader_module="mlflow.diffusers",
+        model_path=_ADAPTER_WEIGHTS_DIR,
+        conda_env=_CONDA_ENV_FILE_NAME,
+        python_env=_PYTHON_ENV_FILE_NAME,
+        code=code_path_subdir,
+    )
+
+    if size := get_total_file_size(path):
+        mlflow_model.model_size_bytes = size
+    mlflow_model.save(str(path / MLMODEL_FILE_NAME))
+
+    # Save environment files
+    if conda_env is None:
+        default_reqs = get_default_pip_requirements() if pip_requirements is None else None
+        conda_env, pip_requirements, pip_constraints = _process_pip_requirements(
+            default_reqs,
+            pip_requirements,
+            extra_pip_requirements,
+        )
+    else:
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+
+    with open(path / _CONDA_ENV_FILE_NAME, "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
+
+    if pip_constraints:
+        write_to(str(path / _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+
+    write_to(str(path / _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+    _PythonEnv.current().to_yaml(str(path / _PYTHON_ENV_FILE_NAME))
+
+
+@format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="diffusers"))
+def log_model(
+    adapter_path,
+    base_model_id,
+    adapter_type: Literal["lora", "lokr", "loha"] = "lora",
+    artifact_path: str | None = None,
+    conda_env=None,
+    code_paths=None,
+    registered_model_name=None,
+    signature: ModelSignature = None,
+    input_example: ModelInputExample = None,
+    await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+    pip_requirements=None,
+    extra_pip_requirements=None,
+    metadata=None,
+    params: dict[str, Any] | None = None,
+    tags: dict[str, Any] | None = None,
+    model_type: str | None = None,
+    step: int = 0,
+    model_id: str | None = None,
+    name: str | None = None,
+    **kwargs,
+):
+    """Log a diffusers adapter model as an MLflow artifact for the current run.
+
+    Args:
+        adapter_path: Path to the adapter weights. Can be a single .safetensors file
+            or a directory containing adapter files.
+        base_model_id: HuggingFace model ID or local path of the base diffusion model.
+        adapter_type: Type of adapter. One of "lora", "lokr", "loha".
+        artifact_path: Deprecated. Use ``name`` instead.
+        conda_env: {{ conda_env }}
+        code_paths: {{ code_paths }}
+        registered_model_name: If given, create a model version under this name.
+        signature: {{ signature }}
+        input_example: {{ input_example }}
+        await_registration_for: Number of seconds to wait for model version creation.
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        metadata: {{ metadata }}
+        params: {{ params }}
+        tags: {{ tags }}
+        model_type: {{ model_type }}
+        step: {{ step }}
+        model_id: {{ model_id }}
+        name: {{ name }}
+        kwargs: Extra arguments to pass to :py:func:`mlflow.models.Model.log`.
+
+    Returns:
+        A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance.
+    """
+    return Model.log(
+        artifact_path=artifact_path,
+        name=name,
+        flavor=mlflow.diffusers,
+        adapter_path=adapter_path,
+        base_model_id=base_model_id,
+        adapter_type=adapter_type,
+        conda_env=conda_env,
+        code_paths=code_paths,
+        registered_model_name=registered_model_name,
+        signature=signature,
+        input_example=input_example,
+        await_registration_for=await_registration_for,
+        pip_requirements=pip_requirements,
+        extra_pip_requirements=extra_pip_requirements,
+        metadata=metadata,
+        params=params,
+        tags=tags,
+        model_type=model_type,
+        step=step,
+        model_id=model_id,
+        **kwargs,
+    )
+
+
+def load_model(model_uri, dst_path=None):
+    """Load a diffusers adapter model from a local file or a run.
+
+    Args:
+        model_uri: The location, in URI format, of the MLflow model. Examples:
+
+            - ``/Users/me/path/to/local/model``
+            - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+            - ``models:/<model_name>/<model_version>``
+
+        dst_path: The local filesystem path to download the model artifact to.
+
+    Returns:
+        A :py:class:`DiffusersAdapterModel` with adapter_path, base_model_id,
+        and adapter_type. Call ``.load_pipeline()`` to get a ready-to-use
+        diffusers pipeline with the adapter applied.
+    """
+    local_model_path = Path(
+        _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+    )
+    flavor_conf = _get_flavor_configuration(
+        model_path=str(local_model_path), flavor_name=FLAVOR_NAME
+    )
+    _add_code_from_conf_to_system_path(str(local_model_path), flavor_conf)
+
+    adapter_weights_path = local_model_path / flavor_conf["adapter_weights"]
+
+    return DiffusersAdapterModel(
+        adapter_path=str(adapter_weights_path),
+        base_model_id=flavor_conf["base_model_id"],
+        adapter_type=flavor_conf["adapter_type"],
+    )
+
+
+def _load_pyfunc(path, model_config=None):
+    from mlflow.diffusers.wrapper import _DiffusersAdapterWrapper
+
+    path = Path(path)
+    flavor_conf = _get_flavor_configuration(model_path=str(path), flavor_name=FLAVOR_NAME)
+    pyfunc_conf = _get_flavor_configuration(model_path=str(path), flavor_name=pyfunc.FLAVOR_NAME)
+    adapter_path = str(path / pyfunc_conf["model_path"])
+
+    return _DiffusersAdapterWrapper(
+        adapter_path=adapter_path,
+        flavor_conf=flavor_conf,
+        model_config=model_config,
+    )

--- a/mlflow/diffusers/wrapper.py
+++ b/mlflow/diffusers/wrapper.py
@@ -1,0 +1,101 @@
+import io
+import logging
+from types import MappingProxyType
+from typing import Any
+
+import pandas as pd
+
+from mlflow.diffusers import _detect_device
+from mlflow.exceptions import MlflowException
+
+_logger = logging.getLogger(__name__)
+
+
+class _DiffusersAdapterWrapper:
+    def __init__(self, adapter_path, flavor_conf, model_config=None):
+        self._adapter_path = adapter_path
+        self._flavor_conf = flavor_conf
+        self._model_config = MappingProxyType(model_config or {})
+        self._pipeline = None
+
+    def _load_pipeline(self):
+        from diffusers import DiffusionPipeline
+
+        base_model_id = self._flavor_conf["base_model_id"]
+        adapter_type = self._flavor_conf.get("adapter_type", "lora")
+        device = _detect_device(self._model_config.get("device", None))
+        torch_dtype = self._model_config.get("torch_dtype", "auto")
+
+        _logger.info("Loading base pipeline: %s", base_model_id)
+        pipe = DiffusionPipeline.from_pretrained(base_model_id, torch_dtype=torch_dtype)
+
+        _logger.info("Loading LoRA adapter from: %s", self._adapter_path)
+        if adapter_type == "lora":
+            pipe.load_lora_weights(self._adapter_path)
+        else:
+            raise MlflowException(
+                f"Loading adapter type '{adapter_type}' is not yet supported. "
+                f"Currently only 'lora' adapters can be loaded at inference time."
+            )
+
+        self._pipeline = pipe.to(device)
+
+    def get_raw_model(self):
+        if self._pipeline is None:
+            self._load_pipeline()
+        return self._pipeline
+
+    def predict(self, data, params: dict[str, Any] | None = None):
+        if self._pipeline is None:
+            self._load_pipeline()
+
+        # Extract prompts
+        if isinstance(data, pd.DataFrame):
+            if "prompt" not in data.columns:
+                raise ValueError(
+                    f"Input DataFrame must contain a 'prompt' column. "
+                    f"Got columns: {list(data.columns)}"
+                )
+            prompts = data["prompt"].tolist()
+        elif isinstance(data, str):
+            prompts = [data]
+        elif isinstance(data, dict):
+            if "prompt" not in data:
+                raise ValueError(
+                    f"Input dict must contain a 'prompt' key. Got keys: {list(data.keys())}"
+                )
+            prompts = data["prompt"]
+            if isinstance(prompts, str):
+                prompts = [prompts]
+        elif isinstance(data, list):
+            prompts = data
+        else:
+            raise ValueError(f"Unsupported input type: {type(data)}")
+
+        if not prompts:
+            raise ValueError("No prompts provided. Input must contain at least one prompt string.")
+
+        # Extract generation params
+        params = params or {}
+        gen_kwargs = {
+            "num_inference_steps": params.get("num_inference_steps", 30),
+            "guidance_scale": params.get("guidance_scale", 7.5),
+            "height": params.get("height", 512),
+            "width": params.get("width", 512),
+        }
+
+        output = self._pipeline(prompt=prompts, **gen_kwargs)
+
+        if not hasattr(output, "images") or output.images is None:
+            raise MlflowException(
+                "Pipeline returned no images. The output may have been filtered "
+                "by the safety checker, or the pipeline does not support image generation."
+            )
+
+        results = []
+        for image in output.images:
+            buf = io.BytesIO()
+            image.save(buf, format="PNG")
+            results.append(buf.getvalue())
+
+        return results

--- a/tests/diffusers/test_diffusers_model_export.py
+++ b/tests/diffusers/test_diffusers_model_export.py
@@ -1,0 +1,272 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+from safetensors.numpy import save_file
+
+import mlflow
+import mlflow.diffusers
+from mlflow.diffusers import FLAVOR_NAME, DiffusersAdapterModel
+from mlflow.models.model import MLMODEL_FILE_NAME
+
+
+def _create_fake_adapter(tmp_path, filename="adapter.safetensors"):
+    adapter_dir = tmp_path / "fake_adapter"
+    adapter_dir.mkdir(exist_ok=True)
+    tensors = {"lora_weight": np.random.randn(4, 4).astype(np.float32)}
+    save_file(tensors, str(adapter_dir / filename))
+    return adapter_dir
+
+
+@pytest.fixture
+def adapter_dir(tmp_path):
+    return _create_fake_adapter(tmp_path)
+
+
+@pytest.fixture
+def adapter_file(tmp_path):
+    adapter_dir = _create_fake_adapter(tmp_path)
+    return adapter_dir / "adapter.safetensors"
+
+
+@pytest.fixture
+def model_path(tmp_path):
+    return tmp_path / "model_output"
+
+
+BASE_MODEL_ID = "stabilityai/stable-diffusion-xl-base-1.0"
+
+
+class TestSaveModel:
+    def test_save_model_from_directory(self, adapter_dir, model_path):
+        mlflow.diffusers.save_model(
+            adapter_path=str(adapter_dir),
+            path=str(model_path),
+            base_model_id=BASE_MODEL_ID,
+        )
+
+        mlmodel_path = model_path / MLMODEL_FILE_NAME
+        assert mlmodel_path.exists()
+
+        with open(mlmodel_path) as f:
+            mlmodel = yaml.safe_load(f)
+
+        assert FLAVOR_NAME in mlmodel["flavors"]
+        assert "python_function" in mlmodel["flavors"]
+
+        flavor_conf = mlmodel["flavors"][FLAVOR_NAME]
+        assert flavor_conf["base_model_id"] == BASE_MODEL_ID
+        assert flavor_conf["adapter_type"] == "lora"
+        assert flavor_conf["adapter_weights"] == "adapter_weights"
+
+    def test_save_model_from_file(self, adapter_file, model_path):
+        mlflow.diffusers.save_model(
+            adapter_path=str(adapter_file),
+            path=str(model_path),
+            base_model_id=BASE_MODEL_ID,
+        )
+
+        weights_dir = model_path / "adapter_weights"
+        assert weights_dir.exists()
+        assert (weights_dir / "adapter.safetensors").exists()
+
+    def test_save_model_copies_adapter_weights(self, adapter_dir, model_path):
+        mlflow.diffusers.save_model(
+            adapter_path=str(adapter_dir),
+            path=str(model_path),
+            base_model_id=BASE_MODEL_ID,
+        )
+
+        weights_dir = model_path / "adapter_weights"
+        assert weights_dir.exists()
+        assert (weights_dir / "adapter.safetensors").exists()
+
+    def test_save_model_writes_adapter_config(self, adapter_dir, model_path):
+        mlflow.diffusers.save_model(
+            adapter_path=str(adapter_dir),
+            path=str(model_path),
+            base_model_id=BASE_MODEL_ID,
+            adapter_type="lora",
+        )
+
+        config_path = model_path / "adapter_config.json"
+        assert config_path.exists()
+
+        with open(config_path) as f:
+            config = json.load(f)
+
+        assert config["base_model_id"] == BASE_MODEL_ID
+        assert config["adapter_type"] == "lora"
+
+    def test_save_model_writes_environment_files(self, adapter_dir, model_path):
+        mlflow.diffusers.save_model(
+            adapter_path=str(adapter_dir),
+            path=str(model_path),
+            base_model_id=BASE_MODEL_ID,
+        )
+
+        assert (model_path / "conda.yaml").exists()
+        assert (model_path / "requirements.txt").exists()
+        assert (model_path / "python_env.yaml").exists()
+
+    def test_save_model_default_signature(self, adapter_dir, model_path):
+        mlflow.diffusers.save_model(
+            adapter_path=str(adapter_dir),
+            path=str(model_path),
+            base_model_id=BASE_MODEL_ID,
+        )
+
+        with open(model_path / MLMODEL_FILE_NAME) as f:
+            mlmodel = yaml.safe_load(f)
+
+        assert "signature" in mlmodel
+        sig = mlmodel["signature"]
+        inputs = json.loads(sig["inputs"])
+        assert inputs[0]["name"] == "prompt"
+        assert inputs[0]["type"] == "string"
+
+    def test_save_model_custom_signature(self, adapter_dir, model_path):
+        from mlflow.types import DataType, Schema
+        from mlflow.types.schema import ColSpec
+
+        custom_sig = mlflow.models.ModelSignature(
+            inputs=Schema([ColSpec(type=DataType.string, name="text")]),
+            outputs=Schema([ColSpec(type=DataType.binary, name="img")]),
+        )
+
+        mlflow.diffusers.save_model(
+            adapter_path=str(adapter_dir),
+            path=str(model_path),
+            base_model_id=BASE_MODEL_ID,
+            signature=custom_sig,
+        )
+
+        with open(model_path / MLMODEL_FILE_NAME) as f:
+            mlmodel = yaml.safe_load(f)
+
+        inputs = json.loads(mlmodel["signature"]["inputs"])
+        assert inputs[0]["name"] == "text"
+
+    def test_save_model_invalid_adapter_type(self, adapter_dir, model_path):
+        with pytest.raises(mlflow.exceptions.MlflowException, match="Unsupported adapter type"):
+            mlflow.diffusers.save_model(
+                adapter_path=str(adapter_dir),
+                path=str(model_path),
+                base_model_id=BASE_MODEL_ID,
+                adapter_type="invalid",
+            )
+
+    def test_save_model_nonexistent_path(self, model_path):
+        with pytest.raises(mlflow.exceptions.MlflowException, match="does not exist"):
+            mlflow.diffusers.save_model(
+                adapter_path="/nonexistent/path",
+                path=str(model_path),
+                base_model_id=BASE_MODEL_ID,
+            )
+
+    def test_save_model_with_metadata(self, adapter_dir, model_path):
+        test_metadata = {"training_dataset": "my-dataset", "lora_rank": 16}
+
+        mlflow.diffusers.save_model(
+            adapter_path=str(adapter_dir),
+            path=str(model_path),
+            base_model_id=BASE_MODEL_ID,
+            metadata=test_metadata,
+        )
+
+        with open(model_path / MLMODEL_FILE_NAME) as f:
+            mlmodel = yaml.safe_load(f)
+
+        assert mlmodel["metadata"] == test_metadata
+
+
+class TestLogModel:
+    def test_log_model(self, adapter_dir):
+        with mlflow.start_run() as run:
+            model_info = mlflow.diffusers.log_model(
+                adapter_path=str(adapter_dir),
+                base_model_id=BASE_MODEL_ID,
+                name="test_adapter",
+            )
+
+        assert model_info is not None
+
+        client = mlflow.MlflowClient()
+        artifacts = [a.path for a in client.list_artifacts(run.info.run_id, "test_adapter")]
+        assert any("adapter_weights" in a for a in artifacts)
+        assert any(MLMODEL_FILE_NAME in a for a in artifacts)
+
+    def test_log_model_with_registered_name(self, adapter_dir):
+        with mlflow.start_run():
+            model_info = mlflow.diffusers.log_model(
+                adapter_path=str(adapter_dir),
+                base_model_id=BASE_MODEL_ID,
+                name="test_adapter",
+                registered_model_name="my-lora-model",
+            )
+
+        assert model_info is not None
+
+
+class TestLoadModel:
+    def test_load_model_roundtrip(self, adapter_dir):
+        with mlflow.start_run() as run:
+            mlflow.diffusers.log_model(
+                adapter_path=str(adapter_dir),
+                base_model_id=BASE_MODEL_ID,
+                name="test_adapter",
+            )
+
+        model_uri = f"runs:/{run.info.run_id}/test_adapter"
+        loaded = mlflow.diffusers.load_model(model_uri)
+
+        assert isinstance(loaded, DiffusersAdapterModel)
+        assert loaded.base_model_id == BASE_MODEL_ID
+        assert loaded.adapter_type == "lora"
+        assert Path(loaded.adapter_path).exists()
+        assert (Path(loaded.adapter_path) / "adapter.safetensors").exists()
+
+
+class TestLoadPyfunc:
+    def test_load_pyfunc_returns_wrapper(self, adapter_dir):
+        from mlflow.diffusers.wrapper import _DiffusersAdapterWrapper
+
+        with mlflow.start_run() as run:
+            mlflow.diffusers.log_model(
+                adapter_path=str(adapter_dir),
+                base_model_id=BASE_MODEL_ID,
+                name="test_adapter",
+            )
+
+        model_uri = f"runs:/{run.info.run_id}/test_adapter"
+        loaded_pyfunc = mlflow.pyfunc.load_model(model_uri)
+
+        assert hasattr(loaded_pyfunc, "predict")
+        wrapper = loaded_pyfunc._model_impl
+        assert isinstance(wrapper, _DiffusersAdapterWrapper)
+        assert wrapper._flavor_conf["base_model_id"] == BASE_MODEL_ID
+
+
+class TestPipRequirements:
+    @pytest.mark.parametrize("package", ["diffusers", "transformers", "torch"])
+    def test_default_pip_requirements_contains_core(self, package):
+        reqs = mlflow.diffusers.get_default_pip_requirements()
+        req_names = [r.split("==")[0] for r in reqs]
+        assert package in req_names
+
+    @pytest.mark.parametrize("package", ["accelerate", "safetensors", "peft"])
+    def test_default_pip_requirements_contains_optional_if_installed(self, package):
+        import importlib.util
+
+        reqs = mlflow.diffusers.get_default_pip_requirements()
+        req_names = [r.split("==")[0] for r in reqs]
+        if importlib.util.find_spec(package):
+            assert package in req_names
+        else:
+            assert package not in req_names
+
+    def test_default_conda_env(self):
+        env = mlflow.diffusers.get_default_conda_env()
+        assert "dependencies" in env


### PR DESCRIPTION
### Related Issues/PRs

Closes #22122

### What changes are proposed in this pull request?

Native MLflow flavor for logging, versioning, and serving diffusion model adapters (LoRA, LoKr, LoHa).

- `save_model` / `log_model` / `load_model` following the standard MLflow flavor pattern
- `load_model()` returns a `DiffusersAdapterModel` with `load_pipeline()` for direct inference
- pyfunc `predict()` support: prompt string in, PNG bytes out
- Default signature: `prompt (string) → image (binary)` with params (`num_inference_steps`, `guidance_scale`, `height`, `width`)
- Base model stored as a reference string in flavor config, adapter weights copied as artifacts

**Design decisions:**

- **Separate flavor vs extending transformers**: `DiffusionPipeline` has no `.task` or `.model` attributes, uses method-based adapter loading (`load_lora_weights`) instead of constructor wrapping, and has a completely different class hierarchy
- **Base model as reference, not artifact**: only the adapter weights (~1-500MB) are stored. The base model is downloaded at inference time via `DiffusionPipeline.from_pretrained()`
- **Model-agnostic**: uses `DiffusionPipeline.from_pretrained()` which auto-resolves the pipeline class (Flux2KleinPipeline, StableDiffusionXLPipeline, etc.)
- **LoRA only for inference in v1**: save/log works for lora/lokr/loha, but `load_pipeline()` currently only supports LoRA via `load_lora_weights()`. Other types raise a clear error

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

21 unit tests covering save/load/log roundtrip, signature, metadata, pip requirements, and error handling.

Manually tested end-to-end with:
- FLUX.2 Klein 4B + real LoRA fine-tune (30 steps) on Modal A100
- AI Toolkit (Ostris) training integration with checkpoint logging at each save step
- MLflow tracking server with artifact verification via REST API and UI

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add `mlflow.diffusers` flavor for logging and serving diffusion model adapters (LoRA). Enables `save_model`, `log_model`, `load_model`, and pyfunc inference for adapters trained with diffusers/PEFT.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release