### PR TITLE
Fix GenAIEvaluateEvent arguments parsing issue

### DIFF
--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -60,30 +60,30 @@ PGBAR_FORMAT = (
 )
 
 
-def _get_eval_data_type(data: "EvaluationDatasetTypes") -> dict[str, Any]:
+def _get_eval_data_type(data: "EvaluationDatasetTypes") -> str | None:
     data_type = type(data)
 
     if data_type is list:
         if len(data) > 0 and all(isinstance(item, Trace) for item in data):
-            return {"eval_data_type": "list[Trace]"}
-        return {"eval_data_type": "list[dict]"}
+            return "list[Trace]"
+        return "list[dict]"
 
     if data_type is EntityEvaluationDataset:
-        return {"eval_data_type": "EntityEvaluationDataset"}
+        return "EntityEvaluationDataset"
     if data_type is ManagedEvaluationDataset:
-        return {"eval_data_type": "EvaluationDataset"}
+        return "EvaluationDataset"
 
     module = data_type.__module__
     qualname = data_type.__qualname__
 
     if qualname == "DataFrame":
         if module.startswith("pandas"):
-            return {"eval_data_type": "pd.DataFrame"}
+            return "pd.DataFrame"
         if module.startswith("pyspark"):
-            return {"eval_data_type": "pyspark.sql.DataFrame"}
+            return "pyspark.sql.DataFrame"
 
     if qualname == "ConversationSimulator":
-        return {"eval_data_type": "ConversationSimulator"}
+        return "ConversationSimulator"
 
     return "unknown"
 

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -60,7 +60,7 @@ PGBAR_FORMAT = (
 )
 
 
-def _get_eval_data_type(data: "EvaluationDatasetTypes") -> str | None:
+def _get_eval_data_type(data: "EvaluationDatasetTypes") -> str:
     data_type = type(data)
 
     if data_type is list:

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -133,7 +133,7 @@ class GenAIEvaluateEvent(Event):
         if eval_data is not None:
             from mlflow.genai.evaluation.utils import _get_eval_data_type
 
-            record_params.update(_get_eval_data_type(eval_data))
+            record_params["eval_data_type"] = _get_eval_data_type(eval_data)
 
         # Track scorer information
         scorers = arguments.get("scorers") or []

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 
 from mlflow.entities.evaluation_dataset import DatasetGranularity, EvaluationDataset
@@ -33,6 +34,7 @@ from mlflow.telemetry.events import (
     GatewayListEndpointsEvent,
     GatewayListSecretsEvent,
     GatewayUpdateEndpointEvent,
+    GenAIEvaluateEvent,
     LogAssessmentEvent,
     MakeJudgeEvent,
     MergeRecordsEvent,
@@ -710,3 +712,18 @@ def test_discover_issues_parse_result(result, expected_params):
 def test_update_issue_parse_params(arguments, expected_params):
     assert UpdateIssueEvent.name == "update_issue"
     assert UpdateIssueEvent.parse(arguments) == expected_params
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_eval_data_type"),
+    [
+        ({"data": [{"inputs": {"q": "a"}}]}, "list[dict]"),
+        ({"data": pd.DataFrame([{"inputs": {"q": "a"}}])}, "pd.DataFrame"),
+        ({"data": "unexpected_type"}, "unknown"),
+        ({"data": None}, None),
+        ({}, None),
+    ],
+)
+def test_genai_evaluate_event_parse_eval_data_type(arguments, expected_eval_data_type):
+    result = GenAIEvaluateEvent.parse(arguments)
+    assert result.get("eval_data_type") == expected_eval_data_type


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?
Fix the issue that `_get_eval_data_type` returns `unknown` instead of a dictionary when the type is not known, added test.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
