### PR TITLE
Fix dropdown showing wrong selection state before endpoints load in issue detection modal

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModelSelection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModelSelection.tsx
@@ -141,7 +141,7 @@ export const IssueDetectionModelSelection = forwardRef<
 
   // Get display value for the dropdown
   const dropdownDisplayValue = useMemo(() => {
-    if (mode === 'direct') {
+    if (hasInitializedMode && mode === 'direct') {
       return intl.formatMessage({
         defaultMessage: 'Configure model directly',
         description: 'Option to configure model directly instead of using an endpoint',
@@ -153,7 +153,7 @@ export const IssueDetectionModelSelection = forwardRef<
     }
     // No endpoint selected yet - return empty to show placeholder
     return '';
-  }, [mode, selectedEndpointName, endpointOptions, intl]);
+  }, [mode, selectedEndpointName, endpointOptions, intl, hasInitializedMode]);
 
   // Handle selection from dropdown
   const handleDropdownSelect = useCallback((value: string) => {
@@ -295,7 +295,11 @@ export const IssueDetectionModelSelection = forwardRef<
               componentId="mlflow.traces.issue-detection-modal.model-source"
               id="mlflow.traces.issue-detection-modal.model-source"
               value={
-                mode === 'direct' ? [CONFIGURE_DIRECTLY_VALUE] : selectedEndpointName ? [selectedEndpointName] : []
+                hasInitializedMode && mode === 'direct'
+                  ? [CONFIGURE_DIRECTLY_VALUE]
+                  : selectedEndpointName
+                    ? [selectedEndpointName]
+                    : []
               }
             >
               <DialogComboboxTrigger
@@ -307,28 +311,32 @@ export const IssueDetectionModelSelection = forwardRef<
                 })}
                 renderDisplayedValue={() => (dropdownDisplayValue ? <span>{dropdownDisplayValue}</span> : null)}
               />
-              <DialogComboboxContent maxHeight={350}>
+              <DialogComboboxContent>
                 <DialogComboboxOptionList>
-                  {endpointOptions.map((option) => (
-                    <DialogComboboxOptionListSelectItem
-                      key={option.value}
-                      value={option.value}
-                      onChange={() => handleDropdownSelect(option.value)}
-                      checked={mode === 'endpoint' && selectedEndpointName === option.value}
-                    >
-                      {option.label}
-                      {option.provider && option.modelName && (
-                        <DialogComboboxHintRow>
-                          {option.provider} / {option.modelName}
-                        </DialogComboboxHintRow>
-                      )}
-                    </DialogComboboxOptionListSelectItem>
-                  ))}
+                  {endpointOptions.length > 0 && (
+                    <div css={{ maxHeight: 150, overflowY: 'auto' }}>
+                      {endpointOptions.map((option) => (
+                        <DialogComboboxOptionListSelectItem
+                          key={option.value}
+                          value={option.value}
+                          onChange={() => handleDropdownSelect(option.value)}
+                          checked={mode === 'endpoint' && selectedEndpointName === option.value}
+                        >
+                          {option.label}
+                          {option.provider && option.modelName && (
+                            <DialogComboboxHintRow>
+                              {option.provider} / {option.modelName}
+                            </DialogComboboxHintRow>
+                          )}
+                        </DialogComboboxOptionListSelectItem>
+                      ))}
+                    </div>
+                  )}
                   {endpointOptions.length > 0 && <DialogComboboxSeparator />}
                   <DialogComboboxOptionListSelectItem
                     value={CONFIGURE_DIRECTLY_VALUE}
                     onChange={() => handleDropdownSelect(CONFIGURE_DIRECTLY_VALUE)}
-                    checked={mode === 'direct'}
+                    checked={hasInitializedMode && mode === 'direct'}
                   >
                     <FormattedMessage
                       defaultMessage="Configure model directly"


### PR DESCRIPTION
### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

In `IssueDetectionModelSelection`, the `mode` state defaults to `'direct'` before endpoints finish loading. This caused the dropdown to briefly (or permanently, if loading is slow) show "Configure model directly" as the selected option even when endpoints are available and `endpoint` mode should be selected.

Changes:
- Introduce `hasInitializedMode` flag that is set to `true` only after the endpoint loading `useEffect` fires and sets the correct initial mode.
- Gate all mode-based display logic (`dropdownDisplayValue`, `value` prop, `checked` prop) on `hasInitializedMode`, so the dropdown shows an empty/unselected placeholder until the real mode is known.
- Move the scroll height constraint from `DialogComboboxContent` to an inner `div` wrapping only the endpoint list items, so the "Configure model directly" option remains always visible outside the scrollable area.
Before:

https://github.com/user-attachments/assets/ef861360-97f6-4e20-a300-800d63516850



After:

https://github.com/user-attachments/assets/1f91e974-811b-4d9c-bcf1-9eb65d392cc1



### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug in the issue detection model selection dropdown where "Configure model directly" was incorrectly shown as selected before serving endpoints finished loading.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release