### PR TITLE
Fix telemetry initialization and flush in job subprocesses

### DIFF
--- a/mlflow/server/jobs/_job_subproc_entry.py
+++ b/mlflow/server/jobs/_job_subproc_entry.py
@@ -29,13 +29,18 @@ from mlflow.server.jobs.utils import (
     _exit_when_orphaned,
     _load_function,
 )
+from mlflow.telemetry.client import get_telemetry_client, set_telemetry_client
 from mlflow.utils.workspace_context import WorkspaceContext
 
 _logger = logging.getLogger(__name__)
 # Configure Python logging to suppress noisy job logs
 configure_logging_for_jobs()
 
-if __name__ == "__main__":
+
+def _main():
+    # ensure telemetry can be captured within jobs
+    set_telemetry_client()
+
     # ensure the subprocess is killed when parent process dies.
     threading.Thread(
         target=_exit_when_orphaned,
@@ -91,3 +96,10 @@ if __name__ == "__main__":
     finally:
         if job_id:
             _set_job_tracker(None)
+        if telemetry_client := get_telemetry_client():
+            # flush the records before job exits
+            telemetry_client.flush()
+
+
+if __name__ == "__main__":
+    _main()

--- a/mlflow/server/jobs/_job_subproc_entry.py
+++ b/mlflow/server/jobs/_job_subproc_entry.py
@@ -99,7 +99,9 @@ def _main():
         if telemetry_client := get_telemetry_client():
             # best-effort flush before job exits; timeout avoids blocking shutdown
             try:
-                flush_thread = threading.Thread(target=telemetry_client.flush, daemon=True)
+                flush_thread = threading.Thread(
+                    target=telemetry_client.flush, daemon=True, name="FlushTelemetryRecords"
+                )
                 flush_thread.start()
                 flush_thread.join(timeout=5)
             except Exception:

--- a/mlflow/server/jobs/_job_subproc_entry.py
+++ b/mlflow/server/jobs/_job_subproc_entry.py
@@ -97,8 +97,13 @@ def _main():
         if job_id:
             _set_job_tracker(None)
         if telemetry_client := get_telemetry_client():
-            # flush the records before job exits
-            telemetry_client.flush()
+            # best-effort flush before job exits; timeout avoids blocking shutdown
+            try:
+                flush_thread = threading.Thread(target=telemetry_client.flush, daemon=True)
+                flush_thread.start()
+                flush_thread.join(timeout=5)
+            except Exception:
+                pass
 
 
 if __name__ == "__main__":

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import json
 import multiprocessing
 import os
 import time
@@ -19,7 +20,14 @@ from mlflow.server.jobs import (
     job,
     submit_job,
 )
-from mlflow.server.jobs.utils import _enqueue_unfinished_jobs
+from mlflow.server.jobs._job_subproc_entry import _main
+from mlflow.server.jobs.utils import (
+    MLFLOW_SERVER_JOB_FUNCTION_FULLNAME_ENV_VAR,
+    MLFLOW_SERVER_JOB_PARAMS_ENV_VAR,
+    MLFLOW_SERVER_JOB_RESULT_DUMP_PATH_ENV_VAR,
+    MLFLOW_SERVER_JOB_TRANSIENT_ERROR_CLASSES_PATH_ENV_VAR,
+    _enqueue_unfinished_jobs,
+)
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
 from mlflow.utils.workspace_context import WorkspaceContext
@@ -925,3 +933,34 @@ def test_update_status_details_on_nonexistent_job(tmp_path: Path):
 
     with pytest.raises(MlflowException, match="Job .+ not found"):
         store.update_status_details("nonexistent-job-id", {"stage": "test"})
+
+
+def test_subproc_entry_telemetry(tmp_path, monkeypatch):
+    result_path = str(tmp_path / "result.json")
+    transient_error_path = tmp_path / "transient_errors.txt"
+    transient_error_path.write_text("")
+    monkeypatch.setenv(
+        MLFLOW_SERVER_JOB_FUNCTION_FULLNAME_ENV_VAR,
+        "tests.server.jobs.test_jobs.basic_job_fun",
+    )
+    monkeypatch.setenv(MLFLOW_SERVER_JOB_PARAMS_ENV_VAR, json.dumps({"x": 1, "y": 2}))
+    monkeypatch.setenv(MLFLOW_SERVER_JOB_RESULT_DUMP_PATH_ENV_VAR, result_path)
+    monkeypatch.setenv(
+        MLFLOW_SERVER_JOB_TRANSIENT_ERROR_CLASSES_PATH_ENV_VAR, str(transient_error_path)
+    )
+
+    mock_client = mock.Mock()
+    with (
+        mock.patch(
+            "mlflow.server.jobs._job_subproc_entry.set_telemetry_client"
+        ) as mock_set_telemetry,
+        mock.patch(
+            "mlflow.server.jobs._job_subproc_entry.get_telemetry_client",
+            return_value=mock_client,
+        ),
+        mock.patch("mlflow.server.jobs._job_subproc_entry._exit_when_orphaned"),
+    ):
+        _main()
+
+    mock_set_telemetry.assert_called_once()
+    mock_client.flush.assert_called_once()


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Set telemetry client inside job entry file to ensure the telemetry is captured in job subprocesses (since today it's initialized when mlflow is imported, but it's not imported within the job); also add flush to ensure the records are pushed before job ends, otherwise we won't be able to track anything.
Verified this manually as well.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
