### PR TITLE
Fix static `componentId` lint warnings in gateway components

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionAdvancedSettings.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionAdvancedSettings.tsx
@@ -35,7 +35,7 @@ export function IssueDetectionAdvancedSettings({
           provider={provider}
           value={model}
           onChange={onModelChange}
-          componentIdPrefix="mlflow.traces.issue-detection-modal.model"
+          componentId="mlflow.traces.issue-detection-modal.model"
           label={
             <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
               <FormattedMessage defaultMessage="Model *" description="Label for model selection (required)" />

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModelSelection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/IssueDetectionModelSelection.tsx
@@ -408,7 +408,7 @@ export const IssueDetectionModelSelection = forwardRef<
                     provider={provider}
                     value={model}
                     onChange={setModel}
-                    componentIdPrefix="mlflow.traces.issue-detection-modal.model"
+                    componentId="mlflow.traces.issue-detection-modal.model"
                     label={
                       <Typography.Text css={{ fontSize: theme.typography.fontSizeSm }}>
                         <FormattedMessage defaultMessage="Model *" description="Label for model selection (required)" />

--- a/mlflow/server/js/src/gateway/components/api-keys/ApiKeysFilterButton.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/ApiKeysFilterButton.tsx
@@ -14,7 +14,7 @@ export const ApiKeysFilterButton = ({ availableProviders, filter, onFilterChange
       availableProviders={availableProviders}
       filter={filter}
       onFilterChange={onFilterChange}
-      componentIdPrefix="mlflow.gateway.api-keys-list"
+      componentId="mlflow.gateway.api-keys-list"
     />
   );
 };

--- a/mlflow/server/js/src/gateway/components/api-keys/CreateApiKeyModal.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/CreateApiKeyModal.tsx
@@ -196,7 +196,7 @@ export const CreateApiKeyModal = ({ open, onClose, onSuccess }: CreateApiKeyModa
           value={provider}
           onChange={handleProviderChange}
           error={errors.provider}
-          componentIdPrefix="mlflow.gateway.create-api-key-modal.provider"
+          componentId="mlflow.gateway.create-api-key-modal.provider"
         />
 
         {provider && (
@@ -205,7 +205,7 @@ export const CreateApiKeyModal = ({ open, onClose, onSuccess }: CreateApiKeyModa
             value={formData}
             onChange={handleFormDataChange}
             errors={errors}
-            componentIdPrefix="mlflow.gateway.create-api-key-modal"
+            componentId="mlflow.gateway.create-api-key-modal"
           />
         )}
 

--- a/mlflow/server/js/src/gateway/components/api-keys/DeleteApiKeyModal.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/DeleteApiKeyModal.tsx
@@ -86,7 +86,7 @@ export const DeleteApiKeyModal = ({ open, secret, endpoints, onClose, onSuccess 
       title="Delete API Key"
       itemName={secret.secret_name}
       itemType="API key"
-      componentIdPrefix="mlflow.gateway.delete-api-key-modal"
+      componentId="mlflow.gateway.delete-api-key-modal"
       requireConfirmation={hasEndpoints}
       warningMessage={
         hasEndpoints ? (

--- a/mlflow/server/js/src/gateway/components/api-keys/EditApiKeyModal.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/EditApiKeyModal.tsx
@@ -131,7 +131,7 @@ export const EditApiKeyModal = ({ open, secret, onClose, onSuccess }: EditApiKey
           value={formData}
           onChange={handleFormDataChange}
           errors={errors}
-          componentIdPrefix="mlflow.gateway.edit-api-key-modal"
+          componentId="mlflow.gateway.edit-api-key-modal"
           hideNameField
         />
       </div>

--- a/mlflow/server/js/src/gateway/components/budgets/DeleteBudgetPolicyModal.tsx
+++ b/mlflow/server/js/src/gateway/components/budgets/DeleteBudgetPolicyModal.tsx
@@ -29,7 +29,7 @@ export const DeleteBudgetPolicyModal = ({ open, policy, onClose, onSuccess }: De
       title="Delete Budget Policy"
       itemName={formatBudgetPolicySummary(policy)}
       itemType="budget policy"
-      componentIdPrefix="mlflow.gateway.delete-budget-policy-modal"
+      componentId="mlflow.gateway.delete-budget-policy-modal"
     />
   );
 };

--- a/mlflow/server/js/src/gateway/components/common/DeleteConfirmationModal.tsx
+++ b/mlflow/server/js/src/gateway/components/common/DeleteConfirmationModal.tsx
@@ -9,7 +9,7 @@ export interface DeleteConfirmationModalProps {
   title: string;
   itemName: string;
   itemType: string;
-  componentIdPrefix: string;
+  componentId: string;
   warningMessage?: React.ReactNode;
   additionalContent?: React.ReactNode;
   requireConfirmation?: boolean;
@@ -22,7 +22,7 @@ export const DeleteConfirmationModal = ({
   title,
   itemName,
   itemType,
-  componentIdPrefix,
+  componentId,
   warningMessage,
   additionalContent,
   requireConfirmation = false,
@@ -74,17 +74,17 @@ export const DeleteConfirmationModal = ({
 
   return (
     <Modal
-      componentId={`${componentIdPrefix}.modal`}
+      componentId={`${componentId}.modal`}
       title={title}
       visible={open}
       onCancel={handleClose}
       footer={
         <div css={{ display: 'flex', justifyContent: 'flex-end', gap: theme.spacing.sm }}>
-          <Button componentId={`${componentIdPrefix}.cancel`} onClick={handleClose} disabled={isDeleting}>
+          <Button componentId={`${componentId}.cancel`} onClick={handleClose} disabled={isDeleting}>
             <FormattedMessage defaultMessage="Cancel" description="Cancel button text" />
           </Button>
           <Button
-            componentId={`${componentIdPrefix}.delete`}
+            componentId={`${componentId}.delete`}
             type="primary"
             danger
             onClick={handleDelete}
@@ -98,7 +98,7 @@ export const DeleteConfirmationModal = ({
       size="normal"
     >
       <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
-        {error && <Alert componentId={`${componentIdPrefix}.error`} type="error" message={error} closable={false} />}
+        {error && <Alert componentId={`${componentId}.error`} type="error" message={error} closable={false} />}
 
         <Typography.Text>
           <FormattedMessage
@@ -113,7 +113,7 @@ export const DeleteConfirmationModal = ({
 
         {warningMessage && (
           <Alert
-            componentId={`${componentIdPrefix}.warning`}
+            componentId={`${componentId}.warning`}
             type="warning"
             message={warningMessage}
             closable={false}
@@ -132,7 +132,7 @@ export const DeleteConfirmationModal = ({
               />
             </Typography.Text>
             <Input
-              componentId={`${componentIdPrefix}.confirmation-input`}
+              componentId={`${componentId}.confirmation-input`}
               value={confirmationText}
               onChange={(e) => setConfirmationText(e.target.value)}
               placeholder={itemName}

--- a/mlflow/server/js/src/gateway/components/common/DeleteConfirmationModal.tsx
+++ b/mlflow/server/js/src/gateway/components/common/DeleteConfirmationModal.tsx
@@ -112,12 +112,7 @@ export const DeleteConfirmationModal = ({
         </Typography.Text>
 
         {warningMessage && (
-          <Alert
-            componentId={`${componentId}.warning`}
-            type="warning"
-            message={warningMessage}
-            closable={false}
-          />
+          <Alert componentId={`${componentId}.warning`} type="warning" message={warningMessage} closable={false} />
         )}
 
         {additionalContent}

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
@@ -12,7 +12,7 @@ interface ModelSelectProps {
   disabled?: boolean;
   error?: string;
   /** Component ID prefix for telemetry (default: 'mlflow.gateway.model-select') */
-  componentIdPrefix?: string;
+  componentId?: string;
   /** Custom label for the select field. If not provided, defaults to "Model" */
   label?: React.ReactNode;
   /** If true, hides the model capabilities tags (Tools, Reasoning, Caching) */
@@ -25,7 +25,7 @@ export const ModelSelect = ({
   onChange,
   disabled,
   error,
-  componentIdPrefix = 'mlflow.gateway.model-select',
+  componentId = 'mlflow.gateway.model-select',
   label,
   hideCapabilities,
 }: ModelSelectProps) => {
@@ -56,12 +56,12 @@ export const ModelSelect = ({
 
   return (
     <div>
-      <FormUI.Label htmlFor={componentIdPrefix}>
+      <FormUI.Label htmlFor={componentId}>
         {label ?? <FormattedMessage defaultMessage="Model" description="Label for model select field" />}
       </FormUI.Label>
       <Input
-        id={componentIdPrefix}
-        componentId={componentIdPrefix}
+        id={componentId}
+        componentId={componentId}
         placeholder={
           !provider
             ? intl.formatMessage({
@@ -125,7 +125,7 @@ const ModelCapabilities = memo(function ModelCapabilities({ model }: { model: Pr
       }}
     >
       {capabilities.map((cap) => (
-        <Tag key={cap} componentId={`mlflow.gateway.model-select.capability.${cap.toLowerCase()}`}>
+        <Tag key={cap} componentId="mlflow.gateway.model-select.capability">
           {cap}
         </Tag>
       ))}

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ModelSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, memo } from 'react';
+import { useState, useRef, useMemo, useCallback, memo } from 'react';
 import { Input, useDesignSystemTheme, FormUI, Tag, ModelsIcon } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { ModelSelectorModal } from '../model-selector/ModelSelectorModal';
@@ -11,7 +11,7 @@ interface ModelSelectProps {
   onChange: (model: string) => void;
   disabled?: boolean;
   error?: string;
-  /** Component ID prefix for telemetry (default: 'mlflow.gateway.model-select') */
+  /** Component ID for telemetry (default: 'mlflow.gateway.model-select') */
   componentId?: string;
   /** Custom label for the select field. If not provided, defaults to "Model" */
   label?: React.ReactNode;
@@ -31,6 +31,7 @@ export const ModelSelect = ({
 }: ModelSelectProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
+  const domId = useRef(`model-select-${Math.random().toString(36).slice(2, 9)}`).current;
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   // Fetch models to get the selected model's details
@@ -56,11 +57,11 @@ export const ModelSelect = ({
 
   return (
     <div>
-      <FormUI.Label htmlFor={componentId}>
+      <FormUI.Label htmlFor={domId}>
         {label ?? <FormattedMessage defaultMessage="Model" description="Label for model select field" />}
       </FormUI.Label>
       <Input
-        id={componentId}
+        id={domId}
         componentId={componentId}
         placeholder={
           !provider

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useRef } from 'react';
 import { useDesignSystemTheme, FormUI, Spinner, Typography } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { NavigableCombobox } from '../../../common/components/navigable-combobox/NavigableCombobox';
@@ -31,6 +31,7 @@ export const ProviderSelect = ({
 }: ProviderSelectProps) => {
   const intl = useIntl();
   const { theme } = useDesignSystemTheme();
+  const domId = useRef(`provider-select-${Math.random().toString(36).slice(2, 9)}`).current;
   const { data: providers, isLoading, error: queryError } = useProvidersQuery();
 
   const { config, hasOtherProviders } = useMemo((): {
@@ -171,7 +172,7 @@ export const ProviderSelect = ({
     return (
       <div>
         {!hideLabel && (
-          <FormUI.Label htmlFor={componentId}>
+          <FormUI.Label htmlFor={domId}>
             <FormattedMessage defaultMessage="Provider" description="Label for provider select field" />
           </FormUI.Label>
         )}
@@ -184,7 +185,7 @@ export const ProviderSelect = ({
     return (
       <div>
         {!hideLabel && (
-          <FormUI.Label htmlFor={componentId}>
+          <FormUI.Label htmlFor={domId}>
             <FormattedMessage defaultMessage="Provider" description="Label for provider select field" />
           </FormUI.Label>
         )}
@@ -199,7 +200,7 @@ export const ProviderSelect = ({
   return (
     <div css={{ minWidth: 300 }}>
       {!hideLabel && (
-        <FormUI.Label htmlFor={componentId}>
+        <FormUI.Label htmlFor={domId}>
           <FormattedMessage defaultMessage="Provider" description="Label for provider select field" />
         </FormUI.Label>
       )}

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
@@ -17,7 +17,7 @@ interface ProviderSelectProps {
   onChange: (provider: string) => void;
   disabled?: boolean;
   error?: string;
-  componentIdPrefix?: string;
+  componentId?: string;
   hideLabel?: boolean;
 }
 
@@ -26,7 +26,7 @@ export const ProviderSelect = ({
   onChange,
   disabled,
   error,
-  componentIdPrefix = 'mlflow.gateway.provider-select',
+  componentId = 'mlflow.gateway.provider-select',
   hideLabel = false,
 }: ProviderSelectProps) => {
   const intl = useIntl();
@@ -171,7 +171,7 @@ export const ProviderSelect = ({
     return (
       <div>
         {!hideLabel && (
-          <FormUI.Label htmlFor={componentIdPrefix}>
+          <FormUI.Label htmlFor={componentId}>
             <FormattedMessage defaultMessage="Provider" description="Label for provider select field" />
           </FormUI.Label>
         )}
@@ -184,7 +184,7 @@ export const ProviderSelect = ({
     return (
       <div>
         {!hideLabel && (
-          <FormUI.Label htmlFor={componentIdPrefix}>
+          <FormUI.Label htmlFor={componentId}>
             <FormattedMessage defaultMessage="Provider" description="Label for provider select field" />
           </FormUI.Label>
         )}
@@ -199,12 +199,12 @@ export const ProviderSelect = ({
   return (
     <div css={{ minWidth: 300 }}>
       {!hideLabel && (
-        <FormUI.Label htmlFor={componentIdPrefix}>
+        <FormUI.Label htmlFor={componentId}>
           <FormattedMessage defaultMessage="Provider" description="Label for provider select field" />
         </FormUI.Label>
       )}
       <NavigableCombobox
-        componentId={componentIdPrefix}
+        componentId={componentId}
         config={config}
         value={value || null}
         onChange={handleChange}

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -299,7 +299,7 @@ export const EditEndpointFormRenderer = ({
                         <TrafficSplitConfigurator
                           value={field.value}
                           onChange={field.onChange}
-                          componentIdPrefix="mlflow.gateway.edit-endpoint.traffic-split"
+                          componentId="mlflow.gateway.edit-endpoint.traffic-split"
                         />
                       )}
                     />
@@ -335,7 +335,7 @@ export const EditEndpointFormRenderer = ({
                         <FallbackModelsConfigurator
                           value={field.value}
                           onChange={field.onChange}
-                          componentIdPrefix="mlflow.gateway.edit-endpoint.fallback"
+                          componentId="mlflow.gateway.edit-endpoint.fallback"
                         />
                       )}
                     />
@@ -363,7 +363,7 @@ export const EditEndpointFormRenderer = ({
                         <UsageTrackingConfigurator
                           value={field.value}
                           onChange={field.onChange}
-                          componentIdPrefix="mlflow.gateway.edit-endpoint.usage-tracking"
+                          componentId="mlflow.gateway.edit-endpoint.usage-tracking"
                         />
                       )}
                     />

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/FallbackModelItem.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/FallbackModelItem.tsx
@@ -157,11 +157,7 @@ export const FallbackModelItem = ({
             description: 'Tooltip for remove fallback model button',
           })}
         >
-          <Button
-            componentId={`${componentId}.remove`}
-            icon={<TrashIcon />}
-            onClick={() => onRemove(index)}
-          />
+          <Button componentId={`${componentId}.remove`} icon={<TrashIcon />} onClick={() => onRemove(index)} />
         </Tooltip>
       </div>
 

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/FallbackModelItem.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/FallbackModelItem.tsx
@@ -33,7 +33,7 @@ interface FallbackModelItemProps {
   onModelChange: (index: number, updates: Partial<FallbackModel>) => void;
   onRemove: (index: number) => void;
   onMove: (fromIndex: number, toIndex: number) => void;
-  componentIdPrefix: string;
+  componentId: string;
 }
 
 export const FallbackModelItem = ({
@@ -42,7 +42,7 @@ export const FallbackModelItem = ({
   onModelChange,
   onRemove,
   onMove,
-  componentIdPrefix,
+  componentId,
 }: FallbackModelItemProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -132,7 +132,7 @@ export const FallbackModelItem = ({
             <DragIcon css={{ color: theme.colors.textSecondary }} />
           </div>
           <Button
-            componentId={`${componentIdPrefix}.expand.${index}`}
+            componentId={`${componentId}.expand`}
             icon={isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
             onClick={() => setIsExpanded(!isExpanded)}
             size="small"
@@ -151,14 +151,14 @@ export const FallbackModelItem = ({
           )}
         </div>
         <Tooltip
-          componentId={`${componentIdPrefix}.remove-tooltip.${index}`}
+          componentId={`${componentId}.remove-tooltip`}
           content={intl.formatMessage({
             defaultMessage: 'Remove fallback model',
             description: 'Tooltip for remove fallback model button',
           })}
         >
           <Button
-            componentId={`${componentIdPrefix}.remove.${index}`}
+            componentId={`${componentId}.remove`}
             icon={<TrashIcon />}
             onClick={() => onRemove(index)}
           />
@@ -183,14 +183,14 @@ export const FallbackModelItem = ({
                 },
               });
             }}
-            componentIdPrefix={`${componentIdPrefix}.provider.${index}`}
+            componentId={`${componentId}.provider`}
           />
 
           <ModelSelect
             provider={model.provider}
             value={model.modelName}
             onChange={(modelName) => onModelChange(index, { modelName })}
-            componentIdPrefix={`${componentIdPrefix}.model.${index}`}
+            componentId={`${componentId}.model`}
           />
 
           <ApiKeyConfigurator
@@ -202,7 +202,7 @@ export const FallbackModelItem = ({
             authModes={authModes}
             defaultAuthMode={defaultAuthMode}
             isLoadingProviderConfig={isLoadingProviderConfig}
-            componentIdPrefix={`${componentIdPrefix}.api-key.${index}`}
+            componentId={`${componentId}.api-key`}
           />
         </>
       )}

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/FallbackModelsConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/FallbackModelsConfigurator.tsx
@@ -9,13 +9,13 @@ import { FallbackModelItem } from './FallbackModelItem';
 export interface FallbackModelsConfiguratorProps {
   value: FallbackModel[];
   onChange: (value: FallbackModel[]) => void;
-  componentIdPrefix?: string;
+  componentId?: string;
 }
 
 export const FallbackModelsConfigurator = ({
   value,
   onChange,
-  componentIdPrefix = 'mlflow.gateway.fallback',
+  componentId = 'mlflow.gateway.fallback',
 }: FallbackModelsConfiguratorProps) => {
   const { theme } = useDesignSystemTheme();
 
@@ -89,11 +89,11 @@ export const FallbackModelsConfigurator = ({
             onModelChange={handleModelChange}
             onRemove={handleRemoveModel}
             onMove={handleMoveModel}
-            componentIdPrefix={componentIdPrefix}
+            componentId={componentId}
           />
         ))}
 
-        <Button componentId={`${componentIdPrefix}.add`} icon={<PlusIcon />} onClick={handleAddModel}>
+        <Button componentId={`${componentId}.add`} icon={<PlusIcon />} onClick={handleAddModel}>
           <FormattedMessage defaultMessage="Add fallback" description="Button to add fallback model" />
         </Button>
       </div>

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitConfigurator.tsx
@@ -7,13 +7,13 @@ import { TrafficSplitModelItem } from './TrafficSplitModelItem';
 export interface TrafficSplitConfiguratorProps {
   value: TrafficSplitModel[];
   onChange: (value: TrafficSplitModel[]) => void;
-  componentIdPrefix?: string;
+  componentId?: string;
 }
 
 export const TrafficSplitConfigurator = ({
   value,
   onChange,
-  componentIdPrefix = 'mlflow.gateway.traffic-split',
+  componentId = 'mlflow.gateway.traffic-split',
 }: TrafficSplitConfiguratorProps) => {
   const { theme } = useDesignSystemTheme();
 
@@ -75,12 +75,12 @@ export const TrafficSplitConfigurator = ({
           onModelChange={handleModelChange}
           onWeightChange={handleWeightChange}
           onRemove={handleRemoveModel}
-          componentIdPrefix={componentIdPrefix}
+          componentId={componentId}
         />
       ))}
 
       <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Button componentId={`${componentIdPrefix}.add`} icon={<PlusIcon />} onClick={handleAddModel}>
+        <Button componentId={`${componentId}.add`} icon={<PlusIcon />} onClick={handleAddModel}>
           <FormattedMessage
             defaultMessage="Add model for traffic split"
             description="Button to add model for traffic split"

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitModelItem.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitModelItem.tsx
@@ -107,11 +107,7 @@ export const TrafficSplitModelItem = ({
             description: 'Tooltip for remove traffic split model button',
           })}
         >
-          <Button
-            componentId={`${componentId}.remove`}
-            icon={<TrashIcon />}
-            onClick={() => onRemove(index)}
-          />
+          <Button componentId={`${componentId}.remove`} icon={<TrashIcon />} onClick={() => onRemove(index)} />
         </Tooltip>
       </div>
 

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitModelItem.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitModelItem.tsx
@@ -25,7 +25,7 @@ interface TrafficSplitModelItemProps {
   onModelChange: (index: number, updates: Partial<TrafficSplitModel>) => void;
   onWeightChange: (index: number, weight: number) => void;
   onRemove: (index: number) => void;
-  componentIdPrefix: string;
+  componentId: string;
 }
 
 export const TrafficSplitModelItem = ({
@@ -34,7 +34,7 @@ export const TrafficSplitModelItem = ({
   onModelChange,
   onWeightChange,
   onRemove,
-  componentIdPrefix,
+  componentId,
 }: TrafficSplitModelItemProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -79,7 +79,7 @@ export const TrafficSplitModelItem = ({
       <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm, flex: 1 }}>
           <Button
-            componentId={`${componentIdPrefix}.expand.${index}`}
+            componentId={`${componentId}.expand`}
             icon={isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
             onClick={() => setIsExpanded(!isExpanded)}
             size="small"
@@ -101,14 +101,14 @@ export const TrafficSplitModelItem = ({
           )}
         </div>
         <Tooltip
-          componentId={`${componentIdPrefix}.remove-tooltip.${index}`}
+          componentId={`${componentId}.remove-tooltip`}
           content={intl.formatMessage({
             defaultMessage: 'Remove model',
             description: 'Tooltip for remove traffic split model button',
           })}
         >
           <Button
-            componentId={`${componentIdPrefix}.remove.${index}`}
+            componentId={`${componentId}.remove`}
             icon={<TrashIcon />}
             onClick={() => onRemove(index)}
           />
@@ -133,14 +133,14 @@ export const TrafficSplitModelItem = ({
                 },
               });
             }}
-            componentIdPrefix={`${componentIdPrefix}.provider.${index}`}
+            componentId={`${componentId}.provider`}
           />
 
           <ModelSelect
             provider={model.provider}
             value={model.modelName}
             onChange={(modelName) => onModelChange(index, { modelName })}
-            componentIdPrefix={`${componentIdPrefix}.model.${index}`}
+            componentId={`${componentId}.model`}
           />
 
           <ApiKeyConfigurator
@@ -152,16 +152,16 @@ export const TrafficSplitModelItem = ({
             authModes={authModes}
             defaultAuthMode={defaultAuthMode}
             isLoadingProviderConfig={isLoadingProviderConfig}
-            componentIdPrefix={`${componentIdPrefix}.api-key.${index}`}
+            componentId={`${componentId}.api-key`}
           />
 
           <div css={{ width: 120 }}>
-            <FormUI.Label htmlFor={`${componentIdPrefix}.weight.${index}`}>
+            <FormUI.Label htmlFor={`${componentId}.weight`}>
               <FormattedMessage defaultMessage="Weight" description="Label for traffic split weight input" />
             </FormUI.Label>
             <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
               <GatewayInput
-                componentId={`${componentIdPrefix}.weight.${index}`}
+                componentId={`${componentId}.weight`}
                 type="number"
                 min={0}
                 max={100}

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitModelItem.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/TrafficSplitModelItem.tsx
@@ -9,7 +9,7 @@ import {
   TrashIcon,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { GatewayInput } from '../common';
 import type { TrafficSplitModel } from '../../hooks/useEditEndpointForm';
 import { ProviderSelect } from '../create-endpoint/ProviderSelect';
@@ -38,6 +38,7 @@ export const TrafficSplitModelItem = ({
 }: TrafficSplitModelItemProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
+  const domId = useRef(`traffic-split-${Math.random().toString(36).slice(2, 9)}`).current;
   const [isExpanded, setIsExpanded] = useState(!model.provider && !model.modelName);
   const [localWeightInput, setLocalWeightInput] = useState<string | null>(null);
 
@@ -152,11 +153,12 @@ export const TrafficSplitModelItem = ({
           />
 
           <div css={{ width: 120 }}>
-            <FormUI.Label htmlFor={`${componentId}.weight`}>
+            <FormUI.Label htmlFor={`${domId}.weight`}>
               <FormattedMessage defaultMessage="Weight" description="Label for traffic split weight input" />
             </FormUI.Label>
             <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
               <GatewayInput
+                id={`${domId}.weight`}
                 componentId={`${componentId}.weight`}
                 type="number"
                 min={0}

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/UsageTrackingConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/UsageTrackingConfigurator.tsx
@@ -6,13 +6,13 @@ type ComponentIds = 'mlflow.gateway.edit-endpoint.usage-tracking' | 'mlflow.gate
 export interface UsageTrackingConfiguratorProps {
   value: boolean;
   onChange: (value: boolean) => void;
-  componentIdPrefix?: ComponentIds;
+  componentId?: ComponentIds;
 }
 
 export const UsageTrackingConfigurator = ({
   value,
   onChange,
-  componentIdPrefix = 'mlflow.gateway.edit-endpoint.usage-tracking',
+  componentId = 'mlflow.gateway.edit-endpoint.usage-tracking',
 }: UsageTrackingConfiguratorProps) => {
   const { theme } = useDesignSystemTheme();
 
@@ -20,7 +20,7 @@ export const UsageTrackingConfigurator = ({
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
         <Switch
-          componentId={`${componentIdPrefix}.toggle`}
+          componentId={`${componentId}.toggle`}
           checked={value}
           onChange={(checked) => onChange(checked)}
           aria-label="Enable usage tracking"

--- a/mlflow/server/js/src/gateway/components/endpoint-form/CreateEndpointModal.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoint-form/CreateEndpointModal.tsx
@@ -63,7 +63,7 @@ export const CreateEndpointModal = ({ open, onClose, onSuccess }: CreateEndpoint
           onSubmit={handleSubmit}
           onCancel={handleCancel}
           onNameBlur={handleNameBlur}
-          componentIdPrefix="mlflow.gateway.create-endpoint-modal"
+          componentId="mlflow.gateway.create-endpoint-modal"
           embedded
         />
       </FormProvider>

--- a/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
@@ -44,7 +44,7 @@ export interface EndpointFormRendererProps {
   /** Handler for name field blur (for duplicate checking) */
   onNameBlur: () => void;
   /** Component ID prefix for telemetry */
-  componentIdPrefix?: string;
+  componentId?: string;
   /** When true, adapts layout for use inside containers like modals */
   embedded?: boolean;
 }
@@ -70,7 +70,7 @@ export const EndpointFormRenderer = ({
   onSubmit,
   onCancel,
   onNameBlur,
-  componentIdPrefix = `mlflow.gateway.endpoint`,
+  componentId = `mlflow.gateway.endpoint`,
   embedded = false,
 }: EndpointFormRendererProps) => {
   const { theme } = useDesignSystemTheme();
@@ -128,7 +128,7 @@ export const EndpointFormRenderer = ({
       {error && (
         <div css={{ padding: embedded ? 0 : `0 ${theme.spacing.md}px` }}>
           <Alert
-            componentId={`${componentIdPrefix}.error`}
+            componentId={`${componentId}.error`}
             closable={false}
             message={errorMessage}
             type="error"
@@ -176,8 +176,8 @@ export const EndpointFormRenderer = ({
               render={({ field, fieldState }) => (
                 <div>
                   <GatewayInput
-                    id={`${componentIdPrefix}.name`}
-                    componentId={`${componentIdPrefix}.name`}
+                    id={`${componentId}.name`}
+                    componentId={`${componentId}.name`}
                     {...field}
                     onChange={(e) => {
                       field.onChange(e);
@@ -216,7 +216,7 @@ export const EndpointFormRenderer = ({
                   <UsageTrackingConfigurator
                     value={field.value}
                     onChange={field.onChange}
-                    componentIdPrefix="mlflow.gateway.create-endpoint.usage-tracking"
+                    componentId="mlflow.gateway.create-endpoint.usage-tracking"
                   />
                 )}
               />
@@ -253,7 +253,7 @@ export const EndpointFormRenderer = ({
                       });
                     }}
                     error={fieldState.error?.message}
-                    componentIdPrefix={`${componentIdPrefix}.provider`}
+                    componentId={`${componentId}.provider`}
                   />
                 )}
               />
@@ -267,7 +267,7 @@ export const EndpointFormRenderer = ({
                     value={field.value}
                     onChange={field.onChange}
                     error={fieldState.error?.message}
-                    componentIdPrefix={`${componentIdPrefix}.model`}
+                    componentId={`${componentId}.model`}
                   />
                 )}
               />
@@ -290,7 +290,7 @@ export const EndpointFormRenderer = ({
                     authModes={authModes}
                     defaultAuthMode={defaultAuthMode}
                     isLoadingProviderConfig={isLoadingProviderConfig}
-                    componentIdPrefix={`${componentIdPrefix}.api-key`}
+                    componentId={`${componentId}.api-key`}
                   />
                 </div>
               )}
@@ -375,12 +375,12 @@ export const EndpointFormRenderer = ({
           flexShrink: 0,
         }}
       >
-        <Button componentId={`${componentIdPrefix}.cancel`} onClick={onCancel}>
+        <Button componentId={`${componentId}.cancel`} onClick={onCancel}>
           <FormattedMessage defaultMessage="Cancel" description="Cancel button" />
         </Button>
-        <Tooltip componentId={`${componentIdPrefix}.submit-tooltip`} content={buttonTooltip}>
+        <Tooltip componentId={`${componentId}.submit-tooltip`} content={buttonTooltip}>
           <Button
-            componentId={`${componentIdPrefix}.submit`}
+            componentId={`${componentId}.submit`}
             type="primary"
             onClick={form.handleSubmit(onSubmit)}
             loading={isSubmitting}

--- a/mlflow/server/js/src/gateway/components/endpoints/DeleteEndpointModal.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoints/DeleteEndpointModal.tsx
@@ -85,7 +85,7 @@ export const DeleteEndpointModal = ({ open, endpoint, bindings, onClose, onSucce
       title="Delete Endpoint"
       itemName={endpoint.name}
       itemType="endpoint"
-      componentIdPrefix="mlflow.gateway.delete-endpoint-modal"
+      componentId="mlflow.gateway.delete-endpoint-modal"
       requireConfirmation={hasBindings}
       warningMessage={
         hasBindings ? (

--- a/mlflow/server/js/src/gateway/components/endpoints/EndpointUsageModal.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoints/EndpointUsageModal.tsx
@@ -264,7 +264,7 @@ export const EndpointUsageModal = ({ open, onClose, endpointName, baseUrl }: End
     <div css={{ marginBottom: theme.spacing.md }}>
       <div css={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginBottom: theme.spacing.xs }}>
         <CopyButton
-          componentId={`mlflow.gateway.usage-modal.copy-${label.toLowerCase().replace(/\s+/g, '-')}`}
+          componentId="mlflow.gateway.usage-modal.copy"
           copyText={code}
           icon={<CopyIcon />}
           showLabel={false}
@@ -410,7 +410,7 @@ export const EndpointUsageModal = ({ open, onClose, endpointName, baseUrl }: End
                       />
                     )
                   }
-                  requestTooltipComponentId="mlflow.gateway.usage-modal.try-it.request-tooltip"
+                  componentId="mlflow.gateway.usage-modal.try-it.request-tooltip"
                   tryItRequestUrl={tryItRequestUrl}
                   tryItDefaultBody={tryItDefaultBody}
                 />
@@ -531,7 +531,7 @@ export const EndpointUsageModal = ({ open, onClose, endpointName, baseUrl }: End
                       }}
                     />
                   }
-                  requestTooltipComponentId="mlflow.gateway.usage-modal.try-it.request-tooltip-passthrough"
+                  componentId="mlflow.gateway.usage-modal.try-it.request-tooltip-passthrough"
                   tryItRequestUrl={tryItRequestUrl}
                   tryItDefaultBody={tryItDefaultBody}
                   tryItOptions={

--- a/mlflow/server/js/src/gateway/components/endpoints/EndpointsFilterButton.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoints/EndpointsFilterButton.tsx
@@ -14,7 +14,7 @@ export const EndpointsFilterButton = ({ availableProviders, filter, onFilterChan
       availableProviders={availableProviders}
       filter={filter}
       onFilterChange={onFilterChange}
-      componentIdPrefix="mlflow.gateway.endpoints-list"
+      componentId="mlflow.gateway.endpoints-list"
     />
   );
 };

--- a/mlflow/server/js/src/gateway/components/endpoints/TryItPanel.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoints/TryItPanel.tsx
@@ -11,7 +11,7 @@ const ERROR_LINE_MIN_HEIGHT = '1.5em';
 export interface TryItPanelProps {
   description: ReactNode;
   requestTooltipContent: ReactNode;
-  requestTooltipComponentId: string;
+  componentId: string;
   tryItRequestUrl: string;
   tryItDefaultBody: string;
   /** Optional fetch options (headers, signal) passed through to Try-it requests. */
@@ -21,7 +21,7 @@ export interface TryItPanelProps {
 export const TryItPanel = ({
   description,
   requestTooltipContent,
-  requestTooltipComponentId,
+  componentId,
   tryItRequestUrl,
   tryItDefaultBody,
   tryItOptions,
@@ -88,7 +88,7 @@ export const TryItPanel = ({
               <Typography.Text bold>
                 <FormattedMessage defaultMessage="Request" description="Request body label" />
               </Typography.Text>
-              <Tooltip componentId={requestTooltipComponentId} content={requestTooltipContent}>
+              <Tooltip componentId={componentId} content={requestTooltipContent}>
                 <span css={{ cursor: 'help', color: theme.colors.textSecondary }} aria-label="Request help">
                   ?
                 </span>

--- a/mlflow/server/js/src/gateway/components/model-configuration/components/ApiKeyConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/model-configuration/components/ApiKeyConfigurator.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useEffect } from 'react';
+import { useCallback, useMemo, useEffect, useRef } from 'react';
 import { FormUI, Radio, Spinner, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { GatewayInput } from '../../common';
@@ -44,6 +44,7 @@ export function ApiKeyConfigurator({
 }: ApiKeyConfiguratorProps) {
   const { theme } = useDesignSystemTheme();
   const { formatMessage } = useIntl();
+  const outerDomId = useRef(`api-key-${Math.random().toString(36).slice(2, 9)}`).current;
 
   const hasExistingSecrets = existingSecrets.length > 0;
   const hasMultipleAuthModes = authModes.length > 1;
@@ -153,7 +154,7 @@ export function ApiKeyConfigurator({
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       <Radio.Group
         componentId={`${componentId}.mode`}
-        name={`${componentId}.mode`}
+        name={`${outerDomId}.mode`}
         value={value.mode}
         onChange={(e) => handleModeChange(e.target.value as 'new' | 'existing')}
         layout="horizontal"
@@ -242,6 +243,7 @@ function NewSecretForm({
 }: NewSecretFormProps) {
   const { theme } = useDesignSystemTheme();
   const { formatMessage } = useIntl();
+  const domId = useRef(`api-key-config-${Math.random().toString(36).slice(2, 9)}`).current;
 
   // Combine secret and config fields into a single sorted list
   const sortedFields = useMemo(() => {
@@ -260,12 +262,12 @@ function NewSecretForm({
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       <div>
-        <FormUI.Label htmlFor={`${componentId}.name`}>
+        <FormUI.Label htmlFor={`${domId}.name`}>
           <FormattedMessage defaultMessage="API key name" description="Label for API key name input" />
           <span css={{ color: theme.colors.textValidationDanger }}> *</span>
         </FormUI.Label>
         <GatewayInput
-          id={`${componentId}.name`}
+          id={`${domId}.name`}
           componentId={`${componentId}.name`}
           value={value.name}
           onChange={(e) => onNameChange(e.target.value)}
@@ -294,7 +296,7 @@ function NewSecretForm({
             <FormattedMessage defaultMessage="Authentication method" description="Label for auth mode selector" />
           </FormUI.Label>
           <Radio.Group
-            name={`${componentId}.auth-mode`}
+            name={`${domId}.auth-mode`}
             componentId={`${componentId}.auth-mode`}
             value={value.authMode || defaultAuthMode}
             onChange={(e) => onAuthModeChange(e.target.value)}
@@ -320,13 +322,13 @@ function NewSecretForm({
 
       {sortedFields.map((field) => (
         <div key={field.name}>
-          <FormUI.Label htmlFor={`${componentId}.${field.fieldType}.${field.name}`}>
+          <FormUI.Label htmlFor={`${domId}.${field.fieldType}.${field.name}`}>
             {formatCredentialFieldName(field.name)}
             {field.required && <span css={{ color: theme.colors.textValidationDanger }}> *</span>}
           </FormUI.Label>
           {field.fieldType === 'secret' ? (
             <SecretInput
-              id={`${componentId}.secret.${field.name}`}
+              id={`${domId}.secret.${field.name}`}
               componentId={`${componentId}.secret`}
               value={value.secretFields[field.name] ?? ''}
               onChange={(e) => onSecretFieldChange(field.name, e.target.value)}
@@ -336,7 +338,7 @@ function NewSecretForm({
             />
           ) : (
             <GatewayInput
-              id={`${componentId}.config.${field.name}`}
+              id={`${domId}.config.${field.name}`}
               componentId={`${componentId}.config`}
               value={value.configFields[field.name] ?? ''}
               onChange={(e) => onConfigFieldChange(field.name, e.target.value)}

--- a/mlflow/server/js/src/gateway/components/model-configuration/components/ApiKeyConfigurator.tsx
+++ b/mlflow/server/js/src/gateway/components/model-configuration/components/ApiKeyConfigurator.tsx
@@ -26,7 +26,7 @@ interface ApiKeyConfiguratorProps {
     };
   };
   disabled?: boolean;
-  componentIdPrefix?: string;
+  componentId?: string;
 }
 
 export function ApiKeyConfigurator({
@@ -40,7 +40,7 @@ export function ApiKeyConfigurator({
   isLoadingProviderConfig,
   errors,
   disabled,
-  componentIdPrefix = 'mlflow.gateway.api-key-config',
+  componentId = 'mlflow.gateway.api-key-config',
 }: ApiKeyConfiguratorProps) {
   const { theme } = useDesignSystemTheme();
   const { formatMessage } = useIntl();
@@ -152,8 +152,8 @@ export function ApiKeyConfigurator({
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       <Radio.Group
-        componentId={`${componentIdPrefix}.mode`}
-        name={`${componentIdPrefix}.mode`}
+        componentId={`${componentId}.mode`}
+        name={`${componentId}.mode`}
         value={value.mode}
         onChange={(e) => handleModeChange(e.target.value as 'new' | 'existing')}
         layout="horizontal"
@@ -194,7 +194,7 @@ export function ApiKeyConfigurator({
           defaultAuthMode={defaultAuthMode}
           errors={errors?.newSecret}
           disabled={disabled}
-          componentIdPrefix={componentIdPrefix}
+          componentId={componentId}
           onNameChange={handleNameChange}
           onAuthModeChange={handleAuthModeChange}
           onSecretFieldChange={handleSecretFieldChange}
@@ -218,7 +218,7 @@ interface NewSecretFormProps {
     configFields?: Record<string, string>;
   };
   disabled?: boolean;
-  componentIdPrefix: string;
+  componentId: string;
   onNameChange: (name: string) => void;
   onAuthModeChange: (mode: string) => void;
   onSecretFieldChange: (fieldName: string, fieldValue: string) => void;
@@ -234,7 +234,7 @@ function NewSecretForm({
   defaultAuthMode,
   errors,
   disabled,
-  componentIdPrefix,
+  componentId,
   onNameChange,
   onAuthModeChange,
   onSecretFieldChange,
@@ -260,13 +260,13 @@ function NewSecretForm({
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       <div>
-        <FormUI.Label htmlFor={`${componentIdPrefix}.name`}>
+        <FormUI.Label htmlFor={`${componentId}.name`}>
           <FormattedMessage defaultMessage="API key name" description="Label for API key name input" />
           <span css={{ color: theme.colors.textValidationDanger }}> *</span>
         </FormUI.Label>
         <GatewayInput
-          id={`${componentIdPrefix}.name`}
-          componentId={`${componentIdPrefix}.name`}
+          id={`${componentId}.name`}
+          componentId={`${componentId}.name`}
           value={value.name}
           onChange={(e) => onNameChange(e.target.value)}
           placeholder={formatMessage({
@@ -294,8 +294,8 @@ function NewSecretForm({
             <FormattedMessage defaultMessage="Authentication method" description="Label for auth mode selector" />
           </FormUI.Label>
           <Radio.Group
-            name={`${componentIdPrefix}.auth-mode`}
-            componentId={`${componentIdPrefix}.auth-mode`}
+            name={`${componentId}.auth-mode`}
+            componentId={`${componentId}.auth-mode`}
             value={value.authMode || defaultAuthMode}
             onChange={(e) => onAuthModeChange(e.target.value)}
             disabled={disabled}
@@ -320,14 +320,14 @@ function NewSecretForm({
 
       {sortedFields.map((field) => (
         <div key={field.name}>
-          <FormUI.Label htmlFor={`${componentIdPrefix}.${field.fieldType}.${field.name}`}>
+          <FormUI.Label htmlFor={`${componentId}.${field.fieldType}.${field.name}`}>
             {formatCredentialFieldName(field.name)}
             {field.required && <span css={{ color: theme.colors.textValidationDanger }}> *</span>}
           </FormUI.Label>
           {field.fieldType === 'secret' ? (
             <SecretInput
-              id={`${componentIdPrefix}.secret.${field.name}`}
-              componentId={`${componentIdPrefix}.secret.${field.name}`}
+              id={`${componentId}.secret.${field.name}`}
+              componentId={`${componentId}.secret`}
               value={value.secretFields[field.name] ?? ''}
               onChange={(e) => onSecretFieldChange(field.name, e.target.value)}
               placeholder={field.description}
@@ -336,8 +336,8 @@ function NewSecretForm({
             />
           ) : (
             <GatewayInput
-              id={`${componentIdPrefix}.config.${field.name}`}
-              componentId={`${componentIdPrefix}.config.${field.name}`}
+              id={`${componentId}.config.${field.name}`}
+              componentId={`${componentId}.config`}
               value={value.configFields[field.name] ?? ''}
               onChange={(e) => onConfigFieldChange(field.name, e.target.value)}
               placeholder={field.description}

--- a/mlflow/server/js/src/gateway/components/model-definitions/ModelDefinitionConfigSection.tsx
+++ b/mlflow/server/js/src/gateway/components/model-definitions/ModelDefinitionConfigSection.tsx
@@ -11,7 +11,7 @@ interface ModelDefinitionConfigSectionProps {
   selectedModelDefinitionId?: string;
   onModelDefinitionSelect: (modelDefinitionId: string) => void;
   error?: string;
-  componentIdPrefix?: string;
+  componentId?: string;
   children?: React.ReactNode;
 }
 
@@ -21,7 +21,7 @@ export const ModelDefinitionConfigSection = ({
   selectedModelDefinitionId,
   onModelDefinitionSelect,
   error,
-  componentIdPrefix = 'mlflow.gateway.model-definition-config',
+  componentId = 'mlflow.gateway.model-definition-config',
   children,
 }: ModelDefinitionConfigSectionProps) => {
   const { theme } = useDesignSystemTheme();
@@ -36,7 +36,7 @@ export const ModelDefinitionConfigSection = ({
           <FormattedMessage defaultMessage="Model configuration" description="Label for model configuration section" />
         </FormUI.Label>
         <Radio.Group
-          componentId={`${componentIdPrefix}.mode`}
+          componentId={`${componentId}.mode`}
           name="modelDefinitionMode"
           value={mode}
           onChange={(e) => onModeChange(e.target.value as ModelDefinitionMode)}

--- a/mlflow/server/js/src/gateway/components/model-definitions/ModelDefinitionSelector.tsx
+++ b/mlflow/server/js/src/gateway/components/model-definitions/ModelDefinitionSelector.tsx
@@ -9,7 +9,7 @@ interface ModelDefinitionSelectorProps {
   provider?: string;
   disabled?: boolean;
   error?: string;
-  componentIdPrefix?: string;
+  componentId?: string;
 }
 
 export const ModelDefinitionSelector = ({
@@ -18,7 +18,7 @@ export const ModelDefinitionSelector = ({
   provider,
   disabled,
   error,
-  componentIdPrefix = 'mlflow.gateway.model-definition',
+  componentId = 'mlflow.gateway.model-definition',
 }: ModelDefinitionSelectorProps) => {
   const { theme } = useDesignSystemTheme();
   const { data: modelDefinitions, isLoading } = useModelDefinitionsQuery();
@@ -46,16 +46,14 @@ export const ModelDefinitionSelector = ({
       ? `No existing model definitions for ${formatProviderName(provider)}`
       : 'No model definitions available';
 
-  const selectId = `${componentIdPrefix}.select`;
-
   return (
     <div css={{ width: '100%' }}>
-      <FormUI.Label htmlFor={selectId}>
+      <FormUI.Label htmlFor={`${componentId}.select`}>
         <FormattedMessage defaultMessage="Model definition" description="Label for model definition selector" />
       </FormUI.Label>
       <SimpleSelect
-        id={selectId}
-        componentId={selectId}
+        id={`${componentId}.select`}
+        componentId={`${componentId}.select`}
         value={value}
         onChange={({ target }) => onChange(target.value)}
         disabled={disabled || !hasOptions}

--- a/mlflow/server/js/src/gateway/components/secrets/SecretFormFields.tsx
+++ b/mlflow/server/js/src/gateway/components/secrets/SecretFormFields.tsx
@@ -19,7 +19,7 @@ export interface SecretFormFieldsProps {
     configFields?: Record<string, string>;
   };
   disabled?: boolean;
-  componentIdPrefix?: string;
+  componentId?: string;
   hideNameField?: boolean;
 }
 
@@ -29,7 +29,7 @@ export const SecretFormFields = ({
   onChange,
   errors,
   disabled,
-  componentIdPrefix = 'mlflow.gateway.secret-form',
+  componentId = 'mlflow.gateway.secret-form',
   hideNameField = false,
 }: SecretFormFieldsProps) => {
   const { theme } = useDesignSystemTheme();
@@ -125,13 +125,13 @@ export const SecretFormFields = ({
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       {!hideNameField && (
         <div>
-          <FormUI.Label htmlFor={`${componentIdPrefix}.name`}>
+          <FormUI.Label htmlFor={`${componentId}.name`}>
             <FormattedMessage defaultMessage="API key name" description="Label for API key name input" />
             <span css={{ color: theme.colors.textValidationDanger }}> *</span>
           </FormUI.Label>
           <GatewayInput
-            id={`${componentIdPrefix}.name`}
-            componentId={`${componentIdPrefix}.name`}
+            id={`${componentId}.name`}
+            componentId={`${componentId}.name`}
             value={value.name}
             onChange={(e: ChangeEvent<HTMLInputElement>) => handleNameChange(e.target.value)}
             placeholder={formatMessage({
@@ -151,8 +151,8 @@ export const SecretFormFields = ({
             <FormattedMessage defaultMessage="Authentication method" description="Label for auth mode selector" />
           </FormUI.Label>
           <Radio.Group
-            name={`${componentIdPrefix}.auth-mode`}
-            componentId={`${componentIdPrefix}.auth-mode`}
+            name={`${componentId}.auth-mode`}
+            componentId={`${componentId}.auth-mode`}
             value={effectiveAuthMode}
             onChange={(e: RadioChangeEvent) => handleAuthModeChange(e.target.value)}
             disabled={disabled}
@@ -177,14 +177,14 @@ export const SecretFormFields = ({
 
       {sortedFields.map((field) => (
         <div key={field.name}>
-          <FormUI.Label htmlFor={`${componentIdPrefix}.${field.fieldType}.${field.name}`}>
+          <FormUI.Label htmlFor={`${componentId}.${field.fieldType}.${field.name}`}>
             {formatCredentialFieldName(field.name)}
             {field.required && <span css={{ color: theme.colors.textValidationDanger }}> *</span>}
           </FormUI.Label>
           {field.fieldType === 'secret' ? (
             <SecretInput
-              id={`${componentIdPrefix}.secret.${field.name}`}
-              componentId={`${componentIdPrefix}.secret.${field.name}`}
+              id={`${componentId}.secret.${field.name}`}
+              componentId={`${componentId}.secret`}
               value={value.secretFields[field.name] ?? ''}
               onChange={(e: ChangeEvent<HTMLInputElement>) => handleSecretFieldChange(field.name, e.target.value)}
               placeholder={field.description}
@@ -193,8 +193,8 @@ export const SecretFormFields = ({
             />
           ) : (
             <GatewayInput
-              id={`${componentIdPrefix}.config.${field.name}`}
-              componentId={`${componentIdPrefix}.config.${field.name}`}
+              id={`${componentId}.config.${field.name}`}
+              componentId={`${componentId}.config`}
               value={value.configFields[field.name] ?? ''}
               onChange={(e: ChangeEvent<HTMLInputElement>) => handleConfigFieldChange(field.name, e.target.value)}
               placeholder={field.description}

--- a/mlflow/server/js/src/gateway/components/secrets/SecretFormFields.tsx
+++ b/mlflow/server/js/src/gateway/components/secrets/SecretFormFields.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent } from 'react';
 import { FormUI, Spinner, useDesignSystemTheme, Radio, type RadioChangeEvent } from '@databricks/design-system';
 import { GatewayInput } from '../common';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useRef } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useProviderConfigQuery } from '../../hooks/useProviderConfigQuery';
 import { formatCredentialFieldName, sortFieldsByProvider } from '../../utils/providerUtils';
@@ -34,6 +34,7 @@ export const SecretFormFields = ({
 }: SecretFormFieldsProps) => {
   const { theme } = useDesignSystemTheme();
   const { formatMessage } = useIntl();
+  const domId = useRef(`secret-form-${Math.random().toString(36).slice(2, 9)}`).current;
   const { data: providerConfig, isLoading } = useProviderConfigQuery({ provider });
 
   const authModes = useMemo(() => providerConfig?.auth_modes ?? [], [providerConfig?.auth_modes]);
@@ -125,12 +126,12 @@ export const SecretFormFields = ({
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
       {!hideNameField && (
         <div>
-          <FormUI.Label htmlFor={`${componentId}.name`}>
+          <FormUI.Label htmlFor={`${domId}.name`}>
             <FormattedMessage defaultMessage="API key name" description="Label for API key name input" />
             <span css={{ color: theme.colors.textValidationDanger }}> *</span>
           </FormUI.Label>
           <GatewayInput
-            id={`${componentId}.name`}
+            id={`${domId}.name`}
             componentId={`${componentId}.name`}
             value={value.name}
             onChange={(e: ChangeEvent<HTMLInputElement>) => handleNameChange(e.target.value)}
@@ -151,7 +152,7 @@ export const SecretFormFields = ({
             <FormattedMessage defaultMessage="Authentication method" description="Label for auth mode selector" />
           </FormUI.Label>
           <Radio.Group
-            name={`${componentId}.auth-mode`}
+            name={`${domId}.auth-mode`}
             componentId={`${componentId}.auth-mode`}
             value={effectiveAuthMode}
             onChange={(e: RadioChangeEvent) => handleAuthModeChange(e.target.value)}
@@ -177,13 +178,13 @@ export const SecretFormFields = ({
 
       {sortedFields.map((field) => (
         <div key={field.name}>
-          <FormUI.Label htmlFor={`${componentId}.${field.fieldType}.${field.name}`}>
+          <FormUI.Label htmlFor={`${domId}.${field.fieldType}.${field.name}`}>
             {formatCredentialFieldName(field.name)}
             {field.required && <span css={{ color: theme.colors.textValidationDanger }}> *</span>}
           </FormUI.Label>
           {field.fieldType === 'secret' ? (
             <SecretInput
-              id={`${componentId}.secret.${field.name}`}
+              id={`${domId}.secret.${field.name}`}
               componentId={`${componentId}.secret`}
               value={value.secretFields[field.name] ?? ''}
               onChange={(e: ChangeEvent<HTMLInputElement>) => handleSecretFieldChange(field.name, e.target.value)}
@@ -193,7 +194,7 @@ export const SecretFormFields = ({
             />
           ) : (
             <GatewayInput
-              id={`${componentId}.config.${field.name}`}
+              id={`${domId}.config.${field.name}`}
               componentId={`${componentId}.config`}
               value={value.configFields[field.name] ?? ''}
               onChange={(e: ChangeEvent<HTMLInputElement>) => handleConfigFieldChange(field.name, e.target.value)}

--- a/mlflow/server/js/src/gateway/components/shared/ExperimentSelect.test.tsx
+++ b/mlflow/server/js/src/gateway/components/shared/ExperimentSelect.test.tsx
@@ -27,7 +27,7 @@ describe('ExperimentSelect', () => {
       error: null,
     });
 
-    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentIdPrefix="test" />);
+    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentId="test" />);
 
     expect(screen.getByText('Loading experiments...')).toBeInTheDocument();
   });
@@ -39,7 +39,7 @@ describe('ExperimentSelect', () => {
       error: new Error('Failed to fetch experiments'),
     });
 
-    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentIdPrefix="test" />);
+    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentId="test" />);
 
     expect(screen.getByText('Failed to fetch experiments')).toBeInTheDocument();
   });
@@ -51,7 +51,7 @@ describe('ExperimentSelect', () => {
       error: null,
     });
 
-    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentIdPrefix="test" />);
+    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentId="test" />);
 
     expect(screen.getByRole('combobox')).toBeInTheDocument();
   });
@@ -63,7 +63,7 @@ describe('ExperimentSelect', () => {
       error: null,
     });
 
-    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentIdPrefix="test" />);
+    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentId="test" />);
 
     expect(screen.getByText('Auto-create experiment')).toBeInTheDocument();
   });
@@ -75,7 +75,7 @@ describe('ExperimentSelect', () => {
       error: null,
     });
 
-    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentIdPrefix="test" disabled />);
+    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentId="test" disabled />);
 
     // The SimpleSelect component uses a button role for the trigger
     const trigger = screen.getByRole('combobox');
@@ -90,7 +90,7 @@ describe('ExperimentSelect', () => {
       error: new Error(),
     });
 
-    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentIdPrefix="test" />);
+    renderWithDesignSystem(<ExperimentSelect value="" onChange={jest.fn()} componentId="test" />);
 
     expect(screen.getByText('Failed to load experiments')).toBeInTheDocument();
   });

--- a/mlflow/server/js/src/gateway/components/shared/ExperimentSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/shared/ExperimentSelect.tsx
@@ -7,10 +7,10 @@ interface ExperimentSelectProps {
   onChange: (experimentId: string) => void;
   disabled?: boolean;
   error?: string;
-  componentIdPrefix: string;
+  componentId: string;
 }
 
-export const ExperimentSelect = ({ value, onChange, disabled, error, componentIdPrefix }: ExperimentSelectProps) => {
+export const ExperimentSelect = ({ value, onChange, disabled, error, componentId }: ExperimentSelectProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const { experiments, isLoading, error: queryError } = useExperimentsForSelect();
@@ -34,8 +34,8 @@ export const ExperimentSelect = ({ value, onChange, disabled, error, componentId
 
   return (
     <SimpleSelect
-      id={componentIdPrefix}
-      componentId={componentIdPrefix}
+      id={componentId}
+      componentId={componentId}
       value={value}
       onChange={({ target }) => onChange(target.value)}
       disabled={disabled}

--- a/mlflow/server/js/src/gateway/components/shared/ProviderFilterButton.tsx
+++ b/mlflow/server/js/src/gateway/components/shared/ProviderFilterButton.tsx
@@ -19,14 +19,14 @@ interface ProviderFilterButtonProps {
   availableProviders: string[];
   filter: ProviderFilter;
   onFilterChange: (filter: ProviderFilter) => void;
-  componentIdPrefix: string;
+  componentId: string;
 }
 
 export const ProviderFilterButton = ({
   availableProviders,
   filter,
   onFilterChange,
-  componentIdPrefix,
+  componentId,
 }: ProviderFilterButtonProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -58,10 +58,10 @@ export const ProviderFilterButton = ({
   );
 
   return (
-    <Popover.Root componentId={`${componentIdPrefix}.filter-popover`} open={isOpen} onOpenChange={setIsOpen}>
+    <Popover.Root componentId={`${componentId}.filter-popover`} open={isOpen} onOpenChange={setIsOpen}>
       <Popover.Trigger asChild>
         <Button
-          componentId={`${componentIdPrefix}.filter-button`}
+          componentId={`${componentId}.filter-button`}
           endIcon={<ChevronDownIcon />}
           css={{
             border: hasActiveFilters ? `1px solid ${theme.colors.actionDefaultBorderFocus} !important` : '',
@@ -104,7 +104,7 @@ export const ProviderFilterButton = ({
             sortedProviders.map((provider) => (
               <Checkbox
                 key={provider}
-                componentId={`${componentIdPrefix}.filter.provider.${provider}`}
+                componentId={`${componentId}.filter.provider`}
                 isChecked={filter.providers.includes(provider)}
                 onChange={() => handleProviderToggle(provider)}
               >


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

- Rename `componentIdPrefix` prop to `componentId` across all gateway components so the `@databricks/no-dynamic-property-value` lint rule recognizes it as an allowed parameter
- Remove dynamic suffixes (`index`, `field.name`, `provider`, `label.toLowerCase()`) from `componentId` values to make them fully static
- Rename `requestTooltipComponentId` to `componentId` in `TryItPanel`
- Inline `selectId` const in `ModelDefinitionSelector` to use `componentId` directly

This eliminates all 41 `@databricks/no-dynamic-property-value` warnings in `src/gateway/` with zero `eslint-disable` comments. No changes to componentIds that are referenced externally (e.g. `mlflow.gateway.endpoint.submit`, `mlflow.gateway.delete-endpoint-modal.delete`, modal footer IDs).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified with `npx eslint src/gateway/` — 0 warnings (was 41). TypeScript compilation clean.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request was AI-assisted by Isaac.