### PR TITLE
Fix langchain audio tests to expect `mlflow-attachment://` URIs

### DIFF
--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -246,7 +246,10 @@ def test_chat_model_autolog_audio_input_normalization(mime_type, expected_format
     audio_block = msgs[0]["content"][1]
     assert audio_block["type"] == "input_audio"
     assert audio_block["input_audio"]["format"] == expected_format
-    assert audio_block["input_audio"]["data"] == audio_b64
+    attachment_uri = audio_block["input_audio"]["data"]
+    assert attachment_uri.startswith("mlflow-attachment://")
+    expected_mime = "mpeg" if expected_format == "mp3" else expected_format
+    assert f"content_type=audio%2F{expected_mime}" in attachment_uri
 
 
 def test_chat_model_autolog_audio_output_normalization():
@@ -281,7 +284,9 @@ def test_chat_model_autolog_audio_output_normalization():
     audio_block = span.outputs["choices"][0]["message"]["content"][1]
     assert audio_block["type"] == "input_audio"
     assert audio_block["input_audio"]["format"] == "wav"
-    assert audio_block["input_audio"]["data"] == audio_b64
+    attachment_uri = audio_block["input_audio"]["data"]
+    assert attachment_uri.startswith("mlflow-attachment://")
+    assert "content_type=audio%2Fwav" in attachment_uri
 
 
 def test_chat_model_autolog_openai_audio_output_with_format():
@@ -324,7 +329,9 @@ def test_chat_model_autolog_openai_audio_output_with_format():
     assert isinstance(content, list)
     assert content[0] == {"type": "text", "text": "Yes, I am."}
     assert content[1]["type"] == "input_audio"
-    assert content[1]["input_audio"]["data"] == audio_b64
+    attachment_uri = content[1]["input_audio"]["data"]
+    assert attachment_uri.startswith("mlflow-attachment://")
+    assert "content_type=audio%2Fwav" in attachment_uri
     assert content[1]["input_audio"]["format"] == "wav"
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #21955

### What changes are proposed in this pull request?

PR #21955 (auto-extract base64 multimodal content as trace attachments) landed on master and now replaces base64 audio data in span inputs/outputs with `mlflow-attachment://` URIs. Four langchain audio normalization tests were still asserting raw base64 strings.

Updated the 4 tests to assert:
- The data field contains an `mlflow-attachment://` URI (extraction happened)
- The URI contains the correct content type (`audio/wav` or `audio/mpeg`)

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release