### PR TITLE
Move LLM calling utilities to `mlflow/genai/utils/llm_utils.py`

### DIFF
--- a/mlflow/genai/discovery/clustering.py
+++ b/mlflow/genai/discovery/clustering.py
@@ -15,7 +15,7 @@ from mlflow.genai.discovery.entities import (
     _ConversationAnalysis,
     _IdentifiedIssue,
 )
-from mlflow.genai.discovery.utils import _call_llm, _TokenCounter
+from mlflow.genai.utils.llm_utils import _call_llm, _TokenCounter
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/genai/discovery/extraction.py
+++ b/mlflow/genai/discovery/extraction.py
@@ -12,7 +12,7 @@ from mlflow.genai.discovery.constants import (
     FAILURE_LABEL_SYSTEM_PROMPT,
 )
 from mlflow.genai.discovery.entities import _ConversationAnalysis, _TriageResult
-from mlflow.genai.discovery.utils import _call_llm, _TokenCounter
+from mlflow.genai.utils.llm_utils import _call_llm, _TokenCounter
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/genai/discovery/pipeline.py
+++ b/mlflow/genai/discovery/pipeline.py
@@ -43,8 +43,6 @@ from mlflow.genai.discovery.extraction import (
 )
 from mlflow.genai.discovery.sampling import sample_traces
 from mlflow.genai.discovery.utils import (
-    _call_llm,
-    _TokenCounter,
     build_summary,
     collect_affected_trace_ids,
     compute_latency_percentiles,
@@ -57,6 +55,7 @@ from mlflow.genai.discovery.utils import (
 )
 from mlflow.genai.judges.make_judge import make_judge
 from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.utils.llm_utils import _call_llm, _TokenCounter
 from mlflow.telemetry.events import DiscoverIssuesEvent
 from mlflow.telemetry.track import record_usage_event
 from mlflow.tracing.constant import AssessmentMetadataKey, TraceMetadataKey

--- a/mlflow/genai/discovery/utils.py
+++ b/mlflow/genai/discovery/utils.py
@@ -11,13 +11,6 @@ from mlflow.genai.discovery.constants import (
 )
 from mlflow.genai.discovery.entities import Issue, _ConversationAnalysis, _IdentifiedIssue
 from mlflow.genai.scorers.base import Scorer
-from mlflow.genai.utils.llm_utils import (  # noqa: F401 — re-exported for backwards compatibility
-    _call_llm,
-    _lookup_model_cost,
-    _ModelCost,
-    _pydantic_to_response_format,
-    _TokenCounter,
-)
 from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracing.provider import trace_disabled
 

--- a/mlflow/genai/discovery/utils.py
+++ b/mlflow/genai/discovery/utils.py
@@ -1,37 +1,25 @@
 from __future__ import annotations
 
-import functools
 import logging
-import threading
-import time
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
-
-import pydantic
-import requests
 
 import mlflow
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.trace import Trace
-from mlflow.gateway.config import EndpointType
 from mlflow.genai.discovery.constants import (
-    LLM_MAX_TOKENS,
-    NUM_RETRIES,
     TRACE_CONTENT_TRUNCATION,
 )
 from mlflow.genai.discovery.entities import Issue, _ConversationAnalysis, _IdentifiedIssue
-from mlflow.genai.judges.adapters.litellm_adapter import (
-    _is_litellm_available,
-)
 from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.utils.llm_utils import (  # noqa: F401 — re-exported for backwards compatibility
+    _call_llm,
+    _lookup_model_cost,
+    _ModelCost,
+    _pydantic_to_response_format,
+    _TokenCounter,
+)
 from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracing.provider import trace_disabled
-
-if TYPE_CHECKING:
-    import litellm
-
-    from mlflow.gateway.schemas.chat import ResponsePayload
 
 _logger = logging.getLogger(__name__)
 
@@ -138,242 +126,6 @@ def compute_latency_percentiles(traces: list[Trace]) -> dict[str, float | int] |
         "p99": round(percentile_values[4], 2),
         "count": len(durations_s),
     }
-
-
-class _TokenCounter:
-    """Thread-safe accumulator for LLM token usage across pipeline phases."""
-
-    def __init__(
-        self,
-        input_tokens: int = 0,
-        output_tokens: int = 0,
-        cost_usd: float = 0.0,
-        model: str | None = None,
-    ):
-        self._lock = threading.RLock()
-        self.input_tokens = input_tokens
-        self.output_tokens = output_tokens
-        self._cost_usd = cost_usd
-        self._cost_resolved = False
-        self._model = model
-
-    @property
-    def cost_usd(self) -> float | None:
-        """Return the total cost, falling back to the LiteLLM pricing API if needed."""
-        with self._lock:
-            if self._cost_usd == 0 and not self._cost_resolved:
-                total = self.input_tokens + self.output_tokens
-                if total > 0 and self._model:
-                    if cost := _lookup_model_cost(
-                        self._model, self.input_tokens, self.output_tokens
-                    ):
-                        self._cost_usd = cost
-                # Mark resolved once we've attempted lookup with tokens present,
-                # or when there are no tokens yet (nothing to look up).
-                self._cost_resolved = total > 0 or not self._model
-            return self._cost_usd or None
-
-    def add_cost(self, cost: float) -> None:
-        with self._lock:
-            self._cost_usd += cost
-
-    def track(self, response: litellm.ModelResponse | ResponsePayload) -> None:
-        with self._lock:
-            if response.usage:
-                self.input_tokens += response.usage.prompt_tokens or 0
-                self.output_tokens += response.usage.completion_tokens or 0
-            if hidden := getattr(response, "_hidden_params", None):
-                if cost := hidden.get("response_cost"):
-                    self.add_cost(cost)
-
-    def to_dict(self) -> dict[str, int | float]:
-        result = {}
-        total = self.input_tokens + self.output_tokens
-        if total > 0:
-            result["input_tokens"] = self.input_tokens
-            result["output_tokens"] = self.output_tokens
-            result["total_tokens"] = total
-        if cost := self.cost_usd:
-            result["cost_usd"] = round(cost, 6)
-        return result
-
-
-@trace_disabled
-def _call_llm(
-    model: str,
-    messages: list[dict[str, str]],
-    *,
-    json_mode: bool = False,
-    response_format: type[pydantic.BaseModel] | None = None,
-    token_counter: _TokenCounter | None = None,
-    inference_params: dict[str, Any] | None = None,
-) -> Any:
-    if _is_litellm_available():
-        return _call_llm_via_litellm(
-            model,
-            messages,
-            json_mode=json_mode,
-            response_format=response_format,
-            token_counter=token_counter,
-            inference_params=inference_params,
-        )
-    return _call_llm_via_gateway(
-        model,
-        messages,
-        json_mode=json_mode,
-        response_format=response_format,
-        token_counter=token_counter,
-        inference_params=inference_params,
-    )
-
-
-def _call_llm_via_litellm(
-    model: str,
-    messages: list[dict[str, str]],
-    *,
-    json_mode: bool = False,
-    response_format: type[pydantic.BaseModel] | None = None,
-    token_counter: _TokenCounter | None = None,
-    inference_params: dict[str, Any] | None = None,
-) -> Any:
-    from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm
-    from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
-    from mlflow.metrics.genai.model_utils import _parse_model_uri, convert_mlflow_uri_to_litellm
-
-    provider, model_name = _parse_model_uri(model)
-
-    if provider == "gateway":
-        config = get_gateway_litellm_config(model_name)
-        litellm_model = config.model
-        api_base = config.api_base
-        api_key = config.api_key
-        extra_headers = config.extra_headers
-    else:
-        litellm_model = convert_mlflow_uri_to_litellm(model)
-        api_base = None
-        api_key = None
-        extra_headers = None
-
-    use_format = response_format or ({"type": "json_object"} if json_mode else None)
-    merged_params = {"max_completion_tokens": LLM_MAX_TOKENS}
-    if inference_params:
-        merged_params.update(inference_params)
-    response = _invoke_litellm(
-        litellm_model=litellm_model,
-        messages=messages,
-        tools=[],
-        num_retries=NUM_RETRIES,
-        response_format=use_format,
-        include_response_format=use_format is not None,
-        inference_params=merged_params,
-        api_base=api_base,
-        api_key=api_key,
-        extra_headers=extra_headers,
-    )
-    if token_counter is not None:
-        token_counter.track(response)
-    return response
-
-
-def _call_llm_via_gateway(
-    model: str,
-    messages: list[dict[str, str]],
-    *,
-    json_mode: bool = False,
-    response_format: type[pydantic.BaseModel] | None = None,
-    token_counter: _TokenCounter | None = None,
-    inference_params: dict[str, Any] | None = None,
-) -> Any:
-    # Lightweight fallback for when LiteLLM is not installed. Supports
-    # providers with MLflow gateway adapters (OpenAI, Anthropic, Gemini, Mistral)
-    # and the MLflow AI Gateway (gateway:/ URIs).
-    # Known gaps vs the LiteLLM path: no drop_params
-    # (https://docs.litellm.ai/docs/completion/drop_params) - LiteLLM silently
-    # strips unsupported params (e.g. response_format) per model before sending
-    # the request, while this path sends them as-is. Not an issue for OpenAI
-    # and Anthropic which both support structured outputs. Also missing:
-    # no context window management and no per-request cost tracking.
-    from mlflow.metrics.genai.model_utils import (
-        _get_provider_instance,
-        _parse_model_uri,
-        _send_request,
-    )
-
-    provider_name, model_name = _parse_model_uri(model)
-    provider = _get_provider_instance(provider_name, model_name)
-
-    payload = {"messages": messages, "max_completion_tokens": LLM_MAX_TOKENS}
-    if inference_params:
-        payload.update(inference_params)
-    if response_format is not None:
-        payload["response_format"] = _pydantic_to_response_format(response_format)
-    elif json_mode:
-        payload["response_format"] = {"type": "json_object"}
-
-    chat_payload = provider.adapter_class.chat_to_model(payload, provider.config)
-
-    for attempt in range(NUM_RETRIES + 1):
-        try:
-            raw_response = _send_request(
-                endpoint=provider.get_endpoint_url(EndpointType.LLM_V1_CHAT),
-                headers=provider.headers,
-                payload=chat_payload,
-            )
-            break
-        except (
-            requests.exceptions.RequestException,
-            mlflow.exceptions.MlflowException,
-        ):
-            if attempt >= NUM_RETRIES:
-                raise
-            time.sleep(2**attempt)
-
-    response = provider.adapter_class.model_to_chat(raw_response, provider.config)
-    if token_counter is not None:
-        token_counter.track(response)
-    return response
-
-
-def _pydantic_to_response_format(cls: type[pydantic.BaseModel]) -> dict[str, Any]:
-    return {
-        "type": "json_schema",
-        "json_schema": {
-            "name": cls.__name__,
-            "schema": cls.model_json_schema(),
-        },
-    }
-
-
-@dataclass(frozen=True)
-class _ModelCost:
-    input_cost_per_token: float
-    output_cost_per_token: float
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> _ModelCost:
-        return cls(
-            input_cost_per_token=data.get("input_cost_per_token") or 0,
-            output_cost_per_token=data.get("output_cost_per_token") or 0,
-        )
-
-
-@functools.lru_cache(maxsize=64)
-def _fetch_model_cost(model_name: str) -> _ModelCost | None:
-    from mlflow.utils.providers import _get_model_cost
-
-    model_cost = _get_model_cost()
-    if entry := model_cost.get(model_name):
-        return _ModelCost.from_dict(entry)
-    return None
-
-
-def _lookup_model_cost(model_uri: str, input_tokens: int, output_tokens: int) -> float | None:
-    from mlflow.metrics.genai.model_utils import _parse_model_uri
-
-    _, model_name = _parse_model_uri(model_uri)
-    if cost := _fetch_model_cost(model_name):
-        return input_tokens * cost.input_cost_per_token + output_tokens * cost.output_cost_per_token
-    return None
 
 
 def build_summary(issues: list[Issue], total_traces: int) -> str:

--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -26,7 +26,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import EndpointType
 from mlflow.gateway.constants import MLFLOW_GATEWAY_CALLER_HEADER, GatewayCaller
 from mlflow.gateway.provider_registry import is_supported_provider
-from mlflow.genai.discovery.utils import _pydantic_to_response_format
 from mlflow.genai.judges.adapters.base_adapter import (
     AdapterInvocationInput,
     AdapterInvocationOutput,
@@ -47,6 +46,7 @@ from mlflow.genai.judges.utils.tool_calling_utils import (
     _raise_iteration_limit_exceeded,
     _remove_oldest_tool_call_pair,
 )
+from mlflow.genai.utils.llm_utils import _pydantic_to_response_format
 from mlflow.metrics.genai.model_utils import (
     _call_llm_provider_api,
     _get_provider_instance,

--- a/mlflow/genai/optimize/optimizers/metaprompt_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/metaprompt_optimizer.py
@@ -574,7 +574,7 @@ improve the prompt's effectiveness."""
         self, meta_prompt: str, enable_tracking: bool = True
     ) -> dict[str, str]:
         """Call the reflection model to generate improved prompts."""
-        from mlflow.genai.discovery.utils import _call_llm
+        from mlflow.genai.utils.llm_utils import _call_llm
 
         content = None  # Initialize to avoid NameError in exception handler
 

--- a/mlflow/genai/utils/llm_utils.py
+++ b/mlflow/genai/utils/llm_utils.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import functools
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import pydantic
+import requests
+
+import mlflow
+from mlflow.gateway.config import EndpointType
+from mlflow.genai.judges.adapters.litellm_adapter import _is_litellm_available
+from mlflow.tracing.provider import trace_disabled
+
+if TYPE_CHECKING:
+    import litellm
+
+    from mlflow.gateway.schemas.chat import ResponsePayload
+
+_logger = logging.getLogger(__name__)
+
+# Defaults for LLM calls; callers may override via inference_params.
+_DEFAULT_MAX_TOKENS = 8192
+_DEFAULT_NUM_RETRIES = 5
+
+
+class _TokenCounter:
+    """Thread-safe accumulator for LLM token usage across pipeline phases."""
+
+    def __init__(
+        self,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cost_usd: float = 0.0,
+        model: str | None = None,
+    ):
+        self._lock = threading.RLock()
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self._cost_usd = cost_usd
+        self._cost_resolved = False
+        self._model = model
+
+    @property
+    def cost_usd(self) -> float | None:
+        """Return the total cost, falling back to the LiteLLM pricing API if needed."""
+        with self._lock:
+            if self._cost_usd == 0 and not self._cost_resolved:
+                total = self.input_tokens + self.output_tokens
+                if total > 0 and self._model:
+                    if cost := _lookup_model_cost(
+                        self._model, self.input_tokens, self.output_tokens
+                    ):
+                        self._cost_usd = cost
+                # Mark resolved once we've attempted lookup with tokens present,
+                # or when there are no tokens yet (nothing to look up).
+                self._cost_resolved = total > 0 or not self._model
+            return self._cost_usd or None
+
+    def add_cost(self, cost: float) -> None:
+        with self._lock:
+            self._cost_usd += cost
+
+    def track(self, response: litellm.ModelResponse | ResponsePayload) -> None:
+        with self._lock:
+            if response.usage:
+                self.input_tokens += response.usage.prompt_tokens or 0
+                self.output_tokens += response.usage.completion_tokens or 0
+            if hidden := getattr(response, "_hidden_params", None):
+                if cost := hidden.get("response_cost"):
+                    self.add_cost(cost)
+
+    def to_dict(self) -> dict[str, int | float]:
+        result = {}
+        total = self.input_tokens + self.output_tokens
+        if total > 0:
+            result["input_tokens"] = self.input_tokens
+            result["output_tokens"] = self.output_tokens
+            result["total_tokens"] = total
+        if cost := self.cost_usd:
+            result["cost_usd"] = round(cost, 6)
+        return result
+
+
+@trace_disabled
+def _call_llm(
+    model: str,
+    messages: list[dict[str, str]],
+    *,
+    json_mode: bool = False,
+    response_format: type[pydantic.BaseModel] | None = None,
+    token_counter: _TokenCounter | None = None,
+    inference_params: dict[str, Any] | None = None,
+    max_tokens: int = _DEFAULT_MAX_TOKENS,
+    num_retries: int = _DEFAULT_NUM_RETRIES,
+) -> Any:
+    if _is_litellm_available():
+        return _call_llm_via_litellm(
+            model,
+            messages,
+            json_mode=json_mode,
+            response_format=response_format,
+            token_counter=token_counter,
+            inference_params=inference_params,
+            max_tokens=max_tokens,
+            num_retries=num_retries,
+        )
+    return _call_llm_via_gateway(
+        model,
+        messages,
+        json_mode=json_mode,
+        response_format=response_format,
+        token_counter=token_counter,
+        inference_params=inference_params,
+        max_tokens=max_tokens,
+        num_retries=num_retries,
+    )
+
+
+def _call_llm_via_litellm(
+    model: str,
+    messages: list[dict[str, str]],
+    *,
+    json_mode: bool = False,
+    response_format: type[pydantic.BaseModel] | None = None,
+    token_counter: _TokenCounter | None = None,
+    inference_params: dict[str, Any] | None = None,
+    max_tokens: int = _DEFAULT_MAX_TOKENS,
+    num_retries: int = _DEFAULT_NUM_RETRIES,
+) -> Any:
+    from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm
+    from mlflow.genai.utils.gateway_utils import get_gateway_litellm_config
+    from mlflow.metrics.genai.model_utils import _parse_model_uri, convert_mlflow_uri_to_litellm
+
+    provider, model_name = _parse_model_uri(model)
+
+    if provider == "gateway":
+        config = get_gateway_litellm_config(model_name)
+        litellm_model = config.model
+        api_base = config.api_base
+        api_key = config.api_key
+        extra_headers = config.extra_headers
+    else:
+        litellm_model = convert_mlflow_uri_to_litellm(model)
+        api_base = None
+        api_key = None
+        extra_headers = None
+
+    use_format = response_format or ({"type": "json_object"} if json_mode else None)
+    merged_params = {"max_completion_tokens": max_tokens}
+    if inference_params:
+        merged_params.update(inference_params)
+    response = _invoke_litellm(
+        litellm_model=litellm_model,
+        messages=messages,
+        tools=[],
+        num_retries=num_retries,
+        response_format=use_format,
+        include_response_format=use_format is not None,
+        inference_params=merged_params,
+        api_base=api_base,
+        api_key=api_key,
+        extra_headers=extra_headers,
+    )
+    if token_counter is not None:
+        token_counter.track(response)
+    return response
+
+
+def _call_llm_via_gateway(
+    model: str,
+    messages: list[dict[str, str]],
+    *,
+    json_mode: bool = False,
+    response_format: type[pydantic.BaseModel] | None = None,
+    token_counter: _TokenCounter | None = None,
+    inference_params: dict[str, Any] | None = None,
+    max_tokens: int = _DEFAULT_MAX_TOKENS,
+    num_retries: int = _DEFAULT_NUM_RETRIES,
+) -> Any:
+    # Lightweight fallback for when LiteLLM is not installed. Supports
+    # providers with MLflow gateway adapters (OpenAI, Anthropic, Gemini, Mistral)
+    # and the MLflow AI Gateway (gateway:/ URIs).
+    # Known gaps vs the LiteLLM path: no drop_params
+    # (https://docs.litellm.ai/docs/completion/drop_params) - LiteLLM silently
+    # strips unsupported params (e.g. response_format) per model before sending
+    # the request, while this path sends them as-is. Not an issue for OpenAI
+    # and Anthropic which both support structured outputs. Also missing:
+    # no context window management and no per-request cost tracking.
+    from mlflow.metrics.genai.model_utils import (
+        _get_provider_instance,
+        _parse_model_uri,
+        _send_request,
+    )
+
+    provider_name, model_name = _parse_model_uri(model)
+    provider = _get_provider_instance(provider_name, model_name)
+
+    payload = {"messages": messages, "max_completion_tokens": max_tokens}
+    if inference_params:
+        payload.update(inference_params)
+    if response_format is not None:
+        payload["response_format"] = _pydantic_to_response_format(response_format)
+    elif json_mode:
+        payload["response_format"] = {"type": "json_object"}
+
+    chat_payload = provider.adapter_class.chat_to_model(payload, provider.config)
+
+    for attempt in range(num_retries + 1):
+        try:
+            raw_response = _send_request(
+                endpoint=provider.get_endpoint_url(EndpointType.LLM_V1_CHAT),
+                headers=provider.headers,
+                payload=chat_payload,
+            )
+            break
+        except (
+            requests.exceptions.RequestException,
+            mlflow.exceptions.MlflowException,
+        ):
+            if attempt >= num_retries:
+                raise
+            time.sleep(2**attempt)
+
+    response = provider.adapter_class.model_to_chat(raw_response, provider.config)
+    if token_counter is not None:
+        token_counter.track(response)
+    return response
+
+
+def _pydantic_to_response_format(cls: type[pydantic.BaseModel]) -> dict[str, Any]:
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": cls.__name__,
+            "schema": cls.model_json_schema(),
+        },
+    }
+
+
+@dataclass(frozen=True)
+class _ModelCost:
+    input_cost_per_token: float
+    output_cost_per_token: float
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> _ModelCost:
+        return cls(
+            input_cost_per_token=data.get("input_cost_per_token") or 0,
+            output_cost_per_token=data.get("output_cost_per_token") or 0,
+        )
+
+
+@functools.lru_cache(maxsize=64)
+def _fetch_model_cost(model_name: str) -> _ModelCost | None:
+    from mlflow.utils.providers import _get_model_cost
+
+    model_cost = _get_model_cost()
+    if entry := model_cost.get(model_name):
+        return _ModelCost.from_dict(entry)
+    return None
+
+
+def _lookup_model_cost(model_uri: str, input_tokens: int, output_tokens: int) -> float | None:
+    from mlflow.metrics.genai.model_utils import _parse_model_uri
+
+    _, model_name = _parse_model_uri(model_uri)
+    if cost := _fetch_model_cost(model_name):
+        return input_tokens * cost.input_cost_per_token + output_tokens * cost.output_cost_per_token
+    return None

--- a/tests/genai/discovery/test_utils.py
+++ b/tests/genai/discovery/test_utils.py
@@ -1,7 +1,6 @@
 import time
 from unittest import mock
 
-import pydantic
 import pytest
 
 from mlflow.entities.issue import Issue, IssueStatus
@@ -13,11 +12,6 @@ from mlflow.entities.trace_state import TraceState
 from mlflow.genai.discovery.constants import CATEGORY_LATENCY, build_satisfaction_instructions
 from mlflow.genai.discovery.entities import _ConversationAnalysis, _IdentifiedIssue
 from mlflow.genai.discovery.utils import (
-    _call_llm,
-    _lookup_model_cost,
-    _ModelCost,
-    _pydantic_to_response_format,
-    _TokenCounter,
     build_summary,
     collect_affected_trace_ids,
     compute_latency_percentiles,
@@ -27,10 +21,9 @@ from mlflow.genai.discovery.utils import (
     group_traces_by_session,
     log_discovery_artifacts,
 )
-from mlflow.genai.utils.gateway_utils import GatewayConfig, GatewayLiteLLMConfig
+from mlflow.genai.utils.gateway_utils import GatewayConfig
 from mlflow.genai.utils.trace_utils import _extract_trace_timing_info
 from mlflow.metrics.genai.model_utils import _get_provider_instance
-from mlflow.types.chat import ChatChoice, ChatCompletionResponse, ChatMessage, ChatUsage
 
 
 def test_format_trace_content_includes_errors(make_trace):
@@ -226,56 +219,6 @@ def test_build_summary_with_issues():
     assert "Network instability; Upstream service issues" in result
 
 
-def test_token_counter_tracks_usage():
-    counter = _TokenCounter()
-    assert counter.input_tokens == 0
-    assert counter.output_tokens == 0
-    assert counter.cost_usd is None
-
-    mock_response = mock.MagicMock()
-    mock_response.usage = mock.MagicMock()
-    mock_response.usage.prompt_tokens = 100
-    mock_response.usage.completion_tokens = 50
-    mock_response._hidden_params = {"response_cost": 0.005}
-
-    counter.track(mock_response)
-
-    assert counter.input_tokens == 100
-    assert counter.output_tokens == 50
-    assert counter.cost_usd == 0.005
-
-
-def test_token_counter_tracks_gateway_response_without_hidden_params():
-    counter = _TokenCounter(model="openai:/gpt-5-mini")
-    response = ChatCompletionResponse(
-        created=0,
-        model="gpt-5-mini",
-        choices=[ChatChoice(index=0, message=ChatMessage(role="assistant", content="hi"))],
-        usage=ChatUsage(prompt_tokens=200, completion_tokens=80, total_tokens=280),
-    )
-
-    counter.track(response)
-
-    assert counter.input_tokens == 200
-    assert counter.output_tokens == 80
-    assert counter._cost_usd == 0.0
-    assert counter._model == "openai:/gpt-5-mini"
-
-
-def test_token_counter_to_dict_looks_up_cost_when_zero():
-    counter = _TokenCounter(input_tokens=100, output_tokens=50, model="openai:/gpt-5-mini")
-
-    with mock.patch(
-        "mlflow.genai.discovery.utils._lookup_model_cost",
-        return_value=0.0042,
-    ) as mock_lookup:
-        result = counter.to_dict()
-
-    mock_lookup.assert_called_once()
-    assert result["cost_usd"] == 0.0042
-    assert result["total_tokens"] == 150
-
-
 def test_group_traces_by_session_groups_by_session_id(make_trace):
     traces = [
         make_trace(session_id="session-1"),
@@ -324,79 +267,6 @@ def test_group_traces_by_session_sorts_by_timestamp(make_trace):
     assert session_traces[0].info.trace_id == trace1.info.trace_id
     assert session_traces[1].info.trace_id == trace2.info.trace_id
     assert session_traces[2].info.trace_id == trace3.info.trace_id
-
-
-def test_call_llm_uses_gateway_when_litellm_unavailable():
-    with (
-        mock.patch(
-            "mlflow.genai.discovery.utils._is_litellm_available", return_value=False
-        ) as mock_avail,
-        mock.patch(
-            "mlflow.genai.discovery.utils._call_llm_via_gateway",
-        ) as mock_gw,
-    ):
-        _call_llm("openai:/gpt-5-mini", [{"role": "user", "content": "hi"}])
-
-    mock_avail.assert_called_once()
-    mock_gw.assert_called_once()
-
-
-def test_call_llm_uses_litellm_when_available():
-    with (
-        mock.patch(
-            "mlflow.genai.discovery.utils._is_litellm_available", return_value=True
-        ) as mock_avail,
-        mock.patch(
-            "mlflow.genai.discovery.utils._call_llm_via_litellm",
-        ) as mock_ll,
-    ):
-        _call_llm("openai:/gpt-5-mini", [{"role": "user", "content": "hi"}])
-
-    mock_avail.assert_called_once()
-    mock_ll.assert_called_once()
-
-
-def test_pydantic_to_response_format():
-    class MySchema(pydantic.BaseModel):
-        name: str
-        score: int
-
-    result = _pydantic_to_response_format(MySchema)
-
-    assert result["type"] == "json_schema"
-    assert result["json_schema"]["name"] == "MySchema"
-    schema = result["json_schema"]["schema"]
-    assert "name" in schema["properties"]
-    assert "score" in schema["properties"]
-
-
-def test_lookup_model_cost_returns_calculated_cost():
-    cost_info = _ModelCost(input_cost_per_token=0.00001, output_cost_per_token=0.00003)
-    with mock.patch(
-        "mlflow.genai.discovery.utils._fetch_model_cost", return_value=cost_info
-    ) as mock_fetch:
-        cost = _lookup_model_cost("openai:/gpt-5-mini", 1000, 500)
-
-    mock_fetch.assert_called_once()
-    assert cost == pytest.approx(1000 * 0.00001 + 500 * 0.00003)
-
-
-def test_lookup_model_cost_returns_none_on_missing_model():
-    with mock.patch(
-        "mlflow.genai.discovery.utils._fetch_model_cost", return_value=None
-    ) as mock_fetch:
-        assert _lookup_model_cost("openai:/gpt-5-mini", 100, 50) is None
-
-    mock_fetch.assert_called_once()
-
-
-def test_lookup_model_cost_returns_none_on_network_error():
-    with mock.patch(
-        "mlflow.genai.discovery.utils._fetch_model_cost", return_value=None
-    ) as mock_fetch:
-        assert _lookup_model_cost("openai:/gpt-5-mini", 100, 50) is None
-
-    mock_fetch.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -483,235 +353,6 @@ def test_build_satisfaction_instructions_latency_variations(
             assert expected_text in result or expected_text in result.lower()
         else:
             assert expected_text not in result
-
-
-def test_call_llm_handles_gateway_models():
-    mock_response = mock.MagicMock()
-    mock_response.usage = mock.MagicMock()
-    mock_response.usage.prompt_tokens = 10
-    mock_response.usage.completion_tokens = 20
-
-    gateway_config = GatewayLiteLLMConfig(
-        model="openai/test-endpoint",
-        api_base="http://localhost:5000/gateway",
-        api_key="test-key",
-        extra_headers={"X-Custom": "header"},
-    )
-
-    with (
-        mock.patch(
-            "mlflow.genai.utils.gateway_utils.get_gateway_litellm_config",
-            return_value=gateway_config,
-        ) as mock_get_config,
-        mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
-            return_value=mock_response,
-        ) as mock_invoke,
-    ):
-        messages = [{"role": "user", "content": "test"}]
-        result = _call_llm("gateway:/test-endpoint", messages)
-
-        mock_get_config.assert_called_once_with("test-endpoint")
-        mock_invoke.assert_called_once()
-
-        call_kwargs = mock_invoke.call_args[1]
-        assert call_kwargs["litellm_model"] == "openai/test-endpoint"
-        assert call_kwargs["api_base"] == "http://localhost:5000/gateway"
-        assert call_kwargs["api_key"] == "test-key"
-        assert call_kwargs["extra_headers"] == {"X-Custom": "header"}
-        assert call_kwargs["messages"] == messages
-        assert result == mock_response
-
-
-def test_call_llm_handles_non_gateway_models():
-    mock_response = mock.MagicMock()
-    mock_response.usage = mock.MagicMock()
-    mock_response.usage.prompt_tokens = 10
-    mock_response.usage.completion_tokens = 20
-
-    with (
-        mock.patch(
-            "mlflow.metrics.genai.model_utils.convert_mlflow_uri_to_litellm",
-            return_value="openai/gpt-4",
-        ) as mock_convert,
-        mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
-            return_value=mock_response,
-        ) as mock_invoke,
-    ):
-        messages = [{"role": "user", "content": "test"}]
-        result = _call_llm("openai:/gpt-4", messages)
-
-        mock_convert.assert_called_once_with("openai:/gpt-4")
-        mock_invoke.assert_called_once()
-
-        call_kwargs = mock_invoke.call_args[1]
-        assert call_kwargs["litellm_model"] == "openai/gpt-4"
-        assert call_kwargs["api_base"] is None
-        assert call_kwargs["api_key"] is None
-        assert call_kwargs["extra_headers"] is None
-        assert call_kwargs["messages"] == messages
-        assert result == mock_response
-
-
-def test_call_llm_with_json_mode():
-    mock_response = mock.MagicMock()
-    with mock.patch(
-        "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
-        return_value=mock_response,
-    ) as mock_invoke:
-        messages = [{"role": "user", "content": "test"}]
-        _call_llm("openai:/gpt-4", messages, json_mode=True)
-
-        call_kwargs = mock_invoke.call_args[1]
-        assert call_kwargs["response_format"] == {"type": "json_object"}
-        assert call_kwargs["include_response_format"] is True
-
-
-def test_call_llm_with_response_format():
-    class TestModel(pydantic.BaseModel):
-        field: str
-
-    mock_response = mock.MagicMock()
-    with mock.patch(
-        "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
-        return_value=mock_response,
-    ) as mock_invoke:
-        messages = [{"role": "user", "content": "test"}]
-        _call_llm("openai:/gpt-4", messages, response_format=TestModel)
-
-        call_kwargs = mock_invoke.call_args[1]
-        assert call_kwargs["response_format"] == TestModel
-        assert call_kwargs["include_response_format"] is True
-
-
-def test_call_llm_tracks_tokens():
-    mock_response = mock.MagicMock()
-    mock_response.usage = mock.MagicMock()
-    mock_response.usage.prompt_tokens = 100
-    mock_response.usage.completion_tokens = 50
-    mock_response._hidden_params = {"response_cost": 0.01}
-
-    with mock.patch(
-        "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
-        return_value=mock_response,
-    ):
-        counter = _TokenCounter()
-        messages = [{"role": "user", "content": "test"}]
-        _call_llm("openai:/gpt-4", messages, token_counter=counter)
-
-        assert counter.input_tokens == 100
-        assert counter.output_tokens == 50
-        assert counter.cost_usd == 0.01
-
-
-def test_call_llm_inference_params_forwarded_to_litellm():
-    mock_response = mock.MagicMock()
-    with (
-        mock.patch("mlflow.genai.discovery.utils._is_litellm_available", return_value=True),
-        mock.patch(
-            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
-            return_value=mock_response,
-        ) as mock_invoke,
-    ):
-        messages = [{"role": "user", "content": "test"}]
-        _call_llm(
-            "openai:/gpt-4",
-            messages,
-            inference_params={"temperature": 0.5, "max_completion_tokens": 1024},
-        )
-
-        call_kwargs = mock_invoke.call_args[1]
-        # inference_params should override the default max_completion_tokens
-        assert call_kwargs["inference_params"]["temperature"] == 0.5
-        assert call_kwargs["inference_params"]["max_completion_tokens"] == 1024
-
-
-def test_call_llm_inference_params_forwarded_to_gateway():
-    mock_provider = mock.MagicMock()
-    captured_payload = {}
-    mock_provider.adapter_class.chat_to_model.side_effect = lambda payload, config: (
-        captured_payload.update(payload) or payload
-    )
-    mock_provider.get_endpoint_url.return_value = "http://localhost:5000/v1/chat/completions"
-    mock_provider.headers = {}
-
-    mock_chat_response = mock.MagicMock()
-    mock_chat_response.usage = mock.MagicMock(prompt_tokens=10, completion_tokens=5)
-    mock_provider.adapter_class.model_to_chat.return_value = mock_chat_response
-
-    with (
-        mock.patch("mlflow.genai.discovery.utils._is_litellm_available", return_value=False),
-        mock.patch(
-            "mlflow.metrics.genai.model_utils._get_provider_instance",
-            return_value=mock_provider,
-        ),
-        mock.patch(
-            "mlflow.metrics.genai.model_utils._send_request",
-            return_value={},
-        ),
-    ):
-        _call_llm(
-            "openai:/gpt-4",
-            [{"role": "user", "content": "test"}],
-            inference_params={"temperature": 0.7, "max_completion_tokens": 512},
-        )
-
-    assert captured_payload["temperature"] == 0.7
-    # inference_params should override the default max_completion_tokens
-    assert captured_payload["max_completion_tokens"] == 512
-
-
-# ---- gateway:/ URI via _get_provider_instance ----
-
-
-def test_call_llm_via_gateway_dispatches_gateway_uri_without_litellm():
-    mock_provider = mock.MagicMock()
-    mock_provider.adapter_class.chat_to_model.side_effect = lambda payload, config: payload
-    mock_provider.get_endpoint_url.return_value = (
-        "http://localhost:5000/gateway/mlflow/v1/chat/completions"
-    )
-    mock_provider.headers = {"Authorization": "Bearer token"}
-
-    raw_response = {
-        "id": "chatcmpl-gw",
-        "object": "chat.completion",
-        "created": 1234567890,
-        "model": "my-endpoint",
-        "choices": [
-            {
-                "index": 0,
-                "message": {"role": "assistant", "content": "gateway response"},
-                "finish_reason": "stop",
-            }
-        ],
-        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-    }
-
-    mock_chat_response = mock.MagicMock()
-    mock_chat_response.choices = [
-        mock.MagicMock(message=mock.MagicMock(content="gateway response"))
-    ]
-    mock_chat_response.usage = mock.MagicMock(prompt_tokens=10, completion_tokens=5)
-    mock_provider.adapter_class.model_to_chat.return_value = mock_chat_response
-
-    with (
-        mock.patch("mlflow.genai.discovery.utils._is_litellm_available", return_value=False),
-        mock.patch(
-            "mlflow.metrics.genai.model_utils._get_provider_instance",
-            return_value=mock_provider,
-        ) as mock_get_provider,
-        mock.patch(
-            "mlflow.metrics.genai.model_utils._send_request",
-            return_value=raw_response,
-        ) as mock_send,
-    ):
-        messages = [{"role": "user", "content": "test"}]
-        result = _call_llm("gateway:/my-endpoint", messages)
-
-    mock_get_provider.assert_called_once_with("gateway", "my-endpoint")
-    mock_send.assert_called_once()
-    assert result.choices[0].message.content == "gateway response"
 
 
 def test_get_mlflow_gateway_provider():

--- a/tests/genai/optimize/optimizers/test_metaprompt_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_metaprompt_optimizer.py
@@ -8,7 +8,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.optimize.optimizers.metaprompt_optimizer import MetaPromptOptimizer
 from mlflow.genai.optimize.types import EvaluationResultRecord, PromptOptimizerOutput
 
-_CALL_LLM = "mlflow.genai.discovery.utils._call_llm"
+_CALL_LLM = "mlflow.genai.utils.llm_utils._call_llm"
 
 
 @pytest.fixture

--- a/tests/genai/utils/test_llm_utils.py
+++ b/tests/genai/utils/test_llm_utils.py
@@ -1,0 +1,368 @@
+from unittest import mock
+
+import pydantic
+import pytest
+
+from mlflow.genai.utils.gateway_utils import GatewayLiteLLMConfig
+from mlflow.genai.utils.llm_utils import (
+    _call_llm,
+    _lookup_model_cost,
+    _ModelCost,
+    _pydantic_to_response_format,
+    _TokenCounter,
+)
+from mlflow.types.chat import ChatChoice, ChatCompletionResponse, ChatMessage, ChatUsage
+
+
+def test_token_counter_tracks_usage():
+    counter = _TokenCounter()
+    assert counter.input_tokens == 0
+    assert counter.output_tokens == 0
+    assert counter.cost_usd is None
+
+    mock_response = mock.MagicMock()
+    mock_response.usage = mock.MagicMock()
+    mock_response.usage.prompt_tokens = 100
+    mock_response.usage.completion_tokens = 50
+    mock_response._hidden_params = {"response_cost": 0.005}
+
+    counter.track(mock_response)
+
+    assert counter.input_tokens == 100
+    assert counter.output_tokens == 50
+    assert counter.cost_usd == 0.005
+
+
+def test_token_counter_tracks_gateway_response_without_hidden_params():
+    counter = _TokenCounter(model="openai:/gpt-5-mini")
+    response = ChatCompletionResponse(
+        created=0,
+        model="gpt-5-mini",
+        choices=[ChatChoice(index=0, message=ChatMessage(role="assistant", content="hi"))],
+        usage=ChatUsage(prompt_tokens=200, completion_tokens=80, total_tokens=280),
+    )
+
+    counter.track(response)
+
+    assert counter.input_tokens == 200
+    assert counter.output_tokens == 80
+    assert counter._cost_usd == 0.0
+    assert counter._model == "openai:/gpt-5-mini"
+
+
+def test_token_counter_to_dict_looks_up_cost_when_zero():
+    counter = _TokenCounter(input_tokens=100, output_tokens=50, model="openai:/gpt-5-mini")
+
+    with mock.patch(
+        "mlflow.genai.utils.llm_utils._lookup_model_cost",
+        return_value=0.0042,
+    ) as mock_lookup:
+        result = counter.to_dict()
+
+    mock_lookup.assert_called_once()
+    assert result["cost_usd"] == 0.0042
+    assert result["total_tokens"] == 150
+
+
+def test_call_llm_uses_gateway_when_litellm_unavailable():
+    with (
+        mock.patch(
+            "mlflow.genai.utils.llm_utils._is_litellm_available", return_value=False
+        ) as mock_avail,
+        mock.patch(
+            "mlflow.genai.utils.llm_utils._call_llm_via_gateway",
+        ) as mock_gw,
+    ):
+        _call_llm("openai:/gpt-5-mini", [{"role": "user", "content": "hi"}])
+
+    mock_avail.assert_called_once()
+    mock_gw.assert_called_once()
+
+
+def test_call_llm_uses_litellm_when_available():
+    with (
+        mock.patch(
+            "mlflow.genai.utils.llm_utils._is_litellm_available", return_value=True
+        ) as mock_avail,
+        mock.patch(
+            "mlflow.genai.utils.llm_utils._call_llm_via_litellm",
+        ) as mock_ll,
+    ):
+        _call_llm("openai:/gpt-5-mini", [{"role": "user", "content": "hi"}])
+
+    mock_avail.assert_called_once()
+    mock_ll.assert_called_once()
+
+
+def test_pydantic_to_response_format():
+    class MySchema(pydantic.BaseModel):
+        name: str
+        score: int
+
+    result = _pydantic_to_response_format(MySchema)
+
+    assert result["type"] == "json_schema"
+    assert result["json_schema"]["name"] == "MySchema"
+    schema = result["json_schema"]["schema"]
+    assert "name" in schema["properties"]
+    assert "score" in schema["properties"]
+
+
+def test_lookup_model_cost_returns_calculated_cost():
+    cost_info = _ModelCost(input_cost_per_token=0.00001, output_cost_per_token=0.00003)
+    with mock.patch(
+        "mlflow.genai.utils.llm_utils._fetch_model_cost", return_value=cost_info
+    ) as mock_fetch:
+        cost = _lookup_model_cost("openai:/gpt-5-mini", 1000, 500)
+
+    mock_fetch.assert_called_once()
+    assert cost == pytest.approx(1000 * 0.00001 + 500 * 0.00003)
+
+
+def test_lookup_model_cost_returns_none_on_missing_model():
+    with mock.patch(
+        "mlflow.genai.utils.llm_utils._fetch_model_cost", return_value=None
+    ) as mock_fetch:
+        assert _lookup_model_cost("openai:/gpt-5-mini", 100, 50) is None
+
+    mock_fetch.assert_called_once()
+
+
+def test_call_llm_handles_gateway_models():
+    mock_response = mock.MagicMock()
+    mock_response.usage = mock.MagicMock()
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 20
+
+    gateway_config = GatewayLiteLLMConfig(
+        model="openai/test-endpoint",
+        api_base="http://localhost:5000/gateway",
+        api_key="test-key",
+        extra_headers={"X-Custom": "header"},
+    )
+
+    with (
+        mock.patch("mlflow.genai.utils.llm_utils._is_litellm_available", return_value=True),
+        mock.patch(
+            "mlflow.genai.utils.gateway_utils.get_gateway_litellm_config",
+            return_value=gateway_config,
+        ) as mock_get_config,
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+            return_value=mock_response,
+        ) as mock_invoke,
+    ):
+        messages = [{"role": "user", "content": "test"}]
+        result = _call_llm("gateway:/test-endpoint", messages)
+
+        mock_get_config.assert_called_once_with("test-endpoint")
+        mock_invoke.assert_called_once()
+
+        call_kwargs = mock_invoke.call_args[1]
+        assert call_kwargs["litellm_model"] == "openai/test-endpoint"
+        assert call_kwargs["api_base"] == "http://localhost:5000/gateway"
+        assert call_kwargs["api_key"] == "test-key"
+        assert call_kwargs["extra_headers"] == {"X-Custom": "header"}
+        assert call_kwargs["messages"] == messages
+        assert result == mock_response
+
+
+def test_call_llm_handles_non_gateway_models():
+    mock_response = mock.MagicMock()
+    mock_response.usage = mock.MagicMock()
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 20
+
+    with (
+        mock.patch("mlflow.genai.utils.llm_utils._is_litellm_available", return_value=True),
+        mock.patch(
+            "mlflow.metrics.genai.model_utils.convert_mlflow_uri_to_litellm",
+            return_value="openai/gpt-4",
+        ) as mock_convert,
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+            return_value=mock_response,
+        ) as mock_invoke,
+    ):
+        messages = [{"role": "user", "content": "test"}]
+        result = _call_llm("openai:/gpt-4", messages)
+
+        mock_convert.assert_called_once_with("openai:/gpt-4")
+        mock_invoke.assert_called_once()
+
+        call_kwargs = mock_invoke.call_args[1]
+        assert call_kwargs["litellm_model"] == "openai/gpt-4"
+        assert call_kwargs["api_base"] is None
+        assert call_kwargs["api_key"] is None
+        assert call_kwargs["extra_headers"] is None
+        assert call_kwargs["messages"] == messages
+        assert result == mock_response
+
+
+def test_call_llm_with_json_mode():
+    mock_response = mock.MagicMock()
+    with (
+        mock.patch("mlflow.genai.utils.llm_utils._is_litellm_available", return_value=True),
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+            return_value=mock_response,
+        ) as mock_invoke,
+    ):
+        messages = [{"role": "user", "content": "test"}]
+        _call_llm("openai:/gpt-4", messages, json_mode=True)
+
+        call_kwargs = mock_invoke.call_args[1]
+        assert call_kwargs["response_format"] == {"type": "json_object"}
+        assert call_kwargs["include_response_format"] is True
+
+
+def test_call_llm_with_response_format():
+    class TestModel(pydantic.BaseModel):
+        field: str
+
+    mock_response = mock.MagicMock()
+    with (
+        mock.patch("mlflow.genai.utils.llm_utils._is_litellm_available", return_value=True),
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+            return_value=mock_response,
+        ) as mock_invoke,
+    ):
+        messages = [{"role": "user", "content": "test"}]
+        _call_llm("openai:/gpt-4", messages, response_format=TestModel)
+
+        call_kwargs = mock_invoke.call_args[1]
+        assert call_kwargs["response_format"] == TestModel
+        assert call_kwargs["include_response_format"] is True
+
+
+def test_call_llm_tracks_tokens():
+    mock_response = mock.MagicMock()
+    mock_response.usage = mock.MagicMock()
+    mock_response.usage.prompt_tokens = 100
+    mock_response.usage.completion_tokens = 50
+    mock_response._hidden_params = {"response_cost": 0.01}
+
+    with (
+        mock.patch("mlflow.genai.utils.llm_utils._is_litellm_available", return_value=True),
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+            return_value=mock_response,
+        ),
+    ):
+        counter = _TokenCounter()
+        messages = [{"role": "user", "content": "test"}]
+        _call_llm("openai:/gpt-4", messages, token_counter=counter)
+
+        assert counter.input_tokens == 100
+        assert counter.output_tokens == 50
+        assert counter.cost_usd == 0.01
+
+
+def test_call_llm_inference_params_forwarded_to_litellm():
+    mock_response = mock.MagicMock()
+    with (
+        mock.patch("mlflow.genai.utils.llm_utils._is_litellm_available", return_value=True),
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm",
+            return_value=mock_response,
+        ) as mock_invoke,
+    ):
+        messages = [{"role": "user", "content": "test"}]
+        _call_llm(
+            "openai:/gpt-4",
+            messages,
+            inference_params={"temperature": 0.5, "max_completion_tokens": 1024},
+        )
+
+        call_kwargs = mock_invoke.call_args[1]
+        # inference_params should override the default max_completion_tokens
+        assert call_kwargs["inference_params"]["temperature"] == 0.5
+        assert call_kwargs["inference_params"]["max_completion_tokens"] == 1024
+
+
+def test_call_llm_inference_params_forwarded_to_gateway():
+    mock_provider = mock.MagicMock()
+    captured_payload = {}
+    mock_provider.adapter_class.chat_to_model.side_effect = lambda payload, config: (
+        captured_payload.update(payload) or payload
+    )
+    mock_provider.get_endpoint_url.return_value = "http://localhost:5000/v1/chat/completions"
+    mock_provider.headers = {}
+
+    mock_chat_response = mock.MagicMock()
+    mock_chat_response.usage = mock.MagicMock(prompt_tokens=10, completion_tokens=5)
+    mock_provider.adapter_class.model_to_chat.return_value = mock_chat_response
+
+    with (
+        mock.patch("mlflow.genai.utils.llm_utils._is_litellm_available", return_value=False),
+        mock.patch(
+            "mlflow.metrics.genai.model_utils._get_provider_instance",
+            return_value=mock_provider,
+        ),
+        mock.patch(
+            "mlflow.metrics.genai.model_utils._send_request",
+            return_value={},
+        ),
+    ):
+        _call_llm(
+            "openai:/gpt-4",
+            [{"role": "user", "content": "test"}],
+            inference_params={"temperature": 0.7, "max_completion_tokens": 512},
+        )
+
+    assert captured_payload["temperature"] == 0.7
+    # inference_params should override the default max_completion_tokens
+    assert captured_payload["max_completion_tokens"] == 512
+
+
+# ---- gateway:/ URI via _get_provider_instance ----
+
+
+def test_call_llm_via_gateway_dispatches_gateway_uri_without_litellm():
+    mock_provider = mock.MagicMock()
+    mock_provider.adapter_class.chat_to_model.side_effect = lambda payload, config: payload
+    mock_provider.get_endpoint_url.return_value = (
+        "http://localhost:5000/gateway/mlflow/v1/chat/completions"
+    )
+    mock_provider.headers = {"Authorization": "Bearer token"}
+
+    raw_response = {
+        "id": "chatcmpl-gw",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": "my-endpoint",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "gateway response"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    mock_chat_response = mock.MagicMock()
+    mock_chat_response.choices = [
+        mock.MagicMock(message=mock.MagicMock(content="gateway response"))
+    ]
+    mock_chat_response.usage = mock.MagicMock(prompt_tokens=10, completion_tokens=5)
+    mock_provider.adapter_class.model_to_chat.return_value = mock_chat_response
+
+    with (
+        mock.patch("mlflow.genai.utils.llm_utils._is_litellm_available", return_value=False),
+        mock.patch(
+            "mlflow.metrics.genai.model_utils._get_provider_instance",
+            return_value=mock_provider,
+        ) as mock_get_provider,
+        mock.patch(
+            "mlflow.metrics.genai.model_utils._send_request",
+            return_value=raw_response,
+        ) as mock_send,
+    ):
+        messages = [{"role": "user", "content": "test"}]
+        result = _call_llm("gateway:/my-endpoint", messages)
+
+    mock_get_provider.assert_called_once_with("gateway", "my-endpoint")
+    mock_send.assert_called_once()
+    assert result.choices[0].message.content == "gateway response"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/22234/files) to review incremental changes.
- [**stack/refactor-llm-utils**](https://github.com/mlflow/mlflow/pull/22234) [[Files changed](https://github.com/mlflow/mlflow/pull/22234/files)]

---------
### Related Issues/PRs

Depends on #22233

### What changes are proposed in this pull request?

- Extract shared LLM calling utilities (`_call_llm`, `_TokenCounter`, `_pydantic_to_response_format`, `_ModelCost`, `_lookup_model_cost`) from `mlflow/genai/discovery/utils.py` into a new shared module `mlflow/genai/utils/llm_utils.py`
- Parameterize `max_tokens` and `num_retries` in `_call_llm` (previously hardcoded from discovery constants) so callers can override them
- Update all imports in discovery, judges, and optimize modules to use the new shared location
- Re-export moved symbols from `discovery/utils.py` for backwards compatibility
- Move LLM-related tests from `tests/genai/discovery/test_utils.py` to `tests/genai/utils/test_llm_utils.py`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
