### PR TITLE
Add telemetry click tracking to homepage feature cards

### DIFF
--- a/mlflow/server/js/src/home/components/features/FeatureCard.test.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.test.tsx
@@ -17,13 +17,13 @@ describe('FeatureCard', () => {
   const evaluationFeature = featureDefinitions.find((f) => f.id === 'evaluation')!;
 
   it('renders feature title and summary', () => {
-    renderWithDesignSystem(<FeatureCard feature={tracingFeature} />);
+    renderWithDesignSystem(<FeatureCard feature={tracingFeature} componentId={tracingFeature.componentId} />);
 
     expect(screen.getByRole('heading', { level: 2, name: 'Tracing' })).toBeInTheDocument();
   });
 
   it('renders as a button and opens drawer for features with hasDrawer', async () => {
-    renderWithDesignSystem(<FeatureCard feature={tracingFeature} />);
+    renderWithDesignSystem(<FeatureCard feature={tracingFeature} componentId={tracingFeature.componentId} />);
 
     await userEvent.click(screen.getByRole('button'));
 
@@ -31,7 +31,7 @@ describe('FeatureCard', () => {
   });
 
   it('renders as a link for features without hasDrawer', () => {
-    renderWithDesignSystem(<FeatureCard feature={evaluationFeature} />);
+    renderWithDesignSystem(<FeatureCard feature={evaluationFeature} componentId={evaluationFeature.componentId} />);
 
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', evaluationFeature.docsLink);

--- a/mlflow/server/js/src/home/components/features/FeatureCard.test.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.test.tsx
@@ -17,13 +17,13 @@ describe('FeatureCard', () => {
   const evaluationFeature = featureDefinitions.find((f) => f.id === 'evaluation')!;
 
   it('renders feature title and summary', () => {
-    renderWithDesignSystem(<FeatureCard feature={tracingFeature} componentId={tracingFeature.componentId} />);
+    renderWithDesignSystem(<FeatureCard feature={tracingFeature} componentId="" />);
 
     expect(screen.getByRole('heading', { level: 2, name: 'Tracing' })).toBeInTheDocument();
   });
 
   it('renders as a button and opens drawer for features with hasDrawer', async () => {
-    renderWithDesignSystem(<FeatureCard feature={tracingFeature} componentId={tracingFeature.componentId} />);
+    renderWithDesignSystem(<FeatureCard feature={tracingFeature} componentId="" />);
 
     await userEvent.click(screen.getByRole('button'));
 
@@ -31,7 +31,7 @@ describe('FeatureCard', () => {
   });
 
   it('renders as a link for features without hasDrawer', () => {
-    renderWithDesignSystem(<FeatureCard feature={evaluationFeature} componentId={evaluationFeature.componentId} />);
+    renderWithDesignSystem(<FeatureCard feature={evaluationFeature} componentId="" />);
 
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', evaluationFeature.docsLink);

--- a/mlflow/server/js/src/home/components/features/FeatureCard.test.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.test.tsx
@@ -25,10 +25,10 @@ describe('FeatureCard', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Tracing' })).toBeInTheDocument();
   });
 
-  it('renders as a button and opens drawer for features with hasDrawer', async () => {
+  it('opens drawer on click for features with hasDrawer', async () => {
     renderWithRouter(<FeatureCard feature={tracingFeature} componentId="" />);
 
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByRole('link'));
 
     expect(mockOpenLogTracesDrawer).toHaveBeenCalled();
   });

--- a/mlflow/server/js/src/home/components/features/FeatureCard.test.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
 import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { MemoryRouter } from '../../../common/utils/RoutingUtils';
 import { FeatureCard } from './FeatureCard';
 import { featureDefinitions } from './feature-definitions';
 
@@ -12,18 +13,20 @@ jest.mock('../../HomePageViewStateContext', () => ({
   }),
 }));
 
+const renderWithRouter = (ui: React.ReactElement) => renderWithDesignSystem(<MemoryRouter>{ui}</MemoryRouter>);
+
 describe('FeatureCard', () => {
   const tracingFeature = featureDefinitions.find((f) => f.id === 'tracing')!;
   const evaluationFeature = featureDefinitions.find((f) => f.id === 'evaluation')!;
 
   it('renders feature title and summary', () => {
-    renderWithDesignSystem(<FeatureCard feature={tracingFeature} componentId="" />);
+    renderWithRouter(<FeatureCard feature={tracingFeature} componentId="" />);
 
     expect(screen.getByRole('heading', { level: 2, name: 'Tracing' })).toBeInTheDocument();
   });
 
   it('renders as a button and opens drawer for features with hasDrawer', async () => {
-    renderWithDesignSystem(<FeatureCard feature={tracingFeature} componentId="" />);
+    renderWithRouter(<FeatureCard feature={tracingFeature} componentId="" />);
 
     await userEvent.click(screen.getByRole('button'));
 
@@ -31,7 +34,7 @@ describe('FeatureCard', () => {
   });
 
   it('renders as a link for features without hasDrawer', () => {
-    renderWithDesignSystem(<FeatureCard feature={evaluationFeature} componentId="" />);
+    renderWithRouter(<FeatureCard feature={evaluationFeature} componentId="" />);
 
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', evaluationFeature.docsLink);

--- a/mlflow/server/js/src/home/components/features/FeatureCard.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.tsx
@@ -1,11 +1,4 @@
-import { useMemo } from 'react';
-import {
-  Typography,
-  useDesignSystemTheme,
-  DesignSystemEventProviderAnalyticsEventTypes,
-  DesignSystemEventProviderComponentTypes,
-  useDesignSystemEventComponentCallbacks,
-} from '@databricks/design-system';
+import { Button, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import type { FeatureDefinition } from './feature-definitions';
 import { useHomePageViewState } from '../../HomePageViewStateContext';
 
@@ -17,12 +10,6 @@ interface FeatureCardProps {
 export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
   const { theme } = useDesignSystemTheme();
   const { openLogTracesDrawer } = useHomePageViewState();
-  const events = useMemo(() => [DesignSystemEventProviderAnalyticsEventTypes.OnClick], []);
-  const eventContext = useDesignSystemEventComponentCallbacks({
-    componentType: DesignSystemEventProviderComponentTypes.Button,
-    componentId,
-    analyticsEvents: events,
-  });
 
   const containerStyles = {
     overflow: 'hidden',
@@ -66,6 +53,22 @@ export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
     minWidth: 0,
   };
 
+  // Reset all Button styles so it acts as an invisible wrapper,
+  // letting the inner <div> handle all card styling.
+  const buttonResetStyles = {
+    '&&&': {
+      all: 'unset' as const,
+      cursor: 'pointer',
+      display: 'block',
+      flex: 1,
+      minWidth: 240,
+    },
+    // Remove layout effects of Button's inner span wrapper
+    '&&& > *': {
+      display: 'contents',
+    },
+  };
+
   const card = (
     <div css={containerStyles}>
       <div css={iconWrapperStyles}>
@@ -93,46 +96,22 @@ export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
 
   if (feature.hasDrawer) {
     return (
-      <button
-        type="button"
-        onClick={(e) => {
-          eventContext.onClick(e);
-          openLogTracesDrawer();
-        }}
-        css={{
-          textDecoration: 'none',
-          color: theme.colors.textPrimary,
-          display: 'block',
-          border: 0,
-          padding: 0,
-          background: 'transparent',
-          cursor: 'pointer',
-          font: 'inherit',
-          textAlign: 'left',
-          flex: 1,
-          minWidth: 240,
-        }}
-      >
+      <Button componentId={componentId} type="tertiary" onClick={openLogTracesDrawer} css={buttonResetStyles}>
         {card}
-      </button>
+      </Button>
     );
   }
 
   return (
-    <a
+    <Button
+      componentId={componentId}
+      type="tertiary"
       href={feature.docsLink}
       target="_blank"
       rel="noopener noreferrer"
-      onClick={(e) => eventContext.onClick(e)}
-      css={{
-        textDecoration: 'none',
-        color: theme.colors.textPrimary,
-        display: 'block',
-        flex: 1,
-        minWidth: 240,
-      }}
+      css={buttonResetStyles}
     >
       {card}
-    </a>
+    </Button>
   );
 };

--- a/mlflow/server/js/src/home/components/features/FeatureCard.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
 import type { FeatureDefinition } from './feature-definitions';
 import { useHomePageViewState } from '../../HomePageViewStateContext';
 import { Link } from '../../../common/utils/RoutingUtils';
@@ -87,32 +87,18 @@ export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
 
   if (feature.hasDrawer) {
     return (
-      <Button
+      <Link
         componentId={componentId}
-        type="tertiary"
-        onClick={openLogTracesDrawer}
-        css={{
-          '&&&&': {
-            ...wrapperStyles,
-            padding: 0,
-            height: 'auto',
-            border: 'none',
-            background: 'transparent',
-            boxShadow: 'none',
-            borderRadius: 0,
-            whiteSpace: 'normal' as const,
-            lineHeight: 'inherit',
-            font: 'inherit',
-            cursor: 'pointer',
-          },
-          // Reset Button's inner span wrappers without affecting card content
-          '&&&& > span, &&&& > span > span': {
-            display: 'contents',
-          },
+        to="#"
+        disableWorkspacePrefix
+        onClick={(e: React.MouseEvent) => {
+          e.preventDefault();
+          openLogTracesDrawer();
         }}
+        css={wrapperStyles}
       >
         {card}
-      </Button>
+      </Link>
     );
   }
 

--- a/mlflow/server/js/src/home/components/features/FeatureCard.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.tsx
@@ -1,4 +1,11 @@
-import { Button, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useMemo } from 'react';
+import {
+  Typography,
+  useDesignSystemTheme,
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+  useDesignSystemEventComponentCallbacks,
+} from '@databricks/design-system';
 import type { FeatureDefinition } from './feature-definitions';
 import { useHomePageViewState } from '../../HomePageViewStateContext';
 
@@ -10,6 +17,12 @@ interface FeatureCardProps {
 export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
   const { theme } = useDesignSystemTheme();
   const { openLogTracesDrawer } = useHomePageViewState();
+  const events = useMemo(() => [DesignSystemEventProviderAnalyticsEventTypes.OnClick], []);
+  const eventContext = useDesignSystemEventComponentCallbacks({
+    componentType: DesignSystemEventProviderComponentTypes.Button,
+    componentId,
+    analyticsEvents: events,
+  });
 
   const containerStyles = {
     overflow: 'hidden',
@@ -78,41 +91,48 @@ export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
     </div>
   );
 
-  const wrapperStyles = {
-    '&&': {
-      textDecoration: 'none',
-      color: theme.colors.textPrimary,
-      display: 'block',
-      border: 0,
-      padding: 0,
-      background: 'transparent',
-      font: 'inherit',
-      textAlign: 'left' as const,
-      flex: 1,
-      minWidth: 240,
-      height: 'auto',
-      cursor: 'pointer',
-    },
-  };
-
   if (feature.hasDrawer) {
     return (
-      <Button componentId={componentId} type="tertiary" onClick={openLogTracesDrawer} css={wrapperStyles}>
+      <button
+        type="button"
+        onClick={(e) => {
+          eventContext.onClick(e);
+          openLogTracesDrawer();
+        }}
+        css={{
+          textDecoration: 'none',
+          color: theme.colors.textPrimary,
+          display: 'block',
+          border: 0,
+          padding: 0,
+          background: 'transparent',
+          cursor: 'pointer',
+          font: 'inherit',
+          textAlign: 'left',
+          flex: 1,
+          minWidth: 240,
+        }}
+      >
         {card}
-      </Button>
+      </button>
     );
   }
 
   return (
-    <Button
-      componentId={componentId}
-      type="tertiary"
+    <a
       href={feature.docsLink}
       target="_blank"
       rel="noopener noreferrer"
-      css={wrapperStyles}
+      onClick={(e) => eventContext.onClick(e)}
+      css={{
+        textDecoration: 'none',
+        color: theme.colors.textPrimary,
+        display: 'block',
+        flex: 1,
+        minWidth: 240,
+      }}
     >
       {card}
-    </Button>
+    </a>
   );
 };

--- a/mlflow/server/js/src/home/components/features/FeatureCard.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.tsx
@@ -1,6 +1,7 @@
 import { Button, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import type { FeatureDefinition } from './feature-definitions';
 import { useHomePageViewState } from '../../HomePageViewStateContext';
+import { Link } from '../../../common/utils/RoutingUtils';
 
 interface FeatureCardProps {
   feature: FeatureDefinition;
@@ -10,6 +11,26 @@ interface FeatureCardProps {
 export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
   const { theme } = useDesignSystemTheme();
   const { openLogTracesDrawer } = useHomePageViewState();
+
+  const containerStyles = {
+    overflow: 'hidden',
+    border: `1px solid ${theme.colors.borderDecorative}`,
+    borderRadius: theme.borders.borderRadiusMd,
+    background: theme.colors.backgroundPrimary,
+    padding: theme.spacing.sm + theme.spacing.xs,
+    display: 'flex',
+    gap: theme.spacing.sm,
+    boxSizing: 'border-box' as const,
+    boxShadow: theme.shadows.sm,
+    cursor: 'pointer',
+    transition: 'background 150ms ease',
+    '&:hover': {
+      background: theme.colors.actionDefaultBackgroundHover,
+    },
+    '&:active': {
+      background: theme.colors.actionDefaultBackgroundPress,
+    },
+  };
 
   const iconWrapperStyles = {
     borderRadius: theme.borders.borderRadiusSm,
@@ -31,36 +52,8 @@ export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
     minWidth: 0,
   };
 
-  // Invisible Button overlay that captures clicks and handles telemetry
-  // via built-in componentId support. Positioned on top of the card.
-  const buttonOverlayStyles = {
-    '&&&': {
-      position: 'absolute' as const,
-      inset: 0,
-      opacity: 0,
-      width: '100%',
-      height: '100%',
-      padding: 0,
-      cursor: 'pointer',
-    },
-  };
-
   const card = (
-    <div
-      css={{
-        overflow: 'hidden',
-        border: `1px solid ${theme.colors.borderDecorative}`,
-        borderRadius: theme.borders.borderRadiusMd,
-        background: theme.colors.backgroundPrimary,
-        padding: theme.spacing.sm + theme.spacing.xs,
-        display: 'flex',
-        gap: theme.spacing.sm,
-        boxSizing: 'border-box' as const,
-        boxShadow: theme.shadows.sm,
-        transition: 'background 150ms ease',
-        height: '100%',
-      }}
-    >
+    <div css={containerStyles}>
       <div css={iconWrapperStyles}>
         <feature.icon />
       </div>
@@ -85,38 +78,55 @@ export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
   );
 
   const wrapperStyles = {
-    position: 'relative' as const,
+    textDecoration: 'none',
+    color: theme.colors.textPrimary,
+    display: 'block',
     flex: 1,
     minWidth: 240,
-    cursor: 'pointer',
-    '&:hover > div': {
-      background: theme.colors.actionDefaultBackgroundHover,
-    },
-    '&:active > div': {
-      background: theme.colors.actionDefaultBackgroundPress,
-    },
   };
 
   if (feature.hasDrawer) {
     return (
-      <div css={wrapperStyles}>
+      <Button
+        componentId={componentId}
+        type="tertiary"
+        onClick={openLogTracesDrawer}
+        css={{
+          '&&&&': {
+            ...wrapperStyles,
+            padding: 0,
+            height: 'auto',
+            border: 'none',
+            background: 'transparent',
+            boxShadow: 'none',
+            borderRadius: 0,
+            whiteSpace: 'normal' as const,
+            lineHeight: 'inherit',
+            font: 'inherit',
+            cursor: 'pointer',
+          },
+          // Reset Button's inner span wrappers without affecting card content
+          '&&&& > span, &&&& > span > span': {
+            display: 'contents',
+          },
+        }}
+      >
         {card}
-        <Button componentId={componentId} type="tertiary" onClick={openLogTracesDrawer} css={buttonOverlayStyles} />
-      </div>
+      </Button>
     );
   }
 
   return (
-    <div css={wrapperStyles}>
+    <Link
+      componentId={componentId}
+      to={feature.docsLink}
+      target="_blank"
+      rel="noopener noreferrer"
+      reloadDocument
+      disableWorkspacePrefix
+      css={wrapperStyles}
+    >
       {card}
-      <Button
-        componentId={componentId}
-        type="tertiary"
-        href={feature.docsLink}
-        target="_blank"
-        rel="noopener noreferrer"
-        css={buttonOverlayStyles}
-      />
-    </div>
+    </Link>
   );
 };

--- a/mlflow/server/js/src/home/components/features/FeatureCard.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.tsx
@@ -11,28 +11,6 @@ export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
   const { theme } = useDesignSystemTheme();
   const { openLogTracesDrawer } = useHomePageViewState();
 
-  const containerStyles = {
-    overflow: 'hidden',
-    border: `1px solid ${theme.colors.borderDecorative}`,
-    borderRadius: theme.borders.borderRadiusMd,
-    background: theme.colors.backgroundPrimary,
-    padding: theme.spacing.sm + theme.spacing.xs,
-    display: 'flex',
-    gap: theme.spacing.sm,
-    minWidth: 240,
-    flex: 1,
-    boxSizing: 'border-box' as const,
-    boxShadow: theme.shadows.sm,
-    cursor: 'pointer',
-    transition: 'background 150ms ease',
-    '&:hover': {
-      background: theme.colors.actionDefaultBackgroundHover,
-    },
-    '&:active': {
-      background: theme.colors.actionDefaultBackgroundPress,
-    },
-  };
-
   const iconWrapperStyles = {
     borderRadius: theme.borders.borderRadiusSm,
     background: theme.colors.actionDefaultBackgroundHover,
@@ -53,24 +31,36 @@ export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
     minWidth: 0,
   };
 
-  // Reset all Button styles so it acts as an invisible wrapper,
-  // letting the inner <div> handle all card styling.
-  const buttonResetStyles = {
+  // Invisible Button overlay that captures clicks and handles telemetry
+  // via built-in componentId support. Positioned on top of the card.
+  const buttonOverlayStyles = {
     '&&&': {
-      all: 'unset' as const,
+      position: 'absolute' as const,
+      inset: 0,
+      opacity: 0,
+      width: '100%',
+      height: '100%',
+      padding: 0,
       cursor: 'pointer',
-      display: 'block',
-      flex: 1,
-      minWidth: 240,
-    },
-    // Remove layout effects of Button's inner span wrapper
-    '&&& > *': {
-      display: 'contents',
     },
   };
 
   const card = (
-    <div css={containerStyles}>
+    <div
+      css={{
+        overflow: 'hidden',
+        border: `1px solid ${theme.colors.borderDecorative}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        background: theme.colors.backgroundPrimary,
+        padding: theme.spacing.sm + theme.spacing.xs,
+        display: 'flex',
+        gap: theme.spacing.sm,
+        boxSizing: 'border-box' as const,
+        boxShadow: theme.shadows.sm,
+        transition: 'background 150ms ease',
+        height: '100%',
+      }}
+    >
       <div css={iconWrapperStyles}>
         <feature.icon />
       </div>
@@ -94,24 +84,39 @@ export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
     </div>
   );
 
+  const wrapperStyles = {
+    position: 'relative' as const,
+    flex: 1,
+    minWidth: 240,
+    cursor: 'pointer',
+    '&:hover > div': {
+      background: theme.colors.actionDefaultBackgroundHover,
+    },
+    '&:active > div': {
+      background: theme.colors.actionDefaultBackgroundPress,
+    },
+  };
+
   if (feature.hasDrawer) {
     return (
-      <Button componentId={componentId} type="tertiary" onClick={openLogTracesDrawer} css={buttonResetStyles}>
+      <div css={wrapperStyles}>
         {card}
-      </Button>
+        <Button componentId={componentId} type="tertiary" onClick={openLogTracesDrawer} css={buttonOverlayStyles} />
+      </div>
     );
   }
 
   return (
-    <Button
-      componentId={componentId}
-      type="tertiary"
-      href={feature.docsLink}
-      target="_blank"
-      rel="noopener noreferrer"
-      css={buttonResetStyles}
-    >
+    <div css={wrapperStyles}>
       {card}
-    </Button>
+      <Button
+        componentId={componentId}
+        type="tertiary"
+        href={feature.docsLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        css={buttonOverlayStyles}
+      />
+    </div>
   );
 };

--- a/mlflow/server/js/src/home/components/features/FeatureCard.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.tsx
@@ -1,4 +1,11 @@
-import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useMemo } from 'react';
+import {
+  Typography,
+  useDesignSystemTheme,
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+  useDesignSystemEventComponentCallbacks,
+} from '@databricks/design-system';
 import type { FeatureDefinition } from './feature-definitions';
 import { useHomePageViewState } from '../../HomePageViewStateContext';
 
@@ -9,6 +16,12 @@ interface FeatureCardProps {
 export const FeatureCard = ({ feature }: FeatureCardProps) => {
   const { theme } = useDesignSystemTheme();
   const { openLogTracesDrawer } = useHomePageViewState();
+  const events = useMemo(() => [DesignSystemEventProviderAnalyticsEventTypes.OnClick], []);
+  const eventContext = useDesignSystemEventComponentCallbacks({
+    componentType: DesignSystemEventProviderComponentTypes.Button,
+    componentId: feature.componentId,
+    analyticsEvents: events,
+  });
 
   const containerStyles = {
     overflow: 'hidden',
@@ -81,7 +94,10 @@ export const FeatureCard = ({ feature }: FeatureCardProps) => {
     return (
       <button
         type="button"
-        onClick={openLogTracesDrawer}
+        onClick={(e) => {
+          eventContext.onClick(e);
+          openLogTracesDrawer();
+        }}
         css={{
           textDecoration: 'none',
           color: theme.colors.textPrimary,
@@ -106,6 +122,7 @@ export const FeatureCard = ({ feature }: FeatureCardProps) => {
       href={feature.docsLink}
       target="_blank"
       rel="noopener noreferrer"
+      onClick={(e) => eventContext.onClick(e)}
       css={{
         textDecoration: 'none',
         color: theme.colors.textPrimary,

--- a/mlflow/server/js/src/home/components/features/FeatureCard.tsx
+++ b/mlflow/server/js/src/home/components/features/FeatureCard.tsx
@@ -1,27 +1,15 @@
-import { useMemo } from 'react';
-import {
-  Typography,
-  useDesignSystemTheme,
-  DesignSystemEventProviderAnalyticsEventTypes,
-  DesignSystemEventProviderComponentTypes,
-  useDesignSystemEventComponentCallbacks,
-} from '@databricks/design-system';
+import { Button, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import type { FeatureDefinition } from './feature-definitions';
 import { useHomePageViewState } from '../../HomePageViewStateContext';
 
 interface FeatureCardProps {
   feature: FeatureDefinition;
+  componentId: string;
 }
 
-export const FeatureCard = ({ feature }: FeatureCardProps) => {
+export const FeatureCard = ({ feature, componentId }: FeatureCardProps) => {
   const { theme } = useDesignSystemTheme();
   const { openLogTracesDrawer } = useHomePageViewState();
-  const events = useMemo(() => [DesignSystemEventProviderAnalyticsEventTypes.OnClick], []);
-  const eventContext = useDesignSystemEventComponentCallbacks({
-    componentType: DesignSystemEventProviderComponentTypes.Button,
-    componentId: feature.componentId,
-    analyticsEvents: events,
-  });
 
   const containerStyles = {
     overflow: 'hidden',
@@ -90,48 +78,41 @@ export const FeatureCard = ({ feature }: FeatureCardProps) => {
     </div>
   );
 
+  const wrapperStyles = {
+    '&&': {
+      textDecoration: 'none',
+      color: theme.colors.textPrimary,
+      display: 'block',
+      border: 0,
+      padding: 0,
+      background: 'transparent',
+      font: 'inherit',
+      textAlign: 'left' as const,
+      flex: 1,
+      minWidth: 240,
+      height: 'auto',
+      cursor: 'pointer',
+    },
+  };
+
   if (feature.hasDrawer) {
     return (
-      <button
-        type="button"
-        onClick={(e) => {
-          eventContext.onClick(e);
-          openLogTracesDrawer();
-        }}
-        css={{
-          textDecoration: 'none',
-          color: theme.colors.textPrimary,
-          display: 'block',
-          border: 0,
-          padding: 0,
-          background: 'transparent',
-          cursor: 'pointer',
-          font: 'inherit',
-          textAlign: 'left',
-          flex: 1,
-          minWidth: 240,
-        }}
-      >
+      <Button componentId={componentId} type="tertiary" onClick={openLogTracesDrawer} css={wrapperStyles}>
         {card}
-      </button>
+      </Button>
     );
   }
 
   return (
-    <a
+    <Button
+      componentId={componentId}
+      type="tertiary"
       href={feature.docsLink}
       target="_blank"
       rel="noopener noreferrer"
-      onClick={(e) => eventContext.onClick(e)}
-      css={{
-        textDecoration: 'none',
-        color: theme.colors.textPrimary,
-        display: 'block',
-        flex: 1,
-        minWidth: 240,
-      }}
+      css={wrapperStyles}
     >
       {card}
-    </a>
+    </Button>
   );
 };

--- a/mlflow/server/js/src/home/components/features/FeaturesSection.tsx
+++ b/mlflow/server/js/src/home/components/features/FeaturesSection.tsx
@@ -61,7 +61,7 @@ export const FeaturesSection = () => {
             }}
           >
             {featureDefinitions.map((feature) => (
-              <FeatureCard key={feature.id} feature={feature} />
+              <FeatureCard key={feature.id} feature={feature} componentId={feature.componentId} />
             ))}
           </div>
         </div>

--- a/mlflow/server/js/src/home/components/features/feature-definitions.tsx
+++ b/mlflow/server/js/src/home/components/features/feature-definitions.tsx
@@ -9,6 +9,7 @@ export interface FeatureDefinition {
   summary: ReactNode;
   docsLink: string;
   hasDrawer?: boolean;
+  componentId: string;
 }
 
 export const featureDefinitions: FeatureDefinition[] = [
@@ -24,6 +25,7 @@ export const featureDefinitions: FeatureDefinition[] = [
     ),
     docsLink: 'https://mlflow.org/docs/latest/llms/tracing/index.html',
     hasDrawer: true,
+    componentId: 'mlflow.home.feature_card.tracing',
   },
   {
     id: 'evaluation',
@@ -36,6 +38,7 @@ export const featureDefinitions: FeatureDefinition[] = [
       />
     ),
     docsLink: 'https://mlflow.org/docs/latest/llms/llm-evaluate/index.html',
+    componentId: 'mlflow.home.feature_card.evaluation',
   },
   {
     id: 'prompts',
@@ -48,6 +51,7 @@ export const featureDefinitions: FeatureDefinition[] = [
       />
     ),
     docsLink: 'https://mlflow.org/docs/latest/genai/prompt-registry/',
+    componentId: 'mlflow.home.feature_card.prompts',
   },
   {
     id: 'ai-gateway',
@@ -60,6 +64,7 @@ export const featureDefinitions: FeatureDefinition[] = [
       />
     ),
     docsLink: 'https://mlflow.org/docs/latest/genai/governance/ai-gateway/',
+    componentId: 'mlflow.home.feature_card.ai_gateway',
   },
   {
     id: 'experiments',
@@ -72,5 +77,6 @@ export const featureDefinitions: FeatureDefinition[] = [
       />
     ),
     docsLink: 'https://mlflow.org/docs/latest/ml/tracking/quickstart/',
+    componentId: 'mlflow.home.feature_card.experiments',
   },
 ];


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22241

### What changes are proposed in this pull request?

The homepage "Getting Started" feature cards (Tracing, Evaluation, Prompts, AI Gateway, Model Training) were missing telemetry click tracking. This PR adds `componentId` to each feature card using design system `<Button>` with built-in telemetry support.

**Changes:**
- Added `componentId: string` to the `FeatureDefinition` interface
- Assigned component IDs to all 5 feature cards (`mlflow.home.feature_card.*`)
- Replaced raw `<button>` and `<a>` elements with design system `<Button>` which handles telemetry automatically via `componentId`
- Pass `componentId` as a top-level prop on `FeatureCard` for lint rule compliance

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Manually verified by enabling dev logging with `localStorage.setItem("mlflow.settings.telemetry.enable-dev-logging_v1", true)` and clicking each feature card. All 5 cards fire `OnClick` telemetry events with correct `componentId` values.

<img width="1406" height="490" alt="image" src="https://github.com/user-attachments/assets/6ff20990-46d9-449b-ac96-bf8cc9b17aa2" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release