### PR TITLE
Lazy load trace modals and `GraphViewWorkflowCanvas` to reduce initial bundle size

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -2,7 +2,7 @@ import type { RowSelectionState, OnChangeFn, ColumnDef, Row } from '@tanstack/re
 import { getCoreRowModel, getSortedRowModel } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { isNil } from 'lodash';
-import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Empty, SearchIcon, Table, useDesignSystemTheme } from '@databricks/design-system';
 import { useIntl } from '@databricks/i18n';
@@ -20,12 +20,6 @@ import { MemoizedGenAiTracesTableSessionGroupedRows } from './GenAiTracesTableSe
 import { GenAiTracesTableHeader } from './GenAiTracesTableHeader';
 import { groupTracesBySessionForTable } from './utils/SessionGroupingUtils';
 import { HeaderCellRenderer } from './cellRenderers/HeaderCellRenderer';
-const GenAITraceComparisonModal = React.lazy(() =>
-  import('./components/GenAITraceComparisonModal').then((m) => ({ default: m.GenAITraceComparisonModal })),
-);
-const GenAiEvaluationTracesReviewModal = React.lazy(() =>
-  import('./components/GenAiEvaluationTracesReviewModal').then((m) => ({ default: m.GenAiEvaluationTracesReviewModal })),
-);
 import type { GetTraceFunction } from './hooks/useGetTrace';
 import { REQUEST_TIME_COLUMN_ID, SESSION_COLUMN_ID, SERVER_SORTABLE_INFO_COLUMNS } from './hooks/useTableColumns';
 import {
@@ -44,6 +38,15 @@ import {
 import { getAssessmentAggregates } from './utils/AggregationUtils';
 import { escapeCssSpecialCharacters } from './utils/DisplayUtils';
 import { getExperimentIdFromTraceLocation, getRowIdFromEvaluation } from './utils/TraceUtils';
+
+const GenAITraceComparisonModal = React.lazy(() =>
+  import('./components/GenAITraceComparisonModal').then((m) => ({ default: m.GenAITraceComparisonModal })),
+);
+const GenAiEvaluationTracesReviewModal = React.lazy(() =>
+  import('./components/GenAiEvaluationTracesReviewModal').then((m) => ({
+    default: m.GenAiEvaluationTracesReviewModal,
+  })),
+);
 
 export const GenAiTracesTableBody = React.memo(
   // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
@@ -614,7 +617,7 @@ export const GenAiTracesTableBody = React.memo(
             )}
           </Table>
         </div>
-        <Suspense fallback={null}>
+        <React.Suspense fallback={null}>
           {comparedTraceIds && shouldUseUnifiedModelTraceComparisonUI() ? (
             <GenAITraceComparisonModal
               traceIds={comparedTraceIds}
@@ -639,7 +642,7 @@ export const GenAiTracesTableBody = React.memo(
               />
             )
           )}
-        </Suspense>
+        </React.Suspense>
       </>
     );
   },

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAiTracesTableBody.tsx
@@ -2,7 +2,7 @@ import type { RowSelectionState, OnChangeFn, ColumnDef, Row } from '@tanstack/re
 import { getCoreRowModel, getSortedRowModel } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { isNil } from 'lodash';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Empty, SearchIcon, Table, useDesignSystemTheme } from '@databricks/design-system';
 import { useIntl } from '@databricks/i18n';
@@ -20,8 +20,12 @@ import { MemoizedGenAiTracesTableSessionGroupedRows } from './GenAiTracesTableSe
 import { GenAiTracesTableHeader } from './GenAiTracesTableHeader';
 import { groupTracesBySessionForTable } from './utils/SessionGroupingUtils';
 import { HeaderCellRenderer } from './cellRenderers/HeaderCellRenderer';
-import { GenAITraceComparisonModal } from './components/GenAITraceComparisonModal';
-import { GenAiEvaluationTracesReviewModal } from './components/GenAiEvaluationTracesReviewModal';
+const GenAITraceComparisonModal = React.lazy(() =>
+  import('./components/GenAITraceComparisonModal').then((m) => ({ default: m.GenAITraceComparisonModal })),
+);
+const GenAiEvaluationTracesReviewModal = React.lazy(() =>
+  import('./components/GenAiEvaluationTracesReviewModal').then((m) => ({ default: m.GenAiEvaluationTracesReviewModal })),
+);
 import type { GetTraceFunction } from './hooks/useGetTrace';
 import { REQUEST_TIME_COLUMN_ID, SESSION_COLUMN_ID, SERVER_SORTABLE_INFO_COLUMNS } from './hooks/useTableColumns';
 import {
@@ -610,30 +614,32 @@ export const GenAiTracesTableBody = React.memo(
             )}
           </Table>
         </div>
-        {comparedTraceIds && shouldUseUnifiedModelTraceComparisonUI() ? (
-          <GenAITraceComparisonModal
-            traceIds={comparedTraceIds}
-            onClose={() => onChangeEvaluationId(undefined)}
-            // prettier-ignore
-          />
-        ) : (
-          selectedEvaluationId &&
-          selectedEvaluationExperimentId && (
-            <GenAiEvaluationTracesReviewModal
-              experimentId={selectedEvaluationExperimentId}
-              runUuid={runUuid}
-              runDisplayName={runDisplayName}
-              otherRunDisplayName={compareToRunDisplayName}
-              evaluations={rows.map((row) => row.original)}
-              selectedEvaluationId={selectedEvaluationId}
-              onChangeEvaluationId={onChangeEvaluationId}
-              exportToEvalsInstanceEnabled={exportToEvalsInstanceEnabled}
-              assessmentInfos={assessmentInfos}
-              getTrace={getTrace}
-              saveAssessmentsQuery={saveAssessmentsQuery}
+        <Suspense fallback={null}>
+          {comparedTraceIds && shouldUseUnifiedModelTraceComparisonUI() ? (
+            <GenAITraceComparisonModal
+              traceIds={comparedTraceIds}
+              onClose={() => onChangeEvaluationId(undefined)}
+              // prettier-ignore
             />
-          )
-        )}
+          ) : (
+            selectedEvaluationId &&
+            selectedEvaluationExperimentId && (
+              <GenAiEvaluationTracesReviewModal
+                experimentId={selectedEvaluationExperimentId}
+                runUuid={runUuid}
+                runDisplayName={runDisplayName}
+                otherRunDisplayName={compareToRunDisplayName}
+                evaluations={rows.map((row) => row.original)}
+                selectedEvaluationId={selectedEvaluationId}
+                onChangeEvaluationId={onChangeEvaluationId}
+                exportToEvalsInstanceEnabled={exportToEvalsInstanceEnabled}
+                assessmentInfos={assessmentInfos}
+                getTrace={getTrace}
+                saveAssessmentsQuery={saveAssessmentsQuery}
+              />
+            )
+          )}
+        </Suspense>
       </>
     );
   },

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDetailView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDetailView.tsx
@@ -1,6 +1,6 @@
 import { Global } from '@emotion/react';
 import { clamp, values, isString } from 'lodash';
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import {
   Button,
@@ -32,7 +32,9 @@ import {
 import { DEFAULT_WORKFLOW_LAYOUT_CONFIG, EXPANDED_WORKFLOW_LAYOUT_CONFIG } from './graph-view/GraphView.types';
 import { computeWorkflowPathToRoot } from './graph-view/GraphView.utils';
 import { computeWorkflowLayout } from './graph-view/GraphView.workflow';
-import { GraphViewWorkflowCanvas } from './graph-view/GraphViewWorkflowCanvas';
+const GraphViewWorkflowCanvas = React.lazy(() =>
+  import('./graph-view/GraphViewWorkflowCanvas').then((m) => ({ default: m.GraphViewWorkflowCanvas })),
+);
 import { GraphViewSpanNavigator } from './graph-view/GraphViewSpanNavigator';
 import { useGraphTreeLinkedState } from './graph-view/useGraphTreeLinkedState';
 
@@ -344,14 +346,16 @@ export const ModelTraceExplorerDetailView = ({
         </div>
       </div>
 
-      <GraphViewWorkflowCanvas
-        layout={workflowLayout}
-        selectedNodeId={selectedWorkflowNode?.id ?? null}
-        highlightedPathNodeIds={highlightedWorkflowNodeIds}
-        highlightedPathEdgeIds={highlightedWorkflowEdgeIds}
-        onSelectNode={handleSelectWorkflowNode}
-        onViewSpanDetails={handleViewSpanDetails}
-      />
+      <Suspense fallback={null}>
+        <GraphViewWorkflowCanvas
+          layout={workflowLayout}
+          selectedNodeId={selectedWorkflowNode?.id ?? null}
+          highlightedPathNodeIds={highlightedWorkflowNodeIds}
+          highlightedPathEdgeIds={highlightedWorkflowEdgeIds}
+          onSelectNode={handleSelectWorkflowNode}
+          onViewSpanDetails={handleViewSpanDetails}
+        />
+      </Suspense>
     </div>
   );
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDetailView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDetailView.tsx
@@ -1,6 +1,6 @@
 import { Global } from '@emotion/react';
 import { clamp, values, isString } from 'lodash';
-import React, { Suspense, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import {
   Button,
@@ -32,11 +32,12 @@ import {
 import { DEFAULT_WORKFLOW_LAYOUT_CONFIG, EXPANDED_WORKFLOW_LAYOUT_CONFIG } from './graph-view/GraphView.types';
 import { computeWorkflowPathToRoot } from './graph-view/GraphView.utils';
 import { computeWorkflowLayout } from './graph-view/GraphView.workflow';
+import { GraphViewSpanNavigator } from './graph-view/GraphViewSpanNavigator';
+import { useGraphTreeLinkedState } from './graph-view/useGraphTreeLinkedState';
+
 const GraphViewWorkflowCanvas = React.lazy(() =>
   import('./graph-view/GraphViewWorkflowCanvas').then((m) => ({ default: m.GraphViewWorkflowCanvas })),
 );
-import { GraphViewSpanNavigator } from './graph-view/GraphViewSpanNavigator';
-import { useGraphTreeLinkedState } from './graph-view/useGraphTreeLinkedState';
 
 const LEFT_PANE_MIN_WIDTH_LARGE_SPACINGS = 7;
 const LEFT_PANE_HEADER_MIN_WIDTH_PX = 350;
@@ -346,7 +347,7 @@ export const ModelTraceExplorerDetailView = ({
         </div>
       </div>
 
-      <Suspense fallback={null}>
+      <React.Suspense fallback={null}>
         <GraphViewWorkflowCanvas
           layout={workflowLayout}
           selectedNodeId={selectedWorkflowNode?.id ?? null}
@@ -355,7 +356,7 @@ export const ModelTraceExplorerDetailView = ({
           onSelectNode={handleSelectWorkflowNode}
           onViewSpanDetails={handleViewSpanDetails}
         />
-      </Suspense>
+      </React.Suspense>
     </div>
   );
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #20607

### What changes are proposed in this pull request?

**Problem:** After #20607 added `@xyflow/react` as a dependency for the graph trace viewer, several MLflow UI pages (Gateway tab, Experiments trace tab, etc.) fail to render if the package is missing or fails to install. This happens because `@xyflow/react` is eagerly imported through a chain of 8+ eager imports starting from shared components like `GenAiTracesTableBody`, even though the graph view is only needed when a user opens a specific trace detail modal and navigates to the graph tab.

I discovered this when `@xyflow/react` failed to install locally due to npm registry being blocked by my network, which caused the Gateway page and other pages to crash with `Cannot find module '@xyflow/react'`.

**Fix:** Lazy load `GenAITraceComparisonModal`, `GenAiEvaluationTracesReviewModal`, and `GraphViewWorkflowCanvas` using `React.lazy()` so that `@xyflow/react` and the `model-trace-explorer` component tree are not eagerly pulled into pages that don't need them on first render.

Changes:
- **`GenAiTracesTableBody.tsx`**: Convert `GenAITraceComparisonModal` and `GenAiEvaluationTracesReviewModal` from eager imports to `React.lazy()` with a `React.Suspense` boundary. Both are conditionally rendered modals, making them ideal lazy loading candidates.
- **`ModelTraceExplorerDetailView.tsx`**: Convert `GraphViewWorkflowCanvas` from an eager import to `React.lazy()` with a `React.Suspense` boundary. This is the component that directly imports `@xyflow/react`.

This follows the existing lazy loading pattern used throughout the codebase (e.g., `LazyTraceLatencyChart`, `AgGridLoader`, `LogTracesDrawerLoader`).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Manually verified the Gateway page loads without the `@xyflow/react` runtime error, and trace modals still render correctly when opened.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release